### PR TITLE
feat(engine): player-targeted discover/blight (Champion of the Weird, Zoyowa's Justice)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2663,8 +2663,12 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             d.push(("kept".into(), format!("{:?}", kept_destination)));
             d.push(("rest".into(), format!("{:?}", rest_destination)));
         }
-        Effect::Discover { mana_value_limit } => {
+        Effect::Discover {
+            mana_value_limit,
+            player,
+        } => {
             d.push(("mv limit".into(), format!("{:?}", mana_value_limit)));
+            d.push(("player".into(), format!("{player:?}")));
         }
         // Heist (Arena digital-only): look step records the look count.
         Effect::Heist { look_count, .. } => {
@@ -2797,8 +2801,9 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::Endure { amount } => {
             d.push(("amount".into(), amount.to_string()));
         }
-        Effect::BlightEffect { count } => {
+        Effect::BlightEffect { count, player } => {
             d.push(("count".into(), count.to_string()));
+            d.push(("player".into(), format!("{player:?}")));
         }
         Effect::Seek {
             filter,

--- a/crates/engine/src/game/effects/blight.rs
+++ b/crates/engine/src/game/effects/blight.rs
@@ -20,23 +20,30 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let count = match &ability.effect {
-        Effect::BlightEffect { count } => *count,
+    let (count, blighting_player) = match &ability.effect {
+        Effect::BlightEffect { count, player } => {
+            // CR 701.68a: the blighting player puts the counters on a creature
+            // *they* control. Default `TargetFilter::Controller` keeps "you
+            // blight"; Champion of the Weird redirects to the targeted opponent
+            // ("Target opponent blights 2").
+            let blighting_player =
+                crate::game::effects::resolve_player_for_context_ref(state, ability, player);
+            (*count, blighting_player)
+        }
         _ => return Ok(()),
     };
 
-    let controller = ability.controller;
     let source_id = ability.source_id;
 
-    // CR 701.68a: Eligible creatures are those the controller of this ability
-    // controls on the battlefield.
+    // CR 701.68a: Eligible creatures are those the blighting player controls on
+    // the battlefield.
     let eligible: Vec<ObjectId> = state
         .battlefield
         .iter()
         .copied()
         .filter(|id| {
             state.objects.get(id).is_some_and(|obj| {
-                obj.controller == controller
+                obj.controller == blighting_player
                     && !obj.is_emblem
                     && obj.card_types.core_types.contains(&CoreType::Creature)
             })
@@ -54,11 +61,11 @@ pub fn resolve(
         return Ok(());
     }
 
-    // CR 701.68a: The controller chooses exactly one creature they control.
+    // CR 701.68a: The blighting player chooses exactly one creature they control.
     // `count` (in EffectZoneChoice) is the number of creatures chosen (1);
     // `count_param` carries N — the number of -1/-1 counters to place.
     state.waiting_for = WaitingFor::EffectZoneChoice {
-        player: controller,
+        player: blighting_player,
         cards: eligible,
         count: 1,
         min_count: 1,
@@ -113,7 +120,10 @@ mod tests {
 
     fn blight_ability(source_id: ObjectId, controller: PlayerId, count: u32) -> ResolvedAbility {
         ResolvedAbility::new(
-            Effect::BlightEffect { count },
+            Effect::BlightEffect {
+                count,
+                player: TargetFilter::Controller,
+            },
             vec![],
             source_id,
             controller,
@@ -252,10 +262,18 @@ mod tests {
             Some(1),
             "blight ignores hexproof — it is a choice, not a target"
         );
-        // target_filter() must return None for BlightEffect.
+        // CR 701.68a: a default-controller blight surfaces NO real target slot.
+        // `target_filter()` returns `Some(Controller)` (mirroring the other
+        // player-axis effects), but `extract_target_filter_from_effect` drops the
+        // context ref via its final `is_context_ref()` guard, so the controller's
+        // creature choice is never declared as a target (hexproof is irrelevant).
         assert!(
-            Effect::BlightEffect { count: 1 }.target_filter().is_none(),
-            "BlightEffect must be non-targeted"
+            crate::game::triggers::extract_target_filter_from_effect(&Effect::BlightEffect {
+                count: 1,
+                player: TargetFilter::Controller,
+            })
+            .is_none(),
+            "default 'you blight' must surface no target slot"
         );
         let _ = TargetFilter::Any; // keep import used across cfg
     }
@@ -305,6 +323,95 @@ mod tests {
             obj.counters.get(&CounterType::Minus1Minus1).copied(),
             Some(2),
             "counter-doubling replacement (CR 614.1a) must double blight's counters"
+        );
+    }
+
+    /// Discriminator 6 (player-redirect): CR 701.68a — "Target opponent blights
+    /// N" (Champion of the Weird) makes the *targeted player*, not the
+    /// controller, blight. The prompt goes to the opponent and only the
+    /// opponent's creatures are eligible. Reverting the `player` plumbing (back
+    /// to `ability.controller`) flips both assertions: the prompt would address
+    /// PlayerId(0) and scope eligibility to PlayerId(0)'s creature.
+    #[test]
+    fn blight_redirects_to_targeted_opponent() {
+        use crate::types::ability::{ControllerRef, TargetRef, TypedFilter};
+
+        let mut state = GameState::new_two_player(7);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+        // Controller has a creature too — it must NOT be eligible when the
+        // opponent is the blighting player.
+        let mine = make_creature(&mut state, 1, controller);
+        let theirs = make_creature(&mut state, 2, opponent);
+
+        // Mirror the exact parser output for "Target opponent blights 2": an
+        // Opponent player filter carried in `player` (a non-context-ref target),
+        // with the chosen opponent in `targets` (declared at announcement).
+        let ability = ResolvedAbility::new(
+            Effect::BlightEffect {
+                count: 2,
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+            },
+            vec![TargetRef::Player(opponent)],
+            mine, // source is the controller's permanent
+            controller,
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::EffectZoneChoice {
+                player,
+                cards,
+                count_param,
+                ..
+            } => {
+                assert_eq!(
+                    *player, opponent,
+                    "the targeted opponent (not the controller) must be prompted to blight"
+                );
+                assert_eq!(
+                    cards,
+                    &[theirs],
+                    "only the opponent's creatures are eligible to be blighted"
+                );
+                assert_eq!(*count_param, 2);
+            }
+            other => panic!("expected EffectZoneChoice, got {other:?}"),
+        }
+
+        // Drive the opponent's choice through the real handler.
+        apply(
+            &mut state,
+            opponent,
+            GameAction::SelectCards {
+                cards: vec![theirs],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            state
+                .objects
+                .get(&theirs)
+                .unwrap()
+                .counters
+                .get(&CounterType::Minus1Minus1)
+                .copied(),
+            Some(2),
+            "the opponent's chosen creature receives the 2 -1/-1 counters"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&mine)
+                .unwrap()
+                .counters
+                .contains_key(&CounterType::Minus1Minus1),
+            "the controller's creature is untouched when the opponent blights"
         );
     }
 }

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -337,4 +337,79 @@ mod tests {
             other => panic!("expected CastOffer addressed to the opponent, got {other:?}"),
         }
     }
+
+    /// CR 701.57a + CR 608.2c: Zoyowa's Justice-style "that player discovers X"
+    /// binds the discovering player through the parent object target's owner. A
+    /// direct `target opponent` filter takes the declared player-target branch;
+    /// this regression exercises the context-ref branch used by the actual
+    /// "that player" parser output.
+    #[test]
+    fn discover_parent_target_owner_uses_parent_object_owner_library() {
+        use crate::types::ability::TargetRef;
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+
+        let parent_target = create_object(
+            &mut state,
+            CardId(8),
+            opponent,
+            "Opponent-Owned Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&parent_target)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let hit = create_object(
+            &mut state,
+            CardId(9),
+            opponent,
+            "Opponent Two Drop".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&hit).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::generic(2);
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::Discover {
+                mana_value_limit: QuantityExpr::Fixed { value: 3 },
+                player: TargetFilter::ParentTargetOwner,
+            },
+            vec![TargetRef::Object(parent_target)],
+            ObjectId(100),
+            controller,
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::CastOffer {
+                player,
+                kind: CastOfferKind::Discover { hit_card, .. },
+                ..
+            } => {
+                assert_eq!(
+                    *player, opponent,
+                    "the parent target's owner, not the controller, is offered the discover"
+                );
+                assert_eq!(
+                    *hit_card, hit,
+                    "ParentTargetOwner discover scans the parent target owner's library"
+                );
+            }
+            other => {
+                panic!("expected CastOffer addressed to the parent target owner, got {other:?}")
+            }
+        }
+    }
 }

--- a/crates/engine/src/game/effects/discover.rs
+++ b/crates/engine/src/game/effects/discover.rs
@@ -16,9 +16,20 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let limit = match &ability.effect {
-        Effect::Discover { mana_value_limit } => {
-            quantity::resolve_quantity_with_targets(state, mana_value_limit, ability).max(0) as u32
+    let (limit, discovering_player) = match &ability.effect {
+        Effect::Discover {
+            mana_value_limit,
+            player,
+        } => {
+            let limit = quantity::resolve_quantity_with_targets(state, mana_value_limit, ability)
+                .max(0) as u32;
+            // CR 701.57a: the discovering player exiles from *their* library.
+            // Default `TargetFilter::Controller` keeps "you discover"; Zoyowa's
+            // Justice redirects to the parent target's owner ("that player
+            // discovers X").
+            let discovering_player =
+                crate::game::effects::resolve_player_for_context_ref(state, ability, player);
+            (limit, discovering_player)
         }
         _ => return Err(EffectError::InvalidParam("Expected Discover".to_string())),
     };
@@ -26,7 +37,7 @@ pub fn resolve(
     let player = state
         .players
         .iter()
-        .find(|p| p.id == ability.controller)
+        .find(|p| p.id == discovering_player)
         .ok_or(EffectError::PlayerNotFound)?;
 
     // Collect library IDs (top to bottom)
@@ -75,9 +86,10 @@ pub fn resolve(
 
     match hit_card {
         Some(hit) => {
-            // Player chooses: cast without paying or put to hand
+            // CR 701.57a: the discovering player chooses to cast without paying
+            // or put the hit card into their hand.
             state.waiting_for = WaitingFor::CastOffer {
-                player: ability.controller,
+                player: discovering_player,
                 kind: CastOfferKind::Discover {
                     hit_card: hit,
                     exiled_misses,
@@ -87,7 +99,7 @@ pub fn resolve(
         }
         None => {
             // CR 701.57a: No hit — put all exiled misses on bottom in random order
-            shuffle_to_bottom(state, &exiled_misses, ability.controller, events);
+            shuffle_to_bottom(state, &exiled_misses, discovering_player, events);
         }
     }
 
@@ -115,7 +127,7 @@ fn shuffle_to_bottom(
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
-    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef};
+    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, TargetFilter};
     use crate::types::events::GameEvent;
     use crate::types::identifiers::CardId;
     use crate::types::mana::ManaCost;
@@ -174,6 +186,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::Discover {
                 mana_value_limit: QuantityExpr::Fixed { value: 3 },
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -239,6 +252,7 @@ mod tests {
                         scope: ObjectScope::EventSource,
                     },
                 },
+                player: TargetFilter::Controller,
             },
             vec![],
             ObjectId(100),
@@ -255,5 +269,72 @@ mod tests {
                 ..
             } if hit_card == hit
         ));
+    }
+
+    /// CR 701.57a (player-redirect): "Then that player discovers X" (Zoyowa's
+    /// Justice) makes a *redirected* player — not the controller — exile from
+    /// their own library. The discover scans the opponent's library and the
+    /// cast/keep offer is addressed to the opponent. Reverting the `player`
+    /// plumbing (back to `ability.controller`) flips this: the controller's
+    /// empty library would yield no hit and no `CastOffer` at all.
+    #[test]
+    fn discover_redirects_to_other_player_library() {
+        use crate::types::ability::{ControllerRef, TargetRef, TypedFilter};
+
+        let mut state = GameState::new_two_player(42);
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+
+        // The hit lives in the OPPONENT's library; the controller's library is
+        // empty, so a non-redirected discover would find nothing.
+        let hit = create_object(
+            &mut state,
+            CardId(7),
+            opponent,
+            "Opponent Two Drop".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&hit).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::generic(2);
+        }
+
+        // Mirror the parser output for a redirected discover: a player filter in
+        // `player` with the chosen player declared in `targets`. (Zoyowa uses
+        // `ParentTargetOwner`; an explicit `Opponent` Player target exercises the
+        // same resolver redirect through a directly assertable seam.)
+        let ability = ResolvedAbility::new(
+            Effect::Discover {
+                mana_value_limit: QuantityExpr::Fixed { value: 3 },
+                player: TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::Opponent),
+                ),
+            },
+            vec![TargetRef::Player(opponent)],
+            ObjectId(100),
+            controller,
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::CastOffer {
+                player,
+                kind: CastOfferKind::Discover { hit_card, .. },
+                ..
+            } => {
+                assert_eq!(
+                    *player, opponent,
+                    "the redirected player (not the controller) is offered the discover"
+                );
+                assert_eq!(
+                    *hit_card, hit,
+                    "discover scans the redirected player's library, not the controller's"
+                );
+            }
+            other => panic!("expected CastOffer addressed to the opponent, got {other:?}"),
+        }
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2268,6 +2268,7 @@ fn collect_effect_quantity_exprs<'a>(effect: &'a Effect, out: &mut Vec<&'a Quant
         | Effect::GainEnergy { amount, .. }
         | Effect::Discover {
             mana_value_limit: amount,
+            ..
         }
         | Effect::PutAtLibraryPosition { count: amount, .. }
         | Effect::GrantExtraLoyaltyActivations { amount, .. }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6850,6 +6850,8 @@ pub(super) fn parse_imperative_family_ast(
                 .unwrap_or(1);
             Some(ImperativeFamilyAst::GainKeyword(Effect::BlightEffect {
                 count,
+                // CR 701.68a: bare "blight N" is the controller blighting.
+                player: crate::types::ability::TargetFilter::Controller,
             }))
         }
         // Forage keyword action (CR 701.61a)

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5893,6 +5893,7 @@ pub(super) fn apply_where_x_effect_expression(
         | Effect::ExileTop { count: amount, .. }
         | Effect::Discover {
             mana_value_limit: amount,
+            ..
         }
         | Effect::Incubate { count: amount } => {
             *amount = apply_where_x_quantity_expression(amount.clone(), where_x_expression);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5229,33 +5229,31 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         });
     }
 
-    // CR 701.57a: "discover N" / "discover X" — effect variant.
+    // CR 701.57a: "[player] discover[s] N" / "[player] discover[s] X" — effect
+    // variant. An optional leading player subject ("you", "that player", "target
+    // opponent", …) redirects who performs the discover (Zoyowa's Justice: "Then
+    // that player discovers X"). Bare "discover N" defaults to the controller.
     let (discover_tp, discover_where_x) = strip_trailing_where_x(tp);
-    if let Some((limit, rest_orig)) =
-        super::oracle_nom::bridge::nom_on_lower(discover_tp.original, discover_tp.lower, |i| {
-            let (rest, _) = tag("discover ").parse(i)?;
-            let (rest, limit) = alt((
-                map(nom_primitives::parse_number, |value| QuantityExpr::Fixed {
-                    value: value as i32,
-                }),
-                value(
-                    QuantityExpr::Ref {
-                        qty: QuantityRef::Variable {
-                            name: "X".to_string(),
-                        },
-                    },
-                    tag("x"),
-                ),
-            ))
-            .parse(rest)?;
-            let (rest, _) = opt(tag(".")).parse(rest)?;
-            Ok((rest, limit))
-        })
-    {
+    if let Some((discover_player, limit, rest_orig)) = parse_discover_with_player(discover_tp) {
         if rest_orig.trim().is_empty() {
             let limit = apply_where_x_quantity_expression(limit, discover_where_x.as_deref());
             return parsed_clause(Effect::Discover {
                 mana_value_limit: limit,
+                player: discover_player,
+            });
+        }
+    }
+
+    // CR 701.68a: "[player] blight[s] N" — blight with a redirected player.
+    // "Target opponent blights 2" (Champion of the Weird) makes the targeted
+    // player put the -1/-1 counters on a creature *they* control. Bare
+    // "blight N" (controller blights) is handled by the imperative parser's
+    // first-word dispatch; this arm covers the leading-player-subject form.
+    if let Some((blight_player, count, rest_orig)) = parse_blight_with_player(tp) {
+        if rest_orig.trim().is_empty() {
+            return parsed_clause(Effect::BlightEffect {
+                count,
+                player: blight_player,
             });
         }
     }
@@ -6351,6 +6349,117 @@ fn try_parse_put_on_top_or_bottom(
     }
 
     None
+}
+
+/// CR 701.57a: Parse "[player] discover[s] N/X" and return the discovering
+/// player, the mana-value limit, and the unconsumed remainder.
+///
+/// The optional leading player subject redirects who performs the discover:
+/// - no subject / "you " → `TargetFilter::Controller` (the common case).
+/// - "that player " → `TargetFilter::ParentTargetOwner`. In the only printed
+///   pattern (Zoyowa's Justice: "The owner of target … shuffles it into their
+///   library. Then that player discovers X"), "that player" is the owner of the
+///   parent target established by the preceding clause, so it binds to the
+///   parent target's owner at resolution via `resolve_player_for_context_ref`.
+/// - any other leading "target …"/"each …" player phrase → the parsed
+///   `TargetFilter` (e.g. "target opponent" surfaces as a real target).
+///
+/// The verb is matched as "discover" or "discovers" so both the imperative
+/// ("discover N") and third-person ("that player discovers N") forms parse.
+fn parse_discover_with_player(tp: TextPair) -> Option<(TargetFilter, QuantityExpr, String)> {
+    // A `fn` item (rather than a closure) so it is generic over the input
+    // lifetime and can be invoked inside the `nom_on_lower` closures below.
+    fn limit_parser(i: &str) -> super::oracle_nom::error::OracleResult<'_, QuantityExpr> {
+        let (rest, _) = alt((tag("discovers "), tag("discover "))).parse(i)?;
+        let (rest, limit) = alt((
+            map(nom_primitives::parse_number, |value| QuantityExpr::Fixed {
+                value: value as i32,
+            }),
+            value(
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                tag("x"),
+            ),
+        ))
+        .parse(rest)?;
+        let (rest, _) = opt(tag(".")).parse(rest)?;
+        Ok((rest, limit))
+    }
+
+    // No leading player subject (or "you …") → the controller discovers.
+    if let Some((limit, rest_orig)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (rest, _) = opt(tag("you ")).parse(i)?;
+        limit_parser(rest)
+    }) {
+        return Some((TargetFilter::Controller, limit, rest_orig.to_string()));
+    }
+
+    // "that player discovers …" — binds to the owner of the parent target
+    // established by the preceding clause (Zoyowa's Justice).
+    if let Some((limit, rest_orig)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (rest, _) = tag("that player ").parse(i)?;
+        limit_parser(rest)
+    }) {
+        return Some((
+            TargetFilter::ParentTargetOwner,
+            limit,
+            rest_orig.to_string(),
+        ));
+    }
+
+    // "target opponent discovers …" and similar explicit player targets.
+    let (filter, remainder) = parse_target(tp.original);
+    let remainder = remainder.trim_start();
+    if remainder.eq_ignore_ascii_case(tp.original.trim_start()) {
+        return None;
+    }
+    let remainder_lower = remainder.to_ascii_lowercase();
+    nom_on_lower(remainder, &remainder_lower, limit_parser)
+        .map(|(limit, rest_orig)| (filter, limit, rest_orig.to_string()))
+}
+
+/// CR 701.68a: Parse "[player] blight[s] N" where a leading player subject
+/// redirects who blights, and return that player, the count, and the remainder.
+///
+/// Only the leading-player-subject form is handled here ("target opponent
+/// blights 2", "that player blights N"). Bare "blight N" (the controller
+/// blights) is dispatched by the imperative first-word parser, so this helper
+/// returns `None` when there is no player subject — leaving the bare form to its
+/// owner.
+fn parse_blight_with_player(tp: TextPair) -> Option<(TargetFilter, u32, String)> {
+    // A `fn` item (rather than a closure) so it is generic over the input
+    // lifetime and can be invoked inside the `nom_on_lower` closures below.
+    fn count_parser(i: &str) -> super::oracle_nom::error::OracleResult<'_, u32> {
+        let (rest, _) = alt((tag("blights "), tag("blight "))).parse(i)?;
+        let (rest, count) = nom_primitives::parse_number.parse(rest)?;
+        let (rest, _) = opt(tag(".")).parse(rest)?;
+        Ok((rest, count))
+    }
+
+    // "that player blights …" — binds to the owner of the parent target.
+    if let Some((count, rest_orig)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (rest, _) = tag("that player ").parse(i)?;
+        count_parser(rest)
+    }) {
+        return Some((
+            TargetFilter::ParentTargetOwner,
+            count,
+            rest_orig.to_string(),
+        ));
+    }
+
+    // "target opponent blights …" and similar explicit player targets.
+    let (filter, remainder) = parse_target(tp.original);
+    let remainder = remainder.trim_start();
+    if remainder.eq_ignore_ascii_case(tp.original.trim_start()) {
+        return None;
+    }
+    let remainder_lower = remainder.to_ascii_lowercase();
+    nom_on_lower(remainder, &remainder_lower, count_parser)
+        .map(|(count, rest_orig)| (filter, count, rest_orig.to_string()))
 }
 
 /// CR 701.24a + CR 400.3: Parse "the owner of target [filter] shuffles it into their library".
