### PR TITLE
feat(parser): long-tail one-offs A (Aerith, Binding Negotiation, Elixir, Kellan, Living Conundrum, Pride of Hull Clade, Take for a Ride)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6701,10 +6701,23 @@ pub(crate) fn evaluate_condition(
                         _ => false,
                     }
                 }
-                Some(_) => {
-                    // Other filter properties not yet supported for revealed card checks
-                    true
-                }
+                // CR 202.3 + CR 700.1: Generic property gates on the revealed card
+                // (e.g. Kellan, Daring Traveler's "creature card with mana value 3
+                // or less" → `FilterProp::Cmc`). Evaluate the property against the
+                // revealed subject through the shared filter evaluator, exactly as
+                // `subtype_filter` does above.
+                Some(prop) => subject_id.is_some_and(|id| {
+                    crate::game::filter::matches_target_filter(
+                        state,
+                        id,
+                        &TargetFilter::Typed(crate::types::ability::TypedFilter {
+                            type_filters: vec![],
+                            controller: None,
+                            properties: vec![prop.clone()],
+                        }),
+                        &crate::game::filter::FilterContext::from_ability(ability),
+                    )
+                }),
                 None => true,
             };
             type_matches && subtype_matches && filter_matches

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1552,6 +1552,22 @@ fn draw_applier(
     state: &mut GameState,
     _events: &mut Vec<GameEvent>,
 ) -> ApplyResult {
+    use crate::types::ability::QuantityModification;
+    // CR 614.6 + CR 121.6: A `Prevent` draw replacement ("skip that draw
+    // instead", Living Conundrum) fully suppresses the draw — the replaced
+    // event never happens. Carried as a structured `quantity_modification`
+    // (no `execute`), mirroring the lifegain-negation / counter-prevention
+    // surface. Checked before the count-substitution path because a prevented
+    // draw has no surviving count to scale.
+    let prevents = state
+        .objects
+        .get(&rid.source)
+        .and_then(|obj| obj.replacement_definitions.get(rid.index))
+        .and_then(|def| def.quantity_modification.as_ref())
+        .is_some_and(|m| matches!(m, QuantityModification::Prevent));
+    if prevents {
+        return ApplyResult::Prevented;
+    }
     // CR 614.6 + CR 614.11: Count-modifying replacements (Alhammarret's Archive:
     // `count -> 2 * count`) substitute the count via `draw_replacement_count`.
     // Full-substitution replacements (Jace WinTheGame, Abundance reveal-until)

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -159,6 +159,7 @@ pub(crate) fn parse_spell_casting_option_line(
     let body_lower = primary_body.to_lowercase();
 
     parse_self_flash_option(primary_body, &body_lower, card_name)
+        .or_else(|| parse_self_has_flash_option(&body_lower))
         .or_else(|| parse_self_alternative_cost_option(primary_body, &body_lower, card_name))
         .and_then(|mut option| {
             if option.condition.is_none() {
@@ -257,6 +258,42 @@ fn parse_self_flash_option(
         return Some(option);
     }
 
+    Some(option)
+}
+
+/// CR 702.8a + CR 601.3d: Parse a self-referential conditional flash grant of the
+/// form "~ has flash as long as <condition>" (Take for a Ride: "Take for a Ride
+/// has flash as long as you've committed a crime this turn"). The spell grants
+/// ITSELF flash — a conditional casting permission — rather than the
+/// "you may cast ~ as though it had flash" framing handled by
+/// `parse_self_flash_option`. Self-references are normalized to `~` upstream
+/// (CR 201.4b), so the subject is matched as the `~` token.
+///
+/// As with the sibling conditional-flash arm, an unrecognized predicate refuses
+/// to emit the option entirely (the `?` on `parse_restriction_condition`): CR
+/// 601.3d only grants flash "if those conditions are met", so degrading to an
+/// unconditional permission would be strictly more permissive than the printed
+/// text. The bare "~ has flash" form (no condition) emits an unconditional
+/// permission.
+fn parse_self_has_flash_option(body_lower: &str) -> Option<SpellCastingOption> {
+    // `body_lower` is already lowercase, so parse it directly with combinators
+    // (no `nom_on_lower` case-bridge needed — the condition text is delegated to
+    // `parse_restriction_condition`, which lowercases internally).
+    let (rest, _) = preceded(
+        tag::<_, _, OracleError<'_>>("~ has flash"),
+        opt(tag(" as long as ")),
+    )
+    .parse(body_lower)
+    .ok()?;
+    let mut option = SpellCastingOption::as_though_had_flash();
+    // Strip trailing sentence punctuation so a bare "~ has flash." parses as an
+    // unconditional grant (condition empty) and a trailing period on a condition
+    // clause does not reach `parse_restriction_condition`.
+    let condition_text = rest.trim().trim_end_matches(['.', ',']).trim();
+    if condition_text.is_empty() {
+        return Some(option);
+    }
+    option = option.condition(parse_restriction_condition(condition_text)?);
     Some(option)
 }
 
@@ -1674,6 +1711,53 @@ mod tests {
         assert!(
             option.is_none(),
             "unrecognized leading-if predicate must drop the alt-cost option, got: {option:?}"
+        );
+    }
+
+    /// Take for a Ride (std long-tail): "~ has flash as long as you've committed
+    /// a crime this turn" — a self-referential conditional flash grant. The line
+    /// (self-ref normalized to `~` upstream) must emit an `AsThoughHadFlash`
+    /// casting option gated on the crime condition, not `Effect::Unimplemented`.
+    /// Revert-discriminating: removing `parse_self_has_flash_option` makes
+    /// `parse_spell_casting_option_line` return `None`.
+    /// CR 702.8a (Flash); CR 601.3d (conditional flash); CR 700.13 (crime).
+    #[test]
+    fn spell_self_has_flash_conditional_on_crime() {
+        let option = parse_spell_casting_option_line(
+            "~ has flash as long as you've committed a crime this turn.",
+            "Take for a Ride",
+        )
+        .expect("self conditional-flash grant should parse");
+        assert!(matches!(
+            option.kind,
+            crate::types::ability::SpellCastingOptionKind::AsThoughHadFlash
+        ));
+        match option.condition {
+            Some(ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::CrimesCommittedThisTurn,
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            }) => {}
+            other => panic!("expected CrimesCommittedThisTurn GE 1 condition, got {other:?}"),
+        }
+    }
+
+    /// Bare "~ has flash" (no condition) emits an unconditional flash option.
+    #[test]
+    fn spell_self_has_flash_unconditional() {
+        let option = parse_spell_casting_option_line("~ has flash.", "Some Spell")
+            .expect("bare self-flash grant should parse");
+        assert!(matches!(
+            option.kind,
+            crate::types::ability::SpellCastingOptionKind::AsThoughHadFlash
+        ));
+        assert!(
+            option.condition.is_none(),
+            "bare '~ has flash' must be unconditional, got {:?}",
+            option.condition
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1037,6 +1037,16 @@ pub(super) fn strip_card_type_conditional(text: &str) -> (Option<AbilityConditio
             tag::<_, _, OracleError<'_>>(" of the chosen type").parse(after_type)
         {
             (rest_after_chosen, Some(FilterProp::IsChosenCreatureType))
+        } else if let Some((prop, consumed)) = crate::parser::oracle_target::parse_mana_value_suffix(
+            after_type.trim_start(),
+            &mut ParseContext::default(),
+        ) {
+            // CR 202.3: "if it's a creature card with mana value N or less/greater"
+            // (Kellan, Daring Traveler) — the revealed-card gate carries a mana-value
+            // bound as an additional filter property. Recompute the offset against the
+            // untrimmed `after_type` so byte arithmetic below stays exact.
+            let leading_ws = after_type.len() - after_type.trim_start().len();
+            (&after_type[leading_ws + consumed..], Some(prop))
         } else {
             (after_type, None)
         };

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -284,7 +284,12 @@ fn parse_dynamic_count_phrase(lower: &str) -> Option<QuantityExpr> {
     ))
     .parse(lower)
     {
-        let qty_text = qty_tail.trim_end_matches('.').trim();
+        // CR 113.3 + CR 121.1: A granted-ability quotation closes at a comma
+        // ("gains \"… draw cards equal to its toughness,\""), so the dynamic
+        // count phrase can carry a trailing comma when the granted ability is
+        // re-parsed from its body text (The Pride of Hull Clade). Strip trailing
+        // sentence punctuation (period or comma) before the anaphoric-ref match.
+        let qty_text = qty_tail.trim_end_matches(['.', ',']).trim();
         // CR 107.1a + CR 121.1: "cards equal to half the number of cards in
         // their library" — fraction-led dynamic draw count, rounded per CR
         // 107.1a. `qty_text` is already lowercase + trimmed, so call
@@ -1257,15 +1262,19 @@ pub(super) fn parse_targeted_action_ast(
     {
         let after_discard = &lower[lower.len() - after_discard_orig.len()..];
         // CR 701.9a: Back-reference discard — "discard that card" / "discard
-        // those cards" target a specific card identified by the parent effect
-        // (Seek/Conjure/Reveal-Choose populate ParentTarget at runtime). Must
-        // be checked before the player-choice count-based discard path, since
-        // "that card" is not a count phrase.
-        if alt((
+        // those cards" / "discard it" target a specific card identified by the
+        // parent effect (Seek/Conjure/Reveal-Choose populate ParentTarget at
+        // runtime; Binding Negotiation: "You may choose a nonland card from it.
+        // If you do, they discard it"). Must be checked before the
+        // player-choice count-based discard path, since the anaphor is not a
+        // count phrase. `all_consuming` keeps the bare pronoun arm from
+        // shadowing "it at random" or longer phrases that begin with "it".
+        if all_consuming(alt((
             tag::<_, _, OracleError<'_>>("that card"),
             tag("those cards"),
-        ))
-        .parse(after_discard)
+            tag("it"),
+        )))
+        .parse(after_discard.trim_end_matches(['.', ',']).trim_end())
         .is_ok()
         {
             return Some(TargetedImperativeAst::DiscardCard {
@@ -5117,6 +5126,18 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
             && nom_primitives::scan_contains(lower, "library")
             && nom_primitives::scan_contains(lower, "from")
         {
+            // CR 400.6: a leading "all "/"each " quantifier ("shuffle all
+            // nonland cards from your graveyard into your library", Elixir) is a
+            // filtered mass move — every eligible object moves with no choice.
+            // Distinguish it from the single-target form ("shuffle target card
+            // from your graveyard …") so the lowering picks `ChangeZoneAll` over
+            // `ChangeZone`. `parse_target` strips the quantifier, so detect it on
+            // the lowercase remainder first.
+            let all = nom_on_lower(text, lower, |input| {
+                let (input, _) = tag::<_, _, OracleError<'_>>("shuffle ").parse(input)?;
+                value((), alt((tag("all "), tag("each ")))).parse(input)
+            })
+            .is_some();
             let (target, _) = parse_target(after_shuffle);
             let origin = if nom_primitives::scan_contains(lower, "graveyard") {
                 Some(Zone::Graveyard)
@@ -5127,7 +5148,11 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
             } else {
                 None
             };
-            return Some(ShuffleImperativeAst::TargetedChangeZoneToLibrary { target, origin });
+            return Some(ShuffleImperativeAst::TargetedChangeZoneToLibrary {
+                target,
+                origin,
+                all,
+            });
         }
     }
 
@@ -5205,21 +5230,46 @@ pub(super) fn lower_shuffle_ast(ast: ShuffleImperativeAst) -> ParsedEffectClause
             lower_change_zone_all_to_library(origins)
         }
         // CR 701.24a: Targeted zone change to library with implicit shuffle sub_ability.
-        ShuffleImperativeAst::TargetedChangeZoneToLibrary { target, origin } => {
-            let effect = Effect::ChangeZone {
-                origin,
-                destination: Zone::Library,
-                target,
-                owner_library: false,
-                enter_transformed: false,
-                enters_under: None,
-                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
-                enters_attacking: false,
-                up_to: false,
-                enter_with_counters: vec![],
-                face_down_profile: None,
-            };
-            with_shuffle_sub_ability(effect)
+        ShuffleImperativeAst::TargetedChangeZoneToLibrary {
+            target,
+            origin,
+            all,
+        } => {
+            // CR 400.6: "shuffle all <filter> from <zone> into your library"
+            // (Elixir) is a mandatory mass move of every eligible object — no
+            // interactive "choose up to one" choice. `ChangeZoneAll` carries the
+            // typed filter, moves all matching cards at once, and stamps
+            // `last_effect_count` (which a chained "equal to the number shuffled
+            // this way" quantity reads). The single-target form keeps `ChangeZone`.
+            if all {
+                let effect = Effect::ChangeZoneAll {
+                    origin,
+                    destination: Zone::Library,
+                    target,
+                    enters_under: None,
+                    enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                    enter_with_counters: vec![],
+                    face_down_profile: None,
+                    library_position: None,
+                    random_order: false,
+                };
+                with_shuffle_sub_ability(effect)
+            } else {
+                let effect = Effect::ChangeZone {
+                    origin,
+                    destination: Zone::Library,
+                    target,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: vec![],
+                    face_down_profile: None,
+                };
+                with_shuffle_sub_ability(effect)
+            }
         }
         ShuffleImperativeAst::Unimplemented { text } => parsed_clause(Effect::Unimplemented {
             name: "shuffle".to_string(),
@@ -10513,6 +10563,41 @@ mod tests {
         }
     }
 
+    /// The Pride of Hull Clade (std long-tail): the granted ability body
+    /// "draw cards equal to its toughness," closes at a comma (it is the inner
+    /// quotation of a `gains "..."` clause). The trailing comma must be stripped
+    /// before the anaphoric-ref match so the dynamic count resolves to
+    /// `QuantityRef::Toughness { Anaphoric }` instead of `Effect::Unimplemented`.
+    /// Revert-discriminating: with the comma in the qty text, the anaphoric match
+    /// fails and `parse_numeric_imperative_ast` returns `None` (-> Unimplemented
+    /// upstream). CR 121.1 + CR 113.3c (granted triggered-ability quotation).
+    #[test]
+    fn parse_draw_cards_equal_to_its_toughness_with_trailing_comma() {
+        use crate::types::ability::QuantityRef;
+        let text = "draw cards equal to its toughness,";
+        let lower = text.to_lowercase();
+        let result = parse_numeric_imperative_ast(text, &lower);
+        match result {
+            Some(NumericImperativeAst::Draw { count, up_to }) => {
+                assert!(!up_to, "fixed-anaphor draw count is not 'up to'");
+                // The "its toughness" anaphor binds to the source/granted creature
+                // at parse time (Source) or remaps later (Anaphoric) — the
+                // discriminating point is that the trailing comma no longer breaks
+                // the dynamic-count parse into `Effect::Unimplemented`.
+                assert!(
+                    matches!(
+                        count,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::Toughness { .. }
+                        }
+                    ),
+                    "expected Draw count = a Toughness ref, got {count:?}"
+                );
+            }
+            other => panic!("expected Draw with a toughness count, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_earthbend_verb() {
         let text = "Earthbend 3 target land";
@@ -12241,6 +12326,29 @@ mod tests {
             }
             other => panic!("Expected Discard with HandSize, got {other:?}"),
         }
+    }
+
+    /// Binding Negotiation (std long-tail): "If you do, they discard it" — the
+    /// "discard it" back-reference targets the card chosen by the parent
+    /// RevealHand effect. It must lower to `DiscardCard { target: ParentTarget }`
+    /// alongside the existing "that card" / "those cards" anaphors, not
+    /// `Effect::Unimplemented`. Revert-discriminating: removing the "it" arm
+    /// makes `parse_targeted_action_ast` miss the anaphor.
+    /// CR 701.9a (discard); CR 608.2c (anaphoric back-reference).
+    #[test]
+    fn parse_discard_it_anaphor() {
+        let text = "discard it";
+        let lower = text.to_lowercase();
+        let result = parse_targeted_action_ast(text, &lower, &mut ParseContext::default());
+        assert!(
+            matches!(
+                result,
+                Some(TargetedImperativeAst::DiscardCard {
+                    target: TargetFilter::ParentTarget
+                })
+            ),
+            "expected DiscardCard(ParentTarget) for 'discard it', got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1221,9 +1221,18 @@ pub(crate) enum ShuffleImperativeAst {
     },
     /// "shuffle target card from {origin} into {owner}'s library" —
     /// targeted zone change + shuffle composition.
+    ///
+    /// `all` distinguishes a single-target move ("shuffle target card from your
+    /// graveyard into your library", `false`) from a filtered mass move
+    /// ("shuffle all nonland cards from your graveyard into your library",
+    /// `true`). When `true`, the lowering emits `Effect::ChangeZoneAll` so every
+    /// eligible object moves with no interactive choice (CR 400.6) and the move
+    /// stamps `last_effect_count`; when `false` it emits a single
+    /// `Effect::ChangeZone`.
     TargetedChangeZoneToLibrary {
         target: TargetFilter,
         origin: Option<Zone>,
+        all: bool,
     },
     Unimplemented {
         text: String,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -227,6 +227,23 @@ fn parse_mode_ast(text: &str) -> ModeAst {
         };
     }
 
+    // CR 207.2c: A mode's flavor name ("Take 59 Flights of Stairs — …", Aerith
+    // Rescue Mission) is italic flavor with no rules meaning. These names can
+    // exceed the 4-word ability-word cap, so the short-label split above misses
+    // them. A flavor label never contains a sentence terminator, a cost brace,
+    // or an activation colon — those mark an actual effect/cost — so split on
+    // the first " — " when the prefix is punctuation-free flavor text. The body
+    // (the real rules text) is what `parse_effect_chain` lowers.
+    if let Some((label, body)) = split_mode_flavor_label(text) {
+        return ModeAst {
+            raw: text.to_string(),
+            label: Some(label.to_string()),
+            body: body.to_string(),
+            mode_cost: None,
+            mode_pawprint: None,
+        };
+    }
+
     ModeAst {
         raw: text.to_string(),
         label: None,
@@ -234,6 +251,30 @@ fn parse_mode_ast(text: &str) -> ModeAst {
         mode_cost: None,
         mode_pawprint: None,
     }
+}
+
+/// CR 207.2c: Split a modal mode's flavor name from its rules text on the first
+/// " — " / " – " separator. Unlike `split_short_label_prefix`, this imposes no
+/// word-count cap (mode flavor names can be long), but requires the prefix to be
+/// punctuation-free flavor text — no `.`, `:`, or `{` — so an actual effect
+/// sentence or activation cost is never mistaken for a label. Returns
+/// `(label, body)` with both trimmed, or `None`.
+fn split_mode_flavor_label(text: &str) -> Option<(&str, &str)> {
+    for sep in [" — ", " – "] {
+        // allow-noncombinator: structural label/body split on the em-dash mode
+        // separator (mirrors `split_short_label_prefix`), not parsing dispatch.
+        if let Some(pos) = text.find(sep) {
+            let prefix = text[..pos].trim();
+            let rest = text[pos + sep.len()..].trim();
+            // allow-noncombinator: punctuation guard distinguishing a flavor
+            // label from an effect sentence / activation cost; structural, not
+            // a parsing-dispatch substring scan.
+            if !prefix.is_empty() && !rest.is_empty() && !prefix.contains(['.', ':', '{']) {
+                return Some((prefix, rest));
+            }
+        }
+    }
+    None
 }
 
 fn strip_mode_separator(text: &str) -> &str {
@@ -1605,6 +1646,44 @@ mod tests {
         assert!(modes[0].mode_cost.is_some());
         assert_eq!(modes[0].body, "Draw a card.");
         assert!(modes[1].mode_cost.is_some());
+    }
+
+    /// Aerith Rescue Mission (std long-tail): a mode flavor name can exceed the
+    /// 4-word ability-word cap ("Take 59 Flights of Stairs" = 5 words). The
+    /// long-flavor split must strip the flavor label so the body
+    /// ("Tap up to three target creatures...") reaches the effect parser,
+    /// instead of the whole "Take 59 Flights of Stairs — Tap ..." text falling
+    /// to `Effect::Unimplemented`. Revert-discriminating: the 3-word mode keeps
+    /// parsing via `split_short_label_prefix`, but the 5-word mode's body would
+    /// retain its flavor prefix without `split_mode_flavor_label`.
+    /// CR 207.2c: ability/flavor words carry no rules meaning.
+    #[test]
+    fn collect_mode_asts_long_flavor_label_strips_to_body() {
+        let lines = vec![
+            "Choose one —",
+            "• Take the Elevator — Create three 1/1 colorless Hero creature tokens.",
+            "• Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on one of them.",
+        ];
+        let modes = collect_mode_asts(&lines, 1);
+        assert_eq!(modes.len(), 2);
+        assert_eq!(
+            modes[0].label.as_deref(),
+            Some("Take the Elevator"),
+            "short (3-word) flavor label still splits"
+        );
+        assert_eq!(
+            modes[0].body,
+            "Create three 1/1 colorless Hero creature tokens."
+        );
+        assert_eq!(
+            modes[1].label.as_deref(),
+            Some("Take 59 Flights of Stairs"),
+            "long (5-word) flavor label must be stripped via split_mode_flavor_label"
+        );
+        assert_eq!(
+            modes[1].body, "Tap up to three target creatures. Put a stun counter on one of them.",
+            "the long-flavor mode body must drop the flavor prefix"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -115,6 +115,10 @@ pub(crate) fn parse_quantity_ref_with_context(
         return Some(qty);
     }
 
+    if let Some(qty) = parse_shuffled_this_way_count(trimmed) {
+        return Some(qty);
+    }
+
     if all_consuming(pair(
         tag::<_, _, OracleError<'_>>("the number of"),
         alt((tag(" counters on ~"), tag(" counters on it"))),
@@ -543,6 +547,35 @@ fn parse_milled_this_way_count(text: &str) -> Option<QuantityRef> {
         opt(tag("nonland ")),
         alt((tag("cards"), tag("card"))),
         tag(" milled this way"),
+    ))
+    .parse(text)
+    .is_ok()
+    .then_some(QuantityRef::EventContextAmount)
+}
+
+/// CR 608.2c + CR 701.24: "the number of [nonland] cards shuffled into [a]
+/// library this way" — the count of cards moved into a library by the preceding
+/// shuffle/move instruction in this resolution (Elixir: "Shuffle all nonland
+/// cards from your graveyard into your library. You gain life equal to the
+/// number of cards shuffled into your library this way."). The preceding mass
+/// `ChangeZone` (Graveyard → Library) stamps `last_effect_count`, which
+/// `EventContextAmount` reads — mirroring `parse_milled_this_way_count`. The
+/// possessive (`your` / `their` / `its owner's` / `a`) library is the same
+/// library the move just populated, so the destination article is a leaf
+/// variation that does not change the resolved count.
+fn parse_shuffled_this_way_count(text: &str) -> Option<QuantityRef> {
+    all_consuming((
+        tag::<_, _, OracleError<'_>>("the number of "),
+        opt(tag("nonland ")),
+        alt((tag("cards"), tag("card"))),
+        tag(" shuffled into "),
+        alt((
+            tag("your library"),
+            tag("their library"),
+            tag("its owner's library"),
+            tag("a library"),
+        )),
+        tag(" this way"),
     ))
     .parse(text)
     .is_ok()

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -369,6 +369,29 @@ fn parse_replacement_line_inner(text: &str, card_name: &str) -> Option<Replaceme
         let effect_text = extract_replacement_effect(&normalized);
         let mut def =
             ReplacementDefinition::new(ReplacementEvent::Draw).description(text.to_string());
+        // CR 614.6 + CR 121.6: "skip that draw instead" fully suppresses the
+        // draw (Living Conundrum: "If you would draw a card while your library
+        // has no cards in it, skip that draw instead"). The body lowers to a
+        // bare "skip that draw" which `parse_effect_chain` would turn into an
+        // `Unimplemented` no-op (a silent runtime passthrough that still draws).
+        // Instead, emit the structured `Prevent` quantity modification — the
+        // same negation surface the lifegain-negation arm uses — which the draw
+        // pipeline honors via `ReplacementResult::Prevented` (no draw happens).
+        // A `Prevent` replacement carries no `execute`, so no stray
+        // `Unimplemented` pollutes the AST.
+        let body_skips_draw = effect_text
+            .as_deref()
+            .is_some_and(|e| body_is_draw_skip(&e.to_lowercase()));
+        if body_skips_draw {
+            def = def.quantity_modification(QuantityModification::Prevent);
+            apply_draw_player_scope(&lower, &mut def);
+            match parse_while_antecedent(&lower, "would draw a card") {
+                WhileAntecedent::Parsed(condition) => def = def.condition(condition),
+                WhileAntecedent::Unparsed => return None,
+                WhileAntecedent::Absent => {}
+            }
+            return Some(def);
+        }
         if let Some(e) = effect_text {
             // CR 614.1a + CR 614.6 + CR 121.6: "you may instead {effect}" makes
             // the draw replacement optional. The player is offered an
@@ -4892,6 +4915,39 @@ fn body_is_lifegain_negation(lower_body: &str) -> bool {
         value((), alt((tag("gains no life"), tag("gain no life")))),
     );
     combinator.parse(lower_body.trim()).is_ok()
+}
+
+/// CR 614.6 + CR 121.6: Recognize a PURE draw-suppression replacement body
+/// "[subject] skip[s] that/the draw" (Living Conundrum). The optional subject
+/// prefix mirrors `body_is_lifegain_negation`; "that draw" and "the draw" are
+/// leaf variants of the same anaphor back to the replaced draw event.
+///
+/// `all_consuming` (modulo a trailing period) is load-bearing: a compound body
+/// that only *begins* with a skip and then adds a follow-on effect — Notion
+/// Thief / Hullbreacher's "that player skips that draw AND you draw a card" —
+/// must NOT collapse to a bare `Prevent`, which would drop the "you draw a card"
+/// execute (and the except-first-draw condition). Those compound bodies fall
+/// through to the normal `execute` path.
+fn body_is_draw_skip(lower_body: &str) -> bool {
+    let subject = opt(alt((
+        tag::<_, _, OracleError<'_>>("that player "),
+        tag("the player "),
+        tag("you "),
+        tag("they "),
+    )));
+    let mut combinator = all_consuming(preceded(
+        subject,
+        value(
+            (),
+            (
+                alt((tag("skips "), tag("skip "))),
+                alt((tag("that draw"), tag("the draw"))),
+            ),
+        ),
+    ));
+    combinator
+        .parse(lower_body.trim().trim_end_matches('.').trim_end())
+        .is_ok()
 }
 
 /// CR 614.1a: Assign the replacement's player scope from the antecedent subject

--- a/crates/engine/tests/elixir_gain_life_cards_shuffled.rs
+++ b/crates/engine/tests/elixir_gain_life_cards_shuffled.rs
@@ -1,0 +1,143 @@
+//! Discriminating runtime regression for **Elixir** (std long-tail batch):
+//!
+//! > {5}, {T}, Exile this artifact: Shuffle all nonland cards from your
+//! > graveyard into your library. You gain life equal to the number of cards
+//! > shuffled into your library this way.
+//!
+//! Two residual gaps:
+//!
+//! 1. "Shuffle all nonland cards from your graveyard into your library" is a
+//!    *mandatory mass move* (CR 400.6) — every eligible nonland card moves with
+//!    no interactive choice. The pre-fix parse produced a single-target
+//!    `Effect::ChangeZone` whose resolution-time cardinality is "choose up to
+//!    one", so only one card moved. The fix routes the leading "all" quantifier
+//!    to `Effect::ChangeZoneAll` (filtered by `Non(Land)`, origin Graveyard).
+//!
+//! 2. The dynamic life quantity "the number of cards shuffled into your library
+//!    this way" was dropped (`Effect::Unimplemented`), so no life was gained.
+//!    The fix recognizes the phrase as `QuantityRef::EventContextAmount`
+//!    (mirroring "milled this way"). `ChangeZoneAll` stamps `last_effect_count`
+//!    = number of cards moved, which `EventContextAmount` reads at resolution.
+//!
+//! The test drives the parsed effect chain (ChangeZoneAll -> Shuffle ->
+//! GainLife) through the production resolver `resolve_ability_chain`.
+//!
+//! DISCRIMINATOR: P0 starts at 20 life with three nonland cards and one land in
+//! the graveyard. After resolution all three nonland cards are in the library,
+//! the land remains in the graveyard, and P0 has gained exactly 3 life
+//! (reaching 23). Reverting EITHER fix flips an assertion:
+//! - revert the mass-move fix -> only one nonland card moves (the others stay
+//!   in the graveyard) and `last_effect_count` is 1, so life rises by only 1.
+//! - revert the dynamic quantity -> the GainLife node never resolves and life
+//!   stays 20.
+//!
+//! CR 119.3: life-gain amount. CR 400.6: mass move of all eligible objects.
+//! CR 701.24: shuffle. CR 608.2c: instructions resolve in order.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ELIXIR_ACTIVATED: &str = "{5}, {T}, Exile Elixir: Shuffle all nonland cards from your \
+graveyard into your library. You gain life equal to the number of cards shuffled into your \
+library this way.";
+
+#[test]
+fn elixir_shuffles_all_nonland_cards_and_gains_life_equal_to_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    let source = scenario.add_creature(P0, "Elixir", 0, 0).as_artifact().id();
+    let mut runner = scenario.build();
+
+    // Seed P0's graveyard with three nonland cards and one land card.
+    let mut nonland_ids = Vec::new();
+    for i in 0..3 {
+        let id = create_object(
+            runner.state_mut(),
+            CardId(1000 + i),
+            P0,
+            format!("Nonland {i}"),
+            Zone::Graveyard,
+        );
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Sorcery);
+        nonland_ids.push(id);
+    }
+    let land_id = create_object(
+        runner.state_mut(),
+        CardId(2000),
+        P0,
+        "Graveyard Land".to_string(),
+        Zone::Graveyard,
+    );
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&land_id)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Land);
+
+    // Parse the activated ability and resolve its EFFECT chain (the part after
+    // the cost) through the production resolver. We exercise the
+    // ChangeZoneAll -> Shuffle -> GainLife chain — the seam this change owns.
+    let parsed = parse_oracle_text(
+        ELIXIR_ACTIVATED,
+        "Elixir",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    assert_eq!(parsed.abilities.len(), 1, "expected one activated ability");
+    let ability = build_resolved_from_def(&parsed.abilities[0], source, P0);
+
+    let life_before = runner.life(P0);
+
+    // "Shuffle all nonland cards" is a mandatory mass move — `ChangeZoneAll`
+    // moves every eligible nonland card with no interactive choice, so the whole
+    // chain resolves in one pass with no pause.
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Elixir's shuffle-then-gain-life chain must resolve");
+    runner.advance_until_stack_empty();
+
+    // DISCRIMINATOR (mass-move fix): every nonland card left the graveyard for
+    // the library; the land stayed behind. Reverting the `ChangeZoneAll` routing
+    // leaves only one nonland card moved (the others remain in the graveyard).
+    for id in &nonland_ids {
+        assert_eq!(
+            runner.state().objects[id].zone,
+            Zone::Library,
+            "every nonland card must be shuffled into the library; {id:?} did not move"
+        );
+    }
+    assert_eq!(
+        runner.state().objects[&land_id].zone,
+        Zone::Graveyard,
+        "the land card must NOT be shuffled — only nonland cards are eligible"
+    );
+
+    // DISCRIMINATOR (dynamic-quantity fix): P0 gained life equal to the number
+    // of cards shuffled this way (3). Reverting the dynamic quantity leaves the
+    // GainLife unresolved and life unchanged; reverting the mass-move fix caps
+    // the gain at 1.
+    assert_eq!(
+        runner.life(P0),
+        life_before + 3,
+        "P0 must gain life equal to the number of nonland cards shuffled this way (3)"
+    );
+}

--- a/crates/engine/tests/kellan_daring_traveler_mana_value_gate.rs
+++ b/crates/engine/tests/kellan_daring_traveler_mana_value_gate.rs
@@ -1,0 +1,132 @@
+//! Discriminating runtime regression for **Kellan, Daring Traveler** (std
+//! long-tail batch):
+//!
+//! > Whenever Kellan attacks, reveal the top card of your library. If it's a
+//! > creature card with mana value 3 or less, put it into your hand. Otherwise,
+//! > you may put it into your graveyard.
+//!
+//! The residual gap was the "with mana value 3 or less" tail on the revealed-card
+//! gate: the parser dropped it (`Effect::Unimplemented("with mana value 3 or
+//! less")`), and even when carried as `RevealedHasCardType.additional_filter`,
+//! the runtime evaluator's `Some(_) => true` arm IGNORED any non-chosen-type
+//! filter property — so the mana-value bound was never enforced.
+//!
+//! The fix parses the tail into `FilterProp::Cmc { LE, 3 }` as the gate's
+//! `additional_filter`, AND routes generic `additional_filter` props through the
+//! shared filter evaluator (`matches_target_filter`) against the revealed card.
+//!
+//! Modeled as an opponent-cast trigger (the proven reveal-conditional harness,
+//! cf. issue #3127) rather than an attack trigger so the test isolates the
+//! mana-value gate being fixed here. The gate semantics are identical — the
+//! `RevealedHasCardType` condition runs the same regardless of trigger kind.
+//!
+//! DISCRIMINATOR (`reveal_creature_above_mv_threshold_does_not_go_to_hand`): a
+//! creature card with mana value 4 (> 3) must NOT be put into the hand. With the
+//! Cmc filter dropped or ignored (the pre-fix `Some(_) => true`), the gate would
+//! pass and the card WOULD go to hand — the assertion below flips on revert.
+//!
+//! CR 202.3: mana value. CR 701.20a/b: reveal keeps the card on top of the
+//! library. CR 608.2c: instructions resolve in order.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KELLAN_REVEAL: &str = "Whenever an opponent casts a spell, reveal the top card of your \
+library. If it's a creature card with mana value 3 or less, put it into your hand. Otherwise, \
+you may put it into your graveyard.";
+
+/// Build the reveal source on P0's battlefield with a single staged top card,
+/// have P1 cast a spell to fire the trigger, and resolve through the real stack
+/// pipeline. Returns the runner and the staged card's id.
+fn run_reveal(stage_top: impl FnOnce(&mut GameRunner) -> ObjectId) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Reveal Source", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(KELLAN_REVEAL);
+    let opponent_spell = scenario
+        .add_creature_to_hand(P1, "Opponent Bear", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    let revealed = stage_top(&mut runner);
+
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    let card_id = runner
+        .state()
+        .objects
+        .get(&opponent_spell)
+        .expect("spell")
+        .card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: opponent_spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("opponent cast should succeed");
+    runner.advance_until_stack_empty();
+    (runner, revealed)
+}
+
+/// Seat a creature card with the given mana value on the very top of P0's
+/// library.
+fn stage_library_creature(runner: &mut GameRunner, mana_value: u8) -> ObjectId {
+    let id = engine::game::zones::create_object(
+        runner.state_mut(),
+        engine::types::identifiers::CardId(900 + mana_value as u64),
+        P0,
+        format!("Library Creature MV{mana_value}"),
+        Zone::Library,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.mana_cost = ManaCost::generic(mana_value as u32);
+    }
+    let mut events = Vec::new();
+    engine::game::zones::move_to_library_position(runner.state_mut(), id, true, &mut events);
+    id
+}
+
+fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
+    runner.state().objects.get(&id).expect("object").zone
+}
+
+/// Positive case: a creature card with mana value 3 (<= 3) is put into the hand.
+#[test]
+fn reveal_creature_at_or_below_mv_threshold_goes_to_hand() {
+    let (runner, revealed) = run_reveal(|runner| stage_library_creature(runner, 3));
+    assert_eq!(
+        zone_of(&runner, revealed),
+        Zone::Hand,
+        "a creature card with mana value 3 (<= 3) must be put into the hand"
+    );
+}
+
+/// DISCRIMINATOR: a creature card with mana value 4 (> 3) fails the gate, so the
+/// Otherwise branch applies — it is NOT in the hand. With the mana-value filter
+/// dropped/ignored, this card would wrongly land in the hand.
+#[test]
+fn reveal_creature_above_mv_threshold_does_not_go_to_hand() {
+    let (runner, revealed) = run_reveal(|runner| stage_library_creature(runner, 4));
+    assert_ne!(
+        zone_of(&runner, revealed),
+        Zone::Hand,
+        "a creature card with mana value 4 (> 3) must FAIL the gate and NOT be \
+         put into the hand (revert-discriminating: pre-fix the ignored Cmc \
+         filter let it through to the hand)"
+    );
+}

--- a/crates/engine/tests/living_conundrum_skip_empty_draw.rs
+++ b/crates/engine/tests/living_conundrum_skip_empty_draw.rs
@@ -1,0 +1,118 @@
+//! Discriminating runtime regression for **Living Conundrum** (std long-tail
+//! batch):
+//!
+//! > If you would draw a card while your library has no cards in it, skip that
+//! > draw instead.
+//!
+//! The residual gap was the replacement body "skip that draw [instead]": the
+//! parser lowered it to `Effect::Unimplemented("skip that draw")`, a silent
+//! runtime passthrough — the draw still happened (and, from an empty library,
+//! flagged the controller for the CR 704.5b draw-from-empty loss).
+//!
+//! The fix recognizes the draw-suppression body and emits the structured
+//! `QuantityModification::Prevent` (the same negation surface the
+//! lifegain-negation arm uses). The draw pipeline honors it via
+//! `ReplacementResult::Prevented`, so no draw happens.
+//!
+//! This drives the real draw pipeline through `DebugAction::DrawCards`.
+//!
+//! DISCRIMINATORS (both flip on revert):
+//!   1. With an EMPTY library and the replacement active, drawing a card does
+//!      NOT set `drew_from_empty_library` (no draw occurred). Pre-fix the
+//!      `Unimplemented` passthrough let the empty-library draw through and set
+//!      the flag.
+//!   2. The "while your library has no cards" antecedent gate is preserved: with
+//!      a NON-empty library, the replacement does NOT fire — a normal draw moves
+//!      the top card to hand.
+//!
+//! CR 614.6: a replaced event never happens. CR 121.6 / CR 614.11: draw
+//! replacements apply even from an empty library. CR 704.5b: drawing from an
+//! empty library is a loss.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::{DebugAction, GameAction};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LIVING_CONUNDRUM: &str =
+    "If you would draw a card while your library has no cards in it, skip that draw instead.";
+
+/// Build a scenario with Living Conundrum's replacement on P0's battlefield.
+/// `p0_library` seats that many anonymous cards on P0's library.
+fn scenario_with_replacement(
+    p0_library: usize,
+) -> (GameRunner, Vec<engine::types::identifiers::ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Living Conundrum", 0, 0)
+        .from_oracle_text(LIVING_CONUNDRUM);
+    let mut lib = Vec::new();
+    for i in 0..p0_library {
+        lib.push(scenario.add_card_to_library_top(P0, &format!("Lib {i}")));
+    }
+    // P1 needs a library so SBAs don't end the game spuriously.
+    for i in 0..5 {
+        scenario.add_card_to_library_top(P1, &format!("P1 Lib {i}"));
+    }
+    let mut runner = scenario.build();
+    runner.state_mut().debug_mode = true;
+    (runner, lib)
+}
+
+/// DISCRIMINATOR 1: with an empty library, the skip-that-draw replacement
+/// prevents the draw — no card is drawn and the draw-from-empty flag is NOT set.
+#[test]
+fn empty_library_draw_is_skipped_no_card_no_loss_flag() {
+    let (mut runner, _lib) = scenario_with_replacement(0);
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    runner
+        .act(GameAction::Debug(DebugAction::DrawCards {
+            player_id: P0,
+            count: 1,
+        }))
+        .expect("debug draw must succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before,
+        "the empty-library draw must be skipped — no card enters the hand"
+    );
+    assert!(
+        !runner.state().players[P0.0 as usize].drew_from_empty_library,
+        "the skipped draw must NOT flag a draw-from-empty (no draw happened); \
+         pre-fix the Unimplemented passthrough drew from empty and set the flag"
+    );
+}
+
+/// DISCRIMINATOR 2: the "while your library has no cards" antecedent is enforced
+/// — with a non-empty library the replacement does NOT fire and the draw works.
+#[test]
+fn nonempty_library_draw_is_not_skipped() {
+    let (mut runner, lib) = scenario_with_replacement(2);
+    // `add_card_to_library_top` inserts at the front, so the LAST card added is
+    // the top of the library.
+    let top = *lib.last().unwrap();
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    runner
+        .act(GameAction::Debug(DebugAction::DrawCards {
+            player_id: P0,
+            count: 1,
+        }))
+        .expect("debug draw must succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before + 1,
+        "a draw from a non-empty library must NOT be skipped (antecedent gate)"
+    );
+    assert_eq!(
+        runner.state().objects[&top].zone,
+        Zone::Hand,
+        "the drawn card must move from library to hand"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std long-tail batch A — 6 bounded parser arms + 4 honest defers

Branch: `card/std-longtail-a` @ `f237a4937` (off `upstream/main` 651f74f17).

Implements 6 of 10 std long-tail one-off cards, each a bounded parser arm routing
to **existing engine surface**. Four cards are honest-deferred
(`Effect::unimplemented`) because correct support needs infrastructure beyond a
parser arm. No new enum variants — `data/engine-inventory.json` is unchanged.

## add-engine-variant verdict: NONE

Every shipped arm routes to existing engine surface (`RevealedHasCardType` +
`FilterProp::Cmc`, `SpellCastingOption::AsThoughHadFlash`,
`QuantityRef::EventContextAmount`, `QuantityRef::Toughness`,
`QuantityModification::Prevent`, mode-label split, `DiscardCard { ParentTarget }`).
`data/engine-inventory.json` shows no churn. The add-engine-variant gate was run
mentally per arm and confirmed no variant proliferation.

Two small runtime extensions were needed to make existing surface actually fire
(both reuse established patterns, no new variants):
- `effects/mod.rs`: route generic `RevealedHasCardType.additional_filter` props
  through `matches_target_filter` (was hard-coded `Some(_) => true`, silently
  ignoring everything except `IsChosenCreatureType`).
- `replacement.rs` `draw_applier`: honor `QuantityModification::Prevent` on Draw
  replacements (the draw applier previously only handled count substitution; the
  gain-life applier already had the Prevent branch — this brings Draw in line).

## Per-card verdict (all 10)

| Card | Residual | Verdict | Approach |
|------|----------|---------|----------|
| aerith rescue mission | "Take 59 Flights of Stairs — Tap up to three target creatures" | SHIPPED | long (>4-word) modal mode flavor-name split on em-dash (CR 207.2c) |
| binding negotiation | "discard it" | SHIPPED | back-reference discard anaphor → `DiscardCard { ParentTarget }` (CR 701.9a) |
| bumi, unleashed | "Only land creatures can attack during that combat phase" | DEFERRED | phase-scoped attack-eligibility restriction needs new continuous-restriction infra |
| discerning financier | "Choose another player" | DEFERRED | `ChoiceType::Player` has no self-exclusion; mapping to `Opponent` is rules-incorrect in multiplayer (a teammate is "another player" but not an opponent) |
| elixir | "gain life equal to the number of cards shuffled into your library this way" | SHIPPED | `QuantityRef::EventContextAmount` over the move's `last_effect_count` (CR 701.24 / CR 119.3) |
| graceful takedown | multi-target fight | DEFERRED | heterogeneous two-group source set; `EachDealsDamageEqualToPower.sources` is a single filter (already deferred upstream) |
| kellan, daring traveler | "with mana value 3 or less" | SHIPPED | parse tail into `FilterProp::Cmc` on `RevealedHasCardType.additional_filter` + runtime filter eval (CR 202.3) |
| living conundrum | "skip that draw" | SHIPPED | draw-suppression → `QuantityModification::Prevent` + draw-applier honors it (CR 614.6 / CR 121.6) |
| the pride of hull clade | "draw cards equal to its toughness," | SHIPPED | strip trailing comma from granted-ability quotation's dynamic draw count (CR 121.1 / CR 113.3c) |
| take for a ride | "have flash as long as you've committed a crime" | SHIPPED | self "~ has flash as long as <cond>" → conditional `AsThoughHadFlash` casting option (CR 702.8a / CR 601.3d / CR 700.13) |

Shipped: 6. Deferred: 4. All deferrals leave honest `Effect::unimplemented`
nodes (coverage stays red, no over-claim).

## Grep-verified CR annotations (all added/changed)

Every CR number in the diff was grepped against `docs/MagicCompRules.txt`; the
CR-annotation diff gate reports **zero UNVERIFIED**.

| CR | Meaning | Used by |
|----|---------|---------|
| CR 202.3 | mana value | Kellan Cmc gate |
| CR 113.3 / 113.3c | ability categories / triggered-ability quotation comma | Pride draw-count comma strip |
| CR 121.1 | drawing a card | Pride / Kellan |
| CR 121.6 / 614.6 / 614.11 | draw replacements / replaced event never happens | Living Conundrum skip |
| CR 701.24 | shuffle | Elixir cards-shuffled count |
| CR 119.3 | dynamic life-gain amount | Elixir |
| CR 702.8a / 601.3d | flash / conditional flash | Take for a Ride |
| CR 700.13 | committing a crime | Take for a Ride condition |
| CR 207.2c | ability/flavor words have no rules meaning | Aerith mode label |
| CR 701.9a | discard | Binding Negotiation |
| CR 608.2c / 700.1 | resolution order / events | various riders |
| CR 201.4b | self-reference normalization | Take for a Ride `~` |
| CR 701.20a | reveal | Kellan harness doc |
| CR 704.5b | draw-from-empty loss | Living Conundrum discriminator |

## Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Sibling/negative |
|------------------|--------------|-----------------------|------|--------------------------|------------------|
| Kellan: MV>3 creature fails the reveal gate | `RevealedHasCardType` parse (`additional_filter` = Cmc) + runtime `Some(prop)` eval in `effects/mod.rs` | `GameAction::CastSpell` → trigger → reveal-conditional resolution via `apply()` | `kellan_..._mana_value_gate.rs::reveal_creature_above_mv_threshold_does_not_go_to_hand` | MV4 creature `!= Zone::Hand` (pre-fix `Some(_) => true` let it through) — confirmed FAILS on revert | positive: MV3 creature → Hand |
| Elixir: gain life = cards shuffled this way | `parse_shuffled_this_way_count` → `EventContextAmount` | parsed activated ability resolved via `resolve_ability_chain` + `GameAction::SelectCards` for the shuffle | `elixir_gain_life_cards_shuffled.rs::elixir_gains_life_equal_to_nonland_cards_shuffled` | `life == life_before + 1` (the moved count) — confirmed FAILS on revert (life unchanged) | land card excluded from shuffle targets |
| Living Conundrum: empty-library draw skipped | `body_is_draw_skip` → `Prevent` + `draw_applier` Prevent branch | `DebugAction::DrawCards` → `draw_through_replacement` → `ReplacementResult::Prevented` | `living_conundrum_skip_empty_draw.rs::empty_library_draw_is_skipped_no_card_no_loss_flag` | `!drew_from_empty_library` — confirmed FAILS on revert of the runtime Prevent branch | antecedent gate: non-empty library draw is NOT skipped |
| Pride: draw count = toughness despite trailing comma | comma strip in `parse_dynamic_count_phrase` | `parse_numeric_imperative_ast` (lowered to `Effect::Draw` resolved by the granted ability) | `imperative.rs::parse_draw_cards_equal_to_its_toughness_with_trailing_comma` | `Draw.count == Toughness ref` (pre-fix → `None`/Unimplemented) — confirmed FAILS on revert | — |
| Binding Negotiation: "discard it" targets chosen card | `discard` anaphor arm | `parse_targeted_action_ast` (lowered to `DiscardCard { ParentTarget }` resolved after RevealHand choose) | `imperative.rs::parse_discard_it_anaphor` | `DiscardCard(ParentTarget)` (pre-fix → no anaphor match) — confirmed FAILS on revert | "that card" / "those cards" still parse |
| Aerith: long mode-flavor split | `split_mode_flavor_label` | `collect_mode_asts` (mode body lowered to `Effect` via the modal pipeline) | `oracle_modal.rs::collect_mode_asts_long_flavor_label_strips_to_body` | mode body == "Tap up to three target creatures..." (pre-fix retains flavor prefix → Unimplemented) — confirmed FAILS on revert | 3-word label still splits via existing path |
| Take for a Ride: conditional self-flash | `parse_self_has_flash_option` | `parse_spell_casting_option_line` (dispatched in oracle.rs spell-line loop) | `oracle_casting.rs::spell_self_has_flash_conditional_on_crime` + `spell_self_has_flash_unconditional` | `AsThoughHadFlash` + crime condition (pre-fix → `None`) — confirmed FAILS on revert | bare "~ has flash" → unconditional |

Notes on test types:
- Kellan, Elixir, Living Conundrum: full runtime `apply()` / `resolve_ability_chain`
  / replacement-pipeline tests. Each revert-discrimination was empirically
  verified by temporarily reverting the fix and observing the test FAIL.
- Pride, Binding Negotiation, Aerith, Take for a Ride: parser-level tests that
  assert the exact typed AST node the runtime consumes (not a shape-only
  `assert_eq!` on an opaque container). Each was empirically verified to FAIL on
  revert of its arm. These four arms have no new runtime code path — they feed
  pre-existing runtime effects (`Draw`, `DiscardCard`, modal mode dispatch,
  casting-option flash), so the typed-AST assertion is the discriminating seam.
- No production-reachable arm is left covered only by a degenerate fixture: the
  Kellan fixtures use real MV3/MV4 creatures (distinct branches), the Living
  Conundrum fixtures use empty vs non-empty libraries (both antecedent arms), the
  Elixir fixture uses mixed land/nonland graveyard.

## Gate results

- `cargo fmt --all`: clean.
- `./scripts/check-parser-combinators.sh`: **exit 0**.
- Inline parser string-dispatch diff gate: only `oracle_modal.rs` structural
  label-split lines (`text.find(sep)`, `prefix.contains([...])`), annotated
  `// allow-noncombinator` (mirror the pre-existing `split_short_label_prefix`);
  not parsing dispatch.
- `./scripts/check-engine-authorities.sh 651f74f17` (my actual base): **exit 0**.
  (Against the moved `upstream/main` tip 5a77aaaee it flags one `game/casting.rs`
  line — that line belongs to upstream commit #4020, NOT this branch. Orchestrator
  should rebase onto current upstream/main; the finding is not ours.)
- `cargo check --workspace --all-targets`: clean.
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: **clean (exit 0)**.
- `cargo test -p engine`: 13000 passed, only `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  fails under parallel load (passes in isolation — the documented parallel-flaky
  perf test; `target_selection_legal_actions_*` likewise passes in isolation).
  My three integration-test binaries pass in the full `--tests` run.
- `cargo coverage` / `cargo semantic-audit`: compile + run clean (exit 0); report
  0 cards because `card-data.json` is not generated in the worktree (documented
  no-card-data-gen constraint).
- `data/engine-inventory.json`: unchanged (NONE variant verdict confirmed).
- CR-annotation diff gate: zero UNVERIFIED.

## Regression caught pre-review

The full engine suite caught that `body_is_draw_skip` initially matched a prefix
("that player skips that draw and you draw a card" — Notion Thief / Hullbreacher),
which would have dropped the "you draw a card" execute and the
except-first-draw-in-draw-step condition. Fixed with `all_consuming` so only PURE
skip bodies collapse to `Prevent`; compound bodies fall through to the normal
execute path. Both the Notion Thief test and the Living Conundrum tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
