### PR TITLE
fix(engine): suppress rules-text abilities when SetBasicLandType appl…

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4210,8 +4210,13 @@ fn apply_continuous_effect_filtered(
             // subtypes (e.g., creature subtypes on Land Creatures) are preserved.
             // Abilities granted by other effects are re-added in Layer 6.
             // Intrinsic mana abilities are derived from subtypes in mana_sources.rs.
+            // CR 613.1f: mirror RemoveAllAbilities — suppress the recipient's
+            // own printed continuous statics for the rest of this pass so layer
+            // 6 cannot re-install rules-text abilities the subtype change removed
+            // (Song of the Dryads class — issue #3279).
             ContinuousModification::SetBasicLandType { land_type } => {
                 set_land_subtype_replacing(obj, land_type.as_subtype_str().to_string());
+                abilities_suppressed.insert(id);
             }
             // CR 305.7 + CR 305.6: Set the land's subtype to the basic land type
             // chosen by the granting source (Phantasmal Terrain, Convincing
@@ -4225,6 +4230,7 @@ fn apply_continuous_effect_filtered(
             ContinuousModification::SetChosenBasicLandType => {
                 if let Some(ref subtype) = chosen_subtype {
                     set_land_subtype_replacing(obj, subtype.clone());
+                    abilities_suppressed.insert(id);
                 }
             }
             // CR 707.9a: Retain the source's printed trigger on the copy.
@@ -10287,6 +10293,49 @@ mod tests {
                 .iter()
                 .any(|ability| matches!(&*ability.effect, Effect::GainLife { .. })),
             "CR 305.7: attach_to must flush layers so rules-text abilities are removed"
+        );
+    }
+
+    #[test]
+    fn song_of_dryads_from_oracle_strips_host_triggers_and_statics() {
+        use crate::game::effects::attach::attach_to;
+
+        let mut scenario = GameScenario::new();
+        let host = {
+            let mut card = scenario.add_creature(PlayerId(0), "Obuun, Mul Daya Ancestor", 3, 3);
+            card.from_oracle_text(
+                "At the beginning of combat on your turn, up to one target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is Obuun's power. It's still a land.\nLandfall — Whenever a land you control enters, put a +1/+1 counter on target creature.",
+            );
+            card.with_trigger(TriggerMode::Attacks);
+            card.id()
+        };
+        let song = scenario
+            .add_creature(PlayerId(0), "Song of the Dryads", 0, 0)
+            .as_enchantment()
+            .from_oracle_text("Enchant permanent\nEnchanted permanent is a colorless Forest land.")
+            .id();
+
+        let mut state = scenario.build().state().clone();
+        state
+            .objects
+            .get_mut(&song)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Aura".to_string());
+
+        attach_to(&mut state, song, host);
+
+        let host_obj = state.objects.get(&host).unwrap();
+        assert_eq!(host_obj.card_types.core_types, vec![CoreType::Land]);
+        assert!(host_obj.card_types.subtypes.contains(&"Forest".to_string()));
+        assert!(
+            host_obj.trigger_definitions.is_empty(),
+            "CR 305.7: printed triggers must be removed"
+        );
+        assert!(
+            host_obj.static_definitions.is_empty(),
+            "CR 305.7: printed statics must be removed"
         );
     }
 

--- a/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
+++ b/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
@@ -39,7 +39,7 @@ fn issue_3279_song_of_dryads_strips_enchanted_permanent_abilities() {
             obuun_obj
                 .base_trigger_definitions
                 .iter()
-                .any(|t| matches!(t.mode, TriggerMode::BeginCombat)),
+                .any(|t| t.mode == TriggerMode::Phase && t.phase == Some(Phase::BeginCombat)),
             "Obuun must carry a begin-combat trigger before Song attaches"
         );
     }
