### PR TITLE
feat(parser): classify ability-word-labeled activated abilities (M.O.D.O.K.)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4476,9 +4476,32 @@ pub(super) fn find_activated_colon(line: &str) -> Option<usize> {
     let colon_pos = find_top_level_colon(line)?;
     let prefix = &line[..colon_pos];
 
+    if cost_prefix_is_activated(prefix) {
+        return Some(colon_pos);
+    }
+
+    // CR 207.2c + CR 602.1: an ability-word label may precede the activation
+    // cost ("Mental Organism — Pay 3 life: ~ connives" — M.O.D.O.K.). Ability
+    // words have no rules meaning, so strip the italic 1–4 word label and re-test
+    // the remaining cost prefix. `split_short_label_prefix` already guards against
+    // matching real cost text (it rejects prefixes containing `{` or `:`), so this
+    // never misclassifies an em-dash that lives inside the cost itself.
+    if let Some(after_word) = strip_ability_word(prefix) {
+        if cost_prefix_is_activated(&after_word) {
+            return Some(colon_pos);
+        }
+    }
+
+    None
+}
+
+/// Whether the text preceding a top-level colon reads as an activation cost
+/// (mana symbols or a cost-starter verb). Shared by `find_activated_colon` so
+/// the bare and ability-word-prefixed paths apply identical cost recognition.
+fn cost_prefix_is_activated(prefix: &str) -> bool {
     // Contains mana symbols
     if prefix.contains('{') {
-        return Some(colon_pos);
+        return true;
     }
 
     // Starts with cost-like words (all ASCII — case-insensitive prefix check)
@@ -4496,11 +4519,7 @@ pub(super) fn find_activated_colon(line: &str) -> Option<usize> {
     ];
     // Only lowercase when needed (skipped entirely if '{' was found above)
     let lower_prefix = trimmed.to_lowercase();
-    if cost_starters.iter().any(|s| lower_prefix.starts_with(s)) {
-        return Some(colon_pos);
-    }
-
-    None
+    cost_starters.iter().any(|s| lower_prefix.starts_with(s))
 }
 
 fn find_top_level_colon(line: &str) -> Option<usize> {
@@ -5260,6 +5279,96 @@ mod tests {
     use super::*;
     use crate::parser::oracle_effect::parse_effect_chain;
     use crate::types::ability::{CountScope, DoorLockOp};
+
+    /// CR 207.2c + CR 602.1: an activated ability may carry an italic ability-word
+    /// label before its cost ("Mental Organism — Pay 3 life: ~ connives" —
+    /// M.O.D.O.K.). The ability word has no rules meaning, so `find_activated_colon`
+    /// must look past it and still classify the line as `[Cost]: [Effect]`.
+    ///
+    /// This is the building-block test for the whole class
+    /// `[ability-word] — [cost]: [effect] [restriction]` — it asserts the cost,
+    /// effect, and restriction all survive the label. The card-specific runtime
+    /// discrimination lives in `tests/connive_trigger_msh_wave1.rs`.
+    ///
+    /// Revert-discriminating: with the ability-word strip removed from
+    /// `find_activated_colon`, this line falls through to `Effect::Unimplemented`
+    /// and `abilities` is empty — every assertion below fails.
+    #[test]
+    fn ability_word_labeled_activated_ability_parses_cost_effect_restriction() {
+        use crate::types::ability::QuantityExpr;
+        let r = parse(
+            "Mental Organism — Pay 3 life: M.O.D.O.K. connives. Activate only during your turn.",
+            "M.O.D.O.K.",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(
+            r.abilities.len(),
+            1,
+            "ability-word-labeled line must parse to one activated ability, got {:#?}",
+            r.abilities
+        );
+        let def = &r.abilities[0];
+        assert_eq!(def.kind, AbilityKind::Activated);
+        assert!(
+            !has_unimplemented(def),
+            "no residual Unimplemented node, got {:#?}",
+            def.effect
+        );
+        assert_eq!(
+            def.cost,
+            Some(AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 3 },
+            }),
+            "ability word must be stripped from the cost, leaving Pay 3 life"
+        );
+        assert!(
+            matches!(
+                def.effect.as_ref(),
+                Effect::Connive {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ),
+            "'~ connives' must lower to a self-targeted Connive, got {:?}",
+            def.effect
+        );
+        assert!(
+            def.activation_restrictions
+                .contains(&ActivationRestriction::DuringYourTurn),
+            "'Activate only during your turn' must yield DuringYourTurn, got {:?}",
+            def.activation_restrictions
+        );
+    }
+
+    /// The static half of M.O.D.O.K. ("Designed Only for Killing — Creatures your
+    /// opponents control get -1/-1") already parses on its own ability-word label;
+    /// this guards that the activated-ability fix above doesn't regress it.
+    #[test]
+    fn modok_static_minus_one_to_opponents_creatures() {
+        use crate::types::statics::StaticMode;
+        let r = parse(
+            "Designed Only for Killing — Creatures your opponents control get -1/-1.",
+            "M.O.D.O.K.",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(r.statics.len(), 1, "got {:#?}", r.statics);
+        let st = &r.statics[0];
+        assert_eq!(st.mode, StaticMode::Continuous);
+        let Some(TargetFilter::Typed(tf)) = &st.affected else {
+            panic!("expected typed affected filter, got {:?}", st.affected);
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::Opponent));
+        assert!(st
+            .modifications
+            .contains(&ContinuousModification::AddPower { value: -1 }));
+        assert!(st
+            .modifications
+            .contains(&ContinuousModification::AddToughness { value: -1 }));
+    }
 
     /// Issue #69 (Banewhip Punisher): "Destroy target creature that has a -1/-1
     /// counter on it" — the relative-clause counter restriction was dropped, so

--- a/crates/engine/tests/connive_trigger_msh_wave1.rs
+++ b/crates/engine/tests/connive_trigger_msh_wave1.rs
@@ -13,12 +13,14 @@
 
 use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
-use engine::game::scenario::GameScenario;
+use engine::game::scenario::{GameRunner, GameScenario};
 use engine::game::triggers::process_triggers;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{Effect, ResolvedAbility, TargetRef};
 use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 
@@ -214,5 +216,135 @@ fn connive_self_trigger_fires_for_the_conniving_source() {
         runner.life(P0),
         life_before + 2,
         "a permanent's self-connive must fire its own 'whenever ~ connives' trigger"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// M.O.D.O.K. (MSH) — ability-word-labeled, pay-life, your-turn-restricted,
+// self-connive ACTIVATED ability.
+//
+// Oracle: "Mental Organism — Pay 3 life: M.O.D.O.K. connives. Activate only
+// during your turn."
+//
+// On main, the whole line landed as `Effect::Unimplemented[unknown]` because
+// `find_activated_colon` did not recognize the cost behind the "Mental Organism
+// —" ability-word label (CR 207.2c). These tests drive the REAL activation
+// pipeline (`GameAction::ActivateAbility` via the `GameScenario`/`GameRunner`
+// harness) through that fix.
+// ---------------------------------------------------------------------------
+
+const MODOK_ABILITY: &str =
+    "Mental Organism — Pay 3 life: M.O.D.O.K. connives. Activate only during your turn.";
+
+/// Resolve the runtime index of M.O.D.O.K.'s self-connive activated ability by
+/// effect shape (it is the only activated ability on the card).
+fn modok_connive_index(runner: &GameRunner, id: ObjectId) -> usize {
+    runner.state().objects[&id]
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::Connive { .. }))
+        .expect("M.O.D.O.K. must carry a Connive activated ability")
+}
+
+/// CR 207.2c + CR 118.3b + CR 701.50a: activating M.O.D.O.K.'s ability pays 3
+/// life and connives — draw one card, discard it, and (because the discarded
+/// card is nonland) put a +1/+1 counter on M.O.D.O.K. itself (the `~` /
+/// self-target conniver).
+///
+/// Revert-discriminating: if the `find_activated_colon` ability-word strip is
+/// reverted, the line parses to `Effect::Unimplemented` with no cost, so
+/// `modok_connive_index` panics (no Connive ability) — and even past that, no
+/// `PayLife` cost would be charged and no +1/+1 counter placed. The
+/// `life_delta == -3` AND `counters == 1` pair pins down the cost, the connive
+/// effect, and the self-target simultaneously.
+#[test]
+fn modok_activation_pays_3_life_and_self_connives() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Empty hand + exactly one nonland card on top: connive draws 1 → hand has
+    // 1 → auto-discards it → nonland → one +1/+1 counter. No discard prompt.
+    scenario.with_library_top(P0, &["Spell Top"]);
+    let id = scenario
+        .add_creature_from_oracle(P0, "M.O.D.O.K.", 4, 4, MODOK_ABILITY)
+        .id();
+    let mut runner = scenario.build();
+
+    let idx = modok_connive_index(&runner, id);
+    assert_eq!(
+        runner.state().objects[&id]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "precondition: no +1/+1 counter before activation"
+    );
+
+    let outcome = runner.activate(id, idx).resolve();
+
+    // CR 118.3b: Pay 3 life.
+    assert_eq!(
+        outcome.life_delta(P0),
+        -3,
+        "activating M.O.D.O.K. must pay exactly 3 life"
+    );
+    // CR 701.50a: nonland discard places one +1/+1 counter on the SELF conviver.
+    assert_eq!(
+        outcome.state().objects[&id]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "self-connive with a nonland discard must place one +1/+1 counter on M.O.D.O.K."
+    );
+}
+
+/// CR 602.5 + CR 602.1: "Activate only during your turn" — the ability is
+/// illegal to activate while it is an opponent's turn, even with priority.
+///
+/// Revert-discriminating: drop `ActivationRestriction::DuringYourTurn` from the
+/// parse (or remove the strip so the ability never parses at all) and the
+/// `act(..).is_err()` assertion flips — either the activation is accepted, or
+/// the line never produces an activated ability to gate. Paired with the
+/// positive test above (same turn = legal), this isolates the restriction.
+#[test]
+fn modok_activation_rejected_on_opponents_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Spell Top"]);
+    let id = scenario
+        .add_creature_from_oracle(P0, "M.O.D.O.K.", 4, 4, MODOK_ABILITY)
+        .id();
+    let mut runner = scenario.build();
+
+    let idx = modok_connive_index(&runner, id);
+
+    // It is the OPPONENT's (P1) turn, but P0 (M.O.D.O.K.'s controller) holds
+    // priority — a legal priority window during an opponent's turn at which an
+    // unrestricted activated ability could be used.
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let life_before = runner.life(P0);
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: id,
+        ability_index: idx,
+    });
+
+    assert!(
+        result.is_err(),
+        "CR 602.5: M.O.D.O.K.'s 'Activate only during your turn' ability must be \
+         rejected on the opponent's turn, got {result:?}"
+    );
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "a rejected activation must not pay the 3-life cost"
+    );
+    assert!(
+        runner.state().stack.is_empty(),
+        "a rejected activation must not put the ability on the stack"
     );
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Card
**M.O.D.O.K.** (MSH)
> Flying, lifelink
> Mental Organism — Pay 3 life: M.O.D.O.K. connives. Activate only during your turn.
> Designed Only for Killing — Creatures your opponents control get -1/-1.

