### PR TITLE
feat(engine): grant embalm/harmonize/flashback with cost = mana cost (Cursecloth Wrappings, Songcrafter Mage, Sphinx of Forgotten Lore)

### DIFF
--- a/crates/engine/src/database/embalm_eternalize.rs
+++ b/crates/engine/src/database/embalm_eternalize.rs
@@ -66,6 +66,33 @@ pub fn synthesize_embalm_eternalize(face: &mut CardFace) {
     face.abilities.extend(abilities);
 }
 
+/// CR 702.128a / CR 702.129a + CR 604.1: Synthesize the graveyard-activated
+/// token-copy ability for a single Embalm / Eternalize keyword **granted at
+/// runtime** (e.g. Cursecloth Wrappings' "target creature card in your graveyard
+/// gains embalm until end of turn. The embalm cost is equal to its mana cost.").
+/// Mirrors `database::synthesis::graveyard_activated_ability_for_keyword` for the
+/// Encore / Scavenge family: the `AddKeyword` continuous-effect seam installs
+/// only the keyword, so the activatable ability must be synthesized on demand.
+/// Returns `None` for any non-Embalm/Eternalize keyword.
+///
+/// The caller is responsible for resolving a `ManaCost::SelfManaCost` payload to
+/// the recipient card's concrete mana cost BEFORE calling — the activated-ability
+/// payment path treats `SelfManaCost` as a free cost, so a self-cost grant must
+/// arrive here already concretized.
+pub fn embalm_eternalize_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    match keyword {
+        Keyword::Embalm(cost) => Some(token_copy_ability(
+            embalm_cost_part(cost),
+            embalm_overrides(),
+        )),
+        Keyword::Eternalize(cost) => Some(token_copy_ability(
+            eternalize_cost_part(cost),
+            eternalize_overrides(),
+        )),
+        _ => None,
+    }
+}
+
 /// CR 702.128a: Embalm's copy exceptions — "it's white, it has no mana cost,
 /// and it's a Zombie in addition to its other types."
 fn embalm_overrides() -> Vec<ContinuousModification> {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -96,7 +96,21 @@ fn runtime_granted_graveyard_activated_abilities(
         .into_iter()
         .filter(|keyword| !obj.base_keywords.iter().any(|printed| printed == keyword))
         .filter_map(|keyword| {
-            crate::database::synthesis::graveyard_activated_ability_for_keyword(&keyword)
+            // CR 702.128a / CR 702.129a: Embalm / Eternalize granted with a
+            // self-cost ("the embalm cost is equal to its mana cost") carry
+            // `ManaCost::SelfManaCost`; concretize it to the card's mana cost
+            // before synthesizing the activated ability (the activated-ability
+            // payment path would otherwise treat SelfManaCost as free).
+            let keyword = super::keywords::resolve_self_cost_graveyard_activated_keyword(
+                state, source_id, &keyword,
+            );
+            crate::database::synthesis::graveyard_activated_ability_for_keyword(&keyword).or_else(
+                || {
+                    crate::database::embalm_eternalize::embalm_eternalize_ability_for_keyword(
+                        &keyword,
+                    )
+                },
+            )
         })
         .collect()
 }
@@ -663,7 +677,7 @@ fn graveyard_spell_objects_available_to_cast(
         // Cards in graveyard with graveyard-cast keywords. Escape and Retrace
         // must have enough eligible non-mana additional-cost material available.
         if has_effective_graveyard_cast_keyword(state, obj_id, obj)
-            && (has_harmonize_keyword(obj)
+            && (has_harmonize_keyword(state, obj_id)
                 || has_flashback_keyword(state, obj_id)
                 || has_aftermath_keyword(state, obj_id)
                 || has_disturb_keyword(state, obj_id)
@@ -752,11 +766,11 @@ fn can_pay_escape_additional_cost(
     residual.is_payable(state, player, escape_obj_id)
 }
 
-/// CR 702.180: Check if an object has the Harmonize keyword.
-fn has_harmonize_keyword(obj: &crate::game::game_object::GameObject) -> bool {
-    obj.keywords
-        .iter()
-        .any(|k| matches!(k, crate::types::keywords::Keyword::Harmonize(_)))
+/// CR 702.180: Check if an object has the Harmonize keyword. Off-zone-aware so a
+/// granted graveyard harmonize (Songcrafter Mage) is recognized, mirroring
+/// `has_flashback_keyword`.
+fn has_harmonize_keyword(state: &GameState, object_id: ObjectId) -> bool {
+    super::keywords::object_has_effective_keyword_kind(state, object_id, KeywordKind::Harmonize)
 }
 
 /// CR 702.34: Check if an object has the Flashback keyword.
@@ -939,15 +953,14 @@ pub fn handle_foretell(
 fn has_effective_graveyard_cast_keyword(
     state: &GameState,
     object_id: ObjectId,
-    obj: &crate::game::game_object::GameObject,
+    // Retained for call-site symmetry with the surrounding graveyard scan; all
+    // keyword checks below are now off-zone-aware and key on `object_id` only.
+    _obj: &crate::game::game_object::GameObject,
 ) -> bool {
     super::keywords::object_has_effective_keyword_kind(state, object_id, KeywordKind::Escape)
         || has_retrace_keyword(state, object_id)
         || jumpstart_castable_from_graveyard(state, object_id)
-        || obj
-            .keywords
-            .iter()
-            .any(|k| matches!(k, crate::types::keywords::Keyword::Harmonize(_)))
+        || has_harmonize_keyword(state, object_id)
         || has_flashback_keyword(state, object_id)
         || has_aftermath_keyword(state, object_id)
         || super::keywords::effective_disturb_cost(state, object_id).is_some()
@@ -3112,11 +3125,9 @@ fn casting_variant_candidates(
         if has_retrace_keyword(state, object_id) {
             candidates.push(CastingVariant::Retrace);
         }
-        if obj
-            .keywords
-            .iter()
-            .any(|k| matches!(k, crate::types::keywords::Keyword::Harmonize(_)))
-        {
+        // CR 702.180a: Harmonize may be printed or granted to a graveyard card
+        // (Songcrafter Mage), so query the effective off-zone keyword.
+        if has_harmonize_keyword(state, object_id) {
             candidates.push(CastingVariant::Harmonize);
         }
         // CR 702.187b: Mayhem is available only while the card was discarded this
@@ -3645,13 +3656,13 @@ fn prepare_spell_cast_with_variant_override_inner(
         None
     };
 
-    // Harmonize: use harmonize mana cost when casting from graveyard.
-    // Tap cost reduction is handled in casting_costs::pay_and_push_adventure.
+    // CR 702.180a: Harmonize — use the harmonize mana cost when casting from
+    // graveyard. Off-zone-aware and `SelfManaCost`-resolving so a granted
+    // harmonize whose cost equals the card's mana cost (Songcrafter Mage) is paid
+    // correctly. Tap cost reduction is handled in
+    // casting_costs::pay_and_push_adventure.
     let harmonize_cost = if obj.zone == Zone::Graveyard {
-        obj.keywords.iter().find_map(|k| match k {
-            crate::types::keywords::Keyword::Harmonize(cost) => Some(cost.clone()),
-            _ => None,
-        })
+        super::keywords::effective_harmonize_cost(state, object_id)
     } else {
         None
     };
@@ -23955,6 +23966,174 @@ mod tests {
             encore.1.activation_zone,
             Some(Zone::Graveyard),
             "synthesized Encore ability must function only from the graveyard"
+        );
+    }
+
+    /// CR 702.180a + CR 604.1: Harmonize granted to a graveyard sorcery with a
+    /// self-cost (Songcrafter Mage: "gains harmonize until end of turn. Its
+    /// harmonize cost is equal to its mana cost.") must make the card castable
+    /// from the graveyard, and the effective harmonize cost must resolve to the
+    /// card's OWN mana cost. Discriminating: reverting the off-zone-aware
+    /// `has_harmonize_keyword` flips `can_cast_object_now` to false (granted
+    /// keyword unseen); reverting the `effective_harmonize_cost` SelfManaCost
+    /// resolution makes the cost wrong (free instead of the card's mana cost).
+    #[test]
+    fn granted_self_cost_harmonize_is_castable_at_card_mana_cost() {
+        let mut state = setup_game_at_main_phase();
+
+        let grantor = create_object(
+            &mut state,
+            CardId(9300),
+            PlayerId(0),
+            "Songcrafter Mage".to_string(),
+            Zone::Battlefield,
+        );
+        let card_cost = ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::Blue],
+        };
+        let spell = create_object(
+            &mut state,
+            CardId(9301),
+            PlayerId(0),
+            "Graveyard Sorcery".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.base_card_types = obj.card_types.clone();
+            obj.mana_cost = card_cost.clone();
+            let ability = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            );
+            Arc::make_mut(&mut obj.abilities).push(ability.clone());
+            Arc::make_mut(&mut obj.base_abilities).push(ability);
+        }
+
+        // Sanity: with no grant, the card is not castable from the graveyard.
+        assert!(
+            !can_cast_object_now(&state, PlayerId(0), spell),
+            "card must not be graveyard-castable before the harmonize grant"
+        );
+
+        // Grant harmonize with cost = its mana cost — exactly the parser output.
+        state.add_transient_continuous_effect(
+            grantor,
+            PlayerId(0),
+            crate::types::ability::Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: spell },
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Harmonize(ManaCost::SelfManaCost),
+            }],
+            None,
+        );
+
+        // The effective harmonize cost resolves to the card's own mana cost.
+        assert_eq!(
+            super::super::keywords::effective_harmonize_cost(&state, spell),
+            Some(card_cost.clone()),
+            "granted harmonize cost must equal the card's mana cost"
+        );
+
+        // Enough mana for {2}{U}; the card must now be castable from graveyard.
+        add_mana(&mut state, PlayerId(0), ManaType::Blue, 3);
+        assert!(
+            can_cast_object_now(&state, PlayerId(0), spell),
+            "granted self-cost harmonize must be castable from the graveyard"
+        );
+        assert!(
+            casting_variant_candidates(&state, PlayerId(0), spell)
+                .contains(&CastingVariant::Harmonize),
+            "granted harmonize must surface the Harmonize casting variant"
+        );
+    }
+
+    /// CR 702.128a + CR 604.1: Embalm granted to a graveyard creature with a
+    /// self-cost (Cursecloth Wrappings: "gains embalm until end of turn. The
+    /// embalm cost is equal to its mana cost.") must surface the embalm activated
+    /// ability from the graveyard, with the mana sub-cost concretized to the
+    /// card's OWN mana cost. Discriminating: before the grant no embalm ability
+    /// exists; reverting the embalm-synthesis wiring removes the granted ability;
+    /// reverting the SelfManaCost concretization leaves the ability free (the
+    /// activated-ability payment path treats SelfManaCost as no cost).
+    #[test]
+    fn granted_self_cost_embalm_surfaces_graveyard_ability_at_card_mana_cost() {
+        let mut state = setup_game_at_main_phase();
+
+        let grantor = create_object(
+            &mut state,
+            CardId(9400),
+            PlayerId(0),
+            "Cursecloth Wrappings".to_string(),
+            Zone::Battlefield,
+        );
+        let card_cost = ManaCost::Cost {
+            generic: 3,
+            shards: vec![ManaCostShard::White],
+        };
+        let creature = create_object(
+            &mut state,
+            CardId(9401),
+            PlayerId(0),
+            "Graveyard Creature".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.mana_cost = card_cost.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+        }
+
+        // Sanity: no embalm ability before the grant.
+        assert!(
+            !activated_ability_definitions(&state, creature)
+                .iter()
+                .any(|(_, a)| matches!(&*a.effect, Effect::CopyTokenOf { .. })),
+            "no embalm ability should exist before the grant"
+        );
+
+        state.add_transient_continuous_effect(
+            grantor,
+            PlayerId(0),
+            crate::types::ability::Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: creature },
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Embalm(crate::types::keywords::EmbalmCost::Mana(
+                    ManaCost::SelfManaCost,
+                )),
+            }],
+            None,
+        );
+
+        let abilities = activated_ability_definitions(&state, creature);
+        let (_, embalm) = abilities
+            .iter()
+            .find(|(_, a)| matches!(&*a.effect, Effect::CopyTokenOf { .. }))
+            .expect("granted embalm must surface a graveyard activated ability");
+        assert_eq!(
+            embalm.activation_zone,
+            Some(Zone::Graveyard),
+            "embalm ability must function only from the graveyard"
+        );
+        // The mana sub-cost must be the card's concrete mana cost, NOT a free
+        // SelfManaCost placeholder. The activation cost is a Composite of the mana
+        // cost + the self-exile; assert the card's mana cost appears in it.
+        let Some(AbilityCost::Composite { costs }) = &embalm.cost else {
+            panic!("embalm cost must be a Composite, got {:?}", embalm.cost);
+        };
+        assert!(
+            costs
+                .iter()
+                .any(|c| matches!(c, AbilityCost::Mana { cost } if *cost == card_cost)),
+            "embalm mana sub-cost must equal the card's mana cost, got {costs:?}"
         );
     }
 

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -8,7 +8,9 @@ use crate::types::ability::{AbilityCost, CastVariantPaid, NinjutsuVariant};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId};
-use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind, ProtectionTarget};
+use crate::types::keywords::{
+    EmbalmCost, EternalizeCost, FlashbackCost, Keyword, KeywordKind, ProtectionTarget,
+};
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
@@ -243,7 +245,6 @@ pub fn resolve_self_cost_graveyard_activated_keyword(
     object_id: ObjectId,
     keyword: &Keyword,
 ) -> Keyword {
-    use crate::types::keywords::{EmbalmCost, EternalizeCost};
     match keyword {
         Keyword::Embalm(EmbalmCost::Mana(cost)) => Keyword::Embalm(EmbalmCost::Mana(
             resolve_keyword_mana_cost(state, object_id, cost),

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -160,6 +160,22 @@ pub fn effective_mayhem_cost(state: &GameState, object_id: ObjectId) -> Option<M
     }
 }
 
+/// CR 702.180a: Effective Harmonize alt-cost for a card in the graveyard,
+/// honoring off-zone keyword grants (e.g. Songcrafter Mage's "target instant or
+/// sorcery card in your graveyard gains harmonize until end of turn. Its
+/// harmonize cost is equal to its mana cost.") in addition to a printed Harmonize
+/// keyword. Resolves `ManaCost::SelfManaCost` to the card's own mana cost via
+/// `resolve_keyword_mana_cost`, mirroring `effective_mayhem_cost`. The
+/// tap-a-creature cost reduction (CR 702.180a/b) is applied separately at
+/// payment time.
+pub fn effective_harmonize_cost(state: &GameState, object_id: ObjectId) -> Option<ManaCost> {
+    let keyword = effective_keyword_for_object(state, object_id, KeywordKind::Harmonize)?;
+    match keyword {
+        Keyword::Harmonize(cost) => Some(resolve_keyword_mana_cost(state, object_id, &cost)),
+        _ => None,
+    }
+}
+
 /// CR 702.190a: Effective Sneak alt-cost for an object, honoring off-zone characteristic
 /// grants (e.g., Ninja Teen's "creature cards in your graveyard have sneak {cost}").
 pub fn effective_sneak_cost(state: &GameState, object_id: ObjectId) -> Option<ManaCost> {
@@ -211,6 +227,31 @@ fn resolve_keyword_mana_cost(state: &GameState, object_id: ObjectId, cost: &Mana
             .map(|obj| obj.mana_cost.clone())
             .unwrap_or(ManaCost::NoCost),
         _ => cost.clone(),
+    }
+}
+
+/// CR 702.128a / CR 702.129a + CR 602.1a: Resolve a `ManaCost::SelfManaCost`
+/// payload carried by a granted Embalm / Eternalize keyword to the recipient
+/// card's concrete mana cost. Embalm / Eternalize are graveyard *activated*
+/// abilities whose mana sub-cost is paid through `AbilityCost::Mana`, and that
+/// payment path treats `SelfManaCost` as a free cost — so a self-cost grant must
+/// be concretized before the activated ability is synthesized. Non-self-cost
+/// keywords (printed Embalm `{3}{W}`, or any other keyword) pass through
+/// unchanged.
+pub fn resolve_self_cost_graveyard_activated_keyword(
+    state: &GameState,
+    object_id: ObjectId,
+    keyword: &Keyword,
+) -> Keyword {
+    use crate::types::keywords::{EmbalmCost, EternalizeCost};
+    match keyword {
+        Keyword::Embalm(EmbalmCost::Mana(cost)) => Keyword::Embalm(EmbalmCost::Mana(
+            resolve_keyword_mana_cost(state, object_id, cost),
+        )),
+        Keyword::Eternalize(EternalizeCost::Mana(cost)) => Keyword::Eternalize(
+            EternalizeCost::Mana(resolve_keyword_mana_cost(state, object_id, cost)),
+        ),
+        other => other.clone(),
     }
 }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5408,6 +5408,45 @@ mod tests {
                 .any(def_chain_has_unimplemented)
     }
 
+    /// CR 702.34a / CR 702.128a / CR 702.180a: the three self-cost graveyard
+    /// keyword-grant cards (Cursecloth Wrappings / Songcrafter Mage / Sphinx of
+    /// Forgotten Lore) must parse with zero Unimplemented effects. The grant
+    /// lowers to `AddKeyword(<keyword>(SelfManaCost))` and the redundant cost
+    /// clarification sentence is absorbed; the printed keyword lines (Flash,
+    /// Flying) are supplied via the MTGJSON keyword list as in production.
+    #[test]
+    fn self_cost_graveyard_keyword_grant_cards_parse_zero_unimplemented() {
+        let cards: [(&str, &str, &[Keyword], &[&str]); 3] = [
+            (
+                "Cursecloth Wrappings",
+                "Zombies you control get +1/+1.\n{T}: Target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
+                &[],
+                &["Artifact"],
+            ),
+            (
+                "Songcrafter Mage",
+                "Flash\nWhen this creature enters, target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost.",
+                &[Keyword::Flash],
+                &["Creature"],
+            ),
+            (
+                "Sphinx of Forgotten Lore",
+                "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
+                &[Keyword::Flash, Keyword::Flying],
+                &["Creature"],
+            ),
+        ];
+        for (name, text, kw, types) in cards {
+            let r = parse(text, name, kw, types, &[]);
+            assert!(
+                !parsed_has_unimplemented(&r),
+                "{name} must parse with zero Unimplemented effects: abilities={:?} triggers={:?}",
+                r.abilities,
+                r.triggers
+            );
+        }
+    }
+
     /// CR 709.5f + CR 709.5j: Ghostly Keybearer's combat-damage trigger
     /// ("unlock a locked door of up to one target Room you control") must reach
     /// zero Unimplemented effects now that the door-lock effect parser arm

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -31189,6 +31189,60 @@ mod tests {
         );
     }
 
+    /// CR 702.34a / CR 702.128a / CR 702.180a: the self-cost graveyard keyword
+    /// grant is one parameterized parser primitive — assert all three members
+    /// (flashback "that card's", embalm "its", harmonize "Its ... its") lower to
+    /// `AddKeyword(<keyword>(SelfManaCost))` with the redundant cost-clarification
+    /// sentence absorbed (no trailing `Unimplemented` sub-ability). Builds for the
+    /// class, not the card.
+    #[test]
+    fn self_cost_graveyard_keyword_grants_absorb_cost_clarification() {
+        use crate::types::keywords::{EmbalmCost, FlashbackCost, Keyword};
+
+        let cases: [(&str, Keyword); 3] = [
+            (
+                "target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost.",
+                Keyword::Flashback(FlashbackCost::Mana(ManaCost::SelfManaCost)),
+            ),
+            (
+                "target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
+                Keyword::Embalm(EmbalmCost::Mana(ManaCost::SelfManaCost)),
+            ),
+            (
+                "target instant or sorcery card in your graveyard gains harmonize until end of turn. Its harmonize cost is equal to its mana cost.",
+                Keyword::Harmonize(ManaCost::SelfManaCost),
+            ),
+        ];
+
+        for (text, expected_keyword) in cases {
+            let def = parse_effect_chain(text, AbilityKind::Spell);
+            let Effect::GenericEffect {
+                static_abilities,
+                duration,
+                target: Some(_),
+            } = &*def.effect
+            else {
+                panic!("Expected GenericEffect for {text:?}, got {:?}", def.effect);
+            };
+            assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+            assert!(
+                static_abilities
+                    .iter()
+                    .any(|static_def| static_def.modifications.contains(
+                        &ContinuousModification::AddKeyword {
+                            keyword: expected_keyword.clone()
+                        }
+                    )),
+                "missing {expected_keyword:?} grant for {text:?}: {static_abilities:?}"
+            );
+            assert!(
+                def.sub_ability.is_none(),
+                "cost clarification must be absorbed for {text:?}, got {:?}",
+                def.sub_ability
+            );
+        }
+    }
+
     #[test]
     fn effect_target_creature_becomes_blue_uses_continuous_effect() {
         let e = parse_effect("Target creature becomes blue until end of turn");

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2545,7 +2545,7 @@ pub(super) fn apply_clause_continuation(
                 },
             ));
         }
