### PR TITLE
feat(engine): defender-scoped "that player can't attack you or permanents you control" restriction (Willie Lumpkin)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -2183,6 +2183,65 @@ pub fn declare_attackers_with_bands(
         }
     }
 
+    // CR 508.1c + CR 109.5: Player-scoped temporary attack prohibitions
+    // (`GameRestriction::ProhibitActivity { activity: Attack { defended } }` —
+    // Willie Lumpkin: "that player can't attack you or permanents you control
+    // during their next turn"). Each restriction defends a specific player (the
+    // grant's controller per CR 109.5) against the affected players. Reuse the
+    // SAME `attack_target_matches_defended_scope` authority static `CantAttack`
+    // uses, so both seams share one scope matcher.
+    for (attacker_id, target) in attacks {
+        let Some(attacker_controller) = state.objects.get(attacker_id).map(|o| o.controller) else {
+            continue;
+        };
+        for restriction in &state.restrictions {
+            let crate::types::ability::GameRestriction::ProhibitActivity {
+                source,
+                affected_players,
+                activity: crate::types::ability::ProhibitedActivity::Attack { defended },
+                ..
+            } = restriction
+            else {
+                continue;
+            };
+            // CR 109.5: the protected player ("you") is the grant's controller.
+            let Some(protected) = state.objects.get(source).map(|o| o.controller) else {
+                continue;
+            };
+            // CR 101.2: only the affected players are prohibited. Targeted scopes
+            // are resolved to `SpecificPlayer` by `add_restriction` before this
+            // gate ever runs.
+            let attacker_is_affected = match affected_players {
+                crate::types::ability::RestrictionPlayerScope::AllPlayers => true,
+                crate::types::ability::RestrictionPlayerScope::SpecificPlayer(p) => {
+                    *p == attacker_controller
+                }
+                crate::types::ability::RestrictionPlayerScope::OpponentsOfSourceController => {
+                    attacker_controller != protected
+                }
+                crate::types::ability::RestrictionPlayerScope::TargetedPlayer
+                | crate::types::ability::RestrictionPlayerScope::ParentTargetedPlayer
+                | crate::types::ability::RestrictionPlayerScope::DefendingPlayer => false,
+            };
+            if !attacker_is_affected {
+                continue;
+            }
+            // CR 508.5: the defended planeswalker/battle compares on controller,
+            // so pass `protected` as both source-controller and source-owner.
+            if crate::game::restrictions::attack_target_matches_defended_scope(
+                state,
+                Some(target),
+                defended,
+                protected,
+                protected,
+            ) {
+                return Err(format!(
+                    "{attacker_id:?} can't attack {target:?} (CR 508.1c player-scoped attack prohibition)"
+                ));
+            }
+        }
+    }
+
     // CR 701.15b: a goaded creature must attack a player other than the goading
     // player *if able*. "Able" is measured against the players this creature
     // could legally be declared attacking: `get_valid_attack_targets` already

--- a/crates/engine/src/game/conditions.rs
+++ b/crates/engine/src/game/conditions.rs
@@ -134,6 +134,7 @@ pub(crate) fn eval_recipient_attacking_owner_target(
         AttackTargetFilter::Player
         | AttackTargetFilter::Planeswalker
         | AttackTargetFilter::PlayerOrPlaneswalker
+        | AttackTargetFilter::PlayerOrPermanents
         | AttackTargetFilter::Battle => false,
     }
 }

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -408,6 +408,10 @@ fn player_status_views(state: &GameState) -> Vec<PlayerStatusView> {
                     allowed_zones: allowed_zones.clone(),
                 }
             }
