### PR TITLE
fix(parser): parse granted 'Cumulative upkeep {cost}' (Mana Chains, Dreams of the Dead, Decomposition)

### DIFF
--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1055,6 +1055,15 @@ pub(crate) fn parse_keyword_from_oracle(text: &str) -> Option<Keyword> {
         return result;
     }
 
+    // CR 702.24: Cumulative upkeep granted via a quoted ability ("[enchanted
+    // creature] has \"Cumulative upkeep {1}\"") routes through this shared keyword
+    // parser; the top-level keyword-line path calls the dedicated cost-aware
+    // parser directly, so delegate to it here too (Mana Chains, Dreams of the
+    // Dead, Decomposition).
+    if let Some(kw) = super::oracle_special::parse_cumulative_upkeep_keyword(text) {
+        return Some(kw);
+    }
+
     if let Some(kw) = parse_bloodthirst_keyword_line(text) {
         return Some(kw);
     }
@@ -2058,6 +2067,26 @@ mod tests {
         // CR 702.85a: Cascade is a no-parameter keyword.
         let kw = parse_keyword_from_oracle("cascade").unwrap();
         assert_eq!(kw, Keyword::Cascade);
+    }
+
+    /// CR 702.24: a GRANTED cumulative upkeep (the quoted-ability grant path
+    /// routes through `parse_keyword_from_oracle`) must parse with its cost, like
+    /// the top-level keyword-line path — Mana Chains / Dreams of the Dead (mana),
+    /// Decomposition (pay-life em-dash form).
+    #[test]
+    fn parse_keyword_from_oracle_granted_cumulative_upkeep() {
+        assert!(matches!(
+            parse_keyword_from_oracle("cumulative upkeep {1}"),
+            Some(Keyword::CumulativeUpkeep(AbilityCost::Mana { .. }))
+        ));
+        assert!(matches!(
+            parse_keyword_from_oracle("cumulative upkeep {2}"),
+            Some(Keyword::CumulativeUpkeep(AbilityCost::Mana { .. }))
+        ));
+        assert!(matches!(
+            parse_keyword_from_oracle("cumulative upkeep\u{2014}pay 1 life"),
+            Some(Keyword::CumulativeUpkeep(AbilityCost::PayLife { .. }))
+        ));
     }
 
     /// CR 702.85c: a spell printing cascade as repeated bare words has one instance


### PR DESCRIPTION
Fixes #4040.

## What

A **granted** cumulative upkeep â€” "[Enchanted/that] creature has/gains \"Cumulative upkeep {cost}\"" â€” was dropping to `Unimplemented`, even though a card's own cumulative-upkeep line parses fine and the keyword resolves at runtime.

Cards fixed (Scryfall-verified):

- **Mana Chains** â€” "Enchanted creature has \"Cumulative upkeep {1}.\""
- **Dreams of the Dead** â€” "That creature gains \"Cumulative upkeep {2}.\""
- **Decomposition** â€” "Enchanted creature has \"Cumulative upkeepâ€”Pay 1 life.\""

## How

The top-level keyword-line path calls `parse_cumulative_upkeep_keyword` directly, so a card's *own* cumulative upkeep works. But a keyword **granted** via a quoted ability is parsed by the shared `parse_keyword_from_oracle` (the `"<subject> has/gains \"<keyword>\""` grant path in `oracle_static/keyword_grant.rs`), which had no "cumulative upkeep" arm. This adds a one-line dispatch from `parse_keyword_from_oracle` to the existing `parse_cumulative_upkeep_keyword`.

Pure routing â€” reuses the existing `Keyword::CumulativeUpkeep(AbilityCost)`, its cost parser (mana / pay-life / sacrifice / discard / library-exile), and the runtime upkeep age-counter payment loop. No new keyword/cost/runtime.

## Verification

- New unit test `parse_keyword_from_oracle_granted_cumulative_upkeep`: `parse_keyword_from_oracle` yields `CumulativeUpkeep(Mana)` for "cumulative upkeep {1}"/"{2}" and `CumulativeUpkeep(PayLife)` for the "cumulative upkeepâ€”pay 1 life" em-dash form.
- Regenerated `card-data.json`: Mana Chains, Dreams of the Dead, and Decomposition now carry the granted `CumulativeUpkeep` keyword and are no longer `Unimplemented`.
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) are green.

CR 702.24 (cumulative upkeep); CR 702.24a (cost shapes).
