### PR TITLE
fix(feeds): improve mobile stacking layout in Manage Feeds modal

### DIFF
--- a/client/src/components/menu/FeedManagerModal.tsx
+++ b/client/src/components/menu/FeedManagerModal.tsx
@@ -108,7 +108,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
               <button
                 onClick={handleRefreshAll}
                 disabled={loading === "all" || subs.length === 0}
-                className="self-start rounded px-3 py-1.5 text-xs text-slate-300 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:self-auto"
+                className="flex min-h-11 items-center justify-center self-start rounded px-3 py-1.5 text-xs text-slate-300 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:min-h-0 sm:self-auto"
               >
                 {loading === "all" ? t("feedManager.refreshing") : t("feedManager.refreshAll")}
               </button>
@@ -159,7 +159,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                         <button
                           onClick={() => handleRefresh(source.id)}
                           disabled={isLoading}
-                          className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:flex-none sm:px-2 sm:py-1"
+                          className="min-h-11 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:min-h-0 sm:flex-none sm:px-2 sm:py-1"
                         >
                           {isLoading ? "…" : t("feedManager.refresh")}
                         </button>
@@ -167,7 +167,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                       <button
                         onClick={() => isSubscribed ? handleUnsubscribe(source.id) : handleSubscribe(source.id)}
                         disabled={isLoading}
