### PR TITLE
feat(parser): anthem filters — attack-defender + chosen-type grant (Oviya, Selfless Safewright)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -7981,4 +7981,77 @@ mod tests {
             "placing a creature already attacking must mark layers dirty"
         );
     }
+
+    /// CR 508.1b + CR 702.19a (Oviya, Automech Artisan): the static
+    /// "Each creature that's attacking one of your opponents has trample" must
+    /// parse to a `Continuous` static whose affected filter carries
+    /// `Attacking { defender: Some(Opponent) }` and grant Trample only to
+    /// creatures attacking the controller's opponent — not to a creature that
+    /// isn't attacking. Drives the REAL static parser (`parse_static_line`) →
+    /// `evaluate_layers`.
+    ///
+    /// REVERT-PROOF: reverting the `parse_attacking_defender_suffix` "that's
+    /// attacking one of your opponents" extension leaves the static line at
+    /// `Effect::Unimplemented` (no `StaticDefinition` produced), so
+    /// `parse_static_line` returns `None`, the `.expect` below panics, and the
+    /// grant never reaches the attacker.
+    #[test]
+    fn oviya_grants_trample_only_to_creatures_attacking_an_opponent() {
+        use crate::game::layers::evaluate_layers;
+        use crate::types::keywords::Keyword;
+
+        let mut state = setup();
+
+        // Oviya on the battlefield, controlled by PlayerId(0). Static parsed
+        // from its printed Oracle text.
+        let oviya = create_creature(&mut state, PlayerId(0), "Oviya, Automech Artisan", 2, 2);
+        let def =
+            parse_static_line("Each creature that's attacking one of your opponents has trample.")
+                .expect("Oviya static line must parse to a StaticDefinition");
+        assert_eq!(def.mode, StaticMode::Continuous);
+        assert_eq!(
+            def.affected,
+            Some(TargetFilter::Typed(TypedFilter::creature().properties(
+                vec![FilterProp::Attacking {
+                    defender: Some(ControllerRef::Opponent),
+                }]
+            ))),
+            "affected filter must scope to creatures attacking an opponent"
+        );
+        state
+            .objects
+            .get_mut(&oviya)
+            .unwrap()
+            .static_definitions
+            .push(def);
+
+        // An attacker controlled by PlayerId(0) attacking the opponent.
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        // A second creature that is NOT attacking — the negative control.
+        let idle = create_creature(&mut state, PlayerId(0), "Wall", 0, 4);
+
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state
+                .objects
+                .get(&attacker)
+                .unwrap()
+                .has_keyword(&Keyword::Trample),
+            "a creature attacking the controller's opponent must gain trample"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&idle)
+                .unwrap()
+                .has_keyword(&Keyword::Trample),
+            "a creature that isn't attacking must NOT gain trample"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -2776,4 +2776,141 @@ mod tests {
             "no keyword present on any creature → zero TCEs registered"
         );
     }