On `main` the activated ability landed as `Unimplemented[unknown]: "Mental Organism — Pay 3 life: ~ connives. Activate only during your turn."`. The keywords and the static -1/-1 already parsed correctly.

## Root cause
`find_activated_colon` only recognized a `[cost]: [effect]` line when the text before the colon started with a mana symbol (`{`) or a cost-starter verb (`pay`, `sacrifice`, …). An italic **ability-word label** preceding the cost (CR 207.2c — ability words have no rules meaning) hid the cost token, so the line was never classified as an activated ability and dropped to `Effect::Unimplemented`.

## Class built (not the card)
The fix strips a 1–4 word ability-word label via the **existing** `split_short_label_prefix`/`strip_ability_word` helper and re-tests the remaining prefix, so the whole class **`[ability-word] — [cost]: [effect] [restriction]`** classifies as an activated ability. `split_short_label_prefix` already rejects prefixes containing `{` or `:`, so an em-dash inside a real cost is never misclassified. Once the line is recognized, every component reuses existing primitives:
- cost → `AbilityCost::PayLife { amount: Fixed(3) }` (cost parser already strips the ability-word label and parses "Pay 3 life")
- effect → `Effect::Connive { target: SelfRef, count: Fixed(1) }` ("~ connives" subject-verb path)
- restriction → `ActivationRestriction::DuringYourTurn` ("Activate only during your turn" suffix handler)

