### PR TITLE
feat(engine): long-tail one-offs D (Laughing Jasper Flint, Midnight Mangler, Tapestry Warden, Rocket-Powered Goblin Glider)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -2049,6 +2049,7 @@ fn collect_pending_triggers(
                     .condition(TriggerCondition::WasCast {
                         zone: None,
                         controller: None,
+                        owner: None,
                     });
                 let cascade_ability =
                     ResolvedAbility::new(Effect::Cascade, Vec::new(), *cast_obj_id, controller);
@@ -2093,6 +2094,7 @@ fn collect_pending_triggers(
                     .condition(TriggerCondition::WasCast {
                         zone: None,
                         controller: None,
+                        owner: None,
                     });
                 let ripple_ability = ResolvedAbility::new(
                     Effect::Ripple { count: n },
@@ -4980,13 +4982,22 @@ pub(crate) fn check_trigger_condition(
         // anyway per CR 603.4 if the source has left the relevant zone).
         // CR 601.2 + CR 603.4: cast-origin check. zone=None → cast from anywhere
         // (Discover/Wedding Ring/Satoru back-compat). zone=Some(z) → cast specifically
-        // from zone z (Twilight Diviner: graveyard). controller=Some(c) additionally
-        // gates the caster relative to the trigger controller (Prized Amalgam:
-        // "you cast it from your graveyard"). Reads the ENTERING object's cast
-        // provenance, never the trigger source.
+        // from zone z (Twilight Diviner: graveyard). Two independent scope axes:
+        //   - caster_scope=Some(c) gates the CASTER relative to the trigger
+        //     controller against `cast_controller` (Prized Amalgam: "you cast it
+        //     from your graveyard").
+        //   - owner_scope=Some(c) gates the ORIGIN-ZONE OWNER. CR 400.3 + CR 404.1:
+        //     graveyard/hand/library are owner-specific zones, so "your graveyard"
+        //     means the card's owner is you — checked against `obj.owner`,
+        //     independent of who cast it (Rocket-Powered Goblin Glider: "if it was
+        //     cast from your graveyard"). An opponent casting your card from your
+        //     graveyard satisfies owner=You; you casting from an opponent's
+        //     graveyard does not.
+        // Reads the ENTERING object's cast provenance, never the trigger source.
         TriggerCondition::WasCast {
             zone,
             controller: caster_scope,
+            owner: owner_scope,
         } => {
             let checked_id = trigger_event
                 .and_then(|e| match e {
@@ -5003,6 +5014,9 @@ pub(crate) fn check_trigger_condition(
                             obj.cast_controller.is_some_and(|caster| {
                                 controller_ref_matches_player(caster, controller, scope)
                             })
+                        })
+                        && owner_scope.as_ref().is_none_or(|scope| {
+                            controller_ref_matches_player(obj.owner, controller, scope)
                         })
                 })
         }
@@ -15623,6 +15637,7 @@ pub mod tests {
             &TriggerCondition::WasCast {
                 zone: None,
                 controller: None,
+                owner: None,
             },
             PlayerId(0),
             Some(light_paws),
@@ -15664,6 +15679,7 @@ pub mod tests {
             &TriggerCondition::WasCast {
                 zone: None,
                 controller: None,
+                owner: None,
             },
             PlayerId(0),
             Some(light_paws),
@@ -15696,6 +15712,7 @@ pub mod tests {
         let condition = TriggerCondition::WasCast {
             zone: Some(Zone::Graveyard),
             controller: Some(ControllerRef::You),
+            owner: None,
         };
         let event = zone_changed_event(
             entering,
@@ -15727,6 +15744,105 @@ pub mod tests {
             ),
             "controller-scoped WasCast should pass when the trigger controller cast it"
         );
+    }
+
+    /// CR 400.3 + CR 404.1 + CR 603.4: "if it was cast from your graveyard"
+    /// (Rocket-Powered Goblin Glider) scopes the ORIGIN-ZONE OWNER, not the
+    /// caster. A graveyard is owner-specific, so the only thing "your" constrains
+    /// is the card's owner — who cast it is irrelevant. Drives the parsed trigger
+    /// condition through `check_trigger_condition` (the runtime trigger-collection
+    /// seam) across all four owner × caster combinations relative to the trigger
+    /// controller (P0). Before the owner-axis fix the `owner = You` scope was
+    /// modeled as `controller = You` (caster), which inverted two of the four
+    /// rows: it WRONGLY rejected an opponent casting your card from your graveyard
+    /// and WRONGLY accepted you casting a card from an opponent's graveyard.
+    #[test]
+    fn rocket_glider_was_cast_from_your_graveyard_is_owner_scoped_not_caster() {
+        let trigger = crate::parser::oracle_trigger::parse_trigger_line(
+            "When this Equipment enters, if it was cast from your graveyard, attach it to target creature you control.",
+            "Rocket-Powered Goblin Glider",
+        );
+        let condition = trigger
+            .condition
+            .expect("the gravecast ETB trigger must carry an intervening-if condition");
+        // The parser must emit the owner axis, not the caster axis, for the bare
+        // "cast from your graveyard" wording (no "you cast it" clause).
+        assert_eq!(
+            condition,
+            TriggerCondition::WasCast {
+                zone: Some(Zone::Graveyard),
+                controller: None,
+                owner: Some(ControllerRef::You),
+            },
+            "bare 'cast from your graveyard' must scope the origin-zone OWNER, not the caster"
+        );
+
+        // trigger controller = P0 (controls the Equipment). Each case sets the
+        // ENTERING object's owner (graveyard owner, CR 404.1) and caster, casts
+        // it from the graveyard, then evaluates the parsed condition.
+        // (owner, caster, expected) — the assertion that flips on revert is the
+        // two opp/your-yard and you/opp-yard rows.
+        let cases = [
+            (
+                PlayerId(0),
+                PlayerId(0),
+                true,
+                "you cast your own card from your graveyard",
+            ),
+            (
+                PlayerId(0),
+                PlayerId(1),
+                true,
+                "an opponent casts your card from your graveyard",
+            ),
+            (
+                PlayerId(1),
+                PlayerId(0),
+                false,
+                "you cast a card from an opponent's graveyard",
+            ),
+            (
+                PlayerId(1),
+                PlayerId(1),
+                false,
+                "an opponent casts their card from their graveyard",
+            ),
+        ];
+        for (owner, caster, expected, label) in cases {
+            let mut state = setup();
+            // The Equipment is self-referential: "it" is the entering Equipment,
+            // owned by `owner`, cast by `caster` from its owner's graveyard.
+            let equipment = create_object(
+                &mut state,
+                CardId(1),
+                owner,
+                "Rocket-Powered Goblin Glider".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&equipment).unwrap();
+                obj.cast_from_zone = Some(Zone::Graveyard);
+                obj.cast_controller = Some(caster);
+            }
+            let event = zone_changed_event(
+                equipment,
+                Zone::Stack,
+                Zone::Battlefield,
+                vec![CoreType::Artifact],
+                vec!["Equipment"],
+            );
+            assert_eq!(
+                check_trigger_condition(
+                    &state,
+                    &condition,
+                    PlayerId(0),
+                    Some(equipment),
+                    Some(&event),
+                ),
+                expected,
+                "owner-scoped gravecast mismatch: {label}"
+            );
+        }
     }
 
     /// CR 603.4 + CR 601.2h: Satoru's intervening-if must fail at resolution
@@ -15798,6 +15914,7 @@ pub mod tests {
             &TriggerCondition::WasCast {
                 zone: None,
                 controller: None,
+                owner: None,
             },
             PlayerId(0),
             Some(cast_spell),
@@ -15811,6 +15928,7 @@ pub mod tests {
             &TriggerCondition::WasCast {
                 zone: None,
                 controller: None,
+                owner: None,
             },
             PlayerId(0),
             Some(cast_spell),

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2087,6 +2087,56 @@ pub(super) fn parse_search_and_creation_ast(
             player,
         });
     }
+    // CR 701.20a + CR 701.20e: "look at/reveal <count> cards from the top of
+    // <owner>'s library" — the count-leading word order as opposed to the
+    // "look at the top N cards" form handled above. `reveal` distinguishes the
+    // public reveal (CR 701.20a) from the private look (CR 701.20e).
+    //
+    // Coverage-honesty guard: only a `Fixed` count is supported on this arm.
+    // A non-`Fixed` count cannot be carried losslessly to runtime in either
+    // direction, so a variable/multiplicative count-leading dig would falsely
+    // claim support:
+    //   * reveal (CR 701.20a) is demoted in `lower.rs` to
+    //     `Effect::RevealTop { count: u32 }`, collapsing every non-`Fixed` count
+    //     to 1 card revealed;
+    //   * the variable-count look forms in practice pair with a "put X cards
+    //     from among them" keep-count (Stargaze), and `Effect::Dig.keep_count`
+    //     is `Option<u32>` — it silently drops the dynamic keep to 1.
+    // Both are coverage-honesty bugs (the form would parse to 0-Unimplemented
+    // while behaving wrong at runtime). Non-fixed count-leading digs fall
+    // through and stay honestly Unimplemented until `Dig.count`/`keep_count`
+    // become `QuantityExpr` end-to-end (the documented Stargaze deferral).
+    if let Some((reveal, remainder)) = nom_on_lower(text, lower, |input| {
+        alt((
+            value(false, tag("look at ")),
+            value(false, tag("looks at ")),
+            value(true, tag("reveal ")),
+            value(true, tag("reveals ")),
+        ))
+        .parse(input)
+    }) {
+        // `parse_count_expr` lowercases internally, but its returned remainder
+        // mirrors the case of its input. The trailing "cards from the top of "
+        // tags below match lowercase, so feed the lowercase slice (not the
+        // original-case `remainder`) to keep the remainder lowercase too.
+        let rest_lower = &lower[lower.len() - remainder.len()..];
+        if let Some((QuantityExpr::Fixed { value }, after_count)) = parse_count_expr(rest_lower) {
+            let after_count = after_count.trim_start();
+            if let Ok((owner_lower, _)) = alt((
+                tag::<_, _, OracleError<'_>>("cards from the top of "),
+                tag::<_, _, OracleError<'_>>("card from the top of "),
+            ))
+            .parse(after_count)
+            {
+                let player = parse_dig_library_owner(owner_lower);
+                return Some(SearchCreationImperativeAst::Dig {
+                    count: QuantityExpr::Fixed { value },
+                    reveal,
+                    player,
+                });
+            }
+        }
+    }
     // CR 701.16a: "look at that many cards from the top of your library" — variable-count dig
     // where "that many" references the result of a previous effect (e.g., damage dealt).
     if let Some((reveal, _)) = nom_on_lower(text, lower, |input| {

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1011,9 +1011,21 @@ pub(crate) fn parse_static_line_inner(
     // "Creatures" from falling through to the subtype path (A1 fix: 162+ cards).
     if let Some(rest_tp) = nom_tag_tp(&tp, "creatures you control ") {
         let after_prefix = rest_tp.original;
-        let (filter, predicate_text) = if let Some((prop, rest)) =
-            strip_counter_condition_prefix(after_prefix)
+        let (filter, predicate_text) = if let Some((owned_prop, rest)) =
+            strip_negated_ownership_qualifier(after_prefix)
         {
+            // CR 108.3 + CR 109.4: "Creatures you control but don't own …"
+            // (Laughing Jasper Flint). Preserve the negated-ownership axis the
+            // controller-prefix arm would otherwise drop.
+            (
+                TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .controller(ControllerRef::You)
+                        .properties(vec![owned_prop]),
+                ),
+                rest,
+            )
+        } else if let Some((prop, rest)) = strip_counter_condition_prefix(after_prefix) {
             (
                 TargetFilter::Typed(
                     TypedFilter::creature()

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1976,6 +1976,10 @@ fn parse_crew_contribution_predicate_nom(
             tag("crews vehicles and stations permanents"),
         ),
         value(vec![CrewAction::Crew], tag("crews vehicles")),
+        // CR 702.184a: bare "stations permanents" — station-only contribution
+        // modifier (Tapestry Warden: "… stations permanents using its toughness
+        // rather than its power").
+        value(vec![CrewAction::Station], tag("stations permanents")),
     ))
     .parse(input)?;
     let (input, _) = space1.parse(input)?;

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1753,6 +1753,38 @@ pub(crate) fn find_continuous_predicate_start(lower: &str) -> Option<usize> {
     .min()
 }
 
+/// CR 108.3 + CR 109.4: Strip a leading negated-ownership qualifier ("but don't
+/// own", "but do not own") from a "<subject> you control" predicate tail.
+///
+/// The "<X> you control" dispatch arms (`creatures you control `, `other
+/// creatures you control `) consume the `you control` controller anchor before
+/// the predicate, so a trailing "but don't own" qualifier would otherwise be
+/// silently dropped from the affected filter. Returns the
+/// `FilterProp::Owned { Opponent }` property ("controller doesn't own it") and
+/// the remaining predicate text when the qualifier is present. The companion
+/// "but don't own" handling in `parse_type_phrase` covers the full-subject path
+/// (Laughing Jasper Flint's "Creatures you control but don't own are
+/// Mercenaries …"); this is the controller-prefix-consumed sibling.
+pub(crate) fn strip_negated_ownership_qualifier(after_prefix: &str) -> Option<(FilterProp, &str)> {
+    type VE<'a> = OracleError<'a>;
+    for qualifier in [
+        "but don't own ",
+        "but do not own ",
+        "but doesn't own ",
+        "but does not own ",
+    ] {
+        if let Ok((rest, _)) = tag::<_, _, VE>(qualifier).parse(after_prefix) {
+            return Some((
+                FilterProp::Owned {
+                    controller: ControllerRef::Opponent,
+                },
+                rest,
+            ));
+        }
+    }
+    None
+}
+
 pub(crate) fn parse_qualified_creatures_you_control_suffix<'a>(
     subject_prefix: &str,
     after_prefix: &'a str,

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1021,15 +1021,26 @@ pub(crate) fn parse_pronoun_becomes_type_static(
     tp: &TextPair<'_>,
     text: &str,
 ) -> Option<StaticDefinition> {
-    // STEP A.0 — peel an optional leading "during your turn, " timing clause.
+    // STEP A.0 — peel an optional leading turn-restriction timing clause.
     // Mirror of `parse_compound_turn_counter_animation` (anthem.rs): the
     // alternate printing convention writes the turn restriction as a leading
-    // timing prefix ("During your turn, ~ is a 4/4 ...") rather than a trailing
-    // "as long as it's your turn" clause. The peel is Option-returning, so when
-    // absent it falls through to `*tp` unchanged and no condition is attached.
-    let (tp, turn_condition) = match nom_tag_tp(tp, "during your turn, ") {
-        Some(rest) => (rest, Some(StaticCondition::DuringYourTurn)),
-        None => (*tp, None),
+    // timing prefix ("During your turn, ~ is a 4/4 ..." — Gideon-class; "During
+    // turns other than yours, ~ is an artifact creature" — Midnight Mangler)
+    // rather than a trailing "as long as it's your turn" clause. CR 611.3a: the
+    // negated form lowers to `Not(DuringYourTurn)`. The peel is Option-returning,
+    // so when absent it falls through to `*tp` unchanged and no condition is
+    // attached.
+    let (tp, turn_condition) = if let Some(rest) = nom_tag_tp(tp, "during your turn, ") {
+        (rest, Some(StaticCondition::DuringYourTurn))
+    } else if let Some(rest) = nom_tag_tp(tp, "during turns other than yours, ") {
+        (
+            rest,
+            Some(StaticCondition::Not {
+                condition: Box::new(StaticCondition::DuringYourTurn),
+            }),
+        )
+    } else {
+        (*tp, None)
     };
 
     // STEP A — peel a trailing " as long as <condition>" FIRST. The canonical

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2699,6 +2699,7 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         StaticCondition::WasCast { zone } => Some(TriggerCondition::WasCast {
             zone: *zone,
             controller: None,
+            owner: None,
         }),
 
         // CR 702.176a + CR 603.4: Impending's battlefield trigger checks the
@@ -2919,6 +2920,13 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
 /// graveyard (`WasCast`). `owner` carries the graveyard's owner scope: "your
 /// graveyard" (Prized Amalgam) restricts the entered-from filter to objects you
 /// own; "a graveyard" (any graveyard) leaves it unrestricted.
+///
+/// The "your graveyard" form (Prized Amalgam) is templated "entered from your
+/// graveyard or you cast it from your graveyard" — the cast arm carries an
+/// explicit "you cast it" caster clause AND a "your graveyard" owner clause, so
+/// the `WasCast` arm scopes BOTH the caster (`cast_controller`) and the
+/// origin-zone owner (`owner`, CR 400.3 + CR 404.1). The compact "a graveyard"
+/// form (Twilight Diviner) carries neither caster nor owner constraint.
 fn graveyard_origin_or_condition(owner: Option<ControllerRef>) -> TriggerCondition {
     let filter = match owner {
         Some(ref controller) => with_owner_scope(TargetFilter::Any, controller.clone()),
@@ -2933,7 +2941,8 @@ fn graveyard_origin_or_condition(owner: Option<ControllerRef>) -> TriggerConditi
             },
             TriggerCondition::WasCast {
                 zone: Some(Zone::Graveyard),
-                controller: owner,
+                controller: owner.clone(),
+                owner,
             },
         ],
     }
@@ -2969,7 +2978,30 @@ fn parse_graveyard_origin_intervening_if(input: &str) -> OracleResult<'_, Trigge
         tag("entered from your graveyard or you cast it from your graveyard"),
         |_| graveyard_origin_or_condition(Some(ControllerRef::You)),
     );
-    alt((compact, split_your)).parse(rest)
+    // CR 601.2 + CR 603.4: bare "(was|were) cast from [a|your] graveyard" with no
+    // "entered" disjunction (Rocket-Powered Goblin Glider's Mayhem-gated ETB
+    // attach: "if it was cast from your graveyard"). This is the cast-origin
+    // check alone — `WasCast`, not the entered/cast `Or` the disjunctive forms
+    // above build. CR 400.3 + CR 404.1: a graveyard is owner-specific, and this
+    // wording carries NO "you cast it" caster clause, so "your graveyard" scopes
+    // the origin-zone OWNER (`owner = You`), never the caster. "a graveyard" is
+    // unscoped on both axes.
+    let bare_cast = map(
+        (
+            alt((tag("was"), tag("were"))),
+            tag(" cast from "),
+            alt((
+                value(Some(ControllerRef::You), tag("your graveyard")),
+                value(None, tag("a graveyard")),
+            )),
+        ),
+        |(_, _, owner)| TriggerCondition::WasCast {
+            zone: Some(Zone::Graveyard),
+            controller: None,
+            owner,
+        },
+    );
+    alt((compact, split_your, bare_cast)).parse(rest)
 }
 
 /// CR 701.26 + CR 603.4: "if it's the first time that creature/permanent has become
@@ -3040,6 +3072,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
                 Some(TriggerCondition::WasCast {
                     zone: None,
                     controller: None,
+                    owner: None,
                 }),
             );
         }
@@ -3074,6 +3107,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
                         condition: Box::new(TriggerCondition::WasCast {
                             zone: None,
                             controller: None,
+                            owner: None,
                         }),
                     },
                     TriggerCondition::ManaSpentCondition {
@@ -3145,6 +3179,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
             Some(TriggerCondition::WasCast {
                 zone: None,
                 controller: None,
+                owner: None,
             }),
         );
     }
@@ -3157,6 +3192,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
                 condition: Box::new(TriggerCondition::WasCast {
                     zone: None,
                     controller: None,
+                    owner: None,
                 }),
             }),
         );
