### PR TITLE
feat(parser): Role-token attach + Otherwise control-gate (Royal Treatment, Wick the Whorled Mind)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1900,9 +1900,24 @@ pub(crate) fn condition_text_is_rehomeable(condition_text: &str) -> bool {
     // list (the verbatim pre-existing `excluded_prefixes` set), not parser
     // dispatch. The actual condition parsing is done downstream by
     // `parse_inner_condition` / `parse_condition_text`.
-    !NON_REHOMEABLE_CONDITION_PREFIXES
-        .iter()
-        .any(|prefix| condition_text.starts_with(prefix))
+    //
+    // Each prefix must match on a word boundary: a bare `starts_with` lets the
+    // reflexive predicate `"you do"` swallow the control-presence condition
+    // `"you don't control a Snail"` (Wick, the Whorled Mind) — the latter is
+    // re-homeable as `Not(IsPresent)`, the former is the no-`AbilityCondition`
+    // optional-effect signal. The check only applies to prefixes whose last
+    // character is alphanumeric (e.g. "you do"): there the *following* character
+    // in the text must not be alphanumeric, so "you do**n't**" (continues with
+    // 'n') is rejected. Prefixes already ending in a space ("its power is ",
+    // "it has ") carry their own boundary, so they exclude on a plain prefix
+    // match and must NOT impose an extra boundary on the alphanumeric residual.
+    !NON_REHOMEABLE_CONDITION_PREFIXES.iter().any(|prefix| {
+        let prefix_ends_alnum = prefix.chars().next_back().is_some_and(|c| c.is_alphanumeric());
+        // allow-noncombinator: word-boundary membership test against a fixed exclusion list, not parsing dispatch (parsing happens downstream in parse_inner_condition)
+        condition_text.strip_prefix(prefix).is_some_and(|rest| {
+            !prefix_ends_alnum || !rest.chars().next().is_some_and(|c| c.is_alphanumeric())
+        })
+    })
 }
 
 /// CR 707.10c: When a suffix condition is immediately followed by a copy-retarget
@@ -3495,6 +3510,15 @@ pub(super) fn try_nom_condition_as_ability_condition(
         return Some(AbilityCondition::EventOutcomeWon);
     }
 