+            // CR 508.1c: a "can't attack" prohibition is enforced only at the
+            // declare-attackers gate; it has no cast/activate HUD badge, so no
+            // player-status row is produced for it.
+            ProhibitedActivity::Attack { .. } => continue,
         };
         for pid in restriction_affected_players(state, affected_players, *source) {
             views.push(PlayerStatusView {

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -80,8 +80,22 @@ fn fill_runtime_fields(
     }
 
     match restriction {
-        GameRestriction::ProhibitActivity { expiry, .. } => {
-            use crate::types::ability::{Duration, PlayerScope};
+        GameRestriction::ProhibitActivity {
+            expiry,
+            affected_players,
+            ..
+        } => {
+            use crate::types::ability::{Duration, PlayerScope, RestrictionPlayerScope};
+            // CR 109.5 + CR 514.2: when the restriction targets a specific player
+            // ("that player can't attack …"), a "during their next turn" duration
+            // must expire at the RESTRICTED player's next turn — not the grant
+            // controller's. The affected-player resolution above already lowered a
+            // `TargetedPlayer`/`ParentTargetedPlayer` scope to `SpecificPlayer(p)`,
+            // so read that resolved player here (Willie Lumpkin).
+            let restricted_player = match affected_players {
+                RestrictionPlayerScope::SpecificPlayer(p) => Some(*p),
+                _ => None,
+            };
             match ability.duration.as_ref() {
                 // CR 514.2 + CR 611.2a: "until your next turn" expires at the
                 // *beginning* of the controller's next turn.
@@ -102,7 +116,11 @@ fn fill_runtime_fields(
                     player: PlayerScope::Controller,
                 }) => {
                     *expiry = RestrictionExpiry::UntilEndOfNextTurnOf {
-                        player: ability.controller,
+                        // CR 109.5 + CR 514.2: a player-targeted prohibition
+                        // ("during their next turn") anchors on the restricted
+                        // player; fall back to the controller for grants with no
+                        // resolved specific player (Kang's self-controller form).
+                        player: restricted_player.unwrap_or(ability.controller),
                     };
                 }
                 _ => {}

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1935,6 +1935,22 @@ pub(crate) fn attack_target_matches_defended_scope(
         (AttackTargetFilter::OwnerOrPlaneswalker, AttackTarget::Planeswalker(pw_id)) => {
             permanent_controller(*pw_id) == Some(source_owner)
         }
+        // CR 508.1c + CR 109.5: "can't attack you or permanents you control" — the
+        // "you" being defended is the static's/restriction's controller.
+        (AttackTargetFilter::PlayerOrPermanents, AttackTarget::Player(p)) => {
+            *p == source_controller
+        }
+        // CR 109.4 + CR 508.5: a defended planeswalker compares its controller
+        // against the protected player.
+        (AttackTargetFilter::PlayerOrPermanents, AttackTarget::Planeswalker(pw_id)) => {
+            permanent_controller(*pw_id) == Some(source_controller)
+        }
+        // CR 109.4 + CR 508.5 + CR 310.5: battles are attackable permanents, so
+        // "permanents you control" also defends a battle the protected player
+        // controls (the distinctive arm vs `PlayerOrPlaneswalker`, which has none).
+        (AttackTargetFilter::PlayerOrPermanents, AttackTarget::Battle(b_id)) => {
+            permanent_controller(*b_id) == Some(source_controller)
+        }
         _ => false,
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2240,6 +2240,85 @@ fn try_parse_during_that_turn_powerup_prohibition(tp: TextPair<'_>) -> Option<Pa
     })
 }
 
+/// CR 508.1c + CR 514.2 + CR 500.7: "that player can't attack you [or your
+/// permanents/planeswalkers] during their next turn" (Willie Lumpkin) — a
+/// player-scoped, next-turn-expiring attack prohibition. The "that player"
+/// anaphor reuses the parent draw-trigger's targeted player (CR 608.2c), so the
+/// restriction's `affected_players` is `ParentTargetedPlayer`, resolved to a
+/// `SpecificPlayer` at resolution by `add_restriction`. The defended scope rides
+/// the shared `AttackTargetFilter` via `parse_cant_attack_defended_scope_nom`
+/// (the single scope authority), so the declare-attackers gate reuses the same
+/// matcher as static `CantAttack`. The `UntilEndOfNextTurnOf` duration anchors on
+/// the RESTRICTED player (the resolved `SpecificPlayer`), not the controller —
+/// see `add_restriction::fill_runtime_fields`.
+fn try_parse_that_player_cant_attack_prohibition(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    use crate::parser::oracle_static::parse_cant_attack_defended_scope_nom;
+    use crate::types::triggers::AttackTargetFilter;
+
+    // Subject: "that player" / "they" (the parent draw-trigger's targeted
+    // opponent). Both anaphors bind to `ParentTargetedPlayer` (CR 608.2c). The
+    // subject is OPTIONAL: an earlier player-scope subject strip removes the
+    // "that player" / "they" head before this clause is parsed, leaving the bare
+    // "can't attack …" predicate. The full Willie shape (predicate + scope +
+    // "during their next turn") is the discriminator, so defaulting an absent
+    // subject to the parent-target anaphor is safe.
+    let (_, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+        value((), opt((alt((tag("that player"), tag("they"))), tag(" ")))).parse(input)
+    })?;
+    let affected_players = RestrictionPlayerScope::ParentTargetedPlayer;
+    let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
+
+    // "can't attack" / "cannot attack" + the shared defended-scope combinator.
+    let (defended, rest_orig) = nom_on_lower(rest_orig, rest_lower, |input| {
+        let (input, _) =
+            preceded(alt((tag("can't"), tag("cannot"))), tag(" attack")).parse(input)?;
+        let (input, defended) = parse_cant_attack_defended_scope_nom(input)?;
+        // A bare "can't attack" with no scope defends the player only.
+        Ok((input, defended.unwrap_or(AttackTargetFilter::Player)))
+    })?;
+    let rest_lower = &rest_lower[rest_lower.len() - rest_orig.len()..];
+
+    // Duration: "during their next turn" / "during that player's next turn".
+    // REQUIRED — this is the discriminator that gates the whole recognizer, so a
+    // generic "can't attack you" static line never reaches it.
+    let (_, remaining) = nom_on_lower(rest_orig, rest_lower, |input| {
+        value(
+            (),
+            alt((
+                tag(" during their next turn"),
+                tag(" during that player's next turn"),
+            )),
+        )
+        .parse(input)
+    })?;
+    let remaining_lower = &rest_lower[rest_lower.len() - remaining.len()..];
+    if !remaining_lower.trim_matches(['.', ' ']).is_empty() {
+        return None;
+    }
+
+    Some(ParsedEffectClause {
+        effect: Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                source: ObjectId(0),
+                affected_players,
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::Attack { defended },
+            },
+        },
+        // CR 514.2 + CR 500.7: pre-armed end-of-next-turn anchor. The expiry is
+        // lowered in `add_restriction` to the RESTRICTED player's next turn.
+        duration: Some(Duration::UntilEndOfNextTurnOf {
+            player: PlayerScope::Controller,
+        }),
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
 fn try_parse_self_name_exile(
     tp: TextPair<'_>,
     ctx: &mut ParseContext,
@@ -5018,6 +5097,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // activated" (Kang). Tag-scoped prohibition for the granted extra turn — try
     // before the generic non-mana-ability prohibition.
     if let Some(clause) = try_parse_during_that_turn_powerup_prohibition(tp) {
+        return clause;
+    }
+
+    // CR 508.1c + CR 514.2: "that player can't attack you [or your permanents]
+    // during their next turn" (Willie Lumpkin) — player-scoped, next-turn-expiring
+    // attack prohibition. Run before the generic restriction-mode path, which
+    // would otherwise drop the defended scope / duration as Unimplemented.
+    if let Some(clause) = try_parse_that_player_cant_attack_prohibition(tp) {
         return clause;
     }
 

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2122,6 +2122,12 @@ pub(crate) fn parse_combat_tax_body(input: &str) -> OracleResult<'_, CombatTaxPa
     // so the longer phrase wins (nom `alt` is leftmost-match).
     use crate::types::triggers::AttackTargetFilter;
     let (input, defended) = opt(alt((
+        // CR 508.1c + CR 310.5: " you or permanents you control" also defends
+        // battles — a distinct filter from the planeswalker-only phrase.
+        value(
+            AttackTargetFilter::PlayerOrPermanents,
+            tag_no_case::<_, _, OracleError<'_>>(" you or permanents you control"),
+        ),
         value(
             AttackTargetFilter::PlayerOrPlaneswalker,
             tag_no_case::<_, _, OracleError<'_>>(" you or planeswalkers you control"),

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -142,6 +142,7 @@ pub(crate) use keyword_grant::{
 };
 pub(crate) use mana_transform::try_parse_retain_unspent_mana_static;
 pub(crate) use restriction::parse_cant_be_activated_exemption_in_text;
+pub(crate) use shared::parse_cant_attack_defended_scope_nom;
 pub(crate) use shared::parse_dynamic_x_clause;
 pub use shared::parse_static_line_multi;
 pub(crate) use shared::parse_subtype_or_list_insensitive_prefix;

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2997,7 +2997,14 @@ pub(crate) fn parse_cant_attack_defended_scope_nom(
     input: &str,
 ) -> OracleResult<'_, Option<crate::types::triggers::AttackTargetFilter>> {
     use crate::types::triggers::AttackTargetFilter;
+    // CR 508.1c + CR 310.5: " you or permanents you control" defends battles too,
+    // so it is a distinct filter from " you or planeswalkers you control". Both
+    // longer phrases precede the bare " you" (nom `alt` is leftmost-match).
     opt(alt((
+        value(
+            AttackTargetFilter::PlayerOrPermanents,
+            tag(" you or permanents you control"),
+        ),
         value(
             AttackTargetFilter::PlayerOrPlaneswalker,
             tag(" you or planeswalkers you control"),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1635,6 +1635,14 @@ pub enum ProhibitedActivity {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         only_tag: Option<AbilityTag>,
     },
+    /// CR 508.1c: A temporary effect prohibits an affected player from declaring
+    /// attacks against the defended scope ("that player can't attack you [or your
+    /// permanents/planeswalkers]"). The scope rides the shared `AttackTargetFilter`
+    /// so the declare-attackers gate reuses the same defended-scope matcher as
+    /// static `CantAttack` restrictions.
+    Attack {
+        defended: crate::types::triggers::AttackTargetFilter,
+    },
 }
 
 /// When a game restriction expires.

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -190,6 +190,12 @@ pub enum AttackTargetFilter {
     /// controls" restricts attacks against the owning player and planeswalkers
     /// that player controls.
     OwnerOrPlaneswalker,
+    /// CR 508.1c + CR 508.5 + CR 109.4: "you or permanents you control" defends
+    /// you plus every attackable permanent you control — planeswalkers AND
+    /// battles (CR 310.5: battles can be attacked). Distinct from
+    /// `PlayerOrPlaneswalker`, which excludes battles. Control of the defended
+    /// planeswalker/battle is compared per CR 109.4.
+    PlayerOrPermanents,
 }
 
 /// All trigger modes from Forge's TriggerType enum (CR 603).

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -484,6 +484,7 @@ mod well_of_lost_dreams_may_pay_x;
 mod wernog_riders_chaplain_investigate_count;
 mod white_suns_twilight;
 mod who_villainous_choice_scoped_player;
+mod willie_lumpkin_cant_attack;
 mod wise_mothman_milled_trigger;
 mod wise_mothman_target_distinctness;
 mod wolverine_fierce_fighter_heal;

--- a/crates/engine/tests/integration/willie_lumpkin_cant_attack.rs
+++ b/crates/engine/tests/integration/willie_lumpkin_cant_attack.rs
@@ -1,0 +1,353 @@
+//! MSH Wave 6: Willie Lumpkin, Postman — "Whenever Willie Lumpkin deals combat
+//! damage to an opponent, you draw a card and that player may draw a card. If
+//! they do, that player can't attack you or permanents you control during their
+//! next turn."
+//!
+//! The trailing "that player can't attack you or permanents you control during
+//! their next turn" was a parser `Effect::Unimplemented { name: "can't" }` leaf.
+//! This suite locks in:
+//!   1. PARSE: the trigger sub-chain leaf lowers to
+//!      `Effect::AddRestriction { ProhibitActivity { Attack { PlayerOrPermanents },
+//!      ParentTargetedPlayer } }`, NOT `Unimplemented`.
+//!   2. RUNTIME: the new player-scoped declare-attackers gate rejects the
+//!      restricted player's attacks against the protected player, their
+//!      planeswalker, AND their battle (the `PlayerOrPermanents` Battle arm),
+//!      while a third (unrestricted) player may attack freely.
+//!   3. EXPIRY: the restriction anchors on the RESTRICTED player's next turn.
+//!
+//! CR 508.1c: attack restrictions checked at declare-attackers. CR 508.5: the
+//! defended planeswalker/battle compares on controller. CR 310.5: battles are
+//! attackable permanents (the `PlayerOrPermanents` distinction from
+//! `PlayerOrPlaneswalker`). CR 514.2 + CR 500.7: next-turn expiry.
+
+use engine::game::combat::{declare_attackers, AttackTarget};
+use engine::game::effects::add_restriction;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, Duration, Effect, GameRestriction, PlayerScope, ProhibitedActivity,
+    ResolvedAbility, RestrictionExpiry, RestrictionPlayerScope, TargetRef,
+};
+use engine::types::card_type::CoreType;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::triggers::AttackTargetFilter;
+use engine::types::zones::Zone;
+
+const WILLIE_ORACLE: &str = "Willie Lumpkin can't be blocked.\nWhenever Willie Lumpkin deals combat damage to an opponent, you draw a card and that player may draw a card. If they do, that player can't attack you or permanents you control during their next turn.";
+
+const PROTECTED: PlayerId = PlayerId(0); // Willie's controller ("you")
+const RESTRICTED: PlayerId = PlayerId(1); // the opponent dealt damage
+const THIRD: PlayerId = PlayerId(2); // an unrestricted third player
+
+/// Walk the trigger sub-chain to the deepest sub_ability (the "that player can't
+/// attack ..." leaf).
+fn deepest_sub_effect(mut ability: &AbilityDefinition) -> &Effect {
+    while let Some(sub) = ability.sub_ability.as_deref() {
+        ability = sub;
+    }
+    &ability.effect
+}
+
+#[test]
+fn willie_cant_attack_clause_parses_to_player_scoped_prohibition() {
+    let parsed = parse_oracle_text(
+        WILLIE_ORACLE,
+        "Willie Lumpkin, Postman",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Citizen".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Willie has a DamageDone trigger with an execute chain");
+
+    let leaf = deepest_sub_effect(trigger);
+    match leaf {
+        Effect::AddRestriction {
+            restriction:
+                GameRestriction::ProhibitActivity {
+                    affected_players,
+                    activity: ProhibitedActivity::Attack { defended },
+                    ..
+                },
+        } => {
+            // REVERT-FAIL: reverting the Willie parser leaves `Effect::Unimplemented`.
+            assert_eq!(
+                *defended,
+                AttackTargetFilter::PlayerOrPermanents,
+                "Willie defends 'you or permanents you control' (battles included)"
+            );
+            // NEGATIVE: must NOT be the planeswalker-only scope (proves the
+            // permanents-vs-planeswalkers distinction).
+            assert_ne!(*defended, AttackTargetFilter::PlayerOrPlaneswalker);
+            assert_eq!(
+                *affected_players,
+                RestrictionPlayerScope::ParentTargetedPlayer,
+                "'that player' binds to the parent draw-trigger target"
+            );
+        }
+        other => panic!("expected AddRestriction(Attack), got {other:?}"),
+    }
+}
+
+/// Build a 3-player board with Willie's restriction in force against RESTRICTED,
+/// defended scope `PlayerOrPermanents`, and a creature each of RESTRICTED and
+/// THIRD control. Returns the state with active_player = RESTRICTED.
+fn board_with_restriction() -> (GameState, ObjectId, ObjectId, ObjectId, ObjectId) {
+    let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+    state.active_player = RESTRICTED;
+    state.turn_number = 2;
+
+    // Willie (the protected player's permanent — the restriction source).
+    let willie_card = CardId(state.next_object_id);
+    let willie = create_object(
+        &mut state,
+        willie_card,
+        PROTECTED,
+        "Willie Lumpkin, Postman".to_string(),
+        Zone::Battlefield,
+    );
+
+    // RESTRICTED's attacker.
+    let restricted_attacker = make_creature(&mut state, RESTRICTED, "Restricted Bear");
+    // THIRD's attacker.
+    let third_attacker = make_creature(&mut state, THIRD, "Third Bear");
+
+    // PROTECTED's planeswalker (a defended permanent).
+    let pw_card = CardId(state.next_object_id);
+    let pw = create_object(
+        &mut state,
+        pw_card,
+        PROTECTED,
+        "Jace".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&pw)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Planeswalker);
+
+    // Install the restriction via the real resolver so affected_players and the
+    // expiry anchor are lowered exactly as in production.
+    let ability = ResolvedAbility::new(
+        Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                source: ObjectId(0),
+                affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::Attack {
+                    defended: AttackTargetFilter::PlayerOrPermanents,
+                },
+            },
+        },
+        vec![TargetRef::Player(RESTRICTED)],
+        willie,
+        PROTECTED,
+    )
+    .duration(Duration::UntilEndOfNextTurnOf {
+        player: PlayerScope::Controller,
+    });
+    let mut events = Vec::new();
+    add_restriction::resolve(&mut state, &ability, &mut events).unwrap();
+
+    (state, restricted_attacker, third_attacker, pw, willie)
+}
+
+fn make_creature(state: &mut GameState, controller: PlayerId, name: &str) -> ObjectId {
+    let card = CardId(state.next_object_id);
+    let id = create_object(state, card, controller, name.to_string(), Zone::Battlefield);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = Some(2);
+    obj.toughness = Some(2);
+    obj.base_power = Some(2);
+    obj.base_toughness = Some(2);
+    id
+}
+
+#[test]
+fn willie_restricted_player_cannot_attack_protected_third_player_can() {
+    let (state, restricted_attacker, third_attacker, _pw, _willie) = board_with_restriction();
+
+    // REVERT-FAIL (combat gate): the restricted player's attack on PROTECTED is rejected.
+    let mut s = state.clone();
+    let mut events = Vec::new();
+    assert!(
+        declare_attackers(
+            &mut s,
+            &[(restricted_attacker, AttackTarget::Player(PROTECTED))],
+            &mut events,
+        )
+        .is_err(),
+        "CR 508.1c: restricted player can't attack the protected player"
+    );
+
+    // SIBLING: a THIRD (unrestricted) player attacking PROTECTED is allowed.
+    let mut s = state.clone();
+    s.active_player = THIRD;
+    let mut events = Vec::new();
+    assert!(
+        declare_attackers(
+            &mut s,
+            &[(third_attacker, AttackTarget::Player(PROTECTED))],
+            &mut events,
+        )
+        .is_ok(),
+        "CR 101.2: only the restricted player is prohibited; THIRD may attack"
+    );
+}
+
+#[test]
+fn willie_restricted_player_cannot_attack_protected_planeswalker_or_battle() {
+    let (mut state, restricted_attacker, _third, pw, _willie) = board_with_restriction();
+
+    // Planeswalker arm.
+    let mut s = state.clone();
+    let mut events = Vec::new();
+    assert!(
+        declare_attackers(
+            &mut s,
+            &[(restricted_attacker, AttackTarget::Planeswalker(pw))],
+            &mut events,
+        )
+        .is_err(),
+        "CR 508.5: restricted player can't attack the protected player's planeswalker"
+    );
+
+    // Battle arm — the PlayerOrPermanents distinctive case (CR 310.5).
+    let battle_card = CardId(state.next_object_id);
+    let battle = create_object(
+        &mut state,
+        battle_card,
+        THIRD, // a battle the restricted player is NOT the protector of
+        "Invasion Battle".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&battle).unwrap();
+        obj.card_types.core_types = vec![CoreType::Battle];
+        obj.base_card_types = obj.card_types.clone();
+        // CR 508.5: the matcher compares the battle's CONTROLLER against the
+        // protected player, so set the battle's controller to PROTECTED.
+        obj.controller = PROTECTED;
+    }
+    let mut events = Vec::new();
+    // REVERT-FAIL (Battle matcher arm): removing the (PlayerOrPermanents, Battle)
+    // arm lets this attack through.
+    assert!(
+        declare_attackers(
+            &mut state,
+            &[(restricted_attacker, AttackTarget::Battle(battle))],
+            &mut events,
+        )
+        .is_err(),
+        "CR 310.5 + CR 508.5: 'permanents you control' defends the protected player's battle"
+    );
+}
+
+#[test]
+fn willie_expiry_anchors_on_restricted_player_not_controller() {
+    let (state, _ra, _ta, _pw, _willie) = board_with_restriction();
+    // REVERT-FAIL (Step 5 expiry arm): the round-1 bug anchored on ability.controller
+    // (PROTECTED). The fix anchors on the resolved SpecificPlayer (RESTRICTED).
+    let restriction = state
+        .restrictions
+        .iter()
+        .find(|r| {
+            matches!(
+                r,
+                GameRestriction::ProhibitActivity {
+                    activity: ProhibitedActivity::Attack { .. },
+                    ..
+                }
+            )
+        })
+        .expect("the Attack prohibition is in state.restrictions");
+    match restriction {
+        GameRestriction::ProhibitActivity {
+            affected_players,
+            expiry,
+            ..
+        } => {
+            assert_eq!(
+                *affected_players,
+                RestrictionPlayerScope::SpecificPlayer(RESTRICTED),
+                "affected player resolves to the restricted opponent"
+            );
+            assert_eq!(
+                *expiry,
+                RestrictionExpiry::UntilEndOfNextTurnOf { player: RESTRICTED },
+                "CR 514.2: expiry anchors on the RESTRICTED player's next turn, not the controller"
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// MANDATORY no-over-application regression: an UNSCOPED `CantAttack` static
+/// (`attack_defended: None` — Propaganda/Pacifism family) must still reject the
+/// creature from attacking ANY target. This guards the `attack_defended.is_none()`
+/// fast path (combat.rs) against accidental narrowing by the scoped paths added
+/// for Willie/Promise. CR 508.1c.
+#[test]
+fn unscoped_cant_attack_still_rejects_all_targets() {
+    use engine::game::layers::evaluate_layers;
+    use engine::types::ability::{ContinuousModification, StaticDefinition, TargetFilter};
+    use engine::types::statics::StaticMode;
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.active_player = RESTRICTED;
+    state.turn_number = 2;
+
+    let attacker = make_creature(&mut state, RESTRICTED, "Pacified Bear");
+    // Intrinsic unscoped CantAttack (attack_defended: None) on the creature.
+    {
+        let def = StaticDefinition::new(StaticMode::CantAttack)
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::CantAttack,
+            }]);
+        let obj = state.objects.get_mut(&attacker).unwrap();
+        obj.static_definitions = vec![def.clone()].into();
+        obj.base_static_definitions = std::sync::Arc::new(vec![def]);
+    }
+    evaluate_layers(&mut state);
+
+    // A potential defender player + their planeswalker.
+    let pw_card = CardId(state.next_object_id);
+    let pw = create_object(
+        &mut state,
+        pw_card,
+        PROTECTED,
+        "Jace".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&pw)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Planeswalker);
+
+    for target in [
+        AttackTarget::Player(PROTECTED),
+        AttackTarget::Planeswalker(pw),
+    ] {
+        let mut s = state.clone();
+        let mut events = Vec::new();
+        assert!(
+            declare_attackers(&mut s, &[(attacker, target)], &mut events).is_err(),
+            "CR 508.1c: an unscoped CantAttack must reject attacking {target:?}"
+        );
+    }
+}


### PR DESCRIPTION
Adds a player-scoped, next-turn-expiring attack prohibition covering the
"that player can't attack you or [your permanents/planeswalkers] during their
next turn" deterrent class (Willie Lumpkin, Postman and siblings).

- New leaf AttackTargetFilter::PlayerOrPermanents (Player + Planeswalker +
  Battle), distinct from PlayerOrPlaneswalker (excludes Battle) per CR 310.5.
- New ProhibitedActivity::Attack { defended } restriction; declare-attackers
  gate loop in combat.rs scans state.restrictions and reuses the shared
  attack_target_matches_defended_scope authority (CR 508.1c).
- Expiry-anchor fix in add_restriction.rs: UntilEndOfNextTurnOf now anchors on
  the resolved restricted player (SpecificPlayer), not ability.controller.
- Parser recognizer lowers Willie's trigger leaf (was Effect::Unimplemented)
  via nom combinators reusing parse_cant_attack_defended_scope_nom.

5 discriminating runtime tests drive the real declare_attackers pipeline incl.
a Propaganda no-over-application regression. Promise of Loyalty deferred (its
counter-keep-sacrifice head infra is absent; not falsely marked supported).