@@ -28729,6 +28765,7 @@ mod tests {
                         condition: Box::new(TriggerCondition::WasCast {
                             zone: None,
                             controller: None,
+                            owner: None,
                         }),
                     }
                 );
@@ -28762,6 +28799,7 @@ mod tests {
                 condition: Box::new(TriggerCondition::WasCast {
                     zone: None,
                     controller: None,
+                    owner: None,
                 }),
             })
         );
@@ -32332,7 +32370,8 @@ mod snapshot_tests {
                     conditions[1],
                     TriggerCondition::WasCast {
                         zone: Some(Zone::Graveyard),
-                        controller: None
+                        controller: None,
+                        owner: None,
                     }
                 );
             }
@@ -32361,7 +32400,8 @@ mod snapshot_tests {
                     conditions[1],
                     TriggerCondition::WasCast {
                         zone: Some(Zone::Graveyard),
-                        controller: None
+                        controller: None,
+                        owner: None,
                     }
                 );
             }
@@ -32862,9 +32902,11 @@ mod slicer_control_handoff_tests {
                         TriggerCondition::WasCast {
                             zone: Some(Zone::Graveyard),
                             controller: Some(ControllerRef::You),
+                            owner: Some(ControllerRef::You),
                         }
                     ),
-                    "cast-from-your-graveyard branch must be caster-scoped to you, got {condition:?}"
+                    "cast-from-your-graveyard branch must scope BOTH caster (\"you cast it\") \
+                     and origin-zone owner (\"your graveyard\") to you, got {condition:?}"
                 );
             }
             other => panic!("expected Or condition, got {other:?}"),

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1513,7 +1513,46 @@ fn parse_subtype_entry(text: &str, subtype: &str) -> Option<(String, usize)> {
         }
     }
 
