### PR TITLE
feat(engine): exile-cast permission with any-type mana + flash grant (Azula, Cunning Usurper)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1819,6 +1819,13 @@ pub(super) fn player_can_spend_as_any_color_for_optional_spell(
                     )
                 })
             })
+        // CR 609.4b: A battlefield `StaticMode::ExileCastPermission` static may
+        // grant "mana of any type can be spent to cast those spells" (Azula,
+        // Cunning Usurper) for the cards in its exile pool. Unlike the per-card
+        // `PlayFromExile` grant above, the concession lives on the static, so it
+        // is re-derived from the source's pool + filter at spend time.
+        || source_id
+            .is_some_and(|id| exile_static_permission_grants_any_color(state, player, id))
 }
 
 pub(super) fn player_can_spend_as_any_color_for_payment(
@@ -1935,6 +1942,13 @@ struct ExilePermissionSource<'a> {
     pool: ExileCardPool,
     /// CR 117.1c: When the permission functions — `AnyTime` or `YourTurnOnly`.
     timing: ExileCastTiming,
+    /// CR 609.4b: Optional any-type-mana spend concession riding alongside the
+    /// permission (Azula, Cunning Usurper). `Some(AnyTypeOrColor)` lets the
+    /// controller spend mana of any type to cast a spell offered by this source.
+    mana_spend_permission: Option<crate::types::ability::ManaSpendPermission>,
+    /// CR 601.3b + CR 702.8a: When `true`, spells cast via this permission may
+    /// be cast as though they had flash (Azula, Cunning Usurper).
+    grants_flash: bool,
 }
 
 /// CR 113.6b + CR 406.6: The set of exiled object ids this source's permission
@@ -2001,6 +2015,8 @@ fn exile_permission_sources(state: &GameState, player: PlayerId) -> Vec<ExilePer
                     cost,
                     pool,
                     timing,
+                    mana_spend_permission,
+                    grants_flash,
                 } => definition
                     .affected
                     .as_ref()
@@ -2012,6 +2028,8 @@ fn exile_permission_sources(state: &GameState, player: PlayerId) -> Vec<ExilePer
                         play_mode,
                         pool,
                         timing,
+                        mana_spend_permission,
+                        grants_flash,
                     }),
                 _ => None,
             })
@@ -2138,6 +2156,75 @@ pub(crate) fn exile_cast_permission_source(
         }
         Some((source.source_id, source.frequency, source.cost))
     })
+}
+
+/// CR 601.2a + CR 113.6b: Find the full `ExileCastPermission` source authorizing
+/// `player` to cast `exiled_id`, including its payment/timing concessions
+/// (`mana_spend_permission`, `grants_flash`). Shares the gating logic with
+/// `exile_cast_permission_source` (frequency slot, your-turn timing, pool
+/// membership, affected filter) but surfaces the concession fields so the
+/// any-type-mana and flash wiring can consult them. Returns `None` when no
+/// functioning static authorizes the cast.
+fn exile_cast_permission_source_full(
+    state: &GameState,
+    player: PlayerId,
+    exiled_id: ObjectId,
+) -> Option<ExilePermissionSource<'_>> {
+    let obj = state.objects.get(&exiled_id)?;
+    if !exile_object_can_enter_cast_path(obj) {
+        return None;
+    }
+    if state.cards_exiled_with_source_this_turn.is_empty() && state.exile_links.is_empty() {
+        return None;
+    }
+    let sources = exile_permission_sources(state, player);
+    sources.into_iter().find(|source| {
+        if !exile_cast_frequency_available(state, source.source_id, source.frequency) {
+            return false;
+        }
+        if !exile_permission_timing_active(state, source, player) {
+            return false;
+        }
+        let pool = exile_permission_pool(state, source);
+        if !pool.contains(&exiled_id) {
+            return false;
+        }
+        let ctx =
+            super::filter::FilterContext::from_source_with_controller(source.source_id, player);
+        super::filter::matches_target_filter(state, exiled_id, source.filter, &ctx)
+    })
+}
+
+/// CR 609.4b: True when an `ExileCastPermission` static granting "mana of any
+/// type can be spent to cast those spells" (Azula, Cunning Usurper) authorizes
+/// `player` to cast `exiled_id`. Consulted by
+/// `player_can_spend_as_any_color_for_spell` so the any-type-mana concession is
+/// scoped to spells offered by that static, mirroring the per-card
+/// `CastingPermission::PlayFromExile.mana_spend_permission` path.
+pub(crate) fn exile_static_permission_grants_any_color(
+    state: &GameState,
+    player: PlayerId,
+    exiled_id: ObjectId,
+) -> bool {
+    exile_cast_permission_source_full(state, player, exiled_id).is_some_and(|source| {
+        matches!(
+            source.mana_spend_permission,
+            Some(crate::types::ability::ManaSpendPermission::AnyTypeOrColor)
+        )
+    })
+}
+
+/// CR 601.3b + CR 702.8a: True when an `ExileCastPermission` static granting
+/// "you may cast them as though they had flash" (Azula, Cunning Usurper)
+/// authorizes `player` to cast `exiled_id`. Consulted by the cast-timing check
+/// in `prepare_spell_cast` so the spell may be cast at instant speed.
+pub(crate) fn exile_static_permission_grants_flash(
+    state: &GameState,
+    player: PlayerId,
+    exiled_id: ObjectId,
+) -> bool {
+    exile_cast_permission_source_full(state, player, exiled_id)
+        .is_some_and(|source| source.grants_flash)
 }
 
 fn graveyard_permission_sources(
@@ -4129,8 +4216,13 @@ fn prepare_spell_cast_with_variant_override_inner(
             .or(surge_cost)
             .unwrap_or_else(|| obj.mana_cost.clone())
     };
-    let has_granted_flash =
-        effective_spell_keyword_kinds(state, player, object_id).contains(&KeywordKind::Flash);
+    // CR 601.3b + CR 702.8a: A spell has effective flash from its own keywords
+    // OR from a battlefield `StaticMode::ExileCastPermission` static granting
+    // "you may cast them as though they had flash" (Azula, Cunning Usurper) for
+    // the cards in its exile pool.
+    let has_granted_flash = effective_spell_keyword_kinds(state, player, object_id)
+        .contains(&KeywordKind::Flash)
+        || exile_static_permission_grants_flash(state, player, object_id);
     let cast_outside_sorcery_timing = !restrictions::is_sorcery_speed_window(state, player);
     // CR 304.1: Instants can be cast any time a player has priority.
     // CR 301.1 / CR 306.1: Artifacts and planeswalkers are cast at sorcery speed.
@@ -43345,6 +43437,8 @@ mod tests {
             cost,
             pool,
             timing,
+            mana_spend_permission: None,
+            grants_flash: false,
         })
         .affected(affected);
         let obj = state.objects.get_mut(&source).unwrap();
