### PR TITLE
feat(parser+engine): duration-bound face-down look permission (Lumbering Laundry)

### DIFF
--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -135,6 +135,39 @@ fn register_transient_effect(
 ) {
     let modifications = snapshot_transient_modifications(state, ability, &static_def.modifications);
 
+    // CR 708.5: A duration-bound "you may look at face-down [permanents] you don't
+    // control any time" permission (Lumbering Laundry) is a *player-scoped* look
+    // permission, not an object grant. Unlike a pump or keyword grant, the set of
+    // face-down permanents the looker may see is re-evaluated continuously at look
+    // time (a permanent turned face down after this resolves but before end of
+    // turn is still visible to the looker), so the affected face-down filter must
+    // ride on the TCE intact rather than be expanded to a fixed `SpecificObject`
+    // set by the broadcast branch below. Register ONE TCE whose `controller` is
+    // the looker and whose `affected` keeps the face-down/controller filter; the
+    // visibility check (`viewer_may_look_at_face_down`) reads it exactly like the
+    // printed `MayLookAtFaceDown` static, evaluating the filter against each
+    // face-down permanent from the looker's perspective.
+    if modifications.iter().any(|m| {
+        matches!(
+            m,
+            ContinuousModification::AddStaticMode {
+                mode: crate::types::statics::StaticMode::MayLookAtFaceDown,
+            }
+        )
+    }) {
+        if let Some(affected) = static_def.affected.clone() {
+            state.add_transient_continuous_effect(
+                ability.source_id,
+                ability.controller,
+                duration.clone(),
+                affected,
+                modifications,
+                static_def.condition.clone(),
+            );
+            return;
+        }
+    }
+
     // CR 608.2c (issue #323 class): SelfRef is the printed-name anaphor and
     // always refers to the source object regardless of `ability.targets`.
     // Short-circuit BEFORE the chosen-targets branch so chained Effect
@@ -1880,6 +1913,107 @@ mod tests {
                 "CantPlayLand"
             ),
             "non-targeted player must not be under CantPlayLand"
+        );
+    }
+
+    /// CR 708.5 + CR 611.2c: A `GenericEffect` carrying the `MayLookAtFaceDown`
+    /// permission (Lumbering Laundry's "{2}: Until end of turn, you may look at
+    /// face-down creatures you don't control any time.") registers ONE transient
+    /// continuous effect that KEEPS the face-down/controller filter intact and
+    /// binds to the looker via `controller` — it must NOT be expanded into a
+    /// fixed `SpecificObject` set by the broadcast branch (a look permission is a
+    /// rules-modifying continuous effect per CR 611.2c, re-evaluated continuously
+    /// at look time). Discriminating: the `tce.affected == Typed(..)` assertion
+    /// fails (the broadcast branch would bind to `SpecificObject` per resolution-
+    /// time face-down permanents) if the `register_transient_effect`
+    /// MayLookAtFaceDown branch is removed.
+    #[test]
+    fn generic_effect_may_look_at_face_down_keeps_filter_and_binds_looker() {
+        use crate::types::ability::FilterProp;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let looker = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            looker,
+            "Lumbering Laundry".to_string(),
+            Zone::Battlefield,
+        );
+        // Put an OPPONENT face-down creature on the battlefield, so the broadcast
+        // branch (if it ran) would have a concrete object to bind to — the test
+        // asserts it does NOT bind there.
+        let opp_face_down = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Hidden".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&opp_face_down).unwrap().face_down = true;
+
+        let affected = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::Opponent)
+                .properties(vec![FilterProp::FaceDown]),
+        );
+        let static_def = StaticDefinition::new(StaticMode::MayLookAtFaceDown)
+            .affected(affected.clone())
+            .modifications(vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::MayLookAtFaceDown,
+            }]);
+
+        let ability = ResolvedAbility::new(
+            Effect::GenericEffect {
+                static_abilities: vec![static_def],
+                duration: None,
+                target: None,
+            },
+            vec![],
+            source,
+            looker,
+        )
+        .duration(Duration::UntilEndOfTurn);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.transient_continuous_effects.len(),
+            1,
+            "the look permission registers exactly one TCE"
+        );
+        let tce = &state.transient_continuous_effects[0];
+        assert_eq!(
+            tce.controller, looker,
+            "the TCE controller must be the looker"
+        );
+        assert_eq!(
+            tce.affected, affected,
+            "the face-down/controller filter must ride on the TCE intact, not be expanded to SpecificObject"
+        );
+        assert_eq!(tce.duration, Duration::UntilEndOfTurn);
+        assert!(
+            tce.modifications.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MayLookAtFaceDown,
+                }
+            )),
+            "the TCE must carry the MayLookAtFaceDown mode"
+        );
+
+        // CR 708.5: the layer system must NOT stamp the permission onto the
+        // opponent's face-down creature (player-scoped permission, not an object
+        // grant). Mirrors the gather skip in `layers::gather_transient_continuous_effects`.
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            !state.objects[&opp_face_down]
+                .static_definitions
+                .iter_all()
+                .any(|sd| sd.mode == StaticMode::MayLookAtFaceDown),
+            "the look permission must not be applied to the opponent's creature as an object grant"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2807,6 +2807,24 @@ pub(crate) fn gather_transient_continuous_effects(
             if is_combat_assignment_rule_modification(modification) {
                 continue;
             }
+            // CR 708.5: A `MayLookAtFaceDown` look permission (Lumbering Laundry's
+            // duration-bound grant) is a player-scoped visibility permission read
+            // directly off the TCE by `visibility::viewer_may_look_at_face_down`
+            // — never applied to an object's `static_definitions` through the
+            // layer system. Its `affected` filter (face-down creatures you don't
+            // control) matches OPPONENT permanents, so feeding it into the object
+            // layer gather would erroneously stamp the permission onto each
+            // opponent's face-down creature. Skip it here, mirroring the printed
+            // `MayLookAtFaceDown` static (built with empty `modifications`, read
+            // by mode in `battlefield_active_statics`).
+            if matches!(
+                modification,
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MayLookAtFaceDown,
+                }
+            ) {
+                continue;
+            }
             effects.push(ActiveContinuousEffect {
                 source_id: tce.source_id,
                 controller: tce.controller,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -704,15 +704,23 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
 }
 
 /// CR 708.5: `viewer` may look at face-down permanent `obj_id` they do not
-/// control if they control an active `MayLookAtFaceDown` static (Found Footage,
-/// Lumbering Laundry) whose affected filter matches the permanent. The affected
-/// filter is resolved from the static's source controller (the viewer), so
-/// `controller: Opponent` correctly scopes to the viewer's opponents.
+/// control if they control an active `MayLookAtFaceDown` permission whose
+/// affected filter matches the permanent. The permission has two sources:
+///   1. A printed continuous static (Found Footage) — scanned from the
+///      battlefield. Its affected filter is resolved from the static's source
+///      controller (the viewer), so `controller: Opponent` scopes to the
+///      viewer's opponents.
+///   2. A duration-bound transient continuous effect created by a resolving
+///      activated ability (Lumbering Laundry's "Until end of turn, you may look
+///      at face-down creatures you don't control any time"). The TCE's
+///      `controller` is the viewer and its `affected` carries the same
+///      face-down/controller filter, so it is read identically.
 fn viewer_may_look_at_face_down(
     state: &GameState,
     obj_id: ObjectId,
     can_view_private_for_player: &impl Fn(PlayerId) -> bool,
 ) -> bool {
+    use crate::types::ability::{ContinuousModification, Duration};
     use crate::types::statics::StaticMode;
     for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
         if !matches!(def.mode, StaticMode::MayLookAtFaceDown) {
@@ -726,6 +734,41 @@ fn viewer_may_look_at_face_down(
         };
         let ctx = super::filter::FilterContext::from_source(state, source.id);
         if super::filter::matches_target_filter(state, obj_id, filter, &ctx) {
+            return true;
+        }
+    }
+
+    // CR 708.5 + CR 611.2c: Duration-bound permission from a resolved ability.
+    for tce in &state.transient_continuous_effects {
+        if !can_view_private_for_player(tce.controller) {
+            continue;
+        }
+        let grants_look = tce.modifications.iter().any(|m| {
+            matches!(
+                m,
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MayLookAtFaceDown,
+                }
+            )
+        });
+        if !grants_look {
+            continue;
+        }
+        // Honor the same duration/condition gates the static-mode TCE queries in
+        // `static_abilities.rs` apply (a `ForAsLongAs` duration or explicit
+        // `condition` must still hold this look).
+        if let Duration::ForAsLongAs { condition } = &tce.duration {
+            if !super::layers::evaluate_condition(state, condition, tce.controller, tce.source_id) {
+                continue;
+            }
+        }
+        if let Some(condition) = &tce.condition {
+            if !super::layers::evaluate_condition(state, condition, tce.controller, tce.source_id) {
+                continue;
+            }
+        }
+        let ctx = super::filter::FilterContext::from_source(state, tce.source_id);
+        if super::filter::matches_target_filter(state, obj_id, &tce.affected, &ctx) {
             return true;
         }
     }
@@ -2191,6 +2234,129 @@ mod tests {
         // The opponent (controller) still sees their own permanent regardless.
         let owner_view = filter_state_for_viewer(&state, opponent);
         assert!(owner_view.objects[&secret].back_face.is_some());
+    }
+
+    /// CR 708.5 + CR 611.2c + CR 514.2 (Lumbering Laundry class): the DURATION-BOUND
+    /// look permission. Lumbering Laundry's "{2}: Until end of turn, you may look
+    /// at face-down creatures you don't control any time." resolves into a
+    /// `MayLookAtFaceDown` transient continuous effect controlled by the looker.
+    /// While it is active the looker sees the matched opponent's face-down
+    /// identity; once the `UntilEndOfTurn` TCE is pruned at cleanup, the default
+    /// CR 708.5 redaction returns.
+    ///
+    /// Discriminating on two axes:
+    ///   - the `granted_back.name` assertion (permission active) fails — back_face
+    ///     redacts to None — if the transient-continuous-effect scan added to
+    ///     `viewer_may_look_at_face_down` is removed (the printed-static scan
+    ///     alone never sees this permission).
+    ///   - the post-prune `back_face.is_none()` assertion fails if the permission
+    ///     were modeled as permanent rather than bounded to end of turn.
+    #[test]
+    fn lumbering_laundry_reveals_opponent_face_down_until_end_of_turn() {
+        use crate::types::ability::{
+            ContinuousModification, ControllerRef, Duration, FilterProp, StaticDefinition,
+            TargetFilter, TypedFilter,
+        };
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let looker = PlayerId(0);
+        let opponent = PlayerId(1);
+
+        // The opponent manifests a creature face down on the battlefield.
+        let secret = create_object(
+            &mut state,
+            CardId(7),
+            opponent,
+            "Laundered Spy".to_string(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&secret).unwrap();
+            obj.power = Some(6);
+            obj.toughness = Some(3);
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+        }
+        let mut events = Vec::new();
+        manifest(&mut state, opponent, &mut events).unwrap();
+        assert!(state.objects[&secret].face_down);
+
+        // Without any permission, the looker cannot see the hidden identity.
+        let baseline = filter_state_for_viewer(&state, looker);
+        assert!(
+            baseline.objects[&secret].back_face.is_none(),
+            "without the permission, the looker must not see the opponent's face-down identity"
+        );
+
+        // The looker activates Lumbering Laundry: resolution registers an
+        // UntilEndOfTurn MayLookAtFaceDown transient continuous effect over the
+        // "face-down creatures you don't control" filter, controlled by the looker.
+        let source = create_object(
+            &mut state,
+            CardId(0x1A5),
+            looker,
+            "Lumbering Laundry".to_string(),
+            Zone::Battlefield,
+        );
+        let affected = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::Opponent)
+                .properties(vec![FilterProp::FaceDown]),
+        );
+        state.add_transient_continuous_effect(
+            source,
+            looker,
+            Duration::UntilEndOfTurn,
+            affected,
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::MayLookAtFaceDown,
+            }],
+            None,
+        );
+
+        // With the permission active, the looker sees the opponent's identity.
+        let granted_view = filter_state_for_viewer(&state, looker);
+        let granted_obj = granted_view.objects.get(&secret).unwrap();
+        assert!(
+            granted_obj.face_down,
+            "the permanent is still face down (CR 708.2)"
+        );
+        let granted_back = granted_obj.back_face.as_ref().expect(
+            "with the duration-bound permission, the looker must see the opponent's face-down identity",
+        );
+        assert_eq!(granted_back.name, "Laundered Spy");
+        assert_eq!(granted_back.power, Some(6));
+
+        // The opponent's own face-down creature must NOT have the permission
+        // stamped onto its own static definitions by the layer system (the
+        // permission is player-scoped, not an object grant). The opponent always
+        // sees their own permanent (CR 708.4) regardless.
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            !state.objects[&secret]
+                .static_definitions
+                .iter_all()
+                .any(|sd| sd.mode == StaticMode::MayLookAtFaceDown),
+            "the look permission must not be applied to the opponent's creature as an object grant"
+        );
+
+        // CR 514.2: prune the UntilEndOfTurn effect at cleanup — the permission
+        // ends and the default redaction returns.
+        crate::game::layers::prune_end_of_turn_effects(&mut state);
+        let expired_view = filter_state_for_viewer(&state, looker);
+        assert!(
+            expired_view.objects[&secret].back_face.is_none(),
+            "after end of turn the duration-bound permission must expire and redact again"
+        );
+
+        // Sanity: a `StaticDefinition` carrying the same mode on the source as a
+        // PRINTED static (Found Footage path) would also expose the identity, so
+        // the duration-bound and permanent forms share one visibility authority.
+        let _ = StaticDefinition::new(StaticMode::MayLookAtFaceDown);
     }
 
     /// CR 400.2 — Invoke Calamity's `FreeCastWindow` lists the controller's

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -738,7 +738,10 @@ fn viewer_may_look_at_face_down(
         }
     }
 
