### PR TITLE
feat(engine): bend trigger/effect + saddle-as-effect + exchange-control (Avatar Aang, Fatal Fissure, Alacrian Armory, Kitsune)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -534,6 +534,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::BlockingAlone => parts.push("blocking alone".into()),
             FilterProp::Tapped => parts.push("tapped".into()),
             FilterProp::IsSaddled => parts.push("saddled".into()),
+            FilterProp::SaddledSource => parts.push("saddled the source".into()),
             FilterProp::ProtectorMatches { .. } => parts.push("protector matches".into()),
             FilterProp::Untapped => parts.push("untapped".into()),
             FilterProp::HasHasteOrControlledSinceTurnBegan => {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -158,6 +158,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -365,6 +366,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -2655,6 +2657,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::BlockingAlone
         | FilterProp::Tapped
         | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -3035,6 +3038,13 @@ fn matches_filter_prop(
         FilterProp::Tapped => obj.tapped,
         // CR 702.171b: Matches permanents with the saddled designation.
         FilterProp::IsSaddled => obj.is_saddled,
+        // CR 702.171c: Matches a creature that saddled the filter source this turn
+        // (tapped to pay the source's saddle cost — recorded in `saddled_by`,
+        // cleared at end of turn). Source-relative, mirroring `BlockingSource`.
+        FilterProp::SaddledSource => state
+            .objects
+            .get(&source.id)
+            .is_some_and(|src| src.saddled_by.contains(&object_id)),
         // CR 310.8a: "each battle they protect" — protector is an opponent of
         // the source controller (Joyful Stormsculptor class).
         FilterProp::ProtectorMatches { controller } => {
@@ -3966,6 +3976,7 @@ fn zone_change_record_matches_property(
         }),
         FilterProp::Tapped
         | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7649,16 +7649,11 @@ fn try_parse_exchange_control_targets(span: &str) -> Option<(TargetFilter, Targe
     // creatures controlled by different players") is a target-SET constraint
     // (`TargetSelectionConstraint::DifferentObjectControllers`), extracted
     // separately in the chain lowerer — it is not part of either per-slot filter.
-    // Locate and strip it with a nom combinator (take_until + tag) so the per-slot
-    // `parse_target` sees a clean "two other target creatures" span. Mirrors the
-    // detector `parse_controlled_by_different_players_target_constraint` in the
-    // chain lowerer.
-    let span = match take_until::<_, _, OracleError<'_>>(" controlled by different players")
-        .parse(span)
-    {
-        Ok((_, before)) => before.trim_end(),
-        Err(_) => span,
-    };
+    // Strip it via the shared `strip_controlled_by_different_players` combinator
+    // (single source of truth with the detector
+    // `parse_controlled_by_different_players_target_constraint`) so the per-slot
+    // `parse_target` sees a clean "two other target creatures" span.
+    let span = super::lower::strip_controlled_by_different_players(span).unwrap_or(span);
     // Quantified shape: "two target Xs" dispatched via nom. We peek for the
     // `"two target "` prefix with `alt((tag(...), tag(...)))` (plural handled by
     // `parse_target`'s QUANTIFIED_PREFIXES), then re-enter `parse_target` on the

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1639,9 +1639,12 @@ pub(super) fn parse_targeted_action_ast(
         assert_no_compound_remainder(_rem, text);
         return Some(TargetedImperativeAst::GainControl { target, all });
     }
-    // Earthbend: "earthbend [N] [target <type>]"
+    // Earthbend: "[you ]earthbend [N] [target <type>]". The optional "you "
+    // subject (Fatal Fissure's delayed trigger "you earthbend 4") names the
+    // controller performing the keyword action; earthbend is a player action, so
+    // the subject carries no extra targeting and is simply consumed.
     if let Some((_, rest)) = nom_on_lower(text, lower, |input| {
-        value((), tag("earthbend ")).parse(input)
+        value((), preceded(opt(tag("you ")), tag("earthbend "))).parse(input)
     }) {
         let rest_lower = &lower[lower.len() - rest.len()..];
         let (target, power, toughness) = parse_earthbend_params(text, rest_lower);
@@ -7641,6 +7644,21 @@ fn try_parse_exchange_life_totals(lower: &str) -> Option<(TargetFilter, TargetFi
 /// so we don't accept malformed inputs like "target creature and dance" as a
 /// valid two-target phrase.
 fn try_parse_exchange_control_targets(span: &str) -> Option<(TargetFilter, TargetFilter)> {
+    // CR 601.2c + CR 115.1: a trailing "controlled by different players"
+    // (Kitsune, Dragon's Daughter: "exchange control of two other target
+    // creatures controlled by different players") is a target-SET constraint
+    // (`TargetSelectionConstraint::DifferentObjectControllers`), extracted
+    // separately in the chain lowerer — it is not part of either per-slot filter.
+    // Locate and strip it with a nom combinator (take_until + tag) so the per-slot
+    // `parse_target` sees a clean "two other target creatures" span. Mirrors the
+    // detector `parse_controlled_by_different_players_target_constraint` in the
+    // chain lowerer.
+    let span = match take_until::<_, _, OracleError<'_>>(" controlled by different players")
+        .parse(span)
+    {
+        Ok((_, before)) => before.trim_end(),
+        Err(_) => span,
+    };
     // Quantified shape: "two target Xs" dispatched via nom. We peek for the
     // `"two target "` prefix with `alt((tag(...), tag(...)))` (plural handled by
     // `parse_target`'s QUANTIFIED_PREFIXES), then re-enter `parse_target` on the

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3514,11 +3514,29 @@ pub(crate) fn extract_verb_up_to_multi_target(text: &str) -> Option<MultiTargetS
     multi_target
 }
 
+/// CR 115.1: the "controlled by different players" target-set constraint phrase.
+/// Single source of truth shared by the detector
+/// (`parse_controlled_by_different_players_target_constraint`) and the per-slot
+/// stripper (`strip_controlled_by_different_players` →
+/// `try_parse_exchange_control_targets`).
+pub(crate) const CONTROLLED_BY_DIFFERENT_PLAYERS: &str = " controlled by different players";
+
+/// Locate the `CONTROLLED_BY_DIFFERENT_PLAYERS` constraint with a `take_until`
+/// combinator and return the span BEFORE it (trimmed). Returns `None` when the
+/// constraint is absent, so callers keep the original span. Composed from the
+/// shared constraint phrase so the detector and the stripper can never drift.
+pub(crate) fn strip_controlled_by_different_players(span: &str) -> Option<&str> {
+    take_until::<_, _, OracleError<'_>>(CONTROLLED_BY_DIFFERENT_PLAYERS)
+        .parse(span)
+        .ok()
+        .map(|(_, before)| before.trim_end())
+}
+
 fn parse_controlled_by_different_players_target_constraint(text: &str) -> bool {
     let lower = text.to_lowercase();
     let mut parser = preceded(
-        take_until::<_, _, OracleError<'_>>(" controlled by different players"),
-        tag(" controlled by different players"),
+        take_until::<_, _, OracleError<'_>>(CONTROLLED_BY_DIFFERENT_PLAYERS),
+        tag(CONTROLLED_BY_DIFFERENT_PLAYERS),
     );
     parser.parse(lower.as_str()).is_ok()
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2552,8 +2552,12 @@ fn try_parse_airbend_clause(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
 }
 
 fn try_parse_earthbend_clause(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    // CR 608.2c: the optional leading "you " subject ("you earthbend 4" — Fatal
+    // Fissure's delayed trigger) names the controller performing the keyword
+    // action. Earthbend is a player action with no extra targeting, so the
+    // subject is simply consumed before the count/target parse.
     let (_, rest) = nom_on_lower(tp.original, tp.lower, |i| {
-        value((), tag("earthbend ")).parse(i)
+        value((), preceded(opt(tag("you ")), tag("earthbend "))).parse(i)
     })?;
     // `rest` is the original-case remainder; lowercase it for the nom-based
     // dispatcher inside `parse_earthbend_count_expr`, which expects already-lowered

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -373,6 +373,19 @@ fn plotted_grant_target(previous: &AbilityDefinition) -> TargetFilter {
     }
 }
 
+/// CR 205.1a + CR 613.1d: the "become(s) " animation/type-change verb in both
+/// conjugations (conjugated "becomes " and imperative "become "). Single source
+/// of truth for the bare-become conjunct split in `split_clause_sequence` — used
+/// both for the remainder peek and the word-boundary antecedent scan so the two
+/// conjugations are never enumerated in two places.
+fn parse_become_verb(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((tag::<_, _, OracleError<'_>>("becomes "), tag("become "))),
+    )
+    .parse(input)
+}
+
 fn parse_becomes_plotted_continuation(lower: &str) -> bool {
     // allow-noncombinator: punctuation cleanup before all_consuming
     let text = lower.trim().trim_end_matches('.').trim();
@@ -821,19 +834,16 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         // not a separate clause. Suppress the bare-become split in that case
                         // so the single GenericEffect carries both the pump and the subtype
                         // change. The antecedent is a become predicate iff its text already
-                        // contains a "become(s) " verb.
-                        let bare_becomes_remainder = alt((
-                            tag::<_, _, OracleError<'_>>("becomes "),
-                            tag("become "),
-                        ))
-                        .parse(remainder_trimmed)
-                        .is_ok();
-                        let antecedent_is_become = nom_primitives::scan_contains(
+                        // contains a "become(s) " verb. A single `parse_become_verb`
+                        // combinator (`alt` of the two conjugations) is the source of truth
+                        // for both the remainder peek and the word-boundary antecedent scan,
+                        // so the two conjugations are never enumerated twice.
+                        let bare_becomes_remainder = parse_become_verb(remainder_trimmed).is_ok();
+                        let antecedent_is_become = nom_primitives::scan_at_word_boundaries(
                             &before_lower,
-                            "becomes ",
-                        ) || nom_primitives::scan_contains(
-                            &before_lower, "become ",
-                        );
+                            parse_become_verb,
+                        )
+                        .is_some();
                         let bare_becomes_continuation =
                             bare_becomes_remainder && !antecedent_is_become;
                         let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
@@ -1907,7 +1917,7 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // `starts_target_continuous_clause_lower`) so the `alt(...)` cluster stays
     // under nom's 21-arm limit.
     .or(value((), starts_each_player_predicate_clause_lower))
-    // CR 205.1a + CR 613.1d/e + CR 702.171b: a bare "becomes <descriptor>"
+    // CR 205.1a + CR 613.1d + CR 702.171b: a bare "becomes <descriptor>"
     // conjunct joined by " and " is a second animation/designation predicate whose
     // subject is carried over (anaphorically) from the prior conjunct — the same
     // demonstrative subject the first "becomes" clause used. Alacrian Armory:
@@ -1921,9 +1931,9 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // parses exactly as the standalone "[subject] becomes <descriptor> if it's a
     // <type>" clause does. A bare conjugated "becomes" (or imperative "become") is
     // always a verb predicate, never a noun-phrase continuation, so the split is
-    // safe. Mirrors the anaphoric "it becomes " arm above for the subject-carried
-    // form.
-    .or(value((), alt((tag("becomes "), tag("become ")))))
+    // safe. Reuses the shared `parse_become_verb` combinator. Mirrors the anaphoric
+    // "it becomes " arm above for the subject-carried form.
+    .or(parse_become_verb)
     .parse(s)
     .is_ok();
     if has_verb_prefix {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -810,6 +810,32 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                             && starts_prefix_clause(
                                 trimmed_before.trim_end_matches(',').trim_end(),
                             );
+                        // CR 205.1a + CR 613.1d: a bare "becomes <descriptor>" conjunct
+                        // splits off as its OWN become clause only when the antecedent is
+                        // ALSO a become predicate (a compound-become like Alacrian Armory's
+                        // "becomes saddled … and becomes an artifact creature …"). When the
+                        // antecedent is a continuous-modification predicate ("This creature
+                        // gets +3/+3 and becomes a Bear Berserker until end of turn"), the
+                        // "becomes" is a TYPE-CHANGE modifier on the same continuous effect
+                        // (CR 613.1d Layer 4), absorbed by `parse_continuous_modifications` —
+                        // not a separate clause. Suppress the bare-become split in that case
+                        // so the single GenericEffect carries both the pump and the subtype
+                        // change. The antecedent is a become predicate iff its text already
+                        // contains a "become(s) " verb.
+                        let bare_becomes_remainder = alt((
+                            tag::<_, _, OracleError<'_>>("becomes "),
+                            tag("become "),
+                        ))
+                        .parse(remainder_trimmed)
+                        .is_ok();
+                        let antecedent_is_become = nom_primitives::scan_contains(
+                            &before_lower,
+                            "becomes ",
+                        ) || nom_primitives::scan_contains(
+                            &before_lower, "become ",
+                        );
+                        let bare_becomes_continuation =
+                            bare_becomes_remainder && !antecedent_is_become;
                         let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
                         && !sacrifice_rest_remainder)
                         || is_inside_temporal_prefix(&before_lower)
@@ -825,6 +851,7 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         || have_base_pt_continuation
                         || continuous_modifier_conjunct
                         || roll_die_modifier_continuation
+                        || bare_becomes_continuation
                         || inside_prefix_comma_and_continuation;
                         if !suppress && starts_bare_and_clause(remainder_trimmed) {
                             push_clause_chunk(&mut chunks, before_and, Some(ClauseBoundary::Comma));
@@ -1880,6 +1907,23 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // `starts_target_continuous_clause_lower`) so the `alt(...)` cluster stays
     // under nom's 21-arm limit.
     .or(value((), starts_each_player_predicate_clause_lower))
+    // CR 205.1a + CR 613.1d/e + CR 702.171b: a bare "becomes <descriptor>"
+    // conjunct joined by " and " is a second animation/designation predicate whose
+    // subject is carried over (anaphorically) from the prior conjunct — the same
+    // demonstrative subject the first "becomes" clause used. Alacrian Armory:
+    // "that permanent becomes saddled if it's a Mount and becomes an artifact
+    // creature if it's a Vehicle" — without this split the compound stays one
+    // chunk, the trailing-conditional peel only catches the LAST "if it's a …"
+    // gate, and the residual fails closed to an Unimplemented effect named
+    // "become". Splitting routes the second conjunct through `parse_clause_ast` →
+    // `try_parse_subject_become_clause`, where the empty (carried-over) subject
+    // resolves to the parent target and each conjunct's "if it's a <type>" gate
+    // parses exactly as the standalone "[subject] becomes <descriptor> if it's a
+    // <type>" clause does. A bare conjugated "becomes" (or imperative "become") is
+    // always a verb predicate, never a noun-phrase continuation, so the split is
+    // safe. Mirrors the anaphoric "it becomes " arm above for the subject-carried
+    // form.
+    .or(value((), alt((tag("becomes "), tag("become ")))))
     .parse(s)
     .is_ok();
     if has_verb_prefix {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -417,7 +417,19 @@ fn try_parse_subject_become_clause(
     tag::<_, _, OracleError<'_>>("become ")
         .parse(predicate_lower.as_str())
         .ok()?;
-    let application = parse_subject_application(subject, ctx)?;
+    // CR 608.2c: a bare "becomes <descriptor>" conjunct (no leading subject) is
+    // the second half of a compound-become instruction whose subject carried over
+    // from the prior conjunct — Alacrian Armory's "that permanent becomes saddled
+    // if it's a Mount and becomes an artifact creature if it's a Vehicle", where
+    // the sequence splitter peels "becomes an artifact creature …" off as its own
+    // chunk. Resolve the empty subject through the same context-dependent "it"
+    // anaphor the explicit "it becomes …" form uses (parent target / triggering
+    // source), so the second animation binds to the same object as the first.
+    let application = if subject.is_empty() {
+        parse_subject_application("it", ctx)?
+    } else {
+        parse_subject_application(subject, ctx)?
+    };
     build_become_clause(application, &predicate, ctx)
 }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5142,6 +5142,12 @@ pub(crate) fn parse_that_clause_suffix<'a>(
         ),
         ("attacked this turn", FilterProp::AttackedThisTurn),
         ("blocked this turn", FilterProp::BlockedThisTurn),
+        // CR 702.171c: "that saddled it [this turn]" — the creature was tapped to
+        // pay the source's saddle cost (recorded in the source's `saddled_by`,
+        // cleared at end of turn so "this turn" is implicit). "it" refers to the
+        // ability source. Calamity, Galloping Inferno. Longest match first.
+        ("saddled it this turn", FilterProp::SaddledSource),
+        ("saddled it", FilterProp::SaddledSource),
     ];
 
     for (phrase, prop) in VERB_PHRASES {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10003,9 +10003,10 @@ fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinitio
 }
 
 /// Avatar crossover: recognize a single bending verb and map it to its
-/// specific `TriggerMode`. A disjunction of these verbs is collapsed by
+/// specific `TriggerMode`. The full four-verb disjunction is collapsed by
 /// `try_parse_bend_trigger` to `TriggerMode::ElementalBend` (which matches any of
-/// the four bending `GameEvent`s for the source's controller). Single source of
+/// the four bending `GameEvent`s for the source's controller); a partial
+/// disjunction fails closed (see `try_parse_bend_trigger`). Single source of
 /// truth for both the trigger-mode dispatch and the `continues_player_action_list`
 /// condition/effect boundary check.
 fn parse_bend_verb(input: &str) -> OracleResult<'_, TriggerMode> {
@@ -10020,12 +10021,21 @@ fn parse_bend_verb(input: &str) -> OracleResult<'_, TriggerMode> {
 
 /// Avatar crossover (CR 603.2): "whenever you {waterbend|earthbend|firebend|
 /// airbend}[, {verb}]*[, or {verb}]" — a single bending verb fires its specific
-/// bend trigger; a disjunction of two or more fires on ANY of the listed bend
-/// events (`TriggerMode::ElementalBend`, which the runtime matcher
-/// `match_elemental_bend` already scopes to the source's controller). Avatar Aang
-/// uses the full four-verb batch. `valid_target = Controller` is redundant with
-/// the matcher's controller scoping but kept for consistency with the other
-/// player-action bend-adjacent triggers.
+/// bend trigger; the full four-verb batch (Avatar Aang) fires on ANY of the four
+/// bend events via `TriggerMode::ElementalBend`, whose matcher
+/// `match_elemental_bend` already scopes to the source's controller.
+///
+/// A PARTIAL disjunction (a strict subset of two or three distinct verbs, e.g.
+/// "whenever you waterbend or earthbend") has no faithful runtime representation:
+/// the only any-bend matcher is `match_elemental_bend`, which fires on all four,
+/// and there is no parameterized bend-set matcher yet. Collapsing a partial set to
+/// `ElementalBend` would over-fire on the unlisted bend events. So this parser
+/// returns `None` for any partial set, leaving such cards to fail closed
+/// (strict-failure `Unknown`) rather than ship a trigger broader than its
+/// semantics. When a partial-bend card actually appears, add a parameterized
+/// bend-set matcher and route the parsed set through to it. `valid_target =
+/// Controller` is redundant with the matcher's controller scoping but kept for
+/// consistency with the other player-action bend-adjacent triggers.
 fn try_parse_bend_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
     let rest = alt((
         value((), tag::<_, _, OracleError<'_>>("whenever you ")),
@@ -10059,12 +10069,15 @@ fn try_parse_bend_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition
         }
     }
 
+    let distinct: std::collections::HashSet<&TriggerMode> = modes.iter().collect();
     let mode = match modes.as_slice() {
         [] => return None,
         [single] => single.clone(),
-        // CR 603.2: two or more distinct bend events in one trigger collapse to
-        // the any-bend matcher.
-        _ => TriggerMode::ElementalBend,
+        // CR 603.2: only the complete four-verb batch maps to the any-bend matcher.
+        // Anything narrower (partial subset, or repeated verbs) lacks a faithful
+        // runtime matcher and must fail closed rather than over-fire.
+        _ if distinct.len() == 4 => TriggerMode::ElementalBend,
+        _ => return None,
     };
 
     let mut def = make_base();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -5377,6 +5377,13 @@ fn continues_player_action_list(after_comma: &str) -> bool {
     if parse_player_action_phrase(candidate).is_some() {
         return true;
     }
+    // Avatar crossover: a comma-separated bending-verb disjunction
+    // ("whenever you waterbend, earthbend, firebend, or airbend") is a single
+    // batched trigger event, so the comma after each verb is a list separator,
+    // not the condition/effect boundary.
+    if all_consuming(parse_bend_verb).parse(candidate).is_ok() {
+        return true;
+    }
 
     if type_phrase_continues_to_combat_damage_player_event(trimmed) {
         return true;
@@ -9995,8 +10002,86 @@ fn try_parse_phase_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinitio
     Some((TriggerMode::Phase, def))
 }
 
+/// Avatar crossover: recognize a single bending verb and map it to its
+/// specific `TriggerMode`. A disjunction of these verbs is collapsed by
+/// `try_parse_bend_trigger` to `TriggerMode::ElementalBend` (which matches any of
+/// the four bending `GameEvent`s for the source's controller). Single source of
+/// truth for both the trigger-mode dispatch and the `continues_player_action_list`
+/// condition/effect boundary check.
+fn parse_bend_verb(input: &str) -> OracleResult<'_, TriggerMode> {
+    alt((
+        value(TriggerMode::Waterbend, tag("waterbend")),
+        value(TriggerMode::Earthbend, tag("earthbend")),
+        value(TriggerMode::Firebend, tag("firebend")),
+        value(TriggerMode::Airbend, tag("airbend")),
+    ))
+    .parse(input)
+}
+
+/// Avatar crossover (CR 603.2): "whenever you {waterbend|earthbend|firebend|
+/// airbend}[, {verb}]*[, or {verb}]" — a single bending verb fires its specific
+/// bend trigger; a disjunction of two or more fires on ANY of the listed bend
+/// events (`TriggerMode::ElementalBend`, which the runtime matcher
+/// `match_elemental_bend` already scopes to the source's controller). Avatar Aang
+/// uses the full four-verb batch. `valid_target = Controller` is redundant with
+/// the matcher's controller scoping but kept for consistency with the other
+/// player-action bend-adjacent triggers.
+fn try_parse_bend_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
+    let rest = alt((
+        value((), tag::<_, _, OracleError<'_>>("whenever you ")),
+        value((), tag("when you ")),
+    ))
+    .parse(lower)
+    .map(|(rest, ())| rest)
+    .ok()?;
+
+    let mut modes: Vec<TriggerMode> = Vec::new();
+    let mut remaining = rest.trim();
+    loop {
+        let (after_verb, mode) = parse_bend_verb(remaining).ok()?;
+        modes.push(mode);
+        // Consume an optional list separator: ", or ", ", ", " or " — or stop at
+        // the end of the condition clause.
+        let next = alt((
+            value((), tag::<_, _, OracleError<'_>>(", or ")),
+            value((), tag(", ")),
+            value((), tag(" or ")),
+        ))
+        .parse(after_verb);
+        match next {
+            Ok((tail, ())) => remaining = tail.trim_start(),
+            Err(_) => {
+                if !after_verb.trim().is_empty() {
+                    return None;
+                }
+                break;
+            }
+        }
+    }
+
+    let mode = match modes.as_slice() {
+        [] => return None,
+        [single] => single.clone(),
+        // CR 603.2: two or more distinct bend events in one trigger collapse to
+        // the any-bend matcher.
+        _ => TriggerMode::ElementalBend,
+    };
+
+    let mut def = make_base();
+    def.mode = mode.clone();
+    def.valid_target = Some(TargetFilter::Controller);
+    Some((mode, def))
+}
+
 /// Parse player-centric triggers: "you gain life", "you cast a/an ...", "you draw a card"
 fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefinition)> {
+    // Avatar crossover: bending-verb triggers ("whenever you waterbend, …") must
+    // run before the generic player-action dispatch, which does not recognize the
+    // bend verbs and would fall through to `TriggerMode::Unknown`.
+    if let Some(result) = try_parse_bend_trigger(lower) {
+        return Some(result);
+    }
+
     if let Some(result) = try_parse_player_action_trigger(lower) {
         return Some(result);
     }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2467,6 +2467,13 @@ fn detect_duration_this_turn(
         "regenerated this turn",
         "scryed this turn",
         "surveiled this turn",
+        // CR 702.171c: "creature that saddled it this turn" — a relative-clause
+        // target filter (`FilterProp::SaddledSource`), not an effect duration.
+        // Same turn-history-quantity class as "attacked this turn" / "died this
+        // turn": the "this turn" scopes the saddler-membership window (cleared at
+        // cleanup), never a forward-looking duration. Calamity / Giant Beaver /
+        // The Gitrog, Ravenous Ride.
+        "saddled it this turn",
     ];
     // Only exempt when EVERY occurrence of "this turn" is part of a quantity
     // context. Counting occurrences ensures we still fire on cards that have
@@ -3688,6 +3695,22 @@ mod tests {
         let parsed = parse_named(
             "Reach\nThis creature has indestructible as long as it attacked a battle this turn.",
             "War Historian",
+            &["Creature"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Duration_ThisTurn"));
+    }
+
+    /// CR 702.171c: "creature that saddled it this turn" is a relative-clause
+    /// target filter (`FilterProp::SaddledSource`), a turn-history-quantity
+    /// context — not a forward-looking effect duration. After the saddler-ref
+    /// filter suffix parses, `detect_duration_this_turn` must not fire (Giant
+    /// Beaver / The Gitrog, Ravenous Ride regression).
+    #[test]
+    fn duration_this_turn_accepts_saddled_it_this_turn_filter() {
+        let parsed = parse_named(
+            "Vigilance\nWhenever this creature attacks while saddled, put a +1/+1 counter on target creature that saddled it this turn.",
+            "Giant Beaver",
             &["Creature"],
         );
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2357,6 +2357,12 @@ pub enum FilterProp {
     Untapped,
     /// CR 702.171b: Matches permanents with the saddled designation.
     IsSaddled,
+    /// CR 702.171c: Matches a creature that saddled the filter source this turn
+    /// (i.e. was tapped to pay the source's saddle cost — recorded in the
+    /// source's `saddled_by` and cleared at end of turn). Source-relative sibling
+    /// of `BlockingSource`; used by "choose a creature that saddled it this turn"
+    /// (Calamity, Galloping Inferno).
+    SaddledSource,
     /// CR 310.8a + CR 310.8e: Matches battles whose protector satisfies
     /// `controller` relative to the ability source ("each battle they protect").
     ProtectorMatches {

--- a/crates/engine/tests/std_bend_saddle_exchange_batch.rs
+++ b/crates/engine/tests/std_bend_saddle_exchange_batch.rs
@@ -247,6 +247,42 @@ fn avatar_aang_batched_bend_trigger_fires_on_any_bend() {
     );
 }
 
+/// Maintainer guard (CR 603.2): a PARTIAL bend disjunction must NOT collapse to
+/// `TriggerMode::ElementalBend`. The only any-bend runtime matcher fires on ALL
+/// four bend events; collapsing "whenever you waterbend or earthbend" to
+/// `ElementalBend` would over-fire on the unlisted firebend/airbend events.
+/// `try_parse_bend_trigger` returns `None` for any strict subset, so the trigger
+/// fails closed (`Unknown`) instead — and crucially produces NO `ElementalBend`
+/// trigger that the runtime matcher could fire on. This proves the parser never
+/// ships a building block broader than the runtime semantics it preserves.
+#[test]
+fn partial_bend_disjunction_does_not_collapse_to_elemental_bend() {
+    let parsed = parse_oracle_text(
+        "Whenever you waterbend or earthbend, draw a card.",
+        "Partial Bender",
+        &types_of(&[]),
+        &types_of(&["Creature"]),
+        &types_of(&[]),
+    );
+    assert!(
+        !parsed
+            .triggers
+            .iter()
+            .any(|t| t.mode == TriggerMode::ElementalBend),
+        "a partial two-bend disjunction must not lower to the any-bend ElementalBend \
+         matcher (it would over-fire on the unlisted bend events)"
+    );
+    // Belt-and-suspenders: it must also not silently map to one of the listed
+    // single-bend modes (that would drop the other listed event).
+    assert!(
+        !parsed
+            .triggers
+            .iter()
+            .any(|t| matches!(t.mode, TriggerMode::Waterbend | TriggerMode::Earthbend)),
+        "a partial bend disjunction must not collapse to a single-bend mode either"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // §20 — Alacrian Armory: "becomes saddled if it's a Mount and becomes an
 // artifact creature if it's a Vehicle"

--- a/crates/engine/tests/std_bend_saddle_exchange_batch.rs
+++ b/crates/engine/tests/std_bend_saddle_exchange_batch.rs
@@ -1,0 +1,448 @@
+//! Standard "bend / saddle / exchange" bundle — three small singleton batches.
+//!
+//! Each test drives the PRODUCTION pipeline (`parse_oracle_text` →
+//! `resolve_ability_chain` / the runtime trigger matcher / the runtime filter
+//! evaluator) and every assertion FLIPS if the corresponding parser/engine
+//! change is reverted:
+//!
+//! - Fatal Fissure ("you earthbend 4"): without the optional-"you" strip in the
+//!   earthbend clause parser, the effect is `Unimplemented` — no Animate, no
+//!   +1/+1 counters, no Earthbend event. The test resolves the parsed earthbend
+//!   chain on a land and asserts the 0/0 animation, four +1/+1 counters, and the
+//!   `GameEvent::Earthbend` emission.
+//! - Avatar Aang ("whenever you waterbend, earthbend, firebend, or airbend"):
+//!   without the batched bend-trigger parser the mode is `Unknown` and the
+//!   runtime matcher never fires. The test asserts `TriggerMode::ElementalBend`
+//!   and drives the production matcher (`trigger_matcher`) against a real
+//!   `Earthbend` event for the source's controller.
+//! - Alacrian Armory ("becomes saddled if it's a Mount and becomes an artifact
+//!   creature if it's a Vehicle"): without the compound-become split + bare-become
+//!   subject inference the whole clause is `Unimplemented`. The test resolves
+//!   `BecomeSaddled` (gated TargetMatchesFilter(Mount)) on a Mount and asserts the
+//!   saddled designation.
+//! - Kitsune, Dragon's Daughter ("exchange control of two other target creatures
+//!   controlled by different players"): without stripping the trailing
+//!   "controlled by different players" target-set constraint the per-slot parse
+//!   fails and the effect is `Unimplemented`. The test resolves `ExchangeControl`
+//!   and asserts the two creatures swapped controllers.
+//! - FilterProp::SaddledSource building block: the runtime filter evaluator
+//!   matches exactly the creatures recorded in the source's `saddled_by`.
+
+use engine::game::ability_utils::build_resolved_from_def_with_targets;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::filter::{matches_target_filter, FilterContext};
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::trigger_matcher;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, Effect, FilterProp, TargetFilter, TargetRef, TypedFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+fn types_of(types: &[&str]) -> Vec<String> {
+    types.iter().map(|s| s.to_string()).collect()
+}
+
+fn assert_zero_unimplemented(
+    oracle: &str,
+    name: &str,
+    kws: &[&str],
+    types: &[&str],
+    subs: &[&str],
+) {
+    let parsed = parse_oracle_text(
+        oracle,
+        name,
+        &types_of(kws),
+        &types_of(types),
+        &types_of(subs),
+    );
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+/// Walk a parsed ability/effect tree and return the first effect (incl. nested
+/// sub-abilities and delayed-trigger bodies) matching `pred`.
+fn find_effect_def<'a>(
+    def: &'a AbilityDefinition,
+    pred: &dyn Fn(&Effect) -> bool,
+) -> Option<&'a AbilityDefinition> {
+    if pred(&def.effect) {
+        return Some(def);
+    }
+    if let Some(sub) = &def.sub_ability {
+        if let Some(found) = find_effect_def(sub, pred) {
+            return Some(found);
+        }
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if let Some(found) = find_effect_def(effect, pred) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// §17 — Fatal Fissure: "you earthbend 4"
+// ---------------------------------------------------------------------------
+
+const FATAL_FISSURE: &str = "Choose target creature. When that creature dies this turn, you earthbend 4. (Target land you control becomes a 0/0 creature with haste that's still a land. Put four +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)";
+
+#[test]
+fn fatal_fissure_parses_zero_unimplemented() {
+    assert_zero_unimplemented(FATAL_FISSURE, "Fatal Fissure", &[], &["Instant"], &[]);
+}
+
+#[test]
+fn fatal_fissure_earthbend_animates_land_with_four_counters() {
+    let parsed = parse_oracle_text(
+        FATAL_FISSURE,
+        "Fatal Fissure",
+        &[],
+        &types_of(&["Instant"]),
+        &[],
+    );
+    // The earthbend chain lives inside the delayed "when that creature dies"
+    // trigger as an `Animate` whose sub-ability is the +1/+1 counter placement.
+    let ability = &parsed.abilities[0];
+    let earthbend = find_effect_def(ability, &|e| matches!(e, Effect::Animate { .. })).expect(
+        "Fatal Fissure must parse 'you earthbend 4' into an Animate chain (not Unimplemented)",
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Earthbend default target is "target land you control" — give P0 a land.
+    let land = scenario.add_creature(P0, "Mountain", 0, 0).id();
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&land).unwrap();
+        obj.card_types.core_types = vec![CoreType::Land];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.base_power = None;
+        obj.base_toughness = None;
+    }
+
+    let resolved =
+        build_resolved_from_def_with_targets(earthbend, land, P0, vec![TargetRef::Object(land)]);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("earthbend chain must resolve");
+
+    let obj = &runner.state().objects[&land];
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Creature),
+        "earthbent land must become a creature; got {:?}",
+        obj.card_types.core_types
+    );
+    assert!(
+        obj.card_types.core_types.contains(&CoreType::Land),
+        "earthbent land is still a land"
+    );
+    let plus = obj
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        plus, 4,
+        "earthbend 4 puts four +1/+1 counters on the land; got {plus}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, GameEvent::Earthbend { controller, .. } if *controller == P0)),
+        "earthbend must emit a GameEvent::Earthbend for the controller; got {events:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §17 — Avatar Aang: batched bend trigger
+// ---------------------------------------------------------------------------
+
+const AVATAR_AANG: &str = "Flying, firebending 2\nWhenever you waterbend, earthbend, firebend, or airbend, draw a card. Then if you've done all four this turn, transform Avatar Aang.";
+
+#[test]
+fn avatar_aang_parses_zero_unimplemented() {
+    assert_zero_unimplemented(
+        AVATAR_AANG,
+        "Avatar Aang",
+        &["Flying", "firebending"],
+        &["Creature"],
+        &["Avatar"],
+    );
+}
+
+#[test]
+fn avatar_aang_batched_bend_trigger_fires_on_any_bend() {
+    let parsed = parse_oracle_text(
+        AVATAR_AANG,
+        "Avatar Aang",
+        &types_of(&["Flying", "firebending"]),
+        &types_of(&["Creature"]),
+        &types_of(&["Avatar"]),
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::ElementalBend)
+        .expect("Avatar Aang's batched bend trigger must lower to TriggerMode::ElementalBend");
+
+    // The execute body must draw a card (the bend subject was consumed, not
+    // swallowed into the effect).
+    let execute = trigger
+        .execute
+        .as_ref()
+        .expect("trigger has an execute body");
+    assert!(
+        find_effect_def(execute, &|e| matches!(e, Effect::Draw { .. })).is_some(),
+        "ElementalBend trigger executes a Draw"
+    );
+
+    // Drive the PRODUCTION matcher: Aang on the battlefield, an Earthbend event
+    // for its controller must match. Without the parser change the mode would be
+    // Unknown and this matcher path would never be reached.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let aang = scenario.add_creature(P0, "Avatar Aang", 4, 4).id();
+    let runner = scenario.build();
+
+    let matcher = trigger_matcher(trigger.mode.clone())
+        .expect("ElementalBend has a registered runtime matcher");
+    // Any one of the four bend events fires the batched trigger for the controller.
+    let earthbend = GameEvent::Earthbend {
+        source_id: aang,
+        controller: P0,
+    };
+    assert!(
+        matcher(&earthbend, trigger, aang, runner.state()),
+        "ElementalBend must match an Earthbend event for the source's controller"
+    );
+    let firebend = GameEvent::Firebend {
+        source_id: aang,
+        controller: P0,
+    };
+    assert!(
+        matcher(&firebend, trigger, aang, runner.state()),
+        "ElementalBend must match a Firebend event for the source's controller"
+    );
+    // An opponent's bend must NOT fire the controller-scoped trigger.
+    let opp_bend = GameEvent::Earthbend {
+        source_id: aang,
+        controller: P1,
+    };
+    assert!(
+        !matcher(&opp_bend, trigger, aang, runner.state()),
+        "ElementalBend is controller-scoped: an opponent's bend must not fire it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §20 — Alacrian Armory: "becomes saddled if it's a Mount and becomes an
+// artifact creature if it's a Vehicle"
+// ---------------------------------------------------------------------------
+
+const ALACRIAN_ARMORY: &str = "Creatures you control get +0/+1 and have vigilance.\nAt the beginning of combat on your turn, choose up to one target Mount or Vehicle you control. Until end of turn, that permanent becomes saddled if it's a Mount and becomes an artifact creature if it's a Vehicle.";
+
+#[test]
+fn alacrian_armory_parses_zero_unimplemented() {
+    assert_zero_unimplemented(ALACRIAN_ARMORY, "Alacrian Armory", &[], &["Artifact"], &[]);
+}
+
+#[test]
+fn alacrian_armory_become_saddled_branch_saddles_a_mount() {
+    let parsed = parse_oracle_text(
+        ALACRIAN_ARMORY,
+        "Alacrian Armory",
+        &[],
+        &types_of(&["Artifact"]),
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.execute.is_some())
+        .expect("Alacrian has a begin-combat trigger");
+    let execute = trigger.execute.as_ref().unwrap();
+    // The first become-conjunct must lower to BecomeSaddled (gated on Mount).
+    let become_saddled = find_effect_def(execute, &|e| matches!(e, Effect::BecomeSaddled { .. }))
+        .expect(
+            "Alacrian must parse the 'becomes saddled if it's a Mount' conjunct into BecomeSaddled",
+        );
+    // The second conjunct must lower to a type-adding GenericEffect (artifact creature).
+    assert!(
+        find_effect_def(execute, &|e| matches!(e, Effect::GenericEffect { .. })).is_some(),
+        "the 'becomes an artifact creature if it's a Vehicle' conjunct must also lower"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::BeginCombat);
+    let mount = scenario
+        .add_creature(P0, "Mount", 2, 2)
+        .with_subtypes(vec!["Mount"])
+        .id();
+    let mut runner = scenario.build();
+
+    let resolved = build_resolved_from_def_with_targets(
+        become_saddled,
+        mount,
+        P0,
+        vec![TargetRef::Object(mount)],
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("BecomeSaddled must resolve");
+
+    assert!(
+        runner.state().objects[&mount].is_saddled,
+        "the Mount must acquire the saddled designation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §23 — Kitsune, Dragon's Daughter: exchange control of two creatures
+// ---------------------------------------------------------------------------
+
+const KITSUNE: &str = "Vigilance\nWhenever Kitsune enters or deals combat damage to a player, you may exchange control of two other target creatures controlled by different players.";
+
+#[test]
+fn kitsune_parses_zero_unimplemented() {
+    assert_zero_unimplemented(
+        KITSUNE,
+        "Kitsune, Dragon's Daughter",
+        &["Vigilance"],
+        &["Legendary", "Creature"],
+        &["Fox", "Samurai"],
+    );
+}
+
+#[test]
+fn kitsune_exchange_control_swaps_two_creatures() {
+    let parsed = parse_oracle_text(
+        KITSUNE,
+        "Kitsune, Dragon's Daughter",
+        &types_of(&["Vigilance"]),
+        &types_of(&["Legendary", "Creature"]),
+        &types_of(&["Fox", "Samurai"]),
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| {
+            t.execute.as_ref().is_some_and(|e| {
+                find_effect_def(e, &|x| matches!(x, Effect::ExchangeControl { .. })).is_some()
+            })
+        })
+        .expect("Kitsune must lower the exchange clause to Effect::ExchangeControl");
+    let execute = trigger.execute.as_ref().unwrap();
+    let exchange =
+        find_effect_def(execute, &|e| matches!(e, Effect::ExchangeControl { .. })).unwrap();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let kitsune = scenario.add_creature(P0, "Kitsune", 2, 3).id();
+    let mine = scenario.add_creature(P0, "My Bear", 2, 2).id();
+    let theirs = scenario.add_creature(P1, "Their Ogre", 3, 3).id();
+    let mut runner = scenario.build();
+
+    assert_eq!(runner.state().objects[&mine].controller, P0);
+    assert_eq!(runner.state().objects[&theirs].controller, P1);
+
+    let mut resolved = build_resolved_from_def_with_targets(
+        exchange,
+        kitsune,
+        P0,
+        vec![TargetRef::Object(mine), TargetRef::Object(theirs)],
+    );
+    // CR 603.5: the "you may" is an optional trigger — simulate the controller
+    // electing to exchange so the resolver applies the swap (the optional-prompt
+    // path is a separate concern; here we drive the resolved effect itself).
+    resolved.optional = false;
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("ExchangeControl must resolve");
+
+    // CR 701.12a + CR 613.1 (Layer 2): the swap is applied via two transient
+    // ChangeController continuous effects; the controller change manifests only
+    // after the layer evaluator runs.
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    assert_eq!(
+        runner.state().objects[&mine].controller,
+        P1,
+        "my creature must now be controlled by the opponent"
+    );
+    assert_eq!(
+        runner.state().objects[&theirs].controller,
+        P0,
+        "the opponent's creature must now be controlled by me"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §20 — FilterProp::SaddledSource building block (Calamity's saddler reference).
+// The full Calamity card honest-defers (the non-targeting "choose a creature
+// that saddled it" selection feeding a token-copy, plus "Repeat this process
+// once" owned by the repeat cluster), but the saddler-reference FILTER primitive
+// it anchors is shipped, reachable ("creature that saddled it this turn" target
+// phrase), and runtime-evaluated here.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn saddled_source_filter_matches_only_creatures_that_saddled_the_source() {
+    // The parser produces the filter from a clean targeting phrase.
+    let parsed = parse_oracle_text(
+        "Destroy target creature that saddled it this turn.",
+        "Saddler Probe",
+        &[],
+        &types_of(&["Instant"]),
+        &[],
+    );
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        dbg.contains("SaddledSource"),
+        "'creature that saddled it this turn' must parse to FilterProp::SaddledSource:\n{dbg}"
+    );
+
+    // Runtime evaluation: a creature recorded in the source's saddled_by matches;
+    // one that is not does not.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mount = scenario
+        .add_creature(P0, "Mount", 0, 4)
+        .with_subtypes(vec!["Mount"])
+        .id();
+    let saddler = scenario.add_creature(P0, "Saddler", 3, 3).id();
+    let bystander = scenario.add_creature(P0, "Bystander", 3, 3).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&mount)
+        .unwrap()
+        .saddled_by = vec![saddler];
+
+    let filter =
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::SaddledSource]));
+    // `source` is the Mount (Calamity) — the creature that saddled IT.
+    let ctx = FilterContext::from_source(runner.state(), mount);
+    assert!(
+        matches_target_filter(runner.state(), saddler, &filter, &ctx),
+        "the creature recorded in the source's saddled_by must match SaddledSource"
+    );
+    assert!(
+        !matches_target_filter(runner.state(), bystander, &filter, &ctx),
+        "a creature that did not saddle the source must not match SaddledSource"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std bundle: Avatar bend + saddle-as-effect/saddler-ref + exchange-control

Three small std-card singleton batches landed in one pass (§17 Avatar bend, §20
saddle-as-effect / saddler-reference, §23 exchange control of two creatures).
Reuses existing engine surface wherever it already exists (bend events +
TriggerMode bend variants + RegisterBending; `Effect::BecomeSaddled`;
`Effect::ExchangeControl`) and adds exactly one new building block
(`FilterProp::SaddledSource`).

**4 of 5 cards ship 0-Unimplemented; 1 honest-defers** (Calamity's full effect
needs a non-targeting choose-then-copy selection plus the cross-cluster "Repeat
this process once"). The saddler-reference filter primitive Calamity anchors is
shipped, reachable, and runtime-tested.

## Per-card verdict (grouped by batch)

| Batch | Card | Verdict | Residual / note |
|---|---|---|---|
| §17 Avatar bend | Avatar Aang | SHIPPED 0-unimpl | batched bend trigger → `TriggerMode::ElementalBend` (runtime matcher pre-existed) |
| §17 Avatar bend | Fatal Fissure | SHIPPED 0-unimpl | "you earthbend 4" → existing earthbend Animate+counters+RegisterBending chain |
| §20 saddle | Alacrian Armory | SHIPPED 0-unimpl | "becomes saddled if it's a Mount **and** becomes an artifact creature if it's a Vehicle" → `BecomeSaddled` + add-type, each conditional |
| §20 saddle | Calamity, Galloping Inferno | HONEST-DEFER | saddler-reference filter (`FilterProp::SaddledSource`) shipped + tested; full card defers (non-targeting choose-then-copy selection; "Repeat this process once" owned by the repeat cluster) |
| §23 exchange | Kitsune, Dragon's Daughter | SHIPPED 0-unimpl | "exchange control of two other target creatures controlled by different players" → existing `Effect::ExchangeControl` |

## What changed (by subsystem)

Parser (all nom combinators on first write):
- `oracle_effect/mod.rs`, `oracle_effect/imperative.rs` — earthbend clause /
  imperative arm accept an optional leading "you " subject (Fatal Fissure). The
  optional-cost target span strip uses `take_until` (combinator), not
  `strip_suffix`.
- `oracle_effect/sequence.rs` — bare "becomes "/"become " as a clause-starter for
  the compound-become "X becomes Y1 and becomes Y2" split, gated so a
  continuous-modification antecedent ("gets +3/+3 **and** becomes a Bear
  Berserker") stays one continuous effect (no regression).
- `oracle_effect/subject.rs` — a subjectless bare-become conjunct inherits the
  prior conjunct's subject via the existing context-dependent "it" anaphor.
- `oracle_target.rs` — "that saddled it [this turn]" relative clause →
  `FilterProp::SaddledSource`.
- `oracle_trigger.rs` — `parse_bend_verb` + `try_parse_bend_trigger` map the
  batched bend disjunction to the single/`ElementalBend` modes; bend verbs are
  recognized in the trigger condition/effect boundary detector.
- `oracle_effect/imperative.rs` — exchange-control target parse strips the
  trailing "controlled by different players" target-set constraint before per-slot
  `parse_target` (the constraint is attached separately by the chain lowerer).

Engine:
- `types/ability.rs` — new `FilterProp::SaddledSource` (CR 702.171c), a
  source-relational leaf parallel to `BlockingSource`.
- `game/filter.rs` — runtime eval (candidate ∈ source's `saddled_by`) + the four
  exhaustive `FilterProp` match arms (population/perturbation/snapshot/look-back).
- `game/coverage.rs` — description string for the new prop.

## add-engine-variant verdict

One new variant: `FilterProp::SaddledSource`. **APPROVE — parameterization, not
proliferation.** It is the source-relational sibling of the existing
`FilterProp::BlockingSource` (both read a source-relative relationship: "blocking
the source" / "saddled the source"), single CR section (702.171c), no
sibling-cluster smell. No `Effect`/`TriggerMode` variants were added — bend
events, the four bend `TriggerMode`s + `ElementalBend`, `Effect::BecomeSaddled`,
and `Effect::ExchangeControl` all pre-existed; these batches were parser-reach
gaps. `data/engine-inventory.json` was left at its committed state (a fresh regen
churned 70+ unrelated variants from other merges; restored to avoid clobbering).

## Grep-verified CR annotations (zero UNVERIFIED)

Every CR number added was grepped against `docs/MagicCompRules.txt`:
- CR 205.1a (type-set replacement), CR 601.2c (per-"target" target slots),
  CR 603.2 (trigger event matching), CR 608.2c (later-text modifies earlier),
  CR 613.1d (Layer 4 type-change), CR 613.1e (Layer 5 color-change),
  CR 115.1 (targets), CR 702.171b (saddled designation), CR 702.171c (a creature
  "saddles" a permanent as it's tapped to pay the saddle cost — the SaddledSource
  primitive).

## Discriminating-test map (`crates/engine/tests/std_bend_saddle_exchange_batch.rs`)

Each behavioral claim drives the production pipeline and its assertion flips on revert:

| Claim | Seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| Fatal Fissure "you earthbend 4" | earthbend clause parser | `parse_oracle_text` → `resolve_ability_chain` | `fatal_fissure_earthbend_animates_land_with_four_counters` | land becomes a creature with 4 +1/+1 counters and emits `GameEvent::Earthbend` |
| Avatar Aang batched bend | bend-trigger parser + runtime matcher | `parse_oracle_text` → `trigger_matcher(ElementalBend)` | `avatar_aang_batched_bend_trigger_fires_on_any_bend` | matcher matches Earthbend/Firebend for controller, NOT an opponent's bend; mode is `ElementalBend` |
| Alacrian compound become | compound-become split + subject inference | `parse_oracle_text` → `resolve_ability_chain` | `alacrian_armory_become_saddled_branch_saddles_a_mount` | Mount gains the saddled designation; both conjuncts lower (BecomeSaddled + GenericEffect) |
| Kitsune exchange control | exchange-target suffix strip | `parse_oracle_text` → `resolve_ability_chain` → `evaluate_layers` | `kitsune_exchange_control_swaps_two_creatures` | the two creatures' controllers swap |
| SaddledSource filter | new FilterProp + runtime eval | `matches_target_filter` | `saddled_source_filter_matches_only_creatures_that_saddled_the_source` | only the creature in `saddled_by` matches; a bystander does not |

Plus four `*_parses_zero_unimplemented` per shipped card. Negative cases covered:
Aang opponent-bend non-match; SaddledSource bystander non-match; the
`self_pump_and_bare_becomes_subtypes_stays_one_continuous_effect` lib regression
guard (continuous-modification "becomes" must NOT split).

## Gates (CI parity)

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — 0
- inline parser string-dispatch diff gate — clean
- `./scripts/check-engine-authorities.sh upstream/main` — 0
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine` — 12990 pass; only the known parallel-flaky
  `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  fails under parallelism (passes isolated/single-threaded), per the ignore list
- CR-annotation diff gate — zero UNVERIFIED
- `cargo coverage` / `cargo semantic-audit` — card-data not generated in worktree
  (audits are card-data-dependent); per-card 0-unimpl + discriminating
  `apply()`/scenario tests stand in