@@ -43899,6 +43993,152 @@ mod tests {
         let obj = state.objects.get(&land).unwrap();
         assert_eq!(obj.zone, Zone::Battlefield);
         assert_eq!(obj.played_from_zone, Some(Zone::Exile));
+    }
+
+    /// Build a persistent, your-turn-only, Cast-mode `ExileCastPermission`
+    /// source carrying the Azula, Cunning Usurper concessions: any-type-mana
+    /// spend (CR 609.4b) and flash-grant (CR 702.8a).
+    fn add_azula_exile_cast_source(state: &mut GameState, player: PlayerId) -> ObjectId {
+        use crate::types::ability::StaticDefinition;
+        let card_id = crate::types::identifiers::CardId(state.next_object_id);
+        let source = create_object(
+            state,
+            card_id,
+            player,
+            "Azula, Cunning Usurper".to_string(),
+            Zone::Battlefield,
+        );
+        let def = StaticDefinition::new(StaticMode::ExileCastPermission {
+            frequency: CastFrequency::Unlimited,
+            play_mode: CardPlayMode::Cast,
+            cost: ExileCastCost::PayNormalCost,
+            pool: ExileCardPool::Persistent,
+            timing: ExileCastTiming::YourTurnOnly,
+            mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor),
+            grants_flash: true,
+        })
+        .affected(TargetFilter::Any);
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(def);
+        source
+    }
+
+    /// Add a single-blue sorcery linked to `source_id` in the persistent
+    /// `exile_links` pool. Returns the exiled spell's object id.
+    fn add_linked_blue_sorcery(
+        state: &mut GameState,
+        player: PlayerId,
+        source_id: ObjectId,
+        name: &str,
+    ) -> ObjectId {
+        let card_id = crate::types::identifiers::CardId(state.next_object_id);
+        let object_id = create_object(state, card_id, player, name.to_string(), Zone::Exile);
+        {
+            let obj = state.objects.get_mut(&object_id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Sorcery];
+            // Single blue pip — provably uncastable from a red-only pool unless
+            // the any-type-mana concession is in force.
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 0,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ));
+        }
+        link_exiled_to_source(state, object_id, source_id);
+        object_id
+    }
+
+    /// CR 609.4b: Azula's "Mana of any type can be spent to cast those spells"
+    /// concession lets the controller pay a blue sorcery's {U} from a red-only
+    /// pool. DISCRIMINATING: if `mana_spend_permission` is reverted to `None`,
+    /// `player_can_spend_as_any_color_for_spell` flips to false and
+    /// `can_pay_cost_after_auto_tap` fails — the spell becomes unpayable.
+    #[test]
+    fn azula_exile_static_grants_any_type_mana_spend() {
+        let mut state = setup_game_at_main_phase();
+        let player = PlayerId(0);
+        let source = add_azula_exile_cast_source(&mut state, player);
+        let spell = add_linked_blue_sorcery(&mut state, player, source, "Exiled Blue Bolt");
+        // Only RED mana available — a {U} cost is unpayable without the
+        // any-type-mana concession.
+        add_mana(&mut state, player, ManaType::Red, 1);
+
+        assert!(
+            spell_objects_available_to_cast(&state, player).contains(&spell),
+            "Azula's persistent Cast permission must surface the linked spell"
+        );
+        assert!(
+            player_can_spend_as_any_color_for_spell(&state, player, spell),
+            "the static must grant any-type-mana spend for spells in its pool"
+        );
+        assert!(
+            can_pay_cost_after_auto_tap(&state, player, spell, &state.objects[&spell].mana_cost),
+            "a {{U}} cost must be payable from a red-only pool under the concession"
+        );
+    }
+
+    /// CR 601.3b + CR 702.8a: Azula's "you may cast them as though they had
+    /// flash" concession lets a sorcery be cast at instant speed (here: P0's
+    /// main phase with a non-empty stack, so the window is NOT sorcery-speed).
+    /// DISCRIMINATING: if `grants_flash` is reverted to `false`,
+    /// `exile_static_permission_grants_flash` returns false, `has_granted_flash`
+    /// is false, and `handle_cast_spell` rejects the sorcery for sorcery-speed
+    /// timing.
+    #[test]
+    fn azula_exile_static_grants_flash_timing() {
+        let mut state = setup_game_at_main_phase();
+        let player = PlayerId(0);
+        let source = add_azula_exile_cast_source(&mut state, player);
+        let spell = add_linked_blue_sorcery(&mut state, player, source, "Exiled Blue Bolt");
+        // Mana that pays the {U} cost via the any-type concession, so the cast
+        // clears payment and the timing gate (the behavior under test) is what
+        // decides the outcome.
+        add_mana(&mut state, player, ManaType::Red, 1);
+
+        // Force a non-sorcery-speed window: P0 is active in PreCombatMain, so the
+        // only missing precondition is the empty stack.
+        state.stack.push_back(crate::types::game_state::StackEntry {
+            id: ObjectId(9000),
+            source_id: ObjectId(9000),
+            controller: player,
+            kind: crate::types::game_state::StackEntryKind::Spell {
+                card_id: CardId(9000),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        assert!(
+            !restrictions::is_sorcery_speed_window(&state, player),
+            "test setup must be outside the sorcery-speed window"
+        );
+        assert!(
+            exile_static_permission_grants_flash(&state, player, spell),
+            "the static must report a flash grant for spells in its pool"
+        );
+
+        let card_id = state.objects.get(&spell).unwrap().card_id;
+        let mut events = Vec::new();
+        let result = handle_cast_spell(&mut state, player, spell, card_id, &mut events);
+        assert!(
+            result.is_ok(),
+            "flash-granted exiled sorcery must be castable outside the sorcery window: {result:?}"
+        );
+        assert_eq!(
+            state.objects.get(&spell).unwrap().zone,
+            Zone::Stack,
+            "the cast spell must move to the stack"
+        );
     }
 
     /// PR #1441: Teferi, Time Raveler's +1 ("you may cast sorcery spells as

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5806,6 +5806,88 @@ mod tests {
         );
     }
 
+    /// CR 601.2a + CR 609.4b + CR 601.3b: Azula, Cunning Usurper — the
+    /// cast-from-exile static line must lower to a supported
+    /// `StaticMode::ExileCastPermission` carrying the persistent Cast permission,
+    /// the any-type-mana spend concession, and the flash grant.
+    ///
+    /// Azula is intentionally NOT full-card-0: the "Firebending 2" line is a
+    /// separate, out-of-scope keyword whose triggered mana ability remains an
+    /// honest `Effect::unknown` gap (handled by a different batch). This test
+    /// therefore pins the cast-from-exile line as the supported variant AND
+    /// asserts the only remaining gap is that Firebending ability — so it fails
+    /// both if the static line regresses to a gap and if a new unrelated gap
+    /// appears. (Runtime discrimination — any-type mana payable from a red-only
+    /// pool and instant-speed castability — lives in `game::casting::tests::
+    /// azula_exile_static_grants_any_type_mana_spend` and
+    /// `azula_exile_static_grants_flash_timing`.)
+    #[test]
+    fn azula_cunning_usurper_full_card_supported_with_exile_cast_permission() {
+        let face = oracle_face_for(
+            "Azula, Cunning Usurper",
+            "Firebending 2 (Whenever this creature attacks, add {R}{R}. This mana lasts until end of combat.)\nWhen Azula enters, target opponent exiles a nontoken creature they control, then they exile a nonland card from their graveyard.\nDuring your turn, you may cast cards exiled with Azula and you may cast them as though they had flash. Mana of any type can be spent to cast those spells.",
+            &["Legendary", "Creature"],
+            &["Human"],
+        );
+        // The cast-from-exile static line must be fully supported. Locate it by
+        // its typed parse category + handler label (not by matching Oracle text)
+        // so the assertion stays robust to wording tweaks.
+        let details = crate::game::coverage::build_parse_details_for_face(&face);
+        let cast_static = details
+            .iter()
+            .find(|d| {
+                matches!(d.category, crate::game::coverage::ParseCategory::Static)
+                    // allow-noncombinator: matching the engine's own parse-detail handler label (not Oracle text), in a test.
+                    && d.label.starts_with("ExileCastPermission")
+            })
+            .expect("Azula's cast-from-exile line must appear as an ExileCastPermission static");
+        assert!(
+            cast_static.supported,
+            "the cast-from-exile static line must be supported, got {cast_static:?}"
+        );
+        // The only remaining coverage gap is the out-of-scope Firebending
+        // ability — proving the cast-from-exile line no longer contributes a gap.
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert_eq!(
+            gaps,
+            vec!["Effect:unknown".to_string()],
+            "the only remaining gap must be the out-of-scope Firebending ability"
+        );
+        let firebending = details
+            .iter()
+            .find(|d| !d.supported)
+            .expect("Azula must have exactly the Firebending unsupported ability");
+        assert_eq!(
+            firebending.source_text.as_deref(),
+            Some("Firebending 2"),
+            "the single unsupported item must be the Firebending keyword line"
+        );
+
+        // Pin the structural variant the fix produces — guards against a silent
+        // regression where the line stops parsing entirely.
+        let static_def = face
+            .static_abilities
+            .iter()
+            .find(|s| {
+                matches!(
+                    s.mode,
+                    crate::types::statics::StaticMode::ExileCastPermission {
+                        play_mode: crate::types::ability::CardPlayMode::Cast,
+                        grants_flash: true,
+                        mana_spend_permission: Some(
+                            crate::types::ability::ManaSpendPermission::AnyTypeOrColor
+                        ),
+                        ..
+                    }
+                )
+            })
+            .expect("Azula must emit a Cast permission with flash + any-mana");
+        assert_eq!(
+            static_def.affected,
+            Some(crate::types::ability::TargetFilter::Any)
+        );
+    }
+
     /// CR 106.6 + CR 702.6a: Hydraulic Helper — the full card must parse with
     /// zero `Effect::Unimplemented` parts. "Defender" extracts as a keyword and
     /// the `{T}: Add {U}` mana ability carries the negative spend restriction

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1874,6 +1874,10 @@ pub(crate) fn try_parse_exile_cast_permission(text: &str, lower: &str) -> Option
             // restriction beyond its once-each-turn frequency.
             pool,
             timing: ExileCastTiming::AnyTime,
+            // CR 609.4b / CR 702.8a: Maralen grants no mana-spend or flash
+            // concession.
+            mana_spend_permission: None,
+            grants_flash: false,
         })
         .affected(filter)
         .description(text.to_string()),
