### PR TITLE
fix(parser): keep 'until end of turn' on keyword grants compounded with a non-pump conjunct (Homarid Warrior)

### DIFF
--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -2966,4 +2966,92 @@ mod tests {
             "an opponent's Elf must NOT gain the keywords (wrong controller)"
         );
     }
+
+    /// CR 611.2a + CR 514.2: End-to-end pipeline test for a keyword grant that
+    /// is compounded with a non-pump conjunct (Homarid Warrior: "This creature
+    /// gains shroud until end of turn and doesn't untap during your next untap
+    /// step."). Drives parse → `build_resolved_from_def` → `resolve_ability_chain`
+    /// → `execute_cleanup` against the real engine. A reverted fix loses the
+    /// "doesn't untap" conjunct (silently swallowed by
+    /// `parse_continuous_modifications`), so the CantUntap restriction is never
+    /// registered — this test fails on that.
+    #[test]
+    fn keyword_grant_compounded_with_doesnt_untap_resolves_both_and_shroud_expires() {
+        use crate::game::ability_utils::build_resolved_from_def;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::layers::evaluate_layers;
+        use crate::game::turns::execute_cleanup;
+        use crate::types::ability::AbilityKind;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Homarid Warrior".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // Parse the FULL clause through the real chain parser.
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "This creature gains shroud until end of turn and doesn't untap during your next untap step.",
+            AbilityKind::Activated,
+        );
+        // Parser-shape guard mirrors the lib parser test: the keyword grant must
+        // carry its duration rather than defaulting permanently.
+        assert_eq!(
+            def.duration,
+            Some(Duration::UntilEndOfTurn),
+            "keyword grant must keep its until-end-of-turn duration"
+        );
+
+        let resolved = build_resolved_from_def(&def, source, PlayerId(0));
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &resolved, &mut events, 0).unwrap();
+        evaluate_layers(&mut state);
+
+        // Shroud is live before cleanup.
+        assert!(
+            state
+                .objects
+                .get(&source)
+                .unwrap()
+                .has_keyword(&Keyword::Shroud),
+            "source must have shroud before cleanup"
+        );
+
+        // The "doesn't untap" conjunct survived the split: a CantUntap transient
+        // restriction is registered (it would be dropped if the fix is reverted).
+        assert!(
+            state.transient_continuous_effects.iter().any(|tce| {
+                tce.modifications
+                    .contains(&ContinuousModification::AddStaticMode {
+                        mode: StaticMode::CantUntap,
+                    })
+            }),
+            "the 'doesn't untap' conjunct must register a CantUntap restriction, \
+             not be silently swallowed; TCEs: {:?}",
+            state.transient_continuous_effects
+        );
+
+        // CR 514.2: the until-end-of-turn shroud grant expires at cleanup.
+        execute_cleanup(&mut state, &mut events);
+        evaluate_layers(&mut state);
+        assert!(
+            !state
+                .objects
+                .get(&source)
+                .unwrap()
+                .has_keyword(&Keyword::Shroud),
+            "shroud must be gone after cleanup (until end of turn expiry)"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -31230,9 +31230,98 @@ mod tests {
             e,
             Effect::GenericEffect {
                 target: Some(TargetFilter::Typed(ref tf)),
+                duration: Some(Duration::UntilEndOfTurn),
                 ..
             } if tf.type_filters.contains(&TypeFilter::Creature)
         ));