-    // CR 708.5 + CR 611.2c: Duration-bound permission from a resolved ability.
+    // CR 708.5 + CR 608.2c + CR 611.2c: Duration-bound permission from a resolved
+    // ability. CR 708.5 is the base own-permanent look right; CR 608.2c binds "you"
+    // to the ability's controller at resolution; CR 611.2c makes this rules-modifying
+    // effect's affected set dynamic (re-evaluated each query, not frozen at creation).
     for tce in &state.transient_continuous_effects {
         if !can_view_private_for_player(tce.controller) {
             continue;
@@ -767,7 +770,20 @@ fn viewer_may_look_at_face_down(
                 continue;
             }
         }
-        let ctx = super::filter::FilterContext::from_source(state, tce.source_id);
+        // CR 608.2c: "you" is latched to the player who controlled the ability at
+        // resolution (the stored `tce.controller`), NOT the source's current
+        // battlefield controller. CR 611.2c: because this is a rules-modifying
+        // continuous effect (it grants a look permission, it does not modify
+        // characteristics or change control), its affected set stays dynamic — we
+        // re-evaluate the affected filter (e.g. "you don't control" =
+        // `ControllerRef::Opponent`) against that latched controller on each query.
+        // A later control change of the source must not reinterpret who the looker
+        // may see. `from_source` would derive `source_controller` from the current
+        // object and silently rebind "you" to the new controller.
+        let ctx = super::filter::FilterContext::from_source_with_controller(
+            tce.source_id,
+            tce.controller,
+        );
         if super::filter::matches_target_filter(state, obj_id, &tce.affected, &ctx) {
             return true;
         }
@@ -2334,7 +2350,7 @@ mod tests {
         // The opponent's own face-down creature must NOT have the permission
         // stamped onto its own static definitions by the layer system (the
         // permission is player-scoped, not an object grant). The opponent always
-        // sees their own permanent (CR 708.4) regardless.
+        // sees their own permanent (CR 708.5) regardless.
         crate::game::layers::evaluate_layers(&mut state);
         assert!(
             !state.objects[&secret]
@@ -2357,6 +2373,121 @@ mod tests {
         // PRINTED static (Found Footage path) would also expose the identity, so
         // the duration-bound and permanent forms share one visibility authority.
         let _ = StaticDefinition::new(StaticMode::MayLookAtFaceDown);
+    }
+
+    /// CR 608.2c: the controller of a resolved ability is the one its instructions
+    /// bind, so "you" is fixed to the player who controlled the ability at
+    /// resolution. CR 611.2c: as a rules-modifying continuous effect its affected
+    /// set stays dynamic, so it keeps re-evaluating against that latched "you". The
+    /// duration-bound look permission ("you may look at face-down creatures you
+    /// don't control") must keep evaluating its `ControllerRef::Opponent` filter
+    /// against the original looker even after Lumbering Laundry changes
+    /// controller, so the original looker keeps seeing the same opponents'
+    /// face-down creatures for the rest of the turn.
+    ///
+    /// Three players are needed to make the bug observable. The looker's OWN
+    /// face-down permanents are always visible to them under the CR 708.5 base
+    /// rule, so the wrong-side *gain* can't be seen on the looker's own creature.
+    /// The discriminator is the *loss* of access to a creature controlled by the
+    /// player the source moves to:
+    ///   - CR 608.2c: Correct (filter "you" = stored `tce.controller` = P0): `Opponent`
+    ///     matches every creature P0 doesn't control — both `p1_secret` and
+    ///     `p2_secret` stay visible.
+    ///   - Buggy (`from_source` rebinds "you" to the source's new controller P1):
+    ///     `Opponent` now excludes P1's own creature, so `p1_secret` redacts
+    ///     (`back_face` → `None`) and the first assertion fails. `p2_secret` is a
+    ///     positive control proving the permission is still active (not merely
+    ///     disabled), so a vacuous "permission turned off" regression can't pass.
+    #[test]
+    fn lumbering_laundry_look_permission_survives_source_control_change() {
+        use crate::types::ability::{
+            ContinuousModification, ControllerRef, Duration, FilterProp, TargetFilter, TypedFilter,
+        };
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+        let looker = PlayerId(0);
+        let opp_a = PlayerId(1);
+        let opp_b = PlayerId(2);
+
+        // Each opponent manifests a face-down creature.
+        let p1_secret = create_object(
+            &mut state,
+            CardId(7),
+            opp_a,
+            "Laundered Spy".to_string(),
+            Zone::Library,
+        );
+        let p2_secret = create_object(
+            &mut state,
+            CardId(8),
+            opp_b,
+            "Pressed Shirt".to_string(),
+            Zone::Library,
+        );
+        for (id, p, t) in [(p1_secret, 6, 3), (p2_secret, 1, 1)] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.power = Some(p);
+            obj.toughness = Some(t);
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+        }
+        let mut events = Vec::new();
+        manifest(&mut state, opp_a, &mut events).unwrap();
+        manifest(&mut state, opp_b, &mut events).unwrap();
+        assert!(state.objects[&p1_secret].face_down);
+        assert!(state.objects[&p2_secret].face_down);
+
+        // The looker activates Lumbering Laundry: the resolved ability registers an
+        // UntilEndOfTurn MayLookAtFaceDown TCE over "face-down creatures you don't
+        // control", controlled by the looker.
+        let source = create_object(
+            &mut state,
+            CardId(0x1A5),
+            looker,
+            "Lumbering Laundry".to_string(),
+            Zone::Battlefield,
+        );
+        let affected = TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::Opponent)
+                .properties(vec![FilterProp::FaceDown]),
+        );
+        state.add_transient_continuous_effect(
+            source,
+            looker,
+            Duration::UntilEndOfTurn,
+            affected,
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::MayLookAtFaceDown,
+            }],
+            None,
+        );
+
+        // Lumbering Laundry changes controller to P1 after the ability resolves
+        // (e.g. a control-swap effect). The look permission belongs to the original
+        // looker for the rest of the turn (CR 608.2c) — the source's new controller
+        // is irrelevant to who "you" is.
+        state.objects.get_mut(&source).unwrap().controller = opp_a;
+
+        let view = filter_state_for_viewer(&state, looker);
+        // Discriminator: the original looker still sees P1's face-down creature even
+        // though the source is now controlled by P1.
+        let p1_back = view.objects[&p1_secret].back_face.as_ref().expect(
+            "after the source changes controller to P1, the original looker must still see P1's \
+             face-down identity (CR 608.2c fixes \"you\" to the resolution-time controller)",
+        );
+        assert_eq!(p1_back.name, "Laundered Spy");
+        // Positive control: P2's creature was visible before and stays visible,
+        // proving the permission is still active rather than merely disabled.
+        let p2_back = view.objects[&p2_secret]
+            .back_face
+            .as_ref()
+            .expect("the looker continues to see P2's face-down identity");
+        assert_eq!(p2_back.name, "Pressed Shirt");
     }
 
     /// CR 400.2 — Invoke Calamity's `FreeCastWindow` lists the controller's

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6157,6 +6157,93 @@ mod tests {
         }
     }
 