@@ -1925,31 +1929,50 @@ pub(crate) fn try_parse_persistent_exile_play_permission(
     let uses_anaphor = after_look.is_some();
     let rest = after_look.unwrap_or(rest);
 
-    // Core permission phrase. CR 305.1: both "play lands and cast spells" and
-    // "play cards" lower to Play mode.
-    let after_clause = if let Some(rest) =
+    // Core permission phrase. CR 305.1: "play lands and cast spells" / "play
+    // cards" lower to Play mode (lands are played, non-land cards are cast).
+    // CR 601.2a: the bare "cast cards exiled with ~" wording (Azula, Cunning
+    // Usurper) is spell-cast only and lowers to `Cast` — lands cannot be
+    // "cast", so the Cast branch never admits exiled lands.
+    let (after_clause, play_mode) = if let Some(rest) =
         nom_tag_lower(rest, rest, "you may play lands and cast spells from among ")
     {
         // The play clause either names the source ("cards exiled with <self>") or
         // refers back to the look-at preamble's set ("those cards").
-        if uses_anaphor {
+        let rest = if uses_anaphor {
             nom_tag_lower(rest, rest, "those cards")?
         } else {
             strip_exile_play_source_reference(rest)?
-        }
+        };
+        (rest, CardPlayMode::Play)
+    } else if let Some(rest) = nom_tag_lower(rest, rest, "you may cast ") {
+        // CR 601.2a: "you may cast cards exiled with ~" — spell-cast only.
+        let rest = if uses_anaphor {
+            nom_tag_lower(rest, rest, "those cards")?
+        } else {
+            strip_exile_play_source_reference(rest)?
+        };
+        (rest, CardPlayMode::Cast)
     } else {
         let rest = nom_tag_lower(rest, rest, "you may play ")?;
-        if uses_anaphor {
+        let rest = if uses_anaphor {
             nom_tag_lower(rest, rest, "those cards")?
         } else {
             strip_exile_play_source_reference(rest)?
-        }
+        };
+        (rest, CardPlayMode::Play)
     };
+
+    // CR 601.3b + CR 609.4b: Optional payment/timing-concession riders that ride
+    // alongside the cast permission (Azula, Cunning Usurper). Parse them in
+    // order off the tail so any leftover proves an unmodeled shape.
+    let (after_riders, grants_flash, mana_spend_permission) =
+        strip_exile_cast_concession_riders(after_clause);
 
     // CR 113.6b: A trailing period is the only permitted remainder; any other
     // tail is an unmodeled shape — decline so it surfaces as a coverage gap
     // rather than a silent misparse.
-    let tail = after_clause.trim_start();
+    let tail = after_riders.trim_start();
     // allow-noncombinator: punctuation cleanup (drop the sentence terminator) on a pre-tokenized chunk, not parsing dispatch.
     let tail = tail.strip_prefix('.').unwrap_or(tail); // allow-noncombinator: punctuation cleanup on a pre-tokenized chunk, not parsing dispatch.
     if !tail.trim().is_empty() {
@@ -1959,13 +1982,16 @@ pub(crate) fn try_parse_persistent_exile_play_permission(
     let mut definition = StaticDefinition::new(StaticMode::ExileCastPermission {
         // CR 601.2a: No once-per-turn cap on this class.
         frequency: CastFrequency::Unlimited,
-        // CR 305.1: Play covers lands (played) and non-land cards (cast).
-        play_mode: CardPlayMode::Play,
+        // CR 305.1 / CR 601.2a: `Play` covers lands + non-land cards; `Cast`
+        // covers spells only, set by the "you may cast" wording.
+        play_mode,
         // CR 305.1 / CR 601.3: Cards are played/cast at their normal cost.
         cost: ExileCastCost::PayNormalCost,
         // CR 406.6: Lifetime per-source exile-link pool.
         pool: ExileCardPool::Persistent,
         timing,
+        mana_spend_permission,
+        grants_flash,
     })
     // CR 305.1: The permission applies to every card in the source's exile
     // pool; the pool itself is the scope, so no type/MV constraint.
@@ -1976,6 +2002,49 @@ pub(crate) fn try_parse_persistent_exile_play_permission(
     }
 
     Some(definition)
+}
+
+/// CR 601.3b + CR 609.4b: Strip the optional flash-grant and any-type-mana
+/// concession riders that follow the core exile-cast clause (Azula, Cunning
+/// Usurper: "… and you may cast them as though they had flash. Mana of any type
+/// can be spent to cast those spells."). Returns the remainder plus the parsed
+/// `(grants_flash, mana_spend_permission)` pair. Each rider is optional and
+/// recognized independently so future cards mixing only one of the two still
+/// parse. Riders not present leave the defaults `(false, None)`.
+fn strip_exile_cast_concession_riders(
+    input: &str,
+) -> (
+    &str,
+    bool,
+    Option<crate::types::ability::ManaSpendPermission>,
+) {
+    let mut rest = input.trim_start();
+    let mut grants_flash = false;
+    let mut mana_spend_permission = None;
+
+    // CR 601.3b: "[and] you may cast them as though they had flash[.]"
+    // Optional leading "and "/". " connective consumed via the file-wide
+    // nom-tag idiom so the rider may follow either the period or the conjunction.
+    if let Some(after) = nom_tag_lower(rest, rest, "and you may cast them as though they had flash")
+        .or_else(|| nom_tag_lower(rest, rest, "you may cast them as though they had flash"))
+    {
+        grants_flash = true;
+        let trimmed = after.trim_start();
+        // allow-noncombinator: punctuation cleanup (drop the sentence terminator) between riders on a pre-tokenized chunk, not parsing dispatch.
+        rest = trimmed.strip_prefix('.').unwrap_or(trimmed).trim_start(); // allow-noncombinator: punctuation cleanup between riders, not parsing dispatch.
+    }
+
+    // CR 609.4b: "Mana of any type can be spent to cast those spells[.]"
+    if let Some(after) = nom_tag_lower(
+        rest,
+        rest,
+        "mana of any type can be spent to cast those spells",
+    ) {
+        mana_spend_permission = Some(crate::types::ability::ManaSpendPermission::AnyTypeOrColor);
+        rest = after;
+    }
+
+    (rest, grants_flash, mana_spend_permission)
 }
 
 fn strip_leading_permission_condition(input: &str) -> Option<(&str, StaticCondition)> {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -8232,6 +8232,8 @@ fn exile_cast_permission_maralen_fae_ascendant() {
             cost: ExileCastCost::WithoutPayingManaCost,
             pool: ExileCardPool::ThisTurn,
             timing: ExileCastTiming::AnyTime,
+            mana_spend_permission: None,
+            grants_flash: false,
         },
         "expected ExileCastPermission, got {:?}",
         def.mode
@@ -8277,6 +8279,7 @@ fn exile_cast_permission_during_each_of_your_turns_synonym() {
                 cost: ExileCastCost::WithoutPayingManaCost,
                 pool: ExileCardPool::ThisTurn,
                 timing: ExileCastTiming::AnyTime,
+                ..
             }
         ),
         "expected ExileCastPermission(OncePerTurn, Cast, free), got {:?}",
@@ -8331,6 +8334,8 @@ fn persistent_exile_play_permission_matrix_form() {
             cost: ExileCastCost::PayNormalCost,
             pool: ExileCardPool::Persistent,
             timing: ExileCastTiming::YourTurnOnly,
+            mana_spend_permission: None,
+            grants_flash: false,
         },
         "expected persistent your-turn Play permission, got {:?}",
         def.mode
@@ -8359,6 +8364,8 @@ fn persistent_exile_play_permission_evendo_sacrificed_permanent_gate() {
             cost: ExileCastCost::PayNormalCost,
             pool: ExileCardPool::Persistent,
             timing: ExileCastTiming::YourTurnOnly,
+            mana_spend_permission: None,
+            grants_flash: false,
         },
         "expected persistent your-turn Play permission, got {:?}",
         def.mode
@@ -8433,9 +8440,62 @@ fn persistent_exile_play_permission_look_at_variant() {
             cost: ExileCastCost::PayNormalCost,
             pool: ExileCardPool::Persistent,
             timing: ExileCastTiming::AnyTime,
+            mana_spend_permission: None,
+            grants_flash: false,
         },
         "expected persistent any-time Play permission, got {:?}",
         def.mode
+    );
+}
+
+/// CR 601.2a + CR 609.4b + CR 702.8a: Azula, Cunning Usurper — "During your
+/// turn, you may cast cards exiled with ~ and you may cast them as though they
+/// had flash. Mana of any type can be spent to cast those spells." lowers to a
+/// persistent, your-turn-only, Cast-mode permission carrying both the any-type
+/// mana spend concession and the flash grant.
+#[test]
+fn persistent_exile_cast_permission_azula_flash_and_any_mana() {
+    let text = "During your turn, you may cast cards exiled with ~ and you may cast them as though they had flash. Mana of any type can be spent to cast those spells.";
+    let def = parse_static_line(text).expect("Azula static must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ExileCastPermission {
+            frequency: CastFrequency::Unlimited,
+            // CR 601.2a: "you may cast cards exiled with ~" is spell-cast only.
+            play_mode: CardPlayMode::Cast,
+            cost: ExileCastCost::PayNormalCost,
+            pool: ExileCardPool::Persistent,
+            timing: ExileCastTiming::YourTurnOnly,
+            mana_spend_permission: Some(crate::types::ability::ManaSpendPermission::AnyTypeOrColor),
+            grants_flash: true,
+        },
+        "expected persistent Cast permission with flash + any-mana, got {:?}",
+        def.mode
+    );
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::Any),
+        "the persistent pool is the scope; affected must be Any"
+    );
+
+    // Full Oracle dispatch (with the real "~" normalization of "Azula, Cunning
+    // Usurper" → "Azula" → "~") must route the line to the same static, leaving
+    // no Unimplemented node behind.
+    let card_text = "During your turn, you may cast cards exiled with Azula and you may cast them as though they had flash. Mana of any type can be spent to cast those spells.";
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        card_text,
+        "Azula, Cunning Usurper",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string()],
+    );
+    assert!(
+        parsed
+            .statics
+            .iter()
+            .any(|parsed_def| parsed_def.mode == def.mode),
+        "full Oracle dispatch must route Azula's line to the flash+any-mana static, got {:?}",
+        parsed.statics
     );
 }
 