+
+    /// CR 205.3m + CR 702.11a + CR 702.12a (Selfless Safewright): the grant
+    /// "Other permanents you control of that type gain hexproof and
+    /// indestructible until end of turn" — parsed from real Oracle text — must
+    /// route "of that type" to `FilterProp::IsChosenCreatureType`, bind only to
+    /// your other permanents whose subtypes include the source's chosen creature
+    /// type, and grant both keywords through `evaluate_layers`.
+    ///
+    /// REVERT-PROOF: reverting the "of that type" suffix arm in
+    /// `oracle_target.rs` leaves the grant clause `Effect::Unimplemented` (the
+    /// `match` below panics — no `GenericEffect`), and even reaching resolution,
+    /// the non-matching Goblin and the source itself must NOT gain the keywords.
+    #[test]
+    fn selfless_safewright_grants_to_chosen_type_permanents_only() {
+        use crate::game::layers::evaluate_layers;
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Source permanent that "chose Elf".
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Selfless Safewright".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Elf".to_string());
+            obj.chosen_attributes
+                .push(ChosenAttribute::CreatureType("Elf".to_string()));
+        }
+
+        // Another Elf you control — must be granted.
+        let elf = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Llanowar Elves".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&elf).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Elf".to_string());
+        }
+
+        // A Goblin you control — wrong type, must NOT be granted.
+        let goblin = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Goblin".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&goblin).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Goblin".to_string());
+        }
+
+        // An opponent's Elf — wrong controller, must NOT be granted.
+        let opp_elf = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Enemy Elf".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&opp_elf).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Elf".to_string());
+        }
+
+        // Parse the grant clause through the REAL effect parser.
+        let mut effect = crate::parser::oracle_effect::parse_effect(
+            "Other permanents you control of that type gain hexproof and indestructible until end of turn",
+        );
+        match &mut effect {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => {
+                let modifications = &static_abilities
+                    .first()
+                    .expect("grant must produce a static")
+                    .modifications;
+                assert!(
+                    modifications.contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::Hexproof
+                    }) && modifications.contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::Indestructible
+                    }),
+                    "grant must add hexproof and indestructible, got {modifications:?}"
+                );
+            }
+            other => panic!("expected GenericEffect from grant parser, got {other:?}"),
+        }
+
+        let ability = ResolvedAbility::new(effect, vec![], source, PlayerId(0))
+            .duration(Duration::UntilEndOfTurn);
+        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+        evaluate_layers(&mut state);
+
+        let elf_obj = state.objects.get(&elf).unwrap();
+        assert!(
+            elf_obj.has_keyword(&Keyword::Hexproof)
+                && elf_obj.has_keyword(&Keyword::Indestructible),
+            "another Elf you control must gain both keywords"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&source)
+                .unwrap()
+                .has_keyword(&Keyword::Hexproof),
+            "the source must be excluded by the 'other' (Another) constraint"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&goblin)
+                .unwrap()
+                .has_keyword(&Keyword::Hexproof),
+            "a Goblin must NOT gain the keywords (wrong chosen type)"
+        );
+        assert!(
+            !state
+                .objects
+                .get(&opp_elf)
+                .unwrap()
+                .has_keyword(&Keyword::Hexproof),
+            "an opponent's Elf must NOT gain the keywords (wrong controller)"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2208,12 +2208,22 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     }
 
-    // Check "of the chosen type" suffix (Cavern of Souls, Metallic Mimic, etc.)
+    // Check "of the chosen type" / "of that type" suffix (Cavern of Souls,
+    // Metallic Mimic; Selfless Safewright). CR 205.3m + CR 608.2c: "of that
+    // type" is the anaphor form of "of the chosen type" — same typed reference,
+    // same runtime resolution against the source's chosen creature type — so
+    // both surface forms route to one suffix arm. Mirrors the dual recognition
+    // in `parse_chosen_qualifier_subject` (oracle_static/keyword_grant.rs).
     let remaining = lower[pos..].trim_start();
     let remaining_offset = lower[pos..].len() - remaining.len();
-    if tag::<_, _, OracleError<'_>>("of the chosen type")
-        .parse(remaining)
-        .is_ok()
+    if let Ok((_, of_chosen_len)) = alt((
+        value(
+            "of the chosen type".len(),
+            tag::<_, _, OracleError<'_>>("of the chosen type"),
+        ),
+        value("of that type".len(), tag("of that type")),
+    ))
+    .parse(remaining)
     {
         // CR 205.2a: Disambiguate which "chosen type" axis this refers to by the
         // base type, mirroring the static cost-mod path in
@@ -2245,7 +2255,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
             FilterProp::IsChosenCreatureType
         };
         properties.push(chosen_prop);
-        pos += remaining_offset + "of the chosen type".len();
+        pos += remaining_offset + of_chosen_len;
     }
 
     let mut exclude_chosen_type = false;
