### PR TITLE
fix(engine): add CastVariantPaid::Prowl so prowl-gated ETB triggers fire

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -583,6 +583,26 @@ pub(super) fn strip_additional_cost_conditional(text: &str) -> (Option<AbilityCo
             );
         }
     }
+    if body.is_none() && scan_contains_phrase(&lower, "prowl cost was paid") {
+        if let Some(after) = tp.strip_after("instead ") {
+            return (
+                Some(AbilityCondition::CastVariantPaidInstead {
+                    variant: CastVariantPaid::Prowl,
+                }),
+                after.original.to_string(),
+            );
+        }
+        // CR 702.76a: "if its prowl cost was paid, [effect]" — non-"instead"
+        // variant that gates a sub-ability on prowl payment.
+        if let Some(after) = tp.strip_after("prowl cost was paid, ") {
+            return (
+                Some(AbilityCondition::CastVariantPaid {
+                    variant: CastVariantPaid::Prowl,
+                }),
+                after.original.to_string(),
+            );
+        }
+    }
 
     match body {
         Some(body) => {
@@ -5781,6 +5801,21 @@ mod tests {
             })
         );
         assert_eq!(body, "draw two cards.");
+    }
+
+    /// CR 702.76a: "if its prowl cost was paid, [effect]" — non-"instead"
+    /// variant that gates a sub-ability on prowl payment (Latchkey Faerie).
+    #[test]
+    fn prowl_cost_paid_emits_cast_variant_paid() {
+        let (cond, body) =
+            strip_additional_cost_conditional("if its prowl cost was paid, draw a card.");
+        assert_eq!(
+            cond,
+            Some(AbilityCondition::CastVariantPaid {
+                variant: CastVariantPaid::Prowl,
+            })
+        );
+        assert_eq!(body, "draw a card.");
     }
 
     /// CR 702.33b + CR 603.4: "if it was kicked twice, …" → min_count = 2.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -25042,6 +25042,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cast_variant_paid_prowl_condition() {
+        // CR 702.76a + CR 603.4: "if its prowl cost was paid" intervening-if
+        // (Latchkey Faerie) → CastVariantPaid { variant: Prowl }.
+        let def = parse_trigger_line(
+            "When this creature enters, if its prowl cost was paid, draw a card.",
+            "Test Prowl",
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::CastVariantPaid {
+                variant: CastVariantPaid::Prowl,
+            })
+        );
+    }
+
     // CR 702.138c + CR 603.11: Pharika's Spawn — the linked triggered ability of
     // an "[this permanent] escapes with [counters]" replacement effect. "When it
     // enters this way" must (a) resolve the pronoun "it" to SelfRef, (b) lower to


### PR DESCRIPTION
Fixes #3999

## Summary
- Adds `CastVariantPaid::Prowl` variant (CR 702.76a) to the cast-variant-paid tag enum — mirrors the existing `Surge`/`Spectacle` pattern
- Tags prowl-cast permanents in `stack::resolve_top` so the `CastVariantPaid { Prowl }` marker is present when ETB triggers check their intervening-if condition
- Adds "prowl cost was paid" recognition in both the trigger parser (`oracle_trigger.rs`) and the ability-condition parser (`conditions.rs`)
- Affects Latchkey Faerie (draw a card) and Earwig Squad (exile three cards from opponent's library) — both previously fired unconditionally, ignoring whether prowl was paid

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine -- -D warnings` — clean
- `cargo test -p engine -- prowl` — 8 tests pass (2 new + 6 existing prowl tests)