### PR TITLE
feat(parser): implement Call Damage Control modal graveyard-return (MSH)

### DIFF
--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -913,6 +913,21 @@ impl<'a> CardBuilder<'a> {
         self
     }
 
+    /// CR 305: Make this card a land. Strips the Creature core type pushed by
+    /// `add_creature_to_graveyard` and adds Land. Mirrors `as_artifact`/
+    /// `as_enchantment`; reusable for graveyard-return targeting tests.
+    pub fn as_land(&mut self) -> &mut Self {
+        let obj = self.obj();
+        obj.card_types
+            .core_types
+            .retain(|t| *t != CoreType::Creature);
+        if !obj.card_types.core_types.contains(&CoreType::Land) {
+            obj.card_types.core_types.push(CoreType::Land);
+        }
+        self.sync_base_card_types();
+        self
+    }
+
     /// CR 302: Make this card a creature. Strips the spell core types
     /// (Instant/Sorcery) pushed by `add_spell_to_library_top` and adds Creature.
     /// Mirrors `as_sorcery`/`as_instant`; reusable for search/tutor library tests.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -12035,6 +12035,75 @@ mod tests {
         assert!(r.parse_warnings.is_empty());
     }
 
+    /// CR 700.2 + CR 601.2c + CR 404.1: Call Damage Control (MSH) — a modal
+    /// spell whose shared return-to-hand effect is phrased once in the header
+    /// ("Return those cards from your graveyard to your hand.") and whose four
+    /// bullets are bare targets distinguished only by card-type. The shared
+    /// effect must be distributed across every mode so each lowers to an
+    /// `Effect::Bounce` (return to hand) of a card of its type in the
+    /// controller's graveyard — never an unimplemented target marker.
+    /// Revert-probe: if `distribute_shared_mode_effect` is removed, each mode is
+    /// an unimplemented "target" marker and the Bounce match below fails.
+    #[test]
+    fn call_damage_control_distributes_shared_return_effect_across_modes() {
+        use crate::types::ability::{FilterProp, TypeFilter, TypedFilter};
+        let r = parse(
+            "Choose up to two. Return those cards from your graveyard to your hand.\n• Target artifact card.\n• Target creature card.\n• Target enchantment card.\n• Target land card.",
+            "Call Damage Control",
+            &[],
+            &["Sorcery"],
+            &[],
+        );
+        let modal = r.modal.expect("should have modal metadata");
+        assert_eq!(modal.min_choices, 0, "\"up to two\" => min 0");
+        assert_eq!(modal.max_choices, 2);
+        assert_eq!(modal.mode_count, 4);
+
+        let expected_types = [
+            TypeFilter::Artifact,
+            TypeFilter::Creature,
+            TypeFilter::Enchantment,
+            TypeFilter::Land,
+        ];
+        assert_eq!(r.abilities.len(), 4);
+        for (ability, expected) in r.abilities.iter().zip(expected_types) {
+            match ability.effect.as_ref() {
+                Effect::Bounce {
+                    target,
+                    destination,
+                    ..
+                } => {
+                    assert_eq!(
+                        *destination, None,
+                        "no explicit destination => return to hand"
+                    );
+                    match target {
+                        TargetFilter::Typed(TypedFilter {
+                            type_filters,
+                            controller,
+                            properties,
+                        }) => {
+                            assert_eq!(type_filters.as_slice(), &[expected]);
+                            assert_eq!(*controller, Some(ControllerRef::You));
+                            assert!(
+                                properties.iter().any(|p| matches!(
+                                    p,
+                                    FilterProp::InZone {
+                                        zone: Zone::Graveyard
+                                    }
+                                )),
+                                "target must be scoped to your graveyard (CR 404.1), got {properties:?}"
+                            );
+                        }
+                        other => panic!("expected Typed graveyard target, got {other:?}"),
+                    }
+                }
+                other => panic!("each mode must lower to Bounce, got {other:?}"),
+            }
+        }
+        assert!(r.parse_warnings.is_empty());
+    }
+
     #[test]
     fn conditional_modal_max_supports_kicker_condition() {
         let r = parse(

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -18,11 +18,12 @@ use super::oracle::{find_activated_colon, strip_activated_constraints};
 use super::oracle_cost::parse_oracle_cost;
 use super::oracle_effect::{parse_effect_chain_with_context, try_parse_named_choice};
 use super::oracle_ir::context::ParseContext;
+use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives::{self as nom_primitives, scan_preceded};
 use super::oracle_static::parse_static_line;
 use super::oracle_trigger::parse_trigger_lines;
-use super::oracle_util::{parse_mana_symbols, strip_reminder_text};
+use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
 use crate::parser::oracle_ir::ast::{ModalHeaderAst, ModeAst, OracleBlockAst};
 
 pub(crate) fn parse_oracle_block(lines: &[&str], start: usize) -> Option<(OracleBlockAst, usize)> {
@@ -94,6 +95,12 @@ pub(crate) fn parse_oracle_block(lines: &[&str], start: usize) -> Option<(Oracle
             // unhandled (`modal: None`) rather than emit a mis-routed choice.
             // No in-scope corpus card hits this guard.
             if !header_is_opponent_chooser_with_additional_cost(&header, &modes) {
+                // CR 700.2 + CR 601.2c: When the shared mode effect is phrased
+                // once in the header ("Choose up to two. Return those cards …")
+                // and each bullet is a bare target, distribute the shared effect
+                // into every mode body so each chosen mode resolves its own
+                // effect on its own target (Call Damage Control class).
+                let modes = distribute_shared_mode_effect(&candidate, modes);
                 return Some((OracleBlockAst::Modal { header, modes }, next));
             }
         }
@@ -286,6 +293,135 @@ fn strip_mode_separator(text: &str) -> &str {
     .parse(trimmed)
     .map(|(rest, _)| rest.trim())
     .unwrap_or(trimmed)
+}
+
+/// CR 700.2 + CR 601.2c: Distribute a header-level shared mode effect across
+/// bare-target modes.
+///
+/// Some modal spells phrase the shared instruction once in the header and leave
+/// each bullet mode as a bare target (Call Damage Control: "Choose up to two.
+/// Return those cards from your graveyard to your hand. • Target artifact card.
+/// • Target creature card. …"). The header's second sentence names a `those
+/// <noun>` anaphor that resolves to the chosen modes' targets, and each mode
+/// supplies only its target's card-type. Because the engine resolves every
+/// chosen mode as its own `ResolvedAbility` (CR 700.2c — one target per chosen
+/// mode), the rules-correct lowering rewrites each bare-target mode body into
+/// the full shared effect with the anaphor replaced by that mode's target
+/// phrase: `"Return target artifact card from your graveyard to your hand."`,
+/// etc. Each mode then independently returns its own targeted card.
+///
+/// This builds for the CLASS: the card-type is the only per-mode axis; the
+/// substitution is purely structural over the `those <noun>` slot, so it covers
+/// any "Choose up to N. <verb> those <noun> …. • Target A. • Target B." spell.
+///
+/// Returns the rewritten modes when the class matches, otherwise the modes
+/// unchanged.
+fn distribute_shared_mode_effect(header_full_text: &str, modes: Vec<ModeAst>) -> Vec<ModeAst> {
+    // The shared effect lives in the header sentence(s) after the choose-count.
+    // `parse_modal_header_ast` keys off the first sentence; the remainder is the
+    // shared template. Require at least two modes (CR 700.2 modal) and that
+    // every mode is a bare target so we never clobber a mode that already
+    // carries its own verb/effect.
+    if modes.len() < 2 || !modes.iter().all(|m| mode_body_is_bare_target(&m.body)) {
+        return modes;
+    }
+
+    let Some((prefix, suffix)) = parse_shared_those_template(header_full_text) else {
+        return modes;
+    };
+
+    modes
+        .into_iter()
+        .map(|mode| {
+            // The bare-target body retains the "target" keyword and card-type
+            // phrase ("Target artifact card"); lowercase its leading article so
+            // it reads mid-sentence inside the shared template. Drop a trailing
+            // period — the suffix supplies sentence punctuation.
+            let target_phrase = lowercase_first_word(mode.body.trim().trim_end_matches('.').trim());
+            let distributed = format!("{prefix}{target_phrase}{suffix}");
+            ModeAst {
+                raw: mode.raw,
+                label: mode.label,
+                body: distributed,
+                mode_cost: mode.mode_cost,
+                mode_pawprint: mode.mode_pawprint,
+            }
+        })
+        .collect()
+}
+
+/// True when a modal mode body is a bare target phrase using the "target"
+/// keyword and nothing else — i.e. the body parses fully (modulo a trailing
+/// period) as a single `target …` phrase with no leading or trailing verb. The
+/// parser is the detector: `parse_target_with_syntax` reports `TargetKeyword`
+/// only when the phrase opened with "target", and a leftover non-empty
+/// remainder means there is an effect verb the shared template would wrongly
+/// swallow.
+fn mode_body_is_bare_target(body: &str) -> bool {
+    let body = body.trim().trim_end_matches('.').trim();
+    let lower = body.to_lowercase();
+    // Must open with the "target" keyword (CR 601.2c) — a descriptor phrase
+    // ("an artifact card") is not this class.
+    if tag::<_, _, OracleError<'_>>("target ")
+        .parse(lower.as_str())
+        .is_err()
+    {
+        return false;
+    }
+    let mut ctx = ParseContext::default();
+    let (_, rest, syntax) = crate::parser::oracle_target::parse_target_with_syntax(body, &mut ctx);
+    syntax == crate::parser::oracle_target::TargetSyntax::TargetKeyword && rest.trim().is_empty()
+}
+
+/// CR 700.2: Parse a header's shared mode-effect template into the text on
+/// either side of its `those <noun>` anaphor slot. The first header sentence is
+/// the choose-count (handled by `parse_modal_header_ast`); the shared effect is
+/// the following sentence whose object is `those <plural-noun>` referring to the
+/// chosen modes' targets. Returns `(prefix, suffix)` such that
+/// `format!("{prefix}{target}{suffix}")` reconstructs the per-mode effect, or
+/// `None` when no such template exists.
+fn parse_shared_those_template(header_full_text: &str) -> Option<(String, String)> {
+    // Skip the choose-count sentence; the shared effect is the next non-empty
+    // sentence. Splitting on the sentence terminator mirrors
+    // `parse_modal_header_ast`'s own sentence segmentation.
+    let mut sentences = header_full_text
+        // allow-noncombinator: structural sentence segmentation on the sentence
+        // terminator, mirroring `parse_modal_header_ast`; not parsing dispatch.
+        .split('.')
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let _count_sentence = sentences.next()?;
+    let effect_sentence = sentences.next()?;
+
+    // Split the effect sentence around the `those ` anaphor slot, preserving the
+    // original casing of the surrounding text via `TextPair`. The prefix is the
+    // verb clause before the slot ("Return "); the anaphor noun ("cards") that
+    // immediately follows is discarded, and the remainder is the suffix
+    // ("from your graveyard to your hand").
+    let lower = effect_sentence.to_lowercase();
+    let pair = TextPair::new(effect_sentence, &lower);
+    let (before, after) = pair.split_around("those ")?;
+    let after = after.trim_start();
+    // Consume the (plural) anaphor noun word with a nom combinator; the
+    // remainder (with its leading space preserved) is the shared suffix, kept so
+    // the reconstructed body reads "<target> from your graveyard …" rather than
+    // gluing the target phrase onto the suffix. A bare "those" with no trailing
+    // clause is not a usable template.
+    let (_, suffix) = nom_on_lower(after.original, after.lower, |i| {
+        value((), take_until::<_, _, OracleError<'_>>(" ")).parse(i)
+    })?;
+    Some((before.original.to_string(), format!("{}.", suffix)))
+}
+
+/// Lowercase only the first word of a phrase, leaving the remainder untouched.
+/// Used to make a bullet mode's leading "Target …" read mid-sentence ("…
+/// target …") inside a distributed shared-effect template.
+fn lowercase_first_word(phrase: &str) -> String {
+    let mut chars = phrase.chars();
+    match chars.next() {
+        Some(first) => format!("{}{}", first.to_lowercase(), chars.as_str()),
+        None => String::new(),
+    }
 }
 
 /// CR 614.12c + CR 607.2d: Recognise an anchor-word as-enters header sentence
@@ -1529,6 +1665,102 @@ mod tests {
         // indicates a different pattern (e.g. a keyword with inline reminder).
         let raw = "Increment (reminder) extra text";
         assert_eq!(extract_ability_word_reminder_body(raw), None);
+    }
+
+    fn bare_target_mode(body: &str) -> ModeAst {
+        ModeAst {
+            raw: format!("{body}."),
+            label: None,
+            body: body.to_string(),
+            mode_cost: None,
+            mode_pawprint: None,
+        }
+    }
+
+    #[test]
+    fn parse_shared_those_template_splits_around_anaphor() {
+        let (prefix, suffix) = parse_shared_those_template(
+            "Choose up to two. Return those cards from your graveyard to your hand.",
+        )
+        .expect("template must parse");
+        assert_eq!(prefix, "Return ");
+        assert_eq!(suffix, " from your graveyard to your hand.");
+    }
+
+    #[test]
+    fn parse_shared_those_template_requires_effect_sentence() {
+        // A bare choose-count header carries no shared effect.
+        assert_eq!(parse_shared_those_template("Choose up to two."), None);
+        // A second sentence without a `those <noun>` anaphor is not a template.
+        assert_eq!(
+            parse_shared_those_template("Choose one. You may choose the same mode more than once."),
+            None
+        );
+    }
+
+    #[test]
+    fn distribute_shared_mode_effect_covers_card_type_axis() {
+        // CR 700.2 + CR 601.2c: the card-type is the only per-mode axis; each
+        // bare target gets the shared "Return … from your graveyard to your
+        // hand" effect.
+        let modes = vec![
+            bare_target_mode("Target artifact card"),
+            bare_target_mode("Target creature card"),
+            bare_target_mode("Target enchantment card"),
+            bare_target_mode("Target land card"),
+        ];
+        let out = distribute_shared_mode_effect(
+            "Choose up to two. Return those cards from your graveyard to your hand.",
+            modes,
+        );
+        assert_eq!(
+            out.iter().map(|m| m.body.as_str()).collect::<Vec<_>>(),
+            vec![
+                "Return target artifact card from your graveyard to your hand.",
+                "Return target creature card from your graveyard to your hand.",
+                "Return target enchantment card from your graveyard to your hand.",
+                "Return target land card from your graveyard to your hand.",
+            ]
+        );
+        // `raw` (the bullet text shown in `mode_descriptions`) is preserved.
+        assert_eq!(out[0].raw, "Target artifact card.");
+    }
+
+    #[test]
+    fn distribute_shared_mode_effect_leaves_full_effect_modes_unchanged() {
+        // Standard modal modes already carry their own verb; the bare-target
+        // gate must not clobber them.
+        let modes = vec![
+            bare_target_mode("Draw a card"),
+            bare_target_mode("Gain 3 life"),
+        ];
+        let out = distribute_shared_mode_effect(
+            "Choose one. Return those cards from your graveyard to your hand.",
+            modes.clone(),
+        );
+        assert_eq!(out, modes, "non-bare-target modes must be left untouched");
+    }
+
+    #[test]
+    fn distribute_shared_mode_effect_noop_without_shared_template() {
+        // A plain modal with no shared-effect sentence is unchanged even when
+        // every mode is a bare target.
+        let modes = vec![
+            bare_target_mode("Target artifact card"),
+            bare_target_mode("Target creature card"),
+        ];
+        let out = distribute_shared_mode_effect("Choose up to two.", modes.clone());
+        assert_eq!(out, modes);
+    }
+
+    #[test]
+    fn mode_body_is_bare_target_discriminates_target_keyword() {
+        assert!(mode_body_is_bare_target("Target artifact card"));
+        assert!(mode_body_is_bare_target("Target creature card."));
+        // A descriptor phrase is not a "target" mode.
+        assert!(!mode_body_is_bare_target("Destroy target creature"));
+        // A bare target with a trailing verb is not a bare target.
+        assert!(!mode_body_is_bare_target("Target creature gets +1/+1"));
     }
 
     #[test]

--- a/crates/engine/tests/integration/call_damage_control_modal_return.rs
+++ b/crates/engine/tests/integration/call_damage_control_modal_return.rs
@@ -1,0 +1,220 @@
+//! Pipeline regression for **Call Damage Control** (MSH, green sorcery).
+//!
+//! Oracle:
+//!   Choose up to two. Return those cards from your graveyard to your hand.
+//!   • Target artifact card.
+//!   • Target creature card.
+//!   • Target enchantment card.
+//!   • Target land card.
+//!
+//! The four bullet modes are bare targets; the shared return-to-hand effect is
+//! phrased once in the header ("Return those cards from your graveyard to your
+//! hand."). Before the fix, each mode lowered to
+//! `Effect::Unimplemented { name: "target", description: "Target <type> card" }`
+//! and the shared effect was dropped entirely — the spell did nothing.
+//!
+//! The fix distributes the header's shared `those <noun>` effect across every
+//! bare-target mode (parser: `distribute_shared_mode_effect`), so each chosen
+//! mode resolves an independent `Effect::Bounce` of a card of its card-type from
+//! the controller's graveyard to hand, parameterized solely by card-type.
+//!
+//! CR 700.2 / CR 700.2a: modal spell; the controller chooses the mode(s) and an
+//! illegal mode (no legal target) can't be chosen.
+//! CR 700.2c / CR 601.2c: each chosen mode supplies its own single target.
+//! CR 404.1: the graveyard is the source zone for the returned cards.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const CALL_DAMAGE_CONTROL: &str = "Choose up to two. \
+    Return those cards from your graveyard to your hand.\n\
+    \u{2022} Target artifact card.\n\
+    \u{2022} Target creature card.\n\
+    \u{2022} Target enchantment card.\n\
+    \u{2022} Target land card.";
+
+/// Stage a graveyard with one card of each of the four targetable card-types
+/// plus the spell in hand. Returns `(artifact, creature, enchantment, land,
+/// spell)` object ids.
+fn staged_scenario() -> (
+    GameScenario,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // `add_creature_to_graveyard` + `as_*` converts the core type while keeping
+    // the card in the graveyard zone (CR 404.1).
+    let artifact = scenario
+        .add_creature_to_graveyard(P0, "Gy Artifact", 0, 0)
+        .as_artifact()
+        .id();
+    let creature = scenario
+        .add_creature_to_graveyard(P0, "Gy Creature", 2, 2)
+        .id();
+    let enchantment = scenario
+        .add_creature_to_graveyard(P0, "Gy Enchantment", 0, 0)
+        .as_enchantment()
+        .id();
+    let land = scenario
+        .add_creature_to_graveyard(P0, "Gy Land", 0, 0)
+        .as_land()
+        .id();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Call Damage Control", false, CALL_DAMAGE_CONTROL)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    (scenario, artifact, creature, enchantment, land, spell)
+}
+
+/// Revert-probe: the spell must parse to zero `Effect::Unimplemented`. With the
+/// shared-effect distribution reverted, every mode is
+/// `Effect::Unimplemented { name: "target" }` and this assertion fails.
+#[test]
+fn call_damage_control_modes_have_no_unimplemented() {
+    use engine::types::ability::Effect;
+
+    let (scenario, _artifact, _creature, _enchantment, _land, spell) = staged_scenario();
+    let runner = scenario.build();
+    let abilities = &runner.state().objects[&spell].abilities;
+    assert_eq!(abilities.len(), 4, "four modes expected");
+    for (i, ability) in abilities.iter().enumerate() {
+        assert!(
+            matches!(ability.effect.as_ref(), Effect::Bounce { .. }),
+            "mode {i} must be a Bounce (return to hand), got {:?}",
+            ability.effect
+        );
+    }
+}
+
+/// DISCRIMINATOR: choosing two modes returns exactly those two card-type
+/// matching cards from the graveyard to hand; the unchosen types stay in the
+/// graveyard. With the fix reverted the modes are no-ops and nothing moves.
+#[test]
+fn call_damage_control_two_modes_return_their_two_cards() {
+    let (scenario, artifact, creature, enchantment, land, spell) = staged_scenario();
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(spell)
+        // Modes 0 (artifact) and 1 (creature); per-mode targets in printed order.
+        .modes(&[0, 1])
+        .target_objects(&[artifact, creature])
+        .resolve();
+
+    assert_eq!(
+        outcome.zone_of(artifact),
+        Zone::Hand,
+        "chosen artifact card must return to hand"
+    );
+    assert_eq!(
+        outcome.zone_of(creature),
+        Zone::Hand,
+        "chosen creature card must return to hand"
+    );
+    // Negative control: unchosen card-types stay in the graveyard.
+    assert_eq!(
+        outcome.zone_of(enchantment),
+        Zone::Graveyard,
+        "unchosen enchantment card must stay in graveyard"
+    );
+    assert_eq!(
+        outcome.zone_of(land),
+        Zone::Graveyard,
+        "unchosen land card must stay in graveyard"
+    );
+}
+
+/// "Up to two" permits choosing a single mode (CR 700.2a / "choose up to N").
+/// Exactly one card returns; the others stay put.
+#[test]
+fn call_damage_control_single_mode_is_legal() {
+    let (scenario, artifact, creature, enchantment, land, spell) = staged_scenario();
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(spell)
+        .modes(&[2]) // enchantment mode only
+        .target_objects(&[enchantment])
+        .resolve();
+
+    assert_eq!(
+        outcome.zone_of(enchantment),
+        Zone::Hand,
+        "the single chosen enchantment card must return to hand"
+    );
+    assert_eq!(outcome.zone_of(artifact), Zone::Graveyard);
+    assert_eq!(outcome.zone_of(creature), Zone::Graveyard);
+    assert_eq!(outcome.zone_of(land), Zone::Graveyard);
+}
+
+/// CR 700.2a: a mode with no legal target can't be chosen. With no land card in
+/// any graveyard, the land mode (index 3) is unavailable and selecting it is
+/// rejected.
+#[test]
+fn call_damage_control_land_mode_unavailable_without_land_card() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Graveyard has an artifact and a creature, but NO land card.
+    scenario
+        .add_creature_to_graveyard(P0, "Gy Artifact", 0, 0)
+        .as_artifact();
+    scenario.add_creature_to_graveyard(P0, "Gy Creature", 2, 2);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Call Damage Control", false, CALL_DAMAGE_CONTROL)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("CastSpell must be accepted");
+
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::AbilityModeChoice {
+                unavailable_modes, ..
+            }
+            | WaitingFor::ModeChoice {
+                unavailable_modes, ..
+            } => {
+                // CR 700.2a: land mode (index 3) has no legal target -> unavailable.
+                assert!(
+                    unavailable_modes.contains(&3),
+                    "land mode must be unavailable without a land card in the graveyard, \
+                     got unavailable_modes={unavailable_modes:?}"
+                );
+                assert!(
+                    runner
+                        .act(GameAction::SelectModes { indices: vec![3] })
+                        .is_err(),
+                    "selecting the unavailable land mode must be rejected"
+                );
+                return;
+            }
+            WaitingFor::ManaPayment { .. } | WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("advance to mode choice");
+            }
+            other => panic!("unexpected waiting state before mode choice: {other:?}"),
+        }
+    }
+    panic!("cast pipeline never reached the modal mode choice");
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -30,6 +30,7 @@ mod bounce_destination_redirect;
 mod braids_arisen_nightmare_decline;
 mod brigid_mana_ability;
 mod bring_to_light_free_cast_2880;
+mod call_damage_control_modal_return;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Card
**Call Damage Control** (MSH, green sorcery)
> Choose up to two. Return those cards from your graveyard to your hand.
> • Target artifact card.
> • Target creature card.
> • Target enchantment card.
> • Target land card.

Residual gap on `main`: four `Unimplemented[target]` modes; the shared return-to-hand effect was dropped entirely.

## Class built (not the card)
This card phrases its shared effect **once in the header** and leaves each bullet as a **bare target** that varies only by card-type. New `distribute_shared_mode_effect` (in `oracle_modal.rs`) detects a modal whose header carries a shared `those <noun>` effect sentence and whose every bullet is a bare target, then distributes the header effect into each mode body — replacing the `those <noun>` anaphor slot with that mode's target phrase. Each chosen mode then lowers to an independent `Effect::Bounce` of a card of its card-type from the controller's graveyard to hand.

The **card-type is the only per-mode axis**, so this covers the whole class of `Choose up to N. <verb> those <noun> .... • Target A. • Target B.` spells, not just this card. Composes existing primitives: modal subsystem (`ModalChoice` + per-mode `AbilityDefinition`), `Effect::Bounce` (return-to-hand), and the target-card-in-graveyard `TargetFilter::Typed { controller: You, InZone: Graveyard }` — all reused, **no new effect/filter variant**.

## add-engine-variant verdict
**No new variant.** Reuses `Effect::Bounce`, `TargetFilter::Typed`, and `ModalChoice`. `data/engine-inventory.json` unchanged.

## Trace / composition
- Modal AST recognized correctly on `main` (`min=0, max=2, mode_count=4`); each mode body was a bare target → unimplemented marker.
- `Return target <type> card from your graveyard to your hand` already parses to `Bounce { Typed[<type>], controller: You, InZone Graveyard, destination: None }` (default destination = hand). Distribution feeds each rewritten mode body through the existing `parse_effect_chain_with_context`.
- Runtime resolves each chosen mode as its own `ResolvedAbility` via `build_chained_resolved`, so each mode returns its own targeted card (CR 700.2c).

## Grep-verified CRs (`docs/MagicCompRules.txt`)
- **CR 700.2** — modal spell (bulleted list + choose-count)
- **CR 700.2a** — controller chooses; an illegal mode (no legal target) can't be chosen
- **CR 700.2c** — targets chosen only if that mode is chosen
- **CR 601.2c** — each `target` is a separate target
- **CR 404.1** — graveyard is the source zone
- **CR 305** — land card type (`as_land` test helper)

## Discriminating-test map (parse → cast → resolve)
Integration (`call_damage_control_modal_return.rs`):
- `two_modes_return_their_two_cards` — choose modes 0+1, target the gy artifact+creature → both move to **Hand**; unchosen enchantment+land **stay in Graveyard** (negative control). Revert-fail assertion: `zone_of(artifact) == Hand`.
- `single_mode_is_legal` — `up to two` permits one mode; only the chosen enchantment returns.
- `land_mode_unavailable_without_land_card` — no land card in gy → land mode (index 3) in `unavailable_modes`; `SelectModes{[3]}` is rejected (CR 700.2a).
- `modes_have_no_unimplemented` — all four modes are `Bounce` (revert-probe).

Parser pipeline (`oracle.rs`): `call_damage_control_distributes_shared_return_effect_across_modes` — each mode lowers to `Bounce` with `Typed[<type>], controller: You, InZone Graveyard`; zero parse warnings.

Building-block units (`oracle_modal.rs`): card-type-axis distribution; non-bare-target modes left unchanged; no-template no-op; `mode_body_is_bare_target` discrimination.

**Revert probe:** reverting the one-line distribution hook fails all 4 integration tests + the pipeline test (each mode reverts to an unimplemented `target` marker; nothing moves).

## Gate results
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` (default + `upstream/main` base) — **exit 0**
- Parser diff string-dispatch grep — clean (the one `.split('.')` is annotated structural sentence segmentation, mirroring `parse_modal_header_ast`; not dispatch)
- `./scripts/check-engine-authorities.sh upstream/main` — **exit 0**
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine` — `13076 passed; 1 failed` where the single failure is the known parallel-flaky `delve_payment_skips_state_clone_per_graveyard_candidate` (global perf-counter test; **passes in isolation**, unrelated to this diff)
- `cargo semantic-audit` / `cargo coverage` — run clean against generated card-data; **Call Damage Control: 0 Unimplemented, 4 Bounce, modal present**, and not present in semantic-audit findings.

Card parses to **0 residual Unimplemented**.