### PR TITLE
feat(parser): directional activated-ability cost modifier (Skyseer's Chariot, Firion)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13004,6 +13004,35 @@ fn reduce_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
     reduce_generic_in_cost_with_minimum_mana(cost, amount, 0);
 }
 
+/// CR 601.2f + CR 118.7: Increase the generic mana component of an ability cost
+/// by `amount` (CR 601.2f: "plus all additional costs and cost increases").
+/// The directional analogue of `reduce_generic_in_cost` — a cost increase only
+/// ever grows the generic component (cost increases can't change colored
+/// requirements). For a `Composite`, the increase is applied to the first mana
+/// sub-cost so the net generic delta on the whole cost is exactly `amount`;
+/// non-mana costs are unaffected. Skyseer's Chariot class (Raise direction).
+fn increase_generic_in_cost(cost: &mut AbilityCost, amount: u32) {
+    if amount == 0 {
+        return;
+    }
+    match cost {
+        AbilityCost::Mana {
+            cost: ManaCost::Cost { generic, .. },
+        } => {
+            *generic = generic.saturating_add(amount);
+        }
+        AbilityCost::Composite { costs } => {
+            if let Some(sub) = costs
+                .iter_mut()
+                .find(|c| matches!(c, AbilityCost::Mana { .. }))
+            {
+                increase_generic_in_cost(sub, amount);
+            }
+        }
+        _ => {} // Non-mana costs unaffected
+    }
+}
+
 /// CR 601.2f: Apply self-referential cost reduction to an ability definition's cost.
 /// Mutates `ability_def.cost` in place, reducing generic mana by `amount_per * count`.
 fn apply_cost_reduction(
@@ -13053,6 +13082,7 @@ fn apply_static_activated_ability_cost_reduction(
 
     for (static_source, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::ReduceAbilityCost {
+            mode,
             keyword,
             amount,
             minimum_mana,
@@ -13074,7 +13104,17 @@ fn apply_static_activated_ability_cost_reduction(
         }) {
             continue;
         }
-        reduce_generic_in_cost_with_minimum_mana(cost, *amount, minimum_mana.unwrap_or(0));
+        // CR 118.7: Apply the adjustment in the static's direction. `Reduce`
+        // subtracts generic mana (honoring the optional one-mana floor);
+        // `Raise` adds generic mana (Skyseer's Chariot). `Minimum` is not
+        // emitted for activated-ability statics and is treated as a no-op.
+        match mode {
+            CostModifyMode::Reduce => {
+                reduce_generic_in_cost_with_minimum_mana(cost, *amount, minimum_mana.unwrap_or(0));
+            }
+            CostModifyMode::Raise => increase_generic_in_cost(cost, *amount),
+            CostModifyMode::Minimum => {}
+        }
     }
 }
 
@@ -20650,6 +20690,7 @@ mod tests {
             .static_definitions
             .push(
                 StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: crate::types::statics::CostModifyMode::Reduce,
                     keyword: "activated".to_string(),
                     amount: 1,
                     minimum_mana: None,
@@ -20800,6 +20841,7 @@ mod tests {
             .static_definitions
             .push(
                 StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: crate::types::statics::CostModifyMode::Reduce,
                     keyword: "activated".to_string(),
                     amount: 2,
                     minimum_mana: Some(1),
@@ -46010,6 +46052,7 @@ mod tests {
                 .core_types
                 .push(crate::types::card_type::CoreType::Creature);
             obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: crate::types::statics::CostModifyMode::Reduce,
                 keyword: "exhaust".to_string(),
                 amount: 2,
                 minimum_mana: None,
@@ -46092,6 +46135,209 @@ mod tests {
             generic_of(&def_self),
             6,
             "\"other permanents\" must exclude the static's own source"
+        );
+    }
+
+    /// CR 118.7 + CR 601.2f: Skyseer's Chariot — "Activated abilities of sources
+    /// with the chosen name cost {2} more to activate." The directional
+    /// (`mode: Raise`) parameterization of the activated-ability cost static.
+    ///
+    /// Drives the production seam `apply_cost_reduction` (the same path
+    /// `can_activate_ability` reaches at cost-determination time). Discriminating
+    /// assertions:
+    ///   - An activated ability on a source whose name matches Skyseer's chosen
+    ///     name is INCREASED {3} → {5}. If `mode` were reverted to `Reduce`, this
+    ///     would read {1} and the `assert_eq!(.., 5)` would fail.
+    ///   - A source with a DIFFERENT name is unaffected ({3}), pinning the
+    ///     `HasChosenName` filter.
+    #[test]
+    fn skyseer_increases_chosen_name_activated_ability_cost() {
+        use crate::types::ability::{ChosenAttribute, Effect, StaticDefinition, TargetFilter};
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let mut state = GameState::new_two_player(7);
+
+        // Skyseer's Chariot carries the parsed Raise static and has chosen the
+        // name "Targeted Source".
+        let chariot = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Skyseer's Chariot".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&chariot).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Artifact);
+            obj.chosen_attributes
+                .push(ChosenAttribute::CardName("Targeted Source".to_string()));
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "activated".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+            })
+            .affected(TargetFilter::HasChosenName)]
+            .into();
+        }
+
+        // A source whose name matches the chosen name.
+        let matched = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Targeted Source".to_string(),
+            Zone::Battlefield,
+        );
+        // A source with a different name.
+        let other = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Some Other Card".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [matched, other] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+        }
+
+        let make_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "ability".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 3,
+                },
+            });
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        // Matched-name source: {3} → {5} (increased by {2}). Reverting the
+        // direction field to `Reduce` makes this {1}, flipping the assertion.
+        let mut def_match = make_def();
+        apply_cost_reduction(&state, &mut def_match, PlayerId(1), matched);
+        assert_eq!(
+            generic_of(&def_match),
+            5,
+            "chosen-name source's activated ability must be INCREASED by {{2}}"
+        );
+
+        // Non-matching source: unchanged ({3}).
+        let mut def_other = make_def();
+        apply_cost_reduction(&state, &mut def_other, PlayerId(1), other);
+        assert_eq!(
+            generic_of(&def_other),
+            3,
+            "a source without the chosen name must not be taxed"
+        );
+    }
+
+    /// CR 118.7 + CR 702.6a: Firion, Wild Rose Warrior's granted equip-cost
+    /// reduction — "This Equipment's equip abilities cost {2} less to activate."
+    /// (`mode: Reduce`, keyword `"equip"`, `SelfRef`).
+    ///
+    /// Drives `apply_cost_reduction`. Discriminating assertions:
+    ///   - The Equipment's OWN equip ability ({3} → {1}). Reverting `mode` to
+    ///     `Raise` would yield {5}, flipping the assertion (proves direction).
+    ///   - A non-equip (untagged) ability on the same Equipment is unchanged,
+    ///     pinning the `"equip"` keyword gate.
+    #[test]
+    fn firion_reduces_self_equip_ability_cost() {
+        use crate::types::ability::{AbilityTag, Effect, StaticDefinition, TargetFilter};
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let mut state = GameState::new_two_player(7);
+
+        let equipment = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Firion's Equipment".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&equipment).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Artifact);
+            obj.card_types.subtypes.push("Equipment".to_string());
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
+                keyword: "equip".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+            })
+            .affected(TargetFilter::SelfRef)]
+            .into();
+        }
+
+        let make_equip_def = || {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "equip-effect".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 3,
+                },
+            });
+            def.ability_tag = Some(AbilityTag::Equip);
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        // Equipment's own equip ability: {3} → {1}. Reverting direction → {5}.
+        let mut def_equip = make_equip_def();
+        apply_cost_reduction(&state, &mut def_equip, PlayerId(0), equipment);
+        assert_eq!(
+            generic_of(&def_equip),
+            1,
+            "this Equipment's equip ability must be reduced by {{2}}"
+        );
+
+        // A non-equip activated ability on the same Equipment: unchanged.
+        let mut def_plain = make_equip_def();
+        def_plain.ability_tag = None;
+        apply_cost_reduction(&state, &mut def_plain, PlayerId(0), equipment);
+        assert_eq!(
+            generic_of(&def_plain),
+            3,
+            "a non-equip ability must not be reduced by the equip-keyed static"
         );
     }
 

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -14,7 +14,7 @@ use crate::types::keywords::{
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{CostModifyMode, StaticMode};
 use crate::types::zones::Zone;
 
 /// Check if a game object has a specific keyword, using discriminant-based matching
@@ -807,12 +807,20 @@ fn apply_ability_cost_reduction(
             continue;
         }
         if let StaticMode::ReduceAbilityCost {
+            ref mode,
             ref keyword,
             amount,
             ref dynamic_count,
             ..
         } = static_def.mode
         {
+            // CR 118.7: This ninjutsu-cost path only subtracts. A directional
+            // static in the `Raise` direction keyed on the same keyword must not
+            // reach the subtraction below — skip it (cost increases on ninjutsu
+            // are not modeled here; this path is reduction-only by construction).
+            if !matches!(mode, CostModifyMode::Reduce) {
+                continue;
+            }
             if keyword == ability_keyword {
                 // CR 601.2f: When dynamic_count is present, the total reduction is
                 // amount * resolve_quantity(dynamic_count). E.g., "cost {1} less for each Dragon".

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -7,22 +7,25 @@ use super::support::*;
 use crate::types::ability::CastTimingPermission;
 
 /// CR 602.1: Parse the leading keyword of a "<Keyword> abilities of …" class-wide
-/// activation cost-reduction static, returning the canonical keyword string that
+/// activation cost-modification static, returning the canonical keyword string that
 /// the runtime gate (`apply_static_activated_ability_cost_reduction`) matches
 /// against `AbilityTag::keyword_str()`.
 ///
 /// Restricted to the *tagged activated* keywords — those whose activated
 /// abilities carry an `AbilityTag` at parse time and therefore expose a
-/// `keyword_str()` the gate can compare. Matching an untagged keyword (e.g.
-/// "equip", "plot") here would emit a `ReduceAbilityCost` static that never
-/// fires at runtime, so those are deliberately excluded. Ordered longest-first
-/// so "power-up" wins before any shorter prefix could.
+/// `keyword_str()` the gate can compare. An untagged keyword (e.g. "plot",
+/// which is a special action, not an activated ability) would emit a
+/// `ReduceAbilityCost` static that never fires at runtime, so it is excluded.
+/// `equip` IS tagged (`AbilityTag::Equip`, set at synthesis), so it is included
+/// here (Firion class). Ordered longest-first so "power-up" wins before any
+/// shorter prefix could.
 pub(crate) fn parse_taggable_ability_keyword(input: &str) -> OracleResult<'_, &'static str> {
     alt((
         value(AbilityTag::PowerUp.keyword_str(), tag("power-up")),
         value(AbilityTag::Exhaust.keyword_str(), tag("exhaust")),
-        value(AbilityTag::Boast.keyword_str(), tag("boast")),
         value(AbilityTag::Outlast.keyword_str(), tag("outlast")),
+        value(AbilityTag::Boast.keyword_str(), tag("boast")),
+        value(AbilityTag::Equip.keyword_str(), tag("equip")),
     ))
     .parse(input)
 }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2290,6 +2290,7 @@ pub(crate) fn parse_static_line_inner(
                 });
             return Some(
                 StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Reduce,
                     keyword: keyword.trim().to_string(),
                     amount,
                     minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
@@ -2325,9 +2326,58 @@ pub(crate) fn parse_static_line_inner(
         let (affected, _rest) = parse_type_phrase(&subject);
         return Some(
             StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
                 keyword: keyword.to_string(),
                 amount,
                 minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
+                dynamic_count: None,
+            })
+            .affected(affected)
+            .description(text.to_string()),
+        );
+    }
+
+    // --- "[Subject]'s <keyword> abilities cost {N} less/more to activate" ---
+    // CR 602.1 + CR 601.2f + CR 118.7 + CR 702.6a: Possessive keyword-ability cost
+    // modifier keyed on a tagged activated keyword. Firion, Wild Rose Warrior's
+    // granted ability "This Equipment's equip abilities cost {2} less to activate"
+    // (keyword = "equip", subject = SelfRef). Distinct from the "<keyword>
+    // abilities of [subject]" form above by its possessive ("'s") grammar.
+    if let Some(((subject, keyword, amount, mode), _)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, subject) = take_until("'s ").parse(i)?;
+        let (i, _) = tag("'s ").parse(i)?;
+        let (i, keyword) = parse_taggable_ability_keyword(i)?;
+        let (i, _) = tag(" abilities cost ").parse(i)?;
+        let (i, amount) =
+            nom::sequence::delimited(tag("{"), nom_primitives::parse_number, tag("}")).parse(i)?;
+        let (i, _) = tag(" ").parse(i)?;
+        let (i, mode) = alt((
+            value(CostModifyMode::Reduce, tag("less to activate")),
+            value(CostModifyMode::Raise, tag("more to activate")),
+        ))
+        .parse(i)?;
+        Ok((i, (subject.to_string(), keyword, amount, mode)))
+    }) {
+        // CR 109.5: "This Equipment's …" (and other "this <type>" possessives)
+        // self-reference the source permanent → SelfRef, so the static affects
+        // only this object's equip ability — not every Equipment. Mirrors the
+        // self-reference dispatch in `evasion.rs`.
+        let subject_lower = subject.to_lowercase();
+        let affected = if subject == "~" || SELF_REF_TYPE_PHRASES.contains(&subject_lower.as_str())
+        {
+            TargetFilter::SelfRef
+        } else {
+            parse_type_phrase(&subject).0
+        };
+        let minimum_mana = matches!(mode, CostModifyMode::Reduce)
+            .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
+            .flatten();
+        return Some(
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode,
+                keyword: keyword.to_string(),
+                amount,
+                minimum_mana,
                 dynamic_count: None,
             })
             .affected(affected)