@@ -8465,6 +8525,8 @@ fn exile_cast_permission_soul_jar_persistent_creature_pool() {
             cost: ExileCastCost::PayNormalCost,
             pool: ExileCardPool::Persistent,
             timing: ExileCastTiming::AnyTime,
+            mana_spend_permission: None,
+            grants_flash: false,
         },
         "expected persistent ExileCastPermission, got {:?}",
         def.mode

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1867,7 +1867,7 @@ pub enum CastingPermission {
 }
 
 /// CR 609.4b: Permission modifying how mana may be spent to pay a cost.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ManaSpendPermission {
     /// Mana may be spent as though it were mana of any type or color for this
     /// payment. This preserves the Oracle distinction without changing the

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1015,6 +1015,24 @@ pub enum StaticMode {
         /// cast spells from among cards exiled with ~.").
         #[serde(default)]
         timing: ExileCastTiming,
+        /// CR 609.4b: Optional payment concession riding alongside the cast
+        /// permission — "Mana of any type can be spent to cast those spells."
+        /// (Azula, Cunning Usurper). `None` (default) preserves the existing
+        /// shapes (Maralen, The Matrix of Time). `Some(AnyTypeOrColor)` scopes
+        /// the any-type-mana spend to spells cast via this permission, mirroring
+        /// the per-card `CastingPermission::PlayFromExile.mana_spend_permission`
+        /// for the persistent-static seam. Consulted in
+        /// `casting::player_can_spend_as_any_color_for_spell`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mana_spend_permission: Option<crate::types::ability::ManaSpendPermission>,
+        /// CR 601.3b + CR 702.8a: When `true`, spells cast via this permission
+        /// may be cast "as though they had flash" — i.e. at instant speed
+        /// regardless of their normal timing (Azula, Cunning Usurper: "you may
+        /// cast them as though they had flash"). `false` (default) leaves the
+        /// normal sorcery-speed timing rules in force. Consulted by the
+        /// cast-timing check in `casting::prepare_spell_cast`.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        grants_flash: bool,
     },
     /// CR 113.6 + CR 601.2a: Marker static identifying a source whose linked
     /// "play a card from exile with a collection counter on it" permission is
