### PR TITLE
feat(parser): control target opponent during their next turn (Construct a Cosmic Cube)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -127,20 +127,36 @@ fn parse_dig_library_owner(rest_lower: &str) -> TargetFilter {
     TargetFilter::Controller
 }
 
-/// Shared ControlNextTurn suffix parser (CR 722.1). Called after a prefix
+/// Shared ControlNextTurn suffix parser (CR 723.1). Called after a prefix
 /// combinator ("you control " or "gain control of ") has matched; parses the
-/// target, then " during that player's next turn", then the optional extra-turn
-/// tail (CR 722.1 doesn't require it; some cards like Emrakul grant it).
+/// target, then the "during <possessive> next turn" duration clause, then the
+/// optional extra-turn tail (CR 723.1 doesn't require it; some cards like
+/// Emrakul grant it).
+///
+/// CR 723.1: "control another player during that player's next turn." The
+/// possessive is a single grammatical axis — "that player's" when the target
+/// noun is "player" (Mindslaver), "their" when the target noun is "opponent"
+/// (Construct a Cosmic Cube). Both refer to the targeted player, so they lower
+/// to the same effect; they are composed as one `alt()` over the possessive,
+/// never enumerated as separate full-string arms.
+///
 /// Returns `None` when the suffix doesn't apply, allowing the caller to treat
 /// the match as a different effect (e.g., plain `GainControl`).
 fn try_parse_control_next_turn_suffix(_text: &str, rest: &str) -> Option<(TargetFilter, bool)> {
     let (target_text, _) = super::strip_optional_target_prefix(rest);
     let (target, rem) = parse_target(target_text);
     let rem_lower = rem.to_ascii_lowercase();
-    tag::<_, _, OracleError<'_>>(" during that player's next turn")
-        .parse(rem_lower.as_str())
-        .ok()?;
-    let rem_after_during = &rem[" during that player's next turn".len()..];
+    let (consumed, _) = preceded(
+        tag::<_, _, OracleError<'_>>(" during "),
+        terminated(
+            alt((tag("that player's"), tag("their"), tag("its"))),
+            tag(" next turn"),
+        ),
+    )
+    .parse(rem_lower.as_str())
+    .map(|(remainder, _)| (rem_lower.len() - remainder.len(), remainder))
+    .ok()?;
+    let rem_after_during = &rem[consumed..];
     let rem_after_during_lower = rem_after_during.to_ascii_lowercase();
     let (_tail, grant_extra_turn_after) = if let Ok((tail, _)) = alt((
         tag::<_, _, OracleError<'_>>(". after that turn, that player takes an extra turn"),
@@ -1601,10 +1617,11 @@ pub(super) fn parse_targeted_action_ast(
             multi_target,
         });
     }
-    // CR 722.1: "You control target player during that player's next turn"
-    // (Mindslaver). Declarative form — "you" is not stripped as an imperative
-    // subject because this isn't a verb-on-controller pattern. Must match
-    // before the "gain control of" branch below since the prefixes differ.
+    // CR 723.1: "You control target player during that player's next turn"
+    // (Mindslaver), or "you control target opponent during their next turn"
+    // (Construct a Cosmic Cube). Declarative form — "you" is not stripped as an
+    // imperative subject because this isn't a verb-on-controller pattern. Must
+    // match before the "gain control of" branch below since the prefixes differ.
     if let Some((_, rest)) = nom_on_lower(text, lower, |input| {
         value((), tag("you control ")).parse(input)
     }) {
@@ -6774,7 +6791,7 @@ pub(super) fn parse_imperative_family_ast(
         ));
     }
 
-    // CR 722.1: "You control target player during that player's next turn"
+    // CR 723.1: "You control target player during that player's next turn"
     // (Mindslaver / Word of Command class). "You" is the spell/ability controller
     // in a declarative sentence (not an imperative verb), so this bypasses the
     // first_word dispatch below. Delegates to the ControlNextTurn combinator
@@ -11239,7 +11256,7 @@ mod tests {
         }
     }
 