+    /// CR 708.5: Lumbering Laundry's "{2}: Until end of turn, you may look at
+    /// face-down creatures you don't control any time." is the DURATION-BOUND form
+    /// of Found Footage's continuous look permission. The activated ability lowers
+    /// to an `Effect::GenericEffect` carrying the shared `MayLookAtFaceDown`
+    /// static-mode (over the same opponent-scoped face-down filter); no part of the
+    /// card is `Unimplemented`. The duration rides on the resolving ability (the
+    /// stripped "Until end of turn," prefix), and the `GenericEffect` resolution
+    /// path registers it as an `UntilEndOfTurn` transient continuous effect.
+    /// Runtime visibility + duration discrimination lives in
+    /// `game::visibility::tests::
+    /// lumbering_laundry_reveals_opponent_face_down_until_end_of_turn`.
+    #[test]
+    fn lumbering_laundry_look_at_face_down_until_eot_parses() {
+        use crate::types::ability::{ContinuousModification, ControllerRef, Duration, FilterProp};
+        use crate::types::statics::StaticMode;
+
+        let parsed = parse_oracle_text(
+            "Disguise {2}{G} (You may cast this card face down as a 2/2 creature for {3}. Turn it face up any time for its disguise cost.)\n{2}: Until end of turn, you may look at face-down creatures you don't control any time.",
+            "Lumbering Laundry",
+            &["Disguise".to_string()],
+            &["Artifact".to_string(), "Creature".to_string()],
+            &["Construct".to_string()],
+        );
+        // No part of the card may be Unimplemented (the look line previously
+        // lowered to a "look" parse gap).
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .all(|a| !matches!(&*a.effect, Effect::Unimplemented { .. })),
+            "no ability should be Unimplemented: {:?}",
+            parsed.abilities
+        );
+        // (test-only) Iterator::find over the parsed abilities — not a parsing
+        // dispatch; this is a Vec<AbilityDefinition> lookup, not string matching.
+        let look = parsed
+            .abilities
+            .iter()
+            .find_map(|a| match &*a.effect {
+                Effect::GenericEffect {
+                    static_abilities,
+                    duration,
+                    ..
+                } => Some((static_abilities, duration)),
+                _ => None,
+            })
+            .expect("the activated ability must lower to a GenericEffect");
+        let (static_abilities, duration) = look;
+        // Duration is supplied by the resolving ability ("Until end of turn,");
+        // the GenericEffect itself carries None and resolution defaults it to
+        // UntilEndOfTurn (asserted at runtime below).
+        assert!(
+            duration.is_none() || *duration == Some(Duration::UntilEndOfTurn),
+            "duration must be unset or UntilEndOfTurn, got {duration:?}"
+        );
+        let static_def = static_abilities
+            .first()
+            .expect("GenericEffect must carry the look static");
+        assert_eq!(static_def.mode, StaticMode::MayLookAtFaceDown);
+        assert!(
+            static_def.modifications.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MayLookAtFaceDown,
+                }
+            )),
+            "the static must carry the MayLookAtFaceDown mode modification, got {:?}",
+            static_def.modifications
+        );
+        match static_def.affected.as_ref() {
+            Some(TargetFilter::Typed(t)) => {
+                assert!(
+                    t.properties
+                        .iter()
+                        .any(|p| matches!(p, FilterProp::FaceDown)),
+                    "affected filter must carry FaceDown, got {t:?}"
+                );
+                assert_eq!(
+                    t.controller,
+                    Some(ControllerRef::Opponent),
+                    "'you don't control' must scope to Opponent"
+                );
+            }
+            other => panic!("expected Typed affected filter, got {other:?}"),
+        }
+    }
+
     /// CR 116.2b + CR 708.7: Karlov Watchdog's "Permanents your opponents
     /// control can't be turned face up during your turn" lowers to a
     /// `CantBeTurnedFaceUp` static with the opponent-scoped affected filter and

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -23,7 +23,8 @@ use crate::parser::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_onc
 use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::parser::oracle_nom::quantity as nom_quantity;
 use crate::parser::oracle_static::{
-    parse_continuous_modifications, parse_quoted_ability_modifications,
+    parse_continuous_modifications, parse_may_look_at_face_down_filter,
+    parse_quoted_ability_modifications,
 };
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CardSelectionMode,
@@ -6842,6 +6843,32 @@ pub(super) fn parse_imperative_family_ast(
     if let Some(effect) = crate::parser::oracle_replacement::parse_oneshot_damage_replacement(lower)
     {
         return Some(ImperativeFamilyAst::GainKeyword(effect));
+    }
+
+    // CR 708.5: "[Until end of turn,] you may look at face-down [permanents] you
+    // don't control any time" (Lumbering Laundry's `{2}:` activated ability).
+    // This is the duration-bound form of Found Footage's continuous look
+    // permission: the same `StaticMode::MayLookAtFaceDown` carried by a resolving
+    // ability as a transient continuous effect. The "you may" here is part of the
+    // permission grammar ("you ARE allowed to look"), not an optional one-shot, so
+    // intercept the whole phrase BEFORE the `you`/`may` first-word arms strip
+    // "you may " and re-dispatch it as a generic optional clause (which would
+    // otherwise fail to a `look` Unimplemented). The face-down filter is parsed by
+    // the shared `parse_may_look_at_face_down_filter` (the single authority for
+    // the phrase grammar, also used by the static-line builder), and the duration
+    // rides on the resolving ability via the stripped "Until end of turn," prefix;
+    // the `GenericEffect` resolution path defaults to `UntilEndOfTurn` when no
+    // duration is supplied.
+    if let Some(filter) = parse_may_look_at_face_down_filter(text, lower) {
+        return Some(ImperativeFamilyAst::GainKeyword(Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::new(StaticMode::MayLookAtFaceDown)
+                .affected(filter)
+                .modifications(vec![ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MayLookAtFaceDown,
+                }])],
+            duration: None,
+            target: None,
+        }));
     }
 
     // NOTE: when adding verbs here, also add them to IMPERATIVE_EXTRA_VERBS

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -223,17 +223,30 @@ fn parse_reveal_hand_static(tp: &TextPair<'_>, text: &str) -> Option<StaticDefin
     )
 }
 
