### PR TITLE
fix(parser): populate reveal-hand choose filter when fused with "and" (Biting-Palm Ninja)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1,7 +1,7 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::{one_of, space1};
+use nom::character::complete::{one_of, space0, space1};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value};
 use nom::error::ParseError;
 use nom::sequence::{preceded, terminated};
@@ -2578,18 +2578,20 @@ fn parse_hand_reveal_target_and_card_filter(
     // clause must populate `card_filter`; an empty `None` filter matches nothing, so
     // without it the RevealHand chooses and exiles nothing (a silent no-op).
     if let Ok((rest, target)) = parse_hand_possessive_target(after_reveal_lower) {
-        if let Some(choose) = rest
-            .trim_start()
-            .strip_prefix("and ")
-            .map(str::trim_start)
-            .filter(|clause| {
-                nom_primitives::scan_contains(clause, "card from it")
-                    && alt((tag::<_, _, OracleError<'_>>("you choose "), tag("choose ")))
-                        .parse(*clause)
-                        .is_ok()
-            })
+        if let Ok((_, choose)) = preceded(
+            (space0, tag::<_, _, OracleError<'_>>("and "), space0),
+            nom::combinator::rest,
+        )
+        .parse(rest)
         {
-            return (target, super::parse_choose_filter(choose, ctx));
+            let chooses_card_from_it = nom_primitives::scan_contains(choose, "card from it")
+                && alt((tag::<_, _, OracleError<'_>>("you choose "), tag("choose ")))
+                    .parse(choose)
+                    .is_ok();
+
+            if chooses_card_from_it {
+                return (target, super::parse_choose_filter(choose, ctx));
+            }
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2442,7 +2442,7 @@ pub(super) fn lower_search_and_creation_ast(ast: SearchCreationImperativeAst) ->
 pub(super) fn parse_hand_reveal_ast(
     text: &str,
     lower: &str,
-    _ctx: &mut ParseContext,
+    ctx: &mut ParseContext,
 ) -> Option<HandRevealImperativeAst> {
     // CR 406.6: Private look at source-linked exile (Scroll Rack) — no "hand" in phrase.
     if let Some((_, after_look_at)) =
@@ -2556,7 +2556,8 @@ pub(super) fn parse_hand_reveal_ast(
     // This function only handles hand-related reveals.
 
     if nom_primitives::scan_contains(lower, "hand") {
-        let (target, card_filter) = parse_hand_reveal_target_and_card_filter(after_reveal_lower);
+        let (target, card_filter) =
+            parse_hand_reveal_target_and_card_filter(after_reveal_lower, ctx);
         return Some(HandRevealImperativeAst::RevealAll {
             target,
             card_filter,
@@ -2568,7 +2569,30 @@ pub(super) fn parse_hand_reveal_ast(
 
 fn parse_hand_reveal_target_and_card_filter(
     after_reveal_lower: &str,
+    ctx: &mut ParseContext,
 ) -> (TargetFilter, TargetFilter) {
+    // CR 701.20a + reflexive choose: "<possessive> hand and you choose a [filter]
+    // card from it" names the revealing player's hand directly, then the
+    // controller chooses a filtered card from it (Biting-Palm Ninja: "that player
+    // reveals their hand and you choose a nonland card from it."). The fused choose
+    // clause must populate `card_filter`; an empty `None` filter matches nothing, so
+    // without it the RevealHand chooses and exiles nothing (a silent no-op).
+    if let Ok((rest, target)) = parse_hand_possessive_target(after_reveal_lower) {
+        if let Some(choose) = rest
+            .trim_start()
+            .strip_prefix("and ")
+            .map(str::trim_start)
+            .filter(|clause| {
+                nom_primitives::scan_contains(clause, "card from it")
+                    && alt((tag::<_, _, OracleError<'_>>("you choose "), tag("choose ")))
+                        .parse(*clause)
+                        .is_ok()
+            })
+        {
+            return (target, super::parse_choose_filter(choose, ctx));
+        }
+    }
+
     if let Ok((after_all, _)) = tag::<_, _, OracleError<'_>>("all ").parse(after_reveal_lower) {
         let Ok((hand_phrase, descriptor)) = terminated(
             take_until::<_, _, OracleError<'_>>(" cards"),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -38511,6 +38511,42 @@ mod tests {
     }
 
     #[test]
+    fn fused_reveal_hand_and_choose_populates_card_filter() {
+        // Biting-Palm Ninja (#842): the choose clause is fused to the reveal
+        // sentence with "and" ("that player reveals their hand and you choose a
+        // nonland card from it"), so the separate-sentence RevealHandFilter
+        // continuation never fires. The fused choose must still populate the
+        // RevealHand `card_filter` — otherwise the empty `None` filter matches no
+        // cards and the reveal/choose/exile silently does nothing.
+        let def = parse_effect_chain(
+            "That player reveals their hand and you choose a nonland card from it. Exile that card.",
+            AbilityKind::Spell,
+        );
+
+        fn reveal_hand_parts(def: &AbilityDefinition) -> Option<(&TargetFilter, &TargetFilter)> {
+            match def.effect.as_ref() {
+                Effect::RevealHand {
+                    target,
+                    card_filter,
+                    ..
+                } => Some((target, card_filter)),
+                _ => def.sub_ability.as_deref().and_then(reveal_hand_parts),
+            }
+        }
+
+        let (target, card_filter) = reveal_hand_parts(&def).expect("RevealHand in chain");
+        assert_eq!(*target, TargetFilter::TriggeringPlayer);
+        assert!(
+            matches!(
+                card_filter,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.iter().any(|t| matches!(t, TypeFilter::Non(inner) if **inner == TypeFilter::Land))
+            ),
+            "expected nonland reveal-choice filter, got {card_filter:?}"
+        );
+    }
+
+    #[test]
     fn parse_optional_reveal_hand_choice_marks_choice_optional() {
         let def = parse_effect_chain(
             "Look at target player's hand. You may choose a nonland card from it. That player discards that card.",


### PR DESCRIPTION
Fixes #842

## Summary
- When a reveal-hand clause fuses its reflexive choose with `and` — `<player> reveals their hand and you choose a [filter] card from it` — the separate-sentence `RevealHandFilter` continuation never fires (it only matches when `you choose … card from it` is its own sentence). The `RevealHand` effect was therefore built with `card_filter: None`.
- At runtime an empty `None` filter matches **no** cards, so `reveal_hand` reveals nothing, prompts no choice, and the downstream `Exile that card` has nothing to exile — **Biting-Palm Ninja** (`that player reveals their hand and you choose a nonland card from it. Exile that card.`) silently did nothing.
- `parse_hand_reveal_target_and_card_filter` now recognizes the fused `<possessive> hand and you choose a [filter] card from it` form and delegates the filter to the shared `parse_choose_filter` helper (same helper the separate-sentence continuation uses). Building-block fix for the whole reveal-hand + reflexive-choose class, not just Biting-Palm Ninja.

## Verification
- `cargo fmt --all`
- New building-block test `fused_reveal_hand_and_choose_populates_card_filter` — asserts the fused form yields `RevealHand { target: TriggeringPlayer, card_filter: nonland }` instead of `None` — passed.
- `cargo test -p engine --lib parser::` — 6458 passed, 0 failed (no regression to the existing separate-sentence reveal-choose paths, e.g. Dread Fugue).