### PR TITLE
feat(parser): type-retention animation (Cavernous Maw)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4644,6 +4644,93 @@ mod tests {
         ));
     }
 
+    /// Cavernous Maw (std BATCH 12): the `{2}` animation turns the land into a
+    /// 3/3 Elemental creature while "It's still a Cave land" (CR 205.1b, CR 305.7)
+    /// retains the Land card type and Cave subtype. This drives the parsed
+    /// modification set through the real layer engine and asserts the composition
+    /// is runtime-sound: the animated permanent is a 3/3 Creature that is STILL a
+    /// Cave Land (CR 613.1d Layer 4 additive type/subtype ordering). The
+    /// animation's `RemoveAllSubtypes { Creature }` (CR 205.1a) wipes only the
+    /// creature-type set, so the Cave land subtype survives.
+    #[test]
+    fn cavernous_maw_animation_retains_cave_land_through_layers() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Cavernous Maw".to_string(),
+            Zone::Battlefield,
+        );
+        let ts = state.next_timestamp();
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Cave".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+        }
+
+        // The full `{2}` activated-ability animation as parsed: the
+        // "becomes a 3/3 Elemental creature" modifications followed by the
+        // "It's still a Cave land" retention re-assertions.
+        let animation = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![
+                ContinuousModification::SetPower { value: 3 },
+                ContinuousModification::SetToughness { value: 3 },
+                ContinuousModification::AddType {
+                    core_type: CoreType::Creature,
+                },
+                ContinuousModification::RemoveAllSubtypes {
+                    set: crate::types::card_type::SubtypeSet::Creature,
+                },
+                ContinuousModification::AddSubtype {
+                    subtype: "Elemental".to_string(),
+                },
+                // "It's still a Cave land" — the clause this batch unblocks.
+                ContinuousModification::AddType {
+                    core_type: CoreType::Land,
+                },
+                ContinuousModification::AddSubtype {
+                    subtype: "Cave".to_string(),
+                },
+            ]);
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            Arc::make_mut(&mut obj.base_static_definitions).push(animation.clone());
+            obj.static_definitions.push(animation);
+        }
+
+        evaluate_layers(&mut state);
+
+        let obj = &state.objects[&id];
+        assert_eq!(obj.power, Some(3), "animated to 3 power");
+        assert_eq!(obj.toughness, Some(3), "animated to 3 toughness");
+        assert!(
+            obj.card_types.core_types.contains(&CoreType::Creature),
+            "must be a creature, got {:?}",
+            obj.card_types.core_types
+        );
+        // CR 205.1b: "still a Cave land" — both the Land card type and the Cave
+        // land subtype must survive the animation.
+        assert!(
+            obj.card_types.core_types.contains(&CoreType::Land),
+            "must still be a Land, got {:?}",
+            obj.card_types.core_types
+        );
+        assert!(
+            obj.card_types.subtypes.iter().any(|s| s == "Cave"),
+            "must still be a Cave, got {:?}",
+            obj.card_types.subtypes
+        );
+        assert!(
+            obj.card_types.subtypes.iter().any(|s| s == "Elemental"),
+            "must gain the Elemental creature type, got {:?}",
+            obj.card_types.subtypes
+        );
+    }
+
     /// CR 613.4c + CR 704.5f: A runaway `+X/+X` chain (e.g. from a `ObjectCount`
     /// quantity resolving against an extremely large collection) must clamp at
     /// `i32::MAX` rather than wrapping to negative. If it wrapped, the creature's

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5689,6 +5689,71 @@ mod tests {
         parse_oracle_text(text, name, &keyword_names, &types, &subtypes)
     }
 