@@ -2376,6 +2426,7 @@ pub(crate) fn parse_static_line_inner(
         let (affected, _rest) = parse_type_phrase(&filter_text);
         return Some(
             StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
                 keyword: "activated".to_string(),
                 amount,
                 minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
@@ -2386,34 +2437,46 @@ pub(crate) fn parse_static_line_inner(
         );
     }
 
-    // --- "Activated abilities of [filter] cost {N} less to activate" ---
-    // CR 602.1 + CR 601.2f: Generic activated ability cost reduction (e.g., Training Grounds).
-    if let Some(rest) = nom_tag_lower(tp.lower, tp.lower, "activated abilities of ") {
-        if let Ok((_, (filter_part, after_cost))) = nom_primitives::split_once_on(rest, " cost ") {
-            if nom_primitives::scan_contains(after_cost, "less to activate") {
-                let amount = nom_primitives::split_once_on(after_cost, " less")
-                    .ok()
-                    .and_then(|(_, (mana_str, _))| {
-                        let stripped = mana_str.trim().trim_matches('{').trim_matches('}');
-                        stripped.parse::<u32>().ok()
-                    })
-                    .unwrap_or(1);
-                // Parse the filter between "of" and "cost" using parse_type_phrase
-                let filter_text =
-                    &tp.original["activated abilities of ".len()..][..filter_part.len()];
-                let (affected, _rest) = parse_type_phrase(filter_text);
-                return Some(
-                    StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                        keyword: "activated".to_string(),
-                        amount,
-                        minimum_mana: parse_activated_cost_reduction_minimum_mana(tp.lower),
-                        dynamic_count: None,
-                    })
-                    .affected(affected)
-                    .description(text.to_string()),
-                );
-            }
-        }
+    // --- "Activated abilities of [filter] cost {N} less/more to activate" ---
+    // CR 602.1 + CR 601.2f + CR 118.7: Generic activated-ability cost modifier,
+    // directional. Reduce (Training Grounds: "Activated abilities of creatures you
+    // control cost {2} less to activate") and Raise (Skyseer's Chariot: "Activated
+    // abilities of sources with the chosen name cost {2} more to activate").
+    // Combinator: prefix → subject → " cost {N} " → direction. The subject is
+    // either the chosen-name source phrase (→ HasChosenName) or a type phrase.
+    if let Some(((amount, mode, subject_filter), _)) = nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag("activated abilities of ").parse(i)?;
+        let (i, subject) = take_until(" cost ").parse(i)?;
+        let (i, _) = tag(" cost ").parse(i)?;
+        let (i, amount) =
+            nom::sequence::delimited(tag("{"), nom_primitives::parse_number, tag("}")).parse(i)?;
+        let (i, _) = tag(" ").parse(i)?;
+        let (i, mode) = alt((
+            value(CostModifyMode::Reduce, tag("less to activate")),
+            value(CostModifyMode::Raise, tag("more to activate")),
+        ))
+        .parse(i)?;
+        Ok((i, (amount, mode, subject.to_string())))
+    }) {
+        // CR 113.6 + CR 201.2: "sources with the chosen name" → HasChosenName,
+        // shared with the CantBeActivated name-picker class. Otherwise a type phrase.
+        let affected = parse_chosen_name_source_filter(&subject_filter)
+            .unwrap_or_else(|| parse_type_phrase(&subject_filter).0);
+        // CR 118.7: a one-mana floor only applies to reductions.
+        let minimum_mana = matches!(mode, CostModifyMode::Reduce)
+            .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
+            .flatten();
+        return Some(
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode,
+                keyword: "activated".to_string(),
+                amount,
+                minimum_mana,
+                dynamic_count: None,
+            })
+            .affected(affected)
+            .description(text.to_string()),
+        );
     }
 
     // --- CR 601.2f: Cost-floor statics (Trinisphere class) ---

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -6,6 +6,26 @@ use super::prelude::*;
 use super::support::*;
 use nom::character::complete::multispace0;
 