The cost recognizer was extracted verbatim into a shared `cost_prefix_is_activated` helper so the bare and ability-word paths apply identical logic.

## add-engine-variant verdict
**No new engine surface.** No new enum variant, no `data/engine-inventory.json` change. The fix is purely parser line-classification reusing `Effect::Connive`, `AbilityCost::PayLife`, `ActivationRestriction::DuringYourTurn`, and the `strip_ability_word` helper. Parameterize-don't-proliferate: the change generalizes an existing recognizer rather than adding a card-specific branch.

## Grep-verified CR annotations (against `docs/MagicCompRules.txt`)
- **CR 207.2c** — ability words appear in italics and have no rules meaning (justifies stripping the label).
- **CR 602.1** — activated abilities are written `[Cost]: [Effect.] [Activation instructions]` (the classification target).
- **CR 118.3b / CR 119.4** — paying life subtracts from the life total (the cost).
- **CR 602.5** — a player can't begin to activate a prohibited ability (the during-your-turn gate).
- **CR 701.50a** — connive: draw, discard, +1/+1 counter if a nonland card was discarded.

CR-annotation diff gate: 0 `UNVERIFIED:` lines.

## Discriminating-test map
All tests fail when the `find_activated_colon` ability-word strip is reverted (revert-probed).

| Behavioral claim | Seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| Line classifies as a pay-life self-connive activated ability | `find_activated_colon` | `parse_oracle_text` | `parser::oracle::tests::ability_word_labeled_activated_ability_parses_cost_effect_restriction` | `def.kind == Activated`, `cost == PayLife{3}`, `effect == Connive{SelfRef}`, restriction contains `DuringYourTurn` (all flip; line lowers to `Spell`/`Unimplemented` on revert) |
| Activation pays 3 life and self-connives (+1/+1 on nonland discard) | `handle_activate_ability` → connive resolver | `GameAction::ActivateAbility` via `GameRunner::activate(..).resolve()` | `modok_activation_pays_3_life_and_self_connives` | `life_delta(P0) == -3` AND M.O.D.O.K. `Plus1Plus1 == 1` (on revert: `modok_connive_index` panics — no Connive ability parsed) |
| "Activate only during your turn" blocks an opponent's-turn activation | `restrictions::check_activation_restrictions` (`DuringYourTurn`) | `GameAction::ActivateAbility` via `GameRunner::act` | `modok_activation_rejected_on_opponents_turn` | `act(..).is_err()`, no life paid, empty stack |
| Static -1/-1 to opponents' creatures (regression guard) | static parser | `parse_oracle_text` | `parser::oracle::tests::modok_static_minus_one_to_opponents_creatures` | controller=Opponent, AddPower{-1}+AddToughness{-1} |

