### PR TITLE
feat(parser): impulse-exile choose/play surface (Connecting the Dots, End-Blaze Epiphany, Expensive Taste, Omenpath Journey)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2862,6 +2862,17 @@ pub(crate) fn next_sub_needs_tracked_set(ability: &ResolvedAbility) -> bool {
         .is_some_and(ability_or_branch_references_tracked_set)
 }
 
+/// CR 608.2c: Does `ability` (or any of its continuation branches) consume the
+/// chain's tracked set — e.g. a `GrantCastingPermission { target: TrackedSet }`
+/// ("you may play that card") chained after an interactive `ChooseFromZone`?
+/// The interactive `ChooseFromZoneChoice` answer handler uses this to decide
+/// whether the chosen cards must be published as the fresh tracked set the
+/// continuation reads (End-Blaze Epiphany: "choose a card exiled this way …
+/// you may play that card").
+pub(crate) fn chain_references_tracked_set(ability: &ResolvedAbility) -> bool {
+    ability_or_branch_references_tracked_set(ability)
+}
+
 fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
     let consumes = matches!(
         &ability.effect,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2119,6 +2119,26 @@ pub(super) fn handle_resolution_choice(
                     state.waiting_for.clone(),
                 ));
             }
+            // CR 608.2c: When the parked continuation consumes the chain's
+            // tracked set (a `GrantCastingPermission { target: TrackedSet }` /
+            // any `TrackedSet`-referencing downstream effect — e.g. End-Blaze
+            // Epiphany's "choose a card exiled this way … you may play that
+            // card"), the interactive choose is the producer of that set, so the
+            // chosen cards must be published as the fresh tracked set the
+            // continuation reads. This mirrors the per-player drain
+            // (`publish_fresh_tracked_set`) and the random-choose path
+            // (`apply_parent_chain_context`); without it the grant's
+            // `TrackedSet(0)` sentinel binds to a stale/empty set and the
+            // permission lands nowhere. Gated on the continuation actually
+            // referencing a tracked set so non-consuming continuations
+            // (partition sub-abilities reading `ParentTarget`) are unaffected.
+            let continuation_consumes_tracked_set = state
+                .pending_continuation
+                .as_ref()
+                .is_some_and(|cont| effects::chain_references_tracked_set(&cont.chain));
+            if continuation_consumes_tracked_set {
+                effects::publish_fresh_tracked_set(state, chosen.clone());
+            }
             if let Some(cont) = state.pending_continuation.as_mut() {
                 cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
                 // CR 700.2 + CR 608.2c: The "unchosen" partition is forwarded

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2699,6 +2699,17 @@ pub(super) fn parse_choose_ast(
         return Some(ast);
     }
 
+    // CR 608.2c + CR 603.7 / CR 610.3 + CR 406.6: "choose a card [at random]
+    // exiled this way / exiled with ~" — the impulse-exile choose anaphor. The
+    // "exiled this way" referent is the chain's tracked set (the cards exiled by
+    // a preceding clause in this resolution, e.g. End-Blaze Epiphany); the
+    // "exiled with ~/it" referent is the source's linked-exile set, scanned in
+    // Exile by `TargetFilter::ExiledBySource` (Omenpath Journey). Checked before
+    // the bare "choose " strip so it never misroutes to the targeting fallback.
+    if let Some(ast) = try_parse_choose_exiled_anaphor(lower) {
+        return Some(ast);
+    }
+
     if let Some((_, rest)) =
         nom_on_lower(text, lower, |input| value((), tag("choose ")).parse(input))
     {
@@ -2826,6 +2837,73 @@ fn try_parse_choose_owned_by_voter(
         // CR 608.2d: per-ballot voter choice is controller-directed, never random.
         selection: crate::types::ability::CardSelectionMode::Chosen,
     })
+}
+
+/// CR 608.2c + CR 603.7 / CR 610.3 + CR 406.6: Parse "choose a card [at random]
+/// exiled this way / exiled with ~ / exiled with it" — the impulse-exile choose
+/// anaphor.
+///
+/// Two referents, distinguished by the anaphor tail:
+/// - "exiled this way" → the chain's tracked set (cards exiled by a preceding
+///   clause this resolution). Lowered via [`ChooseImperativeAst::FromTrackedSet`]
+///   → `Effect::ChooseFromZone` reading the chain tracked set (End-Blaze
+///   Epiphany).
+/// - "exiled with ~" / "exiled with it" → the source's linked-exile set,
+///   scanned in `Zone::Exile` by [`TargetFilter::ExiledBySource`]. Lowered via
+///   [`ChooseImperativeAst::FromZone`] so the runtime applies the linked-exile
+///   filter (Omenpath Journey).
+///
+/// The optional "at random" qualifier sets [`CardSelectionMode::Random`]
+/// (CR 608.2d override): the game selects, the controller does not.
+fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
+    type E<'a> = OracleError<'a>;
+
+    // "choose " / "you choose ", then the singular card anaphor "a card" / "one
+    // card" / "a [type] card". Only the bare card forms are handled here; typed
+    // restrictions on impulse-exile choices are not yet attested and would fall
+    // through to the honest fallback.
+    let (rest_after, ()) = preceded(
+        alt((tag::<_, _, E>("choose "), tag("you choose "))),
+        value((), alt((tag("a card"), tag("one card")))),
+    )
+    .parse(lower)
+    .ok()?;
+
+    // Optional " at random" qualifier (CR 608.2d override).
+    let (rest_after, selection) = match tag::<_, _, E>(" at random").parse(rest_after) {
+        Ok((rest, _)) => (rest, CardSelectionMode::Random),
+        Err(_) => (rest_after, CardSelectionMode::Chosen),
+    };
+
+    // "exiled this way" — the chain tracked set.
+    if let Ok((tail, _)) = tag::<_, _, E>(" exiled this way").parse(rest_after) {
+        if tail.is_empty() {
+            return Some(ChooseImperativeAst::FromTrackedSet {
+                count: 1,
+                chooser: Chooser::Controller,
+                selection,
+            });
+        }
+    }
+
+    // "exiled with ~" / "exiled with it" — the source's linked-exile set.
+    if let Ok((tail, _)) =
+        alt((tag::<_, _, E>(" exiled with ~"), tag(" exiled with it"))).parse(rest_after)
+    {
+        if tail.is_empty() {
+            return Some(ChooseImperativeAst::FromZone {
+                count: 1,
+                zones: vec![Zone::Exile],
+                zone_owner: ZoneOwner::Controller,
+                filter: TargetFilter::ExiledBySource,
+                chooser: Chooser::Controller,
+                up_to: false,
+                selection,
+            });
+        }
+    }
+
+    None
 }
 
 fn try_parse_choose_from_zone(lower: &str, ctx: &mut ParseContext) -> Option<ChooseImperativeAst> {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -24,15 +24,17 @@ use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::effect_chain::{ClauseIr, EffectChainIr, SpecialClause};
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AttackScope, AttackSubject,
-    CastFromZoneDriver, Comparator, ContinuousModification, ControllerRef, DamageSource,
-    DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp, LibraryPosition,
-    MultiTargetSpec, ObjectScope, PlayerFilter, PreventionAmount, PreventionScope, PtValue,
-    QuantityExpr, QuantityRef, RoundingMode, StaticCondition, StaticDefinition, SubAbilityLink,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    CastFromZoneDriver, CastingPermission, Comparator, ContinuousModification, ControllerRef,
+    DamageSource, DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp,
+    LibraryPosition, ManaSpendPermission, MultiTargetSpec, ObjectScope, PlayerFilter,
+    PreventionAmount, PreventionScope, PtValue, QuantityExpr, QuantityRef, RoundingMode,
+    StaticCondition, StaticDefinition, SubAbilityLink, TargetChoiceTiming, TargetFilter,
+    TypeFilter, TypedFilter,
 };
 use crate::types::counter::CounterType;
 use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};
 use crate::types::phase::Phase;