@@ -50831,12 +50940,73 @@ mod tests {
                         qty: QuantityRef::ObjectManaValue {
                             scope: ObjectScope::EventSource
                         }
-                    }
+                    },
+                    ..
                 }
             ),
             "expected dynamic Discover limit, got {:?}",
             def.effect
         );
+    }
+
+    /// CR 701.68a: "Target opponent blights N" (Champion of the Weird) parses to
+    /// a `BlightEffect` whose `player` carries the Opponent target, so the
+    /// resolver redirects the blight away from the controller.
+    #[test]
+    fn blight_target_opponent_carries_opponent_player() {
+        let def = parse_effect_chain("Target opponent blights 2.", AbilityKind::Spell);
+        match def.effect.as_ref() {
+            Effect::BlightEffect { count, player } => {
+                assert_eq!(*count, 2);
+                assert!(
+                    matches!(player, TargetFilter::Typed(f) if f.controller == Some(ControllerRef::Opponent)),
+                    "expected Opponent player filter, got {player:?}"
+                );
+            }
+            other => panic!("expected BlightEffect, got {other:?}"),
+        }
+    }
+
+    /// CR 701.57a: "that player discovers X" (Zoyowa's Justice) parses to a
+    /// `Discover` whose `player` binds to the parent target's owner and whose
+    /// limit is the parent target's mana value.
+    #[test]
+    fn discover_that_player_binds_parent_target_owner() {
+        let def = parse_effect_chain(
+            "The owner of target creature with mana value 1 or greater shuffles it into their library. Then that player discovers X, where X is its mana value.",
+            AbilityKind::Spell,
+        );
+        // Walk to the Discover sub-clause.
+        let mut cur = def.sub_ability.as_deref();
+        let mut discover: Option<&Effect> = None;
+        while let Some(ab) = cur {
+            if matches!(ab.effect.as_ref(), Effect::Discover { .. }) {
+                discover = Some(ab.effect.as_ref());
+                break;
+            }
+            cur = ab.sub_ability.as_deref();
+        }
+        match discover.expect("expected a Discover sub-clause") {
+            Effect::Discover {
+                player,
+                mana_value_limit,
+            } => {
+                assert!(
+                    matches!(player, TargetFilter::ParentTargetOwner),
+                    "expected ParentTargetOwner, got {player:?}"
+                );
+                assert!(
+                    matches!(
+                        mana_value_limit,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectManaValue { .. }
+                        }
+                    ),
+                    "expected dynamic MV limit, got {mana_value_limit:?}"
+                );
+            }
+            other => panic!("expected Discover, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14842,7 +14842,9 @@ mod tests {
             .as_ref()
             .expect("trigger should have execute step");
         match execute.effect.as_ref() {
-            Effect::Discover { mana_value_limit } => {
+            Effect::Discover {
+                mana_value_limit, ..
+            } => {
                 assert!(
                     matches!(
                         mana_value_limit,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9290,8 +9290,21 @@ pub enum Effect {
     },
     /// CR 701.57a: Discover N — exile from top until nonland with MV ≤ N,
     /// cast free or put to hand, rest to bottom in random order.
+    ///
+    /// `player` is the player who performs the discover. CR 701.57a is written
+    /// from the controller's perspective ("exile cards from the top of *your*
+    /// library"), so the default is `TargetFilter::Controller` and existing JSON
+    /// (which omits the field) keeps the controller-discovers reading. Cards like
+    /// Zoyowa's Justice ("Then *that player* discovers X") redirect the action to
+    /// another player by carrying a player `TargetFilter` here; the resolver maps
+    /// it through `resolve_player_for_context_ref`.
     Discover {
         mana_value_limit: QuantityExpr,
+        #[serde(
+            default = "default_target_filter_controller",
+            skip_serializing_if = "is_target_filter_controller"
+        )]
+        player: TargetFilter,
     },
     /// Heist — designed-for-digital (MTG Arena) keyword action. NOT in the
     /// Comprehensive Rules; operates per the Arena programmed rules (see
@@ -9635,10 +9648,25 @@ pub enum Effect {
     Endure {
         amount: u32,
     },
-    /// CR 701.68a: Blight N as an effect — the controller of this ability puts
-    /// N -1/-1 counters on a creature they control. Non-targeted controller choice.
+    /// CR 701.68a: Blight N as an effect — the blighting player puts N -1/-1
+    /// counters on a creature *they* control. Non-targeted: the player choosing
+    /// which of their own creatures to blight is a choice, not a target
+    /// (CR 701.68a — hexproof/shroud are irrelevant).
+    ///
+    /// `player` is the player instructed to blight. The default
+    /// `TargetFilter::Controller` keeps the common "you blight" reading and lets
+    /// existing JSON (which omits the field) deserialize unchanged. Cards like
+    /// Champion of the Weird ("Target opponent blights 2") redirect the action to
+    /// a chosen player by carrying a player `TargetFilter` here; the resolver maps
+    /// it through `resolve_player_for_context_ref` and scopes eligible creatures
+    /// to that player.
     BlightEffect {
         count: u32,
+        #[serde(
+            default = "default_target_filter_controller",
+            skip_serializing_if = "is_target_filter_controller"
+        )]
+        player: TargetFilter,
     },
     /// Alchemy digital-only: randomly pick card(s) from library matching filter,
     /// put to destination (default hand). No reveal, no shuffle, no player choice.
@@ -10638,7 +10666,15 @@ impl Effect {
             // CR 119.3: `GainLife.player` is a TargetFilter. `extract_target_filter_from_effect`
             // drops context-refs (Controller) via `.filter(|t| !t.is_context_ref())`, so the
             // default "you gain life" still surfaces no target slot.
-            | Effect::GainLife { player, .. } => Some(player),
+            | Effect::GainLife { player, .. }
+            // CR 701.57a: Discover's discovering player. CR 701.68a: Blight's
+            // blighting player. Both default to `TargetFilter::Controller` (a
+            // context ref), so bare "discover N" / "blight N" surface no target
+            // slot; "Target opponent blights N" surfaces the opponent as a real
+            // target via the same `is_context_ref()` filter the other player-axis
+            // effects use.
+            | Effect::Discover { player, .. }
+            | Effect::BlightEffect { player, .. } => Some(player),
 
             // CR 115.1a + CR 601.2c: "Create a [Role/Aura] token attached to
             // target creature" targets its host — surface `attach_to` as the
@@ -10768,7 +10804,6 @@ impl Effect {
             | Effect::ChooseFromZone { .. }
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::GainEnergy { .. }
-            | Effect::Discover { .. }
             | Effect::HeistExile
             | Effect::Cascade
             | Effect::Ripple { .. }
@@ -10817,10 +10852,6 @@ impl Effect {
             | Effect::Forage
             | Effect::CollectEvidence { .. }
             | Effect::Endure { .. }
-            // CR 701.68a: BlightEffect is a non-targeted controller choice — no
-            // targeting slot. The chosen creature is picked at resolution time
-            // via WaitingFor::EffectZoneChoice, not declared as a target.
-            | Effect::BlightEffect { .. }
             | Effect::ExploreAll { .. }
             | Effect::Seek { .. }
             | Effect::SetDayNight { .. }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

BATCH 11 (discover/blight, Standard singleton batch) — parameterizes the existing `Effect::Discover` and `Effect::BlightEffect` variants so the discover/blight action can be performed by a player **other than the controller**, unlocking two cards whose action is redirected to a chosen/derived player.

- **Champion of the Weird** — `Pay 1 life, Blight 2: Target opponent blights 2.` The targeted opponent (not the controller) puts the -1/-1 counters on a creature **they** control. CR 701.68a/b.
- **Zoyowa's Justice** — `... shuffles it into their library. Then that player discovers X, where X is its mana value.` The parent target's owner exiles from **their** library; X is the parent target's mana value. CR 701.57a.

No new enum variant: the redirect is a leaf-level parameterization of the existing player axis (a `player: TargetFilter` field, default `Controller`, skip-serialized so existing JSON deserializes unchanged), mirroring `Effect::GainLife { player: TargetFilter, .. }`. The resolvers route the player axis through the single-authority `resolve_player_for_context_ref` helper; `target_filter()` surfaces the redirect as a real target slot only when the filter is not a context ref (the controller default surfaces no slot — verified through `extract_target_filter_from_effect`'s `is_context_ref()` guard).

## add-engine-variant verdict: APPROVED (parameterization, no new sibling)

- **Stage 1 (existence):** `Effect::Discover` / `Effect::BlightEffect` already exist. The "different player performs the action" concept is `EXISTS_AS_PARAMETER` territory — the player axis already exists on `GainLife`, `Dig`, `ExileTop`, `ExileFromTopUntil`, etc. as a `player: TargetFilter` field.
- **Stage 2 (parameterization filter):** A `DiscoverByPlayer` / `BlightByTargetOpponent` sibling would be a sibling-cluster smell. The chosen `player: TargetFilter` parameter is exactly the prescribed parameterized form (`LifeTotal { player: PlayerScope }`-class). REFACTOR already done correctly — `EXTEND_OK` via parameter.
- **Stage 3 (categorical boundary):** The `player` axis is `TargetFilter` — the exact layer the skill says cross-subject player references belong at. Discover (CR 701.57a) and Blight (CR 701.68a) each stay within their own rule section. `WITHIN_SECTION`.
- `default_target_filter_controller` / `is_target_filter_controller` already exist and are used 30× in `ability.rs` — established convention.
- `data/engine-inventory.json`: no churn.

## Grep-verified CR annotations

- `CR 701.57a` — `grep -n "^701.57" docs/MagicCompRules.txt` → "Discover N ... Exile cards from the top of **your** library ...". Confirms the controller-perspective default and the redirected-library reading.
- `CR 701.68a` — `grep -n "^701.68" docs/MagicCompRules.txt` → "To 'blight N' means to put N -1/-1 counters on a creature **you** control." 701.68b confirms "if a player is given the choice to blight" (the redirected player). 701.68c "blighted creature" = the object the instructed player chose.

CR-annotation diff gate vs `upstream/main`: zero `UNVERIFIED`.

## Per-card verdict

| Card | Verdict | Notes |
|---|---|---|
| Champion of the Weird | **SHIP** | `BlightEffect { count: 2, player: Typed{controller: Opponent} }`; full oracle parses 0-Unimplemented, behold-Goblin additional cost + LTB Bounce trigger all parse. |
| Zoyowa's Justice | **SHIP** | chained `ChangeZone → Shuffle{ParentTargetOwner} → Discover{ ObjectManaValue(Recipient), player: ParentTargetOwner }`; 0-Unimplemented. |
| Curator of Sun's Creation | **HONEST-DEFER** | `Effect::unimplemented("discover", "discover again for the same value")` — needs a "whenever you discover" trigger + re-trigger-with-captured-value seam. |
| Rottenmouth Viper | **HONEST-DEFER** | `Effect::unimplemented("for", "for each blight counter on it")` — for-each-counter iterated loss is the separate LT for-each cluster seam. |

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| Target opponent blights — opponent prompted, opponent's creatures eligible, counters land on opponent's chosen creature | `blight::resolve` `player` → `resolve_player_for_context_ref` + opponent-scoped eligibility | `resolve()` → `WaitingFor::EffectZoneChoice` → `apply(SelectCards)` | `effects::blight::tests::blight_redirects_to_targeted_opponent` | `EffectZoneChoice.player == opponent` and `cards == [theirs]` and counters land on `theirs`, none on `mine` (reverting to `ability.controller` → prompt PlayerId(0), assertion flips — verified by reverting) | controller-default scoping covered by existing `blight_eligibility_is_controller_scoped`, `blight_n_places_n_counters`, no-creatures no-op, hexproof, replacement-aware |
| That player discovers — redirected player's library scanned, offer addressed to redirected player | `discover::resolve` `player` → `resolve_player_for_context_ref`; library + `CastOffer.player` use `discovering_player` | `resolve()` → `WaitingFor::CastOffer` | `effects::discover::tests::discover_redirects_to_other_player_library` | `CastOffer.player == opponent` and `hit_card` is opponent's library card (reverting → controller's empty library → no CastOffer/Priority, assertion flips — verified by reverting) | controller-default discover covered by existing `test_discover_finds_nonland_card`, dynamic-MV `discover_limit_can_use_triggering_spell_mana_value` |
| Parser: "Target opponent blights N" carries Opponent player | `parse_blight_with_player` | `parse_effect_chain` → `BlightEffect` | `parser::oracle_effect::tests::blight_target_opponent_carries_opponent_player` | `player` is `Typed{controller: Opponent}`, count 2 | (shape test, supports runtime test above) |
| Parser: "that player discovers X" binds ParentTargetOwner + dynamic MV | `parse_discover_with_player` | `parse_effect_chain` → chained `Discover` | `parser::oracle_effect::tests::discover_that_player_binds_parent_target_owner` | `player == ParentTargetOwner`, limit is `ObjectManaValue` | (shape test, supports runtime test above) |

Both runtime redirect tests were confirmed discriminating: with the `player` plumbing reverted to `ability.controller`, `blight_redirects_to_targeted_opponent` fails (`PlayerId(0)` vs `PlayerId(1)`) and `discover_redirects_to_other_player_library` fails (`Priority { player: PlayerId(0) }`, no CastOffer). No production-reachable arm is left covered only by a degenerate fixture: the redirect tests use a real opponent `Player` target and a separately-owned creature/library so the controller path and the redirect path produce different observable states.

The stale existing assertion `Effect::BlightEffect{..}.target_filter().is_none()` (in `blight_succeeds_against_hexproof_creature`) was updated to the true post-parameterization invariant: `extract_target_filter_from_effect(&BlightEffect{ player: Controller }).is_none()` — the function that actually governs whether a target slot is declared.

## Gates

- `cargo fmt --all` — clean.
- `scripts/check-parser-combinators.sh` — exit 0 (pre- and post-rebase).
- Inline parser diff gate (contains/starts_with/find/split/... in added parser lines) — no output (pass).
- `scripts/check-engine-authorities.sh upstream/main` — exit 0 (pre- and post-rebase).
- `cargo check --workspace --all-targets` — exit 0 (post-rebase).
- `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings` — exit 0 (post-rebase, 0 warnings).
- `cargo test -p engine` — 12960+ pass; only `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` flaky under parallelism (passes in isolation — known parallel-flaky, ignored per batch spec).
- CR-annotation diff gate — zero `UNVERIFIED`.
- `data/engine-inventory.json` — no churn.

Rebased cleanly onto `upstream/main` (`0e2200cc5`) with no conflicts; all gates re-run green post-rebase.
