### PR TITLE
ci(nightly): resync broker-wasm Cargo.lock on release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -241,9 +241,13 @@ jobs:
 
           cargo release "$VERSION" --workspace --execute --no-confirm --no-publish --no-push --allow-branch main
 
+          # cargo-release bumps the main workspace but not nested lockfiles whose
+          # path-dependencies it just revved. Resync them so the committed locks
+          # match the new version, then fold them into the release commit + tag.
           cargo update --manifest-path client/src-tauri/Cargo.toml --package phase-tauri
-          if ! git diff --quiet -- client/src-tauri/Cargo.lock; then
-            git add client/src-tauri/Cargo.lock
+          cargo update --manifest-path lobby-worker/broker-wasm/Cargo.toml --package engine --package lobby-broker
+          if ! git diff --quiet -- client/src-tauri/Cargo.lock lobby-worker/broker-wasm/Cargo.lock; then
+            git add client/src-tauri/Cargo.lock lobby-worker/broker-wasm/Cargo.lock
             git commit --amend --no-edit
             git tag -f -a "$TAG" -m "$TAG"
           fi
@@ -307,6 +311,7 @@ jobs:
               client/src-tauri/Cargo.lock \
               client/src-tauri/Cargo.toml \
               client/src-tauri/tauri.conf.json \
+              lobby-worker/broker-wasm/Cargo.lock \
               | sort)
             extra=$(comm -23 <(printf '%s\n' "$changed") <(printf '%s\n' "$allowed"))
             if [ -n "$extra" ]; then


### PR DESCRIPTION
## What

After `cargo release`, also resync `lobby-worker/broker-wasm/Cargo.lock` and fold it into the release commit + tag.

## Why

`broker-wasm` is a separate crate (excluded from the main workspace for its wasm-only `getrandom` config) with its own lockfile that depends on `engine` and `lobby-broker` **by path**. `cargo release --workspace` bumps those crates but never touches this nested lock, so its committed copy drifted — it pinned `0.2.0` while the workspace had moved to `0.2.3`. CI regenerated it transiently on each worker deploy (so releases never broke), but the committed file was stale and showed up as a spurious local diff after any worker build.

## How

Mirrors the existing `client/src-tauri/Cargo.lock` resync pattern already in this workflow:
- `cargo update --manifest-path lobby-worker/broker-wasm/Cargo.toml --package engine --package lobby-broker` (validated locally: resyncs exactly the two path-deps, nothing else)
- include the lock in the existing amend + `git tag -f`
- add `lobby-worker/broker-wasm/Cargo.lock` to the release-commit **allowed-files** list, so the 'Verify release commit and tag' step doesn't reject it as an unexpected change

Self-heals the current `0.2.x` drift on the next nightly (`0.3.0`), which will commit the synced lock.