-                        className={`min-h-9 flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 sm:flex-none sm:py-1 ${
+                        className={`min-h-11 flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 sm:min-h-0 sm:flex-none sm:py-1 ${
                           isSubscribed
                             ? "text-red-300 ring-1 ring-red-500/30 hover:bg-red-500/10"
                             : "text-emerald-300 ring-1 ring-emerald-500/30 hover:bg-emerald-500/10"
@@ -196,13 +196,13 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                       <button
                         onClick={() => handleRefresh(sub.sourceId)}
                         disabled={loading === sub.sourceId}
-                        className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:flex-none sm:px-2 sm:py-1"
+                        className="min-h-11 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:min-h-0 sm:flex-none sm:px-2 sm:py-1"
                       >
                         {loading === sub.sourceId ? "…" : t("feedManager.refresh")}
                       </button>
                       <button
                         onClick={() => handleUnsubscribe(sub.sourceId)}
-                        className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs font-medium text-red-300 ring-1 ring-red-500/30 transition-colors hover:bg-red-500/10 sm:flex-none sm:py-1"
+                        className="min-h-11 flex-1 rounded px-3 py-1.5 text-xs font-medium text-red-300 ring-1 ring-red-500/30 transition-colors hover:bg-red-500/10 sm:min-h-0 sm:flex-none sm:py-1"
                       >
                         {t("feedManager.unsubscribe")}
                       </button>
@@ -225,7 +225,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                 <button
                   onClick={handleCustomSubscribe}
                   disabled={!customUrl.trim() || loading === "custom"}
-                  className={`${menuButtonClass({ tone: "indigo", size: "sm", disabled: !customUrl.trim() || loading === "custom" })} min-h-10 w-full sm:w-auto`}
+                  className={`${menuButtonClass({ tone: "indigo", size: "sm", disabled: !customUrl.trim() || loading === "custom" })} w-full sm:w-auto`}
                 >
                   {loading === "custom" ? "…" : t("feedManager.add")}
                 </button>

--- a/client/src/components/menu/FeedManagerModal.tsx
+++ b/client/src/components/menu/FeedManagerModal.tsx
@@ -103,18 +103,18 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
             exit={{ scale: 0.95, opacity: 0 }}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="shrink-0 flex items-center justify-between gap-3 px-6 pb-4 pt-6">
+            <div className="shrink-0 flex flex-col gap-3 px-4 pb-4 pt-6 sm:flex-row sm:items-center sm:justify-between sm:px-6">
               <h2 className="text-lg font-semibold text-white">{t("feedManager.title")}</h2>
               <button
                 onClick={handleRefreshAll}
                 disabled={loading === "all" || subs.length === 0}
-                className="rounded px-3 py-1 text-xs text-slate-300 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40"
+                className="self-start rounded px-3 py-1.5 text-xs text-slate-300 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:self-auto"
               >
                 {loading === "all" ? t("feedManager.refreshing") : t("feedManager.refreshAll")}
               </button>
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 sm:px-6">
             {error && (
               <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-200">
                 {error}
@@ -130,12 +130,12 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                 return (
                   <div
                     key={source.id}
-                    className="flex items-center justify-between rounded-xl border border-white/10 bg-black/20 px-4 py-3"
+                    className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
                   >
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                         {source.icon && (
-                          <span className="inline-flex h-5 w-5 items-center justify-center rounded bg-white/10 text-[10px] font-bold text-white">
+                          <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded bg-white/10 text-[10px] font-bold text-white">
                             {source.icon}
                           </span>
                         )}
@@ -154,12 +154,12 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                         </p>
                       )}
                     </div>
-                    <div className="ml-3 flex shrink-0 gap-2">
+                    <div className="flex shrink-0 gap-2 sm:ml-3">
                       {isSubscribed && (
                         <button
                           onClick={() => handleRefresh(source.id)}
                           disabled={isLoading}
-                          className="rounded px-2 py-1 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40"
+                          className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:flex-none sm:px-2 sm:py-1"
                         >
                           {isLoading ? "…" : t("feedManager.refresh")}
                         </button>
@@ -167,7 +167,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                       <button
                         onClick={() => isSubscribed ? handleUnsubscribe(source.id) : handleSubscribe(source.id)}
                         disabled={isLoading}
-                        className={`rounded px-3 py-1 text-xs font-medium transition-colors disabled:opacity-40 ${
+                        className={`min-h-9 flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-40 sm:flex-none sm:py-1 ${
                           isSubscribed
                             ? "text-red-300 ring-1 ring-red-500/30 hover:bg-red-500/10"
                             : "text-emerald-300 ring-1 ring-emerald-500/30 hover:bg-emerald-500/10"
@@ -186,23 +186,23 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
                 .map((sub) => (
                   <div
                     key={sub.sourceId}
-                    className="flex items-center justify-between rounded-xl border border-white/10 bg-black/20 px-4 py-3"
+                    className="flex flex-col gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
                   >
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium text-white">{sub.sourceId}</div>
                       <p className="mt-0.5 truncate text-[10px] text-slate-600">{sub.url}</p>
                     </div>
-                    <div className="ml-3 flex shrink-0 gap-2">
+                    <div className="flex shrink-0 gap-2 sm:ml-3">
                       <button
                         onClick={() => handleRefresh(sub.sourceId)}
                         disabled={loading === sub.sourceId}
-                        className="rounded px-2 py-1 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40"
+                        className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white disabled:opacity-40 sm:flex-none sm:px-2 sm:py-1"
                       >
                         {loading === sub.sourceId ? "…" : t("feedManager.refresh")}
                       </button>
                       <button
                         onClick={() => handleUnsubscribe(sub.sourceId)}
-                        className="rounded px-3 py-1 text-xs font-medium text-red-300 ring-1 ring-red-500/30 transition-colors hover:bg-red-500/10"
+                        className="min-h-9 flex-1 rounded px-3 py-1.5 text-xs font-medium text-red-300 ring-1 ring-red-500/30 transition-colors hover:bg-red-500/10 sm:flex-none sm:py-1"
                       >
                         {t("feedManager.unsubscribe")}
                       </button>
@@ -213,19 +213,19 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
 
             <div className="mt-4 border-t border-white/10 pt-4">
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">{t("feedManager.addCustomFeed")}</h3>
-              <div className="flex gap-2">
+              <div className="flex flex-col gap-2 sm:flex-row">
                 <input
                   type="url"
                   value={customUrl}
                   onChange={(e) => setCustomUrl(e.target.value)}
                   placeholder="https://example.com/feed.json"
-                  className="flex-1 rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder-slate-600 outline-none focus:border-white/20"
+                  className="min-w-0 flex-1 rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder-slate-600 outline-none focus:border-white/20"
                   onKeyDown={(e) => e.key === "Enter" && handleCustomSubscribe()}
                 />
                 <button
                   onClick={handleCustomSubscribe}
                   disabled={!customUrl.trim() || loading === "custom"}
-                  className={menuButtonClass({ tone: "indigo", size: "sm", disabled: !customUrl.trim() || loading === "custom" })}
+                  className={`${menuButtonClass({ tone: "indigo", size: "sm", disabled: !customUrl.trim() || loading === "custom" })} min-h-10 w-full sm:w-auto`}
                 >
                   {loading === "custom" ? "…" : t("feedManager.add")}
                 </button>
@@ -234,7 +234,7 @@ export function FeedManagerModal({ open, onClose }: FeedManagerModalProps) {
 
             </div>
 
-            <div className="shrink-0 flex justify-end border-t border-white/10 px-6 py-4">
+            <div className="shrink-0 flex justify-end border-t border-white/10 px-4 py-4 sm:px-6">
               <button
                 onClick={onClose}
                 className={menuButtonClass({ tone: "neutral", size: "sm" })}


### PR DESCRIPTION
## Summary

Improves the mobile layout of the **Manage Feeds** modal so feed cards, action buttons, and the custom feed form stack cleanly on narrow screens instead of compressing controls into side-by-side layouts.

This ensures the modal remains usable and readable on mobile without horizontal crowding or misaligned actions.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Frontend-only responsive layout change in `FeedManagerModal.tsx` (Tailwind class updates). No engine, parser, rules, resolver, or game logic changes.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

None — UI/layout-only change, no rules or backend logic affected.

## Verification

- Manually tested on narrow/mobile viewport:
  - Header title and **Refresh all** button stack without overlap
  - Feed cards display metadata on top with actions (Refresh / Unsubscribe) below
  - Action buttons span full width with proper touch spacing
  - Custom feed input and **Add** button stack vertically on mobile
- Verified desktop layout (`sm+`) remains unchanged with horizontal alignment
- CI: `check-frontend` passes (TypeScript + lint checks)

## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/52f296a5-0182-4aba-8d31-84c03650526e" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/2ace6864-9ee8-4970-84f2-e837f0491e35" />
