### PR TITLE
fix(parser): strip ability-word prefix on token-granted abilities (Ka-Zar of the Savage Land)

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -5496,4 +5496,166 @@ mod tests {
             "static buff line must classify to something"
         );
     }
+
+    // ── Ka-Zar / Zabu landfall: parse → resolve → trigger ────────────────
+
+    /// Parse Ka-Zar's ETB token line into a real `Effect::Token` (so the test
+    /// exercises the actual parser output, not a hand-built trigger), wrapped in
+    /// a `ResolvedAbility` controlled by `controller`.
+    fn kazar_token_ability(controller: PlayerId) -> ResolvedAbility {
+        let txt = "Create Zabu, a legendary 2/2 green Cat creature token with \"Landfall — Whenever a land you control enters, put a +1/+1 counter on Zabu.\"";
+        let effect = crate::parser::oracle_effect::token::try_parse_token(
+            &txt.to_lowercase(),
+            txt,
+            &mut crate::parser::oracle_ir::context::ParseContext::default(),
+        )
+        .expect("Ka-Zar token line must parse");
+        ResolvedAbility::new(effect, vec![], ObjectId(500), controller)
+    }
+
+    /// Resolve Ka-Zar's token effect and return the created Zabu's `ObjectId`.
+    fn create_zabu(state: &mut GameState, controller: PlayerId) -> ObjectId {
+        let ability = kazar_token_ability(controller);
+        let mut events = Vec::new();
+        resolve(state, &ability, &mut events).unwrap();
+        // CR 604.2: run the layers pass so the token's `GrantTrigger` static
+        // modification is installed as a live trigger_definition before any land
+        // ETB is processed.
+        crate::game::layers::flush_layers(state);
+        *state
+            .battlefield
+            .iter()
+            .find(|id| {
+                state
+                    .objects
+                    .get(id)
+                    .is_some_and(|o| o.is_token && o.name == "Zabu")
+            })
+            .expect("Zabu token must be on the battlefield")
+    }
+
+    /// Put a land onto the battlefield under `land_controller` and fire its ETB
+    /// event through the real trigger pipeline, then resolve the stack.
+    fn land_enters(state: &mut GameState, land_controller: PlayerId, card_id: u64) {
+        let land = create_object(
+            state,
+            CardId(card_id),
+            land_controller,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&land).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.controller = land_controller;
+            obj.owner = land_controller;
+        }
+        let mut record = crate::types::game_state::ZoneChangeRecord::test_minimal(
+            land,
+            Some(Zone::Hand),
+            Zone::Battlefield,
+        );
+        record.name = "Forest".to_string();
+        record.core_types = vec![CoreType::Land];
+        record.subtypes = vec!["Forest".to_string()];
+        record.controller = land_controller;
+        record.owner = land_controller;
+        let event = GameEvent::ZoneChanged {
+            object_id: land,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(record),
+        };
+        crate::game::triggers::process_triggers(state, &[event]);
+        // Resolve every triggered ability the land ETB put on the stack.
+        let mut events = Vec::new();
+        while !state.stack.is_empty() {
+            crate::game::stack::resolve_top(state, &mut events);
+        }
+    }
+
+    fn zabu_plus1_counters(state: &GameState, zabu: ObjectId) -> u32 {
+        state
+            .objects
+            .get(&zabu)
+            .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+            .unwrap_or(0)
+    }
+
+    /// CR 603.6a + CR 207.2c: A land entering under Zabu's controller fires
+    /// Zabu's landfall trigger; the +1/+1 counter lands on ZABU. Discriminating:
+    /// reverting the ability-word strip makes the trigger parse as
+    /// `GrantAbility(Unimplemented[landfall])`, which installs no live trigger,
+    /// so this assertion (`counters == 1`) flips to 0.
+    #[test]
+    fn zabu_landfall_puts_counter_on_zabu_for_controllers_land() {
+        let mut state = GameState::new_two_player(42);
+        let zabu = create_zabu(&mut state, PlayerId(0));
+        assert_eq!(
+            zabu_plus1_counters(&state, zabu),
+            0,
+            "no counters before ETB"
+        );
+
+        land_enters(&mut state, PlayerId(0), 700);
+
+        assert_eq!(
+            zabu_plus1_counters(&state, zabu),
+            1,
+            "a land under Zabu's controller must put one +1/+1 counter on Zabu"
+        );
+    }
+
+    /// CR 603.6a: "a land YOU control" binds "you" to Zabu's controller, so a
+    /// land entering under the OPPONENT's control must NOT fire Zabu's landfall.
+    #[test]
+    fn zabu_landfall_ignores_opponents_land() {
+        let mut state = GameState::new_two_player(42);
+        let zabu = create_zabu(&mut state, PlayerId(0));
+
+        land_enters(&mut state, PlayerId(1), 701);
+
+        assert_eq!(
+            zabu_plus1_counters(&state, zabu),
+            0,
+            "an opponent's land must not fire Zabu's landfall trigger"
+        );
+    }
+
+    /// The counter goes on ZABU, not on Ka-Zar (the source permanent). Build a
+    /// distinct Ka-Zar object as the trigger source's controller's other
+    /// permanent and confirm it never receives the counter.
+    #[test]
+    fn zabu_landfall_counter_targets_zabu_not_kazar() {
+        let mut state = GameState::new_two_player(42);
+        // A stand-in Ka-Zar permanent already on the battlefield under P0.
+        let kazar = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(0),
+            "Ka-Zar of the Savage Land".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&kazar)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let zabu = create_zabu(&mut state, PlayerId(0));
+
+        land_enters(&mut state, PlayerId(0), 702);
+
+        assert_eq!(
+            zabu_plus1_counters(&state, zabu),
+            1,
+            "counter must land on Zabu"
+        );
+        assert_eq!(
+            zabu_plus1_counters(&state, kazar),
+            0,
+            "counter must NOT land on Ka-Zar"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -2380,6 +2380,105 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod kazar_token_landfall_tests {
+    use super::*;
+    use crate::types::ability::ContinuousModification;
+
+    /// Ka-Zar of the Savage Land's Zabu token: the granted ability text carries
+    /// an italicized "Landfall —" ability-word prefix (CR 207.2c) before the
+    /// trigger keyword. The token-ability classifier must strip the ability word
+    /// and recognize the inner trigger (CR 603.1 / CR 603.6a) as a `GrantTrigger`
+    /// static modification — not the `GrantAbility(Unimplemented[landfall])`
+    /// catch-all produced before the fix.
+    #[test]
+    fn zabu_token_landfall_trigger_parses_as_grant_trigger() {
+        let txt = "Create Zabu, a legendary 2/2 green Cat creature token with \"Landfall — Whenever a land you control enters, put a +1/+1 counter on Zabu.\"";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("Zabu token line must parse");
+        let Effect::Token {
+            name,
+            supertypes,
+            static_abilities,
+            ..
+        } = effect
+        else {
+            panic!("expected Effect::Token, got {effect:?}");
+        };
+        assert_eq!(name, "Zabu");
+        assert!(
+            supertypes.contains(&Supertype::Legendary),
+            "Zabu must be legendary, got {supertypes:?}"
+        );
+        let grant_trigger = static_abilities
+            .iter()
+            .flat_map(|def| def.modifications.iter())
+            .find_map(|m| match m {
+                ContinuousModification::GrantTrigger { trigger } => Some(trigger),
+                _ => None,
+            });
+        let trigger = grant_trigger.unwrap_or_else(|| {
+            panic!("landfall trigger must classify as GrantTrigger, got {static_abilities:#?}")
+        });
+        // CR 603.6a: the inner trigger is a zone-change (ETB) trigger.
+        assert_eq!(
+            trigger.mode,
+            crate::types::triggers::TriggerMode::ChangesZone
+        );
+        // No residual Unimplemented landfall effect anywhere in the parsed token.
+        assert!(
+            // allow-noncombinator: test assertion scanning debug output, not parsing dispatch.
+            !format!("{static_abilities:?}").contains("Unimplemented"),
+            "token ability must have no residual Unimplemented effect"
+        );
+    }
+
+    /// The catalog-token path (`inject_catalog_token_abilities`) re-parses the
+    /// preset `rules_text` through `classify_quoted_inner`. The Zabu preset's
+    /// rules_text begins with the "Landfall —" ability word; the same strip must
+    /// apply so the runtime injection yields a `GrantTrigger`, not a
+    /// `GrantAbility(Unimplemented)`.
+    #[test]
+    fn catalog_landfall_rules_text_classifies_as_grant_trigger() {
+        let rules_text =
+            "Landfall — Whenever a land you control enters, put a +1/+1 counter on Zabu.";
+        let mods = crate::parser::oracle_static::classify_quoted_inner(rules_text);
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. })),
+            "catalog rules_text must classify as GrantTrigger, got {mods:?}"
+        );
+        assert!(
+            // allow-noncombinator: test assertion scanning debug output, not parsing dispatch.
+            !format!("{mods:?}").contains("Unimplemented"),
+            "catalog classification must have no residual Unimplemented effect"
+        );
+    }
+
+    /// Full-card parse: Ka-Zar's three lines (look at top, play lands from top,
+    /// ETB token with landfall) must produce zero residual `Unimplemented`
+    /// effects after the ability-word strip fix.
+    #[test]
+    fn kazar_full_card_no_residual_unimplemented() {
+        let oracle = "You may look at the top card of your library any time.\n\
+            You may play lands from the top of your library.\n\
+            When Ka-Zar of the Savage Land enters, create Zabu, a legendary 2/2 green Cat creature token with \"Landfall — Whenever a land you control enters, put a +1/+1 counter on Zabu.\"";
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            oracle,
+            "Ka-Zar of the Savage Land",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &["Human".to_string(), "Warrior".to_string()],
+        );
+        let debug = format!("{parsed:?}");
+        assert!(
+            // allow-noncombinator: test assertion scanning debug output, not parsing dispatch.
+            !debug.contains("Unimplemented"),
+            "Ka-Zar must parse to zero residual Unimplemented, got: {debug}"
+        );
+    }
+}
+
 #[test]
 fn copy_token_non_saga_token_you_control_issue_3294() {
     use crate::types::ability::{ControllerRef, FilterProp, TypeFilter};

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1412,6 +1412,15 @@ pub(super) const ABILITY_WORD_NAMES: &[&str] = &[
     "repartee",
 ];
 
+/// CR 207.2c: Is `name` (already lowercased) a recognized ability word? Used by
+/// callers that have already split an em-dash label and need to confirm it is a
+/// flavor ability word (no rules meaning) before re-dispatching the body through
+/// the ordinary trigger/static machinery — e.g. token-granted abilities whose
+/// quoted text begins "Landfall — Whenever a land you control enters, ...".
+pub(super) fn is_known_ability_word(name: &str) -> bool {
+    ABILITY_WORD_NAMES.contains(&name)
+}
+
 /// Match a known ability-word name at the start of a lowercased input, enforcing
 /// a trailing word boundary. Returns the remainder after the name.
 ///

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -1207,6 +1207,21 @@ pub(crate) fn classify_quoted_inner(ability_text: &str) -> Vec<ContinuousModific
     if ability_text.is_empty() {
         return Vec::new();
     }
+
+    // CR 207.2c: A granted ability's text may carry an italicized ability-word
+    // prefix ("Landfall — Whenever a land you control enters, ..."). Ability
+    // words have no rules meaning, so the body parses through ordinary
+    // trigger/keyword/static machinery. Strip a recognized ability-word prefix
+    // and re-classify the remainder so the inner trigger/static is detected
+    // (otherwise the ability-word prefix masks the trigger keyword and the line
+    // falls through to the GrantAbility catch-all as an unimplemented effect).
+    // Gated on a known ability word so a legitimate em-dash body is untouched.
+    if let Some((aw_name, body)) = super::oracle_modal::strip_ability_word_with_name(ability_text) {
+        if super::oracle_modal::is_known_ability_word(&aw_name) {
+            return classify_quoted_inner(&body);
+        }
+    }
+
     let lower = ability_text.to_lowercase();
 
     // CR 603.1: Detect trigger prefixes to route to GrantTrigger.

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -66,7 +66,8 @@ mod prelude {
 }
 
 pub(super) use super::{
-    oracle, oracle_effect, oracle_keyword, oracle_nom, oracle_quantity, oracle_trigger,
+    oracle, oracle_effect, oracle_keyword, oracle_modal, oracle_nom, oracle_quantity,
+    oracle_trigger,
 };
 
 mod anthem;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Card
**Ka-Zar of the Savage Land** (MSH). The residual gap on `main` was `Unimplemented[landfall]: "Landfall — Whenever a land you control enters"` — the **token's granted ability** inside the Zabu `CreateToken` effect. The first two lines (look at top of library, play lands from top) already parsed.

## Trace + composition
- `Effect::Token` carries a token's granted abilities only in `static_abilities: Vec<StaticDefinition>`. There is no separate triggered-ability field — a triggered grant rides as a `StaticDefinition` whose modification is `ContinuousModification::GrantTrigger`.
- Both the parse-time token path (`push_parsed_statics` → `parse_quoted_ability_modifications`) and the runtime catalog path (`inject_catalog_token_abilities`) funnel quoted ability text through the single-authority classifier `classify_quoted_inner` (`oracle_static/keyword_grant.rs`).
- `classify_quoted_inner` already routes `when `/`whenever `/`at ` prefixes to `GrantTrigger` (CR 603.1). The gap: the italicized `Landfall —` ability-word prefix (CR 207.2c) sat in front of `Whenever`, so the trigger check failed and the line fell through to the `GrantAbility` catch-all, producing `Effect::Unimplemented[landfall]`.
- Runtime already supports the fixed shape: the layers pass installs a `GrantTrigger` static modification as a live `trigger_definition` (CR 604.2, `layers.rs`). No runtime change required — the fix is **parse-time classification only**.

**Fix:** at the top of `classify_quoted_inner`, strip a recognized ability-word em-dash prefix via the canonical nom-combinator helper `strip_ability_word_with_name` (built on `split_short_label_prefix`) and re-classify the remainder. Gated on a known ability word (new `is_known_ability_word` predicate over the existing `ABILITY_WORD_NAMES` table) so a legitimate em-dash body is untouched.

## Class built (not the card)
Any token created with an **ability-word-prefixed granted ability** — `with '<AbilityWord> — Whenever/When/At ...'` — now classifies correctly. Reuses existing `ContinuousModification::GrantTrigger` + `Effect::Token.static_abilities`; covers the trigger, keyword, and static body shapes via the recursive re-dispatch.

## add-engine-variant verdict
**N/A — no new variant.** Reused `ContinuousModification::GrantTrigger` and the existing `Effect::Token.static_abilities` mechanism. `data/engine-inventory.json` untouched. Additions are one small predicate (`is_known_ability_word`) and a recursive strip in the existing classifier — parameterization/reuse, not proliferation.

## Grep-verified CRs
- **CR 207.2c** — ability words have no rules meaning; body parses through ordinary machinery (lists "landfall" explicitly).
- **CR 603.1** — triggered ability "[When/Whenever/At] [event], [effect]".
- **CR 603.6a** — enters-the-battlefield triggers ("Whenever a [type] enters").
- **CR 604.2** — static abilities create continuous effects active while the permanent is on the battlefield (justifies the layers flush before the trigger is live).

All four verified against `docs/MagicCompRules.txt`; diff-gate grep reports zero UNVERIFIED.

## Discriminating-test map (parse → resolve)
| Behavioral claim | Test | Revert-failing assertion |
|---|---|---|
| Ka-Zar's token line parses landfall as `GrantTrigger`, not `Unimplemented` | `zabu_token_landfall_trigger_parses_as_grant_trigger` | finds a `GrantTrigger`; no `Unimplemented` |
| Catalog `rules_text` path classifies the same | `catalog_landfall_rules_text_classifies_as_grant_trigger` | `GrantTrigger` present |
| Full card → 0 residual `Unimplemented` | `kazar_full_card_no_residual_unimplemented` | debug contains no `Unimplemented` |
| Controller's land ETB puts +1/+1 on **Zabu** | `zabu_landfall_puts_counter_on_zabu_for_controllers_land` | Zabu counters `1` (flips to `0` on revert) |
| Opponent's land does **not** trigger | `zabu_landfall_ignores_opponents_land` | Zabu counters `0` |
| Counter lands on Zabu, **not** Ka-Zar | `zabu_landfall_counter_targets_zabu_not_kazar` | Zabu `1`, Ka-Zar `0` (Zabu flips to `0` on revert) |

Runtime tests drive the real pipeline: parse → `resolve()` → `flush_layers` → `process_triggers(ZoneChanged)` → `resolve_top`. **Revert probe:** disabling the strip fails 5/6 tests (the residual `Unimplemented` reappears and the positive counter assertions flip 1 → 0).

## Gate results
- `cargo fmt --all`: clean
- `./scripts/check-parser-combinators.sh`: **0 Forbidden** (inline string-dispatch grep clean; three test-only `.contains("Unimplemented")` assertions annotated `allow-noncombinator`)
- `./scripts/check-engine-authorities.sh upstream/main`: exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: clean
- `cargo test -p engine`: `13075 passed; 1 failed` — the single failure (`ai_support::...delve_payment_skips_state_clone_per_graveyard_candidate`, a state-clone-count test) is a known parallel-flaky unrelated to this diff and **passes in isolation**.
- `cargo semantic-audit`: exit 0, no Ka-Zar/Zabu/landfall findings introduced
- `cargo coverage`: exit 0; regenerated card-data shows Ka-Zar of the Savage Land parses with **no `Unimplemented`**
- card-data regenerated via `oracle-gen data` (no token step); `known-tokens.toml` untouched