### PR TITLE
feat(parser): set base P/T to a dynamic count (Porcelain Gallery, Pupu UFO, Sita Varma)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5806,6 +5806,131 @@ mod tests {
         );
     }
 
+    /// CR 613.4b + CR 208.1 + CR 604.3: std BATCH 10 — Porcelain Gallery's static
+    /// "Creatures you control have base power and toughness each equal to the
+    /// number of creatures you control" must parse with zero coverage gaps. The
+    /// dynamic base-P/T set routes to layer-7b `SetPowerDynamic`/
+    /// `SetToughnessDynamic` with an `ObjectCount` value. (Runtime discrimination —
+    /// base P/T becomes and tracks the count — lives in
+    /// `tests/base_pt_dynamic_set_std_base_pt.rs`.)
+    #[test]
+    fn porcelain_gallery_full_card_supported_dynamic_base_pt() {
+        let face = oracle_face_for(
+            "Porcelain Gallery",
+            "Creatures you control have base power and toughness each equal to the number of creatures you control.",
+            &["Artifact"],
+            &[],
+        );
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "Porcelain Gallery must be fully supported, gaps: {gaps:?}"
+        );
+    }
+
+    /// CR 613.4b + CR 208.1: std BATCH 10 — Pupu UFO's activated "{3}: Until end
+    /// of turn, this creature's base power becomes equal to the number of Towns
+    /// you control" must parse with zero coverage gaps. The power-only dynamic
+    /// base-set routes to a layer-7b `SetPowerDynamic(ObjectCount Towns)`; the
+    /// Flying keyword and the land-drop ability are already supported. (Runtime
+    /// discrimination lives in `tests/base_pt_dynamic_set_std_base_pt.rs`.)
+    #[test]
+    fn pupu_ufo_full_card_supported_dynamic_base_power() {
+        // Build the face the way the card-data pipeline does, with MTGJSON's
+        // printed `keywords: ["Flying"]` present so the standalone "Flying" line
+        // is recognized as a keyword (not a stray ability) — exactly the input
+        // production sees.
+        use crate::database::mtgjson::{AtomicCard, AtomicIdentifiers};
+        let card = AtomicCard {
+            name: "Pupu UFO".to_string(),
+            mana_cost: Some("{3}{G}".to_string()),
+            colors: vec!["G".to_string()],
+            color_identity: vec!["G".to_string()],
+            power: Some("2".to_string()),
+            toughness: Some("2".to_string()),
+            loyalty: None,
+            defense: None,
+            text: Some(
+                "Flying\n{T}: You may put a land card from your hand onto the battlefield.\n{3}: Until end of turn, this creature's base power becomes equal to the number of Towns you control.".to_string(),
+            ),
+            layout: "normal".to_string(),
+            type_line: Some("Creature — Alien".to_string()),
+            types: vec!["Creature".to_string()],
+            subtypes: vec!["Alien".to_string()],
+            supertypes: Vec::new(),
+            keywords: Some(vec!["Flying".to_string()]),
+            side: None,
+            face_name: None,
+            mana_value: 4.0,
+            legalities: Default::default(),
+            leadership_skills: None,
+            printings: Vec::new(),
+            rulings: Vec::new(),
+            is_game_changer: false,
+            identifiers: AtomicIdentifiers {
+                scryfall_oracle_id: Some("pupu-ufo-oracle".to_string()),
+                scryfall_id: Some("pupu-ufo-face".to_string()),
+            },
+            foreign_data: Vec::new(),
+        };
+        let face = crate::database::synthesis::build_oracle_face(&card, None);
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "Pupu UFO must be fully supported, gaps: {gaps:?}"
+        );
+    }
+
+    /// CR 613.4b + CR 208.1 + CR 702.177: std BATCH 10 — Sita Varma's Exhaust
+    /// ability "Put X +1/+1 counters … Then you may have the base power and
+    /// toughness of each other creature you control become equal to Sita Varma's
+    /// power until end of turn" must parse with zero coverage gaps. The "Then you
+    /// may have …" half is the inverted-genitive base-P/T set on the other
+    /// creatures you control, set to the source's power (`~`-normalized →
+    /// `Power{Source}`) via layer-7b `SetPowerDynamic`/`SetToughnessDynamic`.
+    #[test]
+    fn sita_varma_full_card_supported_inverted_genitive_base_pt() {
+        use crate::database::mtgjson::{AtomicCard, AtomicIdentifiers};
+        let card = AtomicCard {
+            name: "Sita Varma, Masked Racer".to_string(),
+            mana_cost: Some("{1}{G}{U}".to_string()),
+            colors: vec!["G".to_string(), "U".to_string()],
+            color_identity: vec!["G".to_string(), "U".to_string()],
+            power: Some("3".to_string()),
+            toughness: Some("3".to_string()),
+            loyalty: None,
+            defense: None,
+            text: Some(
+                "Exhaust \u{2014} {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn. (Activate each exhaust ability only once.)".to_string(),
+            ),
+            layout: "normal".to_string(),
+            type_line: Some("Legendary Creature — Human".to_string()),
+            types: vec!["Creature".to_string()],
+            subtypes: vec!["Human".to_string()],
+            supertypes: vec!["Legendary".to_string()],
+            keywords: Some(vec!["Exhaust".to_string()]),
+            side: None,
+            face_name: None,
+            mana_value: 3.0,
+            legalities: Default::default(),
+            leadership_skills: None,
+            printings: Vec::new(),
+            rulings: Vec::new(),
+            is_game_changer: false,
+            identifiers: AtomicIdentifiers {
+                scryfall_oracle_id: Some("sita-varma-oracle".to_string()),
+                scryfall_id: Some("sita-varma-face".to_string()),
+            },
+            foreign_data: Vec::new(),
+        };
+        let face = crate::database::synthesis::build_oracle_face(&card, None);
+        let gaps = crate::game::coverage::card_face_gaps(&face);
+        assert!(
+            gaps.is_empty(),
+            "Sita Varma must be fully supported, gaps: {gaps:?}"
+        );
+    }
+
     /// CR 106.6 + CR 702.6a: Hydraulic Helper — the full card must parse with
     /// zero `Effect::Unimplemented` parts. "Defender" extracts as a keyword and
     /// the `{T}: Add {U}` mana ability carries the negative spend restriction

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -31351,6 +31351,102 @@ mod tests {
         assert_eq!(execute.duration, Some(Duration::UntilEndOfTurn));
     }
 
