### PR TITLE
feat(card-data): exclude officially-removed cards from MTGJSON build

### DIFF
--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use engine::database::legality::{legalities_to_export_map, normalize_legalities};
 use engine::database::mtgjson::{load_atomic_cards, AtomicCard, Ruling, SetFile};
+use engine::database::removed_cards::is_removed_offensive_card;
 use engine::database::synthesis::{
     build_oracle_face, build_oracle_face_multi, layout_faces, map_layout, LayoutKind,
 };
@@ -694,6 +695,15 @@ fn main() {
     atomic_keys.sort_unstable();
     for mtgjson_key in atomic_keys {
         let faces = &atomic.data[mtgjson_key];
+        // Drop officially-removed offensive cards before any other handling,
+        // so they never enter the card database (and not even an explicit
+        // --filter can resurrect them).
+        if faces
+            .first()
+            .is_some_and(|f| is_removed_offensive_card(&f.name))
+        {
+            continue;
+        }
         // --filter: skip cards not matching any filter name
         if !filter_names.is_empty() {
             let card_name = faces
@@ -1416,7 +1426,13 @@ fn run_decks(remaining_args: &[String]) {
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
             .to_string();
-        let raw = parsed.data;
+        let mut raw = parsed.data;
+        // Strip officially-removed cards from every section at ingestion, so
+        // they never reach decks.json, coverage, or the deck-size threshold.
+        // Single authority shared with the card-export path above.
+        for section in [&mut raw.main_board, &mut raw.side_board, &mut raw.commander] {
+            section.retain(|c| !is_removed_offensive_card(&c.name));
+        }
         if deck_card_total(&raw) < MIN_DECK_CARDS {
             too_small += 1;
             continue;

--- a/crates/engine/src/database/mod.rs
+++ b/crates/engine/src/database/mod.rs
@@ -10,6 +10,7 @@ pub mod legality;
 pub mod meld;
 pub mod mtgjson;
 pub mod oracle_loader;
+pub mod removed_cards;
 pub mod search;
 pub mod set_gating;
 pub mod synthesis;

--- a/crates/engine/src/database/removed_cards.rs
+++ b/crates/engine/src/database/removed_cards.rs
@@ -1,0 +1,59 @@
+//! Build-time exclusion of cards Wizards of the Coast officially removed and
+//! banned in every format for racist or culturally offensive depictions (2020
+//! announcement). These names are dropped from every generated artifact — the
+//! card database and the precon deck listings — so they never surface in
+//! search, deckbuilding, coverage, or gameplay.
+//!
+//! This is data-pipeline tooling, not game-rules logic, so no Comprehensive
+//! Rules annotations apply.
+
+/// Officially-removed card names, lowercased for case-insensitive EXACT
+/// matching. Exact match is mandatory: a substring match on "crusade",
+/// "imprison", or "cleanse" would wrongly drop legitimate cards such as
+/// "Cathars' Crusade", the ~27 "...Crusader" cards, "Imprisoned in the Moon",
+/// and "Suncleanser".
+pub const REMOVED_OFFENSIVE_CARDS: [&str; 7] = [
+    "invoke prejudice",
+    "cleanse",
+    "stone-throwing devils",
+    "pradesh gypsies",
+    "jihad",
+    "imprison",
+    "crusade",
+];
+
+/// True if `name` is an officially-removed card that must be excluded from all
+/// build outputs. EXACT case-insensitive match against [`REMOVED_OFFENSIVE_CARDS`].
+pub fn is_removed_offensive_card(name: &str) -> bool {
+    REMOVED_OFFENSIVE_CARDS.contains(&name.to_lowercase().as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_exact_names_case_insensitively() {
+        assert!(is_removed_offensive_card("Crusade"));
+        assert!(is_removed_offensive_card("crusade"));
+        assert!(is_removed_offensive_card("CRUSADE"));
+        assert!(is_removed_offensive_card("Stone-Throwing Devils"));
+        assert!(is_removed_offensive_card("Invoke Prejudice"));
+        assert!(is_removed_offensive_card("Pradesh Gypsies"));
+        assert!(is_removed_offensive_card("Imprison"));
+        assert!(is_removed_offensive_card("Jihad"));
+        assert!(is_removed_offensive_card("Cleanse"));
+    }
+
+    #[test]
+    fn does_not_match_substring_lookalikes() {
+        // These are legitimate cards that share a substring and must be kept.
+        assert!(!is_removed_offensive_card("Cathars' Crusade"));
+        assert!(!is_removed_offensive_card("Mirran Crusader"));
+        assert!(!is_removed_offensive_card("Phyrexian Crusader"));
+        assert!(!is_removed_offensive_card("Imprisoned in the Moon"));
+        assert!(!is_removed_offensive_card("Imprison This Insolent Wretch"));
+        assert!(!is_removed_offensive_card("Suncleanser"));
+        assert!(!is_removed_offensive_card(""));
+    }
+}


### PR DESCRIPTION
Wizards of the Coast officially removed seven cards and banned them in
every format for racist or culturally offensive depictions (2020):
Invoke Prejudice, Cleanse, Stone-Throwing Devils, Pradesh Gypsies, Jihad,
Imprison, and Crusade. They still ship in MTGJSON's AtomicCards data, so
exclude them at the build boundary so they never enter the card database
or precon deck listings.

Add `database::removed_cards` (sibling to `set_gating`) with a single
`is_removed_offensive_card` authority using EXACT case-insensitive name
matching — never substring, which would wrongly drop ~34 legitimate cards
(every "...Crusader", Cathars' Crusade, Imprisoned in the Moon, Suncleanser).
The `oracle-gen` card-export loop skips removed cards, and `run_decks`
strips them from every deck section at ingestion so they never reach
decks.json, coverage, or the deck-size threshold.
