### PR TITLE
feat(parser): graveyard-scope Chroma quantity (Umbra Stalker)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1227,6 +1227,10 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             }
             crate::types::ability::DevotionColors::ChosenColor => "devotion to chosen color".into(),
         },
+        QuantityRef::GraveyardChroma { color, .. } => format!(
+            "number of {} mana symbols among cards in graveyard",
+            fmt_mana_color_full(color)
+        ),
         QuantityRef::DistinctCardTypes { source } => match source {
             CardTypeSetSource::Zone { zone, scope } => {
                 format!(
@@ -5871,6 +5875,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::SelfManaValue => ("SelfManaValue", Handled),
         QuantityRef::Aggregate { .. } => ("Aggregate", Handled),
         QuantityRef::Devotion { .. } => ("Devotion", Handled),
+        QuantityRef::GraveyardChroma { .. } => ("GraveyardChroma", Handled),
         QuantityRef::DistinctCardTypes { .. } => ("DistinctCardTypes", Handled),
         QuantityRef::CardsExiledBySource => ("CardsExiledBySource", Handled),
         QuantityRef::ExiledCardPower { .. } => ("ExiledCardPower", Handled),

--- a/crates/engine/src/game/devotion.rs
+++ b/crates/engine/src/game/devotion.rs
@@ -32,6 +32,35 @@ pub fn count_devotion(state: &GameState, player: PlayerId, colors: &[ManaColor])
     total
 }
 
+/// Count `color` mana symbols among the mana costs of cards in `player`'s
+/// graveyard — the "Chroma" wording's graveyard population (Umbra Stalker).
+///
+/// This is the graveyard sibling of [`count_devotion`]: devotion (CR 700.5) is
+/// defined over permanents you control, while this counts the same colored mana
+/// symbols among a player's graveyard cards. Hybrid symbols (e.g. {U/B}) count
+/// as one symbol toward each color they contain, mirroring `count_devotion`.
+pub fn count_chroma_in_graveyard(state: &GameState, player: PlayerId, color: ManaColor) -> u32 {
+    let Some(p) = state.players.iter().find(|p| p.id == player) else {
+        return 0;
+    };
+    let mut total = 0u32;
+    for &id in &p.graveyard {
+        let Some(obj) = state.objects.get(&id) else {
+            continue;
+        };
+        if let ManaCost::Cost { ref shards, .. } = obj.mana_cost {
+            // CR 700.5: each mana symbol is counted once; a hybrid symbol counts
+            // toward each of its colors but is still a single symbol.
+            for shard in shards {
+                if shard.contributes_to(color) {
+                    total += 1;
+                }
+            }
+        }
+    }
+    total
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,6 +91,54 @@ mod tests {
 
         assert_eq!(count_devotion(&state, PlayerId(0), &[ManaColor::Blue]), 2);
         assert_eq!(count_devotion(&state, PlayerId(0), &[ManaColor::Red]), 0);
+    }
+
+    #[test]
+    fn graveyard_chroma_counts_matching_shards_in_graveyard() {
+        let mut state = setup();
+        // Card with cost {B}{B} in the player's graveyard → 2 chroma to black;
+        // a permanent of the same cost on the battlefield must NOT contribute
+        // (this counts graveyard, not devotion).
+        let gy = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Graveyard Card".to_string(),
+            Zone::Graveyard,
+        );
+        state.objects.get_mut(&gy).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+            generic: 1,
+        };
+        let bf = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Battlefield Card".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&bf).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Black,
+                ManaCostShard::Black,
+                ManaCostShard::Black,
+            ],
+            generic: 0,
+        };
+
+        assert_eq!(
+            count_chroma_in_graveyard(&state, PlayerId(0), ManaColor::Black),
+            2
+        );
+        assert_eq!(
+            count_chroma_in_graveyard(&state, PlayerId(0), ManaColor::Red),
+            0
+        );
+        // An opponent's graveyard is a separate population.
+        assert_eq!(
+            count_chroma_in_graveyard(&state, PlayerId(1), ManaColor::Black),
+            0
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -340,6 +340,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         QuantityRef::HandSize { .. }
         | QuantityRef::LifeTotal { .. }
         | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::GraveyardChroma { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
         | QuantityRef::ObjectCount { .. }
@@ -596,6 +597,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::LifeTotal { .. }
         | QuantityRef::UnspentMana { .. }
         | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::GraveyardChroma { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
         | QuantityRef::PlayerCount { .. }
@@ -779,6 +781,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::LifeTotal { .. }
         | QuantityRef::UnspentMana { .. }
         | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::GraveyardChroma { .. }
         | QuantityRef::LifeAboveStarting
         | QuantityRef::StartingLifeTotal
         | QuantityRef::PlayerCount { .. }
@@ -1486,6 +1489,17 @@ fn resolve_ref(
                 usize_to_i32_saturating(p.graveyard.len())
             })
         }
+        // CR 700.5-style Chroma over a graveyard population (Umbra Stalker): the
+        // number of `color` mana symbols among the mana costs of cards in the
+        // scoped player's graveyard. The graveyard sibling of `Devotion`.
+        QuantityRef::GraveyardChroma {
+            color,
+            player: scope,
+        } => resolve_per_player_scalar(state, scope, controller, ctx, targets, ability, |p| {
+            u32_to_i32_saturating(crate::game::devotion::count_chroma_in_graveyard(
+                state, p.id, *color,
+            ))
+        }),
         QuantityRef::LifeAboveStarting => {
             player.map_or(0, |p| p.life - state.format_config.starting_life)
         }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -641,6 +641,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         |i| parse_basic_land_types_among_lands_controlled_by_ref(i, ControllerRef::TargetPlayer),
         parse_devotion_ref,
         parse_chroma_devotion_ref,
+        parse_graveyard_chroma_ref,
         parse_counters_among_ref,
         // CR 402.1: "the player with the {most|fewest} cards in hand" — the
         // cross-player hand-size extremum, the hand-zone peer of the life
@@ -2681,6 +2682,25 @@ fn parse_chroma_devotion_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         rest,
         QuantityRef::Devotion {
             colors: DevotionColors::Fixed(vec![color]),
+        },
+    ))
+}
+
+/// CR 700.5-style Chroma over the graveyard: "the number of \<color\> mana
+/// symbols in the mana costs of cards in your graveyard" (Umbra Stalker). The
+/// graveyard-population sibling of [`parse_chroma_devotion_ref`], which maps the
+/// permanents-population Chroma to devotion. "your graveyard" scopes to the
+/// controller.
+fn parse_graveyard_chroma_ref(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("the number of ").parse(input)?;
+    let (rest, color) = super::primitives::parse_color(rest)?;
+    let (rest, _) =
+        tag(" mana symbols in the mana costs of cards in your graveyard").parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::GraveyardChroma {
+            color,
+            player: PlayerScope::Controller,
         },
     ))
 }