-    // CR 722.1: Mindslaver's declarative "You control target player during that
+    // CR 723.1: Mindslaver's declarative "You control target player during that
     // player's next turn" must route through the ControlNextTurn combinator.
     #[test]
     fn parse_mindslaver_control_next_turn() {
@@ -11263,7 +11280,39 @@ mod tests {
         }
     }
 
-    // CR 722.1: variant that grants an extra turn afterward (e.g., Emrakul-style).
+    // CR 723.1: "their"-possessive duration variant with an "opponent" target
+    // (Construct a Cosmic Cube: "you control target opponent during their next
+    // turn"). Exercises the possessive `alt()` axis and the opponent target
+    // filter, both of which differ from the Mindslaver "that player's"/"player"
+    // shape — confirms the combinator generalizes the possessive rather than
+    // hard-coding "that player's".
+    #[test]
+    fn parse_control_next_turn_their_possessive_opponent_target() {
+        let text = "You control target opponent during their next turn.";
+        let lower = text.to_lowercase();
+        let result = parse_targeted_action_ast(text, &lower, &mut ParseContext::default());
+        assert!(
+            result.is_some(),
+            "Should parse the 'their next turn' / 'target opponent' variant"
+        );
+        let effect = lower_targeted_action_ast(result.unwrap());
+        match effect {
+            Effect::ControlNextTurn {
+                target,
+                grant_extra_turn_after,
+            } => {
+                assert_eq!(
+                    target,
+                    TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+                    "target opponent → ControllerRef::Opponent filter"
+                );
+                assert!(!grant_extra_turn_after);
+            }
+            other => panic!("Expected Effect::ControlNextTurn, got {other:?}"),
+        }
+    }
+
+    // CR 723.1: variant that grants an extra turn afterward (e.g., Emrakul-style).
     #[test]
     fn parse_control_next_turn_with_extra_turn_tail() {
         let text = "You control target player during that player's next turn. \

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4845,12 +4845,13 @@ mod tests {
         )));
     }
 
