### PR TITLE
feat(parser): grant all activated abilities of cards exiled with the source (Myr Welder, Dark Impostor, ...)

### DIFF
--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -614,14 +614,59 @@ pub(crate) fn parse_chosen_qualifier_subject(tp: &TextPair<'_>) -> Option<Target
 fn parse_grant_all_activated_abilities_source(
     lower: &str,
 ) -> Option<crate::types::ability::TargetFilter> {
+    use crate::types::ability::{TypeFilter, TypedFilter};
     let p = lower.trim().trim_end_matches('.').trim();
-    all_consuming(preceded(
-        tag::<_, _, OracleError<'_>>("all activated abilities of "),
+
+    // CR 205.2a: a card-type qualifier on "all <type> cards exiled with it"
+    // (Dark Impostor / Patchwork Crawler restrict the granted set to creatures).
+    fn core_type_filter(input: &str) -> OracleResult<'_, TargetFilter> {
         alt((
+            value(TypeFilter::Creature, tag("creature")),
+            value(TypeFilter::Artifact, tag("artifact")),
+            value(TypeFilter::Enchantment, tag("enchantment")),
+            value(TypeFilter::Planeswalker, tag("planeswalker")),
+            value(TypeFilter::Land, tag("land")),
+        ))
+        .map(|ty| TargetFilter::Typed(TypedFilter::default().with_type(ty)))
+        .parse(input)
+    }
+
+    // A leading copula ("has"/"have"/"gains"/"gain"/"are"/"is") is present when
+    // the predicate arrives from the subject-predicate static path (e.g. "This
+    // creature has all activated abilities of …"); strip it as the sibling
+    // modification parsers do, then require the "all activated abilities of "
+    // spine.
+    all_consuming(preceded(
+        (
+            opt(alt((
+                tag::<_, _, OracleError<'_>>("has "),
+                tag("have "),
+                tag("gains "),
+                tag("gain "),
+                tag("are "),
+                tag("is "),
+            ))),
+            tag("all activated abilities of "),
+        ),
+        alt((
+            // Territory Forge: "the exiled card".
             value(TargetFilter::ExiledBySource, tag("the exiled card")),
-            value(
-                TargetFilter::ExiledBySource,
-                (tag("all cards exiled with "), alt((tag("it"), tag("~")))),
+            // CR 613.1f: "all [<type>] cards exiled with it/~" — the cards exiled
+            // with the source, optionally restricted to a card type (Myr Welder
+            // untyped; Dark Impostor / Patchwork Crawler creature-typed).
+            map(
+                (
+                    tag("all "),
+                    opt(terminated(core_type_filter, tag(" "))),
+                    tag("cards exiled with "),
+                    alt((tag("it"), tag("~"))),
+                ),
+                |(_, type_filter, _, _)| match type_filter {
+                    Some(tf) => TargetFilter::And {
+                        filters: vec![TargetFilter::ExiledBySource, tf],
+                    },
+                    None => TargetFilter::ExiledBySource,
+                },
             ),
         )),
     ))

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5156,11 +5156,15 @@ fn parse_continuous_modifications_are_goaded_emits_goaded_static_mode() {
 /// Welder, Territory Forge). Issue #3101.
 #[test]
 fn parse_continuous_modifications_grants_all_activated_abilities_of_exiled() {
-    use crate::types::ability::TargetFilter;
+    use crate::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+    // Untyped exiled-with-it forms (Myr Welder, Territory Forge), including the
+    // leading copula that the subject-predicate static path passes through.
     for predicate in [
         "all activated abilities of all cards exiled with it",
         "all activated abilities of all cards exiled with ~",
         "all activated abilities of the exiled card",
+        "has all activated abilities of all cards exiled with it",
+        "has all activated abilities of the exiled card",
     ] {
         let mods = parse_continuous_modifications(predicate);
         assert_eq!(
@@ -5171,13 +5175,22 @@ fn parse_continuous_modifications_grants_all_activated_abilities_of_exiled() {
             "predicate: {predicate}"
         );
     }
-    // Typed/counter/battlefield forms stay a gap (no modification) for now.
-    assert!(
-        parse_continuous_modifications(
-            "all activated abilities of all creature cards exiled with it"
-        )
-        .is_empty(),
-        "typed 'creature cards exiled with it' must stay a gap (follow-up)"
+    // CR 205.2a: the typed "all creature cards exiled with it" restricts the
+    // granted set to creatures (Dark Impostor, Patchwork Crawler).
+    let typed = parse_continuous_modifications(
+        "has all activated abilities of all creature cards exiled with it",
+    );
+    assert_eq!(
+        typed,
+        vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+            source: TargetFilter::And {
+                filters: vec![
+                    TargetFilter::ExiledBySource,
+                    TargetFilter::Typed(TypedFilter::default().with_type(TypeFilter::Creature)),
+                ],
+            },
+        }],
+        "typed 'creature cards exiled with it' should restrict to creatures"
     );
 }
 


### PR DESCRIPTION
Fixes #4014.

## What

The self-referential static **"This creature has all activated abilities of [the cards exiled with it]"** was dropping to `Unimplemented` end-to-end for the whole exiled-with-it cycle, even though the engine already models it via `ContinuousModification::GrantAllActivatedAbilitiesOf { source }`.

Cards fixed (Scryfall-verified):

- **Myr Welder** â€” "â€¦all activated abilities of all cards exiled with it." â†’ `GrantAllActivatedAbilitiesOf { ExiledBySource }`
- **Territory Forge** â€” "â€¦all activated abilities of the exiled card." â†’ `GrantAllActivatedAbilitiesOf { ExiledBySource }`
- **Dark Impostor** / **Patchwork Crawler** â€” "â€¦all activated abilities of all creature cards exiled with it." â†’ `GrantAllActivatedAbilitiesOf { And([ExiledBySource, Typed(creature)]) }`

## How

Two fixes in `parse_grant_all_activated_abilities_source` (the source parser already had a passing *unit* test, but the production subject-predicate static path never reached it):

1. **Copula routing.** The subject-predicate static path passes the predicate **with its copula** ("**has** all activated abilities of â€¦"), but the parser matched `tag("all activated abilities of ")` at position 0 and failed on the leading "has ". Now it strips an optional leading copula (`has`/`have`/`gains`/`gain`/`are`/`is`) â€” mirroring the sibling `parse_all_land_types_modification`. â†’ Myr Welder, Territory Forge.
2. **Typed source.** Added "all **<type>** cards exiled with it/~" â†’ `And([ExiledBySource, Typed(<type>)])` (creature for Dark Impostor / Patchwork Crawler), closing the previously-documented gap. â†’ Dark Impostor, Patchwork Crawler.

Parser-only â€” reuses the existing `GrantAllActivatedAbilitiesOf` modification, its layer-6 dynamic expansion, and the `ExiledBySource`/`And`/typed filters. No engine/runtime change.

## Verification

- Updated `parse_continuous_modifications_grants_all_activated_abilities_of_exiled` to cover the copula forms and assert the typed creature form â†’ `And([ExiledBySource, Typed(creature)])` (it previously asserted that form "stays a gap").
- Regenerated `card-data.json`: Myr Welder, Territory Forge, Dark Impostor, and Patchwork Crawler now carry `GrantAllActivatedAbilitiesOf` and are no longer `Unimplemented`.
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) are green.

## Scope

Out of scope (remain `Unimplemented`, separate follow-ups): non-exiled source sets ("all creatures your opponents control", "all lands on the battlefield", "all legendary creatures you control"), counter-gated exile sets (Mairsil, Rex), and chosen-permanent / except-clause forms (Scheming Fence, Sharkey).

CR 613.1f + CR 113.3 (granting all activated abilities of a dynamic source set); CR 205.2a (card-type qualifier).