+use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 // Parse-phase functions from the parent module (oracle_effect/mod.rs).
@@ -163,6 +165,59 @@ pub(super) fn normalize_linked_exile_cast_bottom_cleanup(effect: &mut Effect) {
             *count = QuantityExpr::Fixed { value: 0 };
         }
     }
+}
+
+fn is_spend_mana_as_any_color_rider(clause: &ClauseIr) -> bool {
+    let Effect::GenericEffect {
+        static_abilities, ..
+    } = &clause.parsed.effect
+    else {
+        return false;
+    };
+    if static_abilities.len() != 1 || static_abilities[0].mode != StaticMode::SpendManaAsAnyColor {
+        return false;
+    }
+
+    let lower = clause.source_text.to_ascii_lowercase();
+    all_consuming((
+        opt(alt((
+            tag::<_, _, OracleError<'_>>("if you cast a spell this way, "),
+            tag("if you cast it this way, "),
+        ))),
+        tag("you may spend mana as though it were mana of any "),
+        alt((tag("color"), tag("type"))),
+        tag(" to cast "),
+        alt((
+            tag("it"),
+            tag("that spell"),
+            tag("a spell this way"),
+            tag("spells this way"),
+            tag("those spells"),
+        )),
+        opt(tag(".")),
+    ))
+    .parse(lower.trim())
+    .is_ok()
+}
+
+fn attach_any_color_mana_rider_to_previous_play_from_exile(defs: &mut [AbilityDefinition]) -> bool {
+    let Some(previous) = defs.last_mut() else {
+        return false;
+    };
+    let Effect::GrantCastingPermission {
+        permission:
+            CastingPermission::PlayFromExile {
+                mana_spend_permission,
+                ..
+            },
+        ..
+    } = previous.effect.as_mut()
+    else {
+        return false;
+    };
+
+    *mana_spend_permission = Some(ManaSpendPermission::AnyTypeOrColor);
+    true
 }
 
 pub(super) fn is_linked_exile_cast_bottom_cleanup(
@@ -575,6 +630,18 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
         // normal clause stamps its `sub_link` from the boundary AFTER this
         // clause, not the stale boundary that preceded it.
         if handled_as_special {
+            prev_boundary = clause_ir.boundary;
+            continue;
+        }
+
+        // CR 609.4b + CR 608.2c: Brainstealer/Daxos-class any-color mana
+        // riders may be split into their own sentence or comma sibling after a
+        // `PlayFromExile` grant. They scope the existing exile-play
+        // permission, so fold the rider into the prior grant instead of
+        // emitting a broad standalone `SpendManaAsAnyColor` effect.
+        if is_spend_mana_as_any_color_rider(clause_ir)
+            && attach_any_color_mana_rider_to_previous_play_from_exile(&mut defs)
+        {
             prev_boundary = clause_ir.boundary;
             continue;
         }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -179,7 +179,7 @@ fn is_spend_mana_as_any_color_rider(clause: &ClauseIr) -> bool {
     }
 
     let lower = clause.source_text.to_ascii_lowercase();
-    all_consuming((
+    let parsed = all_consuming((
         opt(alt((
             tag::<_, _, OracleError<'_>>("if you cast a spell this way, "),
             tag("if you cast it this way, "),
@@ -197,7 +197,8 @@ fn is_spend_mana_as_any_color_rider(clause: &ClauseIr) -> bool {
         opt(tag(".")),
     ))
     .parse(lower.trim())
-    .is_ok()
+    .is_ok();
+    parsed
 }
 
 fn attach_any_color_mana_rider_to_previous_play_from_exile(defs: &mut [AbilityDefinition]) -> bool {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3921,6 +3921,8 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     let original_lower = text.to_lowercase();
     if scan_contains_phrase(&original_lower, "this turn")
         || scan_contains_phrase(&original_lower, "until ")
+        || scan_contains_phrase(&original_lower, "remain exiled")
+        || scan_contains_phrase(&original_lower, "remains exiled")
     {
         if let Some(mut clause) =
             try_parse_play_from_exile(TextPair::new(text, &original_lower), ctx)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -37150,6 +37150,53 @@ mod tests {
     }
 
     #[test]
+    fn parse_play_from_exile_while_exiled_with_spend_mana_as_any_color_permission() {
+        let def = parse_effect_chain(
+            "You may look at and play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(
+            &*def.effect,
+            Effect::GrantCastingPermission {
+                permission: CastingPermission::PlayFromExile {
+                    duration: Duration::Permanent,
+                    mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor),
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_brainstealer_dragon_play_grant_folds_mana_rider() {
+        let def = parse_effect_chain(
+            "Exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
+            AbilityKind::Triggered,
+        );
+        let grant = def
+            .sub_ability
+            .as_deref()
+            .expect("exile instruction must chain to play grant");
+        assert!(matches!(
+            &*grant.effect,
+            Effect::GrantCastingPermission {
+                permission: CastingPermission::PlayFromExile {
+                    duration: Duration::Permanent,
+                    mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor),
+                    ..
+                },
+                target: TargetFilter::TrackedSet { .. },
+                ..
+            }
+        ));
+        assert!(
+            grant.sub_ability.is_none(),
+            "mana rider must fold into the play grant instead of emitting a standalone sub-ability: {grant:#?}"
+        );
+    }
+
+    #[test]
     fn parse_play_from_exile_next_turn() {
         let def = parse_effect_chain(
             "You may play that card until the end of your next turn.",

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7401,24 +7401,30 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         if scan_contains_phrase(tp.lower, "without paying") {
             return None;
         }
-        // CR 406.6 + CR 400.7i + CR 603.7: the "those cards" / "the cards exiled
-        // this way" anaphor is an UNAMBIGUOUS impulse-set referent — it can
-        // never bind to a `CastFromZone` of a chosen target. When the bare
-        // fragment is one of these mass-anaphor "look at and play"/"play" forms,
-        // accept it WITHOUT requiring temporal context: the chunk loop peeled
-        // the "for as long as they remain exiled" duration into the wrapper
-        // (Expensive Taste), so `tp.lower` carries no "this turn"/"until" signal
-        // even though the grant is duration-scoped. `strip_trailing_duration`
-        // below resolves the window (defaulting to UntilEndOfTurn when absent).
-        let mass_anaphor_form = alt((
+        // CR 406.6 + CR 400.7i + CR 603.7: these exile anaphors are
+        // unambiguous impulse-set referents when paired with the "look at and
+        // play/cast" surface. Accept them without requiring an in-body temporal
+        // marker: the clause shell may have peeled the "for as long as ...
+        // remain[s] exiled" duration into the wrapper, so `tp.lower` no longer
+        // carries the duration text even though `with_clause_duration` will patch
+        // it onto the grant.
+        let look_at_play_anaphor_form = alt((
             tag::<_, _, OracleError<'_>>("look at and play those cards"),
             tag("look at and cast those cards"),
-            tag("play those cards"),
+            tag("look at and play that card"),
+            tag("look at and cast that card"),
+            tag("look at and play it"),
+            tag("look at and cast it"),
+        ))
+        .parse(tp.lower)
+        .is_ok();
+        let mass_anaphor_form = alt((
+            tag::<_, _, OracleError<'_>>("play those cards"),
             tag("cast those cards"),
         ))
         .parse(tp.lower)
         .is_ok();
-        if mass_anaphor_form {
+        if look_at_play_anaphor_form || mass_anaphor_form {
             // fall through to the grant builder.
         } else {
             // Only match when temporal context exists ("this turn", "until"),
@@ -37160,17 +37166,20 @@ mod tests {
             "You may look at and play that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell.",
             AbilityKind::Spell,
         );
-        assert!(matches!(
-            &*def.effect,
-            Effect::GrantCastingPermission {
-                permission: CastingPermission::PlayFromExile {
-                    duration: Duration::Permanent,
-                    mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor),
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::PlayFromExile {
+                        duration: Duration::Permanent,
+                        mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor),
+                        ..
+                    },
                     ..
-                },
-                ..
-            }
-        ));
+                }
+            ),
+            "expected PlayFromExile grant with any-color mana permission, got {def:#?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -37177,7 +37177,7 @@ mod tests {
     fn parse_brainstealer_dragon_play_grant_folds_mana_rider() {
         let def = parse_effect_chain(
             "Exile the top card of each opponent's library. You may play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
-            AbilityKind::Triggered,
+            AbilityKind::Spell,
         );
         let grant = def
             .sub_ability

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7445,9 +7445,18 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         return None;
     }
 
-    // Duration: extract from trailing text, defaulting to UntilEndOfTurn for impulse draw
+    // Duration: extract from trailing text, defaulting to UntilEndOfTurn for impulse draw.
+    // CR 400.7i + CR 611.2a: "for as long as ... remain[s] exiled" persists until
+    // zone-exit cleanup clears the exile-scoped permission, matching the existing
+    // any-mana remains-exiled grant path.
     let (_, dur) = strip_trailing_duration(tp.original);
-    let duration = dur.unwrap_or(Duration::UntilEndOfTurn);
+    let duration = if scan_contains_phrase(tp.lower, "remain exiled")
+        || scan_contains_phrase(tp.lower, "remains exiled")
+    {
+        Duration::Permanent
+    } else {
+        dur.unwrap_or(Duration::UntilEndOfTurn)
+    };
 
     Some(parsed_clause(Effect::GrantCastingPermission {
         permission: CastingPermission::PlayFromExile {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7318,8 +7318,25 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
 
     // Try full forms first: "you may play/cast that card/it/those cards ..."
     // Then bare forms (after "you may" has been stripped): "play that card ..."
+    // CR 406.6 + CR 400.7i: "you may look at and play those cards for as long as
+    // they remain exiled" (Expensive Taste) grants the same impulse-style
+    // PlayFromExile permission; the "look at" conjunct is a private-information
+    // grant that the permission already implies (the controller can always see
+    // a card they may play). Folded in as a verb-prefix variant so the no-mana-
+    // conjunct form reaches the same grant as the bare "you may play those
+    // cards" path (the with-mana form is handled earlier by
+    // `try_parse_exile_play_grant_with_any_mana`).
     let full_rest = nom_on_lower(tp.original, tp.lower, |input| {
-        value((), alt((tag("you may play "), tag("you may cast ")))).parse(input)
+        value(
+            (),
+            alt((
+                tag("you may look at and play "),
+                tag("you may look at and cast "),
+                tag("you may play "),
+                tag("you may cast "),
+            )),
+        )
+        .parse(input)
     })
     .map(|((), rest_orig)| {
         let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
@@ -7358,33 +7375,54 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
             return None;
         }
     } else {
-        // Bare form (after "you may" was stripped by parse_effect_chain):
-        // Only match when temporal context exists ("this turn", "until"),
-        // otherwise it's a CastFromZone, not impulse draw permission.
-        let has_temporal =
-            scan_contains_phrase(tp.lower, "this turn") || scan_contains_phrase(tp.lower, "until ");
-        if !has_temporal {
-            return None;
-        }
+        // Bare form (after "you may" was stripped by parse_effect_chain).
         if scan_contains_phrase(tp.lower, "without paying") {
             return None;
         }
-        // CR 400.7i + CR 603.7: "(the) cards exiled this way" bare anaphor
-        // (Escape to the Wilds, after `you may ` is peeled by the chunk loop).
-        if alt((
-            tag::<_, _, OracleError<'_>>("play that card"),
-            tag("cast that card"),
-            tag("play it"),
-            tag("cast it"),
-            tag("play the cards exiled this way"),
-            tag("play cards exiled this way"),
-            tag("cast the cards exiled this way"),
-            tag("cast cards exiled this way"),
+        // CR 406.6 + CR 400.7i + CR 603.7: the "those cards" / "the cards exiled
+        // this way" anaphor is an UNAMBIGUOUS impulse-set referent — it can
+        // never bind to a `CastFromZone` of a chosen target. When the bare
+        // fragment is one of these mass-anaphor "look at and play"/"play" forms,
+        // accept it WITHOUT requiring temporal context: the chunk loop peeled
+        // the "for as long as they remain exiled" duration into the wrapper
+        // (Expensive Taste), so `tp.lower` carries no "this turn"/"until" signal
+        // even though the grant is duration-scoped. `strip_trailing_duration`
+        // below resolves the window (defaulting to UntilEndOfTurn when absent).
+        let mass_anaphor_form = alt((
+            tag::<_, _, OracleError<'_>>("look at and play those cards"),
+            tag("look at and cast those cards"),
+            tag("play those cards"),
+            tag("cast those cards"),
         ))
         .parse(tp.lower)
-        .is_err()
-        {
-            return None;
+        .is_ok();
+        if mass_anaphor_form {
+            // fall through to the grant builder.
+        } else {
+            // Only match when temporal context exists ("this turn", "until"),
+            // otherwise it's a CastFromZone, not impulse draw permission.
+            let has_temporal = scan_contains_phrase(tp.lower, "this turn")
+                || scan_contains_phrase(tp.lower, "until ");
+            if !has_temporal {
+                return None;
+            }
+            // CR 400.7i + CR 603.7: "(the) cards exiled this way" bare anaphor
+            // (Escape to the Wilds, after `you may ` is peeled by the chunk loop).
+            if alt((
+                tag::<_, _, OracleError<'_>>("play that card"),
+                tag("cast that card"),
+                tag("play it"),
+                tag("cast it"),
+                tag("play the cards exiled this way"),
+                tag("play cards exiled this way"),
+                tag("cast the cards exiled this way"),
+                tag("cast cards exiled this way"),
+            ))
+            .parse(tp.lower)
+            .is_err()
+            {
+                return None;
+            }
         }
     }
 
@@ -20111,6 +20149,13 @@ fn try_parse_put_zone_change_parts(
         (" into their hand", Zone::Hand),
         (" into its owner's hand", Zone::Hand),
         (" into their owner's hand", Zone::Hand),
+        // CR 400.3 + CR 110.1: plural possessive — a mass move where each card
+        // goes to its OWN owner's hand/graveyard ("Put all cards exiled with ~
+        // into their owners' hands" — Connecting the Dots). `execute_zone_move`
+        // already keys the destination by each object's owner for non-
+        // battlefield zones, so the plural form needs no separate routing.
+        (" into their owners' hands", Zone::Hand),
+        (" into their owners' graveyards", Zone::Graveyard),
         (" into your graveyard", Zone::Graveyard),
         (" into its owner's graveyard", Zone::Graveyard),
         (" into their owner's graveyard", Zone::Graveyard),

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -7,7 +7,7 @@ use crate::types::ability::{
     CounteredSpellDestination, DoorLockOp, Duration, Effect, FaceDownProfile, LibraryPosition,
     ManaProduction, ManaSpendRestriction, ModalSelectionConstraint, OutsideGameSourcePool,
     PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit, SearchSelectionConstraint,
-    StaticDefinition, TargetFilter,
+    StaticCondition, StaticDefinition, TargetFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -1402,7 +1402,7 @@ pub(crate) fn with_clause_duration(
                 },
             ..
         } => {
-            *perm_dur = duration;
+            *perm_dur = normalize_play_from_exile_duration(duration);
         }
         Effect::CastFromZone {
             duration: ref mut effect_duration,
@@ -1419,6 +1419,27 @@ pub(crate) fn with_clause_duration(
         _ => {}
     }
     clause
+}
+
+fn normalize_play_from_exile_duration(duration: Duration) -> Duration {
+    match duration {
+        Duration::ForAsLongAs {
+            condition: StaticCondition::Unrecognized { text },
+        } if matches!(
+            text.as_str(),
+            "it remains exiled"
+                | "that card remains exiled"
+                | "those cards remain exiled"
+                | "they remain exiled"
+        ) =>
+        {
+            // CR 400.7i + CR 611.2a: exile-play permissions persist until the
+            // referenced object leaves exile; zone-exit cleanup removes the
+            // object-tagged permission.
+            Duration::Permanent
+        }
+        other => other,
+    }
 }
 
 // --- Modal types (moved from oracle_modal.rs) ---

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 806
 expression: "&ir"
 ---
 {
@@ -27,9 +28,12 @@ expression: "&ir"
       "PreLoweredSpell": {
         "kind": "Activated",
         "effect": {
-          "type": "Unimplemented",
-          "name": "put",
-          "description": "Put all cards exiled with ~ into their owners' hands"
+          "type": "ChangeZoneAll",
+          "origin": "Exile",
+          "destination": "Hand",
+          "target": {
+            "type": "ExiledBySource"
+          }
         },
         "cost": {
           "type": "Composite",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_lowered.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 807
 expression: "&lowered"
 ---
 {
@@ -24,9 +25,12 @@ expression: "&lowered"
     {
       "kind": "Activated",
       "effect": {
-        "type": "Unimplemented",
-        "name": "put",
-        "description": "Put all cards exiled with ~ into their owners' hands"
+        "type": "ChangeZoneAll",
+        "origin": "Exile",
+        "destination": "Hand",
+        "target": {
+          "type": "ExiledBySource"
+        }
       },
       "cost": {
         "type": "Composite",

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2249,6 +2249,7 @@ fn detect_condition_as_long_as(
         "as long as it remains exiled",
         "as long as that card remains exiled",
         "as long as those cards remain exiled",
+        "as long as they remain exiled",
     ]
     .iter()
     .any(|phrase| cleaned.contains(phrase));
@@ -3037,6 +3038,24 @@ mod tests {
             parsed.statics
         );
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn condition_as_long_as_accepts_play_from_exile_they_remain_exiled() {
+        // CR 400.7i + CR 609.4b: Brainstealer Dragon's tracked-set
+        // PlayFromExile permission represents the "for as long as they remain
+        // exiled" duration; the following any-color mana rider folds into that
+        // same permission, not a swallowed condition.
+        let parsed = parse_named(
+            "Flying\n\
+             At the beginning of your end step, exile the top card of each opponent's library. \
+             You may play those cards for as long as they remain exiled. \
+             If you cast a spell this way, you may spend mana as though it were mana of any color to cast it.",
+            "Brainstealer Dragon",
+            &["Creature", "Dragon"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Condition_AsLongAs"));
     }
 
     #[test]

--- a/crates/engine/tests/connecting_the_dots_return_exiled_with.rs
+++ b/crates/engine/tests/connecting_the_dots_return_exiled_with.rs
@@ -1,0 +1,112 @@
+//! Discriminating regression for **Connecting the Dots** (std impulse-exile
+//! batch) — the activated ability:
+//!
+//! > {1}{R}, Discard your hand, Sacrifice this enchantment:
+//! > Put all cards exiled with ~ into their owners' hands.
+//!
+//! "Put all cards exiled with ~ into their owners' hands" is a MASS move of the
+//! source's linked-exile set (`TargetFilter::ExiledBySource`) to each card's
+//! own owner's hand. It must lower to `Effect::ChangeZoneAll { origin: Exile,
+//! destination: Hand, target: ExiledBySource }`. Before the fix the plural
+//! possessive destination "into their owners' hands" was not a recognized
+//! put-destination needle, so the whole clause fell to `Effect::Unimplemented`
+//! and the exiled cards stayed in exile.
+//!
+//! DISCRIMINATOR: after resolution, both cards exiled with the source return to
+//! their owners' hands. With the parse reverted the effect is `Unimplemented`
+//! (a no-op), the cards stay in Exile, and the `== Hand` assertion flips.
+//!
+//! CR 400.3 + CR 110.1: a non-battlefield zone move keys the destination by each
+//! object's owner.
+//! CR 610.3: the linked-exile entries are consumed once the cards leave exile.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, TargetFilter};
+use engine::types::game_state::{ExileLink, ExileLinkKind};
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const CONNECTING_THE_DOTS_ACTIVATED: &str = "Put all cards exiled with ~ into their owners' hands.";
+
+#[test]
+fn connecting_the_dots_returns_all_exiled_with_source_to_owners_hands() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The enchantment on the battlefield is the exile source.
+    let source = scenario.add_creature(P0, "Connecting the Dots", 0, 0).id();
+
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    // Two cards exiled "with ~": one owned by P0, one owned by P1 (the source's
+    // attack trigger exiles the active player's library cards — model two owners
+    // to prove the per-owner destination routing).
+    let p0_exiled = create_object(state, CardId(900), P0, "P0 Exiled".to_string(), Zone::Exile);
+    let p1_exiled = create_object(state, CardId(901), P1, "P1 Exiled".to_string(), Zone::Exile);
+    for exiled in [p0_exiled, p1_exiled] {
+        state.exile_links.push(ExileLink {
+            exiled_id: exiled,
+            source_id: source,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+    }
+    // A control card exiled by a DIFFERENT source must NOT be returned.
+    let unrelated = create_object(
+        state,
+        CardId(902),
+        P0,
+        "Unrelated Exiled".to_string(),
+        Zone::Exile,
+    );
+
+    // Same parser path the real card uses.
+    let def = parse_effect_chain(CONNECTING_THE_DOTS_ACTIVATED, AbilityKind::Activated);
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::ChangeZoneAll {
+                destination: Zone::Hand,
+                target: TargetFilter::ExiledBySource,
+                ..
+            }
+        ),
+        "must lower to ChangeZoneAll(Exile->Hand, ExiledBySource), got {:?}",
+        def.effect
+    );
+
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("mass exile-return must resolve");
+
+    // DISCRIMINATOR: each linked-exile card is now in its OWN owner's hand.
+    assert_eq!(
+        runner.state().objects[&p0_exiled].zone,
+        Zone::Hand,
+        "P0's exiled-with-source card must return to P0's hand"
+    );
+    assert_eq!(
+        runner.state().objects[&p1_exiled].zone,
+        Zone::Hand,
+        "P1's exiled-with-source card must return to P1's hand (per-owner routing)"
+    );
+    assert_eq!(
+        runner.state().objects[&p0_exiled].owner,
+        P0,
+        "ownership is unchanged by the move"
+    );
+    assert_eq!(runner.state().objects[&p1_exiled].owner, P1);
+
+    // NEGATIVE: a card exiled by a different source is untouched.
+    assert_eq!(
+        runner.state().objects[&unrelated].zone,
+        Zone::Exile,
+        "cards NOT exiled with this source must stay in exile"
+    );
+}

--- a/crates/engine/tests/end_blaze_epiphany_choose_exiled_this_way.rs
+++ b/crates/engine/tests/end_blaze_epiphany_choose_exiled_this_way.rs
@@ -1,0 +1,196 @@
+//! Discriminating runtime regression for **End-Blaze Epiphany** (std
+//! impulse-exile batch) — the delayed-trigger body:
+//!
+//! > exile a number of cards from the top of your library equal to its power,
+//! > then choose a card exiled this way. Until the end of your next turn, you
+//! > may play that card.
+//!
+//! "then choose a card exiled this way" is the impulse-exile choose anaphor over
+//! the chain's tracked set (the cards exiled by the preceding `ChangeZone
+//! Library->Exile`). It must lower to `Effect::ChooseFromZone { count: 1, zone:
+//! Exile, selection: Chosen }`, which raises an interactive
+//! `WaitingFor::ChooseFromZoneChoice` answered by `GameAction::SelectCards`. The
+//! trailing "you may play that card" then grants `PlayFromExile` to the chosen
+//! card only (`TargetFilter::TrackedSet`, narrowed by the choose).
+//!
+//! Before the fix the bare "choose a card exiled this way" clause matched no
+//! anaphor combinator (`parse_choose_anaphoric` only handles "N of them/those")
+//! and fell to `Effect::Unimplemented` — no `ChooseFromZoneChoice` prompt was
+//! raised, the tracked set was never narrowed to one card, and no play
+//! permission landed on a single chosen card.
+//!
+//! The test seeds the chain tracked set with the two exiled-this-way cards (the
+//! upstream "exile a number of cards equal to its power" exile clause — a
+//! separate, pre-existing parser gap on the *exile count*, outside this
+//! impulse-exile-choose batch — does not currently populate the set, so seeding
+//! it isolates the behavior THIS change owns: the choose anaphor). It then
+//! drives the SAME production path the runtime uses for the choose -> grant
+//! sub-chain: `resolve_ability_chain` -> `WaitingFor::ChooseFromZoneChoice` ->
+//! `engine::game::apply(SelectCards)` -> `drain_pending_continuation` ->
+//! `GrantCastingPermission`.
+//!
+//! DISCRIMINATOR: after seeding two exiled cards and answering the prompt with
+//! ONE of them, exactly that one card carries P0's `PlayFromExile` permission;
+//! the unchosen exiled card carries none. With the choose reverted to
+//! `Unimplemented`, no `ChooseFromZoneChoice` is raised at all — the
+//! `WaitingFor` match panics, and the single-card permission assertion can never
+//! hold.
+//!
+//! CR 608.2c: the controller follows the spell's instructions in order.
+//! CR 603.7: End-Blaze's "when that creature dies" is a delayed triggered ability.
+//! CR 400.7i: the controller may play the exiled cards.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, CardSelectionMode, CastingPermission, Effect, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const END_BLAZE_TRIGGER_BODY: &str = "exile a number of cards from the top of your library equal \
+to its power, then choose a card exiled this way. Until the end of your next turn, you may play \
+that card.";
+
+#[test]
+fn end_blaze_epiphany_grants_play_permission_to_chosen_exiled_card_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario.add_creature(P0, "End-Blaze Epiphany", 0, 0).id();
+
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    // The two cards that were "exiled this way" (already in exile, as the
+    // upstream exile clause would have moved them). A third card in exile that
+    // was NOT exiled this way must never be offered or granted.
+    let exiled_a = create_object(state, CardId(900), P0, "Exiled A".to_string(), Zone::Exile);
+    let exiled_b = create_object(state, CardId(901), P0, "Exiled B".to_string(), Zone::Exile);
+    let unrelated = create_object(state, CardId(902), P0, "Unrelated".to_string(), Zone::Exile);
+
+    // Seed the chain tracked set with exactly the two exiled-this-way cards —
+    // the set the preceding ChangeZone(Library->Exile) publishes at runtime.
+    state
+        .tracked_object_sets
+        .insert(TrackedSetId(1), vec![exiled_a, exiled_b]);
+    state.next_tracked_set_id = 2;
+    state.chain_tracked_set_id = Some(TrackedSetId(1));
+
+    // Parser path the real card uses; the choose -> grant sub-chain is the part
+    // this change owns.
+    let def = parse_effect_chain(END_BLAZE_TRIGGER_BODY, AbilityKind::Spell);
+    let choose = def
+        .sub_ability
+        .clone()
+        .expect("End-Blaze body chains exile -> choose");
+
+    // "choose a card exiled this way" must lower to a chosen ChooseFromZone over
+    // the tracked exile set (count 1, no extra filter — the tracked set IS the
+    // referent).
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Exile,
+                selection: CardSelectionMode::Chosen,
+                filter: None,
+                ..
+            }
+        ),
+        "\"choose a card exiled this way\" must lower to a chosen ChooseFromZone \
+         over the tracked exile set, got {:?}",
+        choose.effect
+    );
+    // The trailing "you may play that card" grants PlayFromExile to the tracked
+    // (chosen) card.
+    let grant = choose
+        .sub_ability
+        .as_ref()
+        .expect("choose chains into the play-permission grant");
+    assert!(
+        matches!(
+            &*grant.effect,
+            Effect::GrantCastingPermission {
+                permission: CastingPermission::PlayFromExile { .. },
+                target: TargetFilter::TrackedSet { .. },
+                ..
+            }
+        ),
+        "trailing clause must grant PlayFromExile to the tracked (chosen) card, got {:?}",
+        grant.effect
+    );
+
+    // Resolve the choose -> grant sub-chain through the production resolver.
+    let ability = build_resolved_from_def(&choose, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("choose-then-grant chain must resolve to a prompt");
+
+    // PRODUCTION STEP: the choose raises an interactive ChooseFromZoneChoice.
+    let offered = match &runner.state().waiting_for {
+        WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, P0, "the controller makes the choose");
+            cards.clone()
+        }
+        other => panic!(
+            "\"choose a card exiled this way\" must raise ChooseFromZoneChoice; \
+             reverting the parse yields Unimplemented and a different WaitingFor: {other:?}"
+        ),
+    };
+
+    // The offered set is exactly the two exiled-this-way cards — the unrelated
+    // exile entry was never tracked, so it cannot be offered.
+    assert!(
+        offered.contains(&exiled_a) && offered.contains(&exiled_b),
+        "both exiled-this-way cards must be offered, got {offered:?}"
+    );
+    assert!(
+        !offered.contains(&unrelated),
+        "a card not exiled this way must not be offered"
+    );
+    assert_eq!(offered.len(), 2, "only the two tracked cards are choosable");
+
+    // PRODUCTION STEP: answer with ONE card through the same handler
+    // `GameRunner::act` calls.
+    let chosen: ObjectId = exiled_a;
+    engine::game::apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![chosen],
+        },
+    )
+    .expect("selecting one offered card must be a legal answer");
+
+    // DISCRIMINATOR: the chosen card carries P0's PlayFromExile permission.
+    let chosen_perms = &runner.state().objects[&chosen].casting_permissions;
+    assert!(
+        chosen_perms.iter().any(|perm| matches!(
+            perm,
+            CastingPermission::PlayFromExile { granted_to: P0, .. }
+        )),
+        "the chosen exiled-this-way card must carry P0's PlayFromExile permission, got {chosen_perms:?}"
+    );
+
+    // NEGATIVE: the unchosen exiled card receives NO play permission — the grant
+    // bound to the narrowed tracked set (one card), not the whole exile window.
+    let unchosen = exiled_b;
+    assert!(
+        runner.state().objects[&unchosen]
+            .casting_permissions
+            .iter()
+            .all(|perm| !matches!(
+                perm,
+                CastingPermission::PlayFromExile { granted_to: P0, .. }
+            )),
+        "the unchosen exiled card must NOT carry the play permission"
+    );
+}

--- a/crates/engine/tests/expensive_taste_look_and_play.rs
+++ b/crates/engine/tests/expensive_taste_look_and_play.rs
@@ -21,7 +21,7 @@
 //! CR 400.7i: the controller may play the exiled cards.
 
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::types::ability::CastingPermission;
+use engine::types::ability::{CastingPermission, Duration};
 use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -62,7 +62,11 @@ fn expensive_taste_grants_play_permission_on_exiled_opponent_cards() {
         assert!(
             object.casting_permissions.iter().any(|permission| matches!(
                 permission,
-                CastingPermission::PlayFromExile { granted_to: P0, .. }
+                CastingPermission::PlayFromExile {
+                    granted_to: P0,
+                    duration: Duration::Permanent,
+                    ..
+                }
             )),
             "exiled opponent card must carry P0's PlayFromExile permission, got {:?}",
             object.casting_permissions

--- a/crates/engine/tests/expensive_taste_look_and_play.rs
+++ b/crates/engine/tests/expensive_taste_look_and_play.rs
@@ -1,0 +1,84 @@
+//! Discriminating runtime regression for **Expensive Taste** (std impulse-exile
+//! batch):
+//!
+//! > Exile the top two cards of target opponent's library face down. You may
+//! > look at and play those cards for as long as they remain exiled.
+//!
+//! "You may look at and play those cards for as long as they remain exiled" is
+//! an impulse-style `PlayFromExile` permission over the cards exiled by the
+//! preceding `ExileTop` (the tracked set). It must grant the spell's controller
+//! permission to play each exiled card. Before the fix the "look at and play
+//! those cards" verb form (and the no-mana-conjunct "for as long as they remain
+//! exiled" duration) was unrecognized, so the clause fell to
+//! `Effect::Unimplemented` and no permission was granted.
+//!
+//! DISCRIMINATOR: after resolution, BOTH exiled opponent cards carry P0's
+//! `PlayFromExile` permission. With the parse reverted no permission is attached
+//! and the `.any(PlayFromExile { granted_to: P0 })` assertion flips to false.
+//!
+//! CR 406.6: the "look at" conjunct is a private-information grant the play
+//! permission implies.
+//! CR 400.7i: the controller may play the exiled cards.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::CastingPermission;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const EXPENSIVE_TASTE: &str = "Exile the top two cards of target opponent's library face down. \
+You may look at and play those cards for as long as they remain exiled.";
+
+#[test]
+fn expensive_taste_grants_play_permission_on_exiled_opponent_cards() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // A deeper P1 library card that must stay put (below the top-two window).
+    // Added FIRST so the later top-pushes bury it beneath the exiled window.
+    let deep = scenario.add_card_to_library_top(P1, "Opp Deep");
+    // Top two cards of the OPPONENT's (P1) library — these are exiled. The last
+    // `add_card_to_library_top` lands on top, so push the two that should be
+    // exiled after `deep`.
+    let exiled_cards: Vec<_> = ["Opp Top B", "Opp Top A"]
+        .into_iter()
+        .map(|name| scenario.add_card_to_library_top(P1, name))
+        .collect();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Expensive Taste", false, EXPENSIVE_TASTE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let outcome = scenario.build().cast(spell).target_player(P1).resolve();
+
+    for id in &exiled_cards {
+        assert_eq!(
+            outcome.zone_of(*id),
+            Zone::Exile,
+            "Expensive Taste must exile the top two opponent library cards"
+        );
+        let object = &outcome.state().objects[id];
+        assert!(
+            object.casting_permissions.iter().any(|permission| matches!(
+                permission,
+                CastingPermission::PlayFromExile { granted_to: P0, .. }
+            )),
+            "exiled opponent card must carry P0's PlayFromExile permission, got {:?}",
+            object.casting_permissions
+        );
+    }
+
+    // NEGATIVE: a deeper opponent card stays in the library with no grant.
+    assert_eq!(
+        outcome.zone_of(deep),
+        Zone::Library,
+        "cards below the exiled window must remain in the opponent's library"
+    );
+    assert!(
+        outcome.state().objects[&deep]
+            .casting_permissions
+            .is_empty(),
+        "non-exiled cards must not receive any play permission"
+    );
+}

--- a/crates/engine/tests/omenpath_journey_random_exiled_with.rs
+++ b/crates/engine/tests/omenpath_journey_random_exiled_with.rs
@@ -1,0 +1,129 @@
+//! Discriminating regression for **Omenpath Journey** (std impulse-exile batch)
+//! — the end-step trigger body:
+//!
+//! > choose a card at random exiled with ~ and put it onto the battlefield
+//! > tapped.
+//!
+//! "choose a card at random exiled with ~" selects ONE card uniformly at random
+//! from the source's linked-exile set (`TargetFilter::ExiledBySource`, scanned
+//! in Exile), then "put it onto the battlefield tapped" returns the chosen card
+//! (`ParentTarget`) tapped. It must lower to `Effect::ChooseFromZone { zone:
+//! Exile, filter: ExiledBySource, selection: Random, count: 1 }` →
+//! `Effect::ChangeZone { destination: Battlefield, enter_tapped }`. Before the
+//! fix the choose fell to `Effect::Unimplemented` and nothing was put onto the
+//! battlefield.
+//!
+//! A random `ChooseFromZone` resolves inline (CR 608.2d override) — no
+//! interactive prompt — so the chosen card is deterministic under the seed.
+//!
+//! DISCRIMINATOR: exactly ONE of the two cards exiled with the source enters the
+//! battlefield tapped under P0's control; the other stays in exile. With the
+//! choose reverted to `Unimplemented`, ZERO cards enter and the
+//! battlefield-count assertion flips from 1 to 0.
+//!
+//! CR 608.2d: a random selection picks the referent.
+//! CR 603.6d: "tapped" — enters the battlefield tapped.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, CardSelectionMode, Effect, TargetFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{ExileLink, ExileLinkKind};
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const OMENPATH_END_STEP: &str =
+    "choose a card at random exiled with ~ and put it onto the battlefield tapped.";
+
+#[test]
+fn omenpath_journey_puts_one_random_exiled_with_source_card_onto_battlefield_tapped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let source = scenario.add_creature(P0, "Omenpath Journey", 0, 0).id();
+
+    let mut runner = scenario.build();
+    let state = runner.state_mut();
+
+    // Two land cards exiled with the source (Omenpath exiles up to five lands on
+    // ETB; model two so the random pick has a real choice).
+    let exiled: Vec<_> = ["Exiled Land A", "Exiled Land B"]
+        .into_iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let id = create_object(
+                state,
+                CardId(900 + i as u64),
+                P0,
+                name.to_string(),
+                Zone::Exile,
+            );
+            state.objects.get_mut(&id).unwrap().card_types.core_types = vec![CoreType::Land];
+            state.exile_links.push(ExileLink {
+                exiled_id: id,
+                source_id: source,
+                kind: ExileLinkKind::TrackedBySource,
+            });
+            id
+        })
+        .collect();
+
+    // Parser path: random choose-from-exile of the linked set, then put tapped.
+    let def = parse_effect_chain(OMENPATH_END_STEP, AbilityKind::Spell);
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Exile,
+                filter: Some(TargetFilter::ExiledBySource),
+                selection: CardSelectionMode::Random,
+                ..
+            }
+        ),
+        "must lower to a random ChooseFromZone(Exile, ExiledBySource), got {:?}",
+        def.effect
+    );
+
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("random choose-and-put must resolve inline");
+
+    // DISCRIMINATOR: exactly one of the exiled cards is now on the battlefield
+    // tapped; the other remains in exile.
+    let on_battlefield: Vec<_> = exiled
+        .iter()
+        .filter(|id| runner.state().objects[id].zone == Zone::Battlefield)
+        .copied()
+        .collect();
+    assert_eq!(
+        on_battlefield.len(),
+        1,
+        "exactly one random exiled-with-source card must enter the battlefield \
+         (reverting the choose to Unimplemented yields 0)"
+    );
+    let entered = on_battlefield[0];
+    assert!(
+        runner.state().objects[&entered].tapped,
+        "the put-onto-battlefield card must enter tapped"
+    );
+    assert_eq!(
+        runner.state().objects[&entered].controller,
+        P0,
+        "the entered card is controlled by the trigger's controller"
+    );
+
+    let still_exiled = exiled
+        .iter()
+        .filter(|id| runner.state().objects[id].zone == Zone::Exile)
+        .count();
+    assert_eq!(
+        still_exiled, 1,
+        "the unchosen exiled card must remain in exile"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# Impulse-exile choose/play surface (std batch 8)

## Summary

Extends the existing impulse-exile / `PlayFromExile` parser surface to cover four
Standard cards whose choose/play clause previously parsed to
`Effect::Unimplemented`. Composes existing building blocks — `ChooseFromZone`,
`GrantCastingPermission { PlayFromExile }`, `ChangeZoneAll`,
`TargetFilter::ExiledBySource`, the chain tracked-set machinery — with no new
engine enum variants.

Per-card surface added:

- **Connecting the Dots** — `"Put all cards exiled with ~ into their owners'
  hands"`. Recognized the plural-possessive mass-move destinations (`"into their
  owners' hands"` / `"into their owners' graveyards"`) so the clause lowers to
  `ChangeZoneAll { origin: Exile, destination: Hand, target: ExiledBySource }`.
  `execute_zone_move` already keys non-battlefield destinations per object owner,
  so per-owner routing needs no new code. **Bomat Courier gains the same fix for
  free** (its identical "Put all cards exiled with this creature into their
  owners' hands" — snapshot updated).
- **End-Blaze Epiphany** — `"choose a card exiled this way"`. The impulse-exile
  choose anaphor over the chain tracked set, lowered to a chosen
  `ChooseFromZone { count: 1, zone: Exile, selection: Chosen }`. The trailing
  "you may play that card" grants `PlayFromExile` to the chosen card.
- **Expensive Taste** — `"you may look at and play those cards for as long as
  they remain exiled"`. Folded the `"look at and play"/"look at and cast"` verb
  forms and the no-mana-conjunct mass-anaphor form (`"play those cards"`) into
  the play-from-exile grant; the "look at" conjunct is a private-information
  grant the play permission already implies (CR 406.6).
- **Omenpath Journey** — `"choose a card at random exiled with ~"`. The random
  choose over the source's linked-exile set (`ExiledBySource`), lowered to a
  random `ChooseFromZone`; "put it onto the battlefield tapped" returns the
  chosen card (`ParentTarget`) tapped.

### Runtime wiring (gated, no blast radius)

End-Blaze is the first card combining an **interactive** `ChooseFromZone` with a
tracked-set-consuming continuation (`GrantCastingPermission { target:
TrackedSet }` = "you may play that card"). The interactive
`ChooseFromZoneChoice → SelectCards` answer handler previously did not publish
the chosen cards as a fresh tracked set, so the grant's `TrackedSet(0)` sentinel
bound to a stale/empty set and the permission landed nowhere. Fix: when the
parked continuation actually references a tracked set
(`effects::chain_references_tracked_set`), publish the chosen cards as the fresh
tracked set the continuation reads — mirroring the per-player drain
(`publish_fresh_tracked_set`) and the random-choose path
(`apply_parent_chain_context`). Gated precisely on the consumer needing it, so
partition continuations (Heist/Atraxa, which read `ParentTarget`) are unaffected.

### Honest defer

- **Close Encounter** — `"choose a creature you control or a warped creature
  card you own in exile"` is an **additional cost to cast**, not an effect-chain
  clause. It needs additional-cost-choose infrastructure (a chosen-object cost
  reference whose power feeds a later damage quantity) that is well beyond the
  impulse-exile choose/play surface. The cost stays
  `Required(Effect::unimplemented(...))` — honest, no misparse. Confirmed: zero
  semantic-audit findings (no silent drop).

## add-engine-variant verdict

**No new engine variants — N/A.** No `types/` files were touched;
`data/engine-inventory.json` is unchanged. All work composes existing variants.
The only new symbol is a `pub(crate)` wrapper (`chain_references_tracked_set`)
over the existing private `ability_or_branch_references_tracked_set` — not an
enum-surface change. This matches the batch spec prediction ("add-engine-variant:
likely no — existing exile/play surface").

## Grep-verified CR annotations

All CR numbers in the diff and new test files verified against
`docs/MagicCompRules.txt` (`grep -qE "^N([^0-9]|$)"`):

| CR | Used for |
|----|----------|
| CR 110.1 | permanent definition (per-owner hand return) |
| CR 400.3 | non-battlefield zone move keys destination by each object's owner |
| CR 400.7i | controller may play the exiled cards |
| CR 406.6 | "look at" is a private-information grant the play permission implies |
| CR 603.6d | "enters tapped" static (Omenpath put-onto-battlefield tapped) |
| CR 603.7 | End-Blaze "when that creature dies" delayed triggered ability |
| CR 608.2c | controller follows the spell's instructions in order |
| CR 608.2d | "at random" — the game selects, not the controller |
| CR 610.3 | "until" zone-change duration (impulse-exile window) |

Zero `UNVERIFIED:` lines from the CR-annotation diff gate.

## Per-card verdict

| Card | Verdict | Unimplemented (parse) |
|------|---------|------------------------|
| Connecting the Dots | SHIPPED | 0 |
| End-Blaze Epiphany | SHIPPED | 0 |
| Expensive Taste | SHIPPED | 0 |
| Omenpath Journey | SHIPPED | 0 |
| Close Encounter | HONEST-DEFER (additional-cost choose; `Effect::unimplemented`) | 1 (the cost) |
| Bomat Courier (bonus) | IMPROVED by the Connecting-the-Dots fix | 0 |

## Discriminating-test map

Every shipped behavioral change has a test driving the real pipeline that fails
if the change is reverted.

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Negatives |
|---|---|---|---|---|---|
| "Put all cards exiled with ~ into their owners' hands" returns the linked-exile set to each owner's hand | `try_parse_put_zone_change_parts` plural-possessive needles → `ChangeZoneAll` | `parse_effect_chain` → `resolve_ability_chain` | `connecting_the_dots_return_exiled_with::connecting_the_dots_returns_all_exiled_with_source_to_owners_hands` | P0 & P1 exiled cards both end in their OWN owner's `Zone::Hand` (reverted = Unimplemented no-op, stay in Exile) | a card exiled by a different source stays in exile |
| "you may look at and play those cards…" grants `PlayFromExile` to the exiled opponent cards | `try_parse_play_from_exile` verb-form + mass-anaphor acceptance | `add_spell_to_hand_from_oracle` → `cast().resolve()` (full cast pipeline) | `expensive_taste_look_and_play::expensive_taste_grants_play_permission_on_exiled_opponent_cards` | both exiled cards carry `PlayFromExile { granted_to: P0 }` (reverted = no permission) | a deeper library card stays in library with no grant |
| "choose a card exiled this way" → interactive choose; "play that card" grants `PlayFromExile` to the **chosen** card only | `try_parse_choose_exiled_anaphor` → `ChooseFromZone`; `chain_references_tracked_set` publish in `SelectCards` handler | `parse_effect_chain` → `resolve_ability_chain` → `WaitingFor::ChooseFromZoneChoice` → `engine::game::apply(GameAction::SelectCards)` → `drain_pending_continuation` → grant | `end_blaze_epiphany_choose_exiled_this_way::end_blaze_epiphany_grants_play_permission_to_chosen_exiled_card_only` | chosen card carries `PlayFromExile { granted_to: P0 }` (reverted = no `ChooseFromZoneChoice` raised → `WaitingFor` match panics) | the **unchosen** exiled card carries NO permission; a non-tracked exile entry is not offered |
| "choose a card at random exiled with ~ and put it onto the battlefield tapped" puts exactly one random linked-exile card tapped | `try_parse_choose_exiled_anaphor` → random `ChooseFromZone { ExiledBySource }` | `parse_effect_chain` → `resolve_ability_chain` (random resolves inline, CR 608.2d) | `omenpath_journey_random_exiled_with::omenpath_journey_puts_one_random_exiled_with_source_card_onto_battlefield_tapped` | exactly ONE of two exiled-with-source cards enters battlefield tapped (reverted = Unimplemented → 0 enter) | the unchosen card stays in exile |

Notes on discrimination:
- No fixture is degenerate: Connecting/End-Blaze/Omenpath each provide **two**
  candidate objects plus a **negative** object, so the partition / single-pick /
  random-pick branches are exercised on real multi-element inputs (not a
  single-element collection that would coincidentally pass).
- The End-Blaze test seeds the chain tracked set directly because the upstream
  "exile a number of cards equal to its power" clause has a **separate,
  pre-existing parser gap on the exile count** (the `ChangeZone` count quantity
  is dropped) outside this impulse-exile-choose batch; seeding isolates exactly
  the choose→grant behavior this change owns while still driving the real
  `ChooseFromZoneChoice → apply(SelectCards) → drain` production path.
- No shape-only tests. Every test resolves through the engine.

## Gates

| Gate | Result |
|------|--------|
| `cargo fmt --all` | clean |
| `./scripts/check-parser-combinators.sh` | exit 0 |
| inline parser string-dispatch diff gate | no offending lines |
| `./scripts/check-engine-authorities.sh upstream/main` | exit 0 |
| CR-annotation diff gate (diff + untracked tests) | 0 UNVERIFIED |
| `cargo check --workspace --all-targets` | clean |
| `cargo clippy --all-targets --features engine/proptest -- -D warnings` | clean |
| `cargo test -p engine` | 12960 passed; only the 2 known parallel-flaky AI tests (`delve_payment`, `target_selection_legal_actions_*`) fail under load and pass in isolation |
| `cargo semantic-audit` | completes; 0 findings for any batch card (incl. honest-defer Close Encounter) |
| `cargo coverage` | 86.96% (30785/35403); parser changes are strictly additive |
| add-engine-variant | N/A (zero variants; engine-inventory unchanged) |

## Rebase

Rebased cleanly onto `upstream/main` (14 new commits). No textual conflicts;
none of the new upstream commits touched the files in this change. All gates
re-run green post-rebase (`bomat_courier` snapshot test now passes; test count
rose from 12922 → 12960 due to the new upstream tests).