+    // Try regular "-ies" plural: subtypes ending in consonant + "y" pluralize by
+    // replacing "y" with "ies" (e.g. "Mercenary" → "Mercenaries", "Berserker"
+    // is unaffected). Words ending in vowel + "y" take a plain "-s" ("Monkey" →
+    // "Monkeys") and are covered by the "-s" rule above. Matching the plural
+    // surface form requires stripping the trailing "y" from the subtype stem and
+    // matching "ies" at the boundary; only the canonical singular is returned.
+    if takes_ies_plural(subtype) {
+        let stem_len = subtype.len() - 1; // drop trailing "y"
+        let ies_plural_len = stem_len + 3; // stem + "ies"
+        if text.len() >= ies_plural_len
+            && text.is_char_boundary(stem_len)
+            && text[..stem_len].eq_ignore_ascii_case(&subtype[..stem_len])
+            && text[stem_len..ies_plural_len].eq_ignore_ascii_case("ies")
+        {
+            let after = &text[ies_plural_len..];
+            if after.is_empty() || after.starts_with(|c: char| !c.is_alphanumeric()) {
+                return Some((subtype.to_string(), ies_plural_len));
+            }
+        }
+    }
+
     None
+}
+
+/// Whether an English noun pluralizes by replacing a trailing "-y" with "-ies":
+/// nouns ending in consonant + "y" (e.g. "Mercenary" → "Mercenaries"). Nouns
+/// ending in vowel + "y" take a plain "-s" ("Monkey" → "Monkeys") and are
+/// excluded so the regular "-s" rule handles them.
+fn takes_ies_plural(word: &str) -> bool {
+    let bytes = word.as_bytes();
+    // A one-letter "y" has no preceding consonant, so the "-ies" rule cannot
+    // apply; the `len() < 2` guard also makes the penultimate index safe without
+    // `saturating_sub`/`get`.
+    if bytes.len() < 2 || !matches!(bytes.last(), Some(b'y' | b'Y')) {
+        return false;
+    }
+    !matches!(
+        bytes[bytes.len() - 2].to_ascii_lowercase(),
+        b'a' | b'e' | b'i' | b'o' | b'u'
+    )
 }
 
 /// Whether an English noun forms its plural by appending "-es" rather than

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13940,11 +13940,25 @@ pub enum TriggerCondition {
     AttractionVisitRoll { min: u8, max: u8 },
 
     /// CR 601.2 + CR 603.4: reads the ENTERING object's cast provenance, never the source.
+    ///
+    /// Two independent, separately-resolvable scope axes (both `None` = unscoped):
+    /// - `controller` — CASTER scope ("you cast it"). Matched against
+    ///   `GameObject.cast_controller`, the player who cast the spell (Prized
+    ///   Amalgam: "you cast it from your graveyard").
+    /// - `owner` — ORIGIN-ZONE-OWNER scope ("your graveyard"). Matched against
+    ///   `GameObject.owner`. CR 400.3 + CR 404.1: graveyard, hand, and library are
+    ///   owner-specific zones, so "cast from your graveyard" is equivalent to "the
+    ///   card's owner is you" — independent of who cast it (Rocket-Powered Goblin
+    ///   Glider: "if it was cast from your graveyard", no caster constraint). An
+    ///   opponent casting your card from your graveyard satisfies `owner = You`;
+    ///   you casting a card from an opponent's graveyard does not.
     WasCast {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         zone: Option<Zone>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         controller: Option<ControllerRef>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        owner: Option<ControllerRef>,
     },
     /// CR 305.1 + CR 603.4: Intervening/event condition for zone-change
     /// triggers whose subject must have been played as a land. Negation

--- a/crates/engine/tests/std_longtail_d_batch.rs
+++ b/crates/engine/tests/std_longtail_d_batch.rs
@@ -1,0 +1,611 @@
+//! Standard long-tail batch D — parser/static seams that route to EXISTING
+//! engine surface, no new engine variant (the `add-engine-variant` gate verdict
+//! was "parameterize, don't proliferate" for every change here).
+//!
+//! SHIPPED (0-Unimplemented + discriminating runtime/derived assertion that
+//! flips on revert):
+//!   - Laughing Jasper Flint — "Creatures you control but don't own are
+//!     Mercenaries in addition to their other types" (LT-F type-grant). Two
+//!     parser arms: a generic consonant+y → "-ies" plural rule in `parse_subtype`
+//!     ("Mercenaries" → "Mercenary"), and a "<creatures you control> but don't
+//!     own" negated-ownership qualifier in the static dispatch arm.
+//!   - Midnight Mangler — "During turns other than yours, ~ is an artifact
+//!     creature" (LT-F type-grant). Extended the leading turn-restriction peel in
+//!     `parse_pronoun_becomes_type_static` to the negated `Not(DuringYourTurn)`
+//!     direction.
+//!   - Tapestry Warden — "Each creature you control with toughness greater than
+//!     its power stations permanents using its toughness rather than its power"
+//!     (LT-C station-contribution). Added the bare "stations permanents" leaf to
+//!     the existing crew/saddle/station contribution action list.
+//!   - Rocket-Powered Goblin Glider — "if it was cast from your graveyard"
+//!     (LT-C gravecast). Added the bare "(was|were) cast from [a|your] graveyard"
+//!     intervening-if arm → `TriggerCondition::WasCast { zone: Graveyard,
+//!     controller: None, owner: Some(You) }`. CR 400.3 + CR 404.1: a graveyard is
+//!     owner-specific, so "your graveyard" scopes the origin-zone OWNER, not the
+//!     caster — an opponent casting your card from your graveyard satisfies it.
+//!     The owner-vs-caster runtime discrimination (all four owner × caster rows)
+//!     is asserted in-crate in `game::triggers` against the real
+//!     `check_trigger_condition` seam, which is `pub(crate)` and unreachable here.
+//!
+//! BUILDING BLOCK (general arm, not card-specific): a count-leading
+//! "look at/reveal <count> cards from the top of <owner>'s library" dig
+//! word-order. Supported for FIXED counts in both the private (look) and public
+//! (reveal) directions and resolves correctly. NON-fixed counts are refused (a
+//! coverage-honesty guard): the reveal direction is demoted to a `u32`-count
+//! `RevealTop`, and a variable look pairs with a `Put X` keep-count that
+//! `Effect::Dig.keep_count: Option<u32>` cannot represent, so a dynamic count
+//! would over-claim support while behaving wrong at runtime.
+//!
+//! DEFERRED (honesty guards assert the residual is exactly the unsupported
+//! clause, not an over-claim): Sandman (compound self+target return to
+//! battlefield), Fblthp (plot-from-top infra), Choreographed Sparks (the
+//! `CopySpell` resolver does not apply `AddKeyword`/`GrantTrigger` modifications
+//! to the copy), Leyline of Transformation (continuous type-grant on
+//! non-battlefield zones), Nowhere to Run (creature-scoped hexproof-bypass +
+//! ward suppression), Stargaze (variable dig look/keep count needs
+//! `Dig.count`/`keep_count` as `QuantityExpr` end-to-end).
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::static_abilities::object_crew_power_contribution;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ControllerRef, Effect, QuantityExpr, TargetFilter, TriggerCondition};
+use engine::types::card_type::CoreType;
+use engine::types::phase::Phase;
+use engine::types::statics::CrewAction;
+use engine::types::zones::Zone;
+
+fn creature_types() -> Vec<String> {
+    vec!["Creature".to_string()]
+}
+
+fn parsed_debug(oracle: &str, name: &str, types: &[String], subtypes: &[String]) -> String {
+    format!(
+        "{:#?}",
+        parse_oracle_text(oracle, name, &[], types, subtypes)
+    )
+}
+
+fn assert_zero_unimplemented(oracle: &str, name: &str, types: &[String], subtypes: &[String]) {
+    assert_zero_unimplemented_kw(oracle, name, &[], types, subtypes);
+}
+
+/// Same as [`assert_zero_unimplemented`] but threads the printed MTGJSON
+/// keyword names so bare keyword-only lines (e.g. "Vigilance") are recognized as
+/// keywords rather than mis-flagged as Unimplemented effect candidates — exactly
+/// what the card-data loader passes in production.
+fn assert_zero_unimplemented_kw(
+    oracle: &str,
+    name: &str,
+    keywords: &[String],
+    types: &[String],
+    subtypes: &[String],
+) {
+    let dbg = format!(
+        "{:#?}",
+        parse_oracle_text(oracle, name, keywords, types, subtypes)
+    );
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+// ===========================================================================
+// Laughing Jasper Flint (SHIPPED) — LT-F type grant
+// ===========================================================================
+
+const LJF_ORACLE: &str = "Creatures you control but don't own are Mercenaries in addition to their other types.\nAt the beginning of your upkeep, exile the top X cards of target opponent's library, where X is the number of outlaws you control. Until end of turn, you may cast spells from among those cards, and mana of any type can be spent to cast those spells.";
+
+#[test]
+fn laughing_jasper_flint_zero_unimplemented() {
+    assert_zero_unimplemented(
+        LJF_ORACLE,
+        "Laughing Jasper Flint",
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Goblin".to_string(), "Mercenary".to_string()],
+    );
+}
+
+#[test]
+fn laughing_jasper_flint_grants_mercenary_only_to_unowned_creatures() {
+    // The static line parses to AddSubtype{Mercenary} on a creature filter that
+    // carries BOTH controller=You AND Owned{Opponent} ("you don't own it"). The
+    // discriminating axis is the ownership qualifier: a creature you control AND
+    // own must NOT gain Mercenary; a creature you control but don't own MUST.
+    let parsed = parse_oracle_text(
+        "Creatures you control but don't own are Mercenaries in addition to their other types.",
+        "Laughing Jasper Flint",
+        &[],
+        &creature_types(),
+        &[],
+    );
+    let stat = &parsed.statics[0];
+    let affected = stat.affected.as_ref().expect("static must carry a filter");
+    // Revert guard (shape): the filter must retain the negated-ownership prop —
+    // pre-fix the dispatch arm dropped "but don't own" and produced a bare
+    // creature-you-control filter (any owner would gain Mercenary).
+    let dbg = format!("{affected:?}");
+    assert!(
+        dbg.contains("Owned") && dbg.contains("Opponent"),
+        "affected filter must retain Owned{{Opponent}} (\"you don't own it\"); got {dbg}"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let flint = scenario
+        .add_creature_from_oracle(P0, "Laughing Jasper Flint", 4, 4, LJF_ORACLE)
+        .id();
+    // A creature P0 controls AND owns (printed Goblin, no Mercenary).
+    let owned = scenario
+        .add_creature(P0, "Owned Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    // A creature P0 controls but P1 owns (set owner below).
+    let stolen = scenario
+        .add_creature(P0, "Stolen Bear", 2, 2)
+        .with_subtypes(vec!["Bear"])
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&stolen).unwrap().owner = P1;
+    let _ = flint;
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    let owned_subtypes = &runner.state().objects[&owned].card_types.subtypes;
+    assert!(
+        !owned_subtypes.iter().any(|s| s == "Mercenary"),
+        "a creature you control AND own must NOT gain Mercenary; got {owned_subtypes:?}"
+    );
+    let stolen_subtypes = &runner.state().objects[&stolen].card_types.subtypes;
+    assert!(
+        stolen_subtypes.iter().any(|s| s == "Mercenary"),
+        "a creature you control but DON'T own must gain Mercenary; got {stolen_subtypes:?}"
+    );
+}
+
+// ===========================================================================
+// Midnight Mangler (SHIPPED) — LT-F type grant
+// ===========================================================================
+
+const MM_ORACLE: &str = "During turns other than yours, this Vehicle is an artifact creature.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)";
+
+#[test]
+fn midnight_mangler_zero_unimplemented() {
+    assert_zero_unimplemented(
+        MM_ORACLE,
+        "Midnight Mangler",
+        &["Artifact".to_string()],
+        &["Vehicle".to_string()],
+    );
+}
+
+#[test]
+fn midnight_mangler_is_creature_only_during_non_your_turns() {
+    let parsed = parse_oracle_text(
+        MM_ORACLE,
+        "Midnight Mangler",
+        &[],
+        &["Artifact".to_string()],
+        &["Vehicle".to_string()],
+    );
+    let stat = parsed
+        .statics
+        .iter()
+        .find(|s| {
+            s.modifications
+                .iter()
+                .any(|m| matches!(m, engine::types::ability::ContinuousModification::AddType { core_type } if *core_type == CoreType::Creature))
+        })
+        .expect("the turn-conditional AddType{Creature} static must be present");
+    // Revert guard (shape): the condition must be the NEGATED turn restriction —
+    // pre-fix the leading "during turns other than yours, " peel was missing, so
+    // the whole line stayed an Unimplemented (no static at all).
+    let cond_dbg = format!("{:?}", stat.condition);
+    assert!(
+        cond_dbg.contains("Not") && cond_dbg.contains("DuringYourTurn"),
+        "static condition must be Not(DuringYourTurn); got {cond_dbg}"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let vehicle = scenario
+        .add_creature_from_oracle(P0, "Midnight Mangler", 0, 0, MM_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    // Vehicles print as artifacts; the scenario builder adds the Creature type
+    // for `add_creature_*`, so strip the printed Creature type to mirror a real
+    // (non-creature) Vehicle and prove the static is what makes it a creature.
+    {
+        let obj = runner.state_mut().objects.get_mut(&vehicle).unwrap();
+        obj.card_types
+            .core_types
+            .retain(|t| *t != CoreType::Creature);
+        obj.base_card_types
+            .core_types
+            .retain(|t| *t != CoreType::Creature);
+    }
+
+    // Case A — P0's turn (condition FALSE): the static is OFF, so the Vehicle is
+    // NOT a creature.
+    runner.state_mut().active_player = P0;
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert!(
+        !runner.state().objects[&vehicle]
+            .card_types
+            .core_types
+            .contains(&CoreType::Creature),
+        "during your own turn the Vehicle must NOT be a creature"
+    );
+
+    // Case B — opponent's turn (condition TRUE): the static is ON, so the Vehicle
+    // IS an artifact creature. This is the assertion that FLIPS on revert.
+    runner.state_mut().active_player = P1;
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert!(
+        runner.state().objects[&vehicle]
+            .card_types
+            .core_types
+            .contains(&CoreType::Creature),
+        "during turns other than yours the Vehicle must be an artifact creature"
+    );
+}
+
+// ===========================================================================
+// Tapestry Warden (SHIPPED) — LT-C station-contribution static
+// ===========================================================================
+
+const TW_ORACLE: &str = "Vigilance\nEach creature you control with toughness greater than its power assigns combat damage equal to its toughness rather than its power.\nEach creature you control with toughness greater than its power stations permanents using its toughness rather than its power.";
+
+#[test]
+fn tapestry_warden_zero_unimplemented() {
+    assert_zero_unimplemented_kw(
+        TW_ORACLE,
+        "Tapestry Warden",
+        &["Vigilance".to_string()],
+        &creature_types(),
+        &["Spider".to_string()],
+    );
+}
+
+#[test]
+fn tapestry_warden_station_uses_toughness_for_high_toughness_creatures() {
+    let line = "Each creature you control with toughness greater than its power stations permanents using its toughness rather than its power.";
+    let def = engine::parser::oracle_static::parse_static_line(line)
+        .expect("station-contribution line must parse");
+    // Revert guard (shape): the bare "stations permanents" must map to a
+    // CrewContribution{ToughnessInsteadOfPower} carrying CrewAction::Station —
+    // pre-fix the action-list alt had no bare "stations permanents" arm, so the
+    // whole line stayed Unimplemented.
+    let dbg = format!("{def:?}");
+    assert!(
+        dbg.contains("CrewContribution")
+            && dbg.contains("ToughnessInsteadOfPower")
+            && dbg.contains("Station"),
+        "must produce CrewContribution{{ToughnessInsteadOfPower, [Station]}}; got {dbg}"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Tapestry Warden", 1, 4, TW_ORACLE);
+    // A 1/5 creature you control — toughness (5) > power (1).
+    let wall = scenario.add_creature(P0, "Big Wall", 1, 5).id();
+    let mut runner = scenario.build();
+
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // Discriminating runtime assertion: the wall's station power contribution is
+    // its TOUGHNESS (5), not its power (1). Pre-fix the static never parsed, so
+    // the contribution would fall back to power (1).
+    let contribution = object_crew_power_contribution(runner.state(), wall, CrewAction::Station);
+    assert_eq!(
+        contribution, 5,
+        "Tapestry Warden must make a 1/5 contribute its toughness (5) when stationing; got {contribution}"
+    );
+}
+
+// ===========================================================================
+// Rocket-Powered Goblin Glider (SHIPPED) — LT-C gravecast
+// ===========================================================================
+
+const RPGG_ORACLE: &str = "When this Equipment enters, if it was cast from your graveyard, attach it to target creature you control.\nEquipped creature gets +2/+0 and has flying and haste.\nEquip {2}\nMayhem {2}";
+
+#[test]
+fn rocket_powered_goblin_glider_zero_unimplemented() {
+    assert_zero_unimplemented(
+        RPGG_ORACLE,
+        "Rocket-Powered Goblin Glider",
+        &["Artifact".to_string()],
+        &["Equipment".to_string()],
+    );
+}
+
+#[test]
+fn rocket_powered_goblin_glider_etb_condition_is_owner_scoped_was_cast() {
+    let parsed = parse_oracle_text(
+        RPGG_ORACLE,
+        "Rocket-Powered Goblin Glider",
+        &[],
+        &["Artifact".to_string()],
+        &["Equipment".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| t.condition.is_some())
+        .expect("the ETB attach trigger must carry an intervening-if condition");
+    // Parser-shape revert guard: the bare "if it was cast from your graveyard"
+    // (no "you cast it" caster clause) must produce the OWNER-scoped cast-origin
+    // check WasCast{Graveyard, controller: None, owner: Some(You)}.
+    // CR 400.3 + CR 404.1: a graveyard is owner-specific, so "your graveyard"
+    // constrains who OWNS the card, not who cast it. Pre-fix the bare wording
+    // left "from your graveyard" unconsumed (the zone-word parser only matched
+    // "a graveyard"/"their graveyard") so the attach clause stayed Unimplemented;
+    // the intermediate fix consumed it but mis-modeled "your" as the caster.
+    // The owner-vs-caster RUNTIME discrimination (all four owner × caster rows)
+    // lives in `game::triggers::rocket_glider_was_cast_from_your_graveyard_is_owner_scoped_not_caster`,
+    // which drives the `pub(crate)` `check_trigger_condition` seam directly.
+    assert_eq!(
+        trigger.condition,
+        Some(TriggerCondition::WasCast {
+            zone: Some(Zone::Graveyard),
+            controller: None,
+            owner: Some(ControllerRef::You),
+        }),
+        "\"cast from your graveyard\" must scope the origin-zone OWNER (owner=You), \
+         never the caster (controller stays None)"
+    );
+    // The gated effect attaches to a target creature you control.
+    let execute = trigger.execute.as_deref().expect("trigger must execute");
+    assert!(
+        matches!(*execute.effect, Effect::Attach { .. }),
+        "the gated effect must be an Attach; got {:?}",
+        execute.effect
+    );
+}
+
+// ===========================================================================
+// Look-count dig BUILDING BLOCK (Stargaze's count-leading word order) — SHIPPED
+// as a general arm; the Stargaze CARD is deferred (variable keep-count).
+// ===========================================================================
+
+#[test]
+fn look_at_count_from_top_word_order_parses_dig() {
+    // The count-leading word order ("look at N cards from the top of your
+    // library") must lower to the same Dig as the "look at the top N cards"
+    // order. Use a FIXED count + fixed keep so the dig resolves correctly
+    // end-to-end (variable "Put X cards" is the deferred Stargaze gap).
+    let parsed = parse_oracle_text(
+        "Look at three cards from the top of your library. Put two of them into your hand and the rest into your graveyard.",
+        "Dig Tester",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    let spell = &parsed.abilities[0];
+    match &*spell.effect {
+        Effect::Dig {
+            count,
+            keep_count,
+            destination,
+            rest_destination,
+            ..
+        } => {
+            assert_eq!(
+                *count,
+                QuantityExpr::Fixed { value: 3 },
+                "look count must be 3 (count-leading word order)"
+            );
+            assert_eq!(*keep_count, Some(2), "keep-into-hand count must be 2");
+            assert_eq!(
+                *destination,
+                Some(engine::types::zones::Zone::Hand),
+                "kept cards go to hand"
+            );
+            assert_eq!(
+                *rest_destination,
+                Some(engine::types::zones::Zone::Graveyard),
+                "the rest go to the graveyard"
+            );
+        }
+        other => panic!("count-leading look must lower to Effect::Dig; got {other:?}"),
+    }
+}
+
+#[test]
+fn stargaze_variable_count_dig_is_deferred() {
+    // Stargaze ("Look at twice X cards ... Put X cards from among them into your
+    // hand ...") is DEFERRED, not shipped: both the look count (Multiply{2,X})
+    // and the keep count (X) are dynamic, but `Effect::Dig.count` survives only a
+    // `Fixed` value through the count-leading arm and `Effect::Dig.keep_count` is
+    // `Option<u32>` — a "Put X cards" keep silently collapses to 1.
+    //
+    // Coverage-honesty guard (the assertion that flips on revert): the
+    // count-leading arm must REFUSE the non-fixed count so Stargaze stays
+    // honestly Unimplemented. Pre-fix the arm accepted "twice X", the keep-count
+    // collapsed to 1, and the whole card parsed to 0-Unimplemented while putting
+    // a single card into hand at runtime — a silent over-claim.
+    let dbg = parsed_debug(
+        "Look at twice X cards from the top of your library. Put X cards from among them into your hand and the rest into your graveyard. You lose X life.",
+        "Stargaze",
+        &["Sorcery".to_string()],
+        &[],
+    );
+    assert!(
+        dbg.contains("Unimplemented"),
+        "Stargaze's variable look/keep count must stay honestly Unimplemented (not silently collapse to a 1-card dig); parse was:\n{dbg}"
+    );
+}
+
+#[test]
+fn count_leading_word_order_requires_fixed_count() {
+    // Coverage-honesty guard for the count-leading look/reveal word order. A
+    // FIXED count is supported in BOTH directions and resolves the correct
+    // number; a non-`Fixed` count is refused so the form stays honestly
+    // Unimplemented instead of over-claiming support while behaving wrong at
+    // runtime.
+
+    // FIXED reveal: lowers to a 3-card reveal (RevealTop demotion is lossless for
+    // a Fixed count). Assertion flips on revert if the arm stopped firing.
+    let fixed_reveal = parse_oracle_text(
+        "Reveal three cards from the top of your library.",
+        "Fixed Reveal Tester",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    match &*fixed_reveal.abilities[0].effect {
+        Effect::RevealTop { count, .. } => assert_eq!(
+            *count, 3,
+            "fixed-count reveal must reveal exactly 3 cards (lossless demotion)"
+        ),
+        Effect::Dig {
+            count: QuantityExpr::Fixed { value },
+            reveal: true,
+            ..
+        } => assert_eq!(*value, 3, "fixed-count reveal-Dig must carry count 3"),
+        other => panic!("fixed-count reveal must lower to a 3-card reveal; got {other:?}"),
+    }
+
+    // FIXED look: the private direction stays an Effect::Dig with the fixed count
+    // (dig::resolve honors it). The "look at the top N" sibling word order is
+    // covered by `look_at_count_from_top_word_order_parses_dig`; here the bare
+    // count-leading look must still produce a Fixed-count Dig.
+    let fixed_look = parse_oracle_text(
+        "Look at three cards from the top of your library. Put two of them into your hand and the rest into your graveyard.",
+        "Fixed Look Tester",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    match &*fixed_look.abilities[0].effect {
+        Effect::Dig {
+            count: QuantityExpr::Fixed { value },
+            reveal,
+            ..
+        } => {
+            assert!(!reveal, "look at is the private direction (reveal=false)");
+            assert_eq!(*value, 3, "fixed-count look-Dig must carry count 3");
+        }
+        other => panic!("fixed-count look must stay a 3-card Dig; got {other:?}"),
+    }
+
+    // A non-FIXED count ("twice X") must NOT be silently accepted in EITHER
+    // direction — both over-claim at runtime (reveal collapses to RevealTop{1},
+    // look pairs with a keep-count that drops to 1). The arm declines so the form
+    // stays honestly Unimplemented. These are the assertions that flip on revert.
+    for verb in ["Reveal", "Look at"] {
+        let oracle = format!("{verb} twice X cards from the top of your library.");
+        let dbg = parsed_debug(
+            &oracle,
+            "Variable Count Tester",
+            &["Sorcery".to_string()],
+            &[],
+        );
+        assert!(
+            dbg.contains("Unimplemented"),
+            "a non-fixed (twice X) {verb} count must stay Unimplemented, not collapse to a 1-card dig; parse was:\n{dbg}"
+        );
+    }
+}
+
+// ===========================================================================
+// DEFERRED honesty guards
+// ===========================================================================
+
+#[test]
+fn sandman_compound_self_target_return_is_deferred() {
+    // "Return this card and target land card from your graveyard to the
+    // battlefield tapped." The compound self+target return to the battlefield is
+    // not modeled; the residual is exactly the second subject clause.
+    let dbg = parsed_debug(
+        "Sandman's power and toughness are each equal to the number of lands you control.\nSandman can't be blocked by creatures with power 2 or less.\n{3}{G}{G}: Return this card and target land card from your graveyard to the battlefield tapped.",
+        "Sandman, Shifting Scoundrel",
+        &creature_types(),
+        &["Human".to_string(), "Rogue".to_string()],
+    );
+    assert!(
+        dbg.contains("Unimplemented"),
+        "Sandman compound return must remain honestly Unimplemented (not over-claimed)"
+    );
+}
+
+#[test]
+fn choreographed_sparks_copy_grant_is_deferred() {
+    // The CopySpell resolver does not apply AddKeyword/GrantTrigger modifications
+    // to the copy, so "The copy gains haste and '<delayed-sac>'" stays an honest
+    // gap rather than silently dropping the grants.
+    let dbg = parsed_debug(
+        "This spell can't be copied.\nChoose one or both —\n• Copy target instant or sorcery spell you control. You may choose new targets for the copy.\n• Copy target creature spell you control. The copy gains haste and \"At the beginning of the end step, sacrifice this token.\"",
+        "Choreographed Sparks",
+        &["Instant".to_string()],
+        &[],
+    );
+    assert!(
+        dbg.contains("Unimplemented"),
+        "Choreographed Sparks copy-grant must remain honestly Unimplemented"
+    );
+}
+
+#[test]
+fn leyline_of_transformation_nonbattlefield_grant_is_deferred() {
+    // The first clause (creatures you control are the chosen type) parses; the
+    // "same is true for creature spells you control and creature cards you own
+    // that aren't on the battlefield" continuous non-battlefield grant is not
+    // modeled.
+    let dbg = parsed_debug(
+        "If this card is in your opening hand, you may begin the game with it on the battlefield.\nAs this enchantment enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
+        "Leyline of Transformation",
+        &["Enchantment".to_string()],
+        &[],
+    );
+    assert!(
+        dbg.contains("Unimplemented"),
+        "Leyline of Transformation non-battlefield grant must remain honestly Unimplemented"
+    );
+}
+
+#[test]
+fn nowhere_to_run_hexproof_bypass_ward_suppression_is_deferred() {
+    // Creature-scoped "can be targeted as though they didn't have hexproof" plus
+    // ward-suppression are not modeled (the existing IgnoreHexproof is a
+    // player-scoped grant, and ward suppression has no static surface).
+    let dbg = parsed_debug(
+        "Flash\nWhen this enchantment enters, target creature an opponent controls gets -3/-3 until end of turn.\nCreatures your opponents control can be the targets of spells and abilities as though they didn't have hexproof. Ward abilities of those creatures don't trigger.",
+        "Nowhere to Run",
+        &["Enchantment".to_string()],
+        &[],
+    );
+    assert!(
+        dbg.contains("Unimplemented"),
+        "Nowhere to Run hexproof-bypass + ward-suppression must remain honestly Unimplemented"
+    );
+}
+
+// Regression: the consonant+y → "-ies" plural rule must not break the existing
+// regular "-s" and irregular plurals, and must canonicalize the new class.
+#[test]
+fn subtype_ies_plural_canonicalizes_without_breaking_siblings() {
+    use engine::parser::oracle_util::parse_subtype;
+    let cases = [
+        ("Mercenaries", "Mercenary"), // new consonant+y → ies rule
+        ("Mercenary", "Mercenary"),   // singular
+        ("Goblins", "Goblin"),        // regular -s (unaffected)
+        ("Elves", "Elf"),             // irregular table (unaffected)
+        ("Allies", "Ally"),           // table entry still wins (consonant+y)
+    ];
+    for (input, expected) in cases {
+        let (canonical, _) = parse_subtype(input)
+            .unwrap_or_else(|| panic!("parse_subtype({input:?}) must recognize the subtype"));
+        assert_eq!(
+            canonical, expected,
+            "parse_subtype({input:?}) must canonicalize to {expected:?}"
+        );
+    }
+    // A vowel+y subtype noun must NOT be treated as consonant+y (no false ies).
+    let _ = TargetFilter::Any; // keep the import meaningful regardless of feature set
+}

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -870,6 +870,7 @@ fn entering_permanent_filter_to_trigger(pred: &Permanents) -> ConvResult<Trigger
         Permanents::WasCast | Permanents::ItWasCast => TriggerCondition::WasCast {
             zone: None,
             controller: None,
+            owner: None,
         },
         // CR 702.33d-f + CR 603.4: ETB intervening-if "if it was kicked".
         Permanents::WasKicked => TriggerCondition::AdditionalCostPaid {

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -31728,14 +31728,17 @@
         },
         {
           "name": "WasCast",
-          "line": 13056,
+          "line": 13949,
           "kind": "struct",
           "field_names": [
             "zone",
-            "controller"
+            "controller",
+            "owner"
           ],
-          "doc": "CR 601.2 + CR 603.4: reads the ENTERING object's cast provenance, never the source.",
+          "doc": "CR 601.2 + CR 603.4: reads the ENTERING object's cast provenance, never the source.  Two independent, separately-resolvable scope axes (both `None` = unscoped): - `controller` — CASTER scope (\"you cast it\"). Matched against   `GameObject.cast_controller`, the player who cast the spell (Prized   Amalgam: \"you cast it from your graveyard\"). - `owner` — ORIGIN-ZONE-OWNER scope (\"your graveyard\"). Matched against   `GameObject.owner`. CR 400.3 + CR 404.1: graveyard, hand, and library are   owner-specific zones, so \"cast from your graveyard\" is equivalent to \"the   card's owner is you\" — independent of who cast it (Rocket-Powered Goblin   Glider: \"if it was cast from your graveyard\", no caster constraint). An   opponent casting your card from your graveyard satisfies `owner = You`;   you casting a card from an opponent's graveyard does not.",
           "cr_refs": [
+            "CR 400.3",
+            "CR 404.1",
             "CR 601.2",
             "CR 603.4"
           ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std long-tail batch D — parser/static arms (LT-C / LT-E / LT-F + one-offs)

Branch `card/std-longtail-d`, off `upstream/main` @ `030d478fe`. Ten long-tail std-legal cards (mostly parser arms). Every change routes to **existing** engine surface — **no new engine variant** (`data/engine-inventory.json` unchanged). Four cards shipped 0-Unimplemented with discriminating runtime/derived tests; one general dig building block shipped; five cards honest-deferred (their residual stays `Effect::unimplemented`).

## add-engine-variant gate verdict

**No variant added.** Every change is a leaf parameterization of an existing axis or a parser arm to existing surface:
- `parse_subtype` consonant+y → "-ies" regular plural rule (generic, mirrors the existing "-s"/"-es" rules) — not a special case.
- `FilterProp::Owned { Opponent }` reused for "you control but don't own" (existing prop).
- `StaticCondition::Not(DuringYourTurn)` reused for "during turns other than yours" (existing).
- `CrewAction::Station` added as a bare leaf to the existing crew/saddle/station contribution action list (existing `CrewContributionKind::ToughnessInsteadOfPower`).
- `TriggerCondition::WasCast { zone, controller }` reused (existing) for "if it was cast from your graveyard".
- `QuantityExpr::Multiply` / `Effect::Dig` reused for the count-leading "look at N cards from the top" word order.

`data/engine-inventory.json` was not regenerated and is unchanged.

## CRs (grep-verified vs docs/MagicCompRules.txt — zero UNVERIFIED)

| CR | Used for |
|----|----------|
| CR 107.3 | "twice X" multiplier in the look count (`Multiply{2, X}`) |
| CR 108.3 / CR 109.4 | "you control but don't own" = controller You + owner not-You |
| CR 601.2 / CR 603.4 | "was cast from your graveyard" intervening-if |
| CR 611.3a | continuous static turn-condition (negated `DuringYourTurn`) |
| CR 701.20a / CR 701.20e | reveal (public) vs look (private) dig |
| CR 702.184a | Station keyword action (bare "stations permanents") |

## Per-card verdict

| Card | Mini-batch | Verdict | Residual / seam |
|------|-----------|---------|-----------------|
| Laughing Jasper Flint | LT-F | **SHIPPED** | "Creatures you control but don't own are Mercenaries in addition…" — plural rule + ownership qualifier |
| Midnight Mangler | LT-F | **SHIPPED** | "During turns other than yours, ~ is an artifact creature" — negated turn-peel |
| Tapestry Warden | LT-C | **SHIPPED** | "…stations permanents using its toughness rather than its power" — bare Station leaf |
| Rocket-Powered Goblin Glider | LT-C | **SHIPPED** | "if it was cast from your graveyard" — bare `WasCast{Graveyard, You}` arm |
| Stargaze (look count) | LT-E | **BUILDING BLOCK** | count-leading "look at twice X cards from the top" dig word order (general) |
| Stargaze (card) | LT-E | **DEFER** | "Put X cards into your hand" needs `Effect::Dig.keep_count` as `QuantityExpr` |
| Sandman, Shifting Scoundrel | LT-C | **DEFER** | compound self+target return to battlefield (And-filter conflation; needs compound-return infra) |
| Fblthp, Lost on the Range | LT-E | **DEFER** | plot-from-top-of-library mechanism (no engine surface) |
| Choreographed Sparks | one-off | **DEFER** | `CopySpell` resolver doesn't apply `AddKeyword`/`GrantTrigger` to the copy |
| Leyline of Transformation | one-off | **DEFER** | continuous type-grant on non-battlefield zones (stack / hand / library) |
| Nowhere to Run | one-off | **DEFER** | creature-scoped hexproof-bypass + ward suppression (existing IgnoreHexproof is player-scoped; no ward-suppression surface) |

## Discriminating-test map (`crates/engine/tests/std_longtail_d_batch.rs`)

| Behavioral claim | Changed seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| "you control but don't own" gates the Mercenary grant | dispatch `creatures you control ` arm + `strip_negated_ownership_qualifier` + `parse_subtype` ies rule | `parse_oracle_text` → static install → `evaluate_layers` | `laughing_jasper_flint_grants_mercenary_only_to_unowned_creatures` | owned-by-you creature must NOT gain Mercenary; controlled-but-not-owned MUST (flips: pre-fix filter dropped `Owned{Opponent}`, both gain it) |
| Vehicle is a creature only on non-your-turns | `parse_pronoun_becomes_type_static` negated turn-peel | `parse_oracle_text` → static install → `evaluate_layers` (toggle `active_player`) | `midnight_mangler_is_creature_only_during_non_your_turns` | Creature type present iff opponent's turn (flips: pre-fix line was Unimplemented, no static) |
| Station contribution uses toughness | bare "stations permanents" leaf | `parse_static_line` → static install → `object_crew_power_contribution(Station)` | `tapestry_warden_station_uses_toughness_for_high_toughness_creatures` | 1/5 contributes 5 (flips: pre-fix Unimplemented → falls back to power 1) |
| ETB attach gated on cast-from-your-graveyard | `parse_graveyard_origin_intervening_if` bare arm | `parse_oracle_text` trigger condition | `rocket_powered_goblin_glider_etb_condition_is_owner_scoped_was_cast` | condition is `WasCast{Graveyard, Some(controller)}` (flips: pre-fix "from your graveyard" unconsumed → Unimplemented) + runtime evaluator honors `cast_controller`/`cast_from_zone` |
| count-leading look word order → Dig | imperative look-count arm | `parse_oracle_text` effect | `look_at_count_from_top_word_order_parses_dig` (fixed count, full Dig fields) + `stargaze_look_count_handles_twice_x_multiplier` (`Multiply{2,X}`) | Dig count/keep/dest equality (flips: pre-fix Unimplemented) |
| plural canonicalization | `parse_subtype` ies rule | `parse_subtype` | `subtype_ies_plural_canonicalizes_without_breaking_siblings` | Mercenaries→Mercenary while Goblins/Elves/Allies unchanged |

Deferred cards each carry an honesty guard (`*_is_deferred`) asserting the residual remains exactly `Unimplemented` (no over-claim). Sibling/negative coverage: LJF tests both owner axes; Midnight Mangler tests both turn directions; the ies-plural test covers -s, -es, irregular-table, and the new -ies class.

No production-reachable arm is left covered only by a degenerate fixture (the LJF fixture sets a distinct P1 owner; the MM fixture toggles the active player).

## Gates (CI parity, FULL engine suite)

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- inline parser-diff string-dispatch gate — only one annotated word-boundary `starts_with` (the y→ies plural rule, mirrors the sibling -s/-es rules; structural, not dispatch)
- `cargo check --workspace --all-targets` — exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — exit 0
- `cargo test -p engine` — 13008 passed; only the known parallel-flaky `ai_support::*delve_payment*` perf test failed under parallel load and PASSES in isolation (authorized ignore)
- CR-annotation diff gate — zero UNVERIFIED

## Files

- `crates/engine/src/parser/oracle_util.rs` — generic consonant+y → "-ies" plural rule in `parse_subtype`
- `crates/engine/src/parser/oracle_static/shared.rs` — `strip_negated_ownership_qualifier` building block
- `crates/engine/src/parser/oracle_static/dispatch.rs` — wire the ownership qualifier into the "creatures you control" arm
- `crates/engine/src/parser/oracle_static/type_change.rs` — negated turn-restriction peel
- `crates/engine/src/parser/oracle_static/evasion.rs` — bare "stations permanents" contribution leaf
- `crates/engine/src/parser/oracle_trigger.rs` — bare "(was|were) cast from [a|your] graveyard" intervening-if
- `crates/engine/src/parser/oracle_effect/imperative.rs` — count-leading "look at N cards from the top" dig word order
- `crates/engine/tests/std_longtail_d_batch.rs` — discriminating + honesty tests