+    /// CR 613.4b + CR 208.1: Pupu UFO's "this creature's base power becomes equal
+    /// to the number of Towns you control" sets the *power* axis only to a
+    /// dynamic count (layer 7b). Proves the power-only axis and the dynamic
+    /// "equal to <count>" value compose in one parser — not a fixed-N/M special
+    /// case.
+    #[test]
+    fn effect_subject_base_power_becomes_equal_to_count_power_only() {
+        use crate::types::ability::{ContinuousModification, QuantityExpr, QuantityRef};
+        let def = parse_effect_chain(
+            "this creature's base power becomes equal to the number of Towns you control",
+            AbilityKind::Activated,
+        );
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = def.effect.as_ref()
+        else {
+            panic!("expected GenericEffect, got {:?}", def.effect);
+        };
+        let mods = &static_abilities[0].modifications;
+        // Power is set dynamically to the Town count.
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::SetPowerDynamic {
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { .. }
+                    }
+                }
+            )),
+            "expected SetPowerDynamic(ObjectCount Towns), got {mods:?}"
+        );
+        // Toughness is NOT touched (power-only axis).
+        assert!(
+            !mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::SetToughnessDynamic { .. }
+                    | ContinuousModification::SetToughness { .. }
+            )),
+            "toughness must be untouched for the power-only axis, got {mods:?}"
+        );
+    }
+
+    /// CR 613.4b + CR 208.1: Sita Varma's inverted-genitive "the base power and
+    /// toughness of each other creature you control become equal to ~'s power"
+    /// sets BOTH axes of a non-self group subject to the source's power. Proves
+    /// the inverted-genitive surface form, the non-self group subject, and the
+    /// self-power (`~`-normalized) dynamic value all compose in one parser.
+    #[test]
+    fn effect_inverted_genitive_base_pt_of_group_equal_to_source_power() {
+        use crate::types::ability::{
+            ContinuousModification, ObjectScope, QuantityExpr, QuantityRef,
+        };
+        let def = parse_effect_chain(
+            "have the base power and toughness of each other creature you control become equal to ~'s power",
+            AbilityKind::Activated,
+        );
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = def.effect.as_ref()
+        else {
+            panic!("expected GenericEffect, got {:?}", def.effect);
+        };
+        let sa = &static_abilities[0];
+        // Affected: other creatures you control.
+        match &sa.affected {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                assert_eq!(
+                    tf.controller,
+                    Some(crate::types::ability::ControllerRef::You)
+                );
+                assert!(tf.properties.contains(&FilterProp::Another));
+            }
+            other => panic!("expected other-creatures-you-control scope, got {other:?}"),
+        }
+        let expected = QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::Source,
+            },
+        };
+        assert!(
+            sa.modifications
+                .contains(&ContinuousModification::SetPowerDynamic {
+                    value: expected.clone(),
+                }),
+            "expected SetPowerDynamic(~ power), got {:?}",
+            sa.modifications
+        );
+        assert!(
+            sa.modifications
+                .contains(&ContinuousModification::SetToughnessDynamic { value: expected }),
+            "expected SetToughnessDynamic(~ power), got {:?}",
+            sa.modifications
+        );
+    }
+
     #[test]
     fn effect_becomes_color_and_attacks_if_able_chains_requirement() {
         let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -4,7 +4,7 @@ use nom::bytes::complete::{tag, take_till, take_until};
 use nom::character::complete::multispace0;
 use nom::combinator::{all_consuming, map, opt, rest, value, verify};
 use nom::multi::separated_list1;
-use nom::sequence::{delimited, pair, preceded, terminated};
+use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
 
 use super::animation::{
@@ -376,20 +376,90 @@ fn try_parse_subject_become_clause(
     build_become_clause(application, &predicate, ctx)
 }
 
-/// CR 613.4b + CR 613.1f: "[subject]'s base power and toughness become N/M [and
-/// (it/they) gain(s)/has/have <keywords>]" — a set-base-P/T plus keyword-grant
-/// continuous effect on the possessor, with NO type/subtype change.
+/// CR 208.1: which base characteristic(s) a "base power [and toughness] become"
+/// clause overwrites. `set_power`/`set_toughness` are independent so the
+/// power-only axis (Pupu UFO) and the both-axes axis (Moon Girl, Porcelain
+/// Gallery, Sita Varma) share one parser rather than proliferating arms.
+struct BasePtSetAxes {
+    set_power: bool,
+    set_toughness: bool,
+}
+
+/// CR 208.1: Parse the "base power [and [base] toughness]" characteristic axes
+/// after the possessive marker, returning the axes and the remainder positioned
+/// at the "become[s] " copula. Factored per the nom mandate so the optional
+/// "base " on the second noun and the optional "and toughness" conjunct are each
+/// a single combinator.
+fn parse_base_pt_axes(input: &str) -> OracleResult<'_, BasePtSetAxes> {
+    let (input, _) = tag("base power").parse(input)?;
+    let (input, toughness) =
+        opt(alt((tag(" and base toughness"), tag(" and toughness")))).parse(input)?;
+    Ok((
+        input,
+        BasePtSetAxes {
+            set_power: true,
+            set_toughness: toughness.is_some(),
+        },
+    ))
+}
+
+/// CR 208.1 + CR 613.4b: The dynamic-or-fixed value side of a "base power …
+/// become[s] <value>" clause, resolved into per-axis layer-7b modifications.
+enum BasePtSetValue {
+    /// Fixed "N/M" — `SetPower`/`SetToughness`.
+    Fixed { power: i32, toughness: i32 },
+    /// Dynamic "[each] equal to <quantity>" — `SetPowerDynamic`/`SetToughnessDynamic`.
+    Dynamic(QuantityExpr),
+}
+
+/// CR 208.1: Parse the value following the "become[s] " copula of a base-P/T-set
+/// clause. Tries the fixed "N/M" form first (so "6/6" is not mis-routed through
+/// the quantity grammar), then the dynamic "[each] equal to <quantity>" form,
+/// which routes through the shared CDA quantity grammar so every recognized
+/// count/aggregate/possessive-power phrase composes ("the number of Towns you
+/// control", "~'s power", …).
+fn parse_base_pt_set_value(remainder: &str) -> Option<(BasePtSetValue, &str)> {
+    if let Some((power, toughness, after_pt)) =
+        super::animation::parse_fixed_become_pt_prefix(remainder)
+    {
+        return Some((BasePtSetValue::Fixed { power, toughness }, after_pt));
+    }
+    // CR 208.1: "[each] equal to <quantity>" dynamic value. "each equal to" and
+    // "equal to" are the two surface forms (each/each-not are not independent
+    // axes here — the optional "each " is the only variation).
+    let lower = remainder.to_lowercase();
+    // Return `()` (owned) from the closure so its result does not borrow the
+    // temporary `lower`; `nom_on_lower` hands back the post-match remainder in
+    // original case.
+    let (_, after_copula) = nom_on_lower(remainder, &lower, |i| {
+        let (i, _) = opt(tag::<_, _, OracleError<'_>>("each ")).parse(i)?;
+        value((), tag::<_, _, OracleError<'_>>("equal to ")).parse(i)
+    })?;
+    let tail = after_copula.trim().trim_end_matches('.').trim();
+    let expr = oracle_quantity::parse_cda_quantity(tail)
+        .or_else(|| oracle_quantity::parse_event_context_quantity(tail))?;
+    Some((BasePtSetValue::Dynamic(expr), ""))
+}
+
+/// CR 613.4b + CR 613.1f: "[subject]'s base power [and toughness] become[s]
+/// <value> [and (it/they) gain(s)/has/have <keywords>]" — a set-base-P/T plus
+/// keyword-grant continuous effect on the possessor, with NO type/subtype
+/// change. Also handles the inverted-genitive surface form "the base power and
+/// toughness of [subject] become[s] <value>" (Sita Varma).
 ///
 /// This differs grammatically from the `becomes a [type] with base power and
 /// toughness N/M` animation form (handled by `parse_animation_spec`): here the
 /// grammatical subject is the *possessive* "[subject]'s base power and
 /// toughness", and the verb "become" acts on the P/T characteristics, not on the
 /// permanent's card type. So it produces a `GenericEffect` carrying
-/// `SetPower`/`SetToughness` (Layer 7b, CR 613.4b) and `AddKeyword` (Layer 6,
-/// CR 613.1f) modifications, without any `AddType`/`AddSubtype`. Covers Moon
-/// Girl and Devil Dinosaur ("~'s base power and toughness become 6/6 and they
-/// gain trample") and the class of "<permanent>'s base power and toughness
-/// become N/M …" effects.
+/// `SetPower`/`SetToughness` (fixed) or `SetPowerDynamic`/`SetToughnessDynamic`
+/// (dynamic, Layer 7b, CR 613.4b) and `AddKeyword` (Layer 6, CR 613.1f)
+/// modifications, without any `AddType`/`AddSubtype`. Covers Moon Girl and Devil
+/// Dinosaur ("~'s base power and toughness become 6/6 and they gain trample"),
+/// Pupu UFO ("this creature's base power becomes equal to the number of Towns you
+/// control"), Sita Varma ("the base power and toughness of each other creature
+/// you control become equal to ~'s power"), and the broader class of
+/// "<permanent>'s base power [and toughness] become[s] <value> …" effects.
 fn try_parse_subject_base_pt_set_clause_ast(
     text: &str,
     ctx: &mut ParseContext,
@@ -403,28 +473,65 @@ fn try_parse_subject_base_pt_set_clause_ast(
     let (body, leading_duration) = strip_leading_duration(text);
 
     let lower = body.to_lowercase();
-    // Split at the possessive characteristic phrase. The possessive marker may be
-    // ASCII `'s` or the Unicode right single quote `\u{2019}s`. `rest_lower` is the
-    // text after the marker; `to_lowercase` preserves byte offsets for this text
-    // (ASCII letters + apostrophes), so the same offsets index `body`.
-    let (rest_lower, (subject_lower, _marker)) = alt((
-        pair(
-            take_until::<_, _, VE>("'s base power and toughness become "),
-            tag("'s base power and toughness become "),
-        ),
-        pair(
-            take_until::<_, _, VE>("\u{2019}s base power and toughness become "),
-            tag("\u{2019}s base power and toughness become "),
-        ),
-    ))
-    .parse(lower.as_str())
-    .ok()?;
 
-    let subject = body[..subject_lower.len()].trim();
-    let remainder = &body[body.len() - rest_lower.len()..];
+    // Two surface forms, each yielding `(subject_text, axes, value_remainder)`:
+    //   1. Possessive:  "<subject>'s base power [and toughness] become[s] <value>"
+    //   2. Inverted:    "the base power and toughness of <subject> become[s] <value>"
+    // The possessive marker may be ASCII `'s` or the Unicode right single quote
+    // `\u{2019}s`. `to_lowercase` preserves byte length/offsets for this text
+    // (ASCII letters, apostrophes, digits, slashes), so a span taken from `lower`
+    // indexes the same bytes in `body`.
+    let (subject, axes, remainder) = if let Ok((rest_lower, (axes, _, subject_lower, _, _, _))) =
+        // Inverted genitive: "the base power and toughness of <subject> become[s] "
+        (
+                preceded(tag::<_, _, VE>("the "), parse_base_pt_axes),
+                tag(" of "),
+                take_until::<_, _, VE>(" become"),
+                tag(" become"),
+                opt(tag("s")),
+                tag(" "),
+            )
+                .parse(lower.as_str())
+    {
+        // `subject_lower` is a sub-slice of `lower`; its byte offset is the
+        // pointer delta. Recover original case at the same span in `body`.
+        let subject_start = subject_lower.as_ptr() as usize - lower.as_ptr() as usize;
+        let subject = body
+            .get(subject_start..subject_start + subject_lower.len())?
+            .trim();
+        let remainder = &body[body.len() - rest_lower.len()..];
+        (subject, axes, remainder)
+    } else {
+        // Possessive: "<subject>'s base power [and toughness] become[s] "
+        let (rest_lower, (subject_lower, axes)) = alt((
+            (
+                take_until::<_, _, VE>("'s base power"),
+                tag("'s "),
+                parse_base_pt_axes,
+                tag(" become"),
+                opt(tag("s")),
+                tag(" "),
+            )
+                .map(|(subject, _, axes, _, _, _)| (subject, axes)),
+            (
+                take_until::<_, _, VE>("\u{2019}s base power"),
+                tag("\u{2019}s "),
+                parse_base_pt_axes,
+                tag(" become"),
+                opt(tag("s")),
+                tag(" "),
+            )
+                .map(|(subject, _, axes, _, _, _)| (subject, axes)),
+        ))
+        .parse(lower.as_str())
+        .ok()?;
+        let subject = body[..subject_lower.len()].trim();
+        let remainder = &body[body.len() - rest_lower.len()..];
+        (subject, axes, remainder)
+    };
 
-    // Parse the fixed N/M P/T values.
-    let (power, toughness, after_pt) = super::animation::parse_fixed_become_pt_prefix(remainder)?;
+    // Parse the value side (fixed N/M or dynamic "[each] equal to <quantity>").
+    let (value, after_pt) = parse_base_pt_set_value(remainder)?;
 
     // Parse the optional trailing keyword-grant conjunct ("and they gain trample").
     let keywords = parse_base_pt_set_trailing_keywords(after_pt);
@@ -432,10 +539,34 @@ fn try_parse_subject_base_pt_set_clause_ast(
     let application = parse_subject_application(subject, ctx)?;
     let affected = static_affected_for_application(&application);
 
-    let mut modifications = vec![
-        ContinuousModification::SetPower { value: power },
-        ContinuousModification::SetToughness { value: toughness },
-    ];
+    // CR 208.1 + CR 613.4b: emit per-axis layer-7b set modifications. Fixed
+    // values stay `SetPower`/`SetToughness`; dynamic values use the
+    // `SetPowerDynamic`/`SetToughnessDynamic` variants the layer system
+    // re-evaluates each tick.
+    let mut modifications = Vec::new();
+    match value {
+        BasePtSetValue::Fixed { power, toughness } => {
+            if axes.set_power {
+                modifications.push(ContinuousModification::SetPower { value: power });
+            }
+            if axes.set_toughness {
+                modifications.push(ContinuousModification::SetToughness { value: toughness });
+            }
+        }
+        BasePtSetValue::Dynamic(expr) => {
+            if axes.set_power {
+                modifications.push(ContinuousModification::SetPowerDynamic {
+                    value: expr.clone(),
+                });
+            }
+            if axes.set_toughness {
+                modifications.push(ContinuousModification::SetToughnessDynamic { value: expr });
+            }
+        }
+    }
+    if modifications.is_empty() {
+        return None;
+    }
     modifications.extend(
         keywords
             .into_iter()

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -921,24 +921,57 @@ pub(crate) fn parse_base_pt_mod(text: &str) -> Option<(i32, i32)> {
     parse_pt_mod(pt_text)
 }
 
-pub(crate) fn parse_base_pt_mana_value_dynamic(lower: &str) -> Option<QuantityExpr> {
+/// CR 613.4b + CR 208.1: Parse the dynamic base-P/T set value in a
+/// "[base] power and [base] toughness [are] each equal to <quantity>" static
+/// grant (layer 7b). The grammar is factored per the nom mandate into
+/// orthogonal axes — the optional "base " on each characteristic, the optional
+/// "are " copula, and the shared " each equal to " suffix — so the arm count is
+/// the SUM of per-axis choices, not their product. The trailing quantity is
+/// dispatched: "its mana value" reads the recipient's mana value (Animate
+/// Artifact class); any other tail routes through the shared CDA quantity
+/// grammar so the same building block covers "the number of creatures you
+/// control" (Porcelain Gallery) and every other recognized count/aggregate
+/// phrase — not just the one card.
+pub(crate) fn parse_base_pt_each_equal_dynamic(lower: &str) -> Option<QuantityExpr> {
     type VE<'a> = OracleError<'a>;
-    nom_primitives::scan_split_at_phrase(lower, |input| {
-        alt((
-            tag::<_, _, VE<'_>>("base power and base toughness each equal to its mana value"),
-            tag("base power and toughness each equal to its mana value"),
-            tag("power and toughness each equal to its mana value"),
-            tag("base power and base toughness are each equal to its mana value"),
-            tag("base power and toughness are each equal to its mana value"),
-            tag("power and toughness are each equal to its mana value"),
-        ))
-        .parse(input)
+    let (_, _, tail) = nom_primitives::scan_preceded(lower, |input| {
+        // CR 208.1: which characteristics are set. "base power and base
+        // toughness", "base power and toughness", and "power and toughness" are
+        // the three observed surface forms; the "base " on the first noun is the
+        // only one that varies in the corpus.
+        let (input, _) = alt((tag::<_, _, VE<'_>>("base power"), tag("power"))).parse(input)?;
+        let (input, _) = tag(" and ").parse(input)?;
+        let (input, _) = opt(tag("base ")).parse(input)?;
+        let (input, _) = tag("toughness ").parse(input)?;
+        // Optional "are " copula ("… are each equal to …").
+        let (input, _) = opt(tag("are ")).parse(input)?;
+        tag("each equal to ").parse(input)
     })?;
-    Some(QuantityExpr::Ref {
-        qty: QuantityRef::ObjectManaValue {
-            scope: ObjectScope::Recipient,
-        },
-    })
+    let tail = tail.trim().trim_end_matches('.').trim();
+
+    // CR 202.3: "its mana value" reads the recipient's own mana value (the
+    // animation-grant idiom). Kept as a dedicated arm because its `ObjectScope`
+    // is `Recipient` (the granted-to object), which the general CDA grammar does
+    // not produce for a bare "its mana value".
+    if tail == "its mana value" {
+        return Some(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectManaValue {
+                scope: ObjectScope::Recipient,
+            },
+        });
+    }
+
+    // Everything else routes through the shared CDA quantity grammar so the
+    // dynamic base-P/T set composes over every count/aggregate phrase the
+    // engine already recognizes (e.g. "the number of creatures you control").
+    parse_cda_quantity(tail)
+}
+
+/// Back-compat shim: the historical name used by callers that only need the
+/// "its mana value" recipient form. Delegates to the generalized parser so the
+/// CDA-quantity tail is also accepted at every existing call site.
+pub(crate) fn parse_base_pt_mana_value_dynamic(lower: &str) -> Option<QuantityExpr> {
+    parse_base_pt_each_equal_dynamic(lower)
 }
 
 pub(crate) fn parse_base_pt_side(input: &str) -> nom::IResult<&str, BasePtSide, OracleError<'_>> {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -19263,3 +19263,50 @@ fn top_of_library_frequency_display_roundtrip() {
         unlimited
     );
 }
+
+/// CR 613.4b + CR 208.1: Porcelain Gallery's "Creatures you control have base
+/// power and toughness each equal to the number of creatures you control" is a
+/// layer-7b dynamic base-P/T set on a controller-scoped group. The dynamic
+/// value routes through the shared CDA quantity grammar to an `ObjectCount`,
+/// proving the base-P/T set composes with arbitrary count quantities (not just
+/// "its mana value"). Each tick re-evaluates the count via the layer system.
+#[test]
+fn porcelain_gallery_base_pt_equal_to_creature_count() {
+    let def = parse_static_line(
+        "Creatures you control have base power and toughness each equal to the number of creatures you control.",
+    )
+    .expect("Porcelain Gallery static must parse");
+
+    // Group scope: creatures you control.
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(tf.type_filters.contains(&TypeFilter::Creature));
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        }
+        other => panic!("expected creatures-you-control scope, got {other:?}"),
+    }
+
+    let expected = QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(
+                TypedFilter::default()
+                    .with_type(TypeFilter::Creature)
+                    .controller(ControllerRef::You),
+            ),
+        },
+    };
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetPowerDynamic {
+                value: expected.clone(),
+            }),
+        "missing SetPowerDynamic(creature count) in {:?}",
+        def.modifications
+    );
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetToughnessDynamic { value: expected }),
+        "missing SetToughnessDynamic(creature count) in {:?}",
+        def.modifications
+    );
+}

--- a/crates/engine/tests/base_pt_dynamic_set_std_base_pt.rs
+++ b/crates/engine/tests/base_pt_dynamic_set_std_base_pt.rs
@@ -1,0 +1,226 @@
+//! std-card BATCH 10 — "set base power/toughness to a dynamic count".
+//!
+//! These tests drive the layer system (`evaluate_layers`) for the base-P/T-set
+//! continuous modifications routed by the parser to the existing layer-7b
+//! `ContinuousModification::SetPowerDynamic`/`SetToughnessDynamic` variants
+//! (CR 613.4b + CR 208.1). No new engine variant is introduced — the batch is a
+//! parser extension onto the established dynamic base-P/T-set primitive.
+//!
+//! Each test is discriminating: the asserted P/T equals the *dynamic count/power*
+//! that differs from the printed value, so reverting the parser fix — which leaves
+//! the line `Unimplemented`, hence no modification and the printed P/T unchanged —
+//! flips the assertion. The permanent-static case (Porcelain Gallery) additionally
+//! proves the value re-evaluates when the count changes; the one-shot
+//! activated-ability cases (Pupu UFO, Sita Varma) prove the CR 608.2h resolution
+//! snapshot (the value is locked in once and does not track later changes).
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::remove_from_zone;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::AbilityKind;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Porcelain Gallery: "Creatures you control have base power and toughness each
+/// equal to the number of creatures you control."
+///
+/// CR 613.4b layer 7b set + CR 208.1: every creature you control has base P/T
+/// equal to the live creature count, re-evaluated each layer pass.
+#[test]
+fn porcelain_gallery_creatures_become_count_and_track_changes() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The static lives on a noncreature artifact (so it does not count itself).
+    scenario
+        .add_creature(P0, "Porcelain Gallery", 0, 0)
+        .as_artifact()
+        .from_oracle_text(
+            "Creatures you control have base power and toughness each equal to the number of creatures you control.",
+        );
+
+    // Three creatures you control with printed P/T differing from the count, so
+    // a passing assertion cannot be a coincidence of the printed value.
+    let bear = scenario.add_creature(P0, "Bear", 2, 2).id();
+    let elf = scenario.add_creature(P0, "Elf", 1, 1).id();
+    let wolf = scenario.add_creature(P0, "Wolf", 5, 5).id();
+    // An opponent's creature must NOT be affected and must NOT be counted.
+    let goblin = scenario.add_creature(P1, "Goblin", 4, 4).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // Three creatures you control → base P/T 3/3 for each (overwriting printed).
+    for id in [&bear, &elf, &wolf] {
+        assert_eq!(
+            runner.state().objects[id].power,
+            Some(3),
+            "base power becomes the creature count (3), not the printed value"
+        );
+        assert_eq!(runner.state().objects[id].toughness, Some(3));
+    }
+
+    // Opponent's creature is untouched (not affected, not counted).
+    assert_eq!(runner.state().objects[&goblin].power, Some(4));
+    assert_eq!(runner.state().objects[&goblin].toughness, Some(4));
+
+    // Perturb the count: remove one of your creatures → count = 2 → base P/T
+    // tracks down to 2/2. This is what discriminates the fix: with the line left
+    // Unimplemented the printed P/T would be unchanged (2/2, 1/1) and would not
+    // track at all.
+    remove_from_zone(runner.state_mut(), wolf, Zone::Battlefield, P0);
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    assert_eq!(
+        runner.state().objects[&bear].power,
+        Some(2),
+        "base power tracks the count down to 2 after a creature leaves"
+    );
+    assert_eq!(runner.state().objects[&bear].toughness, Some(2));
+    assert_eq!(runner.state().objects[&elf].power, Some(2));
+    assert_eq!(runner.state().objects[&elf].toughness, Some(2));
+}
+
+/// Pupu UFO: "{3}: Until end of turn, this creature's base power becomes equal to
+/// the number of Towns you control."
+///
+/// CR 613.4b layer 7b + CR 608.2h: the *power* axis only is set, to the Town
+/// count snapshotted at resolution (a one-shot continuous effect from a resolving
+/// ability locks the count in once — it does NOT track later count changes, in
+/// contrast with Porcelain Gallery's permanent static). Toughness is unchanged.
+#[test]
+fn pupu_ufo_base_power_becomes_town_count_power_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Pupu UFO is a 2/2 flier; its base power will be set, toughness untouched.
+    let pupu = scenario.add_creature(P0, "Pupu UFO", 2, 2).id();
+
+    // Three Towns you control (subtype "Town"); a fourth Town is the opponent's
+    // and must not count.
+    scenario
+        .add_creature(P0, "Town A", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Town"]);
+    scenario
+        .add_creature(P0, "Town B", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Town"]);
+    let town_c = scenario
+        .add_creature(P0, "Town C", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Town"])
+        .id();
+    scenario
+        .add_creature(P1, "Opponent Town", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Town"]);
+
+    let mut runner = scenario.build();
+
+    // Resolve the "{3}" base-power-set effect (parse just the effect body — the
+    // mana cost is irrelevant to the continuous-set semantics under test).
+    let def = parse_effect_chain(
+        "Until end of turn, this creature's base power becomes equal to the number of Towns you control",
+        AbilityKind::Activated,
+    );
+    let ability = build_resolved_from_def(&def, pupu, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("the base-power-set ability must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // Three Towns you control → base power 3 (overwriting the printed 2 — the
+    // count differs from the printed value, so the assertion discriminates).
+    assert_eq!(
+        runner.state().objects[&pupu].power,
+        Some(3),
+        "base power becomes the Town count"
+    );
+    // Toughness untouched (power-only axis): still the printed 2.
+    assert_eq!(
+        runner.state().objects[&pupu].toughness,
+        Some(2),
+        "toughness must remain the printed value (power-only set)"
+    );
+
+    // CR 608.2h: the count is locked in at resolution. Removing a Town afterward
+    // does NOT change the set power — it stays 3 (a one-shot continuous effect,
+    // unlike Porcelain Gallery's continuously-recomputed static).
+    remove_from_zone(runner.state_mut(), town_c, Zone::Battlefield, P0);
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert_eq!(
+        runner.state().objects[&pupu].power,
+        Some(3),
+        "base power was snapshotted at resolution (CR 608.2h) — stays 3 after a Town leaves"
+    );
+    assert_eq!(
+        runner.state().objects[&pupu].toughness,
+        Some(2),
+        "toughness still untouched"
+    );
+}
+
+/// Sita Varma, Masked Racer: "… have the base power and toughness of each other
+/// creature you control become equal to Sita Varma's power until end of turn."
+///
+/// CR 613.4b layer 7b: each OTHER creature you control has both base P/T set to
+/// Sita Varma's (the source's) power. Sita Varma itself and opponents' creatures
+/// are unaffected.
+#[test]
+fn sita_varma_other_creatures_base_pt_become_source_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Sita Varma's power is 5 (printed) — the value the other creatures take.
+    let sita = scenario
+        .add_creature(P0, "Sita Varma, Masked Racer", 5, 5)
+        .id();
+    let ally_a = scenario.add_creature(P0, "Ally A", 1, 1).id();
+    let ally_b = scenario.add_creature(P0, "Ally B", 2, 3).id();
+    let enemy = scenario.add_creature(P1, "Enemy", 4, 4).id();
+
+    let mut runner = scenario.build();
+
+    let def = parse_effect_chain(
+        "have the base power and toughness of each other creature you control become equal to ~'s power until end of turn",
+        AbilityKind::Activated,
+    );
+    let ability = build_resolved_from_def(&def, sita, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("the base-P/T-set ability must resolve");
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // Each OTHER creature you control: base P/T become 5/5 (Sita Varma's power).
+    for id in [&ally_a, &ally_b] {
+        assert_eq!(
+            runner.state().objects[id].power,
+            Some(5),
+            "other creature base power becomes Sita Varma's power (5)"
+        );
+        assert_eq!(
+            runner.state().objects[id].toughness,
+            Some(5),
+            "other creature base toughness becomes Sita Varma's power (5)"
+        );
+    }
+
+    // Sita Varma itself is NOT affected ("each OTHER creature"): still 5/5.
+    assert_eq!(runner.state().objects[&sita].power, Some(5));
+    assert_eq!(runner.state().objects[&sita].toughness, Some(5));
+
+    // The opponent's creature is untouched: still 4/4.
+    assert_eq!(runner.state().objects[&enemy].power, Some(4));
+    assert_eq!(runner.state().objects[&enemy].toughness, Some(4));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std-card BATCH 10 — set base power/toughness to a dynamic count

Routes the "base power [and toughness] become equal to `<dynamic quantity>`" family of Oracle phrasings to the **existing** layer-7b dynamic base-P/T-set primitive. Ships 3 cards at 0 unimplemented; honest-defers 1.

## add-engine-variant gate verdict — REFUSE_WITH_EXISTING_SLOT (parser-only batch)

The plan proposed adding `ContinuousModification::SetBasePowerToughness { value: QuantityExpr }`. Running the gate:

- **Stage 1 (existence verification): EXISTS_AS_PARAMETER.** The concept already exists, parameterized by `QuantityExpr`, as the pair:
  - `ContinuousModification::SetPowerDynamic { value: QuantityExpr }` — `crates/engine/src/types/ability.rs:15604`
  - `ContinuousModification::SetToughnessDynamic { value: QuantityExpr }` — `crates/engine/src/types/ability.rs:15609`

  Both are layer-7b (CR 613.4b), fully wired through `types/layers.rs`, `game/layers.rs`, `game/quantity.rs`, `game/coverage.rs`, `game/printed_cards.rs`, `game/effects/{pump,animate,effect,token_copy}.rs`, and the parser. `Effect::Animate { power: Option<PtValue>, toughness: Option<PtValue> }` is the resolution-time companion that routes `PtValue::Quantity` to them. (The `SetBasePowerToughness` in `data/engine-inventory.json` is a `DebugAction` test helper, not a `ContinuousModification`.)

  Adding `SetBasePowerToughness` would be a redundant sibling for the same value-source axis that `SetPowerDynamic`/`SetToughnessDynamic` already cover — exactly the proliferation the "parameterize, don't proliferate" rule forbids.

- **Stages 2/3: not reached** (Stage 1 refused). No new variant added; `data/engine-inventory.json` is unchanged.

This is therefore a **parser-only** batch: extend the parser to route the count-expression phrasings to the existing variants.

## Grep-verified CR annotations

| CR | Rule (verified in `docs/MagicCompRules.txt`) | Use |
|----|----|-----|
| CR 208.1 | Power/Toughness — "Power and toughness can be modified or set to particular values by effects." | base-P/T set semantics |
| CR 613.4b | Layer 7b: effects that set power/toughness to a value; effects referring to base P/T apply here | layer placement |
| CR 608.2h | "information from the game … is determined only once, when the effect is applied" | one-shot resolution snapshot (Pupu UFO, Sita Varma) |
| CR 604.3 | characteristic-defining abilities | Porcelain Gallery static doc |
| CR 702.177 | Exhaust | Sita Varma ability framing |

Note: the plan said "CR 208/209" — **CR 209 is Loyalty**, not toughness. Power AND toughness are both CR 208; layer 7b is **CR 613.4b** (not 613.3). Annotated accordingly. CR-annotation diff gate: 0 UNVERIFIED.

## Per-card verdict

| Card | Phrasing | Verdict | Notes |
|------|----------|---------|-------|
| Porcelain Gallery | "Creatures you control have base power and toughness each equal to the number of creatures you control" (static) | SHIPPED 0-unimpl | Both axes → `SetPowerDynamic`/`SetToughnessDynamic { ObjectCount(creatures you control) }`. Permanent static → re-evaluates per layer pass. |
| Pupu UFO | "{3}: Until end of turn, this creature's base power becomes equal to the number of Towns you control" (activated) | SHIPPED 0-unimpl | Power-only axis → `SetPowerDynamic { ObjectCount(Towns) }`; toughness untouched. One-shot → snapshot at resolution (CR 608.2h). |
| Sita Varma, Masked Racer | "have the base power and toughness of each other creature you control become equal to Sita Varma's power" (Exhaust) | SHIPPED 0-unimpl | Inverted genitive + non-self group subject (other creatures you control) + self-power value (`~`-normalized → `Power{Source}`). Both axes. |
| The Skullspore Nexus | "create a … token with base power and toughness each equal to the total power of those creatures" (death trigger) | HONEST-DEFER | "those creatures" = the dying nontoken creatures captured by the trigger — an event-context aggregate the quantity grammar does not resolve, and `TokenCharacteristics.power` is `Option<i32>` (fixed). Needs event-context aggregate quantity infra beyond the bounded primitive. Stays `Effect::unimplemented` (name "create"). |

## Parser changes (building blocks, not card special-cases)

- `oracle_static/anthem.rs`: generalized `parse_base_pt_mana_value_dynamic` → `parse_base_pt_each_equal_dynamic`. Factors the "[base] power and [base] toughness [are] each equal to " prefix per the nom mandate (sum-of-axes, not product); the value tail dispatches "its mana value" (recipient scope) vs. the shared `parse_cda_quantity` grammar, so the static base-P/T set composes over every count/aggregate phrase. Back-compat shim preserves the old name/callers.
- `oracle_effect/subject.rs`: generalized `try_parse_subject_base_pt_set_clause_ast` to (a) the power-only / toughness-axis split via `parse_base_pt_axes`, (b) a fixed-or-dynamic value via `parse_base_pt_set_value` (fixed `N/M` → `SetPower`/`SetToughness`; "[each] equal to `<quantity>`" → `SetPowerDynamic`/`SetToughnessDynamic`), and (c) the inverted-genitive "the base power and toughness of `<subject>` become[s] equal to …" surface form. Pre-existing fixed-N/M cases (Moon Girl, etc.) unchanged.

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion |
|---|---|---|---|---|
| Porcelain Gallery static sets both base P/T to creature count | `anthem::parse_base_pt_each_equal_dynamic` → `keyword_grant::parse_continuous_modifications` | `from_oracle_text` static install → `evaluate_layers` | `porcelain_gallery_creatures_become_count_and_track_changes` (tests/base_pt_dynamic_set_std_base_pt.rs) | `objects[elf].power == Some(3)` (printed 1; revert leaves printed) + tracks to 2 after a creature leaves |
| Pupu UFO sets base power only to Town count, snapshotted | `subject::try_parse_subject_base_pt_set_clause_ast` (power-only, dynamic) | `parse_effect_chain` → `build_resolved_from_def` → `resolve_ability_chain` → `evaluate_layers` | `pupu_ufo_base_power_becomes_town_count_power_only` | `power == Some(3)` (printed 2), `toughness == Some(2)` (untouched), stays 3 after a Town leaves (CR 608.2h) |
| Sita Varma sets each other creature's base P/T to source power | `subject::try_parse_subject_base_pt_set_clause_ast` (inverted genitive, group subject, `Power{Source}`) | same pipeline | `sita_varma_other_creatures_base_pt_become_source_power` | allies `power/toughness == Some(5)`, Sita itself `5/5` (excluded), enemy `4/4` (untouched) |
| Full-card 0 coverage gaps | full synthesis | `build_oracle_face` → `card_face_gaps` | `porcelain_gallery_full_card_supported_dynamic_base_pt`, `pupu_ufo_full_card_supported_dynamic_base_power`, `sita_varma_full_card_supported_inverted_genitive_base_pt` | `card_face_gaps(&face).is_empty()` |
| Parser AST shape (Porcelain/Pupu/Sita) | parser | `parse_static_line` / `parse_effect_chain` | `porcelain_gallery_base_pt_equal_to_creature_count`, `effect_subject_base_power_becomes_equal_to_count_power_only`, `effect_inverted_genitive_base_pt_of_group_equal_to_source_power` | exact `SetPowerDynamic`/`SetToughnessDynamic` value-expr match |

Sibling/negative coverage: opponent creatures excluded (Porcelain, Sita); self excluded ("each other", Sita); toughness untouched on the power-only axis (Pupu); pre-existing fixed-N/M base-PT-set and mana-value tests (Moon Girl, Biomass Mutation, Belligerent Yearling, Karn/Sydri, animate cycle) all still green.

No production-reachable seam is left covered only by a degenerate fixture: each runtime test reaches the real layer-evaluation arm with multi-element battlefields, non-trivial printed P/T, and an excluded opponent/self control.

## Gate results (worktree off upstream/main `dea20b1af`)

| Gate | Result |
|------|--------|
| `cargo fmt --all` | clean |
| `./scripts/check-parser-combinators.sh` | 0 |
| `./scripts/check-engine-authorities.sh upstream/main` | 0 |
| `cargo check --workspace --all-targets` | 0 |
| `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` | 0 |
| `cargo test -p engine` | 12969 pass; only the known parallel-flaky `ai_support::*delve_payment*` failed under parallelism (passes in isolation) |
| parser diff gate (inline string-dispatch grep) | clean (only test-assertion `.contains()` on `Vec`) |
| CR-annotation diff gate | 0 UNVERIFIED |
| `data/engine-inventory.json` | unchanged (no variant added) |
| `cargo coverage` / `cargo semantic-audit` | not runnable in worktree (no `card-data.json`); per-card full-card 0-gap tests substitute, per the worktree protocol |