@@ -3410,8 +3420,23 @@ pub(crate) fn parse_combat_status_prefix(text: &str) -> Option<(FilterProp, usiz
 /// CR 508.1b: Postnominal "attacking you" / "attacking your opponents" on a
 /// typed phrase ("target creature attacking you"). The prefix form emits
 /// `Attacking { defender: None }`; this suffix scopes the defending player.
+///
+/// An optional "that's "/"that is "/"that are " relative-clause intro before
+/// "attacking" is consumed first (CR 608.2c). "Each creature that's attacking
+/// one of your opponents" (Oviya) is the relative-clause form of the bare
+/// postnominal "creature attacking your opponents"; both resolve to the same
+/// `Attacking { defender }` property, so the intro is stripped here rather than
+/// forking a second attacking grammar in the `that's`-clause path.
 fn parse_attacking_defender_suffix(text: &str) -> Option<(FilterProp, usize)> {
-    let trimmed = text.trim_start();
+    let trimmed_outer = text.trim_start();
+    let trimmed = opt(alt((
+        tag::<_, _, OracleError<'_>>("that's "),
+        tag("that is "),
+        tag("that are "),
+    )))
+    .parse(trimmed_outer)
+    .map(|(rest, _)| rest)
+    .unwrap_or(trimmed_outer);
     for (pattern, defender) in [
         (
             "attacking you or a planeswalker you control",
@@ -3427,6 +3452,13 @@ fn parse_attacking_defender_suffix(text: &str) -> Option<(FilterProp, usize)> {
             ControllerRef::Opponent,
         ),
         ("attacking your opponents", ControllerRef::Opponent),
+        // CR 508.1b: "attacking one of your opponents" — in a multiplayer
+        // attack-multiple-players game each attacker is assigned one defending
+        // player; "one of your opponents" scopes the defender to any of the
+        // controller's opponents (Oviya, Automech Artisan). Same defender scope
+        // as the plural "your opponents" form; the singular phrasing only
+        // changes the surface text, not the `ControllerRef::Opponent` mapping.
+        ("attacking one of your opponents", ControllerRef::Opponent),
     ] {
         if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(pattern).parse(trimmed) {
             let rest_trim = rest.trim_start();
@@ -13214,5 +13246,45 @@ mod tests {
         assert!(parse_counters_put_this_turn_clause("attacked this turn").is_none());
         // Missing the "on this turn" terminator → not this clause.
         assert!(parse_counters_put_this_turn_clause("you've put a +1/+1 counter on it").is_none());
+    }
+
+    /// CR 508.1b (Oviya, Automech Artisan): the relative-clause attacking suffix
+    /// "that's attacking one of your opponents" must fully consume and emit
+    /// `Attacking { defender: Some(Opponent) }`.
+    #[test]
+    fn that_s_attacking_one_of_your_opponents_suffix() {
+        let (filter, rest) = parse_target("each creature that's attacking one of your opponents");
+        assert!(
+            rest.trim().is_empty(),
+            "suffix must be fully consumed: {rest:?}"
+        );
+        let tf = typed_leg(&filter).expect("typed filter");
+        assert!(
+            tf.properties.contains(&FilterProp::Attacking {
+                defender: Some(ControllerRef::Opponent),
+            }),
+            "must carry Attacking{{defender: Opponent}}, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// CR 205.3m + CR 608.2c (Selfless Safewright): the anaphor suffix "of that
+    /// type" must be recognized identically to "of the chosen type" and emit
+    /// `IsChosenCreatureType` for a non-card-typed base.
+    #[test]
+    fn of_that_type_anaphor_suffix_equals_of_the_chosen_type() {
+        let (filter, rest) = parse_target("other permanents you control of that type");
+        assert!(
+            rest.trim().is_empty(),
+            "suffix must be fully consumed: {rest:?}"
+        );
+        let tf = typed_leg(&filter).expect("typed filter");
+        assert!(
+            tf.properties.contains(&FilterProp::IsChosenCreatureType),
+            "must carry IsChosenCreatureType, got {:?}",
+            tf.properties
+        );
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(tf.properties.contains(&FilterProp::Another));
     }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## std LONG-TAIL mini-batches: LT-A (anthem / keyword-grant static) + LT-B (for-each aggregate)

Branch: `card/std-lt-anthem-foreach` (off latest `upstream/main` @ `030d478fe`)

Two LONG-TAIL mini-batches dispatched together. Outcome: **2 cards shipped (Oviya, Selfless Safewright), 1 confirmed already-covered upstream (Roar of the Fifth People), 5 honest-deferred** (Quick Draw + all 4 LT-B) because they need engine infra well beyond "extend the anthem grammar with a filter."

The two shipped cards are **pure parser extensions** of `parse_target`'s suffix grammar, both routing to **existing** engine filter properties (`FilterProp::Attacking { defender }`, `FilterProp::IsChosenCreatureType`). No new effect/static/enum variants; `data/engine-inventory.json` is unchanged.

### add-engine-variant verdict: NOT NEEDED

No variant proposed. Both fixes reuse pre-existing, already-runtime-wired filter properties:
- `FilterProp::Attacking { defender: Option<ControllerRef> }` (ability.rs:2329) — runtime eval at filter.rs:3000 via `attacking_defender_matches` (resolves `Opponent` relative to the static's controller).
- `FilterProp::IsChosenCreatureType` (ability.rs:2556) — runtime eval at filter.rs:3430/3864 reading `source.chosen_creature_type`.

The new surface is purely the surface-text recognizers that route to these existing props — exactly the "build the class, not the card" parameterization the codebase wants (the "of that type" anaphor and the "one of your opponents" / "that's attacking" forms now compose for every card in those classes, not just these two).

### What changed

`crates/engine/src/parser/oracle_target.rs`:
1. The "of the chosen type" suffix recognizer now also accepts the **anaphor** form "of that type" (CR 205.3m + CR 608.2c) via an `alt()` of two tags, tracking the consumed length per arm. Same typed reference, same runtime resolution — mirrors the dual recognition already in `parse_chosen_qualifier_subject` (oracle_static/keyword_grant.rs).
2. `parse_attacking_defender_suffix` now (a) strips an optional `"that's "`/`"that is "`/`"that are "` relative-clause intro before "attacking" (CR 608.2c), and (b) recognizes `"attacking one of your opponents"` (CR 508.1b) -> `Attacking { defender: Opponent }`, the same defender scope as the plural "your opponents" form.

`crates/engine/src/game/combat.rs`, `crates/engine/src/game/effects/effect.rs`: discriminating runtime tests (below).

### Per-card verdict (all 8)

| # | Card | Mini-batch | Verdict | Reason / residual |
|---|------|-----------|---------|-------------------|
| 1 | Oviya, Automech Artisan | LT-A | **SHIPPED** | "Each creature that's attacking one of your opponents has trample" -> static, `Attacking{defender:Opponent}` + `AddKeyword(Trample)`. 0 Unimplemented. |
| 2 | Selfless Safewright | LT-A | **SHIPPED** | "Other permanents you control of that type gain hexproof and indestructible" -> GenericEffect on `Permanent`/`You`/`[IsChosenCreatureType, Another]` until EOT. 0 Unimplemented. |
| 3 | Roar of the Fifth People | LT-A | **ALREADY COVERED** | Saga chapter II "Creatures you control have '{T}: Add {R},{G}, or {W}.'" already parses to a granted activated mana ability upstream (0 Unimplemented at `030d478fe`). No change in this PR. |
| 4 | Quick Draw | LT-A | **DEFERRED** | "Creatures target opponent controls lose first strike and double strike" — a one-shot **player-targeted** spell needing an opponent-constrained companion `TargetFilter::Player` slot (the companion slot is hardcoded all-players in `companion_target_player_legal_targets`, ability_utils.rs). Constraining it to opponents touches target-slot generation + AI legal-action enumeration. Not an anthem grammar extension. Stays `Effect::unimplemented`. |
| 5 | Portent of Calamity | LT-B | **DEFERRED** | "For each card type, you may exile a card of that type from among them" — per-member iterated choice with per-iteration filter binding (card-type partition). No iteration effect primitive exists. |
| 6 | Sanar, Innovative First-Year | LT-B | **DEFERRED** | "For each of those colors, you may exile a card of that color" — same per-member iterated choice (color partition, anaphoric "those colors"). |
| 7 | Starving Revenant | LT-B | **DEFERRED** | "for each card you put on top of your library, you draw a card and you lose 3 life" — needs a new per-resolution/per-turn "cards put on top" tracked quantity (no `CardsPutOnTopThisTurn` QuantityRef). |
| 8 | Twisted Sewer-Witch | LT-B | **DEFERRED** | "for each Rat you control, create a Wicked Role token attached to that Rat" — per-member iterated token-create with the iterated object ("that Rat") as attach context. Same missing iteration primitive. |

LT-B note: all four LT-B cards need either (a) a per-member iterated-choice subsystem with per-iteration context binding, or (b) a new per-turn tracking quantity. This is precisely the deferred class flagged in PLAN.md (cluster 7 / the #3898 per-player-iterated-OBJECT deferral). The existing `parse_for_each_clause` models for-each only as a scalar `QuantityExpr` count, which none of these four fit. Honest-deferred per the "ship bounded" mandate.

### Grep-verified CR annotations (all added/changed)

Verified against `docs/MagicCompRules.txt`; diff gate: **0 UNVERIFIED**.

| CR | Describes | Used for |
|----|-----------|----------|
| CR 205.3m | creature types (subtype list) | "of that type" -> IsChosenCreatureType |
| CR 508.1b | attacking, defending player announced | "attacking one of your opponents" -> defender:Opponent |
| CR 608.2c | apply the rules of English (anaphora) | "of that type" anaphor; "that's attacking" relative clause |
| CR 702.11a | hexproof is a static ability | Selfless Safewright grant |
| CR 702.12a | indestructible is a static ability | Selfless Safewright grant |
| CR 702.19a | trample is a static ability | Oviya grant |

`git diff | grep -oE 'CR [0-9]{3}(\.[0-9]+[a-z]?)?'` -> all six grep-confirmed present and rule text matches the annotated code.

### Discriminating-test map

| Behavioral claim | Changed seam | Production entry point | Test | Revert-failing assertion | Negative cases |
|---|---|---|---|---|---|
| Oviya grants trample to creatures attacking an opponent | `parse_attacking_defender_suffix` ("that's attacking one of your opponents") | `parse_static_line` -> static_definitions -> `evaluate_layers` | `combat::tests::oviya_grants_trample_only_to_creatures_attacking_an_opponent` | `.expect("Oviya static line must parse")` panics on revert (line -> Unimplemented -> `parse_static_line` None); attacker lacks Trample | non-attacking creature does NOT gain trample |
| Selfless Safewright grants hexproof+indestructible to your other permanents of the chosen type | "of that type" suffix arm in `parse_target` | `parse_effect` -> GenericEffect -> `resolve` -> `evaluate_layers` | `effects::effect::tests::selfless_safewright_grants_to_chosen_type_permanents_only` | `match ... GenericEffect` panics on revert (clause -> Unimplemented); matching Elf gains both keywords | source excluded (Another); Goblin excluded (wrong type); opponent's Elf excluded (wrong controller) |

Both reverts were exercised and confirmed to flip the corresponding assertion (each fix temporarily reverted -> test FAILED -> restored -> test ok). Parser-shape anchors (`that_s_attacking_one_of_your_opponents_suffix`, `of_that_type_anaphor_suffix_equals_of_the_chosen_type`) supplement but do not carry the discrimination weight.

### Gates

- `cargo fmt --all`: clean.
- `./scripts/check-parser-combinators.sh`: **0**.
- `./scripts/check-engine-authorities.sh upstream/main`: **0**.
- Parser diff gate (inline string-dispatch grep on added parser lines): pass (only hits are `Vec::contains` membership assertions inside `#[test]` fns — exempt).
- `cargo check --workspace --all-targets`: ok.
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: ok.
- `cargo test -p engine` (FULL): 13012 passed, 1 failed = the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation, explicitly authorized to ignore). 6 ignored.
- `data/engine-inventory.json`: unchanged (no variants).
- CR-annotation diff gate: 0 UNVERIFIED.
- `cargo coverage` / `cargo semantic-audit`: not run in worktree — both require `client/public/card-data.json`, which the worktree PROTOCOL intentionally does not generate. Per-shipped-card verification used `parse_oracle_text` 0-Unimplemented (Oviya, Selfless Safewright, Roar all confirmed) + discriminating runtime tests. These two audits run in the orchestrator's full-tree CI.
