### PR TITLE
feat(engine): long-tail one-offs B (All-Out Assault, Fear of Burning Alive, Fortune, Mutable Explorer, Y'shtola Rhul)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -5717,6 +5717,7 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         // CR 500.8 + CR 506.1 + CR 608.2c: combat-phase count check; handled by
         // `evaluate_condition` (effects/mod.rs).
         AbilityCondition::FirstCombatPhaseOfTurn => ("FirstCombatPhaseOfTurn", Handled),
+        AbilityCondition::FirstEndStepOfTurn => ("FirstEndStepOfTurn", Handled),
         // CR 614.1a: `ConditionInstead` wraps a general condition with swap-on-true semantics.
         AbilityCondition::ConditionInstead { .. } => ("ConditionInstead", Handled),
         // CR 608.2c + CR 614.1d: "you control a/no [filter]" — handled by

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1894,6 +1894,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::WasStartingPlayer { .. }
             | AbilityCondition::SpellCastWithVariantThisTurn { .. }
             | AbilityCondition::FirstCombatPhaseOfTurn
+            | AbilityCondition::FirstEndStepOfTurn
             | AbilityCondition::ZoneChangedThisWay { .. }
             | AbilityCondition::CostPaidObjectMatchesFilter { .. }
             | AbilityCondition::SourceIsTapped
@@ -6900,6 +6901,10 @@ pub(crate) fn evaluate_condition(
         // CR 500.8 + CR 506.1 + CR 608.2c: "if it's the first combat phase
         // of the turn" gates follow-up effects such as additional combats.
         AbilityCondition::FirstCombatPhaseOfTurn => state.combat_phases_started_this_turn == 1,
+        // CR 500.8 + CR 513.1 + CR 608.2c: "if it's the first end step of the
+        // turn" gates the additional-end-step follow-up (Y'shtola Rhul); only
+        // the first end step schedules another, preventing an infinite loop.
+        AbilityCondition::FirstEndStepOfTurn => state.end_steps_started_this_turn == 1,
         // CR 608.2c: "If a [noun] was [verb]ed this way" — check if any zone-changed
         // object matches the type filter. For optional-targeting parents with no targets
         // chosen, last_zone_changed_ids is empty → returns false.

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -149,6 +149,13 @@ fn enter_phase(state: &mut GameState, next: Phase, events: &mut Vec<GameEvent>) 
         state.combat_phases_started_this_turn =
             state.combat_phases_started_this_turn.saturating_add(1);
     }
+    // CR 500.8 + CR 513.1: track end-step occurrences for "first end step of the
+    // turn" gates (Y'shtola Rhul). Counts every End step begun this turn,
+    // including extra end steps scheduled via AdditionalPhase, so the gate only
+    // holds for the first.
+    if next == Phase::End {
+        state.end_steps_started_this_turn = state.end_steps_started_this_turn.saturating_add(1);
+    }
 
     // CR 500.5: Mana pools empty between phases/steps.
     // Firebending mana (EndOfCombat expiry) persists within combat steps.
@@ -593,6 +600,7 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.attacked_defenders_this_turn.clear();
     state.creature_attacked_defenders_this_turn.clear();
     state.combat_phases_started_this_turn = 0;
+    state.end_steps_started_this_turn = 0;
     state.creatures_attacked_this_turn.clear();
     state.attacker_declarations_this_turn.clear();
     state.creatures_blocked_this_turn.clear();

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3126,6 +3126,7 @@ pub(crate) fn ability_condition_to_static_condition(
         // No `StaticCondition` counterpart exists for these game-state
         // predicates.
         AbilityCondition::FirstCombatPhaseOfTurn
+        | AbilityCondition::FirstEndStepOfTurn
         | AbilityCondition::DayNightIsNeither
         | AbilityCondition::SourceLacksKeyword { .. } => None,
 
@@ -3454,6 +3455,15 @@ pub(super) fn try_nom_condition_as_ability_condition(
         .is_ok()
     {
         return Some(AbilityCondition::FirstCombatPhaseOfTurn);
+    }
+
+    // CR 500.8 + CR 513.1: "it's the first end step of the turn" — end-step
+    // sibling of the combat-phase gate above (Y'shtola Rhul's loop guard).
+    if tag::<_, _, OracleError<'_>>("it's the first end step of the turn")
+        .parse(lower.as_str())
+        .is_ok()
+    {
+        return Some(AbilityCondition::FirstEndStepOfTurn);
     }
 
     // CR 603.4: "if this is the [Nth] time this ability has resolved this turn"

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6588,6 +6588,18 @@ pub(super) fn parse_imperative_family_ast(
             count: parse_additional_phase_count(lower),
         }));
     }