+    }
+
+    /// CR 611.2a + CR 514.2: "gains <keyword> until end of turn and <non-pump
+    /// conjunct>" must keep the `until end of turn` duration on the keyword
+    /// grant. Homarid Warrior: "This creature gains shroud until end of turn
+    /// and doesn't untap during your next untap step." Previously the trailing
+    /// "and …" conjunct kept the clause unified, the suffix-only
+    /// `strip_trailing_duration` could not reach the mid-clause duration, and
+    /// shroud was granted permanently (duration: None).
+    #[test]
+    fn keyword_grant_with_non_pump_conjunct_keeps_until_end_of_turn() {
+        let def = parse_effect_chain(
+            "This creature gains shroud until end of turn and doesn't untap during your next untap step.",
+            AbilityKind::Activated,
+        );
+
+        let Effect::GenericEffect {
+            static_abilities,
+            duration,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected keyword GenericEffect, got {:?}", def.effect);
+        };
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+        assert!(static_abilities.iter().any(|s| s.modifications.contains(
+            &ContinuousModification::AddKeyword {
+                keyword: Keyword::Shroud
+            }
+        )));
+
+        // The "doesn't untap" conjunct must survive as a chained sub_ability —
+        // it must not be silently dropped by the split.
+        let sub = def
+            .sub_ability
+            .as_deref()
+            .expect("non-pump conjunct must be chained as a sub_ability");
+        assert!(
+            matches!(&*sub.effect, Effect::GenericEffect { .. }),
+            "expected the doesn't-untap conjunct to lower to a restriction GenericEffect, got {:?}",
+            sub.effect
+        );
+    }
+
+    /// Over-split guard: a multi-keyword grant whose single duration trails
+    /// both keywords ("gains flying and haste until end of turn") must stay a
+    /// unified clause with the duration applied — the keyword-grant-compound
+    /// split must NOT fire.
+    #[test]
+    fn multi_keyword_grant_with_shared_duration_stays_unified() {
+        let def = parse_effect_chain(
+            "This creature gains flying and haste until end of turn.",
+            AbilityKind::Activated,
+        );
+        assert!(
+            def.sub_ability.is_none(),
+            "multi-keyword grant must not be split into a sub_ability"
+        );
+        let Effect::GenericEffect {
+            static_abilities,
+            duration,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected keyword GenericEffect, got {:?}", def.effect);
+        };
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+        let keywords: Vec<&ContinuousModification> = static_abilities
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .collect();
+        assert!(keywords.contains(&&ContinuousModification::AddKeyword {
+            keyword: Keyword::Flying
+        }));
+        assert!(keywords.contains(&&ContinuousModification::AddKeyword {
+            keyword: Keyword::Haste
+        }));
+    }
+
+    /// Regression: a standalone keyword grant still carries its duration.
+    #[test]
+    fn standalone_keyword_grant_keeps_until_end_of_turn() {
+        let def = parse_effect_chain("It gains haste until end of turn.", AbilityKind::Spell);
+        assert_eq!(def.duration, Some(Duration::UntilEndOfTurn));
+        let Effect::GenericEffect { duration, .. } = &*def.effect else {
+            panic!("expected keyword GenericEffect, got {:?}", def.effect);
+        };
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -884,6 +884,12 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                                     .or_else(|| {
                                         exile_conjunct_prepend(&before_lower, remainder_trimmed)
                                     })
+                                    .or_else(|| {
+                                        untap_restriction_conjunct_prepend(
+                                            before_and,
+                                            remainder_trimmed,
+                                        )
+                                    })
                             {
                                 push_clause_chunk(
                                     &mut chunks,
@@ -2099,10 +2105,45 @@ fn combat_requirement_conjunct_prepend(
     {
         return None;
     }
+    continuous_grant_subject_prepend(before_and)
+}
+
+/// CR 502.3 + CR 611.2a: "<subj> gains <keyword> until end of turn and doesn't
+/// untap during [its controller's | your] next untap step" (Homarid Warrior).
+/// Like the combat-requirement case, the trailing "doesn't untap …" conjunct
+/// is a restriction predicate that is NOT verb-headed by any entry in
+/// `starts_bare_and_clause`, so the bare-and logic never splits it; left
+/// unified, the keyword grant's mid-clause "until end of turn" is hidden from
+/// the suffix-only `strip_trailing_duration` and the grant lowers to
+/// `duration: None` (granted permanently, wrong). Split here and prepend
+/// conjunct 1's subject so the restriction reaches `build_restriction_clause`
+/// with the correct `affected`. Gated on the typed "next untap step" restriction
+/// phrase only, so multi-keyword lists ("gains flying and haste …") stay on the
+/// untouched single-clause path.
+fn untap_restriction_conjunct_prepend(
+    before_and: &str,
+    remainder_trimmed: &str,
+) -> Option<String> {
+    let remainder_lower = remainder_trimmed.to_ascii_lowercase();
+    let is_doesnt_untap = (nom_primitives::scan_contains(&remainder_lower, "doesn't untap")
+        || nom_primitives::scan_contains(&remainder_lower, "does not untap"))
+        && nom_primitives::scan_contains(&remainder_lower, "next untap step");
+    if !is_doesnt_untap {
+        return None;
+    }
+    continuous_grant_subject_prepend(before_and)
+}
+
+/// Shared subject-reattach for a continuous "gain(s)/get(s)" conjunct-1: returns
+/// the subject text (with a trailing space) to prepend onto conjunct-2 so it
+/// parses as its own subject-predicate clause. `""` when the subject was already
+/// lifted (verb at offset 0); `"it "` for a targeted subject (anaphor); the
+/// literal subject otherwise. `None` when conjunct-1 is not a continuous grant.
+fn continuous_grant_subject_prepend(before_and: &str) -> Option<String> {
     let before_lower = before_and.to_ascii_lowercase();
     // CR 508.1d / CR 509.1c: chunk begins with the gain/get verb at offset 0
     // (subject already lifted by the enclosing compound-subject distribution);
-    // emit an empty subject so the trailing combat-requirement conjunct splits.
+    // emit an empty subject so the trailing conjunct splits.
     // This anchor-start check has PRIORITY over the interior `take_until` arms
     // below — those scan for the FIRST " gain"/" get" in the chunk, which would
     // spuriously bind an interior verb (e.g. "get +2/+0 and gain haste ..." has

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2120,10 +2120,7 @@ fn combat_requirement_conjunct_prepend(
 /// with the correct `affected`. Gated on the typed "next untap step" restriction
 /// phrase only, so multi-keyword lists ("gains flying and haste …") stay on the
 /// untouched single-clause path.
-fn untap_restriction_conjunct_prepend(
-    before_and: &str,
-    remainder_trimmed: &str,
-) -> Option<String> {
+fn untap_restriction_conjunct_prepend(before_and: &str, remainder_trimmed: &str) -> Option<String> {
     let remainder_lower = remainder_trimmed.to_ascii_lowercase();
     let is_doesnt_untap = (nom_primitives::scan_contains(&remainder_lower, "doesn't untap")
         || nom_primitives::scan_contains(&remainder_lower, "does not untap"))


### PR DESCRIPTION
## What

`"<subject> gains <keyword> until end of turn and <non-pump conjunct>"` silently dropped the `until end of turn` duration, granting the keyword **permanently** (CR 611.2a: no stated duration ⇒ until end of game), and also dropped the trailing conjunct. Exemplar **Homarid Warrior** — `{U}: This creature gains shroud until end of turn and doesn't untap during your next untap step.` — granted permanent shroud and ignored the untap restriction.

## Root cause

`split_clause_sequence` only split a trailing `and`-conjunct when it was a recognized combat-requirement or exile conjunct. "doesn't untap during your next untap step" is neither, so the clause stayed unified; the keyword-grant builder's suffix-only `strip_trailing_duration` then couldn't see the mid-clause `until end of turn` before `and …`, lowering the grant to `duration: None`. (The pump compound "gets +1/+1 until end of turn and …" was already handled — keyword-grant compounds were the asymmetry.)

## Fix

Mirror the existing combat-requirement conjunct-split for the keyword-grant case (CR 502.3 + CR 611.2a): a narrow `untap_restriction_conjunct_prepend` recognizer (gated on the typed "doesn't untap … next untap step" phrase) that delegates to a shared `continuous_grant_subject_prepend` helper, wired into the existing `.or_else()` split chain. The split prepends conjunct-1's subject onto conjunct-2 so the keyword grant keeps its suffix `until end of turn` and the "doesn't untap" restriction reaches `build_restriction_clause` with the correct `affected`. Pure parser change — no new variant, nom-combinator (`scan_contains`) gated, no verbatim dispatch.

**Over-split guard:** fires only on the typed "next untap step" restriction phrase, so multi-keyword grants ("gains flying and haste until end of turn") and pump compounds stay on their existing single-clause paths (covered by regression tests).

## Tests

- **Parser:** Homarid's grant now carries `duration: Some(UntilEndOfTurn)` + `AddKeyword{Shroud}`, and the untap conjunct survives as a `CantUntap` restriction (not dropped).
- **Runtime (discriminating):** drives parse → resolve → cleanup; the `CantUntap` TCE registers and shroud is gone after the cleanup step. Fails if reverted.
- **Regression:** "target creature gains flying until end of turn" keeps its duration; "gains flying and haste until end of turn" stays a single unified multi-keyword clause; standalone "it gains haste until end of turn" unaffected.

Full engine lib (13085) + integration (1443) green; workspace clippy `-D warnings` clean; CR 611.2a / 514.2 verified against `docs/MagicCompRules.txt`.

Fixes #4085