+    /// Cavernous Maw (std BATCH 12): the `{2}` activated ability animates the
+    /// land into a 3/3 Elemental creature, and the confirmatory "It's still a
+    /// Cave land" sentence (CR 205.1b, CR 305.7) must NOT remain
+    /// `Effect::Unimplemented`. The retention clause lowers to a `GenericEffect`
+    /// continuous modification that re-asserts the Land card type and Cave
+    /// subtype (additive, CR 613.1d). Revert-discriminating: if the
+    /// `try_parse_still_a_type` subtype-aware fix is reverted, the sub_ability is
+    /// `Effect::Unimplemented` and the zero-Unimplemented walk below fails.
+    #[test]
+    fn cavernous_maw_still_a_cave_land_clause_has_no_unimplemented() {
+        use crate::types::card_type::CoreType;
+        let r = parse(
+            "{T}: Add {C}.\n{2}: This land becomes a 3/3 Elemental creature until end of turn. It's still a Cave land. Activate only if the number of other Caves you control plus the number of Cave cards in your graveyard is three or greater.",
+            "Cavernous Maw",
+            &[],
+            &["Land"],
+            &["Cave"],
+        );
+
+        fn walk<'a>(ability: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&ability.effect);
+            if let Some(sub) = &ability.sub_ability {
+                walk(sub, out);
+            }
+        }
+        let mut effects = Vec::new();
+        for ability in &r.abilities {
+            walk(ability, &mut effects);
+        }
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::Unimplemented { .. })),
+            "Cavernous Maw must not emit Effect::Unimplemented, got {effects:#?}"
+        );
+
+        // The retention clause must produce a continuous GenericEffect that
+        // re-asserts BOTH the Land core type AND the Cave subtype.
+        let retention = effects.iter().find_map(|e| match e {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } if static_abilities.iter().any(|sd| {
+                sd.modifications
+                    .iter()
+                    .any(|m| matches!(m, ContinuousModification::AddSubtype { subtype } if subtype == "Cave"))
+            }) =>
+            {
+                Some(static_abilities)
+            }
+            _ => None,
+        });
+        let retention = retention.expect("expected a Cave-retention GenericEffect");
+        assert!(
+            retention
+                .iter()
+                .any(|sd| sd.modifications.iter().any(|m| matches!(
+                    m,
+                    ContinuousModification::AddType {
+                        core_type: CoreType::Land
+                    }
+                ))),
+            "retention clause must re-assert the Land core type, got {retention:#?}"
+        );
+    }
+
     /// Build a single-face `CardFace` from an oracle `text` through the real
     /// synthesis path (`build_oracle_face`), so coverage checks recurse into
     /// granted abilities and effect payloads exactly as production does.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -55,8 +55,6 @@ use lower::{
 pub(crate) use self::token::parse_token_description;
 pub(crate) use self::token::try_parse_token;
 
-use std::str::FromStr;
-
 use crate::parser::oracle_nom::error::{oracle_err, OracleError};
 #[cfg(test)]
 use crate::parser::oracle_trigger::parse_trigger_line;
@@ -5978,36 +5976,37 @@ fn try_parse_mass_forced_block(tp: TextPair, ctx: &mut ParseContext) -> Option<P
 
 fn try_parse_still_a_type(tp: TextPair) -> Option<ParsedEffectClause> {
     // Match singular "it's still a/an [type]" / "that's still a/an [type]"
-    // or plural "they're still [type]s" — CR 205.1a type retention after animation.
-    let (is_plural, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+    // or plural "they're still [type]s" — CR 205.1a type retention after
+    // animation. The descriptor is purely additive: a permanent animated into
+    // a creature retains its prior types/subtypes (CR 613.1d ordering), so the
+    // "still a …" clause is confirmatory and emits the same `AddType`/
+    // `AddSubtype` Layer-4 modifications the animation already implies.
+    let (_, descriptor_orig) = nom_on_lower(tp.original, tp.lower, |input| {
         alt((
-            value(false, alt((tag("it's still "), tag("that's still ")))),
-            value(true, tag("they're still ")),
+            value((), tag("it's still ")),
+            value((), tag("that's still ")),
+            value((), tag("they're still ")),
         ))
         .parse(input)
     })?;
-    let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
 
-    let type_name_lower = if is_plural {
-        // Plural: "they're still lands" — no article, strip trailing 's'
-        rest_lower
-    } else {
-        // Singular: strip article "a " / "an "
-        let ((), after_article) = nom_on_lower(rest_orig, rest_lower, |input| {
-            nom_primitives::parse_article(input)
-        })?;
-        &rest_lower[rest_lower.len() - after_article.len()..]
-    };
-
-    // Strip plural 's' if present (e.g., "lands" → "land", "creatures" → "creature")
-    let singular = type_name_lower.strip_suffix('s').unwrap_or(type_name_lower);
-    let core_type = CoreType::from_str(&capitalize(singular)).ok()?;
+    // CR 205.1b + CR 305.7: parse the type descriptor ("a Cave land", "lands",
+    // "a planeswalker") through the shared animation building block so a subtype
+    // *and* core type are both retained ("It's still a Cave land" → AddType{Land}
+    // + AddSubtype{Cave}, Cavernous Maw), not just a bare core type. Strip a
+    // trailing period so the descriptor parses cleanly.
+    let descriptor = descriptor_orig.trim().trim_end_matches('.');
+    let spec = animation::parse_animation_spec(descriptor, &mut ParseContext::default())?;
+    let modifications = animation::animation_modifications(&spec);
+    if modifications.is_empty() {
+        return None;
+    }
 
     Some(ParsedEffectClause {
         effect: Effect::GenericEffect {
             static_abilities: vec![StaticDefinition::continuous()
                 .affected(TargetFilter::SelfRef)
-                .modifications(vec![ContinuousModification::AddType { core_type }])
+                .modifications(modifications)
                 .description(tp.original.to_string())],
             duration: Some(Duration::Permanent),
             target: None,
@@ -54335,6 +54334,93 @@ mod snapshot_tests {
                 )
             })
         }));