@@ -6992,6 +7012,24 @@ mod tests {
                 colors: DevotionColors::Fixed(vec![ManaColor::Red])
             }
         );
+    }
+
+    /// CR 700.5-style Chroma over the graveyard population (Umbra Stalker) maps
+    /// to `GraveyardChroma`, the graveyard sibling of devotion.
+    #[test]
+    fn test_parse_graveyard_chroma() {
+        let (rest, q) = parse_quantity_ref(
+            "the number of black mana symbols in the mana costs of cards in your graveyard",
+        )
+        .unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::GraveyardChroma {
+                color: ManaColor::Black,
+                player: PlayerScope::Controller,
+            }
+        );
+        assert_eq!(rest, "");
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3685,6 +3685,16 @@ pub enum QuantityRef {
     /// covers "an opponent['s] graveyard" thresholds (e.g. Merfolk Windrobber,
     /// See Double — "if an opponent has eight or more cards in their graveyard").
     GraveyardSize { player: PlayerScope },
+    /// CR 700.5-style Chroma over a graveyard population: the number of `color`
+    /// mana symbols among the mana costs of cards in `player`'s graveyard
+    /// (Umbra Stalker). The graveyard sibling of [`QuantityRef::Devotion`],
+    /// which CR 700.5 defines over permanents you control only — kept a distinct
+    /// variant for that categorical boundary, and parameterized by `player`
+    /// (whose graveyard) so it is not card-specific.
+    GraveyardChroma {
+        color: ManaColor,
+        player: PlayerScope,
+    },
     /// Controller's life total minus the format's starting life total.
     /// Used for "N or more life more than your starting life total" conditions.
     LifeAboveStarting,


### PR DESCRIPTION
Fixes #4066.

## What

The graveyard-scope **Chroma** quantity â€” "the number of \<color\> mana symbols in the mana costs of cards in your graveyard" â€” was dropping to `Unimplemented`. It is the graveyard-population sibling of devotion: devotion (CR 700.5) counts colored mana symbols among **permanents you control**, this counts the same symbols among **cards in your graveyard**.

Card fixed (Scryfall-verified):

- **Umbra Stalker** â€” "Chroma â€” Umbra Stalker's power and toughness are each equal to the number of black mana symbols in the mana costs of cards in your graveyard." (P/T CDA)

## How

Adds `QuantityRef::GraveyardChroma { color, player }` â€” the graveyard sibling of `Devotion`, kept a distinct variant because CR 700.5 defines devotion over permanents you control only (a different population), and parameterized by `player` (whose graveyard) so it is not card-specific.

- **Resolver**: `game::devotion::count_chroma_in_graveyard` mirrors `count_devotion` but iterates the scoped player's graveyard cards' mana costs, reusing `ManaCostShard::contributes_to` (hybrid symbols count toward each color, CR 700.5). Resolved through the shared per-player scalar resolver.
- **Parser**: "the number of \<color\> mana symbols in the mana costs of cards in your graveyard" â†’ `GraveyardChroma { color, player: Controller }`, registered in `parse_quantity_ref` next to the permanents-population chroma arm.
- Registered the new variant at every exhaustive `QuantityRef` match site: resolver, the two leaf classifiers (`uses_unspent_mana`, `uses_object_count`), the entered-object perturbation classifier, and coverage (describe + handled table) â€” mirroring `GraveyardSize`'s placement (both are graveyard reads, unaffected by battlefield entry/exit).

## Verification

- New unit tests: `count_chroma_in_graveyard` counts matching graveyard shards (and excludes battlefield permanents and opponents' graveyards); `parse_quantity_ref` yields `GraveyardChroma { Black, Controller }` for the Umbra Stalker phrasing.
- Regenerated `card-data.json`: Umbra Stalker now resolves its P/T CDA and is no longer `Unimplemented`.
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) are green.

## Scope

- Permanents-population Chroma remains mapped to `Devotion` (unchanged). Single-object Chroma ("â€¦ in the sacrificed creature's mana cost", Fiery Bombardment) is a different shape and out of scope.
- CR 700.5 (devotion / colored mana-symbol counting).
