### PR TITLE
fix(parser): attach equipment to a created token (Field-Tested Frying Pan)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1663,24 +1663,31 @@ fn rewire_cross_sentence_token_counter_attach(def: &mut AbilityDefinition) {
 /// it") — the bare-"it" host anaphor must target `LastCreated`, not
 /// `ParentTarget` (the token-creating effect has no parent target slot).
 fn rewire_token_attach_sibling(def: &mut AbilityDefinition) {
-    if !matches!(&*def.effect, Effect::Token { .. }) {
-        return;
-    }
-    let Some(attach_sub) = def.sub_ability.as_mut() else {
-        return;
-    };
-    // Token → PutCounter → Attach is owned by `rewire_cross_sentence_token_counter_attach`.
-    if matches!(&*attach_sub.effect, Effect::PutCounter { .. }) {
-        return;
-    }
-    let Effect::Attach { target, .. } = attach_sub.effect.as_mut() else {
-        return;
-    };
-    if matches!(
-        target,
-        TargetFilter::ParentTarget | TargetFilter::TriggeringSource
-    ) {
-        *target = TargetFilter::LastCreated;
+    // Walk the whole sub-ability chain: the token + bare-Attach pair is not
+    // always at the root. Field-Tested Frying Pan ("create a Food token, then
+    // create a 1/1 white Halfling creature token and attach this Equipment to
+    // it") nests the Attach under the *second* token, so a root-only check would
+    // miss it and leave "it" bound to ParentTarget/TriggeringSource (which has no
+    // referent here) instead of the just-created token.
+    let mut node: Option<&mut AbilityDefinition> = Some(def);
+    while let Some(current) = node {
+        if matches!(&*current.effect, Effect::Token { .. }) {
+            if let Some(sub) = current.sub_ability.as_mut() {
+                // Token → PutCounter → Attach is owned by
+                // `rewire_cross_sentence_token_counter_attach`.
+                if !matches!(&*sub.effect, Effect::PutCounter { .. }) {
+                    if let Effect::Attach { target, .. } = sub.effect.as_mut() {
+                        if matches!(
+                            target,
+                            TargetFilter::ParentTarget | TargetFilter::TriggeringSource
+                        ) {
+                            *target = TargetFilter::LastCreated;
+                        }
+                    }
+                }
+            }
+        }
+        node = current.sub_ability.as_deref_mut();
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -38473,6 +38473,34 @@ mod tests {
     }
 
     #[test]
+    fn create_token_and_attach_equipment_lowers_attach_to_last_created() {
+        // Field-Tested Frying Pan (#835): "create a Food token, then create a 1/1
+        // white Halfling creature token and attach this Equipment to it." The
+        // fused "and attach this Equipment to it" conjunct must survive as an
+        // Attach sub-ability bound to the just-created Halfling token (LastCreated),
+        // not be dropped (which left the equipment unattached).
+        let def = parse_effect_chain(
+            "Create a Food token, then create a 1/1 white Halfling creature token and attach this Equipment to it.",
+            AbilityKind::Spell,
+        );
+
+        fn find_attach_target(def: &AbilityDefinition) -> Option<&TargetFilter> {
+            match def.effect.as_ref() {
+                Effect::Attach { target, .. } => Some(target),
+                _ => def.sub_ability.as_deref().and_then(find_attach_target),
+            }
+        }
+
+        let target = find_attach_target(&def)
+            .expect("expected an Attach sub-ability for the fused token+attach clause");
+        assert_eq!(
+            *target,
+            TargetFilter::LastCreated,
+            "attach host anaphor must rebind to the just-created token"
+        );
+    }
+
+    #[test]
     fn dread_fugue_choose_from_revealed_hand_includes_cmc_leq_2() {
         // CR 702.148a: Cleave's bracketed text is removed at build time, so the
         // parser receives the bracket-stripped (KeepContent) base text — the

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1679,8 +1679,12 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // 21-arm limit; adding it inline would push the cluster over and trip
     // the `Choice<...>` trait-bound check at compile time.
     .or(value((), tag("puts ")))
-    // CR 608.2c: "put … and attach an Equipment that was attached …" (Zack Fair).
-    .or(value((), tag("attach an equipment that was attached ")))
+    // CR 301.5b + CR 608.2c: "attach " is an imperative game action — always a
+    // clause start, never a noun-phrase continuation. Peels "create a token and
+    // attach this Equipment to it" (Field-Tested Frying Pan) and "put … and attach
+    // an Equipment that was attached …" (Zack Fair) into a standalone Attach clause,
+    // which `rewire_token_attach_sibling` then rebinds onto LastCreated.
+    .or(value((), tag("attach ")))
     .or(alt((
         // CR 608.2c: Subject-prefixed verb patterns — "you [verb]" is always a clause start.
         value((), tag("you gain ")),
@@ -5620,6 +5624,25 @@ mod tests {
         // Lotho: "you lose 1 life and create a Treasure token"
         let chunks = clause_texts("you lose 1 life and create a Treasure token");
         assert_eq!(chunks, vec!["you lose 1 life", "create a Treasure token"]);
+    }
+
+    #[test]
+    fn bare_and_splits_create_token_and_attach() {
+        // Field-Tested Frying Pan (#835): "create a 1/1 white Halfling creature
+        // token and attach this Equipment to it" — "attach " is an imperative game
+        // action, so the conjunct must peel into its own clause and lower to a
+        // Token -> Attach sibling (rewire_token_attach_sibling rebinds onto
+        // LastCreated). Without the split the attach is silently dropped.
+        let chunks = clause_texts(
+            "create a 1/1 white Halfling creature token and attach this Equipment to it",
+        );
+        assert_eq!(
+            chunks,
+            vec![
+                "create a 1/1 white Halfling creature token",
+                "attach this Equipment to it"
+            ]
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1679,12 +1679,14 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // 21-arm limit; adding it inline would push the cluster over and trip
     // the `Choice<...>` trait-bound check at compile time.
     .or(value((), tag("puts ")))
-    // CR 301.5b + CR 608.2c: "attach " is an imperative game action — always a
-    // clause start, never a noun-phrase continuation. Peels "create a token and
-    // attach this Equipment to it" (Field-Tested Frying Pan) and "put … and attach
-    // an Equipment that was attached …" (Zack Fair) into a standalone Attach clause,
-    // which `rewire_token_attach_sibling` then rebinds onto LastCreated.
-    .or(value((), tag("attach ")))
+    // CR 301.5b + CR 608.2c: these attach forms are imperative game actions,
+    // not noun-phrase continuations. Keep the matcher narrow so name-based
+    // chains like "put counters on it and attach Fractal Harness to it" stay
+    // available to the token-counter attach rewriter.
+    .or(alt((
+        value((), tag("attach this equipment ")),
+        value((), tag("attach an equipment that was attached ")),
+    )))
     .or(alt((
         // CR 608.2c: Subject-prefixed verb patterns — "you [verb]" is always a clause start.
         value((), tag("you gain ")),


### PR DESCRIPTION
Fixes #835

## Summary
- `create a <token> and attach this Equipment to it` dropped the attach conjunct entirely. The bare-and clause splitter (`starts_bare_and_clause_lower`) only recognized the narrow `attach an Equipment that was attached …` (Zack Fair) form — not a general `attach ` clause start — so `and attach this Equipment to it` stayed fused to the token clause and was silently discarded. **Field-Tested Frying Pan** created its Halfling token but never equipped it.
- Generalize the bare-and `attach ` recognizer so any `… and attach …` conjunct peels into its own `Attach` clause (this subsumes the Zack Fair variant).
- Make `rewire_token_attach_sibling` walk the full sub-ability chain instead of only the root, so an `Attach` nested under a *second* token (`create a Food token, then create a Halfling token and attach this Equipment to it`) still rebinds its host anaphor onto `LastCreated` (the just-created token) rather than a referent-less `ParentTarget`/`TriggeringSource`.
- All the downstream machinery (`Effect::Attach` parsing, the `LastCreated` rebind) already existed — the only gaps were the split and the root-only rewrite. Building-block fix for the whole `create a token and attach <equipment> to it` class.

## Verification
- `cargo fmt --all`
- `bare_and_splits_create_token_and_attach` — asserts the conjunct splits into `["create a … token", "attach this Equipment to it"]`.
- `create_token_and_attach_equipment_lowers_attach_to_last_created` — asserts the full Frying Pan chain lowers to a `Token → Token → Attach { target: LastCreated }` (attach no longer dropped).
- `cargo test -p engine --lib parser::` — 6459 passed, 0 failed (no regression to the Zack Fair / single-token attach paths).