-/// CR 708.5: "You may look at face-down creatures [you don't control | your
-/// opponents control] any time." (Found Footage). Builds a
-/// `StaticMode::MayLookAtFaceDown` whose `affected` filter is the subject phrase
-/// (carrying `FilterProp::FaceDown` plus the controller scope), parsed via the
-/// shared `parse_target` so both scope wordings route through one handler.
-fn parse_may_look_at_face_down_static(tp: &TextPair<'_>) -> Option<StaticDefinition> {
-    let rest = nom_tag_tp(tp, "you may look at ")?;
+/// CR 708.5: Single authority for the "[you may ]look at face-down [permanents]
+/// [you don't control | your opponents control] any time" permission phrase.
+/// Strips an optional `"you may "` prefix (the static-line surface form carries
+/// it; the activated-ability effect form arrives already peeled of "you may " by
+/// the clause shell) and the required `"look at "` verb, parses the subject via
+/// the shared `parse_target` (so both controller-scope wordings route through one
+/// handler), and returns the affected filter only when it carries
+/// `FilterProp::FaceDown` and the trailing clause is exactly `"any time"`. Shared
+/// by the static-line builder (Found Footage's continuous permission) and the
+/// activated-ability effect intercept (Lumbering Laundry's `Until end of turn`
+/// grant), so the two surface forms never re-encode the grammar independently.
+pub(crate) fn parse_may_look_at_face_down_filter(
+    original: &str,
+    lower: &str,
+) -> Option<TargetFilter> {
+    let tp = TextPair::new(original, lower);
+    // "you may " is optional: the static line keeps it ("You may look at …"),
+    // while the activated-ability clause shell already peeled it.
+    let tp = nom_tag_tp(&tp, "you may ").unwrap_or(tp);
+    let rest = nom_tag_tp(&tp, "look at ")?;
     // `parse_target` consumes the original-cased subject phrase that the
     // lowercase tag matched past.
     let (filter, remainder) = parse_target(rest.original);
-    // The subject must be a face-down creature filter; "any time" is the only
+    // The subject must carry the face-down property; "any time" is the only
     // permitted trailing clause for this permission.
     let has_face_down = matches!(
         &filter,
@@ -246,6 +259,17 @@ fn parse_may_look_at_face_down_static(tp: &TextPair<'_>) -> Option<StaticDefinit
     if !tail.eq_ignore_ascii_case("any time") {
         return None;
     }
+    Some(filter)
+}
+
+/// CR 708.5: "You may look at face-down creatures [you don't control | your
+/// opponents control] any time." (Found Footage). Builds a
+/// `StaticMode::MayLookAtFaceDown` whose `affected` filter is the subject phrase
+/// (carrying `FilterProp::FaceDown` plus the controller scope), parsed via the
+/// shared [`parse_may_look_at_face_down_filter`] so both scope wordings — and
+/// the activated-ability duration-bound form — route through one handler.
+fn parse_may_look_at_face_down_static(tp: &TextPair<'_>) -> Option<StaticDefinition> {
+    let filter = parse_may_look_at_face_down_filter(tp.original, tp.lower)?;
     Some(
         StaticDefinition::new(StaticMode::MayLookAtFaceDown)
             .affected(filter)

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -89,6 +89,7 @@ mod type_change;
 pub(crate) use shared::parse_commander_subject_filter_prefix;
 
 pub(crate) use dispatch::is_speed_unlock_sentence;
+pub(crate) use dispatch::parse_may_look_at_face_down_filter;
 use dispatch::{parse_static_line_inner, InvertedAsLongAs};
 use prelude::StaticIr;
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Implements the **duration-bound "you may look at face-down permanents you don't control any time"** permission for **Lumbering Laundry** — `{2}: Until end of turn, you may look at face-down creatures you don't control any time.`

This is the time-limited sibling of **Found Footage**'s continuous look permission shipped in #4017. It reuses the existing `StaticMode::MayLookAtFaceDown` outright — the controller scope and the duration are the only two parameter axes — so **no new engine variant is added**.

## Building block (reused vs extended)

**Reused** #4017's `StaticMode::MayLookAtFaceDown` permission end-to-end. The only new infrastructure is wiring the duration-bound surface form into the same permission:

- **Parser grammar (single authority):** extracted `parse_may_look_at_face_down_filter` in `oracle_static/dispatch.rs`. It accepts an *optional* `"you may "` prefix (the static line keeps it; the activated-ability clause shell already peels it) and the required `"look at "` verb, returning the affected face-down/controller filter. Both the static-line builder (Found Footage) and the new activated-ability effect intercept call it — the grammar is never re-encoded.
- **Effect intercept:** `oracle_effect/imperative.rs` intercepts the whole `[Until end of turn,] you may look at face-down … any time` phrase before the `you`/`may` first-word arms (which would mark it a spurious optional one-shot and fail to a `look` parse gap), lowering it to `Effect::GenericEffect` carrying the shared `MayLookAtFaceDown` static-mode. The duration rides on the resolving ability via the stripped `Until end of turn,` prefix.
- **Resolution (CR 611.2c):** a look permission is a *rules-modifying* continuous effect, so its affected face-down filter rides on the transient continuous effect **intact** (re-evaluated continuously at look time) rather than being expanded to a fixed `SpecificObject` set — a permanent turned face down after this resolves but before end of turn is still visible. `register_transient_effect` registers one TCE bound to the looker via `controller`.
- **Visibility:** `viewer_may_look_at_face_down` now also scans transient continuous effects carrying the permission, reading them identically to the printed static (honoring `ForAsLongAs`/explicit-condition gates). The permission is never stamped onto objects through the layer system (its filter matches opponents' permanents), so the layer gather skips it — mirroring the printed static's empty-modifications, mode-read design.
- **Duration (CR 514.2):** the `UntilEndOfTurn` TCE expires at cleanup via the existing prune.

## Per-card verdict

| Card | Verdict | Notes |
|---|---|---|
| **Lumbering Laundry** | **Shipped** | Activated look line previously a `look` parse gap; now fully supported. Disguise line already worked. `supported: true, gap_count: 0`. |
| **Found Footage** | Already shipped by #4017 | Verified still fully supported (no regression). `supported: true, gap_count: 0`. |

## CR citations (grep-verified against `docs/MagicCompRules.txt`)

- **CR 708.5** — a player may look only at their own face-down permanents; effects override this to grant looking at others'.
- **CR 611.2c** — a continuous effect from a resolving ability that doesn't modify characteristics/controller "modifies the rules of the game, so it can affect objects that weren't affected when that continuous effect began" — the look permission keeps its filter live rather than fixing an object set.
- **CR 514.2** — "until end of turn" effects end at cleanup.
- **CR 708.2 / 708.4** — face-down 2/2 characteristics; default own-only look rule.

## add-engine-variant verdict

**No new variant.** Reused `StaticMode::MayLookAtFaceDown` (parameterized via the affected filter + duration), `ContinuousModification::AddStaticMode`, `Effect::GenericEffect`, and `TransientContinuousEffect`. Parameterize-don't-proliferate satisfied.

## Discriminating-test map (full production path)

| Behavioral claim | Changed seam | Production entry | Test | Revert-failing assertion |
|---|---|---|---|---|
| Activated line parses to the look permission | `parse_imperative_family_ast` intercept | `parse_oracle_text` | `parser::oracle::tests::lumbering_laundry_look_at_face_down_until_eot_parses` | `GenericEffect` with `MayLookAtFaceDown` over Opponent-scoped face-down filter (no Unimplemented) |
| Resolution keeps the filter live, binds the looker, no object pollution | `register_transient_effect` + layer gather skip | `effects::effect::resolve` | `game::effects::effect::tests::generic_effect_may_look_at_face_down_keeps_filter_and_binds_looker` | `tce.affected == Typed(..)` (not `SpecificObject`); opponent creature not stamped |
| Looker sees opponent's identity only while active, reverts at EOT | `viewer_may_look_at_face_down` TCE scan + `prune_end_of_turn_effects` | `filter_state_for_viewer` | `game::visibility::tests::lumbering_laundry_reveals_opponent_face_down_until_end_of_turn` | `granted_back` expect (flips to None on revert); post-prune `back_face.is_none()` (flips if modeled permanent) |

Negative/sibling coverage: Found Footage's static-path tests (parser + runtime) confirm no regression.

## Gate results

`cargo fmt` clean · `cargo clippy --workspace` clean · `cargo test -p engine` green (only the two known parallel-flaky `delve_payment_skips_state_clone_per_graveyard_candidate` / `target_selection_legal_actions_do_not_fall_back_to_stale_slot_targets` fail under contention, pass in isolation single-threaded) · `check-parser-combinators.sh` (with and without `upstream/main`) exit 0 · parser string-dispatch diff grep clean · `check-engine-authorities.sh upstream/main` exit 0 · `cargo coverage` / `cargo semantic-audit` clean (no findings for either card) · CR-annotation diff grep clean.