### PR TITLE
feat(engine): mana-spend restriction for unlock-door special action (Smoky Lounge)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -10637,9 +10637,53 @@ pub(super) fn pay_effect_mana_cost(
     cost: &crate::types::mana::ManaCost,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
+    pay_non_cast_mana_cost(
+        state,
+        player,
+        source_id,
+        cost,
+        PaymentContext::Effect,
+        events,
+    )
+}
+
+/// CR 116.2m + CR 709.5e: Pay a special action's mana cost (e.g. a Room's unlock
+/// cost) through a `PaymentContext::SpecialAction`, so CR 106.6 special-action
+/// spend restrictions (Smoky Lounge's "spend this mana only to … unlock doors")
+/// gate which restricted mana is eligible. Routes through the same single
+/// authority as effect-time payments, differing only in the payment context.
+pub(super) fn pay_special_action_mana_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    action: crate::types::mana::SpecialAction,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
+    pay_non_cast_mana_cost(
+        state,
+        player,
+        source_id,
+        cost,
+        PaymentContext::SpecialAction(action),
+        events,
+    )
+}
+
+/// CR 106.6: Single-authority core for non-cast, non-activation mana payments
+/// (effect-resolution costs and special-action costs). Auto-taps sources,
+/// validates affordability, and executes the spend with the given payment
+/// context so restriction gating routes through the correct rules category.
+fn pay_non_cast_mana_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    ctx: PaymentContext<'_>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
-    let effect_ctx = PaymentContext::Effect;
     let events_before = events.len();
     super::casting_costs::auto_tap_mana_sources_with_context(
         state,
@@ -10647,7 +10691,7 @@ pub(super) fn pay_effect_mana_cost(
         cost,
         events,
         Some(source_id),
-        Some(&effect_ctx),
+        Some(&ctx),
     );
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline
     // so their bonus mana is in the pool before the affordability check.
@@ -10663,12 +10707,7 @@ pub(super) fn pay_effect_mana_cost(
             .iter()
             .find(|p| p.id == player)
             .expect("player exists");
-        if !mana_payment::can_pay_for_spell(
-            &player_data.mana_pool,
-            cost,
-            Some(&effect_ctx),
-            permissions,
-        ) {
+        if !mana_payment::can_pay_for_spell(&player_data.mana_pool, cost, Some(&ctx), permissions) {
             return Err(EngineError::ActionNotAllowed(
                 "Cannot pay mana cost".to_string(),
             ));
@@ -10684,7 +10723,7 @@ pub(super) fn pay_effect_mana_cost(
         &mut player_data.mana_pool,
         cost,
         None,
-        Some(&effect_ctx),
+        Some(&ctx),
         permissions.any_color,
         None,
         permissions.life_colors,

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -317,6 +317,12 @@ pub(crate) fn resolve_restrictions(
             ManaSpendRestriction::SpellFromZone(zs) => {
                 Some(ManaRestriction::OnlyForSpellFromZone(*zs))
             }
+            // CR 106.6 + CR 116.2m + CR 709.5e: Lower the door-unlock special-action
+            // leaf into the runtime gate checked by `allows_special_action` when a
+            // Room's unlock cost is paid through `PaymentContext::SpecialAction`.
+            ManaSpendRestriction::UnlockDoor => Some(ManaRestriction::OnlyForSpecialAction(
+                crate::types::mana::SpecialAction::UnlockDoor,
+            )),
             // CR 106.6: Disjunction — recursively lower each branch. If every branch
             // dropped (e.g. an unresolvable `ChosenCreatureType` with no chosen type),
             // the disjunction has no payable cases, so drop it too.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -128,7 +128,18 @@ fn handle_unlock_room_door(
         }
     };
 
-    casting::pay_unless_cost(state, player, &cost, events)?;
+    // CR 116.2m + CR 709.5e + CR 106.6: The unlock cost is a special action's
+    // mana cost. Route payment through `PaymentContext::SpecialAction(UnlockDoor)`
+    // so spend-restricted mana ("only to … unlock doors", Smoky Lounge) is
+    // eligible here and spell/activation-restricted mana is correctly rejected.
+    casting::pay_special_action_mana_cost(
+        state,
+        player,
+        object_id,
+        &cost,
+        crate::types::mana::SpecialAction::UnlockDoor,
+        events,
+    )?;
 
     super::room::unlock_door_designation(state, object_id, player, door, events);
     Ok(WaitingFor::Priority { player })
@@ -8180,6 +8191,121 @@ mod tests {
                 ..
             } if *object_id == room
         )));
+    }
+
+    /// CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge produces {R}{R} restricted
+    /// to "cast Room spells and unlock doors". The door-unlock half lowers to
+    /// `OnlyForSpecialAction(UnlockDoor)`; paying a Room's unlock cost routes
+    /// through `PaymentContext::SpecialAction(UnlockDoor)`, so the restricted {R}
+    /// IS eligible. Before this fix the unlock cost paid via
+    /// `PaymentContext::Effect`, which rejects every restriction — the restricted
+    /// {R} could not pay and the unlock failed. Reverting the
+    /// `pay_special_action_mana_cost` wiring flips this assertion (the unlock
+    /// would error "Cannot pay mana cost").
+    #[test]
+    fn unlock_door_restricted_mana_pays_room_unlock_cost() {
+        use crate::types::mana::{ManaRestriction, ManaType, ManaUnit, SpecialAction};
+
+        let mut state = setup_game_at_main_phase();
+        let room = create_object(
+            &mut state,
+            CardId(901),
+            PlayerId(0),
+            "Bottomless Pool".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&room).unwrap();
+            obj.card_types.subtypes.push("Room".to_string());
+            obj.room_unlocks = Some(Default::default());
+            // CR 709.5e: left door's unlock cost is the object's mana cost ({R}).
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![crate::types::mana::ManaCostShard::Red],
+                generic: 0,
+            };
+        }
+
+        // Smoky Lounge's restricted {R}: only for casting Room spells OR unlocking
+        // doors. Mirrors the lowering of `ManaSpendRestriction::Any([SpellType,
+        // UnlockDoor])`.
+        let restriction = ManaRestriction::OnlyForAny(vec![
+            ManaRestriction::OnlyForSpellType("Room".to_string()),
+            ManaRestriction::OnlyForSpecialAction(SpecialAction::UnlockDoor),
+        ]);
+        {
+            let player = state
+                .players
+                .iter_mut()
+                .find(|p| p.id == PlayerId(0))
+                .unwrap();
+            player
+                .mana_pool
+                .add(ManaUnit::new(ManaType::Red, room, false, vec![restriction]));
+        }
+
+        let result = apply_as_current(
+            &mut state,
+            GameAction::UnlockRoomDoor {
+                object_id: room,
+                door: RoomDoor::Left,
+            },
+        )
+        .expect("restricted mana must be able to pay a door's unlock cost");
+
+        let room_obj = state.objects.get(&room).unwrap();
+        assert!(
+            room_obj.room_unlocks.unwrap().left_unlocked,
+            "the door must be unlocked after paying its cost with door-restricted mana"
+        );
+        assert!(result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::RoomDoorUnlocked { object_id, door: RoomDoor::Left, .. } if *object_id == room
+        )));
+        // The restricted {R} was consumed paying the unlock cost.
+        let pool_left = state
+            .players
+            .iter()
+            .find(|p| p.id == PlayerId(0))
+            .unwrap()
+            .mana_pool
+            .mana
+            .len();
+        assert_eq!(
+            pool_left, 0,
+            "the restricted mana must be spent on the unlock"
+        );
+    }
+
+    /// CR 106.6 + CR 116.2m: Door-restricted mana is rejected for unrelated
+    /// payments. The unlock cost is the ONLY thing this {R} can pay (besides Room
+    /// spell casts) — a generic effect cost must not draw on it. Reverting the
+    /// `OnlyForSpecialAction` gate (e.g. making it `true` for `Effect`) flips this.
+    #[test]
+    fn unlock_door_restricted_mana_rejected_for_effect_and_spell_payments() {
+        use crate::types::mana::{
+            ManaRestriction, ManaType, PaymentContext, SpecialAction, SpellMeta,
+        };
+
+        let restriction = ManaRestriction::OnlyForSpecialAction(SpecialAction::UnlockDoor);
+
+        // Accepts the matching special action.
+        assert!(restriction.allows(&PaymentContext::SpecialAction(SpecialAction::UnlockDoor)));
+        // Rejects generic effect-resolution payments (the pre-fix unlock path).
+        assert!(!restriction.allows(&PaymentContext::Effect));
+        // Rejects a Room spell cast (this leaf is the door half only).
+        let room_spell = SpellMeta {
+            types: vec!["Enchantment".to_string()],
+            subtypes: vec!["Room".to_string()],
+            ..SpellMeta::default()
+        };
+        assert!(!restriction.allows(&PaymentContext::Spell(&room_spell)));
+        // Rejects ability activation.
+        assert!(!restriction.allows(&PaymentContext::Activation {
+            source_types: &["Artifact".to_string()],
+            source_subtypes: &["Equipment".to_string()],
+            ability_tag: None,
+        }));
+        let _ = ManaType::Red;
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -10181,6 +10181,48 @@ mod tests {
         );
     }
 