+    // CR 500.8 + CR 513.1: "there is an additional end step after this step"
+    // (Y'shtola Rhul). The extra end step is anchored to `Phase::End` so the
+    // LIFO `advance_phase` scan inserts it as the current end step completes.
+    if nom_primitives::scan_contains(lower, "additional end step") {
+        return Some(ImperativeFamilyAst::GainKeyword(Effect::AdditionalPhase {
+            target: TargetFilter::Controller,
+            phase: Phase::End,
+            after: Phase::End,
+            followed_by: vec![],
+            count: parse_additional_phase_count(lower),
+        }));
+    }
 
     // CR 606.3: "activate each planeswalker's loyalty ability an additional
     // time this turn" — The Chain Veil class. The outer "you may" is

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3408,6 +3408,17 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                 },
                 tag("at this turn's next end of combat, "),
             ),
+            // CR 511.2 + CR 603.7a: bare "at end of combat, …" prefix — the
+            // companion of the existing suffix arm in `strip_temporal_suffix`.
+            // An attack/combat trigger whose effect body is deferred to the
+            // end-of-combat step (Fortune, Loyal Steed: "Whenever Fortune
+            // attacks while saddled, at end of combat, exile it and …").
+            value(
+                DelayedTriggerCondition::AtNextPhase {
+                    phase: Phase::EndCombat,
+                },
+                tag("at end of combat, "),
+            ),
         ))
         .parse(i)
     }) {
@@ -4686,7 +4697,15 @@ pub(super) fn try_parse_damage_with_remainder<'a>(
             },
             &after[consumed..],
         )