-    /// CR 122.1 + CR 603.2: Construct a Cosmic Cube's second-draw trigger body
-    /// (token + plan counter) parses with zero Unimplemented. The
-    /// seventh-plan-counter sacrifice parses too; ONLY the heavy "you control
-    /// target opponent during their next turn" rider stays honestly
-    /// `Effect::Unimplemented` (intentionally deferred). Shape gate paired with
-    /// `tests/construct_cosmic_cube_second_draw_token.rs`.
+    /// CR 122.1 + CR 603.2 + CR 723.1: Construct a Cosmic Cube parses with zero
+    /// Unimplemented across the whole card. The second-draw trigger body (token +
+    /// plan counter) is fully supported; the seventh-plan-counter sacrifice
+    /// parses; and the reflexive "you control target opponent during their next
+    /// turn" rider now lowers to `Effect::ControlNextTurn` via the shared
+    /// turn-control subsystem (CR 723) rather than staying `Unimplemented`. Shape
+    /// gate paired with `tests/construct_cosmic_cube_second_draw_token.rs`.
     #[test]
     fn construct_second_draw_body_parses_token_and_plan_counter() {
         let parsed = parse_named(
@@ -4875,8 +4876,8 @@ mod tests {
             !def_tree_has_unimplemented(second_draw),
             "the token + plan-counter body must be fully supported"
         );
-        // The deferred control-opponent rider remains honest: exactly one
-        // Unimplemented across the whole card.
+        // CR 723.1: the entire card — including the reflexive control-opponent
+        // rider — now parses with zero Unimplemented effects.
         let total_unimpl: usize = parsed
             .triggers
             .iter()
@@ -4884,8 +4885,36 @@ mod tests {
             .filter(|d| def_tree_has_unimplemented(d))
             .count();
         assert_eq!(
-            total_unimpl, 1,
-            "only the deferred 'you control target opponent' rider stays Unimplemented"
+            total_unimpl, 0,
+            "every effect on Construct a Cosmic Cube must be supported (control-opponent rider now lowers to ControlNextTurn)"
+        );
+
+        // CR 723.1: the reflexive rider lowers to `Effect::ControlNextTurn` —
+        // the discriminating shape assertion. Without the "their next turn"
+        // possessive variant in the suffix combinator this would be Unimplemented.
+        fn def_tree_has_control_next_turn(def: &AbilityDefinition) -> bool {
+            if matches!(*def.effect, Effect::ControlNextTurn { .. }) {
+                return true;
+            }
+            def.sub_ability
+                .as_deref()
+                .is_some_and(def_tree_has_control_next_turn)
+                || def
+                    .else_ability
+                    .as_deref()
+                    .is_some_and(def_tree_has_control_next_turn)
+                || def
+                    .mode_abilities
+                    .iter()
+                    .any(def_tree_has_control_next_turn)
+        }
+        assert!(
+            parsed
+                .triggers
+                .iter()
+                .filter_map(|t| t.execute.as_deref())
+                .any(def_tree_has_control_next_turn),
+            "the seventh-counter reflexive rider must lower to Effect::ControlNextTurn"
         );
     }
 }

--- a/crates/engine/tests/construct_cosmic_cube_second_draw_token.rs
+++ b/crates/engine/tests/construct_cosmic_cube_second_draw_token.rs
@@ -9,22 +9,27 @@
 //! stack, creating a 2/1 black Villain token with menace and putting a plan
 //! counter on Construct.
 //!
-//! THE "you control target opponent during their next turn" rider on the
-//! seventh-plan-counter trigger remains honestly `Effect::Unimplemented` (a heavy
-//! deferred mechanic) — this test covers only the second-draw body, which is
-//! fully supported.
+//! The "you control target opponent during their next turn" rider on the
+//! seventh-plan-counter trigger now lowers to `Effect::ControlNextTurn` (CR 723)
+//! via the shared turn-control subsystem and is driven end to end by
+//! `construct_seventh_counter_rider_controls_opponents_next_turn` below.
 //!
-//! THE BUG this discriminates: assertion (a) — a 2/1 Villain token with menace
-//! is created — and assertion (b) — Construct gains exactly one plan counter —
-//! both flip to failure if the second-draw trigger body fails to parse/resolve.
-//! Assertion (c) — only ONE draw does not fire — discriminates the
-//! NthDrawThisTurn=2 gate.
+//! THE BUG `construct_second_draw_creates_villain_token_and_plan_counter`
+//! discriminates: assertion (a) — a 2/1 Villain token with menace is created —
+//! and assertion (b) — Construct gains exactly one plan counter — both flip to
+//! failure if the second-draw trigger body fails to parse/resolve. Assertion
+//! (c) — only ONE draw does not fire — discriminates the NthDrawThisTurn=2 gate.
 
+use engine::game::effects::control_next_turn::resolve as resolve_control_next_turn;
 use engine::game::effects::draw::resolve as resolve_draw;
 use engine::game::scenario::{GameRunner, GameScenario};
 use engine::game::stack::resolve_top;
 use engine::game::triggers::process_triggers;
-use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::game::turns::start_next_turn;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
+};
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
 use engine::types::identifiers::ObjectId;
@@ -34,6 +39,7 @@ use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
 const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
 
 const CONSTRUCT: &str = "Whenever you draw your second card each turn, create a 2/1 black Villain creature token with menace and put a plan counter on this enchantment.\n\
 When the seventh plan counter is put on this enchantment, sacrifice it. When you do, you control target opponent during their next turn.";