Negative/sibling coverage: opponent-turn rejection is the negative case for the timing restriction; the existing connive watcher tests (`connive_watcher_ignores_opponent_conniver`) cover the opponent-conniver negative for the connive payoff. No production-reachable seam is left covered only by a degenerate fixture — the runtime tests reach the real `ActivateAbility` arm with a fully parsed ability, a funded life total, and a one-card library that drives the auto-discard branch.

## Gate results
- `cargo fmt --all --check` — clean
- `./scripts/check-parser-combinators.sh` and `… upstream/main` — exit 0
- Parser diff string-dispatch grep — clean (only the relocated `starts_with(s)` wordlist heuristic, a non-literal variable arg that predates this change; test-only `.contains(&EnumVariant)` slice ops)
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine`: **13070 passed; 2 failed** — the two failures (`ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate`, `ai_support::tests::target_selection_legal_actions_do_not_simulate_each_target`) are the known parallel-flaky clone-count assertions; both pass single-threaded in isolation.
- `cargo test -p engine --test integration`: **1436 passed; 0 failed**
- `cargo test -p engine --test connive_trigger_msh_wave1`: **5 passed; 0 failed**

`cargo semantic-audit` / `cargo coverage` require a generated `client/public/card-data.json` not present in a fresh worktree; M.O.D.O.K. (MSH) is release-gated and not in the local card pool, and the change is additive line-classification (it never alters a line that previously parsed), so these card-data audits were not run.