+    /// CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge — the triggered "add
+    /// {R}{R}. Spend this mana only to cast Room spells and unlock doors" line
+    /// lowers the heterogeneous " and " disjunction to
+    /// `Any([SpellType("Room"), UnlockDoor])`, attached to the produced mana.
+    /// The whole card parses with no `Effect::Unimplemented` anywhere.
+    #[test]
+    fn smoky_lounge_full_mana_line_no_unimplemented() {
+        let r = parse(
+            "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
+            "Smoky Lounge",
+            &[],
+            &["Enchantment"],
+            &["Room"],
+        );
+        assert_eq!(r.triggers.len(), 1, "triggers: {:?}", r.triggers);
+        let exec = r.triggers[0]
+            .execute
+            .as_ref()
+            .expect("trigger has an execute ability");
+        let Effect::Mana { restrictions, .. } = &*exec.effect else {
+            panic!("expected Effect::Mana, got {:?}", exec.effect);
+        };
+        assert_eq!(
+            restrictions,
+            &vec![ManaSpendRestriction::Any(vec![
+                ManaSpendRestriction::SpellType("Room".to_string()),
+                ManaSpendRestriction::UnlockDoor,
+            ])]
+        );
+        // The mana effect itself parsed (not a swallowed Unimplemented), and the
+        // restriction sentence was consumed rather than left as a stray gap.
+        assert!(
+            !matches!(*exec.effect, Effect::Unimplemented { .. }),
+            "Smoky Lounge mana effect must not be Unimplemented"
+        );
+        assert!(
+            exec.sub_ability.is_none(),
+            "the restriction sentence must be folded into the mana effect, not a stray chained effect: {:?}",
+            exec.sub_ability
+        );
+    }
+
     /// CR 106.6 + CR 205.3m + CR 903.3: Path of Ancestry — the passive-voice
     /// "When that mana is spent to cast a creature spell that shares a creature
     /// type with your commander, scry 1" clause folds into the

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1599,9 +1599,37 @@ fn parse_single_cast_clause(rest: &str) -> Option<ManaSpendRestriction> {
 ///
 /// Returns `None` for any clause that does not independently parse — the caller
 /// then drops the whole disjunction rather than guessing.
+/// CR 106.6 + CR 116.2m + CR 709.5e: Recognize the non-cast "unlock [a ]door[s]"
+/// special-action clause of a disjunctive spend restriction (Smoky Lounge: "cast
+/// Room spells and unlock doors"). Tolerates an optional leading "to " (the
+/// split may leave "to unlock ..." on a trailing clause) and the
+/// singular/plural article forms. Returns the `UnlockDoor` leaf, which lowers to
+/// the door-unlock special-action runtime gate. Pure combinator — no string
+/// dispatch.
+fn parse_unlock_door_clause(clause: &str, clause_lower: &str) -> Option<ManaSpendRestriction> {
+    nom_on_lower(clause, clause_lower, |i| {
+        let (i, _) = opt(tag("to ")).parse(i)?;
+        let (i, _) = tag("unlock ").parse(i)?;
+        let (i, _) = opt(alt((tag("a "), tag("an ")))).parse(i)?;
+        value(
+            ManaSpendRestriction::UnlockDoor,
+            all_consuming(alt((tag("doors"), tag("door")))),
+        )
+        .parse(i)
+    })
+    .map(|(restriction, _)| restriction)
+}
+
 fn parse_disjunctive_clause(clause: &str) -> Option<ManaSpendRestriction> {
     let clause = clause.trim();
     let clause_lower = clause.to_lowercase();
+
+    // CR 116.2m + CR 709.5e: Non-cast door-unlock special-action clause — tried
+    // before the cast/activate arms so "unlock doors" isn't mistaken for a cast
+    // clause (it has no " spell" terminator and would otherwise fail to parse).
+    if let Some(restriction) = parse_unlock_door_clause(clause, &clause_lower) {
+        return Some(restriction);
+    }
 
     // ACTIVATE clause: "to activate an ability of an X source" / "activate an
     // equip ability" / "to activate an ability". Reuse the existing activation
@@ -1658,7 +1686,19 @@ fn parse_disjunctive_clause(clause: &str) -> Option<ManaSpendRestriction> {
 /// parser-combinator mandate, rather than `str::split`.
 fn parse_one_disjunction_clause(input: &str) -> OracleResult<'_, &str> {
     recognize(many1(preceded(
-        not(alt((tag(", or "), tag(", "), tag(" or ")))),
+        // CR 106.6: " or ", " and ", and the Oxford-comma forms each separate
+        // distinct acceptable actions in a spend restriction. " and " joins
+        // heterogeneous spend clauses too (Smoky Lounge: "cast Room spells and
+        // unlock doors") — a same-clause type union ("instant and sorcery
+        // spells") never reaches this splitter because the caller tries the
+        // whole remainder as a single clause first.
+        not(alt((
+            tag(", or "),
+            tag(", and "),
+            tag(", "),
+            tag(" or "),
+            tag(" and "),
+        ))),
         anychar,
     )))
     .parse(input)
@@ -1666,13 +1706,20 @@ fn parse_one_disjunction_clause(input: &str) -> OracleResult<'_, &str> {
 
 fn parse_disjunctive_cast_clauses(rest: &str) -> Option<ManaSpendRestriction> {
     // CR 106.6: Split the remainder into top-level disjunction clauses with a nom
-    // separated list — delimiters are " or " and the Oxford-comma forms (", " /
-    // ", or "). Longest delimiter first so ", or " wins over its ", " prefix.
-    // Each clause is the run of input up to the next delimiter; a type union
-    // inside one clause ("instant or sorcery spells") never reaches here because
-    // the caller tries the whole remainder as a single clause first.
+    // separated list — delimiters are " or ", " and ", and the Oxford-comma forms
+    // (", " / ", or " / ", and "). Longest delimiter first so ", or "/", and "
+    // win over their ", " prefix. Each clause is the run of input up to the next
+    // delimiter; a type union inside one clause ("instant or sorcery spells",
+    // "instant and sorcery spells") never reaches here because the caller tries
+    // the whole remainder as a single clause first.
     let (_, fragments) = all_consuming(separated_list1(
-        alt((tag(", or "), tag(", "), tag(" or "))),
+        alt((
+            tag(", or "),
+            tag(", and "),
+            tag(", "),
+            tag(" or "),
+            tag(" and "),
+        )),
         parse_one_disjunction_clause,
     ))
     .parse(rest)
@@ -3433,6 +3480,96 @@ mod tests {
                 zone: Zone::Graveyard,
                 polarity: ZoneSpendPolarity::From,
             }))
+        );
+    }
+
+    // CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge — "cast Room spells and
+    // unlock doors" is a heterogeneous disjunction joined by " and ". It lowers
+    // to `Any([SpellType("Room"), UnlockDoor])`: the door-unlock leaf is a
+    // non-cast special-action restriction sitting alongside a cast clause.
+    #[test]
+    fn mana_spend_restriction_smoky_lounge_room_or_unlock_doors() {
+        let result = parse_mana_spend_restriction(
+            "spend this mana only to cast room spells and unlock doors",
+        );
+        assert_eq!(
+            result.map(|(r, _)| r),
+            Some(ManaSpendRestriction::Any(vec![
+                ManaSpendRestriction::SpellType("Room".to_string()),
+                ManaSpendRestriction::UnlockDoor,
+            ]))
+        );
+    }
+
+    // The door-unlock clause parses with the singular article form too, and on
+    // either side of the connective, so the leaf is order-independent.
+    #[test]
+    fn mana_spend_restriction_unlock_a_door_singular_clause() {
+        let result = parse_mana_spend_restriction(
+            "spend this mana only to cast room spells or unlock a door",
+        );
+        assert_eq!(
+            result.map(|(r, _)| r),
+            Some(ManaSpendRestriction::Any(vec![
+                ManaSpendRestriction::SpellType("Room".to_string()),
+                ManaSpendRestriction::UnlockDoor,
+            ]))
+        );
+    }
+
+    // GUARD: a same-clause type union ("instant and sorcery spells") must still
+    // read as a single `SpellType`, never split by the new " and " delimiter.
+    // The whole-remainder single-clause path consumes it before the splitter.
+    #[test]
+    fn mana_spend_restriction_instant_and_sorcery_stays_single_type() {
+        let result =
+            parse_mana_spend_restriction("spend this mana only to cast instant and sorcery spells");
+        assert_eq!(
+            result.map(|(r, _)| r),
+            Some(ManaSpendRestriction::SpellType(
+                "Instant and Sorcery".to_string()
+            ))
+        );
+    }
+
+    // HONEST-DEFER GUARD: the four batch-7 members whose disjunction contains a
+    // non-cast leaf with no restriction-aware payment seam (turn-face-up,
+    // activate-equip) must NOT produce a partial `Any` that silently drops the
+    // unenforceable leaf — a partial disjunction would over-restrict the mana
+    // (it could no longer pay the legal non-cast action). They stay an honest
+    // gap (None) until the underlying special-action payment seams exist.
+    #[test]
+    fn mana_spend_restriction_unenforceable_noncast_leaves_stay_gap() {
+        // Creeping Peeper: enchantment-spell, unlock-door, turn-face-up. The
+        // turn-face-up leaf is unenforceable, so the whole thing is deferred.
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up",
+            )
+            .map(|(r, _)| r),
+            None,
+        );
+        // Freya Crescent: Equipment-spell or activate-an-equip-ability.
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast an equipment spell or activate an equip ability",
+            )
+            .map(|(r, _)| r),
+            None,
+        );
+        // Tin Street Gossip: face-down spells or turn creatures face up.
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast face-down spells or to turn creatures face up",
+            )
+            .map(|(r, _)| r),
+            None,
+        );
+        // Overgrown Zealot: pure turn-permanents-face-up (no cast clause at all).
+        assert_eq!(
+            parse_mana_spend_restriction("spend this mana only to turn permanents face up")
+                .map(|(r, _)| r),
+            None,
         );
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1528,6 +1528,14 @@ pub enum ManaSpendRestriction {
     /// accepts the legacy bare-`Zone` serialized form for backward compatibility,
     /// mapping it to the inclusion reading.
     SpellFromZone(ZoneSpend),
+    /// CR 106.6 + CR 116.2m + CR 709.5e: "Spend this mana only to unlock
+    /// [a ]door[s]" — the special-action half of a spend restriction. A leaf of
+    /// the [`ManaSpendRestriction::Any`] disjunction (Smoky Lounge: "cast Room
+    /// spells and unlock doors"). Lowered to
+    /// [`ManaRestriction::OnlyForSpecialAction(SpecialAction::UnlockDoor)`](super::mana::ManaRestriction::OnlyForSpecialAction),
+    /// enforced when a Room's CR 709.5e unlock cost is paid through
+    /// [`PaymentContext::SpecialAction`](super::mana::PaymentContext::SpecialAction).
+    UnlockDoor,
     /// CR 106.6: Disjunction of spend restrictions ("cast X or Y or activate Z").
     /// Lowered to `ManaRestriction::OnlyForAny`.
     Any(Vec<ManaSpendRestriction>),

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -285,6 +285,33 @@ pub enum PaymentContext<'a> {
     /// restriction variants name spell-casting or ability-activation use, so
     /// restricted mana is not eligible here.
     Effect,
+    /// CR 116.2: Payment for a special action's mana cost (e.g. a Room's
+    /// unlock cost, CR 116.2m / CR 709.5e). Special actions don't use the stack
+    /// and are neither spell casts nor ability activations, so they need a
+    /// distinct context: spell/activation-restricted mana must reject them, but
+    /// special-action-restricted mana (`OnlyForSpecialAction`) must accept the
+    /// matching action class. Parameterized over [`SpecialAction`] so one
+    /// context variant covers every restrictable special-action class rather
+    /// than a sibling per action.
+    SpecialAction(SpecialAction),
+}
+
+/// CR 116.2: A class of special action whose mana cost can be the subject of a
+/// CR 106.6 mana-spend restriction ("Spend this mana only to unlock doors").
+///
+/// Only special actions that pay a mana cost *through the mana pool* with a
+/// restriction-aware payment context belong here. CR 116.2m / CR 709.5e door
+/// unlock is the first such action (its unlock cost routes through
+/// `pay_special_action_mana_cost`). CR 116.2b turn-face-up does not yet pay its
+/// morph/disguise cost through a restriction-aware pool payment, so it is
+/// intentionally absent — its spend restriction is honest-deferred rather than
+/// silently over-permitted. New variants are added only once the corresponding
+/// special action's payment is routed through `PaymentContext::SpecialAction`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpecialAction {
+    /// CR 116.2m + CR 709.5e: Paying a locked Room half's unlock cost to give
+    /// the permanent the appropriate unlocked designation.
+    UnlockDoor,
 }
 
 /// CR 106.6: The ability-activation half of a "spend only to cast [X] spell or
