### PR TITLE
feat(engine): long-tail one-offs E (Chandra Flameshaper, Contested Game Ball, Spider-Woman Stunning Savior)

### DIFF
--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -76,6 +76,7 @@ pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
         | TargetFilter::ExiledBySource
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
@@ -145,6 +146,7 @@ pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter 
         | TargetFilter::ExiledBySource
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -471,6 +471,7 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::CostPaidObject => "cost-paid object".into(),
         TargetFilter::TriggeringSpellController => "triggering spell's controller".into(),
         TargetFilter::TriggeringSpellOwner => "triggering spell's owner".into(),
+        TargetFilter::TriggeringSourceController => "triggering source's controller".into(),
         TargetFilter::TriggeringPlayer => "triggering player".into(),
         TargetFilter::TriggeringSource => "triggering source".into(),
         TargetFilter::DefendingPlayer => "defending player".into(),

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -301,11 +301,18 @@ fn unique_recipient_from_filter(
         ));
     }
 
-    // CR 603.7c + CR 608.2c: "that player" on triggered abilities lowers to
-    // `TargetFilter::TriggeringPlayer`. The stateless player matcher cannot
-    // resolve event-context refs, so bind the recipient from the active trigger
-    // event (Coveted Jewel: the attacking opponent).
-    if matches!(filter, TargetFilter::TriggeringPlayer) {
+    // CR 603.7c + CR 608.2c: Event-context player anaphors on triggered
+    // abilities. `TriggeringPlayer` ("that player") binds to the player involved
+    // in the trigger (Coveted Jewel: the attacking opponent);
+    // `TriggeringSourceController` ("the attacking player") binds to the
+    // controller of the triggering event's source object (Contested Game Ball:
+    // the player whose creature dealt combat damage). The stateless player
+    // matcher cannot resolve event-context refs, so bind from the active trigger
+    // event.
+    if matches!(
+        filter,
+        TargetFilter::TriggeringPlayer | TargetFilter::TriggeringSourceController
+    ) {
         return crate::game::targeting::resolve_event_context_target(
             state,
             filter,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -79,6 +79,7 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::ExiledCardByIndex { .. }
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
@@ -274,6 +275,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::ExiledCardByIndex { .. }
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
@@ -1664,6 +1666,7 @@ fn filter_inner_for_object(
         // CR 603.7c: Event-context references resolve to players, not objects.
         TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::DefendingPlayer => false,
@@ -1906,6 +1909,7 @@ fn zone_change_filter_inner(
         | TargetFilter::ExiledCardByIndex { .. }
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
@@ -2138,6 +2142,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::ExiledCardByIndex { .. }
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget
@@ -2379,6 +2384,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::ExiledCardByIndex { .. }
         | TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::ParentTarget

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -767,6 +767,18 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
             let obj_id = extract_source_from_event(event)?;
             Some(TargetRef::Object(obj_id))
         }
+        // CR 603.7c + CR 109.4 + CR 110.2: "the attacking player" / "its
+        // controller" — the controller of the triggering event's source object
+        // (the player-level counterpart of `TriggeringSource`, mirroring
+        // `TriggeringSpellController`). Contested Game Ball's DamageReceived
+        // trigger needs the controller of the creature that dealt combat
+        // damage, not the damaged player.
+        TargetFilter::TriggeringSourceController => {
+            let event = event?;
+            let source_obj_id = extract_source_from_event(event)?;
+            let controller = state.objects.get(&source_obj_id)?.controller;
+            Some(TargetRef::Player(controller))
+        }
         TargetFilter::ParentTarget => {
             let event = event?;
             blocked_attacker_from_event(event, source_id).map(TargetRef::Object)

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -776,7 +776,16 @@ pub(crate) fn resolve_event_context_target_for_event_or_state(
         TargetFilter::TriggeringSourceController => {
             let event = event?;
             let source_obj_id = extract_source_from_event(event)?;
-            let controller = state.objects.get(&source_obj_id)?.controller;
+            let controller = state
+                .objects
+                .get(&source_obj_id)
+                .map(|obj| obj.controller)
+                .or_else(|| {
+                    state
+                        .lki_cache
+                        .get(&source_obj_id)
+                        .map(|lki| lki.controller)
+                })?;
             Some(TargetRef::Player(controller))
         }
         TargetFilter::ParentTarget => {

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -733,6 +733,7 @@ pub(super) fn target_filter_matches_object(
         TargetFilter::Neighbor { .. } => false,
         TargetFilter::TriggeringSpellController
         | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringSourceController
         | TargetFilter::TriggeringPlayer
         | TargetFilter::TriggeringSource
         | TargetFilter::DefendingPlayer

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3111,6 +3111,27 @@ pub(crate) fn parse_oracle_ir(
                 i += 1;
                 continue;
             }
+            // CR 207.2c: An ability word (e.g. "Venom Blast —") is an italicized
+            // flavor marker with no rules meaning — its replacement body must
+            // parse through the ordinary replacement machinery. Strip the
+            // prefix and retry so named static-replacement ability words
+            // (Spider-Woman's "Venom Blast — Artifacts and creatures your
+            // opponents control enter tapped.") reach the external-entry parser
+            // exactly as the unprefixed Blind Obedience / Authority of the
+            // Consuls lines do.
+            if let Some(effect_text) = strip_ability_word(&line) {
+                if let Some(rep_defs) = parse_replacement_sentence_sequence(&effect_text, card_name)
+                {
+                    result.replacements.extend(rep_defs);
+                    i += 1;
+                    continue;
+                }
+                if let Some(rep_def) = parse_replacement_line(&effect_text, card_name) {
+                    result.replacements.push(rep_def);
+                    i += 1;
+                    continue;
+                }
+            }
         }
 
         if let Some(def) = try_parse_opening_hand_reveal_delayed_trigger(&line, &lower) {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2858,6 +2858,30 @@ fn try_parse_choose_owned_by_voter(
 fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
 
+    // CR 608.2c + CR 700.2: A standalone "Choose one." / "Choose one card."
+    // clause (empty tail) in a resolution chain is the impulse-exile reduction
+    // idiom — a preceding clause exiled one or more cards and a following clause
+    // grants permission to play one of them ("Exile the top three cards of your
+    // library. Choose one. You may play that card this turn." — Chandra,
+    // Flameshaper). The anaphor referent is the chain's tracked set, mirroring
+    // "choose one of them" but without the explicit anaphor suffix. The modal
+    // header "Choose one —" is consumed earlier by the modal-block dispatch, so
+    // any "choose one" reaching the effect parser is this reduction form.
+    if let Ok((tail, ())) = preceded(
+        alt((tag::<_, _, E>("choose "), tag("you choose "))),
+        value((), alt((tag::<_, _, E>("one card"), tag("one")))),
+    )
+    .parse(lower)
+    {
+        if tail.is_empty() {
+            return Some(ChooseImperativeAst::FromTrackedSet {
+                count: 1,
+                chooser: Chooser::Controller,
+                selection: CardSelectionMode::Chosen,
+            });
+        }
+    }
+
     // "choose " / "you choose ", then the singular card anaphor "a card" / "one
     // card" / "a [type] card". Only the bare card forms are handled here; typed
     // restrictions on impulse-exile choices are not yet attested and would fall

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1667,6 +1667,15 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // exceeds the 2-word cap.
     .or(value((), tag("reveal ")))
     .or(value((), tag("returns ")))
+    // CR 701.26b + CR 701.26a + CR 608.2c: third-person "untaps"/"taps"
+    // conjugation. Control-handoff class: "the attacking player gains control
+    // of ~ and untaps it" (Contested Game Ball) — the followup tap-state clause
+    // must split as its own conjunct so it deconjugates ("untaps it" → "untap
+    // it") and reaches the tap dispatcher. Mirrors the imperative `untap `/`tap
+    // ` axis above, different conjugation; sits in the `.or()` chain because the
+    // first `alt()` tuple is at nom's 21-arm limit.
+    .or(value((), tag("untaps ")))
+    .or(value((), tag("taps ")))
     // CR 122.1 + CR 608.2c: third-person "puts" conjugation. Oversimplify
     // class: "Each player creates a … token and puts a number of +1/+1
     // counters on it equal to …" — the subject ("Each player") iterates and

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1574,6 +1574,13 @@ pub(super) fn parse_subject_application(
             ("that attacking player", true),
             tag::<_, _, OracleError<'_>>("that attacking player may"),
         ),
+        // CR 603.7c: "the attacking player" on a DamageReceived trigger — the
+        // controller of the creature that dealt combat damage (Contested Game
+        // Ball). Longest-match before "the player".
+        value(
+            ("the attacking player", true),
+            tag("the attacking player may"),
+        ),
         value(
             ("that player", true),
             tag::<_, _, OracleError<'_>>("that player may"),
@@ -1583,6 +1590,7 @@ pub(super) fn parse_subject_application(
             ("that attacking player", false),
             tag("that attacking player"),
         ),
+        value(("the attacking player", false), tag("the attacking player")),
         value(("that player", false), tag("that player")),
         value(("the player", false), tag("the player")),
     )))
@@ -1594,7 +1602,9 @@ pub(super) fn parse_subject_application(
         };
         if matches!(
             ctx_filter,
-            TargetFilter::TriggeringPlayer | TargetFilter::DefendingPlayer
+            TargetFilter::TriggeringPlayer
+                | TargetFilter::DefendingPlayer
+                | TargetFilter::TriggeringSourceController
         ) {
             // CR 608.2c + CR 109.4 (issue #534): "That player" after a
             // `Choose(Player)`/`Choose(Opponent)` clause binds to the
@@ -4295,6 +4305,11 @@ pub(crate) fn starts_with_subject_prefix(lower: &str) -> bool {
             value((), tag("target ")),
             value((), tag("that ")),
             value((), tag("the chosen ")),
+            // CR 506.2 + CR 603.7c: "the attacking player" as a control-handoff
+            // subject on a DamageReceived trigger (Contested Game Ball) — the
+            // controller of the creature that dealt combat damage. Longest-match
+            // before the bare "the player " arm.
+            value((), tag("the attacking player ")),
             value((), tag("the player ")),
             // CR 609.7 + CR 615.5: "the source's controller" / "the source's
             // owner" as a subject in a damage-prevention follow-up (Swans of

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -610,16 +610,29 @@ fn parse_token_count_prefix(text: &str) -> Option<(QuantityExpr, &str)> {
 }
 
 fn parse_named_token_preamble(text: &str) -> Option<(String, &str)> {
-    let comma = text.find(',')?;
-    let name = text[..comma].trim().trim_matches('"');
-    if name.is_empty() {
-        return None;
+    // CR 111.4: A named-token preamble is "<Name>, a/an <characteristics> token".
+    // The token name may itself contain a comma ("Primo, the Indivisible";
+    // "Tibalt, the Fiend-Blooded"), so the FIRST comma is not necessarily the
+    // name/body boundary. The boundary is the comma immediately followed by the
+    // article that introduces the token's characteristics (", a "/", an "). Scan
+    // every comma and pick the one whose remainder begins with an article, so
+    // the full epithet stays in the name. Mirrors the article guard already used
+    // for the single-comma case.
+    for (idx, _) in text.match_indices(',') {
+        let after_comma = text[idx + 1..].trim_start();
+        let after_lower = after_comma.to_lowercase();
+        let Some((_, rest)) =
+            nom_on_lower(after_comma, &after_lower, nom_primitives::parse_article)
+        else {
+            continue;
+        };
+        let name = text[..idx].trim().trim_matches('"');
+        if name.is_empty() {
+            continue;
+        }
+        return Some((name.to_string(), rest));
     }
-
-    let after_comma = text[comma + 1..].trim_start();
-    let after_lower = after_comma.to_lowercase();
-    let (_, rest) = nom_on_lower(after_comma, &after_lower, nom_primitives::parse_article)?;
-    Some((name.to_string(), rest))
+    None
 }
 
 /// CR 205.4a: Strip leading supertype words from the token description and

--- a/crates/engine/src/parser/oracle_nom/target.rs
+++ b/crates/engine/src/parser/oracle_nom/target.rs
@@ -359,6 +359,16 @@ pub fn parse_event_context_ref(input: &str) -> OracleResult<'_, TargetFilter> {
         // CR 506.3d: "defending player" / "the defending player"
         value(TargetFilter::DefendingPlayer, tag("the defending player")),
         value(TargetFilter::DefendingPlayer, tag("defending player")),
+        // CR 603.7c + CR 109.4: "the attacking player" on a DamageReceived
+        // trigger — the controller of the creature that dealt combat damage
+        // (Contested Game Ball). Distinct from "that attacking player" (an
+        // attack-declared referent → TriggeringPlayer): the wanted player here
+        // is the controller of the triggering damage *source*, not the
+        // damaged player. Ordered before the bare "the player" arm.
+        value(
+            TargetFilter::TriggeringSourceController,
+            tag("the attacking player"),
+        ),
         // CR 608.2k: "the player" in trigger context is synonymous with
         // "that player" — anaphoric reference to the triggering player.
         // Ordered after "the defending player" so longest-match-first is

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3308,6 +3308,16 @@ pub enum TargetFilter {
     TriggeringPlayer,
     /// CR 603.7c: Resolves to the source object of the triggering event.
     TriggeringSource,
+    /// CR 603.7c + CR 109.4 + CR 110.2: Resolves to the *controller* of the
+    /// triggering event's source object — the player-level counterpart of
+    /// `TriggeringSource`, mirroring how `TriggeringSpellController` is the
+    /// controller of `StackSpell`. Used by "the attacking player" / "its
+    /// controller" anaphors on `DamageReceived` triggers where the wanted
+    /// player is the controller of the creature that dealt combat damage, not
+    /// the damaged player (`TriggeringPlayer`). Powers Contested Game Ball
+    /// ("Whenever you're dealt combat damage, the attacking player gains
+    /// control of this artifact and untaps it.").
+    TriggeringSourceController,
     /// Resolves to the same target(s) as the parent ability.
     /// Used for anaphoric "it"/"that creature"/"that player" in compound effects
     /// (e.g., "tap target creature and put a stun counter on it").

--- a/crates/engine/tests/std_longtail_e.rs
+++ b/crates/engine/tests/std_longtail_e.rs
@@ -232,6 +232,9 @@ fn contested_game_ball_attacker_gains_control_and_untaps() {
         is_combat: true,
         excess: 0,
     });
+    let attacker_lki = runner.state().objects[&attacker].snapshot_for_mana_spent();
+    runner.state_mut().lki_cache.insert(attacker, attacker_lki);
+    runner.state_mut().objects.remove(&attacker);
 
     let ability = build_resolved_from_def(exec, ball, P0);
     let mut events = Vec::new();

--- a/crates/engine/tests/std_longtail_e.rs
+++ b/crates/engine/tests/std_longtail_e.rs
@@ -1,0 +1,255 @@
+//! Standard long-tail batch E — shipped-card parse + runtime gates.
+//!
+//! Shipped cards (each parses with zero `Effect::Unimplemented`):
+//!   - Chandra, Flameshaper (+2 "Choose one." → tracked-set reduction)
+//!   - Contested Game Ball ("the attacking player gains control of ~ and untaps it")
+//!   - Spider-Woman, Stunning Savior ("Venom Blast — Artifacts and creatures your
+//!     opponents control enter tapped." — ability-word-prefixed external ETB-tapped)
+//!
+//! Building-block win (named-token parsing): "Primo, the Indivisible, a legendary
+//! 0/0 … token" — a multi-comma legendary token name now parses.
+//!
+//! Deferred (honest `Effect::unimplemented` / SwallowedClause retained, NOT
+//! asserted 0-unimpl): Ojer Taq (token-triplication replacement — heavy CR 616
+//! commute interaction), Vraska the Silencer (return-as-Treasure-with-ability —
+//! heavy continuous-self-modification infra), Zimone (prime-number intervening-if
+//! condition — heavy primality predicate; the token+counter parse is fixed, the
+//! card stays honestly condition-unsupported via a SwallowedClause warning).
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::TargetFilter;
+use engine::types::ability::TargetRef;
+use engine::types::events::GameEvent;
+use engine::types::phase::Phase;
+
+fn parse(
+    oracle: &str,
+    name: &str,
+    keywords: &[&str],
+    types: &[&str],
+    subtypes: &[&str],
+) -> engine::parser::oracle::ParsedAbilities {
+    let kw: Vec<String> = keywords.iter().map(|s| s.to_string()).collect();
+    let t: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    let s: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(oracle, name, &kw, &t, &s)
+}
+
+fn assert_zero_unimplemented(parsed: &engine::parser::oracle::ParsedAbilities, name: &str) {
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "{name}: expected zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Chandra, Flameshaper — +2 "Choose one." tracked-set reduction
+// ---------------------------------------------------------------------------
+
+/// CR 608.2c + CR 700.2: The standalone "Choose one." sentence inside the impulse
+/// chain ("Exile the top three cards … Choose one. You may play that card this
+/// turn.") lowers to a `ChooseFromZone { Exile }` reduction over the tracked set,
+/// followed by the play grant. Reverting the bare-"choose one" anaphor arm leaves
+/// the clause `Unimplemented`, flipping `assert_zero_unimplemented` AND the
+/// `ChooseFromZone` shape assertion below.
+#[test]
+fn chandra_flameshaper_choose_one_reduces_tracked_set() {
+    let parsed = parse(
+        "[+2]: Add {R}{R}{R}. Exile the top three cards of your library. Choose one. You may play that card this turn.\n[+1]: Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\n[−4]: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.",
+        "Chandra, Flameshaper",
+        &[],
+        &["Legendary", "Planeswalker"],
+        &["Chandra"],
+    );
+    assert_zero_unimplemented(&parsed, "Chandra, Flameshaper");
+
+    // The +2 chain must carry an interactive ChooseFromZone over the exiled set
+    // (the impulse reduction), then a PlayFromExile grant. Reverting the fix
+    // replaces the ChooseFromZone with an Unimplemented sub-effect.
+    use engine::types::ability::Effect;
+    let plus_two = parsed
+        .abilities
+        .iter()
+        .find(|a| format!("{:#?}", a).contains("Exile the top three cards"))
+        .expect("+2 ability present");
+    let chain = format!("{plus_two:#?}");
+    assert!(
+        chain.contains("ChooseFromZone"),
+        "+2 chain must reduce the exiled set via ChooseFromZone, got:\n{chain}"
+    );
+    // Sanity: an exile-top still leads the chain.
+    assert!(
+        matches!(&*plus_two.effect, Effect::Mana { .. }),
+        "+2 leads with the {{R}}{{R}}{{R}} mana ability"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Spider-Woman, Stunning Savior — ability-word-prefixed external ETB-tapped
+// ---------------------------------------------------------------------------
+
+/// CR 207.2c + CR 614.1d: The "Venom Blast —" ability word is flavor; the body
+/// "Artifacts and creatures your opponents control enter tapped." must parse
+/// through the external-entry replacement machinery exactly as the unprefixed
+/// Authority of the Consuls / Blind Obedience lines do. Reverting the
+/// ability-word strip in the replacement priority leaves the whole line
+/// `Unimplemented`.
+#[test]
+fn spider_woman_venom_blast_external_enters_tapped() {
+    let parsed = parse(
+        "Flying\nVenom Blast — Artifacts and creatures your opponents control enter tapped.",
+        "Spider-Woman, Stunning Savior",
+        &["Flying"],
+        &["Legendary", "Creature"],
+        &["Spider"],
+    );
+    assert_zero_unimplemented(&parsed, "Spider-Woman, Stunning Savior");
+
+    // A ChangeZone-event replacement scoped to opponents' artifacts/creatures
+    // must be produced (it would be absent if the ability-word prefix blocked
+    // the replacement parser).
+    assert_eq!(
+        parsed.replacements.len(),
+        1,
+        "expected exactly one external enters-tapped replacement, got {:#?}",
+        parsed.replacements
+    );
+    let dbg = format!("{:#?}", parsed.replacements[0]);
+    assert!(
+        dbg.contains("Opponent") && dbg.contains("SetTapState") && dbg.contains("Tap"),
+        "replacement must tap opponents' permanents on entry, got:\n{dbg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Named-token building block — multi-comma legendary token name
+// ---------------------------------------------------------------------------
+
+/// CR 111.4: A token whose name itself contains a comma ("Primo, the
+/// Indivisible") must parse with the full epithet as the name, the article
+/// boundary being the ", a " that introduces the token's characteristics — not
+/// the first comma. Reverting `parse_named_token_preamble` to first-comma
+/// splitting leaves the clause `Unimplemented`.
+#[test]
+fn named_token_with_comma_in_name_parses() {
+    use engine::types::ability::Effect;
+    let parsed = parse(
+        "When this creature enters, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it.",
+        "Named Token Probe",
+        &[],
+        &["Creature"],
+        &[],
+    );
+    assert_zero_unimplemented(&parsed, "Named Token Probe");
+    let trigger = parsed.triggers.first().expect("ETB trigger present");
+    let exec = trigger.execute.as_ref().expect("trigger execute present");
+    match &*exec.effect {
+        Effect::Token {
+            name, supertypes, ..
+        } => {
+            assert_eq!(
+                name, "Primo, the Indivisible",
+                "named token must keep the full comma-bearing epithet"
+            );
+            assert!(
+                supertypes.iter().any(|s| format!("{s:?}") == "Legendary"),
+                "token must be Legendary, got {supertypes:?}"
+            );
+        }
+        other => panic!("expected Token effect, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Contested Game Ball — runtime: attacking player gains control + untaps it
+// ---------------------------------------------------------------------------
+
+/// CR 110.2 + CR 603.7c + CR 109.4: On a DamageReceived trigger
+/// ("Whenever you're dealt combat damage, the attacking player gains control of
+/// this artifact and untaps it."), the recipient of control is the controller of
+/// the triggering damage *source* (the attacker, P1) — resolved through the new
+/// `TargetFilter::TriggeringSourceController` — and the artifact is untapped.
+///
+/// Discrimination: the artifact starts tapped under P0's control; after resolving
+/// the trigger's execute with the combat-damage event live, it is controlled by
+/// P1 AND untapped. Reverting any of the three pieces flips an assertion:
+///   - drop `TriggeringSourceController` resolution → recipient unresolved →
+///     control stays with P0 (controller assertion fails);
+///   - drop the "untaps" bare-and split → SetTapState becomes Unimplemented and
+///     never runs → artifact stays tapped (tapped assertion fails);
+///   - mis-map "the attacking player" to `TriggeringPlayer` → control would go to
+///     the damaged player P0 (controller assertion fails, since for a DamageDealt
+///     event TriggeringPlayer is the damaged player).
+#[test]
+fn contested_game_ball_attacker_gains_control_and_untaps() {
+    let parsed = parse(
+        "Whenever you're dealt combat damage, the attacking player gains control of this artifact and untaps it.\n{2}, {T}: Draw a card and put a point counter on this artifact. Then if it has five or more point counters on it, sacrifice it and create a Treasure token.",
+        "Contested Game Ball",
+        &[],
+        &["Artifact"],
+        &[],
+    );
+    assert_zero_unimplemented(&parsed, "Contested Game Ball");
+
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| format!("{:?}", t.mode) == "DamageReceived")
+        .expect("DamageReceived trigger present");
+    let exec = trigger.execute.as_ref().expect("trigger execute present");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let ball = scenario
+        .add_creature(P0, "Contested Game Ball", 0, 0)
+        .as_artifact()
+        .id();
+    // The attacking creature is controlled by P1.
+    let attacker = scenario.add_creature(P1, "Attacker", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // The Game Ball starts tapped under P0's control.
+    runner.state_mut().objects.get_mut(&ball).unwrap().tapped = true;
+    assert_eq!(
+        runner.state().objects[&ball].controller,
+        P0,
+        "precondition: P0 controls the ball"
+    );
+    assert!(
+        runner.state().objects[&ball].tapped,
+        "precondition: the ball is tapped"
+    );
+
+    // Make the combat-damage event live: P1's attacker dealt combat damage to P0.
+    runner.state_mut().current_trigger_event = Some(GameEvent::DamageDealt {
+        source_id: attacker,
+        target: TargetRef::Player(P0),
+        amount: 2,
+        is_combat: true,
+        excess: 0,
+    });
+
+    let ability = build_resolved_from_def(exec, ball, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("trigger execute resolves");
+
+    // Control transfers to the attacking player (P1), and the artifact is untapped.
+    runner.state_mut().layers_dirty.mark_full();
+    engine::game::layers::evaluate_layers(runner.state_mut());
+    assert_eq!(
+        runner.state().objects[&ball].controller,
+        P1,
+        "the attacking player (P1) must gain control of the Game Ball"
+    );
+    assert!(
+        !runner.state().objects[&ball].tapped,
+        "the Game Ball must be untapped after the trigger resolves"
+    );
+    // The recipient really came from the triggering source's controller.
+    let _ = TargetFilter::TriggeringSourceController;
+}

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1081,6 +1081,7 @@ fn target_filter_variant_name(f: &TargetFilter) -> &'static str {
         TargetFilter::ExiledBySource => "ExiledBySource",
         TargetFilter::TriggeringSpellController => "TriggeringSpellController",
         TargetFilter::TriggeringSpellOwner => "TriggeringSpellOwner",
+        TargetFilter::TriggeringSourceController => "TriggeringSourceController",
         TargetFilter::TriggeringPlayer => "TriggeringPlayer",
         TargetFilter::TriggeringSource => "TriggeringSource",
         TargetFilter::ParentTarget => "ParentTarget",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

# std long-tail E — Chandra, Contested Game Ball, Spider-Woman + named-token building block

Final residual bundle of the std-card long-tail effort (LT-D token-multiplier cluster + the last parser/effect one-offs). Branch `card/std-longtail-e`, cut off latest `upstream/main` (`c5e903be7`).

## Summary

Ships **3 cards 0-`Unimplemented`** and adds the **named-token (comma-in-name) parsing building block**. Three cards are honest-deferred (heavy infra), each retaining an honest residual (`Effect::unimplemented` or a `SwallowedClause` warning).

| Card | Verdict | Seam | Engine surface |
|---|---|---|---|
| Chandra, Flameshaper | **SHIPPED** | +2 standalone "Choose one." → tracked-set reduction | reuse `ChooseFromZone` (parser-only) |
| Contested Game Ball | **SHIPPED** | "the attacking player gains control of ~ and untaps it" | **new `TargetFilter::TriggeringSourceController`** + reuse `GiveControl`/`SetTapState` |
| Spider-Woman, Stunning Savior | **SHIPPED** | "Venom Blast —" ability-word-prefixed external enters-tapped | reuse external-entry replacement (parser-only) |
| (named-token building block) | **SHIPPED** | multi-comma legendary token name "Primo, the Indivisible" | `parse_named_token_preamble` fix (parser-only) |
| Ojer Taq, Deepest Foundation | DEFERRED | "three times that many" token-triplication replacement | heavy: `QuantityModification` multiplier + CR 616 commute |
| Vraska, the Silencer | DEFERRED | "It's a Treasure artifact with [ability] and loses all other card types" | heavy: return-as-type continuous self-mod (ReturnAsAura-class) |
| Zimone, All-Questioning | DEFERRED | "if you control a prime number of lands" intervening-if | heavy: primality predicate (token+counter parse fixed; card honest via SwallowedClause) |

## add-engine-variant verdict

**APPROVED: `TargetFilter::TriggeringSourceController`** (controller of the triggering event's source object).

- **Stage 1 (existence):** DOES_NOT_EXIST. Greps for `TriggeringSourceController` / "controller of triggering source" / `*SourceController` returned only `TriggeringSpellController` (controller of the triggering *spell*, a structurally different referent), `PostReplacementSourceController` (replacement context), `ParentTargetController` (parent target). No match for the triggering-event source's controller.
- **Stage 2 (parameterization):** EXTEND_OK. Orthogonal referent — the triggering event's source object's controller, exactly paralleling how `TriggeringSpellController` parallels `StackSpell` and `TriggeringSource` is the object form. Not a comparator/scope axis of an existing variant; the "controller of object X" family members each name a structurally distinct object (spell / parent target / replacement source / triggering source), not a single parameterizable axis.
- **Stage 3 (categorical boundary):** WITHIN_SECTION. Control-reference layer, CR 603.7c (triggering-event referents) + CR 109.4/110.2 (control). No cross-section unification.

Runtime: resolved in `targeting::resolve_event_context_target_for_event_or_state` (controller of `extract_source_from_event`), consumed by `gain_control::resolve_give`'s recipient path. Not a type-only stub — the discriminating test proves real resolution.

`data/engine-inventory.json`: a `cargo engine-inventory` regen churned ~6k lines non-deterministically (source-file ordering); restored to the committed state per the effort protocol. The variant is correctly defined in source; the inventory is a discoverability aid, not a correctness gate.

## Grep-verified CRs (all verified against `docs/MagicCompRules.txt`; zero UNVERIFIED)

| CR | Use |
|---|---|
| 109.4 | controller references (TriggeringSourceController) |
| 110.2 | permanent controller / give control |
| 111.4 | token name & subtype (named-token preamble) |
| 207.2c | ability words are flavor (Venom Blast strip) |
| 506.2 | the attacking player definition |
| 603.7c | triggering-event referents |
| 608.2c | resolution-order instructions / anaphora |
| 700.2 | modal "Choose one —" (distinguished from the reduction idiom) |
| 701.26a | tap |
| 701.26b | untap |

## Discriminating-test map (`crates/engine/tests/std_longtail_e.rs`)

| Behavioral claim | Changed seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| Attacker gains control + untap | `TriggeringSourceController` resolution + GiveControl recipient + "untaps" split | `resolve_ability_chain` on the parsed DamageReceived trigger execute, with the combat-damage event live | `contested_game_ball_attacker_gains_control_and_untaps` | `controller == P1` (attacker) AND `!tapped` — verified to FAIL when the recipient resolution is reverted (control stays with P0) |
| +2 "Choose one." reduces exiled set | bare-"choose one" tracked-set anaphor | `parse_oracle_text` pipeline (0-Unimplemented gate + ChooseFromZone shape) | `chandra_flameshaper_choose_one_reduces_tracked_set` | `chain.contains("ChooseFromZone")` + 0-Unimplemented (revert → Unimplemented sub-effect) |
| Ability-word body reaches external-entry replacement | ability-word strip in replacement priority | `parse_oracle_text` (replacements vec) | `spider_woman_venom_blast_external_enters_tapped` | `replacements.len() == 1` + Opponent/SetTapState/Tap (revert → 0 replacements, line Unimplemented) |
| Multi-comma legendary token name | `parse_named_token_preamble` article-boundary split | `parse_oracle_text` (Token effect) | `named_token_with_comma_in_name_parses` | `name == "Primo, the Indivisible"` + Legendary (revert → Unimplemented) |

Contested Game Ball is a true production-path runtime test: it submits the parsed trigger's `execute` through `resolve_ability_chain` with `current_trigger_event` set to the real `GameEvent::DamageDealt`, exercising the live `TriggeringSourceController` → `GiveControl` → `SetTapState` route. Discrimination was confirmed by reverting the recipient-resolution arm and observing the test fail.

The three parser-shipped cards' tests assert both 0-Unimplemented AND the load-bearing typed shape (ChooseFromZone / external-replacement / Token name+supertype). The deferred cards are NOT asserted 0-unimpl and keep honest residuals.

## Gates (CI parity, run in worktree)

- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — exit 0
- inline parser-diff string-dispatch gate (contains/find/split/rsplit/split_once on added parser lines) — no output (clean; named-token uses structural `match_indices` on commas, not phrase dispatch)
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine` — **13013 passed, 1 failed (known parallel-flaky `ai_support::*delve_payment*`, passes in isolation), 6 ignored**. New `std_longtail_e` suite: 4/4 pass.
- CR-annotation diff gate — 0 UNVERIFIED
- `cargo coverage` / `cargo semantic-audit` — not runnable in worktree (require `card-data.json`, intentionally absent per effort protocol); per-shipped-card 0-Unimplemented + discriminating `apply()` test is the protocol substitute.

## Files touched

- `types/ability.rs` — new `TargetFilter::TriggeringSourceController` variant (CR-annotated)
- `game/targeting.rs` — runtime resolution of the new variant
- `game/effects/gain_control.rs` — GiveControl recipient resolves the new variant
- `game/{filter,cost_payability,coverage,trigger_matchers}.rs`, `mtgish-import/convert/condition.rs` — exhaustive-match arms for the new variant (all default/fail-closed)
- `parser/oracle_nom/target.rs` — "the attacking player" → TriggeringSourceController
- `parser/oracle_effect/subject.rs` — "the attacking player" subject + recipient mapping
- `parser/oracle_effect/sequence.rs` — third-person "untaps"/"taps" bare-and split
- `parser/oracle_effect/imperative.rs` — bare "choose one"/"choose one card" tracked-set anaphor (Chandra)
- `parser/oracle.rs` — strip ability word before replacement parse (Spider-Woman)
- `parser/oracle_effect/token.rs` — named-token preamble article-boundary split (Primo)
- `tests/std_longtail_e.rs` — parse + runtime gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
