### PR TITLE
feat(parser): The Kingpin of Crime — duration-bound, filter-scoped "assign combat damage by toughness"

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22080,6 +22080,55 @@ mod tests {
     use super::*;
     use crate::parser::parse_oracle_text;
 
+    /// CR 510.1a + CR 613.11: The Kingpin of Crime's attack ability — "Whenever you
+    /// attack, you may pay 2 life. If you do, until end of turn, creatures you
+    /// control with toughness greater than their power assign combat damage equal
+    /// to their toughness rather than their power." The plural surface form of the
+    /// damage-by-toughness predicate (and the plural "toughness greater than their
+    /// power" filter) must lower with NO residual `Effect::Unimplemented`.
+    #[test]
+    fn the_kingpin_of_crime_full_card_has_no_unimplemented() {
+        let parsed = parse_oracle_text(
+            "Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)\n\
+             Whenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.",
+            "The Kingpin of Crime",
+            &["Extort".to_string()],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &["Spider".to_string()],
+        );
+
+        fn effect_has_unimplemented(effect: &Effect) -> bool {
+            matches!(effect, Effect::Unimplemented { .. })
+        }
+        fn ability_has_unimplemented(ability: &AbilityDefinition) -> bool {
+            effect_has_unimplemented(&ability.effect)
+                || ability
+                    .sub_ability
+                    .as_deref()
+                    .is_some_and(ability_has_unimplemented)
+                || ability
+                    .else_ability
+                    .as_deref()
+                    .is_some_and(ability_has_unimplemented)
+        }
+
+        for trigger in &parsed.triggers {
+            if let Some(execute) = trigger.execute.as_deref() {
+                assert!(
+                    !ability_has_unimplemented(execute),
+                    "trigger lowered to an Unimplemented node: {execute:#?}"
+                );
+            }
+        }
+        for ability in &parsed.abilities {
+            assert!(
+                !ability_has_unimplemented(ability),
+                "ability lowered to an Unimplemented node: {:#?}",
+                ability
+            );
+        }
+    }
+
     /// CR 601.2c + CR 115.1: HONEST DEFERRAL — Graceful Takedown's heterogeneous
     /// compound source set ("any number of target enchanted creatures you control
     /// AND up to one other target creature you control each deal damage equal to

--- a/crates/engine/src/parser/oracle_nom/filter.rs
+++ b/crates/engine/src/parser/oracle_nom/filter.rs
@@ -171,20 +171,13 @@ pub fn parse_no_abilities(input: &str) -> OracleResult<'_, FilterProp> {
 /// Parse the inner content of a "with" clause.
 fn parse_with_inner(input: &str) -> OracleResult<'_, FilterProp> {
     alt((
-        // CR 510.1c relative comparison — must precede the general P/T
-        // combinator so "toughness greater than its power" wins over a
-        // "toughness <comparator>" numeric parse.
-        value(
-            FilterProp::ToughnessGTPower,
-            tag("toughness greater than its power"),
-        ),
-        // CR 208.1 + CR 613.4b self-comparison — must precede the general P/T
-        // combinator so "power greater than its base power" wins over a numeric
-        // "power greater than N" parse (Ms. Marvel, Elastic Ally).
-        value(
-            FilterProp::PowerExceedsBase,
-            tag("power greater than its base power"),
-        ),
+        // CR 208.1 self-referential comparisons (a creature's own toughness vs its
+        // own power, or own power vs own base power) — must precede the general P/T
+        // combinator so they win over a numeric parse. Singular and plural
+        // possessives both accepted via the shared `parse_self_referential_pt`
+        // helper (also reached through `parse_pt_comparison` for the `parse_target`
+        // call sites that bypass `parse_with_inner`).
+        parse_self_referential_pt,
         // CR 509.1b: "greater power" — relative to source.
         value(FilterProp::PowerGTSource, tag("greater power")),
         // CR 208: the shared power/toughness comparison combinator (handles
@@ -216,6 +209,18 @@ pub fn parse_pt_comparison(input: &str) -> OracleResult<'_, FilterProp> {
     // Optional distributive "each " qualifier (no semantic effect).
     let (input, _) = opt(tag("each ")).parse(input)?;
     let (input, _) = opt((tag("with"), space1)).parse(input)?;
+    // CR 208.1: self-referential comparison "(power|toughness) greater than
+    // <poss> (power|toughness)" — a creature's own stat versus its own other
+    // stat. This MUST precede the general "<stat> greater than <quantity>" tail,
+    // which would otherwise resolve the possessive "its/their power" through the
+    // quantity grammar as the *source* object's power (wrong scope for a filter
+    // applied per candidate). Both possessive forms ("its" singular, "their"
+    // plural) and both directions collapse to the dedicated self-referential
+    // props the runtime evaluates against each candidate (`ToughnessGTPower`,
+    // `PowerExceedsBase`).
+    if let Ok((rest, prop)) = parse_self_referential_pt(input) {
+        return Ok((rest, prop));
+    }
     // Optional "base " scope marker (CR 208.4b).
     let (input, scope) = map(opt(tag("base ")), |b| {
         if b.is_some() {
@@ -255,6 +260,40 @@ pub fn parse_pt_comparison(input: &str) -> OracleResult<'_, FilterProp> {
         FilterProp::AnyOf { props }
     };
     Ok((rest, prop))
+}
+
+/// CR 208.1: Possessive pronoun introducing a creature's *own* stat in a
+/// self-referential P/T comparison — "its" (singular subject) or "their" (plural
+/// subject). Both refer to the candidate object itself, not the ability source.
+fn parse_pt_possessive(input: &str) -> OracleResult<'_, &str> {
+    alt((tag("its"), tag("their"))).parse(input)
+}
+
+/// CR 208.1: "toughness greater than <poss> power" → [`FilterProp::ToughnessGTPower`]
+/// and "power greater than <poss> base power" → [`FilterProp::PowerExceedsBase`].
+/// These are the self-referential P/T comparisons (a creature's own stat vs its
+/// own other stat), distinct from the numeric/quantity-threshold comparisons the
+/// rest of `parse_pt_comparison` handles. Accepts singular and plural possessives.
+fn parse_self_referential_pt(input: &str) -> OracleResult<'_, FilterProp> {
+    alt((
+        value(
+            FilterProp::ToughnessGTPower,
+            (
+                tag("toughness greater than "),
+                parse_pt_possessive,
+                tag(" power"),
+            ),
+        ),
+        value(
+            FilterProp::PowerExceedsBase,
+            (
+                tag("power greater than "),
+                parse_pt_possessive,
+                tag(" base power"),
+            ),
+        ),
+    ))
+    .parse(input)
 }
 
 /// CR 208.1 + CR 107.3a: Parse the comparison tail of a P/T constraint, after the

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1531,6 +1531,32 @@ pub(crate) fn try_parse_compound_subtypes(
     Some(TargetFilter::Or { filters })
 }
 
+/// CR 510.1a + CR 613.11: The "assign[s] combat damage equal to <poss> toughness
+/// rather than <poss> power" predicate, in both the singular ("assigns … its …
+/// its") and plural ("assign … their … their") surface forms. CR 510.1a is the
+/// default ("assigns combat damage equal to its power"); this is a continuous
+/// rule-modification effect (CR 613.11) that substitutes toughness for power.
+///
+/// Both forms map to the same [`ContinuousModification::AssignDamageFromToughness`]
+/// rule — only the subject's grammatical number differs (singular "each creature
+/// … assigns" vs plural "creatures you control … assign"). Centralizing the
+/// phrase here keeps the static-line parser and the one-shot continuous-effect
+/// parser (`parse_continuous_modifications`) in lockstep so a new subject scope
+/// never silently drops the plural form. Returns the post-phrase remainder.
+pub(crate) fn parse_assigns_damage_from_toughness_predicate(input: &str) -> OracleResult<'_, ()> {
+    alt((
+        value(
+            (),
+            tag("assigns combat damage equal to its toughness rather than its power"),
+        ),
+        value(
+            (),
+            tag("assign combat damage equal to their toughness rather than their power"),
+        ),
+    ))
+    .parse(input)
+}
+
 /// CR 510.1c: Parse "each creature [you control] [with condition] assigns combat damage
 /// equal to its toughness rather than its power" patterns.
 ///

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -852,11 +852,18 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
 
     // CR 510.1c: Aura/Equipment-style compound statics can attach the
     // toughness-combat-damage rule to the same affected object as a P/T
-    // modification ("Enchanted creature gets +0/+2 and assigns...").
-    if nom_primitives::scan_contains(
+    // modification ("Enchanted creature gets +0/+2 and assigns…"). The same
+    // predicate also rides one-shot duration-bound continuous effects whose
+    // subject is plural ("creatures you control … assign combat damage equal to
+    // their toughness rather than their power" — The Kingpin of Crime), so this
+    // accepts both the singular ("its…its") and plural ("their…their") surface
+    // forms via the shared predicate combinator.
+    if nom_primitives::scan_at_word_boundaries(
         unquoted_lower.as_str(),
-        "assigns combat damage equal to its toughness rather than its power",
-    ) {
+        super::evasion::parse_assigns_damage_from_toughness_predicate,
+    )
+    .is_some()
+    {
         modifications.push(ContinuousModification::AssignDamageFromToughness);
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -463,6 +463,7 @@ mod terra_herald_optional_prompt;
 mod terra_magical_adept_milled_enchantment;
 mod terror_of_the_peaks_issue_2911;
 mod the_chain_veil_loyalty_grants;
+mod the_kingpin_of_crime_combat_damage;
 mod the_ur_dragon_eminence;
 mod thoughtweft_trample_regression;
 mod timely_ward_regression;

--- a/crates/engine/tests/integration/the_kingpin_of_crime_combat_damage.rs
+++ b/crates/engine/tests/integration/the_kingpin_of_crime_combat_damage.rs
@@ -27,14 +27,17 @@
 //! rule-modifying effect), CR 611.2a (the effect lasts until end of turn),
 //! CR 119.3 (paying 2 life). Filter axis: "toughness greater than their power".
 
+use engine::game::combat::AttackTarget;
 use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, ContinuousModification, ControllerRef, Duration, Effect, FilterProp, TargetFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
-
-use engine::game::combat::AttackTarget;
 
 const KINGPIN_ATTACK_ABILITY: &str = "Whenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.";
 
@@ -244,12 +247,6 @@ fn kingpin_effect_lapses_after_end_of_turn() {
 /// runtime tests above (which carry the semantics).
 #[test]
 fn kingpin_clause_lowers_to_assign_damage_from_toughness() {
-    use engine::parser::oracle_effect::parse_effect_chain;
-    use engine::types::ability::{
-        AbilityKind, ContinuousModification, ControllerRef, Duration, Effect, FilterProp,
-        TargetFilter,
-    };
-
     let def = parse_effect_chain(
         "Until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.",
         AbilityKind::Activated,

--- a/crates/engine/tests/integration/the_kingpin_of_crime_combat_damage.rs
+++ b/crates/engine/tests/integration/the_kingpin_of_crime_combat_damage.rs
@@ -1,0 +1,292 @@
+//! The Kingpin of Crime (MSH) — attack-triggered, duration-bound, filter-scoped
+//! "assign combat damage by toughness" continuous effect.
+//!
+//! Oracle (relevant ability):
+//!   Whenever you attack, you may pay 2 life. If you do, until end of turn,
+//!   creatures you control with toughness greater than their power assign combat
+//!   damage equal to their toughness rather than their power.
+//!
+//! The residual gap on main was the effect-side continuous clause:
+//!   Unimplemented[creatures]: "creatures you control with toughness greater than
+//!   their power assign combat damage equal to their toughness rather than their
+//!   power"
+//! The trigger shell (`YouAttack`, optional `PayLife { 2 }`, `IfYouDo`/
+//! `OptionalEffectPerformed` gate, `UntilEndOfTurn` duration) already parsed; the
+//! gap was the *plural* surface form ("assign … their toughness rather than their
+//! power") of the Doran/Assault-Formation damage-by-toughness predicate, which the
+//! singular-only `parse_continuous_modifications` arm did not recognize.
+//!
+//! These tests drive the real combat pipeline through `apply`:
+//! declare-attackers → attack trigger on stack → optional `DecideOptionalEffect`
+//! → layer system → combat damage. They assert the *life delta* on the defending
+//! player, which only changes if the toughness-based assignment is actually
+//! applied at damage time.
+//!
+//! CR 510.1a (a creature assigns combat damage equal to its power — the default),
+//! CR 613.11 (the toughness-rather-than-power substitution is a continuous
+//! rule-modifying effect), CR 611.2a (the effect lasts until end of turn),
+//! CR 119.3 (paying 2 life). Filter axis: "toughness greater than their power".
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+use engine::game::combat::AttackTarget;
+
+const KINGPIN_ATTACK_ABILITY: &str = "Whenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.";
+
+/// Declare `attacker` against P1, resolve the Kingpin attack trigger on the
+/// stack, then accept (`pay = true`) or decline (`pay = false`) the optional
+/// "pay 2 life" cost, and drive combat damage to completion (no blockers).
+fn attack_and_decide(runner: &mut GameRunner, attacker: ObjectId, pay: bool) {
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attackers");
+    // CR 508.2: attack trigger is put on the stack; passing priority resolves it,
+    // which raises the optional "pay 2 life" decision.
+    runner.pass_both_players();
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "Kingpin attack trigger must prompt to pay 2 life, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: pay })
+        .expect("decide optional pay-2-life");
+
+    // The continuous effect (if paid) is now registered; recompute layers so the
+    // affected creatures pick up `assigns_damage_from_toughness` before damage.
+    evaluate_layers(runner.state_mut());
+
+    // Advance through the remaining priority passes to combat damage. No blockers.
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        runner
+            .act(GameAction::DeclareBlockers {
+                assignments: vec![],
+            })
+            .expect("declare (no) blockers");
+    }
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+}
+
+/// Primary positive: a 2/4 (toughness > power) attacker, after paying 2 life,
+/// assigns 4 (toughness) instead of 2 (power) → P1 falls to 16.
+///
+/// REVERT PROBE: with the plural-form fix reverted, the effect clause lowers to
+/// `Effect::Unimplemented` (no continuous modification), so the 2/4 assigns its
+/// power (2) and P1 is left at 18 — this assertion flips from 16 to 18.
+#[test]
+fn kingpin_paid_two_four_assigns_toughness_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "The Kingpin of Crime", 4, 4, KINGPIN_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Defensive Brute", 2, 4).id();
+
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[P0.0 as usize].life;
+
+    attack_and_decide(&mut runner, attacker, true);
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before - 2,
+        "paying the optional cost must deduct 2 life"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        16,
+        "2/4 attacker (toughness > power) must assign 4 combat damage after Kingpin's effect"
+    );
+}
+
+/// Filter axis: a 4/2 attacker (power > toughness) fails the
+/// "toughness greater than their power" filter, so even after paying it assigns
+/// its power (4), not its toughness (2) → P1 falls to 16 (4 damage).
+///
+/// This discriminates the *filter*: if the effect wrongly applied to all
+/// creatures you control (dropping the P/T-comparison filter), the 4/2 would
+/// assign 2 and P1 would be at 18. 16 proves the filter excluded it and normal
+/// power-based assignment governs.
+#[test]
+fn kingpin_paid_four_two_fails_filter_assigns_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "The Kingpin of Crime", 4, 4, KINGPIN_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Glass Cannon", 4, 2).id();
+
+    let mut runner = scenario.build();
+    attack_and_decide(&mut runner, attacker, true);
+
+    let obj = runner.state().objects.get(&attacker).expect("attacker");
+    assert!(
+        !obj.assigns_damage_from_toughness,
+        "4/2 (power > toughness) must NOT be granted toughness-based assignment"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        16,
+        "4/2 attacker fails the toughness>power filter, so it assigns its power (4)"
+    );
+}
+
+/// Optional-cost axis: declining the "pay 2 life" cost leaves normal power-based
+/// assignment — the 2/4 assigns 2 (power) → P1 falls to 18, and P0 loses no life.
+///
+/// Discriminates the `IfYouDo` gate: if the continuous effect applied regardless
+/// of payment, the 2/4 would deal 4 and P1 would be at 16.
+#[test]
+fn kingpin_declined_two_four_assigns_power_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "The Kingpin of Crime", 4, 4, KINGPIN_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Defensive Brute", 2, 4).id();
+
+    let mut runner = scenario.build();
+    let life_before = runner.state().players[P0.0 as usize].life;
+
+    attack_and_decide(&mut runner, attacker, false);
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before,
+        "declining the optional cost must not deduct life"
+    );
+    let obj = runner.state().objects.get(&attacker).expect("attacker");
+    assert!(
+        !obj.assigns_damage_from_toughness,
+        "declining the cost must not grant toughness-based assignment"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        18,
+        "without paying, the 2/4 assigns its power (2)"
+    );
+}
+
+/// Duration axis (CR 514.2 + CR 611.2a): the grant is `until end of turn`. The
+/// 2/4 assigns from toughness during the turn it is paid, and the continuous
+/// effect lapses at that turn's cleanup step.
+///
+/// Discriminates the duration: if the grant were permanent (or had no expiry),
+/// `assigns_damage_from_toughness` would still be set after the turn rolls over;
+/// this asserts it is cleared. Mirrors the Doran +X/+X-lapse test, which passes
+/// priority until `turn_number` advances and then asserts the modification is
+/// gone (no second combat needed, avoiding deck-out edge cases on a minimal
+/// scenario library).
+#[test]
+fn kingpin_effect_lapses_after_end_of_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "The Kingpin of Crime", 4, 4, KINGPIN_ATTACK_ABILITY);
+    let attacker = scenario.add_creature(P0, "Defensive Brute", 2, 4).id();
+
+    let mut runner = scenario.build();
+    let start_turn = runner.state().turn_number;
+
+    // This turn: pay, deal 4 → P1 at 16, and the grant is live.
+    attack_and_decide(&mut runner, attacker, true);
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        16,
+        "the turn it is paid, the 2/4 assigns its toughness (4)"
+    );
+    assert!(
+        runner.state().objects[&attacker].assigns_damage_from_toughness,
+        "grant must be live during the turn it was paid"
+    );
+
+    // Advance one full turn by passing priority. The cleanup step (CR 514.2)
+    // ends the until-end-of-turn effect.
+    for _ in 0..400 {
+        if runner.state().turn_number > start_turn {
+            break;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+    assert!(
+        runner.state().turn_number > start_turn,
+        "the game must advance past the turn the grant was created"
+    );
+
+    evaluate_layers(runner.state_mut());
+    assert!(
+        !runner.state().objects[&attacker].assigns_damage_from_toughness,
+        "until-end-of-turn grant must have lapsed at cleanup — flag cleared next turn"
+    );
+}
+
+/// Parser-level guard: the plural surface form of the damage-by-toughness
+/// predicate now lowers to a `GenericEffect` carrying
+/// `AssignDamageFromToughness` with a `controller=You` + toughness>power filter
+/// and an `UntilEndOfTurn` duration — never `Effect::Unimplemented`.
+///
+/// This locks the exact gap that was closed; it is a shape test that backs the
+/// runtime tests above (which carry the semantics).
+#[test]
+fn kingpin_clause_lowers_to_assign_damage_from_toughness() {
+    use engine::parser::oracle_effect::parse_effect_chain;
+    use engine::types::ability::{
+        AbilityKind, ContinuousModification, ControllerRef, Duration, Effect, FilterProp,
+        TargetFilter,
+    };
+
+    let def = parse_effect_chain(
+        "Until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.",
+        AbilityKind::Activated,
+    );
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        ..
+    } = &*def.effect
+    else {
+        panic!("expected GenericEffect, got {:?}", def.effect);
+    };
+    assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+    let stat = static_abilities
+        .first()
+        .expect("one continuous static ability");
+    assert!(
+        stat.modifications
+            .contains(&ContinuousModification::AssignDamageFromToughness),
+        "plural clause must carry AssignDamageFromToughness, got {:?}",
+        stat.modifications
+    );
+    let affected = stat.affected.as_ref().expect("affected filter");
+    let TargetFilter::Typed(tf) = affected else {
+        panic!("expected a typed affected filter, got {affected:?}");
+    };
+    assert_eq!(
+        tf.controller,
+        Some(ControllerRef::You),
+        "filter must be controller=You"
+    );
+    // CR 208.1: "their power" must lower to the self-referential `ToughnessGTPower`
+    // prop (each creature's own toughness vs its own power) — NOT a source-scoped
+    // `PtComparison` that would compare against the Kingpin's power.
+    assert!(
+        tf.properties.contains(&FilterProp::ToughnessGTPower),
+        "filter must carry the self-referential ToughnessGTPower property, got {:?}",
+        tf.properties
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Card
**The Kingpin of Crime** (MSH, {W}{B}):
> Extort (Whenever you cast a spell, you may pay {W/B}. If you do, each opponent loses 1 life and you gain that much life.)
> Whenever you attack, you may pay 2 life. If you do, until end of turn, creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power.

Extort and the attack-trigger shell (optional `PayLife{2}`, `IfYouDo`/`OptionalEffectPerformed` gate, `UntilEndOfTurn` duration) already parsed. The only residual gap on main was the effect-side continuous clause:
```
Unimplemented[creatures]: "creatures you control with toughness greater than their power assign combat damage equal to their toughness rather than their power"
```

## Class built (not the card)
A **duration-bound, filter-scoped "assign combat damage by toughness" continuous effect**, composed entirely from existing infra:

1. **Predicate (singular + plural).** `parse_continuous_modifications` recognized only the singular `"assigns … its … its"` form; it now accepts both via a shared combinator `parse_assigns_damage_from_toughness_predicate`, keeping the static-line parser (Doran / Assault Formation / High Alert) and the one-shot continuous-effect parser in lockstep. Reuses `ContinuousModification::AssignDamageFromToughness`.
2. **Self-referential P/T filter (singular + plural).** `parse_pt_comparison` now short-circuits `"(toughness|power) greater than <its|their> (power|base power)"` to the dedicated `FilterProp::ToughnessGTPower` / `PowerExceedsBase` props for **both** possessives, before the general numeric comparison tail. Previously only `parse_with_inner` handled this; the `parse_target` path used by subject-scoped effects bypassed it and resolved "their power" through the quantity grammar as the **source** object's power (wrong scope) — so a 2/4 was compared against the source's power instead of its own. This is now the single authority for the self-referential comparison.
3. **Duration + optional cost + trigger:** reuse `Duration::UntilEndOfTurn`, the optional-cost attack-trigger shape, and the `Effect::GenericEffect` continuous-effect registration path. Nothing new.

## add-engine-variant verdict
**No new variant.** Reuses `AssignDamageFromToughness`, `ToughnessGTPower`, `PowerExceedsBase`, `Duration::UntilEndOfTurn`, and the `GenericEffect` path. The fix is parser-side normalization (singular↔plural) plus routing the self-referential filter to the existing dedicated props — parameterize/reuse, do not proliferate.

## Grep-verified CRs
- **CR 510.1a** — "Each attacking/blocking creature assigns combat damage equal to its power" (the default the effect modifies).
- **CR 613.11** — continuous effects that affect game rules (the toughness-rather-than-power substitution).
- **CR 208.1** — a creature's power/toughness (the self-referential comparison filter).

All three confirmed present in `docs/MagicCompRules.txt`.

## Discriminating-test map (drive `apply()`: parse → attack → pay 2 life → combat damage)
`crates/engine/tests/integration/the_kingpin_of_crime_combat_damage.rs`:

| Test | Asserts | Revert-fails because |
|---|---|---|
| `kingpin_paid_two_four_assigns_toughness_damage` | 2/4 (toughness>power), paid → P1 to **16** (assigns 4) | reverted fix lowers clause to `Unimplemented` → 2/4 assigns power (2) → P1 at 18 |
| `kingpin_paid_four_two_fails_filter_assigns_power` | 4/2 (power>toughness) fails filter → assigns power (4); flag NOT set | reverted **filter** fix would compare each creature vs source power, mis-scoping membership |
| `kingpin_declined_two_four_assigns_power_damage` | decline cost → no life paid, flag NOT set, 2/4 assigns power (2) → P1 at **18** | gates the `IfYouDo`/`OptionalEffectPerformed` cost |
| `kingpin_effect_lapses_after_end_of_turn` | grant live this turn, cleared after the turn rolls over | gates `Duration::UntilEndOfTurn` (CR 514.2) vs permanent |

Plus parser shape guards (backing, not substituting, the runtime tests):
- `the_kingpin_of_crime_full_card_has_no_unimplemented` — full card text → **0 residual `Unimplemented`**.
- `kingpin_clause_lowers_to_assign_damage_from_toughness` — clause → `GenericEffect` with `AssignDamageFromToughness`, `controller=You` + `ToughnessGTPower` filter, `UntilEndOfTurn`.

The `4/2` and `2/4` fixtures reach the real `register_transient_effect` broadcast arm and the per-candidate filter evaluation (no degenerate fixture); the positive/negative pair distinguishes the filter scope, the cost gate, and the duration independently.

## Gate results (nightly cargo proxy; Tilt not running for /private/tmp worktrees)
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` (no base **and** `upstream/main`) — exit 0
- parser-diff string-dispatch grep (my changed files) — **clean**
- `./scripts/check-engine-authorities.sh upstream/main` — exit 0
- CR-annotation diff gate (my changed files) — all of CR 208.1 / 510.1a / 613.11 present, **0 UNVERIFIED**
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine` — **13079 passed, 1 failed**; the lone failure is the known parallel-flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (state-clone counting), which **passes in isolation** and is unrelated to this diff.
- New Kingpin suite: **5/5 pass**.

`cargo coverage` / `cargo semantic-audit` require the generated `card-data.json` (absent in a fresh worktree); not regenerated here, so `known-tokens.toml` was left untouched. No new `// Priority N:` parser slot was added.

Test summary line: `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1440 filtered out` (Kingpin suite); `test result: FAILED. 13079 passed; 1 failed` (full engine, lone flaky confirmed green in isolation).