### PR TITLE
feat(parser): implement Super-Adaptoid keyword-counter mirror (MSH)

### DIFF
--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -69,17 +69,33 @@ fn build_face_from_oracle(
     // The parser's `extract_keyword_line` requires keyword name hints to identify
     // keyword-only lines (returns None when hints are empty). Pre-scan each line
     // through Keyword::from_str to detect bare keywords like "Flying", "Haste".
+    //
+    // A line contributes inferred hints ONLY when it is a genuine keyword line —
+    // every comma-separated part parses to a known keyword (e.g. "Flying,
+    // vigilance, trample"). A line with any prose fragment is an effect/ability
+    // line and contributes nothing, even if it lists keywords inside a sentence
+    // (e.g. Super-Adaptoid / Kathril's "Do the same for flying, first strike,
+    // …"): those keyword names are the OBJECT of an effect, not granted
+    // keywords, and must not be inferred as static abilities on the card.
     let inferred_kw_names: Vec<String>;
     let effective_kw_names = if keyword_names.is_empty() {
         inferred_kw_names = oracle_text
             .lines()
             .flat_map(|line| {
-                line.split(',')
+                let parts: Vec<String> = line
+                    .split(',')
                     .map(|part| part.trim().to_lowercase())
-                    .filter(|lower| {
+                    .collect();
+                let is_keyword_line = !parts.is_empty()
+                    && parts.iter().all(|lower| {
                         let kw: Keyword = lower.parse().unwrap_or(Keyword::Unknown(String::new()));
                         !matches!(kw, Keyword::Unknown(_))
-                    })
+                    });
+                if is_keyword_line {
+                    parts
+                } else {
+                    Vec::new()
+                }
             })
             .collect();
         &inferred_kw_names

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1529,32 +1529,96 @@ pub(super) fn strip_player_property_superlative_conditional(
     )
 }
 
+/// CR 608.2e + CR 122.1b: Parse "if that creature has <keyword>[ and ~ doesn't], <effect>".
+///
+/// The optional " and ~ doesn't" conjunct (Super-Adaptoid: "If that creature
+/// has haste and Super-Adaptoid doesn't, put a haste counter on
+/// Super-Adaptoid") yields a compound `And([TargetHasKeywordInstead,
+/// SourceLacksKeyword])` so the keyword counter is only placed when the target
+/// HAS the keyword AND the source LACKS it. Without the conjunct (Toxic riders:
+/// "if that creature has toxic, draw a card") it stays a bare
+/// `TargetHasKeywordInstead`. The keyword is captured up to the next " and " /
+/// "," / "; " boundary and lowered through `Keyword::from_str`, so both
+/// evergreen keywords and parameterized-but-bare keywords (Toxic) are
+/// recognized — and the prose "and ~ doesn't" tail is never folded into the
+/// keyword name (a bare `split_once(", ")` captured "haste and ~ doesn't" as
+/// one `Unknown` keyword). Unrecognized phrases stay `Keyword::Unknown` (see
+/// the inline note at the `from_str` call), preserving the pre-existing inert
+/// rider for target-gated counter/P-T "instead" cards that have no keyword to
+/// mirror. Building block for the whole "if that creature has KW [and ~
+/// doesn't], …" class, not a single card.
 pub(super) fn strip_target_keyword_instead(text: &str) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
-    let prefix = alt((
-        tag::<_, _, OracleError<'_>>("if that creature has "),
-        tag("if that permanent has "),
-    ))
-    .parse(lower.as_str())
-    .ok()
-    .map(|(rest, _)| rest);
-    if let Some(rest) = prefix {
-        if let Some((keyword_str, body)) = rest.split_once(", ") {
-            let keyword = crate::types::keywords::Keyword::from_str(keyword_str.trim()).unwrap();
-            let body = body.trim();
-            let body_text = text[text.len() - body.len()..].trim();
-            let body_text = body_text
-                .strip_suffix(" instead.")
-                .or_else(|| body_text.strip_suffix(" instead"))
-                .unwrap_or(body_text);
-            let body_text = body_text.strip_prefix("it ").unwrap_or(body_text);
-            return (
-                Some(AbilityCondition::TargetHasKeywordInstead { keyword }),
-                body_text.to_string(),
-            );
-        }
-    }
-    (None, text.to_string())
+    type E<'a> = OracleError<'a>;
+    let parsed = nom_on_lower(text, &lower, |i| {
+        let (i, _) = alt((
+            tag::<_, _, E>("if that creature has "),
+            tag("if that permanent has "),
+        ))
+        .parse(i)?;
+        // The keyword name runs up to the first of " and " (the lack conjunct),
+        // "," / "; " (the effect connective). `alt` of three terminators keeps
+        // the captured span to the keyword word(s) only.
+        let (i, keyword_str) = alt((
+            terminated(take_until(" and "), peek(tag::<_, _, E>(" and "))),
+            terminated(take_until(", "), peek(tag(", "))),
+            terminated(take_until("; "), peek(tag("; "))),
+        ))
+        .parse(i)?;
+        // CR 122.1b: `Keyword::from_str` is infallible — an unrecognized phrase
+        // (a counter or power/toughness gate such as "a +1/+1 counter on it" or
+        // "power 4 or greater") becomes `Keyword::Unknown`, leaving a
+        // semantically-inert `TargetHasKeywordInstead { Unknown }` rider. That
+        // mirrors pre-existing engine behavior for the target-gated "instead"
+        // cards in that class (Bring Low, Strider, Urdnan), which have no real
+        // keyword to mirror. Rejecting `Unknown` here would silently un-support
+        // that unrelated class — out of scope for the Super-Adaptoid keyword
+        // mirror, which only needs real keywords ("haste", captured before
+        // " and ~ doesn't"). Honest counter/P-T gate support is deferred to its
+        // own change.
+        let keyword = Keyword::from_str(keyword_str).unwrap();
+        // Optional " and ~ doesn't" lack conjunct (Super-Adaptoid class). `~` is
+        // the normalized card name; the bare anaphora forms cover un-normalized
+        // text.
+        let (i, source_lacks) = opt((
+            tag(" and "),
+            alt((
+                tag::<_, _, E>("~"),
+                tag("this creature"),
+                tag("this permanent"),
+                tag("it"),
+            )),
+            tag(" doesn't"),
+        ))
+        .parse(i)
+        .map(|(rest, matched)| (rest, matched.is_some()))?;
+        // Connective ", " (optionally "; ") separates condition from the effect.
+        let (i, _) = alt((tag(", "), tag("; "))).parse(i)?;
+        let condition = if source_lacks {
+            AbilityCondition::And {
+                conditions: vec![
+                    AbilityCondition::TargetHasKeywordInstead {
+                        keyword: keyword.clone(),
+                    },
+                    AbilityCondition::SourceLacksKeyword { keyword },
+                ],
+            }
+        } else {
+            AbilityCondition::TargetHasKeywordInstead { keyword }
+        };
+        Ok((i, condition))
+    });
+    let Some((condition, body)) = parsed else {
+        return (None, text.to_string());
+    };
+    let body = body.trim();
+    // Structural cleanup of the already-extracted effect body (drop the
+    // trailing "instead" override marker and the leading "it " pronoun), not
+    // parsing dispatch — the condition has already been parsed above.
+    let body = body.strip_suffix(" instead.").unwrap_or(body); // allow-noncombinator: effect-body suffix cleanup
+    let body = body.strip_suffix(" instead").unwrap_or(body); // allow-noncombinator: effect-body suffix cleanup
+    let body = body.strip_prefix("it ").unwrap_or(body); // allow-noncombinator: effect-body pronoun cleanup
+    (Some(condition), body.to_string())
 }
 
 fn parse_counter_threshold(text: &str) -> Option<(Comparator, i32, CounterType, usize)> {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -15417,12 +15417,35 @@ fn attach_repeat_process_keywords(defs: &mut Vec<AbilityDefinition>, keywords: &
 }
 
 /// Swap the gating keyword inside an `AbilityCondition` to `new_keyword`. Used
-/// by `attach_repeat_process_keywords` to rewrite the "if a creature card in
-/// your graveyard has <keyword>" gate of each replicated counter clause.
+/// by `attach_repeat_process_keywords` to rewrite each replicated counter
+/// clause's keyword gate. Covers every keyword-gate shape the antecedent
+/// conditional keyword-counter clause can take:
+///   - `QuantityCheck` over an `ObjectCount` filter — "if a creature card in
+///     your graveyard has <keyword>" (Kathril, Aspect Warper).
+///   - `TargetHasKeywordInstead` / `SourceLacksKeyword` — "if that creature has
+///     <keyword> and ~ doesn't" (Super-Adaptoid).
+///   - `And`/`Or`/`Not` — recurse into each compound conjunct so the
+///     Super-Adaptoid conjunction has BOTH the target-has and the source-lacks
+///     keyword swapped together.
 fn rewrite_ability_condition_keyword(condition: &mut AbilityCondition, new_keyword: &Keyword) {
-    if let AbilityCondition::QuantityCheck { lhs, rhs, .. } = condition {
-        rewrite_quantity_expr_keyword(lhs, new_keyword);
-        rewrite_quantity_expr_keyword(rhs, new_keyword);
+    match condition {
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            rewrite_quantity_expr_keyword(lhs, new_keyword);
+            rewrite_quantity_expr_keyword(rhs, new_keyword);
+        }
+        AbilityCondition::TargetHasKeywordInstead { keyword }
+        | AbilityCondition::SourceLacksKeyword { keyword } => {
+            *keyword = new_keyword.clone();
+        }
+        AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
+            for inner in conditions {
+                rewrite_ability_condition_keyword(inner, new_keyword);
+            }
+        }
+        AbilityCondition::Not { condition } => {
+            rewrite_ability_condition_keyword(condition, new_keyword);
+        }
+        _ => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5592,16 +5592,24 @@ pub(super) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyw
     }
 }
 