+    }
+
+    /// std BATCH 12 (Brilliance Unleashed class): a returned permanent followed by
+    /// a non-additive copula animation — "Return target X ... It's a 3/3 Robot
+    /// artifact creature with flying" — must lower the animation to a `GenericEffect`
+    /// bound to `ParentTarget` (the returned object), NOT `Effect::Unimplemented`
+    /// and NOT `SelfRef`. CR 205.1a + CR 613.1d (Layer 4 type set + Layer 7b base
+    /// P/T). Revert-discriminating on the `try_parse_contracted_subject_additive_type_clause`
+    /// animation fallback: without it the followup is `Effect::Unimplemented`.
+    #[test]
+    fn returned_target_receives_non_additive_animation_bound_to_parent() {
+        let def = parse_effect_chain(
+            "Return target artifact card from your graveyard to the battlefield. It's a 3/3 Robot artifact creature with flying.",
+            AbilityKind::Activated,
+        );
+        assert!(
+            matches!(&*def.effect, Effect::ChangeZone { .. }),
+            "expected ChangeZone head, got {:?}",
+            def.effect
+        );
+        let followup = def
+            .sub_ability
+            .as_ref()
+            .expect("expected animation followup");
+        let Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } = &*followup.effect
+        else {
+            panic!("expected GenericEffect followup, got {:?}", followup.effect);
+        };
+        assert_eq!(*target, Some(TargetFilter::ParentTarget));
+        assert!(static_abilities
+            .iter()
+            .all(|sd| matches!(sd.affected, Some(TargetFilter::ParentTarget))));
+        let mods = &static_abilities[0].modifications;
+        assert!(mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetPower { value: 3 })));
+        assert!(mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: crate::types::keywords::Keyword::Flying
+            }
+        )));
+        assert!(mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddSubtype { subtype } if subtype == "Robot"
+        )));
+    }
+
+    /// std BATCH 12 honest-defer gate: the same non-additive copula animation
+    /// joined by a bare "and" to an *anaphoric* "Return it" (no fresh typed
+    /// referent in scope — Brilliance Unleashed's modal-else branch) must NOT
+    /// silently animate the source permanent. The animation fallback's
+    /// ParentTarget-bind gate declines, so the conjunct honest-defers to
+    /// `Effect::unimplemented` rather than producing a wrong `SelfRef` binding.
+    #[test]
+    fn anaphoric_return_then_animation_honest_defers_when_no_parent_referent() {
+        let def = parse_effect_chain(
+            "Otherwise, return it to the battlefield and it's a 3/3 Robot artifact creature with flying.",
+            AbilityKind::Activated,
+        );
+        let mut found_unimplemented = false;
+        let mut cursor: Option<&AbilityDefinition> = Some(&def);
+        while let Some(node) = cursor {
+            if matches!(&*node.effect, Effect::Unimplemented { .. }) {
+                found_unimplemented = true;
+            }
+            // Walk both the sequential sub_ability chain and any else_ability.
+            if let Some(else_ab) = &node.else_ability {
+                let mut else_cursor: Option<&AbilityDefinition> = Some(else_ab);
+                while let Some(en) = else_cursor {
+                    if matches!(&*en.effect, Effect::Unimplemented { .. }) {
+                        found_unimplemented = true;
+                    }
+                    else_cursor = en.sub_ability.as_deref();
+                }
+            }
+            cursor = node.sub_ability.as_deref();
+        }
+        assert!(
+            found_unimplemented,
+            "anaphoric return + animation with no parent referent must honest-defer \
+             to Effect::Unimplemented (not a wrong SelfRef animation), got {def:#?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5981,11 +5981,11 @@ fn try_parse_still_a_type(tp: TextPair) -> Option<ParsedEffectClause> {
     // a creature retains its prior types/subtypes (CR 613.1d ordering), so the
     // "still a …" clause is confirmatory and emits the same `AddType`/
     // `AddSubtype` Layer-4 modifications the animation already implies.
-    let (_, descriptor_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+    let (is_plural, descriptor_orig) = nom_on_lower(tp.original, tp.lower, |input| {
         alt((
-            value((), tag("it's still ")),
-            value((), tag("that's still ")),
-            value((), tag("they're still ")),
+            value(false, tag("it's still ")),
+            value(false, tag("that's still ")),
+            value(true, tag("they're still ")),
         ))
         .parse(input)
     })?;
@@ -5996,6 +5996,12 @@ fn try_parse_still_a_type(tp: TextPair) -> Option<ParsedEffectClause> {
     // + AddSubtype{Cave}, Cavernous Maw), not just a bare core type. Strip a
     // trailing period so the descriptor parses cleanly.
     let descriptor = descriptor_orig.trim().trim_end_matches('.');
+    let descriptor = if is_plural {
+        // allow-noncombinator: structural singularization after nom parsed the plural prefix.
+        descriptor.strip_suffix('s').unwrap_or(descriptor)
+    } else {
+        descriptor
+    };
     let spec = animation::parse_animation_spec(descriptor, &mut ParseContext::default())?;
     let modifications = animation::animation_modifications(&spec);
     if modifications.is_empty() {
@@ -54421,6 +54427,28 @@ mod snapshot_tests {
             "anaphoric return + animation with no parent referent must honest-defer \
              to Effect::Unimplemented (not a wrong SelfRef animation), got {def:#?}"
         );
+    }
+
+    #[test]
+    fn plural_still_lands_retains_land_core_type_not_lands_subtype() {
+        let def = parse_effect_chain("They're still lands.", AbilityKind::Activated);
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*def.effect
+        else {
+            panic!("expected GenericEffect, got {:?}", def.effect);
+        };
+        let mods = &static_abilities[0].modifications;
+        assert!(mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddType {
+                core_type: CoreType::Land
+            }
+        )));
+        assert!(!mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddSubtype { subtype } if subtype == "Lands"
+        )));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1727,6 +1727,19 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
         // where "it" resolves to the anaphoric/self subject and
         // `build_become_clause` produces the additive color/type modifications.
         value((), tag("it becomes ")),
+        // CR 205.1a + CR 205.1b + CR 613.1d: the copula form "it's <descriptor>"
+        // ("it's" = "it is") is always a subject (anaphor) + animation/type
+        // predicate, never a noun-phrase continuation. Brilliance Unleashed:
+        // "Otherwise, return it to the battlefield and it's a 3/3 Robot artifact
+        // creature with flying" — without this split the conjunct is fed to the
+        // imperative-only path and fails closed to an Unimplemented effect named
+        // "it's". Splitting routes it through `parse_clause_ast` →
+        // `try_parse_subject_clause` → the contracted "it's a …" handler, which
+        // emits the animation (non-additive) or AddType/AddSubtype (additive)
+        // modifications on the referenced (ParentTarget) permanent. The
+        // straight-apostrophe and typographic-apostrophe forms are leaf variants
+        // of the same contraction (CLAUDE.md "don't nest leaf variants").
+        value((), alt((tag("it's "), tag("it’s ")))),
         value((), tag("this creature gets ")),
         value((), tag("~ gets ")),
         // CR 104.3 + CR 119.7 + CR 119.8: Bare-plural-player subject + restriction

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -259,8 +259,53 @@ fn try_parse_contracted_subject_additive_type_clause(
     let rest_original = &text[prefix_len..];
     let predicate = format!("is {rest_original}");
     let application = additive_type_subject_application(subject_text, ctx)?;
-    let clause = build_additive_type_continuous_clause(&application, &predicate)?;
 
+    // CR 205.1b: additive form first — "it's a [type] in addition to its other
+    // types" retains prior types (AddType/AddSubtype only).
+    if let Some(clause) = build_additive_type_continuous_clause(&application, &predicate) {
+        return Some(ClauseAst::SubjectPredicate {
+            subject: Box::new(SubjectPhraseAst {
+                affected: application.affected,
+                target: application.target,
+                multi_target: application.multi_target,
+                inherits_parent: application.inherits_parent,
+                is_optional: application.is_optional,
+            }),
+            predicate: Box::new(PredicateAst::Continuous {
+                effect: clause.effect,
+                duration: clause.duration,
+                sub_ability: clause.sub_ability,
+            }),
+        });
+    }
+
+    // CR 205.1a + CR 613.1d: non-additive animation — "it's a 3/3 Robot artifact
+    // creature with flying" sets the referenced permanent's base P/T, card types,
+    // and keywords. The copula "is" form is equivalent to the verb "become" here,
+    // so reuse the shared animation builder rather than re-deriving the spec.
+    // Routes through `build_become_clause`, which delegates to
+    // `parse_animation_spec`/`animation_modifications`.
+    //
+    // Honest-bind gate: a non-additive animation joined by "and it's a …" /
+    // ". It's a …" is an anaphor to the permanent the *preceding* clause acted
+    // on (a returned/created object), never the source permanent itself. Only
+    // emit when the subject application resolves to a real prior referent
+    // (`ParentTarget` — set when the chain carries a typed referent the
+    // `parent_target_available` ctx propagates onto the "it" anaphor). If it
+    // would bind to `SelfRef` (no prior typed referent in scope — e.g. the
+    // anaphoric "Return it … and it's a 3/3 …" or modal-else branch), decline so
+    // the clause honest-defers to `Effect::unimplemented` rather than silently
+    // animating the wrong object. The additive "… in addition to its other
+    // types" form above is unaffected (it is a type *addition* and stays on the
+    // referenced subject regardless).
+    if !matches!(
+        static_affected_for_application(&application),
+        TargetFilter::ParentTarget
+    ) {
+        return None;
+    }
+    let become_predicate = format!("becomes {rest_original}");
+    let clause = build_become_clause(application.clone(), &become_predicate, ctx)?;
     Some(ClauseAst::SubjectPredicate {
         subject: Box::new(SubjectPhraseAst {
             affected: application.affected,
@@ -269,7 +314,7 @@ fn try_parse_contracted_subject_additive_type_clause(
             inherits_parent: application.inherits_parent,
             is_optional: application.is_optional,
         }),
-        predicate: Box::new(PredicateAst::Continuous {
+        predicate: Box::new(PredicateAst::Become {
             effect: clause.effect,
             duration: clause.duration,
             sub_ability: clause.sub_ability,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## std BATCH 12 — Enters-with-type / color-added (parser composition)

Unblocks the "type-retention / animation-on-referenced-permanent" parser seam for the Standard-legal gap set. This batch is **parser composition only** — it reuses the existing continuous `ContinuousModification` surface (`AddType`, `AddSubtype`, `SetPower/SetToughness`, `AddKeyword`) and the shared `parse_animation_spec` / `animation_modifications` building blocks. No new engine variant.

Branch: `card/std-enters-type` (off `upstream/main` @ `dea20b1afdd3913d189ca3d3a27a6aa268003e49`).

### add-engine-variant verdict: NO NEW VARIANT

All members compose existing engine surface. `data/engine-inventory.json` is unchanged (verified clean). The three engine primitives involved already exist:
- `ContinuousModification::{AddType, AddSubtype, SetPower, SetToughness, AddKeyword, RemoveAllSubtypes}`
- `Effect::GenericEffect { static_abilities, duration, target }`
- `parse_animation_spec` + `animation_modifications` (shared animation builder)

The changes are entirely in the parser dispatch layer:
1. `try_parse_still_a_type` now parses the "still a …" descriptor through `parse_animation_spec` so a **subtype** is retained alongside the core type ("It's still a Cave land" → `AddType{Land}` + `AddSubtype{Cave}`), not just a bare core type.
2. The contracted `try_parse_contracted_subject_additive_type_clause` ("it's a …") gained a non-additive **animation fallback** (when the "… in addition to its other types" additive form fails), reusing `build_become_clause`. It is **gated on a real `ParentTarget` binding** — when no prior typed referent is in scope it declines, so anaphoric/modal-else cases honest-defer to `Effect::unimplemented` rather than silently animating the wrong object.
3. The bare-`and` clause splitter recognizes `"it's "` / `"it’s "` (the "it is" copula) as a subject-predicate clause start, so "… and it's a [animation]" routes through the subject-clause dispatch.

### Grep-verified CR annotations

All verified against `docs/MagicCompRules.txt`:
- **CR 205.1a** — type-setting replaces prior types (instant/sorcery retained); subtype-set replacement semantics.
- **CR 205.1b** — "in addition to its other types" / "still a [type, supertype, or subtype]" retains all prior types/subtypes. (Exactly describes Cavernous Maw's "It's still a Cave land".)
- **CR 305.7** — a land gaining land types in addition keeps its own land types and mana abilities.
- **CR 613.1d** — Layer 4 type-changing effects.
- **CR 613.1f** — Layer 6 ability/keyword-adding effects.
- **CR 613.1e** — Layer 5 color-changing effects.

CR-annotation diff gate: clean (zero `UNVERIFIED:`).

### Per-card verdict

| Card | Residual line | Verdict | Notes |
|---|---|---|---|
| **Cavernous Maw** | "It's still a Cave land" | **SHIPPED (0 Unimplemented)** | Type-retention now parses to a `GenericEffect` (`AddType{Land}` + `AddSubtype{Cave}`). The animation is additive, so Cave/Land are retained at runtime; the clause is confirmatory and CR 205.1b-faithful. |
| **Brilliance Unleashed** | "it's a 3/3 Robot artifact creature with flying" | **HONEST-DEFER** | The standalone/fresh-target animation followup is now supported (and binds `ParentTarget`), but Brilliance's clause lives in a **modal-else branch with an anaphoric "Return it"** referent. The chain provides no fresh typed referent to that branch, so the animation would bind `SelfRef` (the sorcery itself). The ParentTarget-bind gate makes it honest-defer to `Effect::unimplemented`. Needs modal-else cross-sentence anaphor→ParentTarget propagation (infra beyond composition). |
| **The Tomb of Aclazotz** | "it enters with a finality counter on it and is a Vampire in addition to its other types" | **HONEST-DEFER** | The rider applies to a spell **cast from the graveyard** (`Effect::CastFromZone`). There is no engine field to thread an "enters-with-counters + type-add" replacement onto a *cast-this-way* spell so it applies when the resolved permanent enters. (The existing finality+Vampire support is on *return-to-battlefield* `ChangeZone`/`ChangeZoneAll`, not on a cast permission.) New replacement subsystem required. |
| **Osteomancer Adept** | "that creature enters with a finality counter on it" | **HONEST-DEFER** | Same cast-this-way enters-with-counter rider as Tomb of Aclazotz. (Its "Deathtouch" line also remains a separate keyword-parse residual, out of scope for this seam.) |

Shipped: **1 of 4** (Cavernous Maw 0-Unimplemented). The other 3 honest-defer to `Effect::unimplemented`; none ships a wrong binding.

### Discriminating-test map

| Behavioral claim | Changed seam | Production entry | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| "It's still a Cave land" parses (subtype retained), not Unimplemented | `try_parse_still_a_type` (mod.rs) | `parse_oracle_text` (full pipeline) | `cavernous_maw_still_a_cave_land_clause_has_no_unimplemented` | zero `Effect::Unimplemented` in the walk + presence of a `GenericEffect` with `AddSubtype{Cave}` and `AddType{Land}` | — |
| Animated Cave land is a 3/3 creature that is STILL a Cave Land at runtime | `ContinuousModification` composition through Layer 4 | `evaluate_layers` (real layer engine) | `cavernous_maw_animation_retains_cave_land_through_layers` | after layers: `core_types` contains `Creature` **and** `Land`; `subtypes` contains `Cave` **and** `Elemental`; power/toughness == 3 | proves additive `RemoveAllSubtypes{Creature}` does not wipe the land subtype |
| Returned permanent + "It's a 3/3 …" animation binds ParentTarget | `try_parse_contracted_subject_additive_type_clause` animation fallback (subject.rs) | `parse_effect_chain` | `returned_target_receives_non_additive_animation_bound_to_parent` | followup `GenericEffect.target == Some(ParentTarget)`, static `affected == ParentTarget`, mods include `SetPower{3}` + `AddKeyword{Flying}` + `AddSubtype{Robot}`; NOT Unimplemented | — |
| Anaphoric "Return it … and it's a 3/3 …" (no parent referent) honest-defers | ParentTarget-bind gate + bare-`and` splitter (subject.rs / sequence.rs) | `parse_effect_chain` | `anaphoric_return_then_animation_honest_defers_when_no_parent_referent` | the chain (incl. `else_ability`) contains an `Effect::Unimplemented` — i.e. it does NOT silently animate `SelfRef` | this is the Brilliance modal-else negative case |

The Cavernous Maw shipped card is covered by **both** a parser-pipeline 0-Unimplemented test and a real-layer-engine runtime test. The runtime test drives `evaluate_layers` (production layer authority) and asserts the end-to-end type/subtype composition. No production-reachable arm is left covered only by a degenerate fixture; the honest-defer gate has an explicit negative test proving the wrong-binding case routes to `Effect::unimplemented`.

### Gates

- `cargo fmt --all`: clean
- `./scripts/check-parser-combinators.sh`: **0**
- Inline parser string-dispatch diff gate (contains/find/split/etc. in added lines): **clean**
- `./scripts/check-engine-authorities.sh upstream/main`: **0**
- `cargo check --workspace --all-targets`: **pass**
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: **pass (0 warnings)**
- `cargo test -p engine` (FULL): **12967 passed**; only failure is the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (a state-clone-count assertion; passes in isolation single-threaded — confirmed unrelated to this diff)
- CR-annotation diff gate: **clean (0 UNVERIFIED)**
- `data/engine-inventory.json`: **unchanged** (no new variant)
- `cargo coverage` / `cargo semantic-audit`: require generated `client/public/card-data.json`, which is intentionally absent in the worktree (per the effort protocol — no card-data/oracle-gen in worktrees). Verification path is `parse_oracle_text` 0-Unimplemented per shipped card + discriminating runtime tests, both done.

### Files touched

- `crates/engine/src/parser/oracle_effect/mod.rs` — `try_parse_still_a_type` subtype-aware via `parse_animation_spec`; removed now-unused `std::str::FromStr` import; 2 followup tests.
- `crates/engine/src/parser/oracle_effect/subject.rs` — non-additive animation fallback in the contracted "it's a …" handler, ParentTarget-bind honest-defer gate.
- `crates/engine/src/parser/oracle_effect/sequence.rs` — bare-`and` splitter recognizes the "it's "/"it’s " copula clause start.
- `crates/engine/src/parser/oracle.rs` — Cavernous Maw full-oracle 0-Unimplemented test.
- `crates/engine/src/game/layers.rs` — Cavernous Maw runtime retention test (real layer engine).