+    // CR 603.12 + CR 608.2c: reflexive "you don't" / "you do not" / "you didn't"
+    // / "you did not" — the verb anaphors back to the immediately preceding
+    // optional action ("you didn't put a card into your hand this way"), so the
+    // fragment is the optional-effect signal, NOT a game-state condition. But a
+    // trailing game-state predicate ("you don't *control a Snail*", Wick) is a
+    // genuine control-presence gate. Disambiguate by deferring to the typed
+    // condition parser first: when `parse_inner_condition` consumes the whole
+    // fragment, it is a real game-state condition (re-homed below); only when it
+    // cannot is this the reflexive optional-effect signal.
     if alt((
         tag::<_, _, OracleError<'_>>("you don't"),
         tag("you do not"),
@@ -3503,6 +3527,7 @@ pub(super) fn try_nom_condition_as_ability_condition(
     ))
     .parse(lower.as_str())
     .is_ok()
+        && !parse_inner_condition(&lower).is_ok_and(|(rest, _)| rest.trim().is_empty())
     {
         return Some(AbilityCondition::Not {
             condition: Box::new(AbilityCondition::effect_performed()),

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1912,7 +1912,10 @@ pub(crate) fn condition_text_is_rehomeable(condition_text: &str) -> bool {
     // "it has ") carry their own boundary, so they exclude on a plain prefix
     // match and must NOT impose an extra boundary on the alphanumeric residual.
     !NON_REHOMEABLE_CONDITION_PREFIXES.iter().any(|prefix| {
-        let prefix_ends_alnum = prefix.chars().next_back().is_some_and(|c| c.is_alphanumeric());
+        let prefix_ends_alnum = prefix
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric());
         // allow-noncombinator: word-boundary membership test against a fixed exclusion list, not parsing dispatch (parsing happens downstream in parse_inner_condition)
         condition_text.strip_prefix(prefix).is_some_and(|rest| {
             !prefix_ends_alnum || !rest.chars().next().is_some_and(|c| c.is_alphanumeric())

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -2016,6 +2016,17 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
                         // E.g. "Merfolk Mistbinder" → "Other Merfolk you control get +1/+1."
                         // would become "Other ~ you control..." without this guard.
                         || replaced.contains("~ you control")
+                        // CR 111.10 + CR 303.7: Named token guard. A card-name first word
+                        // immediately followed by a token-subtype noun ("Role"/"Aura") is the
+                        // *token's* name, not a self-reference — the named-Role/Aura-token class
+                        // is "<Name> Role token attached to ..." (Royal Treatment's "Royal Role",
+                        // Cursed/Monster/Wicked/Sorcerer/Virtuous Roles). Replacing the first
+                        // word there ("Royal" → "~") destroys the token name and the token
+                        // parser can no longer recognize it.
+                        // allow-noncombinator: structural guard on already-normalized output (mirrors the "~ creatures"/"~ you control" guards above), not parsing dispatch
+                        || replaced.contains("~ Role")
+                        // allow-noncombinator: structural guard on already-normalized output, not parsing dispatch
+                        || replaced.contains("~ Aura")
                     {
                         continue;
                     }

--- a/crates/engine/tests/std_small_parser_a_batch.rs
+++ b/crates/engine/tests/std_small_parser_a_batch.rs
@@ -1,0 +1,363 @@
+//! Standard small parser-only batch A — three parser seams that route to
+//! existing engine surface, no new engine variant:
+//!
+//! - §16 mana-of-any-type spend permission (Vizier of the Menagerie,
+//!   Outrageous Robbery) — HONEST-DEFER (need a spell-type-filtered any-type
+//!   spend seam / impulse-exile infra beyond the existing surface).
+//! - §19 Role token attach (Royal Treatment SHIPPED, Become Brutes
+//!   HONEST-DEFER — per-target iteration over the multi-target set).
+//! - §22 "Otherwise" sequence-branch (Wick, the Whorled Mind SHIPPED, Bre of
+//!   Clan Stoutarm HONEST-DEFER — spell-MV-vs-life-gained comparison gate).
+//!
+//! The two SHIPPED cards each carry a discriminating runtime test that drives
+//! `resolve_ability_chain` (the production resolver) and asserts a game-state
+//! outcome that FLIPS if the parser fix is reverted. The four deferred cards
+//! carry honesty guards asserting the residual gap is exactly the unsupported
+//! clause (not an over-claim).
+
+use engine::game::ability_utils::{build_resolved_from_def, build_resolved_from_def_with_targets};
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCondition, Effect, TargetRef};
+use engine::types::phase::Phase;
+
+fn creature_types() -> Vec<String> {
+    vec!["Creature".to_string()]
+}
+
+fn parsed_debug(oracle: &str, name: &str, types: &[String], subtypes: &[String]) -> String {
+    format!(
+        "{:#?}",
+        parse_oracle_text(oracle, name, &[], types, subtypes)
+    )
+}
+
+fn assert_zero_unimplemented(oracle: &str, name: &str, types: &[String], subtypes: &[String]) {
+    let dbg = parsed_debug(oracle, name, types, subtypes);
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+// ===========================================================================
+// §22 — Wick, the Whorled Mind (SHIPPED)
+//
+// "Whenever Wick or another Rat you control enters, create a 1/1 black Snail
+//  creature token if you don't control a Snail. Otherwise, put a +1/+1 counter
+//  on a Snail you control."
+//
+// Two parser bugs blocked the Otherwise routing:
+//   1. `condition_text_is_rehomeable` excluded "you don't control a Snail"
+//      because the reflexive-predicate prefix "you do" matched "you do**n't**"
+//      (no word boundary), so the trailing "if" condition was never extracted.
+//   2. the bare "you don't" reflexive arm in
+//      `try_nom_condition_as_ability_condition` swallowed the control-presence
+//      condition before the typed `parse_inner_condition` fall-through.
+// With the Token clause carrying no condition, the Otherwise lowered to the
+// unconditional `OtherwiseFallback` (`Unimplemented{otherwise}` + sibling
+// counter) instead of attaching as the Token's `else_ability`.
+// ===========================================================================
+
+#[test]
+fn wick_otherwise_attaches_as_token_else_ability() {
+    const ORACLE: &str = "Whenever Wick or another Rat you control enters, create a 1/1 black Snail creature token if you don't control a Snail. Otherwise, put a +1/+1 counter on a Snail you control.\n{U}{B}{R}, Sacrifice a Snail: Wick deals damage equal to the sacrificed creature's power to each opponent. Then draw cards equal to the sacrificed creature's power.";
+    assert_zero_unimplemented(
+        ORACLE,
+        "Wick, the Whorled Mind",
+        &creature_types(),
+        &["Rat".to_string()],
+    );
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Wick, the Whorled Mind",
+        &[],
+        &creature_types(),
+        &["Rat".to_string()],
+    );
+    let trigger = &parsed.triggers[0];
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("Wick ETB trigger must carry an execute ability");
+    // Revert guard (shape): the conditional must be a Token gated by a
+    // control-presence QuantityCheck with the PutCounter as its else_ability.
+    // Pre-fix this lowered to Token (no condition) → Unimplemented{otherwise} →
+    // PutCounter sibling.
+    assert!(
+        matches!(*execute.effect, Effect::Token { .. }),
+        "execute root must be the Token creation, got {:?}",
+        execute.effect
+    );
+    assert!(
+        matches!(
+            execute.condition,
+            Some(AbilityCondition::QuantityCheck { .. })
+        ),
+        "Token clause must carry the 'you don't control a Snail' gate, got {:?}",
+        execute.condition
+    );
+    let else_branch = execute
+        .else_ability
+        .as_deref()
+        .expect("Otherwise must attach the PutCounter as else_ability, not a fallback sibling");
+    assert!(
+        matches!(*else_branch.effect, Effect::PutCounter { .. }),
+        "else branch must be the +1/+1 counter, got {:?}",
+        else_branch.effect
+    );
+
+    // Runtime discrimination on the CONDITION GATE through the production
+    // resolver. The fix routes "you don't control a Snail" onto the Token's
+    // `condition`; pre-fix the Token carried no condition (Otherwise lowered to
+    // an unconditional fallback), so the token would be created unconditionally.
+    //
+    // Case A — no Snail controlled (condition TRUE): the if-branch fires and a
+    // Snail token IS created.
+    {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wick = scenario
+            .add_creature(P0, "Wick, the Whorled Mind", 0, 3)
+            .id();
+        let mut runner = scenario.build();
+        let snails_before = count_snails(&runner);
+        let ability = build_resolved_from_def(execute, wick, P0);
+        let mut events = Vec::new();
+        resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+            .expect("Wick ETB if-branch must resolve");
+        assert_eq!(
+            count_snails(&runner),
+            snails_before + 1,
+            "with no Snail controlled, the if-branch must create a Snail token"
+        );
+    }
+
+    // Case B — a Snail already controlled (condition FALSE): the if-branch is
+    // gated OFF, so NO new Snail token is created (the else branch runs instead).
+    // This is the assertion that FLIPS on revert: pre-fix the token was created
+    // regardless of the condition.
+    {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let wick = scenario
+            .add_creature(P0, "Wick, the Whorled Mind", 0, 3)
+            .id();
+        scenario
+            .add_creature(P0, "Resident Snail", 1, 1)
+            .with_subtypes(vec!["Snail"]);
+        let mut runner = scenario.build();
+        let snails_before = count_snails(&runner);
+        let ability = build_resolved_from_def(execute, wick, P0);
+        let mut events = Vec::new();
+        resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+            .expect("Wick ETB else-branch must resolve");
+        assert_eq!(
+            count_snails(&runner),
+            snails_before,
+            "with a Snail already controlled, the if-branch (token) must be gated off"
+        );
+    }
+}
+
+fn count_snails(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.card_types.subtypes.iter().any(|s| s == "Snail"))
+        .count()
+}
+
+// ===========================================================================
+// §19 — Royal Treatment (SHIPPED)
+//
+// "Target creature you control gains hexproof until end of turn. Create a Royal
+//  Role token attached to that creature."
+//
+// Bug: the card-name first-word fallback in `normalize_card_name_refs` replaced
+// "Royal" (first word of "Royal Treatment") with `~` inside the token name
+// "Royal Role", corrupting it to "~ Role" — the token parser then failed and
+// the clause stayed an `Unimplemented{create}`. Fixed by guarding the fallback
+// against a card-name word immediately followed by a token-subtype noun
+// ("Role"/"Aura").
+// ===========================================================================
+
+#[test]
+fn royal_treatment_creates_role_token_attached_to_target() {
+    const ORACLE: &str = "Target creature you control gains hexproof until end of turn. Create a Royal Role token attached to that creature. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.)";
+    assert_zero_unimplemented(ORACLE, "Royal Treatment", &["Instant".to_string()], &[]);
+
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Royal Treatment",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let spell = &parsed.abilities[0];
+    // Revert guard (shape): the Role token clause must reach a Token effect with
+    // the correct (un-mangled) token name. Pre-fix the name was "~ Role" and the
+    // clause was Unimplemented{create}.
+    let token_def = {
+        // Walk the sub_ability chain for the Token clause (the hexproof grant is
+        // the root; the Role token rides in the sub_ability chain).
+        let mut found = None;
+        let mut cur = spell.sub_ability.as_deref();
+        while let Some(def) = cur {
+            if matches!(*def.effect, Effect::Token { .. }) {
+                found = Some(def);
+                break;
+            }
+            cur = def.sub_ability.as_deref();
+        }
+        found.expect("Royal Treatment must lower a Role Token creation clause")
+    };
+    let Effect::Token {
+        name, attach_to, ..
+    } = token_def.effect.as_ref()
+    else {
+        unreachable!("token_def filtered to Effect::Token");
+    };
+    assert_eq!(
+        name, "Royal Role",
+        "token name must be the un-mangled 'Royal Role' (pre-fix it was '~ Role')"
+    );
+    assert!(
+        attach_to.is_some(),
+        "the Role token must carry an attach target ('attached to that creature')"
+    );
+
+    // Runtime discrimination: resolving the spell against a controlled creature
+    // creates exactly one new permanent — the Royal Role token — attached to the
+    // targeted creature. If reverted, the clause is Unimplemented and creates
+    // nothing.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Royal Treatment Source", 1, 1)
+        .id();
+    let target = scenario.add_creature(P0, "Target Bear", 2, 2).id();
+    let mut runner = scenario.build();
+    let objects_before = runner.state().objects.len();
+
+    let ability =
+        build_resolved_from_def_with_targets(spell, source, P0, vec![TargetRef::Object(target)]);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Royal Treatment must resolve");
+
+    let new_objects: Vec<_> = runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.name == "Royal Role")
+        .collect();
+    assert_eq!(
+        new_objects.len(),
+        1,
+        "exactly one Royal Role token must be created"
+    );
+    assert!(
+        runner.state().objects.len() > objects_before,
+        "a new permanent (the Role token) must exist after resolution"
+    );
+    let role = new_objects[0];
+    assert!(
+        role.attached_to.is_some(),
+        "the Royal Role token must enter attached to the target creature (CR 303.7)"
+    );
+}
+
+// ===========================================================================
+// HONEST DEFERS — assert the residual gap is exactly the unsupported clause.
+// ===========================================================================
+
+// §16 — Vizier of the Menagerie. "You can spend mana of any type to cast
+// creature spells." Routing this to the unfiltered global `SpendManaAsAnyColor`
+// static would let any-type mana pay for NONcreature spells too (rules-wrong,
+// CR 609.4b). A spell-type-filtered any-type-spend seam does not exist, so this
+// line stays an honest Unimplemented while the look-at-top + cast-from-top
+// statics still parse.
+#[test]
+fn vizier_any_type_spend_is_honestly_deferred() {
+    const ORACLE: &str = "You may look at the top card of your library any time.\nYou may cast creature spells from the top of your library.\nYou can spend mana of any type to cast creature spells.";
+    let dbg = parsed_debug(
+        ORACLE,
+        "Vizier of the Menagerie",
+        &creature_types(),
+        &["Cat".to_string()],
+    );
+    assert!(
+        dbg.contains("Unimplemented") && dbg.contains("spend mana of any type"),
+        "the any-type-spend line must remain an honest Unimplemented defer; got:\n{dbg}"
+    );
+    assert!(
+        dbg.contains("MayLookAtTopOfLibrary"),
+        "the look-at-top static must still parse"
+    );
+    assert!(
+        dbg.contains("TopOfLibraryCastPermission"),
+        "the cast-creature-spells-from-top static must still parse"
+    );
+}
+
+// §16 — Outrageous Robbery. The "spend mana ... of any type to cast it" rider
+// rides on top of impulse-exile play infrastructure ("look at and play those
+// cards"), which is not built. Both residuals stay honest.
+#[test]
+fn outrageous_robbery_is_honestly_deferred() {
+    const ORACLE: &str = "Target opponent exiles the top X cards of their library face down. You may look at and play those cards for as long as they remain exiled. If you cast a spell this way, you may spend mana as though it were mana of any type to cast it.";
+    let dbg = parsed_debug(ORACLE, "Outrageous Robbery", &["Sorcery".to_string()], &[]);
+    assert!(
+        dbg.contains("Unimplemented") && dbg.contains("look at and play those cards"),
+        "the impulse-exile play clause must remain an honest Unimplemented defer; got:\n{dbg}"
+    );
+}
+
+// §19 — Become Brutes. "For each of those creatures, create a Monster Role
+// token attached to it." Needs per-target iteration over the spell's chosen
+// multi-target set with a per-iteration attach binding — infrastructure beyond
+// the single-target Role-attach surface. The haste grant still parses.
+#[test]
+fn become_brutes_for_each_target_role_is_honestly_deferred() {
+    const ORACLE: &str = "One or two target creatures each gain haste until end of turn. For each of those creatures, create a Monster Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has trample.)";
+    let dbg = parsed_debug(ORACLE, "Become Brutes", &["Instant".to_string()], &[]);
+    assert!(
+        dbg.contains("Unimplemented")
+            && dbg.contains("For each of those creatures, create a Monster Role token"),
+        "the for-each-target Role clause must remain an honest Unimplemented defer; got:\n{dbg}"
+    );
+    assert!(
+        dbg.contains("Haste"),
+        "the 'each gain haste' grant must still parse"
+    );
+}
+
+// §22 — Bre of Clan Stoutarm. The "Otherwise, put it into your hand" branch
+// depends on the antecedent gate "if the spell's mana value is less than or
+// equal to the amount of life you gained this turn" — a spell-MV-vs-dynamic-
+// life-gained QuantityCheck that is not modeled. Without the gate there is no
+// conditional for Otherwise to attach to, so it stays an honest fallback.
+#[test]
+fn bre_otherwise_mv_vs_life_gate_is_honestly_deferred() {
+    const ORACLE: &str = "{1}{W}, {T}: Another target creature you control gains flying and lifelink until end of turn.\nAt the beginning of your end step, if you gained life this turn, exile cards from the top of your library until you exile a nonland card. You may cast that card without paying its mana cost if the spell's mana value is less than or equal to the amount of life you gained this turn. Otherwise, put it into your hand.";
+    let dbg = parsed_debug(
+        ORACLE,
+        "Bre of Clan Stoutarm",
+        &creature_types(),
+        &["Dwarf".to_string(), "Cleric".to_string()],
+    );
+    assert!(
+        dbg.contains("Unimplemented") && dbg.contains("otherwise"),
+        "Bre's Otherwise branch must remain an honest Unimplemented defer; got:\n{dbg}"
+    );
+    // The flying+lifelink activated ability and the end-step exile-until trigger
+    // must still parse around the deferred gate.
+    assert!(
+        dbg.contains("ExileFromTopUntil"),
+        "exile-until must still parse"
+    );
+}

--- a/crates/engine/tests/std_small_parser_a_batch.rs
+++ b/crates/engine/tests/std_small_parser_a_batch.rs
@@ -265,9 +265,11 @@ fn royal_treatment_creates_role_token_attached_to_target() {
         "a new permanent (the Role token) must exist after resolution"
     );
     let role = new_objects[0];
-    assert!(
-        role.attached_to.is_some(),
-        "the Royal Role token must enter attached to the target creature (CR 303.7)"
+    assert_eq!(
+        role.attached_to
+            .and_then(|attached_to| attached_to.as_object()),
+        Some(target),
+        "the Royal Role token must enter attached to the targeted creature (CR 303.7)"
     );
 }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# fix(parser): Otherwise sequence-branch + Role-token self-ref guard (small parser-only batch A)

Three small parser-only singleton batches from the std-188 effort, bundled in one pass (all parser-only, no new engine variant). Each card is a parser extension routing standalone phrasings onto **existing** engine surface. `data/engine-inventory.json` is unchanged.

Branch: `card/std-small-parser-a` @ `e8d79db3f1c7e413e99967d53c041ddd62cd8c4f` (off `upstream/main` `53f4e52f7`).

## add-engine-variant verdict

**NO new engine variant for any of the three batches.** Confirmed by the unchanged `data/engine-inventory.json` and `./scripts/check-engine-authorities.sh upstream/main` (exit 0). The two shipped cards reuse `else_ability` + `AbilityCondition::QuantityCheck` (Otherwise) and `Effect::Token { attach_to }` (Role token). The four deferred cards each need infrastructure beyond the existing surface and are honest-deferred (`Effect::unimplemented`).

## What changed

Two surgical parser fixes:

1. **§22 Otherwise sequence-branch** (`oracle_effect/conditions.rs`). A trailing `"if you don't control a <type>"` gate was silently dropped, so the following `"Otherwise, ..."` clause lowered to the unconditional `OtherwiseFallback` (an `Unimplemented` placeholder) instead of attaching as the gated clause's `else_ability`. Two root causes:
   - `condition_text_is_rehomeable` used a bare `starts_with`, so the reflexive non-rehomeable prefix `"you do"` matched `"you do{n't} control a Snail"` (no word boundary) and refused to re-home the genuine control-presence condition. Fixed to require a word boundary, but only for prefixes whose last char is alphanumeric (space-terminated prefixes like `"its power is "` carry their own boundary — preserving the Selvala intervening-if hoist).
   - the bare `"you don't"` reflexive arm in `try_nom_condition_as_ability_condition` returned `Not(OptionalEffectPerformed)` for any `"you don't ..."` text, swallowing the control gate before the typed `parse_inner_condition` fall-through. Now defers to the typed parser first; the reflexive signal only fires when `parse_inner_condition` cannot consume the whole fragment (so `"you didn't put a card into your hand this way"` still maps to the optional-effect signal).

2. **§19 Role token attach** (`oracle_util.rs`). The card-name first-word fallback in `normalize_card_name_refs` replaced `"Royal"` (first word of `"Royal Treatment"`) with `~` inside the token name `"Royal Role"`, corrupting it to `"~ Role"` so the token parser failed. Guarded the fallback against a card-name word immediately followed by a token-subtype noun (`Role`/`Aura`) — the named-Role/Aura-token class (`<Name> Role token attached to ...`).

## Per-card verdict (grouped by batch)

| Batch | Card | Verdict | Residual / reason |
|---|---|---|---|
| §16 any-type spend | Vizier of the Menagerie | HONEST-DEFER | `"spend mana of any type to cast creature spells"` is a **spell-type-filtered** any-type-spend permission. The existing `SpendManaAsAnyColor` static is global/unfiltered and is consulted per-player (not per-spell); routing Vizier there would let any-type mana pay for noncreature spells too (rules-wrong, CR 609.4b). A spell-filtered any-type-spend seam is infra beyond the existing surface. Look-at-top + cast-from-top statics still parse. |
| §16 any-type spend | Outrageous Robbery | HONEST-DEFER | Two residuals; the `"spend mana ... of any type to cast it"` rider rides on impulse-exile play infra (`"look at and play those cards"`) which is not built (§8 cluster). |
| §19 Role token | **Royal Treatment** | **SHIPPED** (0-unimpl) | name-normalization guard; creates a Royal Role token attached to the target. |
| §19 Role token | Become Brutes | HONEST-DEFER | `"For each of those creatures, create a Monster Role token attached to it"` needs per-target iteration over the spell's chosen multi-target set with per-iteration attach binding — infra beyond the single-target Role-attach surface (the per-target-set iteration cluster is separately blocked). Haste grant still parses. |
| §22 Otherwise | **Wick, the Whorled Mind** | **SHIPPED** (0-unimpl) | Otherwise now attaches as the gated Token's `else_ability`. |
| §22 Otherwise | Bre of Clan Stoutarm | HONEST-DEFER | The Otherwise branch depends on the antecedent gate `"if the spell's mana value is less than or equal to the amount of life you gained this turn"` — a spell-MV-vs-dynamic-life-gained `QuantityCheck` that is not modeled. Without the gate there is no conditional for Otherwise to attach to. Exile-until trigger + flying/lifelink ability still parse. |

Net: 2 shipped (0-unimpl), 4 honest-deferred.

## Grep-verified CR annotations

All added CR numbers verified against `docs/MagicCompRules.txt` and confirmed to describe the annotated code:

- **CR 111.10** — predefined token creation (Royal/Aura named-token guard).
- **CR 303.7** — Aura Role subtype (Role-token guard).
- **CR 603.12** — reflexive triggered ability "does or doesn't" (the `"you don't"` optional-effect disambiguation).
- **CR 608.2c** — later text modifies earlier text; read whole text (Otherwise / condition rehome context).
- **CR 609.4b** — spend mana "as though of any type/color" (Vizier defer rationale).

CR-annotation diff gate: zero `UNVERIFIED:`.

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|---|---|---|---|---|---|
| Wick's token is gated off when a Snail is already controlled | `condition_text_is_rehomeable` + `try_nom_condition_as_ability_condition` → Token carries `condition`, PutCounter is `else_ability` | `resolve_ability_chain` on the parsed trigger execute | `wick_otherwise_attaches_as_token_else_ability` (Case B) | `count_snails == snails_before` with a resident Snail (pre-fix the token was created unconditionally) | Case A (no Snail → token created); shape guards on `condition`/`else_ability` |
| Royal Treatment creates a Royal Role token attached to its target | `normalize_card_name_refs` named-token guard → `Effect::Token { attach_to }` | `resolve_ability_chain` on the parsed spell | `royal_treatment_creates_role_token_attached_to_target` | exactly one `"Royal Role"` token exists, attached (pre-fix the clause was `Unimplemented{create}` → zero tokens) | token name un-mangled `"Royal Role"`; attach target present |
| Deferred cards' gap is exactly the unsupported clause | n/a (honesty guards) | `parse_oracle_text` | `vizier_..._deferred`, `outrageous_robbery_..._deferred`, `become_brutes_..._deferred`, `bre_..._deferred` | each asserts the residual `Unimplemented` text is the named clause AND the supported lines still parse | — |

No production-reachable arm is left covered only by a degenerate fixture: the Wick test reaches the real condition-gate branch in `resolve_ability_chain` (both true and false), and the Royal Treatment test reaches the real token-creation/attachment resolver.

## Gate results

- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — exit 0 (the two `.contains("~ Role")`/`.contains("~ Aura")` guards and the `strip_prefix` membership test are annotated `allow-noncombinator`: structural guards on already-normalized output, not parsing dispatch).
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0.
- `cargo check --workspace --all-targets` — exit 0.
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0.
- `cargo test -p engine` — 12975 passed; only the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` fails under parallel load and passes in isolation (per the batch protocol, this perf test is ignored).
- `data/engine-inventory.json` — unchanged.
- `cargo coverage` / `cargo semantic-audit` — **not run**: both require `client/public/card-data.json`, which is gitignored and intentionally absent in the worktree (the batch protocol substitutes per-card `parse_oracle_text` 0-unimpl + discriminating runtime tests).