@@ -1586,12 +1604,19 @@ impl Hash for StaticMode {
                 cost,
                 pool,
                 timing,
+                mana_spend_permission,
+                grants_flash,
             } => {
                 frequency.hash(state);
                 play_mode.hash(state);
                 pool.hash(state);
                 timing.hash(state);
                 cost.hash(state);
+                // `ManaSpendPermission` does not derive `Hash` (mirrors the
+                // `TopOfLibraryCastPermission.alt_cost` treatment above) — hash
+                // its presence so the two payment-concession shapes don't collide.
+                mana_spend_permission.is_some().hash(state);
+                grants_flash.hash(state);
             }
             // CR 122.2: Zone derives Hash; hash the excluded-zone list so
             // [Hand, Library] does not collide with other zone sets.
@@ -1885,10 +1910,13 @@ impl fmt::Display for StaticMode {
                 cost,
                 pool,
                 timing,
+                mana_spend_permission,
+                grants_flash,
             } => {
                 // Positional, lossless round-trip. Segments 1-2 (play_mode,
                 // frequency) are always present; the optional "free" cost
-                // marker, the pool scope, and the timing scope are appended as
+                // marker, the pool scope, the timing scope, the any-type-mana
+                // spend marker, and the flash-grant marker are appended as
                 // tagged segments only when non-default so the historical
                 // 2-/3-segment Maralen forms keep parsing unchanged.
                 write!(f, "ExileCastPermission({play_mode},{frequency}")?;
@@ -1900,6 +1928,12 @@ impl fmt::Display for StaticMode {
                 }
                 if matches!(timing, ExileCastTiming::YourTurnOnly) {
                     write!(f, ",timing={timing}")?;
+                }
+                if mana_spend_permission.is_some() {
+                    write!(f, ",anymana")?;
+                }
+                if *grants_flash {
+                    write!(f, ",flash")?;
                 }
                 write!(f, ")")
             }