@@ -158,4 +164,143 @@ fn construct_second_draw_creates_villain_token_and_plan_counter() {
     // Sanity: Construct stays on the battlefield (the seventh-counter sacrifice
     // has not been reached — only one plan counter so far).
     assert_eq!(runner.state().objects[&construct].zone, Zone::Battlefield);
+}
+
+/// Recursively find the first `ControlNextTurn` effect in an ability tree
+/// (the reflexive "When you do, ..." rider lives in `sub_ability`).
+fn find_control_next_turn(def: &AbilityDefinition) -> Option<&Effect> {
+    if matches!(*def.effect, Effect::ControlNextTurn { .. }) {
+        return Some(&def.effect);
+    }
+    def.sub_ability
+        .as_deref()
+        .and_then(find_control_next_turn)
+        .or_else(|| def.else_ability.as_deref().and_then(find_control_next_turn))
+        .or_else(|| def.mode_abilities.iter().find_map(find_control_next_turn))
+}
+
+/// CR 723.1: Construct a Cosmic Cube's seventh-plan-counter reflexive rider
+/// ("you control target opponent during their next turn") drives the real
+/// turn-control subsystem end to end.
+///
+/// THE BUG this discriminates: the rider lowers to `Effect::ControlNextTurn`
+/// only because the suffix combinator accepts the "their next turn" possessive
+/// (Construct's phrasing). Reverting the parser fix makes the rider
+/// `Effect::Unimplemented`, so `find_control_next_turn` returns `None` and the
+/// `.expect(...)` below panics — the test fails.
+///
+/// Beyond parsing, this resolves the parsed effect through the production
+/// `control_next_turn::resolve` and then advances turns through the real
+/// `start_next_turn`, asserting that on the targeted opponent's next turn
+/// `turn_decision_controller` is the Cube's controller (CR 723.1). Reverting any
+/// of: the parse, the schedule push, or the turn-start activation breaks an
+/// assertion here.
+#[test]
+fn construct_seventh_counter_rider_controls_opponents_next_turn() {
+    // Parse the FULL card through the production parser, then extract the
+    // ControlNextTurn effect from the seventh-counter reflexive rider.
+    let parsed = parse_oracle_text(
+        CONSTRUCT,
+        "Construct a Cosmic Cube",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let rider_effect = parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find_map(find_control_next_turn)
+        .expect("seventh-counter rider must lower to Effect::ControlNextTurn");
+    // The target is "target opponent" → an opponent-scoped player filter.
+    assert!(
+        matches!(rider_effect, Effect::ControlNextTurn { .. }),
+        "rider effect must be ControlNextTurn"
+    );
+
+    // Drive the parsed effect through the real resolver + turn engine.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let construct = scenario
+        .add_creature(P0, "Construct a Cosmic Cube", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(CONSTRUCT)
+        .id();
+    let mut runner = scenario.build();
+
+    // P0 (Cube's controller) is the active player; the opponent is P1.
+    assert_eq!(runner.state().active_player, P0);
+    assert!(
+        runner.state().scheduled_turn_controls.is_empty(),
+        "precondition: no turn-control scheduled yet"
+    );
+
+    // Resolve the parsed ControlNextTurn effect targeting the opponent (P1),
+    // exactly as the resolved reflexive ability would (target opponent → P1 in
+    // two-player).
+    let ability = ResolvedAbility::new(
+        rider_effect.clone(),
+        vec![TargetRef::Player(P1)],
+        construct,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_control_next_turn(runner.state_mut(), &ability, &mut events)
+        .expect("ControlNextTurn resolves");
+
+    // CR 723.1: a turn-control over P1 is scheduled for P1's next turn.
+    assert_eq!(runner.state().scheduled_turn_controls.len(), 1);
+    let scheduled = runner.state().scheduled_turn_controls[0];
+    assert_eq!(scheduled.target_player, P1);
+    assert_eq!(scheduled.controller, P0);
+    assert!(
+        !scheduled.grant_extra_turn_after,
+        "Construct's rider does not grant an extra turn"
+    );
+
+    // CR 723.1: the control does NOT apply to the current (P0's) turn — it waits
+    // for the affected player's next turn.
+    assert_eq!(
+        runner.state().turn_decision_controller,
+        None,
+        "control must not activate during the controller's own turn"
+    );
+
+    // Advance to P1's turn through the real turn engine.
+    let mut events = Vec::new();
+    start_next_turn(runner.state_mut(), &mut events);
+
+    // CR 723.1 / CR 723.5: P1 is the active player but P0 makes P1's decisions.
+    assert_eq!(runner.state().active_player, P1, "it is now P1's turn");
+    assert_eq!(
+        runner.state().turn_decision_controller,
+        Some(P0),
+        "CR 723.1: P0 controls P1 during P1's next turn"
+    );
+    // CR 723: the authorized submitter for P1's seat is the controller P0.
+    assert_eq!(
+        engine::game::turn_control::turn_decision_maker(runner.state()),
+        P0,
+        "CR 723.5: P0 is the decision-maker during the controlled turn"
+    );
+
+    // CR 723.1: the effect "doesn't end until the beginning of the next turn",
+    // so the schedule is consumed only when the controlled turn COMPLETES.
+    // Advance once more: control reverts and the schedule is cleared.
+    let mut events = Vec::new();
+    start_next_turn(runner.state_mut(), &mut events);
+    assert_eq!(
+        runner.state().active_player,
+        P0,
+        "control returns to P0's turn"
+    );
+    assert_eq!(
+        runner.state().turn_decision_controller,
+        None,
+        "CR 723.1: control ends at the beginning of the turn after the controlled turn"
+    );
+    assert!(
+        runner.state().scheduled_turn_controls.is_empty(),
+        "the scheduled control is consumed once the controlled turn ends"
+    );
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

**Construct a Cosmic Cube** (MSH) had one residual gap: its seventh-plan-counter reflexive rider — "you control target opponent during their next turn" — parsed as `Effect::Unimplemented`. The shared `ControlNextTurn` suffix combinator only matched the Mindslaver phrasing `" during that player's next turn"`.

This composes the possessive as a single `alt()` axis so the existing turn-control subsystem handles Construct's phrasing with no new types or variants.

## Change

`try_parse_control_next_turn_suffix` previously hard-coded one full-string `tag`. CR 723.1 ("Controlling Another Player") is a single grammatical axis on the possessive — `"that player's"` when the target noun is "player" (Mindslaver), `"their"` when it is "opponent" (Construct). Both refer to the targeted player and lower to the same `Effect::ControlNextTurn`. The combinator is now:

```
preceded(" during ", terminated(alt(("that player's", "their", "its")), " next turn"))
```

This reuses the entire turn-control subsystem already in the engine:
- schedule push: `control_next_turn::resolve` → `state.scheduled_turn_controls`
- activation on the controlled player's next turn: `turns::start_next_turn`
- decision delegation: `turn_control::turn_decision_maker` / authorized-submitter routing

No new `Effect` variant, no new types, no engine-inventory change.

Also corrects a stale CR annotation on this effect path: it cited **CR 722** (Preparation Cards) where the controlling-another-player rule is **CR 723**.

## Verification

- `cargo fmt --all` clean; clippy `--workspace --exclude phase-tauri --all-targets --features engine/proptest -D warnings` clean.
- `cargo test -p engine`: all pass except the known parallel-flaky `delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation; unrelated).
- Parser combinator gate (`check-parser-combinators.sh`) and the parser-diff string-dispatch grep: clean (no `contains`/`split`/`find` dispatch added).
- `check-engine-authorities.sh upstream/main`: pass.
- Regenerated card-data: **Construct a Cosmic Cube now has 0 Unimplemented effects and 1 `ControlNextTurn`**. `semantic-audit` does not flag the card or any control-next-turn card.

### Discriminating tests
- **Parser shape**: `parse_control_next_turn_their_possessive_opponent_target` (the new "their"/"opponent" axis); the swallow_check gate now asserts the whole card is 0-Unimplemented and the rider lowers to `ControlNextTurn`.
- **Runtime** (`construct_seventh_counter_rider_controls_opponents_next_turn`): parses the full card through the production parser, extracts the `ControlNextTurn` effect, resolves it via `control_next_turn::resolve`, then advances turns through the real `turns::start_next_turn` and asserts control activates on the opponent's next turn (`turn_decision_controller == controller`, CR 723.1) and reverts at the following turn. Reverting the parser fix makes the rider `Unimplemented`, the effect is not found, and the test fails.