-/// CR 608.2c: Parse "Repeat this process for <keyword list>." — Kathril, Aspect
-/// Warper. Returns the keyword list; the chunk loop wraps it in
-/// `SpecialClause::RepeatProcessForKeywords` and lowering replicates the
-/// antecedent conditional keyword-counter clause once per keyword. Mirrors
-/// `try_parse_same_is_true_continuation`; covers every "repeat this process for
-/// <list>" card, not Kathril alone.
+/// CR 608.2c: Parse a counter-class keyword-list continuation —
+/// "Repeat this process for <keyword list>." (Kathril, Aspect Warper) or
+/// "Do the same for <keyword list>." (Super-Adaptoid). Returns the keyword
+/// list; the chunk loop wraps it in `SpecialClause::RepeatProcessForKeywords`
+/// and lowering replicates the antecedent conditional keyword-counter clause
+/// once per keyword. Both phrasings are leaf-level variants of the same
+/// "replicate the prior keyword-counter clause for each listed keyword"
+/// directive, so they share one combinator and one `SpecialClause`. Mirrors
+/// `try_parse_same_is_true_continuation`; covers every card of this class, not
+/// Kathril or Super-Adaptoid alone.
 pub(super) fn try_parse_repeat_process_for_keywords(text: &str) -> Option<Vec<Keyword>> {
     let lower = text.to_lowercase();
     let (keywords, rest) = nom_on_lower(text, &lower, |i| {
-        let (i, _) = tag("repeat this process for ").parse(i)?;
+        let (i, _) = alt((
+            tag::<_, _, OracleError<'_>>("repeat this process for "),
+            tag("do the same for "),
+        ))
+        .parse(i)?;
         parse_keyword_list(i)
     })?;
     // The sentence must be fully consumed by the keyword list (modulo a trailing

--- a/crates/engine/tests/super_adaptoid_keyword_counters.rs
+++ b/crates/engine/tests/super_adaptoid_keyword_counters.rs
@@ -43,6 +43,7 @@ use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{AbilityDefinition, TargetRef};
+use engine::types::card_type::Supertype;
 use engine::types::counter::CounterType;
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::{Keyword, KeywordKind};
@@ -263,7 +264,6 @@ fn super_adaptoid_power_tracks_legendary_creature_count() {
     // the supertype survives the layer reset (the layer system reverts
     // `card_types` to `base_card_types` at the top of each evaluation).
     {
-        use engine::types::card_type::Supertype;
         let obj = runner.state_mut().objects.get_mut(&plain).unwrap();
         obj.base_card_types.supertypes.push(Supertype::Legendary);
         obj.card_types.supertypes.push(Supertype::Legendary);

--- a/crates/engine/tests/super_adaptoid_keyword_counters.rs
+++ b/crates/engine/tests/super_adaptoid_keyword_counters.rs
@@ -1,0 +1,278 @@
+//! Super-Adaptoid (MSH) — keyword-counter mirror + characteristic-defining power.
+//!
+//! Oracle text:
+//!   "Super-Adaptoid's power is equal to the number of legendary creatures you
+//!    control.
+//!    Whenever Super-Adaptoid enters or attacks, choose another target
+//!    creature. If that creature has haste and Super-Adaptoid doesn't, put a
+//!    haste counter on Super-Adaptoid. Do the same for flying, first strike,
+//!    double strike, deathtouch, indestructible, lifelink, menace, reach,
+//!    trample, and vigilance."
+//!
+//! This drives the REAL parse → trigger-resolution → layer pipeline:
+//!   - Line 1 is a characteristic-defining `SetDynamicPower` over the
+//!     legendary-creature `ObjectCount` (CR 604.3a). The CDA-power test asserts
+//!     the layer-computed power equals the live legendary-creature count and
+//!     tracks it.
+//!   - The trigger's execute chain is one `TargetOnly` (choose another target
+//!     creature, CR 601.2c) followed by 11 conditional keyword-counter
+//!     placements (CR 122.1b): each `PutCounter { Keyword(K), target: SelfRef }`
+//!     gated by `And([TargetHasKeywordInstead{K}, SourceLacksKeyword{K}])`.
+//!
+//! Discriminating coverage (each assertion FLIPS on a specific revert):
+//!   (1) target has flying + lifelink (SA lacks both) → SA gains a flying
+//!       counter AND a lifelink counter, and layers grant both keywords.
+//!       Reverting the "Do the same for <list>" expansion drops every counter
+//!       past haste, so flying/lifelink would never be placed.
+//!   (2) a keyword the TARGET lacks (deathtouch) → no deathtouch counter.
+//!       Reverting the `TargetHasKeywordInstead` conjunct would place it
+//!       unconditionally.
+//!   (3) a keyword SUPER-ADAPTOID ALREADY HAS (haste) → no second haste counter.
+//!       Reverting the `SourceLacksKeyword` conjunct (the antecedent `And` fix)
+//!       would place a redundant counter.
+//!   (4) CDA power = legendary-creature count, and it tracks the count.
+//!
+//! The trigger is resolved through the public `resolve_ability_chain`
+//! production seam with the chosen target supplied as a root `TargetRef` — the
+//! exact path the ETB/attack trigger uses in production.
+
+use engine::game::ability_utils::build_resolved_from_def_with_targets;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityDefinition, TargetRef};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::{Keyword, KeywordKind};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+
+const ORACLE: &str = "Super-Adaptoid's power is equal to the number of legendary creatures you control.\n\
+Whenever Super-Adaptoid enters or attacks, choose another target creature. If that creature has haste and Super-Adaptoid doesn't, put a haste counter on Super-Adaptoid. Do the same for flying, first strike, double strike, deathtouch, indestructible, lifelink, menace, reach, trample, and vigilance.";
+
+fn artifact_creature_types() -> Vec<String> {
+    vec!["Artifact".to_string(), "Creature".to_string()]
+}
+
+/// Re-parse the oracle text to get the trigger's execute `AbilityDefinition`
+/// (the harness needs the definition to build a resolved ability with a chosen
+/// target — same definition the object carries in production).
+fn super_adaptoid_trigger_execute() -> AbilityDefinition {
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Super-Adaptoid",
+        &[],
+        &artifact_creature_types(),
+        &[],
+    );
+    assert_eq!(parsed.triggers.len(), 1, "exactly one ETB/attack trigger");
+    parsed
+        .triggers
+        .into_iter()
+        .next()
+        .unwrap()
+        .execute
+        .map(|b| *b)
+        .expect("trigger must carry an execute ability")
+}
+
+fn keyword_counter_count(runner: &GameRunner, id: ObjectId, kind: KeywordKind) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Keyword(kind))
+        .copied()
+        .unwrap_or(0)
+}
+
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// The parse must leave ZERO residual `Unimplemented` nodes — the "Do the same
+/// for <list>" continuation expands into 11 conditional keyword-counter clauses
+/// (pre-fix it stayed `Unimplemented[do]`).
+#[test]
+fn super_adaptoid_parses_with_zero_unimplemented() {
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Super-Adaptoid",
+        &[],
+        &artifact_creature_types(),
+        &[],
+    );
+    let dbg = format!("{parsed:#?}");
+    assert!(
+        !dbg.contains("Unimplemented"),
+        "Super-Adaptoid must parse to zero Unimplemented nodes, parse was:\n{dbg}"
+    );
+
+    // Shape guard: the execute chain must contain exactly the 11 keyword
+    // counters in order. Pre-fix only the haste counter existed (the rest were
+    // swallowed by Unimplemented[do]).
+    let execute = super_adaptoid_trigger_execute();
+    let mut node = Some(&execute);
+    let mut placed: Vec<KeywordKind> = Vec::new();
+    while let Some(def) = node {
+        if let engine::types::ability::Effect::PutCounter {
+            counter_type: CounterType::Keyword(kind),
+            ..
+        } = &*def.effect
+        {
+            placed.push(*kind);
+        }
+        node = def.sub_ability.as_deref();
+    }
+    assert_eq!(
+        placed,
+        vec![
+            KeywordKind::Haste,
+            KeywordKind::Flying,
+            KeywordKind::FirstStrike,
+            KeywordKind::DoubleStrike,
+            KeywordKind::Deathtouch,
+            KeywordKind::Indestructible,
+            KeywordKind::Lifelink,
+            KeywordKind::Menace,
+            KeywordKind::Reach,
+            KeywordKind::Trample,
+            KeywordKind::Vigilance,
+        ],
+        "all 11 keyword counters present, in Oracle order (haste + the 10 repeated)"
+    );
+}
+
+/// (1)+(2)+(3): drive the trigger through the production resolver against a
+/// target with a partial keyword set, and assert which counters land.
+#[test]
+fn super_adaptoid_mirrors_only_keywords_target_has_and_source_lacks() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Super-Adaptoid built from Oracle text through the real parse pipeline.
+    // Give it haste up front (case 3: it already has haste, so the haste
+    // counter must NOT be placed).
+    let sa = scenario
+        .add_creature_from_oracle(P0, "Super-Adaptoid", 0, 5, ORACLE)
+        .haste()
+        .id();
+
+    // Target creature: HAS flying + lifelink + haste; LACKS deathtouch (and the
+    // rest). Super-Adaptoid lacks flying/lifelink but already has haste.
+    let target = scenario
+        .add_creature(P0, "Donor Beast", 3, 3)
+        .flying()
+        .lifelink()
+        .haste()
+        .id();
+
+    let mut runner = scenario.build();
+
+    let execute = super_adaptoid_trigger_execute();
+    let ability =
+        build_resolved_from_def_with_targets(&execute, sa, P0, vec![TargetRef::Object(target)]);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Super-Adaptoid trigger must resolve");
+
+    // (1) Target HAS flying + lifelink, SA LACKS both → both counters placed.
+    // Flips on revert of the "Do the same for <list>" expansion (only haste
+    // would be considered; flying/lifelink counters never placed).
+    assert_eq!(
+        keyword_counter_count(&runner, sa, KeywordKind::Flying),
+        1,
+        "target has flying & SA lacks it → one flying counter placed"
+    );
+    assert_eq!(
+        keyword_counter_count(&runner, sa, KeywordKind::Lifelink),
+        1,
+        "target has lifelink & SA lacks it → one lifelink counter placed"
+    );
+
+    // (2) Target LACKS deathtouch → no deathtouch counter. Flips on revert of
+    // the `TargetHasKeywordInstead` conjunct (would place unconditionally).
+    assert_eq!(
+        keyword_counter_count(&runner, sa, KeywordKind::Deathtouch),
+        0,
+        "target lacks deathtouch → no deathtouch counter"
+    );
+
+    // (3) SA ALREADY HAS haste → no haste counter. Flips on revert of the
+    // `SourceLacksKeyword` conjunct (antecedent `And` fix): pre-fix the
+    // condition was a bare/Unknown keyword check that ignored "and ~ doesn't",
+    // so a redundant haste counter would land.
+    assert_eq!(
+        keyword_counter_count(&runner, sa, KeywordKind::Haste),
+        0,
+        "SA already has haste → no redundant haste counter"
+    );
+
+    // The placed keyword counters actually GRANT their keywords via layers
+    // (CR 122.1b). SA had neither flying nor lifelink before resolution.
+    assert!(
+        has_kw(&mut runner, sa, &Keyword::Flying),
+        "the flying counter grants flying to Super-Adaptoid (CR 122.1b)"
+    );
+    assert!(
+        has_kw(&mut runner, sa, &Keyword::Lifelink),
+        "the lifelink counter grants lifelink to Super-Adaptoid (CR 122.1b)"
+    );
+    // No deathtouch keyword was granted (no counter placed).
+    assert!(
+        !has_kw(&mut runner, sa, &Keyword::Deathtouch),
+        "no deathtouch counter → Super-Adaptoid does not gain deathtouch"
+    );
+}
+
+/// (4): the characteristic-defining power equals the count of legendary
+/// creatures the controller controls, and tracks the count (CR 604.3a).
+#[test]
+fn super_adaptoid_power_tracks_legendary_creature_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Super-Adaptoid (NOT legendary itself) and three other P0 creatures, two
+    // of them legendary. SA must count legendary creatures regardless of which
+    // one it is.
+    let sa = scenario
+        .add_creature_from_oracle(P0, "Super-Adaptoid", 0, 5, ORACLE)
+        .id();
+    scenario.add_creature(P0, "Legend One", 2, 2).as_legendary();
+    scenario.add_creature(P0, "Legend Two", 2, 2).as_legendary();
+    let plain = scenario.add_creature(P0, "Plain Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // Two legendary creatures controlled → SA power = 2. Flips if the CDA power
+    // line fails to parse or counts the wrong objects.
+    assert_eq!(
+        runner.state().objects[&sa].power,
+        Some(2),
+        "CDA power = number of legendary creatures you control (2)"
+    );
+
+    // Make the previously-plain creature legendary → count becomes 3, power
+    // tracks it (CDA is continuous, CR 604.3). Push onto `base_card_types` so
+    // the supertype survives the layer reset (the layer system reverts
+    // `card_types` to `base_card_types` at the top of each evaluation).
+    {
+        use engine::types::card_type::Supertype;
+        let obj = runner.state_mut().objects.get_mut(&plain).unwrap();
+        obj.base_card_types.supertypes.push(Supertype::Legendary);
+        obj.card_types.supertypes.push(Supertype::Legendary);
+    }
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert_eq!(
+        runner.state().objects[&sa].power,
+        Some(3),
+        "CDA power tracks the live legendary-creature count (now 3)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Implements **Super-Adaptoid** (MSH, colorless artifact creature) end-to-end. Parses to **zero residual Unimplemented**.

> Super-Adaptoid's power is equal to the number of legendary creatures you control.
> Whenever Super-Adaptoid enters or attacks, choose another target creature. If that creature has haste and Super-Adaptoid doesn't, put a haste counter on Super-Adaptoid. Do the same for flying, first strike, double strike, deathtouch, indestructible, lifelink, menace, reach, trample, and vigilance.

## Class built (not the card)
A `"do the same for <keyword list>"` continuation that replicates a **conditional keyword-counter** template once per listed keyword — composed entirely from existing infra:

1. **Conjunctive antecedent.** `strip_target_keyword_instead` now parses `"if that creature has <KW> and ~ doesn't, <effect>"` into `And([TargetHasKeywordInstead{KW}, SourceLacksKeyword{KW}])` so the counter lands only when the target HAS the keyword and the source LACKS it. The old `split_once(", ")` had captured `"haste and ~ doesn't"` as one `Unknown` keyword; replaced with nom combinators (`take_until`/`peek`/`alt`/`opt`), keyword validated through `Keyword::from_str` (still recognizes Toxic + the evergreen vocabulary — covered by the existing Toxic test).
2. **List continuation.** `try_parse_repeat_process_for_keywords` now also accepts `"do the same for "` as a leaf-level variant of Kathril's `"repeat this process for "` — both replicate the antecedent keyword-counter clause per keyword. One combinator, one `SpecialClause::RepeatProcessForKeywords`.
3. **Per-keyword rewrite.** `rewrite_ability_condition_keyword` recurses into `And`/`Or`/`Not` and swaps the keyword inside `TargetHasKeywordInstead`/`SourceLacksKeyword`, so each replicated conjunctive gate swaps **both** conjuncts together.

The CDA power line (`SetDynamicPower` over the legendary-creature `ObjectCount`, CR 604.3a) already parsed — verified, no change.

**Scenario-harness fix:** `build_face_from_oracle` now infers keyword hints from a line only when **every** comma-separated part is a keyword (a real keyword line), so an effect sentence listing keywords (`"Do the same for flying, first strike, …"`) no longer grants them as static abilities to the test object. Test-infra only; production `parse_oracle_text` was already correct (`extracted_keywords: []`).

## add-engine-variant verdict: **NO new variant**
Zero `types/` changes. Reused `SpecialClause::RepeatProcessForKeywords`, `AbilityCondition::And`/`SourceLacksKeyword`/`TargetHasKeywordInstead`, `CounterType::Keyword` + the layer-6 keyword-counter grant, and `SetDynamicPower`/`ObjectCount`. Parameterized the continuation-phrase axis rather than adding a sibling.

## Grep-verified CR annotations
- **CR 122.1b** — a keyword counter grants its keyword (enumerates flying/first strike/…/vigilance). `grep -nE "^122\.1b" docs/MagicCompRules.txt`
- **CR 608.2c** — follow instructions in order; later text modifies earlier ("apply the rules of English"). `grep -nE "^608\.2c" docs/MagicCompRules.txt`
- **CR 608.2e** — "if [target] has [keyword], [effect] instead". (in code)
- **CR 604.3a** — characteristic-defining ability defines power, functions in all zones (CDA power line).
- **CR 601.2c** — announce targets ("choose another target creature").

CR-annotation diff gate: clean, zero `UNVERIFIED`.

## Discriminating-test map (`crates/engine/tests/super_adaptoid_keyword_counters.rs`)
Drives parse → `build_resolved_from_def_with_targets` → `resolve_ability_chain` (production seam) with the chosen target supplied as a root `TargetRef`.

| claim | seam | production entry | assertion that flips on revert |
|---|---|---|---|
| "do the same" expands to 11 counters | `try_parse_repeat_process_for_keywords` | `parse_oracle_text` | flying+lifelink counters both placed; revert → only haste considered (probed: `tag("do the same for ")` disabled → fail) |
| counter only if target HAS keyword | `And` antecedent | `resolve_ability_chain` | target lacks deathtouch → no deathtouch counter |
| counter only if source LACKS keyword | `SourceLacksKeyword` | `resolve_ability_chain` | SA already has haste → no haste counter (probed: `SourceLacksKeyword` forced true → redundant counter, fail) |
| keyword counters grant keywords | layer 6 (CR 122.1b) | `evaluate_layers` | SA gains flying + lifelink |
| CDA power = legendary count | `SetDynamicPower`/`ObjectCount` | `evaluate_layers` | power 2 → 3 as count changes |

## Gates
- `cargo fmt --all`: clean
- `./scripts/check-parser-combinators.sh`: pass (3 pre-existing structural `strip_*` body-cleanup lines annotated `// allow-noncombinator`)
- Parser diff string-dispatch grep: clean
- `./scripts/check-engine-authorities.sh upstream/main`: exit 0
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`: clean
- `cargo test -p engine`: `13078 passed; 1 failed` — the one failure is the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (passes in isolation, unrelated to this diff)
- Real card-data: Super-Adaptoid = 0 Unimplemented, 11 keyword counters, 11×`And([TargetHasKeywordInstead, SourceLacksKeyword])`, CDA power present; `cargo semantic-audit` reports no findings for Super-Adaptoid

🤖 Generated with [Claude Code](https://claude.com/claude-code)