### PR TITLE
fix(parser): parse phase-based inline delayed triggers on spells (Full Throttle)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12034,6 +12034,37 @@ mod tests {
     }
 
     #[test]
+    fn spell_temporal_phase_line_builds_delayed_trigger() {
+        // CR 603.7b: Full Throttle's second line. A *phase-based* inline delayed
+        // trigger on a sorcery ("At the beginning of each combat this turn, ...")
+        // must lower to a multi-fire WheneverEvent wrapping a Phase(BeginCombat)
+        // trigger — NOT a printed battlefield trigger, which would never fire for
+        // an instant/sorcery.
+        let r = parse(
+            "At the beginning of each combat this turn, untap all creatures that attacked this turn.",
+            "Full Throttle Test",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+        assert!(
+            r.triggers.is_empty(),
+            "phase-form delayed trigger must not emit a printed trigger: {:?}",
+            r.triggers
+        );
+        assert_eq!(r.abilities.len(), 1);
+        let Effect::CreateDelayedTrigger { condition, .. } = &*r.abilities[0].effect else {
+            panic!("expected delayed trigger, got {:?}", r.abilities[0].effect);
+        };
+        let crate::types::ability::DelayedTriggerCondition::WheneverEvent { trigger } = condition
+        else {
+            panic!("expected WheneverEvent, got {condition:?}");
+        };
+        assert_eq!(trigger.mode, TriggerMode::Phase);
+        assert_eq!(trigger.phase, Some(Phase::BeginCombat));
+    }
+
+    #[test]
     fn spell_temporal_enters_line_builds_delayed_trigger() {
         let r = parse(
             "Whenever a creature enters this turn, you may draw a card.",

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -499,10 +499,23 @@ const DELAYED_TRIGGER_WINDOWS: [&str; 2] = [" this turn, ", " this combat, "];
 /// (Also "whenever [trigger condition] this combat, [effect]".)
 /// These create multi-fire delayed triggers that persist until end of turn.
 /// Example: "whenever a creature you control deals combat damage to a player this turn, draw a card"
+///
+/// CR 603.7b: A spell may also introduce a *phase-based* inline delayed trigger,
+/// "at the beginning of [phase] this turn, [effect]" (Full Throttle: "At the
+/// beginning of each combat this turn, untap all creatures that attacked this
+/// turn."). This is the same multi-fire, end-of-turn-purged delayed trigger; its
+/// embedded `TriggerDefinition` is a Phase trigger, so it fires at the start of
+/// each matching phase for the rest of the turn. Without this path it would fall
+/// through to printed-trigger dispatch and become a battlefield Phase trigger that
+/// never fires for an instant/sorcery.
 fn try_parse_whenever_this_turn(tp: TextPair) -> Option<ParsedEffectClause> {
-    if tag::<_, _, OracleError<'_>>("whenever ")
+    let is_phase_form = tag::<_, _, OracleError<'_>>("at the beginning of ")
         .parse(tp.lower)
-        .is_err()
+        .is_ok();
+    if !is_phase_form
+        && tag::<_, _, OracleError<'_>>("whenever ")
+            .parse(tp.lower)
+            .is_err()
     {
         return None;
     }
@@ -541,11 +554,22 @@ fn try_parse_whenever_this_turn(tp: TextPair) -> Option<ParsedEffectClause> {
     // trigger clause.
     let (before, after) = match window_split {
         Some(split) => split,
+        // CR 603.7b: The phase form is a delayed trigger ONLY when scoped by an
+        // explicit "this turn"/"this combat" window. Without it, "at the beginning
+        // of [phase]" is a printed trigger and must not be intercepted here.
+        None if is_phase_form => return None,
         None => tp.split_around(", ")?,
     };
 
-    // Condition is between "whenever " and the split boundary.
-    let condition_text = &before.lower[9..];
+    // Condition spans the keyword through the split boundary. The "whenever "
+    // keyword is stripped (the trigger parser decomposes the event without it);
+    // the "at the beginning of " keyword is retained because the phase-trigger
+    // parser (`try_parse_phase_trigger`) dispatches on it.
+    let condition_text = if is_phase_form {
+        before.lower
+    } else {
+        &before.lower[9..]
+    };
     // Effect is the remainder after the split boundary.
     let effect_text = after.original;
 


### PR DESCRIPTION
Fixes #828

## Summary
- A spell line of the form `At the beginning of [phase] this turn, [effect]` was not recognized as an inline delayed trigger: `try_parse_whenever_this_turn` only accepted the `whenever ` keyword, so the spell delayed-trigger dispatch (`is_spell && has_trigger_prefix && contains "this turn"`) fell through and the line was classified as a **printed** battlefield `Phase` trigger. A printed trigger never fires for an instant/sorcery, so the line did nothing.
- **Full Throttle** (`After this main phase, there are two additional combat phases.` / `At the beginning of each combat this turn, untap all creatures that attacked this turn.`) therefore only scheduled the extra combats and never untapped the attackers.
- Teaches `try_parse_whenever_this_turn` the phase-keyword form: when a spell line begins with `at the beginning of ` and carries an explicit `this turn`/`this combat` window, it now lowers to the same multi-fire `CreateDelayedTrigger { WheneverEvent { .. } }` (CR 603.7b) wrapping a `Phase` trigger, so it fires at the start of each matching phase for the rest of the turn and is purged at end-of-turn cleanup.
- Reuses the existing `WheneverEvent` delayed-trigger machinery and the `Phase` trigger matcher (`match_phase` enforces no source-zone gate, so a spell-sourced delayed Phase trigger fires correctly) — **no new enum variant**. Building-block fix for the whole "at the beginning of [phase] this turn" one-shot-spell class, not just Full Throttle.

## Verification
- `cargo fmt --all`
- New building-block test `spell_temporal_phase_line_builds_delayed_trigger` asserts the line lowers to `CreateDelayedTrigger { WheneverEvent { trigger: Phase(BeginCombat) } }` and emits **no** printed trigger — passed.
- `cargo test -p engine --lib parser::` — 6458 passed, 0 failed (no regression to the existing `whenever`/`enters` delayed-trigger paths).