@@ -477,6 +504,13 @@ pub enum ManaRestriction {
     /// "… to cast an Assassin spell, a spell that has freerunning, or to activate
     /// an ability of an Assassin source."
     OnlyForAny(Vec<ManaRestriction>),
+    /// CR 106.6 + CR 116.2: "Spend this mana only to [unlock doors]" — the
+    /// special-action half of a spend restriction. Payable only for a
+    /// [`PaymentContext::SpecialAction`] whose [`SpecialAction`] matches.
+    /// Rejects spell casts, ability activations, and generic effect payments.
+    /// Parameterized over the action class so one variant covers every
+    /// restrictable special action (door unlock today; extensible).
+    OnlyForSpecialAction(SpecialAction),
     /// CR 702.51a: Internal marker for a convoke tap that substitutes for
     /// paying mana. The payment algorithm may consume it for the current spell,
     /// but cast-spent metrics and mana-added triggers must ignore it.
@@ -611,6 +645,8 @@ impl ManaRestriction {
             },
             // CR 106.6: Disjunction — the spell is payable if it satisfies any branch.
             ManaRestriction::OnlyForAny(subs) => subs.iter().any(|r| r.allows_spell(meta)),
+            // CR 116.2: Special-action-only mana never pays for a spell cast.
+            ManaRestriction::OnlyForSpecialAction(_) => false,
             ManaRestriction::ConvokePayment => true,
         }
     }