+/// CR 113.6 + CR 201.2: Recognize the "sources with the chosen name" / "cards with
+/// the chosen name" subject phrase and map it to `TargetFilter::HasChosenName`.
+/// Shared by the chosen-name name-picker classes — the `CantBeActivated`
+/// prohibition (Pithing Needle / Phyrexian Revoker / Sorcerous Spyglass) and the
+/// directional activated-ability cost modifier (Skyseer's Chariot). Returns
+/// `None` for any other subject so callers fall back to `parse_type_phrase`.
+pub(crate) fn parse_chosen_name_source_filter(subject_lower: &str) -> Option<TargetFilter> {
+    let trimmed = subject_lower.trim();
+    value(
+        TargetFilter::HasChosenName,
+        all_consuming(alt((
+            tag::<_, _, OracleError<'_>>("sources with the chosen name"),
+            tag("cards with the chosen name"),
+        ))),
+    )
+    .parse(trimmed)
+    .ok()
+    .map(|(_, filter)| filter)
+}
+
 /// CR 601.2f: Parse cost modification statics from Oracle text.
 /// Handles all four sub-patterns:
 /// 1. Type-filtered: "Creature spells you cast cost {1} less to cast"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9650,6 +9650,7 @@ fn static_reduce_ability_cost_ninjutsu() {
         matches!(
             def.mode,
             StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
                 ref keyword,
                 amount: 1,
                 minimum_mana: None,
@@ -9670,6 +9671,7 @@ fn static_reduce_equip_abilities_with_object_qualifier() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "equip".to_string(),
             amount: 1,
             minimum_mana: None,
@@ -14305,6 +14307,7 @@ fn static_reduce_activated_ability_cost_generic() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "activated".to_string(),
             amount: 2,
             minimum_mana: None,
@@ -14322,6 +14325,7 @@ fn static_reduce_activated_ability_cost_generic_with_minimum() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "activated".to_string(),
             amount: 2,
             minimum_mana: Some(1),
@@ -14339,6 +14343,7 @@ fn static_reduce_activated_ability_cost_enchanted_artifact_with_minimum() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "activated".to_string(),
             amount: 2,
             minimum_mana: Some(1),
@@ -14360,6 +14365,7 @@ fn static_reduce_activated_ability_cost_equipped_artifact_with_minimum() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "activated".to_string(),
             amount: 2,
             minimum_mana: Some(1),
@@ -14386,6 +14392,7 @@ fn static_reduce_exhaust_ability_cost_other_permanents() {
     assert_eq!(
         def.mode,
         StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
             keyword: "exhaust".to_string(),
             amount: 2,
             minimum_mana: None,
@@ -14420,6 +14427,113 @@ fn static_reduce_exhaust_ability_cost_other_permanents() {
     );
     assert_eq!(parsed.statics.len(), 1);
     assert_eq!(parsed.abilities.len(), 1);
+}
+
+// --- CR 118.7: Directional activated-ability cost modifier (Reduce vs Raise) ---
+
+#[test]
+fn static_activated_ability_cost_increase_chosen_name() {
+    // Skyseer's Chariot: the Raise direction with a chosen-name source filter.
+    // This is the parameterization that forces reduce → directional.
+    let def = parse_static_line(
+        "Activated abilities of sources with the chosen name cost {2} more to activate.",
+    )
+    .expect("Skyseer cost-increase static must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "activated".to_string(),
+            amount: 2,
+            // CR 118.7: increases never floor.
+            minimum_mana: None,
+            dynamic_count: None,
+        }
+    );
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::HasChosenName),
+        "Skyseer must scope the increase to sources with the chosen name"
+    );
+}
+
+#[test]
+fn static_activated_ability_cost_generic_reduce_vs_raise_discriminates() {
+    // CR 118.7: the same grammar with only the direction word changed must yield
+    // opposite `CostModifyMode`s. Pins reduce ≠ increase at the parser layer.
+    let reduce = parse_static_line(
+        "Activated abilities of creatures you control cost {2} less to activate.",
+    )
+    .expect("reduce form parses");
+    let raise = parse_static_line(
+        "Activated abilities of creatures you control cost {2} more to activate.",
+    )
+    .expect("raise form parses");
+    let reduce_mode = match reduce.mode {
+        StaticMode::ReduceAbilityCost { mode, .. } => mode,
+        other => panic!("expected ReduceAbilityCost, got {other:?}"),
+    };
+    let raise_mode = match raise.mode {
+        StaticMode::ReduceAbilityCost { mode, .. } => mode,
+        other => panic!("expected ReduceAbilityCost, got {other:?}"),
+    };
+    assert_eq!(reduce_mode, CostModifyMode::Reduce);
+    assert_eq!(raise_mode, CostModifyMode::Raise);
+    assert_ne!(reduce_mode, raise_mode);
+}
+
+#[test]
+fn static_possessive_equip_ability_cost_reduction_self_ref() {
+    // Firion, Wild Rose Warrior's granted equip-cost reduction leaf:
+    // "This Equipment's equip abilities cost {2} less to activate." Keyed on the
+    // tagged Equip keyword (CR 702.6a), scoped to the source object (SelfRef).
+    let def = parse_static_line("This Equipment's equip abilities cost {2} less to activate.")
+        .expect("Firion equip-cost reduction must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
+            keyword: "equip".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+        }
+    );
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::SelfRef),
+        "\"This Equipment's …\" must self-reference the source (CR 109.5)"
+    );
+}
+
+#[test]
+fn static_reduce_ability_cost_registry_round_trip_preserves_direction() {
+    // CR 118.7: the Display/from_str registry encoding must round-trip the
+    // direction so a serialized Raise static does not silently decode as Reduce.
+    for mode in [CostModifyMode::Reduce, CostModifyMode::Raise] {
+        let original = StaticMode::ReduceAbilityCost {
+            mode,
+            keyword: "activated".to_string(),
+            amount: 3,
+            minimum_mana: None,
+            dynamic_count: None,
+        };
+        let encoded = original.to_string();
+        let decoded = encoded
+            .parse::<StaticMode>()
+            .expect("registry string parses back into a StaticMode");
+        match decoded {
+            StaticMode::ReduceAbilityCost {
+                mode: decoded_mode,
+                amount: 3,
+                ..
+            } => assert_eq!(
+                decoded_mode, mode,
+                "direction lost in round trip: {encoded}"
+            ),
+            other => panic!("registry round trip dropped variant: {other:?}"),
+        }
+    }
 }
 
 // --- Group C: Spells you cast have keyword ---

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -552,7 +552,7 @@ pub enum BlockExceptionKind {
 
 /// CR 601.2f: Direction/semantic axis for mana-cost modification statics.
 /// All three modes are applied in the CR 601.2f cost-locking step.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CostModifyMode {
     /// Subtractive — reduce generic mana (floor: 0).
     Reduce,
@@ -561,6 +561,13 @@ pub enum CostModifyMode {
     /// Floor — cost cannot fall below `amount` after all Reduce/Raise settle.
     /// CR 601.2f last-step floor. Trinisphere class.
     Minimum,
+}
+
+/// Serde default for the `mode` field on activation-cost statics: the original
+/// subtractive (`Reduce`) form, so card-data serialized before the directional
+/// field was added still deserializes as a reduction (CR 118.7).
+fn cost_modify_mode_reduce() -> CostModifyMode {
+    CostModifyMode::Reduce
 }
 
 /// CR 601.2f: Whether a static-imposed additional cost applies to spell casting.
@@ -802,18 +809,34 @@ pub enum StaticMode {
         spell_filter: Option<TargetFilter>,
         action: AdditionalCostTaxAction,
     },
-    /// CR 601.2f: Reduces the generic mana cost of activated abilities matching a keyword type.
-    /// E.g., "Ninjutsu abilities you activate cost {1} less to activate."
-    /// `keyword` identifies which ability type is reduced (e.g., "ninjutsu", "equip", "cycling").
-    /// `amount` is the fixed generic mana reduction per activation.
+    /// CR 601.2f + CR 118.7: Modifies the generic mana cost of activated abilities
+    /// matching a keyword type, in the direction given by `mode`.
+    /// E.g., "Ninjutsu abilities you activate cost {1} less to activate." (`Reduce`)
+    /// or "Activated abilities of sources with the chosen name cost {2} more to
+    /// activate." (`Raise`, Skyseer's Chariot).
+    /// `keyword` identifies which ability type is modified — `"activated"` matches
+    /// every activated ability, or a tagged keyword (e.g. "ninjutsu", "equip",
+    /// "cycling", "power-up") matches the activating ability's `AbilityTag`.
+    /// `amount` is the fixed generic mana adjustment per activation.
+    ///
+    /// Directional parameterization (not a `Raise`-only sibling): the
+    /// `CostModifyMode` axis is shared with [`StaticMode::ModifyCost`] (the
+    /// cast-cost analogue). `Minimum` is not meaningful here — only `Reduce`
+    /// (CR 118.7) and `Raise` (CR 118.7 increase) are emitted/applied.
     ReduceAbilityCost {
+        /// CR 118.7: Direction of the adjustment. `#[serde(default)]` keeps
+        /// already-serialized card-data (which predates this field) reading as
+        /// the original subtractive form.
+        #[serde(default = "cost_modify_mode_reduce")]
+        mode: CostModifyMode,
         keyword: String,
         amount: u32,
         /// "This effect can't reduce the mana in that cost to less than one mana."
+        /// Only meaningful for `Reduce` — `Raise` never floors.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         minimum_mana: Option<u32>,
-        /// CR 601.2f: Dynamic multiplier for cost reduction (e.g., "for each Dragon you control").
-        /// When present, the total reduction is `amount * resolve_quantity(dynamic_count)`.
+        /// CR 601.2f: Dynamic multiplier for the adjustment (e.g., "for each Dragon you control").
+        /// When present, the total adjustment is `amount * resolve_quantity(dynamic_count)`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         dynamic_count: Option<QuantityRef>,
     },
@@ -1553,11 +1576,13 @@ impl Hash for StaticMode {
         std::mem::discriminant(self).hash(state);
         match self {
             StaticMode::ReduceAbilityCost {
+                mode,
                 keyword,
                 amount,
                 minimum_mana,
                 ..
             } => {
+                mode.hash(state);
                 keyword.hash(state);
                 amount.hash(state);
                 minimum_mana.hash(state);
@@ -1862,15 +1887,26 @@ impl fmt::Display for StaticMode {
                 AdditionalCostTaxAction::Cast => write!(f, "ImposeAdditionalCastCost"),
             },
             StaticMode::ReduceAbilityCost {
+                mode,
                 keyword,
                 amount,
                 minimum_mana,
                 ..
             } => {
+                // CR 118.7: Encode the direction so the registry round-trip is
+                // lossless. A leading "+"/"-" marks Raise/Reduce; legacy strings
+                // with no marker default to Reduce in `from_str` for back-compat.
+                let sign = match mode {
+                    CostModifyMode::Raise => "+",
+                    _ => "-",
+                };
                 if let Some(minimum_mana) = minimum_mana {
-                    write!(f, "ReduceAbilityCost({keyword},{amount},{minimum_mana})")
+                    write!(
+                        f,
+                        "ReduceAbilityCost({sign}{keyword},{amount},{minimum_mana})"
+                    )
                 } else {
-                    write!(f, "ReduceAbilityCost({keyword},{amount})")
+                    write!(f, "ReduceAbilityCost({sign}{keyword},{amount})")
                 }
             }
             StaticMode::ModifyActivationLimit { keyword, new_limit } => {
@@ -2198,7 +2234,9 @@ impl FromStr for StaticMode {
                 dynamic_count: None,
             },
             s if s.starts_with("ReduceAbilityCost(") => {
-                // Parse "ReduceAbilityCost(keyword,amount)"
+                // Parse "ReduceAbilityCost([+|-]keyword,amount[,minimum_mana])".
+                // CR 118.7: a leading "+"/"-" on the keyword marks Raise/Reduce;
+                // legacy strings without a marker default to Reduce.
                 let inner = s
                     .strip_prefix("ReduceAbilityCost(")
                     .and_then(|s| s.strip_suffix(')'));
@@ -2206,8 +2244,16 @@ impl FromStr for StaticMode {
                     let mut parts = inner.split(',');
                     if let (Some(kw), Some(amt), extra) = (parts.next(), parts.next(), parts.next())
                     {
+                        let (mode, keyword) = if let Some(rest) = kw.strip_prefix('+') {
+                            (CostModifyMode::Raise, rest)
+                        } else if let Some(rest) = kw.strip_prefix('-') {
+                            (CostModifyMode::Reduce, rest)
+                        } else {
+                            (CostModifyMode::Reduce, kw)
+                        };
                         StaticMode::ReduceAbilityCost {
-                            keyword: kw.to_string(),
+                            mode,
+                            keyword: keyword.to_string(),
                             amount: amt.parse().unwrap_or(1),
                             minimum_mana: extra.and_then(|value| value.parse().ok()),
                             dynamic_count: None,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Parameterizes the reduce-only `ReduceAbilityCost` static into a **directional** activated-ability cost modifier carrying a `CostModifyMode` (`Reduce` / `Raise`) — the same direction axis already used by the cast-cost `ModifyCost` analogue — instead of adding a `Raise`-only sibling. This is the reduce-only → directional refactor flagged by the prior "reduce-only" note; **Skyseer's Chariot forces it** (it taxes activated abilities, the increase direction).

`CostModifyMode` gains `Copy`; the `mode` field defaults (serde) to `Reduce` so any already-serialized card-data reads as the original subtractive form, and the `Display`/`FromStr` registry round-trip encodes the direction (`+`/`-` keyword prefix). All existing `ReduceAbilityCost` call sites (parser, runtime gates, tests across `engine` / `phase-ai` / `mtgish-import`) were migrated in lockstep; the legacy ninjutsu reduction path skips `Raise`-mode statics.

### add-engine-variant verdict
**Parameterization, not proliferation.** No new sibling variant — a leaf-level `mode: CostModifyMode` field was added to the existing `ReduceAbilityCost`, reusing the existing `CostModifyMode` enum (the cast-cost direction axis). Passes the sibling-cluster smell check.

## Per-card ship/defer

| Card | Line | Status | Rule |
|---|---|---|---|
| **Skyseer's Chariot** (DFT) | "Activated abilities of sources with the chosen name cost {2} more to activate." | **Shipped** — `Raise` + `HasChosenName`; ETB choose-name + Crew already parse, no Unimplemented | CR 118.7 / CR 601.2f / CR 113.6 / CR 201.2 |
| **Firion, Wild Rose Warrior** | token-granted "This Equipment's equip abilities cost {2} less to activate." | **Shipped** — `Reduce`, keyword `equip` (tagged, CR 702.6a), `SelfRef`; the token-grant wrapper already parsed, the equip leaf was the only gap. Full card has no Unimplemented | CR 702.6a / CR 118.7 / CR 109.5 |
| **Doc Aurlock, Grizzled Genius** | L1 graveyard/exile cast reduction | **Covered** (pre-existing) — **clears combo-corpus D3** | CR 601.2f |
| **Doc Aurlock** | L2 "Plotting cards from your hand costs {2} less." | **Deferred** — plot is a special action, not an activated ability; fails closed (`Effect::Unimplemented`) | CR 116.2k / CR 702.170a |
| **Inquisitive Glimmer** | L1 Enchantment cast reduction | **Covered** (pre-existing) | CR 601.2f |
| **Inquisitive Glimmer** | L2 "Unlock costs you pay cost {1} less." | **Deferred** — unlock is a special action, not an activated ability; fails closed | CR 116.2m / CR 709.5e |

**Doc Aurlock is cleared** as the combo-corpus D3 enabler: its combo-relevant graveyard/exile cast-cost reduction line is fully covered. The deferred plot/unlock lines are a distinct special-action-cost subsystem (CR 116) that does not route through the activated-ability cost path; shipping them via the activated-ability static would be a categorical-boundary violation. They fail closed rather than mis-enforcing.

## Discriminating-test map

| Behavioral claim | Seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| Raise increases a chosen-name source's activated-ability cost | `apply_static_activated_ability_cost_reduction` | `apply_cost_reduction` (via `can_activate_ability`) | `skyseer_increases_chosen_name_activated_ability_cost` | matched source {3}→**{5}** (Reduce would give {1}) |
| Reduce reduces this Equipment's equip ability cost | same | same | `firion_reduces_self_equip_ability_cost` | own equip ability {3}→**{1}** (Raise would give {5}); non-equip ability unchanged |
| Parser keeps reduce ≠ increase | `parse_static_line` direction `alt` | parser | `static_activated_ability_cost_generic_reduce_vs_raise_discriminates` | `assert_ne!(Reduce, Raise)` |
| Chosen-name source filter on the Raise static | parser | parser | `static_activated_ability_cost_increase_chosen_name` | `affected == HasChosenName` |
| Possessive equip leaf → SelfRef | parser | parser | `static_possessive_equip_ability_cost_reduction_self_ref` | `affected == SelfRef`, keyword `equip` |
| Direction survives registry round-trip | `Display`/`FromStr` | registry | `static_reduce_ability_cost_registry_round_trip_preserves_direction` | decoded mode == original |

## Gate results
`cargo fmt` clean · `check-parser-combinators.sh` (with + without `upstream/main`) exit 0 · parser diff string-dispatch grep clean (only `SELF_REF_TYPE_PHRASES.contains` — `slice::contains` membership, established precedent) · `check-engine-authorities.sh upstream/main` exit 0 · `clippy --workspace --all-targets -D warnings` clean · `cargo test -p engine`: **13098 passed**, only the known parallel-flaky `delve_payment_skips_state_clone_per_graveyard_candidate` failed under parallelism and passes in isolation (`--test-threads=1`) · `cargo semantic-audit` / `cargo coverage` ran clean with no new findings on the touched patterns. All CR annotations grep-verified against `docs/MagicCompRules.txt`.