### PR TITLE
fix(lobby): correct anchored positioning for format MenuSelect in host setup and deck builder

### DIFF
--- a/client/src/components/deck-builder/DeckBuilderToolbar.tsx
+++ b/client/src/components/deck-builder/DeckBuilderToolbar.tsx
@@ -92,7 +92,8 @@ export function DeckBuilderToolbar({
           selectedValue={format}
           items={formatMenuItems}
           onSelect={(value) => onFormatChange(value as GameFormat)}
-          wrapperClassName="w-full lg:hidden"
+          fitContainer
+          wrapperClassName="w-full min-w-0 lg:hidden"
         />
         <div className="hidden lg:block">
           <FormatFilter selected={format} onChange={onFormatChange} />

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -350,11 +350,15 @@ export function HostSetup({
   // so any format whose minimum is reachable from that ceiling is listable.
   // Formats requiring more seats than the ceiling are hidden here to avoid
   // advertising a configuration we can't actually host.
-  const availableFormats = isP2P
-    ? FORMAT_OPTIONS.filter(
-        (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,
-      )
-    : FORMAT_OPTIONS;
+  const availableFormats = useMemo(
+    () =>
+      isP2P
+        ? FORMAT_OPTIONS.filter(
+            (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,
+          )
+        : FORMAT_OPTIONS,
+    [isP2P],
+  );
 
   // Shared field-input grammar (mockup Host-setup inputs).
   const inp =
@@ -366,11 +370,16 @@ export function HostSetup({
     } ${extra}`;
   const formatMeta = availableFormats.find((f) => f.format === selectedFormat);
   const formatMenuGroups = useMemo((): MenuSelectGroup[] => {
+    const formats = isP2P
+      ? FORMAT_OPTIONS.filter(
+          (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,
+        )
+      : FORMAT_OPTIONS;
     const groups: MenuSelectGroup[] = [];
     for (const group of (Object.keys(GROUP_ORDER) as FormatGroup[]).sort(
       (a, b) => GROUP_ORDER[a] - GROUP_ORDER[b],
     )) {
-      const groupFormats = availableFormats.filter((f) => f.group === group);
+      const groupFormats = formats.filter((f) => f.group === group);
       if (groupFormats.length === 0) continue;
       groups.push({
         label: group,
@@ -381,7 +390,7 @@ export function HostSetup({
       });
     }
     return groups;
-  }, [availableFormats]);
+  }, [isP2P]);
   const submitDisabled =
     hostDisabled || isSubmitting || hostingStatus !== "idle" || (aiSeats.length > 0 && !defaultAiDeck);
 

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -370,16 +370,11 @@ export function HostSetup({
     } ${extra}`;
   const formatMeta = availableFormats.find((f) => f.format === selectedFormat);
   const formatMenuGroups = useMemo((): MenuSelectGroup[] => {
-    const formats = isP2P
-      ? FORMAT_OPTIONS.filter(
-          (f) => FORMAT_DEFAULTS[f.format].min_players <= P2P_MAX_PEERS,
-        )
-      : FORMAT_OPTIONS;
     const groups: MenuSelectGroup[] = [];
     for (const group of (Object.keys(GROUP_ORDER) as FormatGroup[]).sort(
       (a, b) => GROUP_ORDER[a] - GROUP_ORDER[b],
     )) {
-      const groupFormats = formats.filter((f) => f.group === group);
+      const groupFormats = availableFormats.filter((f) => f.group === group);
       if (groupFormats.length === 0) continue;
       groups.push({
         label: group,
@@ -390,7 +385,7 @@ export function HostSetup({
       });
     }
     return groups;
-  }, [isP2P]);
+  }, [availableFormats]);
   const submitDisabled =
     hostDisabled || isSubmitting || hostingStatus !== "idle" || (aiSeats.length > 0 && !defaultAiDeck);
 

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { FormatConfig, FormatGroup, GameFormat, MatchType } from "../../adapter/types";
@@ -8,6 +8,7 @@ import type { AiSeatConfig, HostingSettings } from "../../stores/multiplayerStor
 import { useAiDeckCatalog } from "../../services/aiDeckCatalog";
 import { expandParsedDeck } from "../../services/deckParser";
 import { menuButtonClass } from "../menu/buttonStyles";
+import { MenuSelect, type MenuSelectGroup } from "../ui/MenuSelect";
 import { SelectField } from "../ui/SelectField";
 
 export type { AiSeatConfig };
@@ -364,6 +365,23 @@ export function HostSetup({
       on ? "bg-white/10 text-white" : "text-fg-meta hover:text-slate-200"
     } ${extra}`;
   const formatMeta = availableFormats.find((f) => f.format === selectedFormat);
+  const formatMenuGroups = useMemo((): MenuSelectGroup[] => {
+    const groups: MenuSelectGroup[] = [];
+    for (const group of (Object.keys(GROUP_ORDER) as FormatGroup[]).sort(
+      (a, b) => GROUP_ORDER[a] - GROUP_ORDER[b],
+    )) {
+      const groupFormats = availableFormats.filter((f) => f.group === group);
+      if (groupFormats.length === 0) continue;
+      groups.push({
+        label: group,
+        items: groupFormats.map((opt) => ({
+          value: opt.format,
+          label: opt.label,
+        })),
+      });
+    }
+    return groups;
+  }, [availableFormats]);
   const submitDisabled =
     hostDisabled || isSubmitting || hostingStatus !== "idle" || (aiSeats.length > 0 && !defaultAiDeck);
 
@@ -407,33 +425,21 @@ export function HostSetup({
           </Field>
 
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {/* Format — grouped native <select>. Native is the mobile/tablet UX
-                win: iOS/Android render touch-optimized pickers from <select>.
-                <optgroup>s mirror the engine's FormatGroup taxonomy. */}
-            <Field label={t("hostSetup.format")} htmlFor="host-setup-format" hint={formatMeta?.description}>
-              <SelectField
-                wrapperClassName="w-full"
-                id="host-setup-format"
-                value={selectedFormat}
-                onChange={(e) => handleFormatSelect(e.target.value as GameFormat)}
+            {/* Format — grouped MenuSelect mirrors the engine's FormatGroup
+                taxonomy. fitContainer keeps the trigger inside the grid column;
+                menuLayout="dropdown" anchors below the trigger on all widths. */}
+            <Field label={t("hostSetup.format")} hint={formatMeta?.description}>
+              <MenuSelect
+                ariaLabel={t("hostSetup.format")}
+                label={formatMeta?.label ?? selectedFormat}
+                selectedValue={selectedFormat}
+                groups={formatMenuGroups}
+                onSelect={(value) => handleFormatSelect(value as GameFormat)}
+                menuLayout="dropdown"
+                fitContainer
+                wrapperClassName="w-full min-w-0"
                 className={`${inp} min-h-[44px] w-full cursor-pointer font-medium`}
-              >
-                {(Object.keys(GROUP_ORDER) as FormatGroup[])
-                  .sort((a, b) => GROUP_ORDER[a] - GROUP_ORDER[b])
-                  .map((group) => {
-                    const items = availableFormats.filter((f) => f.group === group);
-                    if (items.length === 0) return null;
-                    return (
-                      <optgroup key={group} label={group} className="bg-[#0a0f1b] text-slate-100">
-                        {items.map((opt) => (
-                          <option key={opt.format} value={opt.format} title={opt.description} className="bg-[#0a0f1b] text-slate-100">
-                            {opt.label}
-                          </option>
-                        ))}
-                      </optgroup>
-                    );
-                  })}
-              </SelectField>
+              />
             </Field>
 
             <Field label={t("hostSetup.startingLife")} htmlFor="host-setup-life">

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -60,7 +60,8 @@ describe("HostSetup", () => {
       />,
     );
 
-    await user.selectOptions(screen.getByLabelText("Format"), "FreeForAll");
+    await user.click(screen.getByRole("button", { name: "Format" }));
+    await user.click(screen.getByRole("option", { name: "Free-for-All" }));
     await user.click(screen.getByRole("button", { name: "40" }));
     await user.click(screen.getByRole("button", { name: "Host Game" }));
 

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -124,6 +124,51 @@ function flattenMenuItems(
   ];
 }
 
+type AnchoredMenuStyle = {
+  top: number | "auto";
+  bottom: number | "auto";
+  left: number;
+  width: number;
+  maxHeight: number;
+  boxSizing: "border-box";
+};
+
+function computeAnchoredMenuStyle(trigger: HTMLElement): AnchoredMenuStyle {
+  const rect = trigger.getBoundingClientRect();
+  const viewport = window.visualViewport;
+  const viewportLeft = viewport?.offsetLeft ?? 0;
+  const viewportWidth = viewport?.width ?? window.innerWidth;
+  const viewportTop = getViewportTop();
+  const viewportBottom = getViewportBottom();
+
+  // Pin the menu to the trigger's box; only nudge when the menu would clip.
+  let width = rect.width;
+  let left = rect.left;
+  const minLeft = viewportLeft + MENU_VIEWPORT_PADDING_PX;
+  const maxRight = viewportLeft + viewportWidth - MENU_VIEWPORT_PADDING_PX;
+
+  if (left + width > maxRight) {
+    left = Math.max(minLeft, maxRight - width);
+  }
+  if (left < minLeft) {
+    left = minLeft;
+    width = Math.min(width, maxRight - minLeft);
+  }
+  const spaceBelow = Math.max(0, viewportBottom - rect.bottom - MENU_GAP_PX);
+  const spaceAbove = Math.max(0, rect.top - viewportTop - MENU_GAP_PX);
+  const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
+  const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
+
+  return {
+    left: Math.round(left),
+    width: Math.round(width),
+    maxHeight: Math.max(maxHeight, 0),
+    top: openUp ? "auto" : Math.round(rect.bottom + MENU_GAP_PX),
+    bottom: openUp ? Math.round(window.innerHeight - rect.top + MENU_GAP_PX) : "auto",
+    boxSizing: "border-box",
+  };
+}
+
 export function MenuSelect({
   label,
   items,
@@ -146,18 +191,13 @@ export function MenuSelect({
   const menuRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
   const allItems = useMemo(() => flattenMenuItems(items, groups), [items, groups]);
-  const [menuStyle, setMenuStyle] = useState<{
-    top: number | "auto";
-    bottom: number | "auto";
-    left: number;
-    width: number;
-    maxHeight: number;
-  }>({
+  const [menuStyle, setMenuStyle] = useState<AnchoredMenuStyle>({
     top: 0,
     bottom: "auto",
     left: 0,
     width: 0,
     maxHeight: MENU_MAX_HEIGHT_PX,
+    boxSizing: "border-box",
   });
 
   useLayoutEffect(() => {
@@ -183,40 +223,21 @@ export function MenuSelect({
     if (useBottomSheet) return;
     const trigger = triggerRef.current;
     if (!trigger) return;
-
-    const rect = trigger.getBoundingClientRect();
-    const viewport = window.visualViewport;
-    const viewportLeft = viewport?.offsetLeft ?? 0;
-    const viewportWidth = viewport?.width ?? window.innerWidth;
-    const viewportTop = getViewportTop();
-    const viewportBottom = getViewportBottom();
-
-    // Pin the menu to the trigger's box; only nudge when the menu would clip.
-    let width = rect.width;
-    let left = rect.left;
-    const minLeft = viewportLeft + MENU_VIEWPORT_PADDING_PX;
-    const maxRight = viewportLeft + viewportWidth - MENU_VIEWPORT_PADDING_PX;
-
-    if (left + width > maxRight) {
-      left = Math.max(minLeft, maxRight - width);
-    }
-    if (left < minLeft) {
-      left = minLeft;
-      width = Math.min(width, maxRight - minLeft);
-    }
-    const spaceBelow = Math.max(0, viewportBottom - rect.bottom - MENU_GAP_PX);
-    const spaceAbove = Math.max(0, rect.top - viewportTop - MENU_GAP_PX);
-    const openUp = spaceBelow < MENU_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
-    const maxHeight = Math.min(MENU_MAX_HEIGHT_PX, openUp ? spaceAbove : spaceBelow);
-
-    setMenuStyle({
-      left,
-      width,
-      maxHeight: Math.max(maxHeight, 0),
-      top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
-      bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
-    });
+    setMenuStyle(computeAnchoredMenuStyle(trigger));
   }, [useBottomSheet]);
+
+  const toggleOpen = useCallback(() => {
+    if (disabled) return;
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    const trigger = triggerRef.current;
+    if (trigger && !useBottomSheet) {
+      setMenuStyle(computeAnchoredMenuStyle(trigger));
+    }
+    setOpen(true);
+  }, [disabled, open, useBottomSheet]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -335,10 +356,7 @@ export function MenuSelect({
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
         aria-label={ariaLabel ?? label}
-        onClick={() => {
-          if (disabled) return;
-          setOpen((prev) => !prev);
-        }}
+        onClick={toggleOpen}
         className={triggerClassName}
       >
         <span className="min-w-0 truncate" title={label}>
@@ -379,6 +397,7 @@ export function MenuSelect({
                       left: menuStyle.left,
                       width: menuStyle.width,
                       maxHeight: menuStyle.maxHeight,
+                      boxSizing: menuStyle.boxSizing,
                     }
               }
             >

--- a/client/src/components/ui/__tests__/MenuSelect.test.tsx
+++ b/client/src/components/ui/__tests__/MenuSelect.test.tsx
@@ -99,6 +99,39 @@ describe("MenuSelect", () => {
     vi.unstubAllGlobals();
   });
 
+  it("anchors the dropdown to the trigger box when opened", () => {
+    const rect = {
+      left: 96,
+      right: 296,
+      top: 48,
+      bottom: 88,
+      width: 200,
+      height: 40,
+      x: 96,
+      y: 48,
+      toJSON: () => ({}),
+    };
+    const spy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(rect as DOMRect);
+
+    render(
+      <MenuSelect
+        label="Standard"
+        items={[{ value: "Standard", label: "Standard" }]}
+        onSelect={vi.fn()}
+        fitContainer
+        wrapperClassName="w-full min-w-0"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Standard" }));
+
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toHaveStyle({ left: "96px", width: "200px" });
+
+    spy.mockRestore();
+  });
+
   it("does not apply content-based minWidth when fitContainer is set", () => {
     const longLabel = "Option ".repeat(12).trimEnd();
     const items = [{ value: "option-a", label: longLabel }];


### PR DESCRIPTION
## Summary

Fixes layout and positioning issues in the **host setup format selector** and related **deck builder format picker** by correcting `MenuSelect` anchoring and enforcing consistent width handling across responsive layouts.

- Fixes dropdown misalignment where the menu was offset and wider than its trigger
- Ensures `MenuSelect` opens flush with the trigger using accurate `left` / `width` calculations
- Migrates host setup format selector from native `<select>` to grouped `MenuSelect`
- Applies consistent `fitContainer` behavior across host setup and deck builder toolbar

## Problem

The format dropdown in host setup was misaligned on both desktop and mobile:

- Menu appeared shifted left relative to the trigger
- Dropdown width exceeded the trigger width
- Trigger container could overflow grid constraints due to missing `fitContainer`
- Portaled menu used stale or mismatched positioning data, especially after layout changes

Root cause was inconsistent sizing between trigger measurement and menu positioning logic.

## Solution

Standardized `MenuSelect` anchoring and layout behavior:

- Introduced reliable anchored positioning via `computeAnchoredMenuStyle()` executed on open
- Ensured menu position is calculated synchronously before render to avoid layout drift
- Migrated host setup format selector to `MenuSelect`:
  - Uses grouped `FormatGroup` taxonomy
  - `menuLayout="dropdown"` for consistent anchored behavior (desktop + mobile)
- Enforced layout stability:
  - `fitContainer` applied to prevent trigger overflow in grid layouts
  - `wrapperClassName="w-full min-w-0"` to constrain width properly
- Extended same fix to deck builder mobile format picker to prevent regression

## Test Plan

- [ ] Open **Host Setup → Format** (desktop)
  - Dropdown aligns exactly with trigger width
  - Grouped format options render correctly (Constructed / Commander / etc.)

- [ ] Open **Host Setup → Format** (mobile <820px)
  - Menu remains anchored (not bottom sheet)
  - No horizontal offset or overflow
  - Scroll behavior remains intact

- [ ] Open **Deck Builder → Format Picker** (mobile)
  - Trigger stays within toolbar bounds
  - Dropdown aligns correctly under trigger

- [ ] Run unit tests:
  - `pnpm exec vitest run src/components/ui/__tests__/MenuSelect.test.tsx` → passes
  
 ## Screenshots
 
 ### Before
 
 <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/28da5f2e-892a-4811-8e22-a5ab02891370" />

 ### After
  
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/b3e252ce-f0aa-4167-90f9-7bce36d1c1c8" />