@@ -71,12 +71,7 @@ fn issue_3279_song_of_dryads_strips_enchanted_permanent_abilities() {
     );
     assert!(
         obuun_obj.trigger_definitions.is_empty(),
-        "CR 305.7: rules-text triggers must be removed, got {:?}",
-        obuun_obj
-            .trigger_definitions
-            .iter_all()
-            .map(|t| &t.mode)
-            .collect::<Vec<_>>()
+        "CR 305.7: rules-text triggers must be removed"
     );
     assert!(
         obuun_obj.static_definitions.is_empty(),
@@ -93,14 +88,14 @@ fn issue_3279_song_of_dryads_strips_enchanted_permanent_abilities() {
         obuun_obj.abilities.len()
     );
 
-    let mana_options = activatable_land_mana_options(obuun_obj);
+    let mana_options = activatable_land_mana_options(runner.state(), obuun, P0);
     assert!(
-        mana_options.contains(&ManaType::Green),
+        mana_options.iter().any(|o| o.mana_type == ManaType::Green),
         "Forest land must tap for {{G}}, got {mana_options:?}"
     );
 
     runner.pass_both_players();
-    assert_eq!(runner.state().phase, Phase::BeginCombat);
+    assert_eq!(runner.state().phase, Phase::PostCombatMain);
     assert!(
         !matches!(
             runner.state().waiting_for,

--- a/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
+++ b/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
@@ -1,0 +1,111 @@
+//! Issue #3279 — Song of the Dryads must strip the enchanted permanent's
+//! rules-text abilities when it becomes a basic land (CR 305.7).
+//!
+//! https://github.com/phase-rs/phase/issues/3279
+
+use engine::game::effects::attach::attach_to;
+use engine::game::mana_sources::activatable_land_mana_options;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+
+const OBUUN_ORACLE: &str = "At the beginning of combat on your turn, up to one target land you control becomes an X/X Elemental creature with trample and haste until end of turn, where X is Obuun's power. It's still a land.\nLandfall — Whenever a land you control enters, put a +1/+1 counter on target creature.";
+
+const SONG_ORACLE: &str = "Enchant permanent\nEnchanted permanent is a colorless Forest land.";
+
+#[test]
+fn issue_3279_song_of_dryads_strips_enchanted_permanent_abilities() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let obuun = scenario
+        .add_creature_from_oracle(P0, "Obuun, Mul Daya Ancestor", 3, 3, OBUUN_ORACLE)
+        .id();
+
+    let song = scenario
+        .add_creature(P0, "Song of the Dryads", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(SONG_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    {
+        let obuun_obj = runner.state().objects.get(&obuun).expect("Obuun present");
+        assert!(
+            obuun_obj
+                .base_trigger_definitions
+                .iter()
+                .any(|t| matches!(t.mode, TriggerMode::BeginCombat)),
+            "Obuun must carry a begin-combat trigger before Song attaches"
+        );
+    }
+
+    {
+        let song_obj = runner
+            .state_mut()
+            .objects
+            .get_mut(&song)
+            .expect("Song present");
+        if !song_obj.card_types.subtypes.iter().any(|s| s == "Aura") {
+            song_obj.card_types.subtypes.push("Aura".to_string());
+            song_obj.base_card_types = song_obj.card_types.clone();
+        }
+    }
+
+    attach_to(runner.state_mut(), song, obuun);
+
+    let obuun_obj = runner.state().objects.get(&obuun).expect("Obuun present");
+    assert_eq!(
+        obuun_obj.card_types.core_types,
+        vec![CoreType::Land],
+        "Song must replace the enchanted permanent's card types with Land"
+    );
+    assert!(
+        obuun_obj.card_types.subtypes.iter().any(|s| s == "Forest"),
+        "Song must grant the Forest basic land subtype, got {:?}",
+        obuun_obj.card_types.subtypes
+    );
+    assert!(
+        obuun_obj.trigger_definitions.is_empty(),
+        "CR 305.7: rules-text triggers must be removed, got {:?}",
+        obuun_obj
+            .trigger_definitions
+            .iter_all()
+            .map(|t| &t.mode)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        obuun_obj.static_definitions.is_empty(),
+        "CR 305.7: rules-text statics must be removed"
+    );
+    assert!(
+        obuun_obj.abilities.iter().all(|a| {
+            matches!(
+                a.effect.as_ref(),
+                engine::types::ability::Effect::Mana { .. }
+            )
+        }),
+        "only the intrinsic Forest mana ability may remain, got {:?}",
+        obuun_obj.abilities.len()
+    );
+
+    let mana_options = activatable_land_mana_options(obuun_obj);
+    assert!(
+        mana_options.contains(&ManaType::Green),
+        "Forest land must tap for {{G}}, got {mana_options:?}"
+    );
+
+    runner.pass_both_players();
+    assert_eq!(runner.state().phase, Phase::BeginCombat);
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. } | WaitingFor::OrderTriggers { .. }
+        ),
+        "Obuun's begin-combat trigger must not fire while enchanted by Song of the Dryads"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -269,6 +269,7 @@ mod issue_3267_sanwell_rest_on_bottom;
 mod issue_3268_nahiri_lithomancer;
 mod issue_3271_search_for_tomorrow_suspend;
 mod issue_3274_elder_deep_fiend;
+mod issue_3279_song_of_dryads;
 mod issue_3282_consign_to_memory_counter;
 mod issue_3283_sevinne_reclamation_copy_no_self_copy;
 mod issue_3285_face_down_public_zone;


### PR DESCRIPTION
## Summary

Fix Song of the Dryads (and all `SetBasicLandType` / `SetChosenBasicLandType` effects) so an enchanted permanent correctly loses its rules-text abilities when its basic land subtype is replaced, per CR 305.7.

Fixes #3279

## Problem

When Song of the Dryads enchanted a creature like Obuun, Mul Daya Ancestor, the host kept functioning as though its printed triggers and abilities still applied — e.g. Obuun's begin-combat animation trigger still fired at the start of combat.

Layer 4 already called `set_land_subtype_replacing()` for `SetBasicLandType`, which clears abilities, triggers, statics, and keywords from the enchanted object. However, unlike `RemoveAllAbilities`, that path did not mark the recipient as `abilities_suppressed`. During the same layer pass, layer 6 could therefore re-apply the object's own printed continuous effects that were gathered at the start of evaluation.

## Solution

After `set_land_subtype_replacing()` in both apply arms:

- `ContinuousModification::SetBasicLandType`
- `ContinuousModification::SetChosenBasicLandType`

insert the affected object into `abilities_suppressed`, mirroring the existing `RemoveAllAbilities` behavior (issue #1321). This prevents the object's self-sourced continuous statics from being re-installed later in the pass while still allowing legitimately granted abilities from other sources to apply in layer 6.

## Files changed

- `crates/engine/src/game/layers.rs` — suppression fix + unit test `song_of_dryads_from_oracle_strips_host_triggers_and_statics`
- `crates/engine/tests/integration/issue_3279_song_of_dryads.rs` — Obuun + Song integration regression
- `crates/engine/tests/integration/main.rs` — register integration module

## Test plan

- [x] `cargo test -p engine song_of_dryads -- --nocapture`
- [x] `cargo test -p engine issue_3279_song_of_dryads -- --nocapture`
- [x] `cargo test -p engine layers::tests::song_style -- --nocapture` (existing Song-of-the-Dryads layer coverage)
- [ ] Manual: enchant Obuun with Song of the Dryads, advance to combat — Obuun's begin-combat trigger must not fire; host should be a Forest land that taps for `{G}` only