@@ -636,7 +672,9 @@ impl ManaRestriction {
             | ManaRestriction::OnlyForSpellWithManaValue { .. }
             | ManaRestriction::OnlyForSpellMatchingCostCriteria { .. }
             | ManaRestriction::OnlyForSpellWithColorCount { .. }
-            | ManaRestriction::OnlyForSpellFromZone(_) => false,
+            | ManaRestriction::OnlyForSpellFromZone(_)
+            // CR 116.2: Special-action-only mana never pays for ability activation.
+            | ManaRestriction::OnlyForSpecialAction(_) => false,
             // CR 106.6: The ability-activation half of the OR. `OfSpellType`
             // restricts to abilities of permanents whose type matches the
             // restriction ("Elemental sources" includes creature type Elemental —
@@ -681,6 +719,26 @@ impl ManaRestriction {
                 ability_tag,
             } => self.allows_activation(source_types, source_subtypes, *ability_tag),
             PaymentContext::Effect => false,
+            // CR 116.2: A special-action payment is permitted only by mana that
+            // is restricted to that exact special-action class, or by a
+            // disjunction that contains such a branch. Spell/activation/generic
+            // effect restrictions all reject it.
+            PaymentContext::SpecialAction(action) => self.allows_special_action(*action),
+        }
+    }
+
+    /// CR 106.6 + CR 116.2: Returns `true` if this restriction permits spending
+    /// mana on the given special action (e.g. a Room door unlock). Only
+    /// [`ManaRestriction::OnlyForSpecialAction`] with a matching action — or a
+    /// disjunction containing one — qualifies; every spell/activation/effect
+    /// restriction rejects special actions.
+    pub fn allows_special_action(&self, action: SpecialAction) -> bool {
+        match self {
+            ManaRestriction::OnlyForSpecialAction(allowed) => *allowed == action,
+            ManaRestriction::OnlyForAny(subs) => {
+                subs.iter().any(|r| r.allows_special_action(action))
+            }
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## fix(parser): ManaSpendRestriction door-unlock leaf → `Any(...)` disjunction (Smoky Lounge)

### Summary

Batch 7 of the std-188 effort targeted five cards whose `Spend this mana only to …` line mixes a cast clause with one or more **non-cast action** clauses, all of which should lower to `ManaSpendRestriction::Any([...])`. Investigation of the runtime payment model determined that only **one** of the four non-cast action classes has a restriction-aware mana-payment seam in the engine today:

| Non-cast action | CR | Pays mana through a restriction-aware `PaymentContext`? |
|---|---|---|
| Unlock a Room door | 116.2m / 709.5e | **Yes** — `handle_unlock_room_door` → `pay_unless_cost` (was `PaymentContext::Effect`) |
| Turn a permanent face up | 116.2b | No — `GameAction::TurnFaceUp` flips the object; morph/disguise cost is not a pool payment with a context |
| Activate an equip ability | 702.6a | No — `GameAction::Equip` pushes a keyword action; the equip cost is not a pool payment with a context |
| Cast face-down spell | — | Yes (the *cast* half only; `PaymentContext::Spell`) |

This PR builds the **door-unlock** leaf class end-to-end (parser → type → lowering → runtime enforcement) and ships **Smoky Lounge** (`cast Room spells and unlock doors` — both leaves enforceable). The four cards whose disjunction contains a turn-face-up or activate-equip leaf are **honest-deferred**: a partial `Any` that silently drops the unenforceable leaf would *over-restrict* the mana (it could no longer pay the legal non-cast action the card explicitly permits), which is a rules error worse than an honest gap. Those four are pinned by a guard test asserting they stay an unparsed gap (`None`) — not a misleading partial disjunction — until the underlying special-action payment seams exist.

### What changed

- **Type — `ManaSpendRestriction::UnlockDoor`** (`types/ability.rs`): a non-cast leaf of the existing `Any` disjunction.
- **Type — `PaymentContext::SpecialAction(SpecialAction)`** + `SpecialAction` enum (`types/mana.rs`): a CR 116.2-grounded payment context parameterized by special-action class (`UnlockDoor` today; extensible). `SpecialAction` deliberately omits turn-face-up / equip because those actions don't yet pay through a restriction-aware pool payment — adding them would require silently over-permitting.
- **Runtime — `ManaRestriction::OnlyForSpecialAction(SpecialAction)`** + `allows_special_action` (`types/mana.rs`): the runtime gate. Rejects spell casts, ability activations, and generic effect payments; accepts only the matching `SpecialAction` (and composes through `OnlyForAny`).
- **Lowering** (`game/effects/mana.rs`): `UnlockDoor` → `OnlyForSpecialAction(UnlockDoor)`.
- **Payment wiring** (`game/casting.rs`, `game/engine.rs`): refactored `pay_effect_mana_cost` to delegate to a context-parameterized single-authority core `pay_non_cast_mana_cost`; added `pay_special_action_mana_cost`. `handle_unlock_room_door` now pays the CR 709.5e unlock cost through `PaymentContext::SpecialAction(UnlockDoor)` (was `PaymentContext::Effect`, which rejected every restriction).
- **Parser** (`parser/oracle_effect/mana.rs`): added a `parse_unlock_door_clause` combinator (`unlock [a ]door[s]`, optional leading `to `) tried before the cast/activate arms; added ` and ` / `, and ` to the disjunction delimiter set (CR 106.6: " or " and " and " both enumerate distinct acceptable spend actions). The whole-remainder single-clause path runs first, so a same-clause type union (`instant and sorcery spells`) still reads as one `SpellType`.

### add-engine-variant gate — APPROVE (parameterization, not proliferation)

- **Stage 1 (existence/sibling-smell):** `ManaSpendRestriction::Any` already exists; `UnlockDoor` is a *leaf* of that disjunction's existing axis. `PaymentContext` already enumerates the payment categories (Spell/Activation/Effect); `SpecialAction` is the missing CR-116 category, parameterized by action class rather than adding `PaymentContext::UnlockDoor` / `PaymentContext::FaceUp` siblings. No sibling-cluster smell introduced.
- **Stage 2 (categorical boundary):** the parameterization axis (`SpecialAction`) lies within a single CR section (CR 116.2 "special actions"). It does not conflate with spell casting (CR 601) or ability activation (CR 602) — those keep their own `PaymentContext` arms.
- **Stage 3 (verdict):** APPROVE. `ManaRestriction::OnlyForSpecialAction(SpecialAction)` is the runtime leaf; `SpecialAction` is the parameterized class so future restrictable special actions (turn-face-up, equip — once they gain pool payment) extend the enum, not the surface.

### grep-verified CR annotations

All verified against `docs/MagicCompRules.txt`:

- `CR 106.6` — spell/ability mana spend restrictions.
- `CR 116.2` — special actions (the twelve special actions).
- `CR 116.2b` — turn-face-up is a special action (cited in `SpecialAction` doc to explain its omission).
- `CR 116.2m` — paying a locked Room half's unlock cost is a special action.
- `CR 709.5e` — Room "unlock cost" definition.

CR-annotation diff gate: `0 UNVERIFIED`.

### Per-card verdict

| Card | Restriction line | Verdict | Reason |
|---|---|---|---|
| **Smoky Lounge** | cast Room spells **and** unlock doors | **SHIP** | both leaves enforceable (`SpellType("Room")` + `UnlockDoor`); 0-Unimplemented on the mana line |
| Creeping Peeper | enchantment spell, **unlock a door**, **or turn a permanent face up** | DEFER | turn-face-up leaf has no restriction-aware payment seam |
| Freya Crescent | Equipment spell **or activate an equip ability** | DEFER | equip-activation has no restriction-aware payment seam |
| Overgrown Zealot | **turn permanents face up** (pure) | DEFER | turn-face-up only; no payment seam |
| Tin Street Gossip | face-down spells **or turn creatures face up** | DEFER | turn-face-up leaf unenforceable; partial `Any` would over-restrict |

### Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| Door-restricted mana pays a Room unlock cost | `handle_unlock_room_door` → `pay_special_action_mana_cost` | `apply(GameAction::UnlockRoomDoor)` | `unlock_door_restricted_mana_pays_room_unlock_cost` | `.expect("restricted mana must be able to pay…")` — verified to flip to `ActionNotAllowed("Cannot pay mana cost")` when wiring reverted to `pay_unless_cost` | door-restricted mana rejected for Effect/Spell/Activation in `unlock_door_restricted_mana_rejected_for_effect_and_spell_payments` |
| Door-restricted mana never pays casts/activations/effects | `allows` / `allows_special_action` | `ManaRestriction::allows(ctx)` | `unlock_door_restricted_mana_rejected_for_effect_and_spell_payments` | the four `assert!(!… .allows(...))` lines flip if `OnlyForSpecialAction` returned `true` for the wrong context | positive `allows(SpecialAction(UnlockDoor))` |
| Smoky Lounge mana line lowers to `Any([Room, UnlockDoor])`, 0-Unimplemented | `parse_unlock_door_clause`, ` and ` delimiter | `parse_oracle_text` | `smoky_lounge_full_mana_line_no_unimplemented` | `restrictions == Any([SpellType("Room"), UnlockDoor])` + `!matches!(Unimplemented)` | parser unit tests below |
| Door clause parses (plural/singular, both orders) | `parse_unlock_door_clause` | `parse_mana_spend_restriction` | `mana_spend_restriction_smoky_lounge_room_or_unlock_doors`, `mana_spend_restriction_unlock_a_door_singular_clause` | exact `Any([...])` equality | — |
| ` and ` delimiter doesn't split same-clause type unions | disjunction splitter | `parse_mana_spend_restriction` | `mana_spend_restriction_instant_and_sorcery_stays_single_type` | `SpellType("Instant and Sorcery")` | — |
| The 4 deferred cards stay an honest gap (no partial `Any`) | full restriction parser | `parse_mana_spend_restriction` | `mana_spend_restriction_unenforceable_noncast_leaves_stay_gap` | each of 4 phrasings → `None` | guards against an over-restricting partial disjunction |

Every behavioral seam has a production-path test driving `apply()` (door payment) or `parse_oracle_text`/`parse_mana_spend_restriction` (parser). The runtime positive case was confirmed to fail on revert. No production-reachable arm is left covered only by a degenerate fixture (the room carries a real `{R}` unlock cost and the pool has exactly the restricted unit, so the spend genuinely exercises the special-action path).

### Honest-deferral statement

The four deferred cards remain `Effect::unimplemented` (unchanged red coverage) on their restriction line — this is honest, not a shape-only pass. The guard test `mana_spend_restriction_unenforceable_noncast_leaves_stay_gap` enforces that they do **not** regress into a misleading partial `Any`. Shipping turn-face-up / activate-equip leaves would require new `PaymentContext` variants plus routing pool payment with a context through `morph::turn_face_up` and equip activation (which bypass the pool today) — heavy cross-subsystem runtime infra, correctly deferred per the brief.

### Gate results

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- inline parser-diff string-dispatch gate — clean (no `contains`/`split`/etc. added in `parser/`)
- CR-annotation diff gate — 0 UNVERIFIED
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0 (covers `cargo check --workspace --all-targets`)
- `cargo test -p engine` — 12968 pass; only failure is the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation, single-threaded)
- `cargo coverage` / `cargo semantic-audit` — build clean; cannot run in worktree (no `data/card-data.json` per protocol). Verified instead via `parse_oracle_text` per-card tests (Smoky Lounge 0-Unimplemented; 4 deferred cards pinned as gaps).
- `data/engine-inventory.json` — not churned.

Branch: `card/std-mana-disjunct` (off upstream/main `0e2200cc5`).