@@ -2299,6 +2333,8 @@ impl FromStr for StaticMode {
                 cost: ExileCastCost::PayNormalCost,
                 pool: ExileCardPool::ThisTurn,
                 timing: ExileCastTiming::AnyTime,
+                mana_spend_permission: None,
+                grants_flash: false,
             },
             s if s.starts_with("ExileCastPermission(") => {
                 // Display form: "ExileCastPermission(<play_mode>,<frequency>[,free]
@@ -2322,9 +2358,18 @@ impl FromStr for StaticMode {
                 let mut cost = ExileCastCost::PayNormalCost;
                 let mut pool = ExileCardPool::ThisTurn;
                 let mut timing = ExileCastTiming::AnyTime;
+                let mut mana_spend_permission = None;
+                let mut grants_flash = false;
                 for seg in parts {
                     if seg == "free" {
                         cost = ExileCastCost::WithoutPayingManaCost;
+                    } else if seg == "anymana" {
+                        // CR 609.4b: any-type-mana spend concession.
+                        mana_spend_permission =
+                            Some(crate::types::ability::ManaSpendPermission::AnyTypeOrColor);
+                    } else if seg == "flash" {
+                        // CR 601.3b: cast-as-though-flash concession.
+                        grants_flash = true;
                     } else if let Some(scope) = seg.strip_prefix("pool=") {
                         if let Ok(p) = scope.parse() {
                             pool = p;
@@ -2341,6 +2386,8 @@ impl FromStr for StaticMode {
                     cost,
                     pool,
                     timing,
+                    mana_spend_permission,
+                    grants_flash,
                 }
             }
             "CantBeCountered" => StaticMode::CantBeCountered,
@@ -2969,6 +3016,8 @@ mod tests {
                 cost: ExileCastCost::WithoutPayingManaCost,
                 pool: ExileCardPool::ThisTurn,
                 timing: ExileCastTiming::AnyTime,
+                mana_spend_permission: None,
+                grants_flash: false,
             },
             StaticMode::ExileCastPermission {
                 frequency: CastFrequency::Unlimited,
@@ -2976,6 +3025,8 @@ mod tests {
                 cost: ExileCastCost::PayNormalCost,
                 pool: ExileCardPool::ThisTurn,
                 timing: ExileCastTiming::AnyTime,
+                mana_spend_permission: None,
+                grants_flash: false,
             },
             // Persistent, your-turn-only exile-play permission
             // (The Matrix of Time; Prosper/Tibalt impulse-commander class).
@@ -2985,6 +3036,21 @@ mod tests {
                 cost: ExileCastCost::PayNormalCost,
                 pool: ExileCardPool::Persistent,
                 timing: ExileCastTiming::YourTurnOnly,
+                mana_spend_permission: None,
+                grants_flash: false,
+            },
+            // CR 609.4b + CR 702.8a: Azula, Cunning Usurper — Cast mode from a
+            // persistent pool, your-turn-only, granting any-type mana and flash.
+            StaticMode::ExileCastPermission {
+                frequency: CastFrequency::Unlimited,
+                play_mode: CardPlayMode::Cast,
+                cost: ExileCastCost::PayNormalCost,
+                pool: ExileCardPool::Persistent,
+                timing: ExileCastTiming::YourTurnOnly,
+                mana_spend_permission: Some(
+                    crate::types::ability::ManaSpendPermission::AnyTypeOrColor,
+                ),
+                grants_flash: true,
             },
             // Casting prohibitions
             StaticMode::CantBeCast {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## feat(parser): cast-from-exile static permission with flash + any-type mana (Azula, Cunning Usurper)

Branch: `card/std-cast-from-exile` · Commit: `d615ec6459c1d84785a8d496f8e2cb12b46dae4b`

### Summary

Extends the persistent cast-from-exile static permission (`StaticMode::ExileCastPermission`) so it can carry the two optional concession riders that ride alongside Azula, Cunning Usurper's "During your turn, you may cast cards exiled with ~ and you may cast them as though they had flash. Mana of any type can be spent to cast those spells."

Two new fields on the existing `ExileCastPermission` variant:

- `mana_spend_permission: Option<ManaSpendPermission>` (CR 609.4b) — reuses the existing typed `ManaSpendPermission` enum (the same field the per-card `CastingPermission::PlayFromExile` grant carries). Parameterization of the existing variant, not a new sibling.
- `grants_flash: bool` (CR 601.3b) — a leaf binary timing concession. The existing `timing` axis (AnyTime / YourTurnOnly) already models the orthogonal timing dimension; "as though it had flash" has no expansion axis at the cast-permission layer.

Parser:
- The persistent exile-play parser now recognizes the bare "you may cast cards exiled with ~" wording (CR 601.2a — spell-cast only → `CardPlayMode::Cast`) in addition to the existing "play lands and cast spells" / "play cards" (→ `Play`) forms.
- A single combinator-based helper (`strip_exile_cast_concession_riders`) strips the optional flash + any-type-mana riders off the tail; any unmatched remainder still declines so unmodeled shapes surface as honest coverage gaps.

Runtime wiring (engine-only):
- `casting::exile_static_permission_grants_any_color` feeds `player_can_spend_as_any_color_for_optional_spell`, scoping the any-type-mana concession to spells in the static's exile pool (re-derived from pool + affected filter at spend time, mirroring the per-card `PlayFromExile` path).
- `casting::exile_static_permission_grants_flash` feeds `has_granted_flash` in `prepare_spell_cast`, so a flash-granted exiled spell may be cast at instant speed.

Lossless `Display`/`FromStr` round-trip and `Hash` for the new fields preserve existing 2-/3-segment Maralen / Matrix forms.

### add-engine-variant verdict

**No new sibling enum variant.** Two new fields on the existing `ExileCastPermission` variant:
- `mana_spend_permission` reuses the existing `ManaSpendPermission` enum → parameterization (CLAUDE.md: "use an existing typed enum, never a raw bool").
- `grants_flash: bool` is a genuine binary concession (CR 601.3b "as though it had flash" — no third state; the `timing` field captures the other axis). No typed flash-grant enum exists in the codebase, and the design space here is binary.

This complies with `feedback_parameterize_dont_proliferate`: the inventory already lists `ExileCastPermission`; this extends it rather than adding an X / OpponentX / TargetX sibling.

### Grep-verified CR annotations (vs `docs/MagicCompRules.txt`)

| CR | Rule text (head) | Use |
|---|---|---|
| 113.6b | "An ability that states which zones it functions in functions only from those zones." | Battlefield-scoped static |
| 305.1 | "A player who has priority may play a land card…" | Play (lands+spells) vs Cast (spells) |
| 601.2a | "To propose the casting of a spell, a player first moves that card…" | Cast-from-exile proposal |
| 601.3b | "If an effect allows a player to cast a spell… as though it had flash…" | Flash grant (primary) |
| 609.4b | "If an effect allows a player to spend mana 'as though it were mana of any [type or color]'…" | Any-type mana |
| 702.8a | "Flash is a static ability…" | Flash definition (supporting, w/ 601.3b) |

CR-annotation diff gate: 0 UNVERIFIED. The bare `702.8a` flash-grant annotations from the partial work were upgraded to `601.3b + 702.8a` to match the codebase precedent (Teferi / Vivien flash-timing grants) and to cite the rule that actually permits casting-as-though-flash.

### Per-card verdict

| Card | Verdict | Notes |
|---|---|---|
| Azula, Cunning Usurper | **SHIP (permission-only)** | Cast pool + any-type mana + flash all wired. Card is intentionally NOT full-card-0: the separate "Firebending 2" keyword line is out of scope and stays an honest `Effect::unknown` gap. |
| Tinybones, Bauble Burglar | **DEFER (honest gap)** | "play cards you don't own with stash counters on them from exile" needs a new stash-counter pool reference + "you don't own" provenance filter — new infra, not a bounded parser extension. |
| Memory Vessel | **DEFER (honest gap)** | "players may play cards they exiled this way, and they can't play cards from their hand" needs all-player scope + a new can't-play-from-hand prohibition rider. |
| Festival of Embers | **DEFER (alt-cost)** | "pay 1 life in addition to their other costs" = CR 601.2f additional cost on a graveyard-cast static — new cost-substitution infra. |
| Dawnhand Dissident | **DEFER (alt-cost)** | "by removing three counters … in addition to paying their other costs" = additional remove-counters cost — new infra. |
| Valgavoth, Terror Eater | **DEFER (alt-cost)** | "pay life equal to its mana value rather than pay its mana cost" = CR 118.9 alternative cost. The clean future path is an `alt_cost: Option<AbilityCost>` field mirroring `TopOfLibraryCastPermission` (Bolas's Citadel `PayLife { SelfManaValue }`); deferred pending the cost-substitution-on-static seam. |
| Warped Space | **DEFER (alt-cost)** | "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile" — once/turn alt-cost replacement. |
| Weftwalking | **DEFER (alt-cost)** | "The first spell each player casts during each of their turns may be cast without paying its mana cost" — first-spell-per-turn-free, all players. |

All deferred cards remain honest `Effect::Unimplemented` gaps via the existing dispatch fallback (no fabricated `Effect::unimplemented` literals needed; an unparsed static line auto-surfaces as `static_structure`). No bandaid parses that fail to enforce the unmodeled semantics.

### Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| Any-type mana from the static lets a {U} spell be paid from a red-only exile pool | `exile_static_permission_grants_any_color` → `player_can_spend_as_any_color_for_optional_spell` | `can_pay_cost_after_auto_tap` (real auto-tap simulator, `PaymentContext::Spell`) | `casting::tests::azula_exile_static_grants_any_type_mana_spend` | `can_pay_cost_after_auto_tap(...{U}...)` is true only with `mana_spend_permission = Some`; reverting to `None` → unpayable | Pre-check `spell_objects_available_to_cast` confirms the spell is in the persistent pool (non-degenerate); red-only mana makes {U} provably unpayable without the concession |
| Flash grant lets an exiled sorcery be cast outside the sorcery-speed window | `exile_static_permission_grants_flash` → `has_granted_flash` in `prepare_spell_cast` | `handle_cast_spell` (real cast pipeline) | `casting::tests::azula_exile_static_grants_flash_timing` | `handle_cast_spell` returns `Ok` + spell on stack only with `grants_flash = true`; reverting to `false` → sorcery-speed rejection | Asserts `!is_sorcery_speed_window` first (non-empty stack), so the timing gate — not payment — decides the outcome |
| The cast-from-exile static line lowers to the correct typed variant | parser `try_parse_persistent_exile_play_permission` + `strip_exile_cast_concession_riders` | `parse_static_line` / `parse_oracle_text` | `oracle_static::tests::persistent_exile_cast_permission_azula_flash_and_any_mana` | `def.mode == ExileCastPermission { Cast, Persistent, YourTurnOnly, anymana, flash }`; also asserts full `parse_oracle_text` dispatch routes the `~`-normalized line to the same static | Shape/parse test (covers the parser seam); runtime semantics covered by the two `apply`-path tests above |
| Azula full card is supported except the out-of-scope Firebending line | coverage over the synthesized face | `build_oracle_face` → `card_face_gaps` / `build_parse_details_for_face` | `oracle::tests::azula_cunning_usurper_full_card_supported_with_exile_cast_permission` | Cast-from-exile detail `supported == true` AND the only gap is `Effect:unknown` = "Firebending 2"; regressing the static line flips `supported` and adds a gap | Negative: pins that the single unsupported item is exactly Firebending, so a new unrelated gap also fails |

Two of the four tests drive the real `apply`-equivalent pipeline (`handle_cast_spell`, `can_pay_cost_after_auto_tap`'s auto-tap simulator); both flip on revert of the exact field under test. The two parser/coverage tests cover the parser + coverage seams and are explicitly paired with the runtime tests.

### Gates (post-rebase onto `upstream/main` @ `0e2200cc5`)

- `cargo fmt --all` — clean
- `cargo check --workspace --all-targets` — Finished (0)
- `cargo clippy --all-targets --features engine/proptest -- -D warnings` — Finished (0)
- `cargo test -p engine` — 12965 passed, 1 failed = `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (known parallel-flaky; passes in isolation, unrelated to this diff)
- `./scripts/check-parser-combinators.sh` — 0
- `./scripts/check-engine-authorities.sh upstream/main` — 0
- CR-annotation diff gate — 0 UNVERIFIED
- Inline parser diff gate — only benign false positives (`Iterator::find` on Vecs and `str::starts_with` on the engine's own handler label in tests, the latter annotated); authoritative combinator gate is green
- `data/engine-inventory.json` — restored (the local generator produced a full-file reordering churn vs the committed file, a generator/base mismatch unrelated to this change; not committed)

### Rebase

Rebased cleanly onto `upstream/main` (`0e2200cc5`), 14 commits forward from the original base. Four upstream commits touched the same files (casting.rs, oracle.rs, oracle_static, types) but the rebase produced no conflicts; all gates re-run green afterward.
