### PR TITLE
fix(parser): handle activation-first ordering in mana spend restrictions

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -15710,6 +15710,25 @@ Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell 
         assert_eq!(grants, vec![ManaSpellGrant::CantBeCountered]);
     }
 
+    /// CR 106.6: Activation-first disjunction — "to activate X or cast Y"
+    /// (Automated Artificer). Must produce `Any([ActivateOnly, SpellType])`.
+    #[test]
+    fn mana_spend_restriction_activation_first_disjunction() {
+        use crate::parser::oracle_effect::mana::parse_mana_spend_restriction;
+        let (restriction, grants) = parse_mana_spend_restriction(
+            "spend this mana only to activate an ability or cast an artifact spell",
+        )
+        .expect("activation-first disjunction should parse");
+        assert_eq!(
+            restriction,
+            ManaSpendRestriction::Any(vec![
+                ManaSpendRestriction::ActivateOnly,
+                ManaSpendRestriction::SpellType("Artifact".to_string()),
+            ])
+        );
+        assert!(grants.is_empty());
+    }
+
     #[test]
     fn top_level_static_flashback_grant_stays_on_graveyard_cards() {
         let result = parse(

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1468,6 +1468,23 @@ pub(crate) fn parse_mana_spend_restriction(
         return Some((ManaSpendRestriction::XCostOnly, vec![]));
     }
 
+    // CR 106.6: Activation-first disjunction — "to activate X or cast Y" (Automated
+    // Artificer). The "to cast " prefix check below would reject this ordering, so
+    // detect the activation-first pattern and route through the disjunction parser
+    // with the full base text (stripped of the leading "to ").
+    if nom_on_lower(base, &base_lower, |i| {
+        value((), (tag("to activate "), take_until(" or cast "))).parse(i)
+    })
+    .is_some()
+    {
+        // Strip leading "to " so each clause starts bare for parse_disjunctive_clause.
+        let without_to = nom_on_lower(base, &base_lower, |i| value((), tag("to ")).parse(i))
+            .map_or(base, |(_, rest)| rest);
+        if let Some(restriction) = parse_disjunctive_cast_clauses(without_to.trim()) {
+            return Some((restriction, vec![]));
+        }
+    }
+
     let (_, rest) = nom_on_lower(base, &base_lower, |i| value((), tag("to cast ")).parse(i))?;
     let rest = rest.trim();
 


### PR DESCRIPTION
## Summary

Fix `parse_mana_spend_restriction` failing to parse activation-first disjunctions like "Spend this mana only to activate an ability or cast an artifact spell" (Automated Artificer).

## Root Cause

`parse_mana_spend_restriction` requires the prefix `"to cast "` (line 1441) before routing to the disjunction parser. When the text starts with `"to activate "` instead, the function returns `None` — even though both clauses (`"activate an ability"` and `"cast an artifact spell"`) parse individually via `parse_disjunctive_clause`.

## Fix

Before the `"to cast "` prefix check, detect the activation-first pattern: when the text matches `"to activate ... or cast ..."`, strip the leading `"to "` and route through `parse_disjunctive_cast_clauses` which handles each clause independently. The result is `Any([ActivateOnly, SpellType("Artifact")])`.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/parser/oracle_effect/mana.rs` | Add activation-first detection path before `tag("to cast ")` |
| `crates/engine/src/parser/oracle.rs` | Add discriminating test `mana_spend_restriction_activation_first_disjunction` |

## Cards Unlocked (1)

| Card | Pattern |
|------|---------|
| Automated Artificer | "to activate an ability or cast an artifact spell" |

## Testing

- `mana_spend_restriction_activation_first_disjunction` — verifies `Any([ActivateOnly, SpellType("Artifact")])` via `parse_mana_spend_restriction`
- Existing `mana_spend_restriction_disjunction_three_way_heterogeneous` continues to pass (cast-first ordering)
- CI green on fork PR: https://github.com/Whovencroft/phase/pull/31