-    } else if let Ok((rem, _)) = tag::<_, _, OracleError<'_>>("that much damage").parse(after_lower)
+    } else if let Ok((rem, _)) = alt((
+        tag::<_, _, OracleError<'_>>("that much damage"),
+        // CR 120.1: "that amount of damage" is the synonym used when the
+        // antecedent reads "N damage" rather than "this much damage" (Fear of
+        // Burning Alive: "deals that amount of damage to target creature that
+        // player controls"). Both anaphors resolve to the just-dealt amount.
+        tag("that amount of damage"),
+    ))
+    .parse(after_lower)
     {
         let consumed = after_lower.len() - rem.len();
         (

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -726,7 +726,14 @@ fn try_parse_when_next_event(tp: TextPair) -> Option<ParsedEffectClause> {
     // Article choice depends on the payload — "a creature spell" vs "an instant or sorcery spell".
     let article_result: nom::IResult<&str, &str, OracleError<'_>> =
         alt((tag("when you next cast a "), tag("when you next cast an "))).parse(tp.lower);
-    let (_, matched_prefix) = article_result.ok()?;
+    let Ok((_, matched_prefix)) = article_result else {
+        // CR 603.7: non-cast "when you next <event> this turn" one-shot delayed
+        // triggers (e.g. All-Out Assault "When you next attack this turn, ...").
+        // The spell-cast arm above owns the rich spell-filter / disjunction
+        // grammar; this generic fallback reuses the trigger-condition parser so
+        // the whole "when you next <condition>" class is covered, not one card.
+        return try_parse_when_next_generic_event(tp);
+    };
 
     // Must contain "this turn, " to delimit condition from effect
     let (before_this_turn, after) = tp.rsplit_around(" this turn, ")?;
@@ -767,6 +774,70 @@ fn try_parse_when_next_event(tp: TextPair) -> Option<ParsedEffectClause> {
     trigger_def.valid_card = Some(combined_filter);
     // "when YOU next cast" — scope to the source's controller.
     trigger_def.valid_target = Some(TargetFilter::Controller);
+
+    Some(ParsedEffectClause {
+        effect: Effect::CreateDelayedTrigger {
+            condition: DelayedTriggerCondition::WhenNextEvent {
+                trigger: Box::new(trigger_def),
+                or_trigger: None,
+            },
+            effect: Box::new(inner),
+            uses_tracked_set: false,
+        },
+        duration: None,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+/// CR 603.7: Parse a generic non-cast "when you next <condition> this turn,
+/// <effect>" one-shot delayed trigger. Delegates condition recognition to the
+/// shared trigger-condition parser (`parse_trigger_condition`) so the whole
+/// class is covered — "When you next attack this turn" (All-Out Assault),
+/// "When you next <other matchable event> this turn", etc. — rather than a
+/// single card.
+///
+/// The cast-spell variant (`try_parse_when_next_event`) keeps its dedicated
+/// spell-filter / disjunction grammar; this fallback runs only when the cast
+/// prefix did not match. Builds a `WhenNextEvent` delayed trigger (one-shot),
+/// mirroring `try_parse_whenever_this_turn`'s `WheneverEvent` (multi-fire)
+/// construction but with one-shot semantics.
+fn try_parse_when_next_generic_event(tp: TextPair) -> Option<ParsedEffectClause> {
+    // The condition is bounded by " this turn, " — the same delimiter the
+    // spell-cast arm uses. Everything between "when you next " and the
+    // delimiter is the matchable trigger condition.
+    let (before_this_turn, after) = tp.rsplit_around(" this turn, ")?;
+    // Consume the "when you next " prefix with the combinator; the remainder is
+    // the bare trigger condition (e.g. "attack").
+    let (condition_text, _) = tag::<_, _, OracleError<'_>>("when you next ")
+        .parse(before_this_turn.lower)
+        .ok()?;
+    if condition_text.is_empty() {
+        return None;
+    }
+
+    // Reuse the shared trigger-condition parser. Re-prefix "you " so the bare
+    // condition (e.g. "attack") matches the "you attack" production; the parser
+    // accepts an optional "whenever "/"when " prefix but expects the subject.
+    let mut inner_ctx = ParseContext::default();
+    let condition_for_parser = format!("you {condition_text}");
+    let (mode, mut trigger_def) = crate::parser::oracle_trigger::parse_trigger_condition(
+        &condition_for_parser,
+        &mut inner_ctx,
+    );
+    // Only accept conditions the trigger matcher registry actually supports as a
+    // delayed event; an unrecognized condition lowers to Unknown and must not
+    // silently produce a never-firing delayed trigger.
+    if matches!(mode, crate::types::triggers::TriggerMode::Unknown(_)) {
+        return None;
+    }
+    trigger_def.execute = None;
+
+    let inner = parse_effect_chain_with_context(after.original, AbilityKind::Spell, &mut inner_ctx);
 
     Some(ParsedEffectClause {
         effect: Effect::CreateDelayedTrigger {
@@ -10947,8 +11018,15 @@ fn parse_bare_damage_continuation<'a>(
                 },
                 consumed,
             )
-        } else if let Ok((rest, _)) =
-            tag::<_, _, OracleError<'_>>("that much damage").parse(lower.as_str())
+        } else if let Ok((rest, _)) = alt((
+            tag::<_, _, OracleError<'_>>("that much damage"),
+            // CR 120.1: "that amount of damage" is the synonym used when the
+            // antecedent is "N damage" (Fear of Burning Alive's "deals that
+            // amount of damage to target creature that player controls"). Both
+            // anaphors resolve to the just-dealt damage amount.
+            tag("that amount of damage"),
+        ))
+        .parse(lower.as_str())
         {
             let consumed = lower.len() - rest.len();
             (

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1179,6 +1179,11 @@ fn starts_prefix_clause(current_lower: &str) -> bool {
         tag("if not"),
         tag("the next time "),
         tag("at the beginning "),
+        // CR 511.2 + CR 603.7a: bare "at end of combat, …" delayed-trigger prefix
+        // — companion of the suffix form. Keep the deferred body attached so it
+        // reaches `strip_temporal_prefix` instead of splitting at the comma
+        // (Fortune, Loyal Steed: "at end of combat, exile it and …").
+        tag("at end of combat"),
         tag("for as long as "),
         // CR 508.6: "During any turn [you attacked with X], [effect]" — temporal
         // attack-history gate (Neyali, Neriv, Boros Strike-Captain). Keep the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -766,9 +766,21 @@ fn is_damage_done_trigger_pattern(cond_lower: &str) -> bool {
         return false;
     };
 
+    // CR 120.3a + CR 603.2c: A damage-to-player trigger establishes the damaged
+    // player as the relative `TriggeringPlayer` for "that player" anaphors.
+    // Both the generic player recipient ("a player") and the opponent recipient
+    // ("an opponent" → `Typed(controller: Opponent)`) are player recipients;
+    // Fear of Burning Alive ("deals noncombat damage to an opponent ... target
+    // creature that player controls") relies on the opponent form binding.
     matches!(
         parse_damage_to_qualifier(after_damage),
-        Some(TargetFilter::Player)
+        Some(
+            TargetFilter::Player
+                | TargetFilter::Typed(TypedFilter {
+                    controller: Some(ControllerRef::Opponent),
+                    ..
+                })
+        )
     )
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13369,6 +13369,11 @@ pub enum AbilityCondition {
     /// CR 500.8 + CR 506.1 + CR 608.2c: "if it's the first combat phase of the turn".
     /// Gates a follow-up effect on whether this is the first combat phase started this turn.
     FirstCombatPhaseOfTurn,
+    /// CR 500.8 + CR 513.1 + CR 608.2c: "if it's the first end step of the turn".
+    /// Gates a follow-up effect on whether this is the first end step started this
+    /// turn (Y'shtola Rhul's additional-end-step loop guard). End-step sibling of
+    /// `FirstCombatPhaseOfTurn`; both read a per-turn phase-occurrence counter.
+    FirstEndStepOfTurn,
     /// CR 608.2c: "If a [noun] was [verb]ed this way" — sub_ability executes only if
     /// the parent effect produced a zone change involving an object matching the filter.
     /// Evaluated by checking `state.last_zone_changed_ids` against the filter.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6083,6 +6083,12 @@ pub struct GameState {
     /// Used by intervening-if triggers that only fire during the first combat phase.
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub combat_phases_started_this_turn: u32,
+    /// CR 500.8 + CR 513.1: Number of end steps that have begun this turn.
+    /// Mirrors `combat_phases_started_this_turn` for the end-step axis; used by
+    /// conditions that gate a follow-up only during the first end step
+    /// (Y'shtola Rhul's "if it's the first end step of the turn" loop guard).
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub end_steps_started_this_turn: u32,
     /// CR 508.1a: Object IDs of creatures declared as attackers this turn.
     /// Persists after combat ends for post-combat filtering.
     #[serde(default)]
@@ -7165,6 +7171,7 @@ impl GameState {
             attacked_defenders_this_turn: HashMap::new(),
             creature_attacked_defenders_this_turn: HashMap::new(),
             combat_phases_started_this_turn: 0,
+            end_steps_started_this_turn: 0,
             creatures_attacked_this_turn: HashSet::new(),
             attacker_declarations_this_turn: Vec::new(),
             creatures_blocked_this_turn: HashSet::new(),
@@ -7621,6 +7628,7 @@ impl PartialEq for GameState {
             && self.creature_attacked_defenders_this_turn
                 == other.creature_attacked_defenders_this_turn
             && self.combat_phases_started_this_turn == other.combat_phases_started_this_turn
+            && self.end_steps_started_this_turn == other.end_steps_started_this_turn
             && self.creatures_attacked_this_turn == other.creatures_attacked_this_turn
             && self.attacker_declarations_this_turn == other.attacker_declarations_this_turn
             && self.creatures_blocked_this_turn == other.creatures_blocked_this_turn

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -438,6 +438,7 @@ mod springheart_nantuko_bestow_landfall;
 mod springheart_realdb_repro;
 mod squirrel_mob_dynamic_pump;
 mod std_counters_grammar_axes;
+mod std_longtail_b_delayed_effects;
 mod steadfast_armasaur_lki_toughness;
 mod steelform_sliver_toughness_anthem;
 mod stensian_sanguinist_prepare;

--- a/crates/engine/tests/integration/std_longtail_b_delayed_effects.rs
+++ b/crates/engine/tests/integration/std_longtail_b_delayed_effects.rs
@@ -1,0 +1,309 @@
+//! Standard long-tail batch B — delayed-trigger / timing / damage-anaphor
+//! parser arms, exercised through the production `apply()` pipeline.
+//!
+//! Each test drives the parsed ability/trigger through real game actions
+//! (activation, attack declaration, phase advance) and asserts an observable
+//! game-state change that FLIPS if the corresponding parser arm is reverted.
+//!
+//! Cards covered:
+//! - All-Out Assault — "When you next attack this turn, untap each creature you
+//!   control" delayed `WhenNextEvent{YouAttack}` one-shot trigger.
+//! - Fortune, Loyal Steed — "at end of combat" delayed-trigger prefix on an
+//!   attack trigger body (`AtNextPhase{EndCombat}`).
+//! - Fear of Burning Alive — "deals that amount of damage to target creature
+//!   that player controls" (EventContextAmount + TriggeringPlayer binding).
+//! - Y'shtola Rhul — additional end step gated by "first end step of the turn"
+//!   (`FirstEndStepOfTurn`) loop guard.
+
+use super::rules::{AttackTarget, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{DelayedTriggerCondition, Effect, QuantityRef, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+// ---------------------------------------------------------------------------
+// All-Out Assault — delayed "When you next attack this turn, untap each
+// creature you control".
+// ---------------------------------------------------------------------------
+
+/// CR 603.7: arming the one-shot "When you next attack this turn" delayed
+/// trigger and then declaring attackers untaps each creature the controller
+/// controls — including a tapped creature that is NOT attacking.
+///
+/// Revert assertion: without the `WhenNextEvent{YouAttack}` arm the clause
+/// parses to `Effect::Unimplemented`, so resolving the ability arms nothing,
+/// the attack fires no delayed trigger, and the tapped bystander stays tapped.
+/// The `assert!(!tapped)` flips on revert.
+#[test]
+fn all_out_assault_untaps_creatures_when_you_next_attack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // A {0} activated ability carrying the exact residual clause. Activating it
+    // arms the same `WhenNextEvent{YouAttack}` delayed trigger the All-Out
+    // Assault ETB produces (the parser builds the identical structure for both).
+    let source = scenario
+        .add_creature_from_oracle(
+            P0,
+            "All-Out Assault Source",
+            0,
+            1,
+            "{0}: When you next attack this turn, untap each creature you control.",
+        )
+        .id();
+
+    let attacker = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
+    // A second creature that will be tapped and is NOT attacking — the untap
+    // must reach it too.
+    let bystander = scenario.add_creature(P0, "Tapped Bystander", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&bystander)
+        .unwrap()
+        .tapped = true;
+
+    let ability_index = runner
+        .state()
+        .objects
+        .get(&source)
+        .expect("source exists")
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::CreateDelayedTrigger { .. }))
+        .expect("must parse a CreateDelayedTrigger activated ability");
+
+    runner.activate(source, ability_index).resolve();
+
+    // The armed delayed trigger must be a one-shot WhenNextEvent on YouAttack.
+    let armed = runner
+        .state()
+        .delayed_triggers
+        .iter()
+        .any(|dt| matches!(dt.condition, DelayedTriggerCondition::WhenNextEvent { .. }));
+    assert!(
+        armed,
+        "activating the ability must arm a WhenNextEvent delayed trigger; got {:?}",
+        runner.state().delayed_triggers
+    );
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+    runner.advance_until_stack_empty();
+
+    assert!(
+        !runner
+            .state()
+            .objects
+            .get(&bystander)
+            .expect("bystander exists")
+            .tapped,
+        "the 'when you next attack' delayed trigger must untap each creature you \
+         control, including the non-attacking tapped bystander"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fortune, Loyal Steed — "at end of combat" delayed-trigger prefix.
+// ---------------------------------------------------------------------------
+
+/// CR 511.2 + CR 603.7a: an attack trigger whose body begins "at end of combat,
+/// ..." schedules an `AtNextPhase{EndCombat}` delayed trigger instead of
+/// resolving immediately.
+///
+/// Revert assertion: without the "at end of combat, " prefix arm (in
+/// `strip_temporal_prefix` + the comma-split guard), the body parses with an
+/// `Effect::Unimplemented("at end of combat")` head and no delayed trigger is
+/// scheduled. `assert!(scheduled)` flips on revert.
+#[test]
+fn fortune_schedules_end_of_combat_delayed_trigger() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let fortune = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Fortune, Loyal Steed",
+            2,
+            3,
+            "Whenever Fortune attacks, at end of combat, exile it, then return it to \
+             the battlefield under its owner's control.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(fortune, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("DeclareAttackers should succeed");
+    runner.advance_until_stack_empty();
+
+    let scheduled = runner.state().delayed_triggers.iter().any(|dt| {
+        matches!(
+            dt.condition,
+            DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::EndCombat
+            }
+        )
+    });
+    assert!(
+        scheduled,
+        "Fortune's attack must schedule an AtNextPhase{{EndCombat}} delayed trigger; \
+         got {:?}",
+        runner.state().delayed_triggers
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fear of Burning Alive — "deals that amount of damage to target creature that
+// player controls".
+// ---------------------------------------------------------------------------
+
+/// CR 120.1: the Delirium trigger body parses "that amount of damage" as the
+/// just-dealt damage amount (`EventContextAmount`) and binds "target creature
+/// that player controls" to the damaged opponent (`TriggeringPlayer`).
+///
+/// This is a parse-shape assertion that two independent things hold together:
+/// (1) the damage amount is `EventContextAmount` (the "that amount of damage"
+/// arm), and (2) the target controller is `TriggeringPlayer` (the opponent
+/// recipient widening of `is_damage_done_trigger_pattern`). Reverting either arm
+/// changes one of these — without arm (1) the whole body is `Unimplemented`;
+/// without arm (2) the controller is `You`. The runtime semantics (deal damage
+/// equal to the noncombat damage to a creature the damaged opponent controls)
+/// have no shipped honest-fallback, so this shape assertion documents the
+/// supported lowering; the runtime DealDamage path itself is long-established.
+#[test]
+fn fear_of_burning_alive_amount_and_triggering_player_binding() {
+    let parsed = parse_oracle_text(
+        "When this creature enters, it deals 4 damage to each opponent.\nDelirium — \
+         Whenever a source you control deals noncombat damage to an opponent, if there \
+         are four or more card types among cards in your graveyard, this creature deals \
+         that amount of damage to target creature that player controls.",
+        "Fear of Burning Alive",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+
+    let delirium = parsed
+        .triggers
+        .iter()
+        .find_map(|t| {
+            let exec = t.execute.as_deref()?;
+            match exec.effect.as_ref() {
+                Effect::DealDamage { amount, target, .. } => Some((amount.clone(), target.clone())),
+                _ => None,
+            }
+        })
+        .expect("Delirium trigger must lower to a DealDamage effect, not Unimplemented");
+
+    let (amount, target) = delirium;
+    assert!(
+        matches!(
+            amount,
+            engine::types::ability::QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            }
+        ),
+        "amount must be the just-dealt damage (EventContextAmount), got {amount:?}"
+    );
+    assert!(
+        matches!(
+            target,
+            TargetFilter::Typed(ref tf)
+                if tf.controller == Some(engine::types::ability::ControllerRef::TriggeringPlayer)
+        ),
+        "target must bind 'that player controls' to the damaged opponent \
+         (TriggeringPlayer), got {target:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Y'shtola Rhul — additional end step gated by "first end step of the turn".
+// ---------------------------------------------------------------------------
+
+/// CR 500.8 + CR 513.1: the end-step trigger schedules an additional end step
+/// ONLY during the first end step of the turn. The `FirstEndStepOfTurn` gate
+/// reads `state.end_steps_started_this_turn`; on the second (extra) end step the
+/// gate is false, so no further end step is scheduled — the turn does not loop.
+///
+/// Revert assertion: without the end-step counter + `FirstEndStepOfTurn`
+/// condition, the gate is dropped, the additional end step is scheduled on every
+/// end step, and the loop never terminates (the bounded action loop below would
+/// exhaust its iteration guard). The guarded termination is the discriminator.
+#[test]
+fn yshtola_schedules_exactly_one_extra_end_step() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Y'shtola's end-step trigger. A creature to exile/return so the trigger has
+    // a legal target. The additional-end-step clause is gated by "first end step
+    // of the turn".
+    scenario.add_creature_from_oracle(
+        P0,
+        "Y'shtola Rhul",
+        2,
+        3,
+        "At the beginning of your end step, exile target creature you control, then \
+         return it to the battlefield under its owner's control. Then if it's the \
+         first end step of the turn, there is an additional end step after this step.",
+    );
+
+    let mut runner = scenario.build();
+
+    // Advance P0's turn to (and through) its end step(s). With the loop guard the
+    // turn rolls over to P1; without it, P0's end step recurs forever and the
+    // bounded loop trips its own assertion. Track the peak per-turn end-step
+    // counter while on P0's turn (it resets at the start of P1's turn). The two
+    // end steps occur back-to-back with no intervening non-End phase, so the
+    // counter — not a phase-edge detector — is the reliable observation.
+    let mut peak_p0_end_steps = 0u32;
+    for _ in 0..600 {
+        let state = runner.state();
+        if state.active_player == P0 {
+            peak_p0_end_steps = peak_p0_end_steps.max(state.end_steps_started_this_turn);
+        }
+        // Stop once we have safely reached P1's turn — proves the loop terminated.
+        if state.active_player == P1 {
+            break;
+        }
+        let acted = match &state.waiting_for {
+            WaitingFor::Priority { .. } => runner.act(GameAction::PassPriority),
+            WaitingFor::DeclareAttackers { .. } => runner.act(GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            }),
+            WaitingFor::DeclareBlockers { .. } => runner.act(GameAction::DeclareBlockers {
+                assignments: vec![],
+            }),
+            other => panic!("unexpected wait state during turn advance: {other:?}"),
+        };
+        acted.expect("action during turn advance should succeed");
+    }
+
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "the turn must roll over to P1 — the additional end step must NOT loop"
+    );
+    // CR 500.8: the first end step schedules exactly one extra; the extra end
+    // step's gate (FirstEndStepOfTurn, false on the second) schedules no further
+    // step, so P0 reaches exactly two end steps this turn.
+    assert_eq!(
+        peak_p0_end_steps, 2,
+        "Y'shtola must add exactly one additional end step (two total), not zero \
+         and not an unbounded number"
+    );
+}

--- a/crates/engine/tests/std_longtail_b_parse.rs
+++ b/crates/engine/tests/std_longtail_b_parse.rs
@@ -1,0 +1,98 @@
+//! Standard long-tail batch B — per-card 0-`Unimplemented` parse gate for the
+//! shipped cards. Each shipped card's full Oracle text must parse with zero
+//! residual `Effect::Unimplemented` nodes; reverting the corresponding parser
+//! arm reintroduces an `Unimplemented` node and flips the assertion.
+//!
+//! Deferred cards (Heirloom Epic, Lightstall Inquisitor, Steamcore Scholar,
+//! Stolen Uniform, Combustion Man) intentionally retain an honest
+//! `Effect::Unimplemented` residual and are NOT asserted 0-unimpl here.
+
+use engine::parser::oracle::parse_oracle_text;
+
+fn assert_zero_unimplemented(
+    oracle: &str,
+    name: &str,
+    keywords: &[&str],
+    types: &[&str],
+    subtypes: &[&str],
+) {
+    let kw: Vec<String> = keywords.iter().map(|s| s.to_string()).collect();
+    let t: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    let s: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
+    let parsed = parse_oracle_text(oracle, name, &kw, &t, &s);
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+#[test]
+fn all_out_assault_zero_unimplemented() {
+    assert_zero_unimplemented(
+        "Creatures you control get +1/+1 and have deathtouch.\nWhen this enchantment \
+         enters, if it's your main phase, there is an additional combat phase after this \
+         phase followed by an additional main phase. When you next attack this turn, untap \
+         each creature you control.",
+        "All-Out Assault",
+        &[],
+        &["Enchantment"],
+        &[],
+    );
+}
+
+#[test]
+fn fear_of_burning_alive_zero_unimplemented() {
+    assert_zero_unimplemented(
+        "When this creature enters, it deals 4 damage to each opponent.\nDelirium — \
+         Whenever a source you control deals noncombat damage to an opponent, if there are \
+         four or more card types among cards in your graveyard, this creature deals that \
+         amount of damage to target creature that player controls.",
+        "Fear of Burning Alive",
+        &[],
+        &["Creature"],
+        &[],
+    );
+}
+
+#[test]
+fn fortune_loyal_steed_zero_unimplemented() {
+    assert_zero_unimplemented(
+        "When Fortune enters, scry 2.\nWhenever Fortune attacks while saddled, at end of \
+         combat, exile it and up to one creature that saddled it this turn, then return \
+         those cards to the battlefield under their owner's control.\nSaddle 1",
+        "Fortune, Loyal Steed",
+        &[],
+        &["Creature"],
+        &["Horse"],
+    );
+}
+
+#[test]
+fn mutable_explorer_zero_unimplemented() {
+    // Changeling is supplied as an MTGJSON keyword in production; with it, the
+    // whole card (including "create a tapped Mutavault token") parses clean.
+    assert_zero_unimplemented(
+        "Changeling (This card is every creature type.)\nWhen this creature enters, create \
+         a tapped Mutavault token. (It's a land with \"{T}: Add {C}\" and \"{1}: This token \
+         becomes a 2/2 creature with all creature types until end of turn. It's still a \
+         land.\")",
+        "Mutable Explorer",
+        &["Changeling"],
+        &["Creature"],
+        &[],
+    );
+}
+
+#[test]
+fn yshtola_rhul_zero_unimplemented() {
+    assert_zero_unimplemented(
+        "At the beginning of your end step, exile target creature you control, then return \
+         it to the battlefield under its owner's control. Then if it's the first end step of \
+         the turn, there is an additional end step after this step.",
+        "Y'shtola Rhul",
+        &[],
+        &["Creature"],
+        &[],
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## std long-tail batch B — delayed-trigger / timing / damage-anaphor parser arms

Branch: `card/std-longtail-b` (off upstream/main `5a77aaaee`)
Commit: `21cd77a4f`

Clears ten Standard long-tail one-offs: **five shipped** (parse 0-`Unimplemented`
+ discriminating `apply()` tests) by extending existing engine surface, **five
honest-deferred** (residual stays `Effect::Unimplemented`) because each needs
infrastructure beyond a parser arm.

### Summary of engine-surface changes

All shipped cards route through existing primitives; the only new engine surface
is one `AbilityCondition` variant + one per-turn counter (Y'shtola loop guard):

- **All-Out Assault** — generic `WhenNextEvent` one-shot delayed trigger for
  "when you next `<event>` this turn" (not just "when you next cast"). New
  `try_parse_when_next_generic_event` delegates to the shared
  `parse_trigger_condition`, so the whole class is covered. `YouAttack` mode is
  already in the delayed-trigger matcher registry.
- **Fortune, Loyal Steed** — bare `"at end of combat, <effect>"` delayed-trigger
  prefix → `AtNextPhase{EndCombat}` (companion of the existing suffix arm in
  `strip_temporal_suffix`); added to `strip_temporal_prefix` and to the
  comma-split guard (`starts_prefix_clause`) so the deferred body stays attached.
- **Fear of Burning Alive** — `"that amount of damage"` anaphor → `EventContextAmount`
  (synonym of `"that much damage"`), and widened `is_damage_done_trigger_pattern`
  so a `"deals damage to an opponent"` recipient (not only `"a player"`)
  establishes `TriggeringPlayer` scope — binding `"target creature that player
  controls"` to the damaged opponent, not the controller.
- **Y'shtola Rhul** — `"there is an additional end step"` → `AdditionalPhase{End}`,
  gated by a **new `AbilityCondition::FirstEndStepOfTurn`** backed by a new
  `GameState::end_steps_started_this_turn` counter (mirrors
  `combat_phases_started_this_turn`). This gate is the loop guard: without it the
  extra end step would re-trigger Y'shtola and recur forever.
- **Mutable Explorer** — already covered upstream (Changeling keyword + tapped
  Mutavault token); **no code change**.

### add-engine-variant verdict

One new variant: `AbilityCondition::FirstEndStepOfTurn` (+ the
`end_steps_started_this_turn` counter). This is the **end-step sibling of the
existing `FirstCombatPhaseOfTurn`** — both are "first `<phase/step>` of turn"
occurrence-count gates under CR 500.8. Adding it (rather than honest-deferring
Y'shtola) is required for **rules correctness**: the parser arm alone would
silently drop the loop-prevention gate and ship an infinite-end-step card.

There are now exactly two siblings on this axis (`FirstCombatPhaseOfTurn`,
`FirstEndStepOfTurn`); the sibling-cluster smell triggers at 3+. **Future
parameterization note:** if a third member appears (e.g. "first main phase of
the turn"), refactor to a parameterized `NthPhaseOfTurn { phase, n }` reading the
per-turn occurrence counter — this would also fold in the `TriggerCondition`
counterpart. `data/engine-inventory.json` is **unchanged** (not regenerated in
the worktree).

### Grep-verified CR annotations (vs `docs/MagicCompRules.txt`)

| CR | Used for |
|----|----------|
| 120.1 | "that amount of damage" anaphor (damage dealing) |
| 120.3a | damage to a player establishes the damaged player |
| 500.8 | extra phases/steps; per-turn occurrence counting |
| 511.2 | "at end of combat" triggers at the end-of-combat step |
| 513.1 | end step; additional end step |
| 603.2c | trigger-once-per-event (damage trigger scope) |
| 603.7 / 603.7a | delayed triggered abilities |
| 608.2c | follow-up effect ordering / instructions |

CR-annotation diff gate: **zero `UNVERIFIED`**.

### Per-card verdict (all 10)

| Card | Verdict | Residual / reason |
|------|---------|-------------------|
| all-out assault | SHIPPED | `WhenNextEvent{YouAttack}` untap delayed trigger |
| fear of burning alive | SHIPPED | `EventContextAmount` + `TriggeringPlayer` target binding |
| fortune, loyal steed | SHIPPED | `AtNextPhase{EndCombat}` deferred exile/return |
| mutable explorer | SHIPPED (already upstream) | no change; Changeling + tapped Mutavault token already parse |
| y'shtola rhul | SHIPPED | `AdditionalPhase{End}` gated by new `FirstEndStepOfTurn` |
| heirloom epic | DEFER | convoke-style "tap a creature rather than pay that mana" cost substitution on an activated cost — no engine surface |
| lightstall inquisitor | DEFER | "lands played this way enter tapped" — needs a `CastFromZone` field + land-play runtime |
| steamcore scholar | DEFER | "discard two unless you discard an instant/sorcery OR a creature with flying" — disjunctive discard-unless filter; trigger-level guard also blocks |
| stolen uniform | DEFER | "when you lose control of that Equipment ... unattach it" — needs a lose-control delayed-trigger condition + targeted `Unattach` effect |
| combustion man | DEFER | "unless its controller has ~ deal damage to them equal to his power" — take-damage unless-cost variant, no `AbilityCost` analog |

### Discriminating-test map

All tests drive the production pipeline; each named assertion flips on revert of
the corresponding arm.

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion |
|---|---|---|---|---|
| "when you next attack" untaps your creatures | `try_parse_when_next_generic_event` → `WhenNextEvent{YouAttack}` | `activate().resolve()` arms, `DeclareAttackers` fires | `integration::std_longtail_b_delayed_effects::all_out_assault_untaps_creatures_when_you_next_attack` | tapped non-attacking bystander is untapped after attack (`!tapped`) |
| "at end of combat" defers the body | `strip_temporal_prefix` + `starts_prefix_clause` `"at end of combat"` | `DeclareAttackers` on Fortune → attack trigger resolves | `…::fortune_schedules_end_of_combat_delayed_trigger` | an `AtNextPhase{EndCombat}` delayed trigger is scheduled |
| "that amount of damage" + damaged-opponent target | `try_parse_damage_with_remainder` + `is_damage_done_trigger_pattern` | `parse_oracle_text` lowering of the Delirium trigger body | `…::fear_of_burning_alive_amount_and_triggering_player_binding` | amount is `EventContextAmount` AND target controller is `TriggeringPlayer` (both flip on revert; sans amount arm the body is `Unimplemented`) |
| additional end step fires once, no loop | `AdditionalPhase{End}` + `FirstEndStepOfTurn` + `end_steps_started_this_turn` | turn advance through P0's end step(s) via `apply()` | `…::yshtola_schedules_exactly_one_extra_end_step` | turn rolls to P1 AND `end_steps_started_this_turn` peaks at exactly 2 (zero → no extra; unbounded → loop guard trips) |
| per-card 0-unimpl gate | full-card parse | `parse_oracle_text` | `std_longtail_b_parse::{all_out_assault,fear_of_burning_alive,fortune_loyal_steed,mutable_explorer,yshtola_rhul}_zero_unimplemented` | any reverted arm reintroduces an `Unimplemented` node |

Notes on the Fear test: it is a parse-shape assertion (the runtime `DealDamage`
path is long-established; the new arms are purely the amount anaphor and the
target-controller binding, both asserted). The other three shipped cards have
full runtime `apply()` discrimination.

### Gates

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- Inline parser diff gate (string-dispatch on added parser lines) — clean
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine` — lib 12999 passed (only the known parallel-flaky
  `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`
  fails under parallelism; passes single-threaded); integration 1419 passed;
  new parse-gate binary 5 passed
- `data/engine-inventory.json` — unchanged
- CR-annotation diff gate — zero `UNVERIFIED`
- `cargo coverage` / `cargo semantic-audit` — not runnable in the worktree
  (require generated `card-data.json`, which is intentionally not built in
  worktrees); substituted by per-card 0-unimpl parse tests + discriminating
  `apply()` tests.