-        ContinuationAst::FlashbackCostEqualsManaCost => {}
+        ContinuationAst::SelfCostKeywordCostClarification => {}
         ContinuationAst::CantRegenerate => {
             let Some(previous) = defs.last_mut() else {
                 return;
@@ -3298,7 +3298,7 @@ pub(super) fn continuation_absorbs_current(
         // parse_followup_continuation_ast, so absorption is unconditional —
         // identical to the CounterSourceStatic precedent.
         ContinuationAst::CopyMayRetarget => true,
-        ContinuationAst::FlashbackCostEqualsManaCost => true,
+        ContinuationAst::SelfCostKeywordCostClarification => true,
         ContinuationAst::SearchDestination { .. } => false,
         ContinuationAst::SuspectLastCreated => matches!(current_effect, Effect::Suspect { .. }),
         ContinuationAst::GoadLastCreated { .. } => true,
@@ -4352,6 +4352,27 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
     }
 }
 
+/// CR 702.34a / CR 702.128a / CR 702.180a: Recognize the redundant cost
+/// clarification sentence that trails a self-cost graveyard keyword grant —
+/// "the/its [flashback|embalm|harmonize] cost is equal to its/that card's mana
+/// cost". The caller gates on the preceding GenericEffect carrying the matching
+/// granted keyword, so this combinator only needs to confirm the grammatical
+/// shape. Composed from chained `alt()` over the determiner, the self-cost
+/// keyword token, and the possessive reference — not an enumeration of
+/// whole-string permutations.
+fn parse_self_cost_keyword_clarification(lower: &str) -> bool {
+    let lower = lower.trim().trim_end_matches('.');
+    all_consuming((
+        opt(alt((tag::<_, _, OracleError<'_>>("the "), tag("its ")))),
+        alt((tag("flashback"), tag("embalm"), tag("harmonize"))),
+        tag(" cost is equal to "),
+        alt((tag("its"), tag("that card's"), tag("that card\u{2019}s"))),
+        tag(" mana cost"),
+    ))
+    .parse(lower)
+    .is_ok()
+}
+
 pub(super) fn parse_followup_continuation_ast(
     text: &str,
     previous_effect: &Effect,
@@ -4425,21 +4446,30 @@ pub(super) fn parse_followup_continuation_ast(
             }
             None
         }
+        // CR 702.34a / CR 702.128a / CR 702.180a: the redundant cost-clarification
+        // sentence ("The/Its [flashback|embalm|harmonize] cost is equal to
+        // its/that card's mana cost") that follows a self-cost graveyard keyword
+        // grant. The grant already carries `ManaCost::SelfManaCost`, so this
+        // sentence adds no semantics — absorb it so it never lowers to
+        // `Effect::Unimplemented`. Gated on the preceding GenericEffect actually
+        // carrying a self-cost graveyard keyword (Flashback/Embalm/Harmonize).
         Effect::GenericEffect {
             static_abilities, ..
-        } if lower == "the flashback cost is equal to its mana cost"
+        } if parse_self_cost_keyword_clarification(&lower)
             && static_abilities.iter().any(|def| {
                 def.modifications.iter().any(|modification| {
                     matches!(
                         modification,
                         crate::types::ability::ContinuousModification::AddKeyword {
                             keyword: crate::types::keywords::Keyword::Flashback(_)
+                                | crate::types::keywords::Keyword::Embalm(_)
+                                | crate::types::keywords::Keyword::Harmonize(_)
                         }
                     )
                 })
             }) =>
         {
-            Some(ContinuationAst::FlashbackCostEqualsManaCost)
+            Some(ContinuationAst::SelfCostKeywordCostClarification)
         }
         Effect::Counter { .. }
             if nom_primitives::scan_contains(&lower, "countered this way")

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -242,8 +242,12 @@ pub(crate) enum ContinuationAst {
     /// CR 701.15a + CR 701.15b: "The token(s) (is|are) goaded [duration]" after token
     /// creation — grants `StaticMode::Goaded` on `TargetFilter::LastCreated`.
     GoadLastCreated { duration: Option<Duration> },
-    /// "The flashback cost is equal to its mana cost." after a flashback grant.
-    FlashbackCostEqualsManaCost,
+    /// CR 702.34a / CR 702.128a / CR 702.180a: "The/Its [flashback|embalm|harmonize]
+    /// cost is equal to its/that card's mana cost." after a self-cost graveyard
+    /// keyword grant. Redundant reminder text — the grant already carries
+    /// `ManaCost::SelfManaCost`, so this continuation is absorbed as a no-op
+    /// rather than lowering to `Effect::Unimplemented`.
+    SelfCostKeywordCostClarification,
     /// CR 701.19c: "It can't be regenerated" / "They can't be regenerated" — sets
     /// `cant_regenerate: true` on the preceding Destroy/DestroyAll effect.
     CantRegenerate,

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1339,6 +1339,35 @@ pub(crate) fn parse_pt_mod(text: &str) -> Option<(i32, i32)> {
     Some((p, t))
 }
 
+/// CR 702.34a / CR 702.128a / CR 702.180a: Map a bare graveyard alt-cost keyword
+/// token (one whose cost, when granted with no explicit value, is the recipient
+/// card's own mana cost) to the `Keyword` carrying `ManaCost::SelfManaCost`.
+/// Parameterized over the keyword by a single `alt()` of token tags — adding a
+/// future self-cost keyword is one more `value(..)` arm, not a new sibling
+/// branch in `map_keyword`. Returns `None` for any other text so `map_keyword`
+/// continues its normal dispatch.
+fn map_self_cost_graveyard_keyword(word: &str) -> Option<Keyword> {
+    let lower = word.to_ascii_lowercase();
+    let (_, keyword) = all_consuming(alt((
+        value(
+            Keyword::Flashback(crate::types::keywords::FlashbackCost::Mana(
+                ManaCost::SelfManaCost,
+            )),
+            tag::<_, _, OracleError<'_>>("flashback"),
+        ),
+        value(
+            Keyword::Embalm(crate::types::keywords::EmbalmCost::Mana(
+                ManaCost::SelfManaCost,
+            )),
+            tag("embalm"),
+        ),
+        value(Keyword::Harmonize(ManaCost::SelfManaCost), tag("harmonize")),
+    )))
+    .parse(lower.as_str())
+    .ok()?;
+    Some(keyword)
+}
+
 /// Map a keyword text to a Keyword enum variant using the FromStr impl.
 /// Returns None only for `Keyword::Unknown`.
 pub(crate) fn map_keyword(text: &str) -> Option<Keyword> {
@@ -1346,10 +1375,18 @@ pub(crate) fn map_keyword(text: &str) -> Option<Keyword> {
     if word.is_empty() {
         return None;
     }
-    if word.eq_ignore_ascii_case("flashback") {
-        return Some(Keyword::Flashback(
-            crate::types::keywords::FlashbackCost::Mana(ManaCost::SelfManaCost),
-        ));
+    // CR 702.34a (Flashback) / CR 702.128a (Embalm) / CR 702.180a (Harmonize):
+    // a bare graveyard alt-cost keyword granted by an effect ("target ... gains
+    // flashback/embalm/harmonize until end of turn. The [keyword] cost is equal
+    // to its mana cost") carries no printed cost — its cost is the granted card's
+    // own mana cost. `ManaCost::SelfManaCost` is the single building block that
+    // resolves to the recipient's mana cost at cast time (see
+    // `game::keywords::resolve_keyword_mana_cost`), so the grant is parameterized
+    // by keyword over one self-cost representation rather than baking a concrete
+    // cost. The trailing "the [keyword] cost is equal to its mana cost" sentence
+    // is therefore redundant reminder text (dropped by the effect-chain parser).
+    if let Some(keyword) = map_self_cost_graveyard_keyword(word) {
+        return Some(keyword);
     }
     // CR 702.73a: "all creature types" is the Changeling CDA effect.
     // Granting Changeling keyword triggers layer system post-fixup to add all types.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std BATCH 14 — Keyword-grant with cost = card's mana cost (embalm / harmonize / flashback)

## Summary

Three Standard-legal cards grant a graveyard alt-cost keyword to a target card "until end of turn" whose cost equals that card's own mana cost:

- **Cursecloth Wrappings** — grants **embalm** (cost = mana cost)
- **Songcrafter Mage** — grants **harmonize** (cost = mana cost)
- **Sphinx of Forgotten Lore** — grants **flashback** (cost = mana cost)

The seam is "grant keyword with cost = the card's own mana cost," parameterized by keyword over the **pre-existing** `ManaCost::SelfManaCost` building block (which `game::keywords::resolve_keyword_mana_cost` already resolves to the recipient's mana cost). Flashback already lowered to `AddKeyword(Flashback(SelfManaCost))` and worked end-to-end. This change extends the same primitive to embalm and harmonize at both the parser and runtime layers, and absorbs the redundant "the [keyword] cost is equal to its/that card's mana cost" reminder sentence for all three.

## add-engine-variant verdict: NOT NEEDED (parameterization, no new variant)

No new `Effect`, `ContinuousModification`, `Keyword`, or `ManaCost` variant was added. `data/engine-inventory.json` is unchanged. The grant reuses:

- `ManaCost::SelfManaCost` (existing) — "cost = the card's own mana cost"
- `ContinuousModification::AddKeyword { keyword }` (existing)
- `Effect::GenericEffect { target, static_abilities, duration }` (existing) — installs the grant as a transient continuous effect on the target via `register_transient_effect` → `add_transient_continuous_effect`

Parameterization, not proliferation: a single `map_self_cost_graveyard_keyword` combinator maps the bare keyword token to the keyword carrying `SelfManaCost` (one `alt()` arm per keyword), replacing what was a one-off `flashback`-only special case in `map_keyword`. The cost-clarification recognizer was generalized from a verbatim `lower == "the flashback cost is equal to its mana cost"` string match (the single most-prohibited parser pattern) to a composed nom combinator over `[the|its] <kw> cost is equal to [its|that card's] mana cost`.

## Parser changes

- `parser/oracle_static/grammar.rs` — `map_keyword` now routes bare `flashback`/`embalm`/`harmonize` through `map_self_cost_graveyard_keyword`, producing `Flashback(SelfManaCost)` / `Embalm(EmbalmCost::Mana(SelfManaCost))` / `Harmonize(SelfManaCost)`.
- `parser/oracle_effect/sequence.rs` — replaced the verbatim flashback-only cost-sentence match with `parse_self_cost_keyword_clarification` (nom combinator) covering all three keywords and both possessive phrasings ("its" / "that card's"), gated on the preceding grant carrying the matching keyword.
- `parser/oracle_ir/ast.rs` — renamed `ContinuationAst::FlashbackCostEqualsManaCost` → `SelfCostKeywordCostClarification` (keyword-agnostic; still a no-op absorb continuation).

## Runtime changes (so the granted keyword is usable from the graveyard at the card's mana cost)

Flashback already used the off-zone-aware, `SelfManaCost`-resolving path. Harmonize and embalm did not:

- `game/keywords.rs` — added `effective_harmonize_cost` (off-zone-aware + resolves `SelfManaCost`, mirroring `effective_mayhem_cost`/`effective_flashback_cost`) and `resolve_self_cost_graveyard_activated_keyword` (concretizes a granted Embalm/Eternalize `SelfManaCost` to the card's mana cost).
- `game/casting.rs` — `has_harmonize_keyword` and the harmonize availability/candidate/cost-resolution sites are now off-zone-aware (was a direct `obj.keywords` read, which never saw a granted keyword and never resolved `SelfManaCost`). `runtime_granted_graveyard_activated_abilities` now synthesizes an Embalm/Eternalize graveyard activated ability for a runtime-granted keyword, with the mana sub-cost concretized first (the activated-ability payment path treats `SelfManaCost` as free).
- `database/embalm_eternalize.rs` — added `embalm_eternalize_ability_for_keyword`, the runtime-grant analogue of `graveyard_activated_ability_for_keyword` (Encore/Scavenge family), reusing `token_copy_ability`.

## grep-verified CR annotations (vs docs/MagicCompRules.txt, zero UNVERIFIED)

- **CR 702.34a** — Flashback (graveyard alt-cast). `grep -nE "^702.34a" docs/MagicCompRules.txt`
- **CR 702.128a** — Embalm (graveyard activated token-copy). `grep -nE "^702.128a" docs/MagicCompRules.txt`
- **CR 702.129a** — Eternalize (parameterized sibling, covered by the same helper). `grep -nE "^702.129a" docs/MagicCompRules.txt`
- **CR 702.180 / 702.180a** — Harmonize (graveyard alt-cast). `grep -nE "^702.180" docs/MagicCompRules.txt`
- **CR 602.1a** — activation cost is everything before the colon. `grep -nE "^602.1a" docs/MagicCompRules.txt`
- **CR 604.1** — handling static abilities (continuous keyword-grant). `grep -nE "^604.1" docs/MagicCompRules.txt`

NOTE: the batch brief's tentative CR guesses for embalm (702.88) and harmonize (702.176) were wrong — 702.88 is Rebound, 702.176 is Impending. Verified correct numbers are 702.128 (Embalm) and 702.180 (Harmonize), matching the existing annotations in `embalm_eternalize.rs` / `keywords.rs`.

## Per-card verdict

| Card | Keyword | Parser 0-Unimpl | Runtime usable @ card mana cost | Verdict |
|------|---------|:---:|:---:|---------|
| Cursecloth Wrappings | embalm | yes | yes (granted embalm surfaces graveyard activated ability w/ concretized cost) | SHIPPED |
| Songcrafter Mage | harmonize | yes | yes (off-zone-aware castable from graveyard at card mana cost) | SHIPPED |
| Sphinx of Forgotten Lore | flashback | yes | yes (pre-existing off-zone flashback path) | SHIPPED |

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion |
|------|------|------|------|------|
| "gain embalm/harmonize/flashback ... cost = its mana cost" lowers to `AddKeyword(<kw>(SelfManaCost))`, cost sentence absorbed | `map_keyword` / `parse_self_cost_keyword_clarification` | `parse_effect_chain` (oracle parse) | `parser::oracle_effect::tests::self_cost_graveyard_keyword_grants_absorb_cost_clarification` | `AddKeyword` membership + `def.sub_ability.is_none()` per keyword |
| Full cards parse with zero Unimplemented | whole-card parse | `parse_oracle_text` | `parser::oracle::tests::self_cost_graveyard_keyword_grant_cards_parse_zero_unimplemented` | `!parsed_has_unimplemented(&r)` per card |
| Granted self-cost harmonize is castable from graveyard at card mana cost | `effective_harmonize_cost`, off-zone `has_harmonize_keyword`, candidate collection | resolved `GenericEffect` → `register_transient_effect` → `add_transient_continuous_effect`; `can_cast_object_now` / `casting_variant_candidates` | `game::casting::tests::granted_self_cost_harmonize_is_castable_at_card_mana_cost` | `effective_harmonize_cost == Some(card_cost)` (verified to flip to `Some(SelfManaCost)` on revert); `can_cast_object_now == true`; `CastingVariant::Harmonize` present |
| Granted self-cost embalm surfaces graveyard activated ability w/ concretized cost | `runtime_granted_graveyard_activated_abilities` + `embalm_eternalize_ability_for_keyword` + `resolve_self_cost_graveyard_activated_keyword` | `activated_ability_definitions` (legal-activation gather) | `game::casting::tests::granted_self_cost_embalm_surfaces_graveyard_ability_at_card_mana_cost` | embalm `CopyTokenOf` ability present + activation_zone Graveyard + Composite mana sub-cost `== card_cost` (not free) |

Discrimination confirmed concretely: temporarily reverting the harmonize `SelfManaCost` resolution flips `effective_harmonize_cost` from `Some(card_cost)` to `Some(SelfManaCost)`, failing the test. No fixture is degenerate — each runtime test asserts no-grant negative state first, then grants and reaches the real off-zone / synthesis arm.

## Gates (CI parity, run directly — Tilt down in worktree)

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0
- `cargo test -p engine` — 12978 passed; only `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` failed under full parallel run (known parallel-flaky perf/clone-count test; passes in isolation, unrelated to this change)
- Inline parser string-dispatch grep — only Vec `.contains` membership in test assertions (not Oracle dispatch)
- CR-annotation diff gate — zero UNVERIFIED
- `data/engine-inventory.json` — unchanged (no new variant)

Branch cut off `upstream/main` @ 53f4e52f7.
