### PR TITLE
feat(parser): token-count ×N replacement multiplier (Ojer Taq, Deepest Foundation)

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -14612,7 +14612,7 @@ its replicate cost was paid.)\nDraw a card.";
 
         // CR 614.1a: counter-doubling replacement effect (Doubling Season-class).
         let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         runner
             .state_mut()
             .objects

--- a/crates/engine/src/game/effects/blight.rs
+++ b/crates/engine/src/game/effects/blight.rs
@@ -299,7 +299,7 @@ mod tests {
             Zone::Battlefield,
         );
         let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         state
             .objects
             .get_mut(&doubler)

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -452,7 +452,7 @@ pub(crate) fn copy_count_with_replacements(
             continue;
         }
         count = match def.quantity_modification {
-            Some(QuantityModification::Double) => count.saturating_mul(2),
+            Some(QuantityModification::Times { factor }) => count.saturating_mul(factor as usize),
             Some(QuantityModification::Half) => count / 2,
             Some(QuantityModification::Plus { value }) => count.saturating_add(value as usize),
             Some(QuantityModification::Minus { value }) => count.saturating_sub(value as usize),

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -2061,7 +2061,7 @@ mod tests {
             .replacement_definitions
             .push(
                 ReplacementDefinition::new(ReplacementEvent::AddCounter)
-                    .quantity_modification(QuantityModification::Double),
+                    .quantity_modification(QuantityModification::DOUBLE),
             );
 
         let plus_id = create_object(
@@ -3276,7 +3276,7 @@ mod tests {
             .insert(CounterType::Plus1Plus1, 1);
         let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter);
         repl.valid_card = Some(TargetFilter::SelfRef);
-        repl.quantity_modification = Some(QuantityModification::Double);
+        repl.quantity_modification = Some(QuantityModification::DOUBLE);
         state
             .objects
             .get_mut(&dest_id)
@@ -4030,7 +4030,7 @@ mod tests {
         );
         let mut doubler_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter);
         doubler_repl.valid_card = Some(TargetFilter::Any);
-        doubler_repl.quantity_modification = Some(QuantityModification::Double);
+        doubler_repl.quantity_modification = Some(QuantityModification::DOUBLE);
         state
             .objects
             .get_mut(&doubler_id)

--- a/crates/engine/src/game/effects/double.rs
+++ b/crates/engine/src/game/effects/double.rs
@@ -393,7 +393,7 @@ mod tests {
     fn double_counters_replacement_choice_stashes_remaining_counter_additions() {
         let mut state = GameState::default();
         for (id, modification) in [
-            (ObjectId(90), QuantityModification::Double),
+            (ObjectId(90), QuantityModification::DOUBLE),
             (ObjectId(91), QuantityModification::Plus { value: 1 }),
         ] {
             let mut source = GameObject::new(
@@ -599,7 +599,7 @@ mod tests {
         );
         let mut repl = ReplacementDefinition::new(ReplacementEvent::AddCounter);
         repl.valid_card = Some(TargetFilter::Any);
-        repl.quantity_modification = Some(QuantityModification::Double);
+        repl.quantity_modification = Some(QuantityModification::DOUBLE);
         doubler.replacement_definitions.push(repl);
         state.objects.insert(doubler_id, doubler);
         state.battlefield.push_back(doubler_id);

--- a/crates/engine/src/game/effects/proliferate.rs
+++ b/crates/engine/src/game/effects/proliferate.rs
@@ -718,7 +718,7 @@ mod tests {
     fn apply_proliferate_replacement_choice_stashes_remaining_counter_additions() {
         let mut state = GameState::new_two_player(42);
         for (id, modification) in [
-            (ObjectId(90), QuantityModification::Double),
+            (ObjectId(90), QuantityModification::DOUBLE),
             (ObjectId(91), QuantityModification::Plus { value: 1 }),
         ] {
             let source = create_object(

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1485,7 +1485,7 @@ mod tests {
             let doubler = state.objects.get_mut(&doubler_id).unwrap();
             let def = ReplacementDefinition::new(ReplacementEvent::CreateToken)
                 .token_owner_scope(ControllerRef::You)
-                .quantity_modification(QuantityModification::Double);
+                .quantity_modification(QuantityModification::DOUBLE);
             doubler.base_replacement_definitions = Arc::new(vec![def.clone()]);
             doubler.replacement_definitions = vec![def].into();
         }
@@ -1585,7 +1585,7 @@ mod tests {
             let doubler = state.objects.get_mut(&doubler_id).unwrap();
             let def = ReplacementDefinition::new(ReplacementEvent::CreateToken)
                 .token_owner_scope(ControllerRef::You)
-                .quantity_modification(QuantityModification::Double);
+                .quantity_modification(QuantityModification::DOUBLE);
             doubler.base_replacement_definitions = Arc::new(vec![def.clone()]);
             doubler.replacement_definitions = vec![def].into();
         }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1947,7 +1947,7 @@ fn gain_life_applier(
         } = event
         {
             let new_amount = match modification {
-                QuantityModification::Double => amount.saturating_mul(2),
+                QuantityModification::Times { factor } => amount.saturating_mul(factor),
                 QuantityModification::Half => amount / 2,
                 QuantityModification::Plus { value } => amount.saturating_add(value),
                 QuantityModification::Minus { value } => amount.saturating_sub(value),
@@ -2155,7 +2155,7 @@ fn add_counter_applier(
         return ApplyResult::Prevented;
     }
     let new_count = |count: u32| match modification {
-        QuantityModification::Double => count.saturating_mul(2),
+        QuantityModification::Times { factor } => count.saturating_mul(factor),
         QuantityModification::Half => count / 2,
         QuantityModification::Plus { value } => count.saturating_add(value),
         QuantityModification::Minus { value } => count.saturating_sub(value),
@@ -2305,7 +2305,7 @@ fn create_token_applier(
         }
         // CR 614.1a: Modify token count per replacement effect.
         let new_count = match modification {
-            Some(QuantityModification::Double) => count.saturating_mul(2),
+            Some(QuantityModification::Times { factor }) => count.saturating_mul(factor),
             Some(QuantityModification::Half) => count / 2,
             Some(QuantityModification::Plus { value }) => count.saturating_add(value),
             Some(QuantityModification::Minus { value }) => count.saturating_sub(value),
@@ -4255,7 +4255,7 @@ pub fn find_applicable_replacements(
                             if !matches!(
                                 repl_def.quantity_modification,
                                 Some(
-                                    QuantityModification::Double
+                                    QuantityModification::Times { .. }
                                         | QuantityModification::Half
                                         | QuantityModification::Plus { .. }
                                         | QuantityModification::Minus { .. }
@@ -5331,7 +5331,11 @@ impl CommuteClass {
 
 fn quantity_commute_class(modification: &QuantityModification) -> CommuteClass {
     match modification {
-        QuantityModification::Double => CommuteClass::Multiplicative,
+        // CR 616.1: all multiplicative modifiers commute with each other
+        // (×2 then ×3 == ×3 then ×2), so Doubling Season + Ojer Taq auto-apply
+        // without a degenerate ordering prompt — the same Multiplicative class
+        // as `ManaModification::Multiply` and `DamageModification::Double/Triple`.
+        QuantityModification::Times { .. } => CommuteClass::Multiplicative,
         // CR 616.1: integer halving (rounded down) does NOT commute with ×2 —
         // e.g. count 3 gives ×2÷2 = 3 but ÷2×2 = 2 — so it cannot share the
         // Multiplicative commuting class. The affected player must always choose
@@ -5485,7 +5489,7 @@ fn candidate_materiality(
     // Tekuthal) multiplies the proliferate action count via a `Multiply`
     // `repeat_for`. Two such doublers commute (x2 then x2 == x2 then x2 == x4),
     // so the ordering is immaterial and they must auto-apply — mirroring the
-    // `QuantityModification::Double` -> `Multiplicative` count-write path. Without
+    // `QuantityModification::DOUBLE` -> `Multiplicative` count-write path. Without
     // this they fall to the conservative `Unconditional` default below and force
     // a degenerate CR 616.1 ordering choice. (A non-`Multiply` `repeat_for` is not
     // a doubler and correctly falls through to the conservative default.)
@@ -6443,7 +6447,7 @@ mod tests {
         );
         doubler.replacement_definitions =
             vec![ReplacementDefinition::new(ReplacementEvent::AddCounter)
-                .quantity_modification(QuantityModification::Double)]
+                .quantity_modification(QuantityModification::DOUBLE)]
             .into();
         state.objects.insert(doubling_season, doubler);
         state.battlefield.push_back(doubling_season);
@@ -6671,7 +6675,7 @@ mod tests {
         use crate::types::counter::CounterType;
 
         let doubling_season = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         let hardened_scales = ReplacementDefinition::new(ReplacementEvent::AddCounter)
             .quantity_modification(QuantityModification::Plus { value: 1 });
 
@@ -6732,7 +6736,7 @@ mod tests {
         let prevent_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
             .quantity_modification(QuantityModification::Prevent);
         let double_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
 
         let mut state = GameState::new_two_player(42);
         let mut solemnity = GameObject::new(
@@ -11214,7 +11218,7 @@ mod tests {
         let primal_vigor = ObjectId(30);
 
         let doubler_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
 
         let mut state = GameState::new_two_player(42);
         let mut ds = GameObject::new(
@@ -11295,6 +11299,117 @@ mod tests {
         assert_eq!(
             count, 8,
             "Three doublers should multiply: 1 * 2 * 2 * 2 = 8"
+        );
+    }
+
+    /// Build a `TokenSpec` of the given core type for replacement-pipeline tests.
+    fn token_spec_of(name: &str, core: CoreType, subtype: &str) -> TokenSpec {
+        use crate::types::proposed_event::TokenCharacteristics;
+        TokenSpec {
+            characteristics: TokenCharacteristics {
+                display_name: name.to_string(),
+                power: (core == CoreType::Creature).then_some(1),
+                toughness: (core == CoreType::Creature).then_some(1),
+                core_types: vec![core],
+                subtypes: vec![subtype.to_string()],
+                supertypes: Vec::new(),
+                colors: Vec::new(),
+                keywords: Vec::new(),
+            },
+            script_name: name.to_string(),
+            static_abilities: Vec::new(),
+            enter_with_counters: Vec::new(),
+            tapped: false,
+            enters_attacking: false,
+            sacrifice_at: None,
+            source_id: ObjectId(0),
+            controller: PlayerId(0),
+            attach_to: None,
+        }
+    }
+
+    /// Run the Ojer Taq creature-token replacement against `spec` with the given
+    /// proposed `count`, returning the post-replacement count. Parses the real
+    /// Oracle line so the test exercises parser → pipeline end-to-end.
+    fn ojer_taq_replaced_count(spec: TokenSpec, count: u32) -> u32 {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "If one or more creature tokens would be created under your control, \
+             three times that many of those tokens are created instead.",
+            "Ojer Taq, Deepest Foundation",
+            &[],
+            &["Creature".to_string()],
+            &["God".to_string()],
+        );
+        assert_eq!(
+            parsed.replacements.len(),
+            1,
+            "Ojer Taq token-multiplier line must parse to exactly one replacement"
+        );
+        let repl = parsed.replacements[0].clone();
+        // CR 614.1a: the multiplier is the parameterized ×N factor (×3 here),
+        // not the legacy ×2 `Double`.
+        assert_eq!(
+            repl.quantity_modification,
+            Some(QuantityModification::Times { factor: 3 }),
+            "Ojer Taq must parse to Times {{ factor: 3 }}"
+        );
+
+        let ojer = ObjectId(10);
+        let mut state = GameState::new_two_player(42);
+        let mut obj = GameObject::new(
+            ojer,
+            CardId(1),
+            PlayerId(0),
+            "Ojer Taq, Deepest Foundation".to_string(),
+            Zone::Battlefield,
+        );
+        obj.replacement_definitions = vec![repl].into();
+        state.objects.insert(ojer, obj);
+        state.battlefield.push_back(ojer);
+
+        let proposed = ProposedEvent::CreateToken {
+            owner: PlayerId(0),
+            spec: Box::new(spec),
+            copy: None,
+            enter_tapped: EtbTapState::Unspecified,
+            count,
+            applied: HashSet::new(),
+        };
+        let mut events = Vec::new();
+        match replace_event(&mut state, proposed, &mut events) {
+            ReplacementResult::Execute(ProposedEvent::CreateToken { count, .. }) => count,
+            other => panic!("expected Execute(CreateToken), got {other:?}"),
+        }
+    }
+
+    /// CR 614.1a + CR 111.1: Ojer Taq, Deepest Foundation triplicates creature
+    /// tokens created under its controller ("three times that many"). Drives the
+    /// real parser output through `replace_event`: a proposed 2 creature tokens
+    /// resolves to 6. Reverting the ×N parameterization (factor 3 → the old ×2
+    /// `Double`) would yield 4, and dropping the replacement entirely yields 2 —
+    /// so the `== 6` assertion flips on either regression.
+    #[test]
+    fn ojer_taq_triplicates_creature_tokens() {
+        let spec = token_spec_of("Soldier", CoreType::Creature, "Soldier");
+        assert_eq!(
+            ojer_taq_replaced_count(spec, 2),
+            6,
+            "Ojer Taq must triple creature-token creation: 2 * 3 = 6"
+        );
+    }
+
+    /// CR 111.1: Ojer Taq's multiplier is gated on creature tokens ("if one or
+    /// more CREATURE tokens would be created") via `TokenCoreTypeMatches`. A
+    /// non-creature (Treasure artifact) token is NOT triplicated — the proposed
+    /// count passes through unchanged. Discriminates the core-type gate: without
+    /// it, the artifact count would become 6.
+    #[test]
+    fn ojer_taq_does_not_multiply_noncreature_tokens() {
+        let spec = token_spec_of("Treasure", CoreType::Artifact, "Treasure");
+        assert_eq!(
+            ojer_taq_replaced_count(spec, 2),
+            2,
+            "Ojer Taq must leave non-creature token creation untouched"
         );
     }
 
@@ -11578,7 +11693,7 @@ mod tests {
         let bloodletter = ObjectId(10);
         let repl = {
             let mut repl = ReplacementDefinition::new(ReplacementEvent::LoseLife)
-                .quantity_modification(QuantityModification::Double);
+                .quantity_modification(QuantityModification::DOUBLE);
             repl.valid_player = Some(ReplacementPlayerScope::Opponent);
             repl
         };
@@ -11615,7 +11730,7 @@ mod tests {
         let bloodletter = ObjectId(10);
         let repl = {
             let mut repl = ReplacementDefinition::new(ReplacementEvent::LoseLife)
-                .quantity_modification(QuantityModification::Double);
+                .quantity_modification(QuantityModification::DOUBLE);
             repl.valid_player = Some(ReplacementPlayerScope::Opponent);
             repl
         };
@@ -11658,7 +11773,7 @@ mod tests {
         let hardened_scales = ObjectId(20);
 
         let doubler_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         let plus_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
             .quantity_modification(QuantityModification::Plus { value: 1 });
 
@@ -11727,7 +11842,7 @@ mod tests {
         use crate::types::counter::CounterType;
 
         let doubler_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         let halver_repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
             .quantity_modification(QuantityModification::Half);
 
@@ -11836,7 +11951,7 @@ mod tests {
             ]);
 
         let doubler_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
 
         let mut state = GameState::new_two_player(42);
         let mut m = GameObject::new(
@@ -12024,7 +12139,7 @@ mod tests {
         let tap_effect2 = ObjectId(25);
 
         let doubler_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
 
         let tap_repl = ReplacementDefinition::new(ReplacementEvent::CreateToken).execute(
             AbilityDefinition::new(
@@ -12353,7 +12468,7 @@ mod tests {
         let target = ObjectId(40);
 
         let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(crate::types::ability::QuantityModification::Double);
+            .quantity_modification(crate::types::ability::QuantityModification::DOUBLE);
         // Note: counter_match is left as None.
         let mut state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
         let mut creature = crate::game::game_object::GameObject::new(
@@ -12733,7 +12848,7 @@ mod tests {
     fn object_counter_replacement_without_player_scope_ignores_player_counter_events() {
         let source = ObjectId(90);
         let repl = ReplacementDefinition::new(ReplacementEvent::AddCounter)
-            .quantity_modification(QuantityModification::Double);
+            .quantity_modification(QuantityModification::DOUBLE);
         let state = test_state_with_object(source, Zone::Battlefield, vec![repl]);
         let registry = build_replacement_registry();
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -6315,7 +6315,7 @@ mod tests {
             use crate::types::replacements::ReplacementEvent;
             let mut def = ReplacementDefinition::new(ReplacementEvent::CreateToken);
             def.mode = ReplacementMode::Optional { decline: None };
-            def.quantity_modification = Some(QuantityModification::Double);
+            def.quantity_modification = Some(QuantityModification::DOUBLE);
             def
         }
 
@@ -6328,7 +6328,7 @@ mod tests {
             use crate::types::replacements::ReplacementEvent;
             let mut def = ReplacementDefinition::new(ReplacementEvent::CreateToken);
             def.mode = ReplacementMode::Mandatory;
-            def.quantity_modification = Some(QuantityModification::Double);
+            def.quantity_modification = Some(QuantityModification::DOUBLE);
             def
         }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -1123,7 +1123,7 @@ fn parse_lose_life_replacement(text: &str, lower: &str) -> Option<ReplacementDef
         let (i, _) = tag(", ").parse(i)?;
         let (i, quantity_modification) = alt((
             value(
-                Some(QuantityModification::Double),
+                Some(QuantityModification::DOUBLE),
                 terminated(parse_double_lose_life_consequence, opt(char('.'))),
             ),
             value(None, parse_lose_life_instead_consequence),
@@ -5628,9 +5628,11 @@ fn parse_copy_count_replacement(lower: &str, original_text: &str) -> Option<Repl
 }
 
 /// CR 614.1a: Parse token creation replacement effects.
-/// Handles "twice that many tokens" (Primal Vigor, Doubling Season, Parallel Lives)
-/// and "those tokens plus [spec]" (Chatterfang — "that many 1/1 green Squirrel
-/// creature tokens"; Donatello — "a Mutagen token").
+/// Handles the multiplicative family "twice that many tokens" (×2 — Primal Vigor,
+/// Doubling Season, Parallel Lives) and "<N> times that many" (×N — Ojer Taq,
+/// Deepest Foundation's "three times that many"), plus "those tokens plus [spec]"
+/// (Chatterfang — "that many 1/1 green Squirrel creature tokens"; Donatello —
+/// "a Mutagen token").
 fn parse_token_replacement(lower: &str, original_text: &str) -> Option<ReplacementDefinition> {
     use crate::types::ability::QuantityModification;
 
@@ -5640,8 +5642,8 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
         .description(original_text.to_string());
 
     match modification_mode {
-        TokenReplacementShape::Double => {
-            def = def.quantity_modification(QuantityModification::Double);
+        TokenReplacementShape::Times { factor } => {
+            def = def.quantity_modification(QuantityModification::Times { factor });
         }
         TokenReplacementShape::Half => {
             def = def.quantity_modification(QuantityModification::Half);
@@ -5657,15 +5659,18 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
             // `create_token_applier` resolves it to a TokenSpec and swaps it in,
             // preserving the event's count and owner.
             def = def.execute(AbilityDefinition::new(AbilityKind::Spell, *token));
-            // CR 111.1: gate the substitution on the proposed token's core card
-            // type ("if one or more CREATURE tokens would be created" — only
-            // creature tokens become Angels).
-            if let Some(core_type) = parse_token_core_type_gate(lower) {
-                def = def.condition(ReplacementCondition::TokenCoreTypeMatches {
-                    core_types: vec![core_type],
-                });
-            }
         }
+    }
+
+    // CR 111.1: gate on the proposed token's core card type when the trigger
+    // names one ("if one or more CREATURE tokens would be created" — Divine
+    // Visitation only affects creature tokens; Ojer Taq, Deepest Foundation
+    // only triplicates creature tokens). Untyped "one or more tokens"
+    // (Doubling Season) emits no gate and applies to every token type.
+    if let Some(core_type) = parse_token_core_type_gate(lower) {
+        def = def.condition(ReplacementCondition::TokenCoreTypeMatches {
+            core_types: vec![core_type],
+        });
     }
 
     // Scope: "under your control" → restrict to controller's tokens
@@ -5683,8 +5688,10 @@ fn parse_token_replacement(lower: &str, original_text: &str) -> Option<Replaceme
 }
 
 enum TokenReplacementShape {
-    /// "twice that many tokens … are created instead" (Doubling Season).
-    Double,
+    /// "twice that many tokens … are created instead" (Doubling Season, factor 2)
+    /// or "three times that many of those tokens are created instead" (Ojer Taq,
+    /// Deepest Foundation, factor 3) — the general ×N multiplier.
+    Times { factor: u32 },
     /// "half that many … tokens … instead, rounded down" (Halving Season).
     Half,
     /// "those tokens plus [spec] are created instead" (Chatterfang, Donatello).
@@ -5706,15 +5713,14 @@ fn parse_token_replacement_shape(lower: &str) -> Option<TokenReplacementShape> {
         return Some(TokenReplacementShape::Half);
     }
 
-    // "twice that many" → Doubling Season pattern.
-    if nom_on_lower(lower, lower, |i| {
-        let (i, _) = take_until::<_, _, OracleError<'_>>("twice that many").parse(i)?;
-        let (i, _) = tag("twice that many").parse(i)?;
-        Ok((i, ()))
-    })
-    .is_some()
-    {
-        return Some(TokenReplacementShape::Double);
+    // "twice that many" (factor 2) or "<N> times that many" (factor N) →
+    // multiplicative pattern. Doubling Season uses "twice"; Ojer Taq, Deepest
+    // Foundation uses "three times that many of those tokens are created
+    // instead." Composed along one axis (the multiplier phrase) via `alt`,
+    // delegating the number word to `parse_number`, so any future ×N card
+    // ("four times that many") is covered without a new tag.
+    if let Some(factor) = scan_token_multiplier_factor(lower) {
+        return Some(TokenReplacementShape::Times { factor });
     }
 
     // "those tokens plus <spec> (is|are) created instead" → Chatterfang / Donatello.
@@ -5734,6 +5740,36 @@ fn parse_token_replacement_shape(lower: &str) -> Option<TokenReplacementShape> {
     }
 
     None
+}
+
+/// CR 614.1a: Scan for a multiplicative token-count phrase and return its
+/// factor. Recognizes "twice that many" (factor 2 — Doubling Season) and
+/// "<number> times that many" (factor N — Ojer Taq's "three times that many").
+/// The number word is parsed by the shared `parse_number` combinator, so the
+/// pattern covers every ×N multiplier card in the class, not just ×3.
+///
+/// The multiplier phrase appears mid-sentence (after "instead"), so the
+/// combinator is tried at each word boundary using the documented word-boundary
+/// scanning idiom — `parse_number` is anchored on the trailing `" times that
+/// many"` tag at each position rather than scanning the string for a substring.
+fn scan_token_multiplier_factor(lower: &str) -> Option<u32> {
+    // The multiplier head anchored at the current word boundary: either the ×2
+    // leaf "twice that many" or the general ×N form "<number> times that many"
+    // (number axis × fixed tail, so any ×N word is covered without per-factor
+    // tags). A standalone fn so it carries no capture lifetime into the scan.
+    fn multiplier_head(i: &str) -> OracleResult<'_, u32> {
+        let n_times = |i| {
+            let (i, factor) = nom_primitives::parse_number.parse(i)?;
+            let (i, _) = tag(" times that many").parse(i)?;
+            Ok((i, factor))
+        };
+        alt((value(2u32, tag("twice that many")), n_times)).parse(i)
+    }
+
+    // Input is already lowercase, so try `multiplier_head` at each word boundary
+    // via the shared scan helper (cf. `scan_for_phase`) rather than re-rolling
+    // the loop.
+    nom_primitives::scan_at_word_boundaries(lower, multiplier_head)
 }
 
 /// CR 614.1a + CR 111.1: Extract the "those tokens plus <spec> (is|are) created
@@ -6152,7 +6188,7 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
     let modification = if nom_primitives::scan_contains(lower, "half that many") {
         QuantityModification::Half
     } else if nom_primitives::scan_contains(lower, "twice that many") {
-        QuantityModification::Double
+        QuantityModification::DOUBLE
     } else if let Some(rest) = strip_after(lower, "that many plus ") {
         // "that many plus one ... counters are put on it instead"
         // Delegate to nom_primitives::parse_number (input already lowercase)
@@ -8883,7 +8919,7 @@ mod tests {
         assert_eq!(def.event, ReplacementEvent::LoseLife);
         assert_eq!(
             def.quantity_modification,
-            Some(QuantityModification::Double)
+            Some(QuantityModification::DOUBLE)
         );
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::Opponent));
     }
@@ -12276,9 +12312,47 @@ mod tests {
         assert_eq!(def.event, ReplacementEvent::CreateToken);
         assert_eq!(
             def.quantity_modification,
-            Some(QuantityModification::Double)
+            Some(QuantityModification::DOUBLE)
         );
         assert_eq!(def.token_owner_scope, Some(ControllerRef::You));
+    }
+
+    #[test]
+    fn ojer_taq_token_triplication_replacement() {
+        // CR 614.1a + CR 111.1: "three times that many" parameterizes the ×N
+        // token multiplier (factor 3), gated to creature tokens.
+        let def = parse_replacement_line(
+            "If one or more creature tokens would be created under your control, three times that many of those tokens are created instead.",
+            "Ojer Taq, Deepest Foundation",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::CreateToken);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Times { factor: 3 })
+        );
+        assert_eq!(def.token_owner_scope, Some(ControllerRef::You));
+        // CR 111.1: gated on creature tokens only.
+        assert!(matches!(
+            def.condition,
+            Some(ReplacementCondition::TokenCoreTypeMatches { ref core_types })
+                if core_types == &vec![crate::types::card_type::CoreType::Creature]
+        ));
+    }
+
+    #[test]
+    fn token_doubling_via_twice_is_factor_two() {
+        // Regression: "twice that many" still parameterizes to factor 2 after
+        // the Double → Times { factor } migration.
+        let def = parse_replacement_line(
+            "If one or more tokens would be created under your control, twice that many tokens are created instead.",
+            "Parallel Lives",
+        )
+        .unwrap();
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Times { factor: 2 })
+        );
     }
 
     #[test]
@@ -12371,7 +12445,7 @@ mod tests {
         assert_eq!(def.event, ReplacementEvent::AddCounter);
         assert_eq!(
             def.quantity_modification,
-            Some(QuantityModification::Double)
+            Some(QuantityModification::DOUBLE)
         );
         assert!(matches!(
             def.valid_card,
@@ -13200,7 +13274,7 @@ mod tests {
         let def = parse_token_replacement(lower, lower).expect("double shape parses");
         assert!(matches!(
             def.quantity_modification,
-            Some(crate::types::ability::QuantityModification::Double)
+            Some(crate::types::ability::QuantityModification::DOUBLE)
         ));
         assert!(def.additional_token_spec.is_none());
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -15102,8 +15102,15 @@ pub enum DamageModification {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum QuantityModification {
-    /// count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession
-    Double,
+    /// count * factor — the general multiplicative replacement. `factor: 2`
+    /// covers Doubling Season / Primal Vigor / Parallel Lives / Anointed
+    /// Procession; `factor: 3` covers Ojer Taq, Deepest Foundation ("three
+    /// times that many of those tokens are created instead"). Parameterized
+    /// from the former `Double` (×2) so the multiplicative axis is one variant
+    /// rather than a `Double` / `Triple` sibling cluster (cf.
+    /// `ManaModification::Multiply { factor }`). `Times { factor: 2 }` is the
+    /// canonical doubling constructor; see `QuantityModification::DOUBLE`.
+    Times { factor: u32 },
     /// count / 2 rounded down — Halving Season
     Half,
     /// count + value — Hardened Scales (+1)
@@ -15130,6 +15137,14 @@ pub enum QuantityModification {
     /// SelfRef` for permanent-scoped protection and with player-scope filters
     /// for the future Solemnity-class global variant.
     Prevent,
+}
+
+impl QuantityModification {
+    /// CR 614.1a: Canonical doubling modifier (×2) — Doubling Season, Primal
+    /// Vigor, Parallel Lives, Hardened Scales' counter peers, etc. A named
+    /// constructor for the common `Times { factor: 2 }` so the dozens of
+    /// doubling call sites stay self-documenting.
+    pub const DOUBLE: Self = Self::Times { factor: 2 };
 }
 
 /// CR 106.3 + CR 614.1a: Mana-production replacement payload.

--- a/crates/engine/tests/std_longtail_e.rs
+++ b/crates/engine/tests/std_longtail_e.rs
@@ -9,9 +9,18 @@
 //! Building-block win (named-token parsing): "Primo, the Indivisible, a legendary
 //! 0/0 … token" — a multi-comma legendary token name now parses.
 //!
+//! Building-block win (token-count multiplier): Ojer Taq, Deepest Foundation —
+//! "three times that many of those tokens are created instead" now parses to the
+//! parameterized `QuantityModification::Times { factor: 3 }` (the former ×2
+//! `Double` is now `Times { factor: 2 }`). See the runtime triplication +
+//! creature-gate tests in `game::replacement::tests`.
+//!
 //! Deferred (honest `Effect::unimplemented` / SwallowedClause retained, NOT
-//! asserted 0-unimpl): Ojer Taq (token-triplication replacement — heavy CR 616
-//! commute interaction), Vraska the Silencer (return-as-Treasure-with-ability —
+//! asserted 0-unimpl): Moonlit Meditation (first-time-each-turn optional
+//! CreateToken replacement that overrides the spec to copies of the enchanted
+//! permanent — needs a per-turn token-creation gate, an Optional CreateToken
+//! pipeline, and a dynamic host-copy spec; out of scope for the multiplier
+//! parameterization), Vraska the Silencer (return-as-Treasure-with-ability —
 //! heavy continuous-self-modification infra), Zimone (prime-number intervening-if
 //! condition — heavy primality predicate; the token+counter parse is fixed, the
 //! card stays honestly condition-unsupported via a SwallowedClause warning).
@@ -255,4 +264,43 @@ fn contested_game_ball_attacker_gains_control_and_untaps() {
     );
     // The recipient really came from the triggering source's controller.
     let _ = TargetFilter::TriggeringSourceController;
+}
+
+// ---------------------------------------------------------------------------
+// Ojer Taq, Deepest Foundation — token-count ×3 multiplier replacement
+// ---------------------------------------------------------------------------
+
+/// CR 614.1a + CR 111.1: The full front-face oracle parses with zero
+/// `Unimplemented` nodes. The previously-deferred token-triplication line
+/// ("three times that many of those tokens are created instead") now lowers to a
+/// `CreateToken` replacement carrying the parameterized
+/// `QuantityModification::Times { factor: 3 }` multiplier, gated to creature
+/// tokens. Vigilance and the dies-trigger already parsed; this asserts they
+/// stay clean alongside the new replacement. Reverting the multiplier parser
+/// leaves the line `Unimplemented`, flipping `assert_zero_unimplemented` and the
+/// replacement-shape assertions below.
+#[test]
+fn ojer_taq_token_triplication_full_card_parses() {
+    use engine::types::ability::QuantityModification;
+    use engine::types::replacements::ReplacementEvent;
+
+    let parsed = parse(
+        "Vigilance\nIf one or more creature tokens would be created under your control, three times that many of those tokens are created instead.\nWhen Ojer Taq, Deepest Foundation dies, return it transformed.",
+        "Ojer Taq, Deepest Foundation",
+        &["Vigilance"],
+        &["Legendary", "Creature"],
+        &["God"],
+    );
+    assert_zero_unimplemented(&parsed, "Ojer Taq, Deepest Foundation");
+
+    let token_repl = parsed
+        .replacements
+        .iter()
+        .find(|r| r.event == ReplacementEvent::CreateToken)
+        .expect("Ojer Taq must produce a CreateToken replacement");
+    assert_eq!(
+        token_repl.quantity_modification,
+        Some(QuantityModification::Times { factor: 3 }),
+        "Ojer Taq must triplicate (Times {{ factor: 3 }}), not double"
+    );
 }

--- a/crates/mtgish-import/src/convert/replacement.rs
+++ b/crates/mtgish-import/src/convert/replacement.rs
@@ -1033,11 +1033,11 @@ fn graveyard_action_to_destination(
 /// - `Plus(WouldPutCounters_NumberOfCounters, Integer(n))` →
 ///   `QuantityModification::Plus { value: n }`
 /// - `Twice(WouldPutCounters_NumberOfCounters)` →
-///   `QuantityModification::Double`
+///   `QuantityModification::DOUBLE` (`Times { factor: 2 }`)
 ///
-/// Other quantity expressions (multipliers other than 2, references to
-/// other game state) strict-fail until `QuantityModification` grows
-/// additional axes.
+/// Other quantity expressions (multipliers other than 2 — the engine's
+/// `Times { factor }` axis exists but no mtgish counter idiom emits a
+/// non-2 multiplier — or references to other game state) strict-fail.
 pub fn convert_replace_would_put_counters(
     event: &ReplacableEventWouldPutCounters,
     actions: &[ReplacementActionWouldPutCounters],
@@ -1179,7 +1179,7 @@ fn game_number_to_modification(
     idiom: &'static str,
 ) -> ConvResult<QuantityModification> {
     match g {
-        GameNumber::Twice(inner) if is_self_ref(inner) => Ok(QuantityModification::Double),
+        GameNumber::Twice(inner) if is_self_ref(inner) => Ok(QuantityModification::DOUBLE),
         GameNumber::Plus(a, b) if is_self_ref(a) || is_self_ref(b) => {
             let n_node = if is_self_ref(a) { &**b } else { &**a };
             match n_node {
@@ -1223,8 +1223,8 @@ fn game_number_to_modification(
 ///
 /// - `GainLife(Plus(LifeAmount, Integer(N)))` →
 ///   `QuantityModification::Plus { value: N }` (Hardened-Heart pattern).
-/// - `GainLife(Twice(LifeAmount))` → `QuantityModification::Double`
-///   (Boon Reflection / Rhox Faithmender).
+/// - `GainLife(Twice(LifeAmount))` → `QuantityModification::DOUBLE`
+///   (`Times { factor: 2 }`; Boon Reflection / Rhox Faithmender).
 ///
 /// Other actions (DrawNumberCards, GainNoLifeInstead, LoseLife,
 /// PlayerAction wrappers) strict-fail.

--- a/crates/phase-ai/src/features/plus_one_counters.rs
+++ b/crates/phase-ai/src/features/plus_one_counters.rs
@@ -292,7 +292,7 @@ pub(crate) fn replacement_modifies_p1p1_counters_parts(rep: &ReplacementDefiniti
         && matches!(
             rep.quantity_modification,
             Some(
-                QuantityModification::Double
+                QuantityModification::Times { .. }
                     | QuantityModification::Plus { .. }
                     | QuantityModification::Minus { .. }
             )
@@ -442,7 +442,7 @@ mod tests {
 
     fn doubler_replacement() -> ReplacementDefinition {
         let mut rep = ReplacementDefinition::new(ReplacementEvent::AddCounter);
-        rep.quantity_modification = Some(QuantityModification::Double);
+        rep.quantity_modification = Some(QuantityModification::DOUBLE);
         rep
     }
 

--- a/crates/phase-ai/src/saved_state.rs
+++ b/crates/phase-ai/src/saved_state.rs
@@ -28,8 +28,11 @@ fn migrate_saved_state(value: &mut Value) {
             if let Some(condition) = map.get_mut("condition") {
                 migrate_condition(condition);
             }
+            if let Some(modification) = map.get_mut("quantity_modification") {
+                migrate_quantity_modification(modification);
+            }
             for (key, value) in map {
-                if key != "effect" && key != "condition" {
+                if key != "effect" && key != "condition" && key != "quantity_modification" {
                     migrate_saved_state(value);
                 }
             }
@@ -54,6 +57,15 @@ fn migrate_condition(condition: &mut Value) {
         }
     }
     migrate_saved_state(condition);
+}
+
+fn migrate_quantity_modification(modification: &mut Value) {
+    if let Value::Object(map) = modification {
+        if migrate_legacy_double_quantity(map) {
+            return;
+        }
+    }
+    migrate_saved_state(modification);
 }
 
 fn migrate_legacy_tap_effect(map: &mut Map<String, Value>) -> bool {
@@ -90,6 +102,20 @@ fn migrate_legacy_attackers_declared_min(map: &mut Map<String, Value>) -> bool {
     map.insert("subject".to_string(), Value::Object(subject));
     map.insert("comparator".to_string(), Value::String("GE".to_string()));
     map.insert("count".to_string(), count);
+    true
+}
+
+/// `QuantityModification::Double` (unit) was parameterized into `Times { factor }`
+/// (factor 2 = the former doubling; factor 3 = Ojer Taq, Deepest Foundation).
+/// Saved states captured before that change carry `{"type":"Double"}`; rewrite
+/// them to the equivalent `{"type":"Times","factor":2}` so old replacement
+/// definitions keep loading.
+fn migrate_legacy_double_quantity(map: &mut Map<String, Value>) -> bool {
+    let Some("Double") = map.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+    map.insert("type".to_string(), Value::String("Times".to_string()));
+    map.insert("factor".to_string(), Value::from(2));
     true
 }
 
@@ -171,6 +197,37 @@ mod tests {
                 "scope": { "type": "All" },
                 "state": { "type": "Untap" }
             })
+        );
+    }
+
+    #[test]
+    fn migrates_legacy_double_quantity_modification_without_touching_effect_double() {
+        let mut value = json!({
+            "gameState": {
+                "replacement_definitions": [
+                    {
+                        "quantity_modification": { "type": "Double" }
+                    }
+                ],
+                "stack": [
+                    {
+                        "effect": { "type": "Double", "target_kind": { "type": "Tokens" } }
+                    }
+                ]
+            }
+        });
+
+        migrate_saved_state(&mut value);
+
+        // The renamed QuantityModification is rewritten to the parameterized form.
+        assert_eq!(
+            value["gameState"]["replacement_definitions"][0]["quantity_modification"],
+            json!({ "type": "Times", "factor": 2 })
+        );
+        // Effect::Double is a different (unchanged) enum and must be left intact.
+        assert_eq!(
+            value["gameState"]["stack"][0]["effect"],
+            json!({ "type": "Double", "target_kind": { "type": "Tokens" } })
         );
     }
 

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -1,32 +1,32 @@
 {
   "sources": [
-    "crates/engine/src/types/zones.rs",
-    "crates/engine/src/types/game_state.rs",
-    "crates/engine/src/types/mana.rs",
-    "crates/engine/src/types/layers.rs",
-    "crates/engine/src/types/mod.rs",
-    "crates/engine/src/types/actions.rs",
-    "crates/engine/src/types/attribution.rs",
-    "crates/engine/src/types/card_type.rs",
-    "crates/engine/src/types/player.rs",
-    "crates/engine/src/types/identifiers.rs",
-    "crates/engine/src/types/counter.rs",
-    "crates/engine/src/types/proposed_event.rs",
     "crates/engine/src/types/format.rs",
-    "crates/engine/src/types/match_config.rs",
+    "crates/engine/src/types/actions.rs",
     "crates/engine/src/types/replacements.rs",
+    "crates/engine/src/types/identifiers.rs",
     "crates/engine/src/types/events.rs",
-    "crates/engine/src/types/definitions.rs",
-    "crates/engine/src/types/log.rs",
-    "crates/engine/src/types/ability.rs",
-    "crates/engine/src/types/phase.rs",
-    "crates/engine/src/types/triggers.rs",
+    "crates/engine/src/types/proposed_event.rs",
     "crates/engine/src/types/keywords.rs",
     "crates/engine/src/types/statics.rs",
-    "crates/engine/src/types/card.rs"
+    "crates/engine/src/types/triggers.rs",
+    "crates/engine/src/types/definitions.rs",
+    "crates/engine/src/types/ability.rs",
+    "crates/engine/src/types/log.rs",
+    "crates/engine/src/types/game_state.rs",
+    "crates/engine/src/types/phase.rs",
+    "crates/engine/src/types/counter.rs",
+    "crates/engine/src/types/mod.rs",
+    "crates/engine/src/types/layers.rs",
+    "crates/engine/src/types/match_config.rs",
+    "crates/engine/src/types/card.rs",
+    "crates/engine/src/types/player.rs",
+    "crates/engine/src/types/mana.rs",
+    "crates/engine/src/types/zones.rs",
+    "crates/engine/src/types/attribution.rs",
+    "crates/engine/src/types/card_type.rs"
   ],
-  "enum_count": 297,
-  "variant_count": 3168,
+  "enum_count": 308,
+  "variant_count": 3250,
   "smell_summary": [
     {
       "enum_name": "AbilityCondition",
@@ -496,7 +496,7 @@
   "enums": {
     "AbilityActivationScope": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 288,
+      "line": 322,
       "doc": "CR 106.6: The ability-activation half of a \"spend only to cast [X] spell or activate …\" restriction. Parameterizes *which* ability activations the mana may also be spent on, so the spell-type + ability-activation OR restriction needs a single variant rather than a sibling per ability scope.",
       "cr_refs": [
         "CR 106.6"
@@ -504,7 +504,7 @@
       "variants": [
         {
           "name": "OfSpellType",
-          "line": 292,
+          "line": 326,
           "kind": "unit",
           "field_names": [],
           "doc": "\"… or activate abilities of [the spell's type]\" — only abilities on a permanent whose type matches the restriction's `spell_type` (e.g. \"cast creature spells or activate abilities of creatures\").",
@@ -512,7 +512,7 @@
         },
         {
           "name": "Any",
-          "line": 295,
+          "line": 329,
           "kind": "unit",
           "field_names": [],
           "doc": "\"… or to activate an ability\" — any ability activation is permitted (e.g. Sage of the Unknowable, \"a colorless spell or to activate an ability\").",
@@ -523,13 +523,13 @@
     },
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12311,
+      "line": 13191,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 12329,
+          "line": 13209,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -550,7 +550,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 12360,
+          "line": 13240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -561,7 +561,7 @@
         },
         {
           "name": "AlternativeManaCostPaid",
-          "line": 12364,
+          "line": 13244,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
@@ -572,7 +572,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 12369,
+          "line": 13249,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -586,7 +586,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 12374,
+          "line": 13254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -596,7 +596,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 12382,
+          "line": 13262,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -606,7 +606,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 12385,
+          "line": 13265,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -618,7 +618,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 12389,
+          "line": 13269,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -631,7 +631,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 12392,
+          "line": 13272,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -644,7 +644,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 12395,
+          "line": 13275,
           "kind": "struct",
           "field_names": [
             "color",
@@ -658,7 +658,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 12405,
+          "line": 13285,
           "kind": "struct",
           "field_names": [
             "card_types",
@@ -672,7 +672,7 @@
         },
         {
           "name": "ObjectsShareQuality",
-          "line": 12427,
+          "line": 13307,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -687,7 +687,7 @@
         },
         {
           "name": "TargetSharesNameWithOtherExiledThisWay",
-          "line": 12435,
+          "line": 13315,
           "kind": "struct",
           "field_names": [
             "target"
@@ -700,7 +700,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 12439,
+          "line": 13319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -711,7 +711,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 12442,
+          "line": 13322,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -724,7 +724,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 12447,
+          "line": 13327,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -738,7 +738,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 12451,
+          "line": 13331,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -752,7 +752,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 12460,
+          "line": 13340,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -766,7 +766,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 12465,
+          "line": 13345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -776,7 +776,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 12467,
+          "line": 13347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -786,7 +786,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 12470,
+          "line": 13350,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the ability controller has the initiative designation.",
@@ -796,7 +796,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 12473,
+          "line": 13353,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -806,7 +806,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 12477,
+          "line": 13357,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -818,7 +818,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 12482,
+          "line": 13362,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -832,7 +832,7 @@
         },
         {
           "name": "TriggeringSpellTargetsFilter",
-          "line": 12494,
+          "line": 13374,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -845,7 +845,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 12498,
+          "line": 13378,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -857,7 +857,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 12503,
+          "line": 13383,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -873,7 +873,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 12515,
+          "line": 13395,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -886,7 +886,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 12519,
+          "line": 13399,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -899,7 +899,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 12523,
+          "line": 13403,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -909,7 +909,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 12531,
+          "line": 13411,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -922,7 +922,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 12536,
+          "line": 13416,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -935,7 +935,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 12541,
+          "line": 13421,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -946,8 +946,20 @@
           ]
         },
         {
+          "name": "FirstEndStepOfTurn",
+          "line": 13426,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 500.8 + CR 513.1 + CR 608.2c: \"if it's the first end step of the turn\". Gates a follow-up effect on whether this is the first end step started this turn (Y'shtola Rhul's additional-end-step loop guard). End-step sibling of `FirstCombatPhaseOfTurn`; both read a per-turn phase-occurrence counter.",
+          "cr_refs": [
+            "CR 500.8",
+            "CR 513.1",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "ZoneChangedThisWay",
-          "line": 12547,
+          "line": 13432,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -959,7 +971,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 12551,
+          "line": 13436,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -973,7 +985,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 12554,
+          "line": 13439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -983,7 +995,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 12562,
+          "line": 13447,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: \"if this permanent is attached to a creature you control\" — checks whether the source Aura/Equipment is currently attached to a creature controlled by the ability's controller. Used at the effect-resolution seam by optional bestow-trigger branches like Springheart Nantuko's landfall pay (the trigger itself fires regardless; only the optional payment / copy-token sub-ability is gated on attachment so the fallback Insect token branch can still resolve when the Aura is unattached).",
@@ -994,7 +1006,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 12571,
+          "line": 13456,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -1007,7 +1019,7 @@
         },
         {
           "name": "And",
-          "line": 12576,
+          "line": 13461,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -1019,7 +1031,7 @@
         },
         {
           "name": "Or",
-          "line": 12581,
+          "line": 13466,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -1031,7 +1043,7 @@
         },
         {
           "name": "Not",
-          "line": 12589,
+          "line": 13474,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1043,7 +1055,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 12593,
+          "line": 13478,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -1053,7 +1065,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 12595,
+          "line": 13480,
           "kind": "struct",
           "field_names": [
             "state"
@@ -1065,7 +1077,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 12605,
+          "line": 13490,
           "kind": "struct",
           "field_names": [
             "n"
@@ -1077,7 +1089,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 12608,
+          "line": 13493,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -1089,7 +1101,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 12628,
+          "line": 13513,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -1115,13 +1127,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5808,
+      "line": 6119,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 5809,
+          "line": 6120,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1131,7 +1143,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 5818,
+          "line": 6129,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -1144,7 +1156,7 @@
         },
         {
           "name": "Tap",
-          "line": 5821,
+          "line": 6132,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1152,7 +1164,7 @@
         },
         {
           "name": "Untap",
-          "line": 5822,
+          "line": 6133,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1160,7 +1172,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 5823,
+          "line": 6134,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1170,7 +1182,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 5826,
+          "line": 6137,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -1178,7 +1190,7 @@
         },
         {
           "name": "PayLife",
-          "line": 5832,
+          "line": 6143,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1190,7 +1202,7 @@
         },
         {
           "name": "Discard",
-          "line": 5835,
+          "line": 6146,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1203,7 +1215,7 @@
         },
         {
           "name": "Exile",
-          "line": 5846,
+          "line": 6157,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1215,7 +1227,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 5860,
+          "line": 6171,
           "kind": "struct",
           "field_names": [
             "materials",
@@ -1228,7 +1240,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 5867,
+          "line": 6178,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1241,18 +1253,22 @@
         },
         {
           "name": "TapCreatures",
-          "line": 5870,
+          "line": 6187,
           "kind": "struct",
           "field_names": [
-            "count",
+            "requirement",
             "filter"
           ],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 601.2b: Tap creatures as an additional/activation cost. The `requirement` axis selects between a fixed count (Conspire's \"tap two creatures\") and an aggregate \"any number with total power N or greater\" constraint (Crew CR 702.122a / Saddle CR 702.171a / Teamwork). Legacy JSON that carries a bare `count` field (no `requirement` discriminant) deserializes into `Count { count }` via `deserialize_tap_creatures_requirement`.",
+          "cr_refs": [
+            "CR 601.2b",
+            "CR 702.122a",
+            "CR 702.171a"
+          ]
         },
         {
           "name": "RemoveCounter",
-          "line": 5880,
+          "line": 6202,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1268,7 +1284,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 5888,
+          "line": 6210,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1278,7 +1294,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 5892,
+          "line": 6214,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1291,7 +1307,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 5900,
+          "line": 6222,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1305,7 +1321,7 @@
         },
         {
           "name": "Unattach",
-          "line": 5909,
+          "line": 6231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1315,7 +1331,7 @@
         },
         {
           "name": "Mill",
-          "line": 5910,
+          "line": 6232,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1325,7 +1341,7 @@
         },
         {
           "name": "Exert",
-          "line": 5913,
+          "line": 6235,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1333,7 +1349,7 @@
         },
         {
           "name": "Blight",
-          "line": 5916,
+          "line": 6238,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1343,7 +1359,7 @@
         },
         {
           "name": "Reveal",
-          "line": 5919,
+          "line": 6241,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1354,7 +1370,7 @@
         },
         {
           "name": "Behold",
-          "line": 5927,
+          "line": 6249,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1366,7 +1382,7 @@
         },
         {
           "name": "Composite",
-          "line": 5933,
+          "line": 6255,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1376,7 +1392,7 @@
         },
         {
           "name": "OneOf",
-          "line": 5950,
+          "line": 6272,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1389,7 +1405,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 5954,
+          "line": 6276,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1399,7 +1415,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 5959,
+          "line": 6281,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1412,7 +1428,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 5966,
+          "line": 6288,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1424,7 +1440,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 5982,
+          "line": 6304,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1438,7 +1454,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 5987,
+          "line": 6309,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1451,13 +1467,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11261,
+      "line": 12083,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 11263,
+          "line": 12085,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1465,7 +1481,7 @@
         },
         {
           "name": "Activated",
-          "line": 11264,
+          "line": 12086,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1473,7 +1489,7 @@
         },
         {
           "name": "Database",
-          "line": 11265,
+          "line": 12087,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1481,7 +1497,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 11268,
+          "line": 12090,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1489,7 +1505,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 11274,
+          "line": 12096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1502,7 +1518,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11439,
+      "line": 12261,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1510,7 +1526,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 11441,
+          "line": 12263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1520,7 +1536,7 @@
         },
         {
           "name": "Evolve",
-          "line": 11443,
+          "line": 12265,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1530,7 +1546,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 11445,
+          "line": 12267,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1540,7 +1556,7 @@
         },
         {
           "name": "Outlast",
-          "line": 11447,
+          "line": 12269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1550,7 +1566,7 @@
         },
         {
           "name": "Cycling",
-          "line": 11452,
+          "line": 12274,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1562,12 +1578,33 @@
         },
         {
           "name": "Backup",
-          "line": 11454,
+          "line": 12276,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.165a: ability originated from a Backup keyword definition.",
           "cr_refs": [
             "CR 702.165a"
+          ]
+        },
+        {
+          "name": "PowerUp",
+          "line": 12278,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 602.5b + CR 602.1: This ability originated from a Power-up keyword definition.",
+          "cr_refs": [
+            "CR 602.1",
+            "CR 602.5b"
+          ]
+        },
+        {
+          "name": "Equip",
+          "line": 12280,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.6a: This ability originated from an Equip keyword definition.",
+          "cr_refs": [
+            "CR 702.6a"
           ]
         }
       ],
@@ -1604,13 +1641,13 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11462,
+      "line": 12307,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 11463,
+          "line": 12308,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1618,7 +1655,7 @@
         },
         {
           "name": "AsInstant",
-          "line": 11464,
+          "line": 12309,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1626,7 +1663,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 11465,
+          "line": 12310,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1634,7 +1671,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 11466,
+          "line": 12311,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1642,7 +1679,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 11467,
+          "line": 12312,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1650,7 +1687,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 11468,
+          "line": 12313,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1658,7 +1695,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 11469,
+          "line": 12314,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1666,7 +1703,7 @@
         },
         {
           "name": "OnlyOnceEachTurn",
-          "line": 11470,
+          "line": 12315,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1674,7 +1711,7 @@
         },
         {
           "name": "OnlyOnce",
-          "line": 11471,
+          "line": 12316,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1682,7 +1719,7 @@
         },
         {
           "name": "MaxTimesEachTurn",
-          "line": 11472,
+          "line": 12317,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1692,7 +1729,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 11475,
+          "line": 12320,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1702,7 +1739,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 11479,
+          "line": 12324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1712,7 +1749,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 11481,
+          "line": 12326,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1724,7 +1761,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 11486,
+          "line": 12331,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1738,7 +1775,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 11497,
+          "line": 12342,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1752,7 +1789,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 11510,
+          "line": 12355,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1765,13 +1802,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6212,
+      "line": 6534,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 6218,
+          "line": 6540,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1782,7 +1819,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6233,
+          "line": 6555,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1798,7 +1835,7 @@
         },
         {
           "name": "Choice",
-          "line": 6245,
+          "line": 6567,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1806,7 +1843,7 @@
         },
         {
           "name": "Required",
-          "line": 6247,
+          "line": 6569,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1817,7 +1854,7 @@
     },
     "AdditionalCostOrigin": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6255,
+      "line": 6577,
       "doc": "CR 113.2c + CR 601.2b/f: Linked identity for one independently functioning additional-cost keyword instance. Cast-time copy triggers read their own Casualty/Replicate payments via CR 702.153b / CR 702.56b; ETB-linked Squad/Offspring triggers read their own payments via CR 607.2g.",
       "cr_refs": [
         "CR 113.2c",
@@ -1829,7 +1866,7 @@
       "variants": [
         {
           "name": "Kicker",
-          "line": 6256,
+          "line": 6578,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1837,7 +1874,7 @@
         },
         {
           "name": "Casualty",
-          "line": 6257,
+          "line": 6579,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1845,7 +1882,7 @@
         },
         {
           "name": "Offspring",
-          "line": 6258,
+          "line": 6580,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1853,7 +1890,7 @@
         },
         {
           "name": "Squad",
-          "line": 6259,
+          "line": 6581,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1861,15 +1898,25 @@
         },
         {
           "name": "Replicate",
-          "line": 6260,
+          "line": 6582,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "Teamwork",
+          "line": 6588,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 601.2b/f: Teamwork's optional \"tap any number of creatures with total power N or more\" additional cost. A dedicated origin lets \"this spell was cast using teamwork\" riders test the Teamwork payment specifically (not any optional additional cost) and lets Teamwork compose with another object additional cost in the announcement queue.",
+          "cr_refs": [
+            "CR 601.2b"
+          ]
+        },
+        {
           "name": "Other",
-          "line": 6262,
+          "line": 6590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1880,7 +1927,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6367,
+      "line": 6695,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1888,7 +1935,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 6369,
+          "line": 6697,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1896,7 +1943,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6370,
+          "line": 6698,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1904,7 +1951,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 6371,
+          "line": 6699,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1915,13 +1962,13 @@
     },
     "AdditionalCostRepeatability": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2906,
+      "line": 3051,
       "doc": "Whether an optional or kicker additional cost may be paid multiple times.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Once",
-          "line": 2909,
+          "line": 3054,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay at most once (ordinary kicker / optional cost).",
@@ -1929,7 +1976,7 @@
         },
         {
           "name": "Repeatable",
-          "line": 2911,
+          "line": 3056,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay any number of times (multikicker, replicate).",
@@ -1940,7 +1987,7 @@
     },
     "AdditionalCostTaxAction": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 569,
+      "line": 576,
       "doc": "CR 601.2f: Whether a static-imposed additional cost applies to spell casting. Distinct from [`CostModifyMode`], which only adjusts the mana component.",
       "cr_refs": [
         "CR 601.2f"
@@ -1948,7 +1995,7 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 571,
+          "line": 578,
           "kind": "unit",
           "field_names": [],
           "doc": "\"... cost an additional N life to cast.\"",
@@ -1959,7 +2006,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4129,
+      "line": 4309,
       "doc": "Reduction applied when collapsing a set of per-object values (CR 208.1 power/ toughness, CR 202.3 mana value) into a single number. The Comprehensive Rules define no standalone \"aggregate function\" rule; this enum names the reduction kind used by the various property-aggregate `QuantityRef` variants.",
       "cr_refs": [
         "CR 202.3",
@@ -1968,7 +2015,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 4130,
+          "line": 4310,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1976,7 +2023,7 @@
         },
         {
           "name": "Min",
-          "line": 4131,
+          "line": 4311,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1984,7 +2031,7 @@
         },
         {
           "name": "Sum",
-          "line": 4132,
+          "line": 4312,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2029,7 +2076,7 @@
     },
     "AlternativeCastKeyword": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2362,
+      "line": 2373,
       "doc": "CR 118.9: Identifies which keyword ability granted an alternative casting cost so the `WaitingFor::AlternativeCastChoice` dispatcher can route to the keyword-specific post-payment handler. The four keywords share a single player decision shape (printed cost vs. alternative cost) but diverge in post-payment semantics — this enum keeps the prompt unified while preserving CR fidelity at resolution.  Adding a new alternative-cost keyword (e.g., Madness CR 702.35a, Spectacle CR 702.137a) is a compile error at every dispatch site until handled.",
       "cr_refs": [
         "CR 118.9",
@@ -2039,7 +2086,7 @@
       "variants": [
         {
           "name": "Warp",
-          "line": 2364,
+          "line": 2375,
           "kind": "unit",
           "field_names": [],
           "doc": "Custom Warp keyword — exile-at-end-step rider; no CR section.",
@@ -2047,7 +2094,7 @@
         },
         {
           "name": "Evoke",
-          "line": 2367,
+          "line": 2378,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: ETB + sacrifice trigger fires when the resolving permanent was cast for its evoke cost (CR 702.74b).",
@@ -2058,7 +2105,7 @@
         },
         {
           "name": "Emerge",
-          "line": 2370,
+          "line": 2381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.119a-c: Emerge alternative cost requires sacrificing a creature while casting and reduces the emerge cost by that creature's mana value.",
@@ -2068,7 +2115,7 @@
         },
         {
           "name": "Dash",
-          "line": 2373,
+          "line": 2384,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.109a: Cast for the dash cost — the resolving permanent gains haste and is returned to its owner's hand at the next end step.",
@@ -2078,7 +2125,7 @@
         },
         {
           "name": "Blitz",
-          "line": 2376,
+          "line": 2387,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.152a: Cast for the blitz cost — the resolving permanent gains haste and a dies-draw trigger, and is sacrificed at the next end step.",
@@ -2088,7 +2135,7 @@
         },
         {
           "name": "Overload",
-          "line": 2378,
+          "line": 2389,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a: Spell's text changes \"target\" to \"each\" (CR 702.96b-c).",
@@ -2099,7 +2146,7 @@
         },
         {
           "name": "Bestow",
-          "line": 2380,
+          "line": 2391,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a: Spell becomes an Aura with enchant creature (CR 702.103b).",
@@ -2110,7 +2157,7 @@
         },
         {
           "name": "Awaken",
-          "line": 2385,
+          "line": 2396,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: \"If this spell's awaken cost was paid, put N +1/+1 counters on target land you control. That land becomes a 0/0 Elemental creature with haste. It's still a land.\" Paying the awaken cost adds the land target (CR 702.113b); casting normally adds no target and no rider.",
@@ -2121,7 +2168,7 @@
         },
         {
           "name": "Cleave",
-          "line": 2388,
+          "line": 2399,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Paying the cleave cost removes every square-bracketed span from the spell's text (a text-changing effect).",
@@ -2132,7 +2179,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 2390,
+          "line": 2401,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a: Cast converted (back face up, CR 712.14a) for the MTMTE cost.",
@@ -2143,7 +2190,7 @@
         },
         {
           "name": "Impending",
-          "line": 2394,
+          "line": 2405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Impending alternative cost paid from hand. On resolution the permanent enters with N time counters and isn't a creature until the last is removed. An end-step trigger removes one counter per turn.",
@@ -2153,7 +2200,7 @@
         },
         {
           "name": "Prototype",
-          "line": 2398,
+          "line": 2409,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Prototype alternative cost paid from hand. The resulting spell/permanent uses the secondary power, toughness, and mana cost characteristics while it is a creature.",
@@ -2163,7 +2210,7 @@
         },
         {
           "name": "Mutate",
-          "line": 2403,
+          "line": 2414,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a: Mutate alternative cost paid from hand. The spell becomes a mutating creature spell targeting a non-Human creature the caster owns (CR 702.140a); on resolution it merges with that creature (CR 730) rather than entering the battlefield, unless the target is illegal (CR 702.140b).",
@@ -2175,12 +2222,22 @@
         },
         {
           "name": "Spectacle",
-          "line": 2407,
+          "line": 2418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cost paid from hand, available only if an opponent lost life this turn. A pure cost substitution — the spell resolves normally (no riders); spectacle changes only how the cost is paid.",
           "cr_refs": [
             "CR 702.137a"
+          ]
+        },
+        {
+          "name": "Prowl",
+          "line": 2424,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.76a: Prowl alternative cost paid from hand, available only if a creature the caster controlled dealt combat damage to a player this turn while sharing one of the spell's creature types. A pure cost substitution — the spell resolves normally; the prowl provenance is recorded so \"if its prowl cost was paid\" intervening-ifs (Latchkey Faerie) can read it.",
+          "cr_refs": [
+            "CR 702.76a"
           ]
         }
       ],
@@ -2226,7 +2283,7 @@
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2161,
+      "line": 2268,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -2235,7 +2292,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 2163,
+          "line": 2270,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -2245,7 +2302,7 @@
         },
         {
           "name": "Equipment",
-          "line": 2165,
+          "line": 2272,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -2256,9 +2313,31 @@
       ],
       "sibling_clusters": []
     },
+    "AttackDefenderScope": {
+      "file": "crates/engine/src/types/statics.rs",
+      "line": 621,
+      "doc": "CR 508.5 + CR 802.1: Which defending player a `MaxAttackersEachCombat` cap restricts. `MaxAttackersEachCombat { defender: None }` is a global cap; `Some(_)` narrows the cap to attacks declared against a specific defending player, leaving attacks against other players unrestricted.",
+      "cr_refs": [
+        "CR 508.5",
+        "CR 802.1"
+      ],
+      "variants": [
+        {
+          "name": "Controller",
+          "line": 626,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 109.5: \"you\" — the controller of the permanent carrying this static (Judoon Enforcers: \"No more than one creature can attack you each combat\"). Resolved against the static source's controller at the declare-attackers step.",
+          "cr_refs": [
+            "CR 109.5"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "AttackScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4238,
+      "line": 4418,
       "doc": "CR 508.6: The time window over which \"attacked [a player]\" is measured.",
       "cr_refs": [
         "CR 508.6"
@@ -2266,7 +2345,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 4240,
+          "line": 4420,
           "kind": "unit",
           "field_names": [],
           "doc": "Across the whole turn, accumulated over every combat (CR 508.5).",
@@ -2276,7 +2355,7 @@
         },
         {
           "name": "ThisCombat",
-          "line": 4242,
+          "line": 4422,
           "kind": "unit",
           "field_names": [],
           "doc": "Within the current combat only (CR 702.121a Melee).",
@@ -2289,7 +2368,7 @@
     },
     "AttackSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4229,
+      "line": 4409,
       "doc": "CR 506.2 + CR 508.1b: Whose attacks the \"opponents attacked\" player set is measured over.",
       "cr_refs": [
         "CR 506.2",
@@ -2298,7 +2377,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 4231,
+          "line": 4411,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller — \"opponents you attacked\".",
@@ -2306,7 +2385,7 @@
         },
         {
           "name": "Source",
-          "line": 4233,
+          "line": 4413,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source creature — \"opponents this creature attacked\".",
@@ -2317,7 +2396,7 @@
     },
     "AttackTargetFilter": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 178,
+      "line": 181,
       "doc": "CR 508.3a: Filter for attack target type in \"attacks [a target]\" triggers.",
       "cr_refs": [
         "CR 508.3a"
@@ -2325,30 +2404,6 @@
       "variants": [
         {
           "name": "Player",
-          "line": 179,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Planeswalker",
-          "line": 180,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlayerOrPlaneswalker",
-          "line": 181,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Battle",
           "line": 182,
           "kind": "unit",
           "field_names": [],
@@ -2356,8 +2411,32 @@
           "cr_refs": []
         },
         {
-          "name": "Owner",
+          "name": "Planeswalker",
+          "line": 183,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PlayerOrPlaneswalker",
+          "line": 184,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Battle",
           "line": 185,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Owner",
+          "line": 188,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.1a: \"can't attack its owner\" — the permanent may not declare an attack against the player who owns it (distinct from controller).",
@@ -2368,7 +2447,7 @@
         },
         {
           "name": "OwnerOrPlaneswalker",
-          "line": 189,
+          "line": 192,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.1c: \"can't attack its owner or planeswalkers its owner controls\" restricts attacks against the owning player and planeswalkers that player controls.",
@@ -2376,13 +2455,26 @@
             "CR 506.2",
             "CR 508.1c"
           ]
+        },
+        {
+          "name": "PlayerOrPermanents",
+          "line": 198,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 508.1c + CR 508.5 + CR 109.4: \"you or permanents you control\" defends you plus every attackable permanent you control — planeswalkers AND battles (CR 310.5: battles can be attacked). Distinct from `PlayerOrPlaneswalker`, which excludes battles. Control of the defended planeswalker/battle is compared per CR 109.4.",
+          "cr_refs": [
+            "CR 109.4",
+            "CR 310.5",
+            "CR 508.1c",
+            "CR 508.5"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "AttackersDeclaredCountSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4772,
+      "line": 4976,
       "doc": "CR 508.1 / CR 508.1b: Subject axis for counting members of a triggering `AttackersDeclared` event.",
       "cr_refs": [
         "CR 508.1",
@@ -2391,7 +2483,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4780,
+          "line": 4984,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -2404,7 +2496,7 @@
         },
         {
           "name": "AttackTarget",
-          "line": 4787,
+          "line": 4991,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -2418,13 +2510,13 @@
     },
     "AutoMayChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 568,
+      "line": 579,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Accept",
-          "line": 569,
+          "line": 580,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2432,7 +2524,7 @@
         },
         {
           "name": "Decline",
-          "line": 570,
+          "line": 581,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2443,13 +2535,13 @@
     },
     "AutoPassMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4611,
+      "line": 4693,
       "doc": "What the engine stores for auto-pass (includes captured state).",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 4614,
+          "line": 4696,
           "kind": "struct",
           "field_names": [
             "initial_stack_len"
@@ -2459,7 +2551,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 4618,
+          "line": 4700,
           "kind": "unit",
           "field_names": [],
           "doc": "Auto-pass through priority/combat stops until the flagged player's next turn starts. Interrupted by opponent stack activity (MTGA-style) or when the current phase matches the player's entry in `GameState::phase_stops`.",
@@ -2470,13 +2562,13 @@
     },
     "AutoPassRequest": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4603,
+      "line": 4685,
       "doc": "What the frontend requests for auto-pass (no internal state).  Phase stops that should interrupt `UntilEndOfTurn` are a separate per-player preference on `GameState::phase_stops`, managed via `GameAction::SetPhaseStops`. Keeping them out of the request preserves a single source of truth and lets the preference change mid-session without requiring a new auto-pass request.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilStackEmpty",
-          "line": 4604,
+          "line": 4686,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2484,7 +2576,7 @@
         },
         {
           "name": "UntilEndOfTurn",
-          "line": 4605,
+          "line": 4687,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2495,7 +2587,7 @@
     },
     "BasicLandType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 427,
+      "line": 429,
       "doc": "The five basic land types (CR 305.6).",
       "cr_refs": [
         "CR 305.6"
@@ -2503,22 +2595,6 @@
       "variants": [
         {
           "name": "Plains",
-          "line": 428,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Island",
-          "line": 429,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Swamp",
           "line": 430,
           "kind": "unit",
           "field_names": [],
@@ -2526,7 +2602,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mountain",
+          "name": "Island",
           "line": 431,
           "kind": "unit",
           "field_names": [],
@@ -2534,8 +2610,24 @@
           "cr_refs": []
         },
         {
-          "name": "Forest",
+          "name": "Swamp",
           "line": 432,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Mountain",
+          "line": 433,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Forest",
+          "line": 434,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2546,7 +2638,7 @@
     },
     "BatchCompletion": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1207,
+      "line": 1218,
       "doc": "CR 701.25a / manifest dread: the post-loop cleanup a rest-pile batch must run once its graveyard pile has been delivered. These flows partition a looked-at pile into a graveyard \"rest\" pile (delivered through the simultaneous-move batch so per-card `Moved` redirects fire — Rest in Peace / Leyline of the Void class) and a \"kept\" remainder whose placement/marker cleanup happens after the whole pile lands. Because a per-card redirect can pause the batch (two simultaneous redirects on one card need a CR 616.1 ordering choice), the cleanup cannot run inline at the end of the loop — it would run before the paused tail finished, then never again. Stashing it as typed data on [`PendingBatchDeliveries`] (not a closure) lets the drain run it exactly once on true completion, mirroring the `PendingCounterPostAction` continuation pattern.",
       "cr_refs": [
         "CR 616.1",
@@ -2555,7 +2647,7 @@
       "variants": [
         {
           "name": "SurveilKeepOnTop",
-          "line": 1211,
+          "line": 1222,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2568,7 +2660,7 @@
         },
         {
           "name": "ManifestDreadCleanup",
-          "line": 1217,
+          "line": 1228,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2579,7 +2671,7 @@
         },
         {
           "name": "RevealRestPile",
-          "line": 1227,
+          "line": 1238,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2598,7 +2690,7 @@
         },
         {
           "name": "RemoveExileLinks",
-          "line": 1257,
+          "line": 1268,
           "kind": "struct",
           "field_names": [
             "returned_ids"
@@ -2611,7 +2703,7 @@
         },
         {
           "name": "NinjutsuPlacement",
-          "line": 1271,
+          "line": 1282,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2630,7 +2722,7 @@
         },
         {
           "name": "AttractionOpenRemainder",
-          "line": 1285,
+          "line": 1296,
           "kind": "struct",
           "field_names": [
             "player",
@@ -2648,13 +2740,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5558,
+      "line": 5781,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 5559,
+          "line": 5782,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2662,7 +2754,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 5560,
+          "line": 5783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2802,7 +2894,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6798,
+      "line": 7209,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2810,7 +2902,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 6801,
+          "line": 7212,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2818,7 +2910,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 6803,
+          "line": 7214,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -2949,7 +3041,7 @@
     },
     "CardPlayMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 599,
+      "line": 612,
       "doc": "CR 601.2 vs CR 305.1: Distinguishes \"cast\" (spells only) from \"play\" (spells + lands).",
       "cr_refs": [
         "CR 305.1",
@@ -2958,7 +3050,7 @@
       "variants": [
         {
           "name": "Cast",
-          "line": 602,
+          "line": 615,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2: Cast a spell (cannot play lands this way).",
@@ -2968,7 +3060,7 @@
         },
         {
           "name": "Play",
-          "line": 604,
+          "line": 617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1: Play a card — cast if it's a spell, play as a land if it's a land.",
@@ -2981,7 +3073,7 @@
     },
     "CardSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2818,
+      "line": 2963,
       "doc": "CR 701.9a: How cards are selected from a zone during an effect or cost.  Analogous to `TargetSelectionMode` but for cards from a player's hand (or other non-target zones) rather than spell/ability targets.",
       "cr_refs": [
         "CR 701.9a"
@@ -2989,7 +3081,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2821,
+          "line": 2966,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d: The affected player or controller chooses the card(s).",
@@ -2999,7 +3091,7 @@
         },
         {
           "name": "Random",
-          "line": 2823,
+          "line": 2968,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: The game selects card(s) uniformly at random.",
@@ -3012,13 +3104,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3462,
+      "line": 3637,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 3464,
+          "line": 3639,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -3032,7 +3124,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3466,
+          "line": 3641,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -3043,7 +3135,7 @@
         },
         {
           "name": "Objects",
-          "line": 3468,
+          "line": 3643,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -3055,7 +3147,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 3474,
+          "line": 3649,
           "kind": "struct",
           "field_names": [
             "caused_by"
@@ -3176,7 +3268,7 @@
     },
     "CastFromZoneDriver": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 634,
+      "line": 647,
       "doc": "CR 608.2g vs CR 118.9: Which casting *mechanism* an `Effect::CastFromZone` drives — i.e. *when* relative to the granting ability's resolution the card is cast. This is orthogonal to `duration` (CR 611.2a permission-expiry), `mode` (CR 601.2 cast vs CR 305.1 play), and `alt_ability_cost` (CR 118.9 cost-substitution); none of those describe the casting mechanism, so the router must read this field rather than inferring the mechanism from them.",
       "cr_refs": [
         "CR 118.9",
@@ -3188,7 +3280,7 @@
       "variants": [
         {
           "name": "LingeringPermission",
-          "line": 643,
+          "line": 656,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9: Grant a lingering `CastingPermission` on the target card(s) and return — the controller casts the card later, during the granting effect's own (or a future) priority window. The default for every permission-granting cast-from-zone effect: Discover/Nashi/Jeleva-style \"you may cast those exiled cards\" and Rebound's next-upkeep recast offer (CR 702.88a), whose `duration: Some(UntilEndOfTurn)` then prunes the unused permission.",
@@ -3199,7 +3291,7 @@
         },
         {
           "name": "DuringResolution",
-          "line": 650,
+          "line": 663,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2g: Cast the card *as the granting ability resolves* — the card goes onto the stack immediately via `initiate_cast_during_resolution`, and the CR 608.2g timing bypass (sorcery-speed / empty-stack / active-player gates do not apply) is armed. Set by Suspend's last-time-counter trigger (CR 702.62a) so a suspended sorcery recast at upkeep is not blocked by the sorcery-speed gate (issue #1520).",
@@ -3213,7 +3305,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3482,
+      "line": 3657,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -3221,7 +3313,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 3484,
+          "line": 3659,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -3229,7 +3321,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 3486,
+          "line": 3661,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -3237,7 +3329,7 @@
         },
         {
           "name": "AbilityTarget",
-          "line": 3490,
+          "line": 3665,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2h: The first object target of the resolving ability — \"it\"/\"that spell\" when the condition gates on the targeted spell (Nix: \"Counter target spell if no mana was spent to cast it\").",
@@ -3251,7 +3343,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3496,
+      "line": 3671,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -3260,7 +3352,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 3498,
+          "line": 3673,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -3268,7 +3360,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 3500,
+          "line": 3675,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -3276,7 +3368,7 @@
         },
         {
           "name": "FromSource",
-          "line": 3502,
+          "line": 3677,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -3289,13 +3381,13 @@
     },
     "CastOfferKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2507,
+      "line": 2537,
       "doc": "The specific kind of cast offer being presented to the player. Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId` at the outer level; the kind-specific payload lives here.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Adventure",
-          "line": 2509,
+          "line": 2539,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3309,7 +3401,7 @@
         },
         {
           "name": "Miracle",
-          "line": 2516,
+          "line": 2546,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3322,7 +3414,7 @@
         },
         {
           "name": "Madness",
-          "line": 2521,
+          "line": 2551,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -3335,7 +3427,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 2526,
+          "line": 2556,
           "kind": "struct",
           "field_names": [
             "offers"
@@ -3347,7 +3439,7 @@
         },
         {
           "name": "Cascade",
-          "line": 2528,
+          "line": 2558,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3361,7 +3453,7 @@
         },
         {
           "name": "Discover",
-          "line": 2534,
+          "line": 2564,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3375,7 +3467,7 @@
         },
         {
           "name": "Ripple",
-          "line": 2549,
+          "line": 2579,
           "kind": "struct",
           "field_names": [
             "hit_card",
@@ -3389,7 +3481,7 @@
         },
         {
           "name": "FreeCastWindow",
-          "line": 2561,
+          "line": 2591,
           "kind": "struct",
           "field_names": [
             "candidates",
@@ -3411,7 +3503,7 @@
     },
     "CastPaymentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1586,
+      "line": 1597,
       "doc": "CR 601.2g-h: Whether the engine may auto-pay an unambiguous spell mana cost or must pause after announcement so the player can activate mana abilities manually before committing payment.",
       "cr_refs": [
         "CR 601.2g"
@@ -3419,7 +3511,7 @@
       "variants": [
         {
           "name": "Auto",
-          "line": 1588,
+          "line": 1599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3427,7 +3519,7 @@
         },
         {
           "name": "Manual",
-          "line": 1589,
+          "line": 1600,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3438,7 +3530,7 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1834,
+      "line": 1941,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
@@ -3446,7 +3538,7 @@
       "variants": [
         {
           "name": "ManaValue",
-          "line": 1837,
+          "line": 1944,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -3463,7 +3555,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5528,
+      "line": 5751,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -3472,7 +3564,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 5531,
+          "line": 5754,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -3480,7 +3572,7 @@
         },
         {
           "name": "Offering",
-          "line": 5535,
+          "line": 5758,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48a: The spell was cast at instant speed by paying an Offering additional cost. When this permission is set, the Offering sacrifice is required (the player used the offering to unlock instant-speed timing).",
@@ -3493,7 +3585,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5477,
+      "line": 5696,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -3504,7 +3596,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5479,
+          "line": 5698,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -3515,7 +3607,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5482,
+          "line": 5701,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -3525,7 +3617,7 @@
         },
         {
           "name": "Sneak",
-          "line": 5484,
+          "line": 5703,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -3535,7 +3627,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 5486,
+          "line": 5705,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -3545,7 +3637,7 @@
         },
         {
           "name": "Evoke",
-          "line": 5489,
+          "line": 5708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -3555,7 +3647,7 @@
         },
         {
           "name": "Suspend",
-          "line": 5495,
+          "line": 5714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -3565,7 +3657,7 @@
         },
         {
           "name": "Escape",
-          "line": 5500,
+          "line": 5719,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -3576,7 +3668,7 @@
         },
         {
           "name": "Foretell",
-          "line": 5503,
+          "line": 5722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -3586,7 +3678,7 @@
         },
         {
           "name": "Bestow",
-          "line": 5508,
+          "line": 5727,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -3597,7 +3689,7 @@
         },
         {
           "name": "Impending",
-          "line": 5513,
+          "line": 5732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: The spell was cast for its impending alternative cost. The permanent entered with N time counters and is not a creature while any remain. Read by the end-step counter-removal trigger and the \"not a creature\" layer fixup.",
@@ -3607,7 +3699,7 @@
         },
         {
           "name": "Surge",
-          "line": 5517,
+          "line": 5736,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Surge alternative cast cost was paid from hand. Read by the \"if its surge cost was paid\" intervening-if (Reckless Bushwhacker, Tyrant of Valakut).",
@@ -3617,12 +3709,22 @@
         },
         {
           "name": "Spectacle",
-          "line": 5521,
+          "line": 5740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cast cost was paid from hand. Read by the \"if its spectacle cost was paid\" intervening-if (Rafter Demon) and the \"...if its spectacle cost was paid, instead\" clause (Rix Maadi Reveler).",
           "cr_refs": [
             "CR 702.137a"
+          ]
+        },
+        {
+          "name": "Prowl",
+          "line": 5744,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.76a: Prowl alternative cast cost was paid from hand. Read by the \"if its prowl cost was paid\" intervening-if (Latchkey Faerie, Oona's Blackguard-style prowl payoffs).",
+          "cr_refs": [
+            "CR 702.76a"
           ]
         }
       ],
@@ -3630,13 +3732,13 @@
     },
     "CastingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1612,
+      "line": 1710,
       "doc": "A permission granted to a `GameObject` allowing it to be cast under specific conditions. Stored in `GameObject::casting_permissions`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdventureCreature",
-          "line": 1614,
+          "line": 1712,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.5: After Adventure resolves to exile, creature face castable from exile.",
@@ -3646,7 +3748,7 @@
         },
         {
           "name": "ExileWithAltCost",
-          "line": 1619,
+          "line": 1717,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3665,7 +3767,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1684,
+          "line": 1782,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -3676,7 +3778,9 @@
             "mana_spend_permission",
             "card_filter",
             "single_use_group",
-            "single_use"
+            "single_use",
+            "cast_cost_raise",
+            "land_enter_tapped"
           ],
           "doc": "CR 400.7i: Play from exile until duration expires (impulse draw). Building block for \"exile top N, choose one, you may play it this turn\" patterns.  `granted_to` records the player the permission was granted to — i.e. the controller of the effect that created it (CR 611.2a/b). This is required to correctly expire `Duration::UntilNextTurnOf` permissions at the grantee's next untap step and `Duration::UntilEndOfTurn` permissions at cleanup (CR 514.2). Cast-permission checks (`has_exile_cast_permission`) do not consult this field — it governs duration pruning only.",
           "cr_refs": [
@@ -3687,7 +3791,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 1741,
+          "line": 1848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -3697,7 +3801,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 1750,
+          "line": 1857,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3712,7 +3816,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 1768,
+          "line": 1875,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -3724,7 +3828,7 @@
         },
         {
           "name": "Plotted",
-          "line": 1778,
+          "line": 1885,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -3737,7 +3841,7 @@
         },
         {
           "name": "Foretold",
-          "line": 1784,
+          "line": 1891,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3816,13 +3920,13 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11518,
+      "line": 12363,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 11519,
+          "line": 12364,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3830,7 +3934,7 @@
         },
         {
           "name": "DuringCombat",
-          "line": 11520,
+          "line": 12365,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3838,7 +3942,7 @@
         },
         {
           "name": "DuringOpponentsTurn",
-          "line": 11521,
+          "line": 12366,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3846,7 +3950,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 11522,
+          "line": 12367,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3854,7 +3958,7 @@
         },
         {
           "name": "DuringYourUpkeep",
-          "line": 11523,
+          "line": 12368,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3862,7 +3966,7 @@
         },
         {
           "name": "DuringOpponentsUpkeep",
-          "line": 11524,
+          "line": 12369,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3870,7 +3974,7 @@
         },
         {
           "name": "DuringAnyUpkeep",
-          "line": 11525,
+          "line": 12370,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3878,7 +3982,7 @@
         },
         {
           "name": "DuringYourEndStep",
-          "line": 11526,
+          "line": 12371,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3886,7 +3990,7 @@
         },
         {
           "name": "DuringOpponentsEndStep",
-          "line": 11527,
+          "line": 12372,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3894,7 +3998,7 @@
         },
         {
           "name": "DeclareAttackersStep",
-          "line": 11528,
+          "line": 12373,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3902,7 +4006,7 @@
         },
         {
           "name": "DeclareBlockersStep",
-          "line": 11529,
+          "line": 12374,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3910,7 +4014,7 @@
         },
         {
           "name": "BeforeAttackersDeclared",
-          "line": 11530,
+          "line": 12375,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3918,7 +4022,7 @@
         },
         {
           "name": "BeforeBlockersDeclared",
-          "line": 11531,
+          "line": 12376,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3926,7 +4030,7 @@
         },
         {
           "name": "BeforeCombatDamage",
-          "line": 11532,
+          "line": 12377,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3934,7 +4038,7 @@
         },
         {
           "name": "AfterCombat",
-          "line": 11533,
+          "line": 12378,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -3942,7 +4046,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 11534,
+          "line": 12379,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -3955,13 +4059,13 @@
     },
     "CastingVariant": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4696,
+      "line": 4786,
       "doc": "How a spell was cast — determines zone routing and post-resolution behavior. Replaces individual boolean flags (cast_as_adventure, cast_as_warp) with a single enum that captures the casting context.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Normal",
-          "line": 4699,
+          "line": 4789,
           "kind": "unit",
           "field_names": [],
           "doc": "Normal spell cast — no special resolution behavior.",
@@ -3969,7 +4073,7 @@
         },
         {
           "name": "Adventure",
-          "line": 4702,
+          "line": 4792,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.4: Cast as the Adventure half. On resolution, exiled with AdventureCreature permission and creature face restored.",
@@ -3979,7 +4083,7 @@
         },
         {
           "name": "Omen",
-          "line": 4705,
+          "line": 4795,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 720.3d / CR 720.4: Cast as the Omen half. On resolution, shuffled into its owner's library with normal characteristics restored.",
@@ -3990,7 +4094,7 @@
         },
         {
           "name": "Warp",
-          "line": 4708,
+          "line": 4798,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.185a: Cast via Warp alternative cost from hand. On resolution, creates a delayed trigger to exile at end step with WarpExile permission.",
@@ -4000,7 +4104,7 @@
         },
         {
           "name": "Escape",
-          "line": 4711,
+          "line": 4801,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138: Cast from graveyard via Escape. On resolution, goes to appropriate zone normally (unlike Flashback which exiles).",
@@ -4010,7 +4114,7 @@
         },
         {
           "name": "Retrace",
-          "line": 4714,
+          "line": 4804,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.81a: Cast from graveyard via Retrace by discarding a land card as an additional cost. Resolution uses normal spell routing.",
@@ -4020,7 +4124,7 @@
         },
         {
           "name": "Harmonize",
-          "line": 4717,
+          "line": 4807,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.180a: Cast from graveyard for harmonize cost. On resolution, exiled instead of going anywhere else (unlike Escape which returns to graveyard).",
@@ -4030,7 +4134,7 @@
         },
         {
           "name": "Mayhem",
-          "line": 4722,
+          "line": 4812,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.187b: Cast from graveyard for mayhem cost (allowed only while the card was discarded this turn). Unlike Flashback/Harmonize, the spell is NOT exiled — it resolves normally (like Escape), so it can be discarded and recast again on a later turn.",
@@ -4040,7 +4144,7 @@
         },
         {
           "name": "Flashback",
-          "line": 4725,
+          "line": 4815,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34a: Cast from graveyard for flashback cost. On resolution (or whenever leaving the stack for any reason), exiled instead of going anywhere else.",
@@ -4050,7 +4154,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 4728,
+          "line": 4818,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Cast an aftermath half of a split card from a graveyard. If it was cast from a graveyard, exile it any time it leaves the stack.",
@@ -4060,7 +4164,7 @@
         },
         {
           "name": "Disturb",
-          "line": 4732,
+          "line": 4822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.146a-b + CR 712.8c: Cast transformed from graveyard for disturb cost. The stack spell uses its back-face characteristics and the permanent enters the battlefield back face up on resolution.",
@@ -4071,7 +4175,7 @@
         },
         {
           "name": "GraveyardPermission",
-          "line": 4736,
+          "line": 4826,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4087,7 +4191,7 @@
         },
         {
           "name": "HandPermission",
-          "line": 4762,
+          "line": 4852,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4102,7 +4206,7 @@
         },
         {
           "name": "ExilePermission",
-          "line": 4778,
+          "line": 4868,
           "kind": "struct",
           "field_names": [
             "source",
@@ -4118,7 +4222,7 @@
         },
         {
           "name": "Sneak",
-          "line": 4795,
+          "line": 4885,
           "kind": "struct",
           "field_names": [
             "returned_creature",
@@ -4132,7 +4236,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 4804,
+          "line": 4894,
           "kind": "struct",
           "field_names": [
             "returned_creature"
@@ -4144,7 +4248,7 @@
         },
         {
           "name": "Miracle",
-          "line": 4811,
+          "line": 4901,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.94a: Cast from hand via Miracle's alternative cost after revealing the card as the first card drawn this turn. The granting keyword carries the miracle mana cost, which `prepare_spell_cast_with_variant_override` substitutes for the printed mana cost. The keyword's `ManaCost` payload is read at preparation time rather than stored here because `prepare_spell_cast` already reads `obj.keywords` for analogous paths.",
@@ -4154,7 +4258,7 @@
         },
         {
           "name": "Madness",
-          "line": 4814,
+          "line": 4904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.35a: Cast from exile via Madness after the discard replacement exiled the card and its madness triggered ability resolved.",
@@ -4164,7 +4268,7 @@
         },
         {
           "name": "Evoke",
-          "line": 4818,
+          "line": 4908,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Cast from hand via Evoke's alternative cost. On resolution, the permanent enters tagged with `CastVariantPaid::Evoke`, which fires the synthesized intervening-if ETB sacrifice trigger.",
@@ -4174,7 +4278,7 @@
         },
         {
           "name": "Emerge",
-          "line": 4824,
+          "line": 4914,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.119a-c: Cast from hand via Emerge's alternative cost. The printed mana cost is replaced by `Keyword::Emerge(cost)` at cast preparation; casting requires sacrificing a creature, then reduces that emerge cost by the sacrificed creature's mana value. Resolution routing matches a normal cast; Emerge has no resolution rider.",
@@ -4184,7 +4288,7 @@
         },
         {
           "name": "Dash",
-          "line": 4828,
+          "line": 4918,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.109a: Cast from hand via Dash's alternative cost. On resolution, `dash::install_dash_riders` grants the permanent haste and schedules a next-end-step return to its owner's hand.",
@@ -4194,7 +4298,7 @@
         },
         {
           "name": "Blitz",
-          "line": 4832,
+          "line": 4922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.152a: Cast from hand via Blitz's alternative cost. On resolution, `blitz::install_blitz_riders` grants the permanent haste and a dies-draw trigger and schedules a next-end-step sacrifice.",
@@ -4204,7 +4308,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 4836,
+          "line": 4926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Cast from hand via Spectacle's alternative cost, available only if an opponent lost life this turn. A pure cost substitution — the spell resolves normally with no resolution riders.",
@@ -4214,7 +4318,7 @@
         },
         {
           "name": "Suspend",
-          "line": 4843,
+          "line": 4933,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast from exile via Suspend's \"play it without paying its mana cost\" trigger after the last time counter was removed. On resolution of the resulting permanent, the stack handler tags `CastVariantPaid::Suspend` and — for creature spells — installs a transient continuous \"has haste\" effect that lasts as long as the resolution-time controller still controls the permanent.",
@@ -4224,7 +4328,7 @@
         },
         {
           "name": "Plot",
-          "line": 4850,
+          "line": 4940,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.170d: Cast from exile via the Plot \"cast without paying its mana cost\" permission during the owner's main phase on a turn after the card was plotted. Detected at cast preparation when the exile-zone source has a `CastingPermission::Plotted { turn_plotted }` and the current turn is strictly greater than `turn_plotted`. Zeroes the mana cost and routes through the normal cast pipeline; no special resolution-time behavior.",
@@ -4234,7 +4338,7 @@
         },
         {
           "name": "Foretell",
-          "line": 4857,
+          "line": 4947,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a-c: Cast from exile via a foretold card's foretell cost on a turn after it was foretold. Detected at cast preparation when the exile-zone source has a `CastingPermission::Foretold { .. }`. The permission supplies the alternative mana cost; stack finalization tags the source with `CastVariantPaid::Foretell` so \"if this spell was foretold\" clauses can evaluate while the spell resolves.",
@@ -4244,7 +4348,7 @@
         },
         {
           "name": "Overload",
-          "line": 4867,
+          "line": 4957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.96a-c: Cast from hand via Overload's alternative cost. The printed mana cost is replaced by `Keyword::Overload(cost)` at cast preparation (mirrors `Evoke`/`Warp`). Per CR 702.96b, every \"target\" in the spell's text is replaced by \"each\" — applied as a cast-time transformation of the spell's ability tree (`Destroy`→`DestroyAll`, `Pump`→`PumpAll`, `DealDamage`→`DamageAll`, `Tap`→`TapAll`, `Bounce`→`ChangeZoneAll`). Per CR 702.96c, the resulting spell has no targets, so target selection is naturally skipped because the transformed effects carry no `TargetRef` slots.",
@@ -4256,7 +4360,7 @@
         },
         {
           "name": "Bestow",
-          "line": 4882,
+          "line": 4972,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a-b: Cast from hand via Bestow's alternative cost. The printed mana cost is replaced by `Keyword::Bestow(cost)` at cast preparation; the spell becomes an Aura with `enchant creature` while on the stack and as the resulting permanent (until it becomes unattached, per CR 702.103f). The type-changing mutation is applied directly to the stack object (mirroring `swap_to_alternative_spell_face` for Adventure/Omen) — Layers cannot be used here because they only apply to battlefield/hand objects, not stack objects.  Per CR 702.103e: if the target is illegal at resolution, the type-changing effect ends and the spell resolves as a creature spell. Per CR 702.103f: when a bestowed Aura becomes unattached on the battlefield, the type-changing effect ends — it remains as an enchantment creature (overrides CR 704.5m for bestow Auras).",
@@ -4269,7 +4373,7 @@
         },
         {
           "name": "Awaken",
-          "line": 4893,
+          "line": 4983,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.113a: Cast from hand via Awaken's alternative cost. The printed mana cost is replaced by `Keyword::Awaken { cost }` at cast preparation (mirrors `Overload`). A resolution rider is appended to the tail of the spell's ability tree (`effects::awaken::append_awaken_rider`): the printed effect resolves first, then \"put N +1/+1 counters on target land you control; that land becomes a 0/0 Elemental creature with haste; it's still a land.\" Per CR 702.113b, the land target only exists on the awaken variant — a normal cast appends no rider and requests no land target. CR 702.113a: the spell goes to the graveyard normally, so this variant is deliberately absent from `exiles_when_leaving_stack_for_any_reason`.",
@@ -4280,7 +4384,7 @@
         },
         {
           "name": "Cleave",
-          "line": 4904,
+          "line": 4994,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.148a-b + CR 612: Cast from hand via Cleave's alternative cost (CR 118.9). The printed mana cost is replaced by `Keyword::Cleave(cost)` at cast preparation (mirrors `Evoke`/`Overload`). Per CR 702.148a, paying the cleave cost is a text-changing effect (CR 612) that removes every square-bracketed span from the spell's rules text. The bracket-removed ability set is parsed at build time into `CardFace::cleave_variant` and swapped onto the stack object before preparation (mirroring the Bestow object-mutation-before-prepare seam). Resolution routing matches a normal spell — there is no on-resolve special behavior, so the spell goes to its owner's graveyard like any instant/sorcery.",
@@ -4292,7 +4396,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 4911,
+          "line": 5001,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.162a + CR 712.14a: Cast from any castable zone via the More Than Meets the Eye alternative cost. The printed mana cost is replaced by the `Keyword::MoreThanMeetsTheEye(cost)` payload at cast preparation (mirrors Overload). On resolution the spell is cast CONVERTED — the resulting permanent enters the battlefield transformed (back face up) via the existing `enter_transformed` ZoneChange seed. CR 701.28 (Convert).",
@@ -4304,7 +4408,7 @@
         },
         {
           "name": "Impending",
-          "line": 4917,
+          "line": 5007,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: Cast from hand via Impending's alternative cost. The printed mana cost is replaced by `Keyword::Impending { cost, .. }` at cast preparation (mirrors Overload/Evoke). On resolution the permanent enters with N time counters (from the keyword) and is not a creature while any remain. At the beginning of your end step one time counter is removed.",
@@ -4314,7 +4418,7 @@
         },
         {
           "name": "Prototype",
-          "line": 4922,
+          "line": 5012,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.160a: Cast from hand prototyped. The printed mana cost is replaced by the prototype cost during cast preparation, and the object is tagged so stack display plus layer evaluation use the secondary mana cost and P/T while it is a creature.",
@@ -4324,7 +4428,7 @@
         },
         {
           "name": "Mutate",
-          "line": 4935,
+          "line": 5025,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.140a-c: Cast from hand via Mutate's alternative cost. The printed mana cost is replaced by `Keyword::Mutate(cost)` at cast preparation (mirrors Bestow). The spell gains a single target — a non-Human creature the caster owns (CR 702.140a) — attached Bestow-style before preparation. On resolution (`stack::resolve_top`): if the target is illegal (CR 702.140b) the spell reverts to a plain creature spell and enters the battlefield normally; if legal (CR 702.140c) it does NOT enter — instead it merges with the target creature (CR 730) and the controller chooses top/bottom. Unlike Bestow this variant neither exiles on leaving the stack nor restores a front face, so it is intentionally absent from `exiles_when_leaving_stack_for_any_reason` and `restores_front_face_after_stack_exit`.",
@@ -4337,7 +4441,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 4943,
+          "line": 5033,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.173a: Cast from hand via Freerunning's alternative cost. Legal only when a player was dealt combat damage this turn by an Assassin creature or a commander under the caster's control. The printed mana cost is replaced by the `Keyword::Freerunning(cost)` payload at cast preparation (mirrors `Overload` / `Foretell`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
@@ -4347,7 +4451,7 @@
         },
         {
           "name": "Prowl",
-          "line": 4951,
+          "line": 5041,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.76a: Cast from hand via Prowl's alternative cost. Legal only when a player was dealt combat damage this turn by a source under the caster's control that, at damage time, had any of this spell's creature types. The printed mana cost is replaced by the `Keyword::Prowl(cost)` payload at cast preparation (mirrors `Freerunning`/`Overload`). Resolution routing matches a normal cast — no on-resolve special behavior — so this is a casting-context tag, not a resolution-affecting variant.",
@@ -4357,7 +4461,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 4959,
+          "line": 5049,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Cast from a graveyard via Jump-start. The card is cast for its normal mana cost plus an additional cost of discarding a card (CR 601.2b/601.2f–h) — so, like `Retrace`/`Aftermath`, this is an additional cost, not an alternative cost, and is absent from `uses_alternative_cost`. Like `Flashback`, a spell cast this way is exiled instead of going anywhere else any time it would leave the stack (see `exiles_when_leaving_stack_for_any_reason`).",
@@ -4368,7 +4472,7 @@
         },
         {
           "name": "Fuse",
-          "line": 4965,
+          "line": 5055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.102a-d: Both halves of a split card cast from hand as a fused split spell. The mana cost is the combined cost of both halves (CR 702.102c). On resolution, the left half's instructions are followed first, then the right half's (CR 702.102d). Not an alternative cost (CR 118.9a) — the player pays the full combined printed mana cost.",
@@ -4381,7 +4485,7 @@
         },
         {
           "name": "Surge",
-          "line": 4969,
+          "line": 5059,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Cast from hand for the surge alternative cost, legal only if the caster has cast another spell this turn. Resolution is normal (no exile/restore), so it appears only in `uses_alternative_cost`.",
@@ -4394,7 +4498,7 @@
     },
     "CategoryChooserScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 73,
+      "line": 75,
       "doc": "CR 101.4: Who selects permanents in a multi-player category choice effect (e.g., Cataclysm, Tragic Arrogance). Determines whether each player independently chooses which of their permanents to keep, or the spell's controller decides for everyone.",
       "cr_refs": [
         "CR 101.4"
@@ -4402,7 +4506,7 @@
       "variants": [
         {
           "name": "EachPlayerSelf",
-          "line": 76,
+          "line": 78,
           "kind": "unit",
           "field_names": [],
           "doc": "Each player chooses their own permanents in APNAP order (Cataclysm, Cataclysmic Gearhulk).",
@@ -4410,7 +4514,7 @@
         },
         {
           "name": "ControllerForAll",
-          "line": 78,
+          "line": 80,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the spell/ability chooses for all players (Tragic Arrogance).",
@@ -4421,13 +4525,13 @@
     },
     "ChoiceType": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 192,
+      "line": 194,
       "doc": "What kind of named choice the player must make at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 193,
+          "line": 195,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4435,7 +4539,7 @@
         },
         {
           "name": "Color",
-          "line": 194,
+          "line": 196,
           "kind": "struct",
           "field_names": [
             "excluded"
@@ -4445,22 +4549,6 @@
         },
         {
           "name": "OddOrEven",
-          "line": 201,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BasicLandType",
-          "line": 202,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CardType",
           "line": 203,
           "kind": "unit",
           "field_names": [],
@@ -4468,7 +4556,7 @@
           "cr_refs": []
         },
         {
-          "name": "CardName",
+          "name": "BasicLandType",
           "line": 204,
           "kind": "unit",
           "field_names": [],
@@ -4476,8 +4564,24 @@
           "cr_refs": []
         },
         {
-          "name": "NumberRange",
+          "name": "CardType",
+          "line": 205,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CardName",
           "line": 206,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "NumberRange",
+          "line": 208,
           "kind": "struct",
           "field_names": [
             "min",
@@ -4488,7 +4592,7 @@
         },
         {
           "name": "Labeled",
-          "line": 211,
+          "line": 213,
           "kind": "struct",
           "field_names": [
             "options"
@@ -4498,7 +4602,7 @@
         },
         {
           "name": "LandType",
-          "line": 215,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a land type\" — includes basic + common nonbasic land types.",
@@ -4506,7 +4610,7 @@
         },
         {
           "name": "Opponent",
-          "line": 226,
+          "line": 228,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -4519,7 +4623,7 @@
         },
         {
           "name": "Player",
-          "line": 230,
+          "line": 232,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a player\" — selects any player in the game.",
@@ -4527,7 +4631,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 232,
+          "line": 234,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose two colors\" — selects two distinct mana colors.",
@@ -4535,7 +4639,7 @@
         },
         {
           "name": "Word",
-          "line": 234,
+          "line": 236,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose a word\" — names any English word (Un-set and silver-border cards).",
@@ -4543,7 +4647,7 @@
         },
         {
           "name": "Artist",
-          "line": 236,
+          "line": 238,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Choose an artist\" — selects a Magic card artist name.",
@@ -4551,7 +4655,7 @@
         },
         {
           "name": "Keyword",
-          "line": 244,
+          "line": 246,
           "kind": "struct",
           "field_names": [
             "options"
@@ -4566,13 +4670,13 @@
     },
     "ChoiceValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 782,
+      "line": 795,
       "doc": "A typed value chosen at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 783,
+          "line": 796,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4580,7 +4684,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 784,
+          "line": 797,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4588,7 +4692,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 785,
+          "line": 798,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4596,7 +4700,7 @@
         },
         {
           "name": "CardType",
-          "line": 786,
+          "line": 799,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4604,7 +4708,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 787,
+          "line": 800,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4612,7 +4716,7 @@
         },
         {
           "name": "CardName",
-          "line": 788,
+          "line": 801,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4620,7 +4724,7 @@
         },
         {
           "name": "Number",
-          "line": 789,
+          "line": 802,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4628,7 +4732,7 @@
         },
         {
           "name": "Label",
-          "line": 790,
+          "line": 803,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4636,7 +4740,7 @@
         },
         {
           "name": "LandType",
-          "line": 791,
+          "line": 804,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4644,7 +4748,7 @@
         },
         {
           "name": "Player",
-          "line": 792,
+          "line": 805,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4652,7 +4756,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 793,
+          "line": 806,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4660,7 +4764,7 @@
         },
         {
           "name": "Keyword",
-          "line": 798,
+          "line": 811,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: typed-keyword choice from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge). Persisted into the source's `chosen_attributes` as `ChosenAttribute::Keyword` for later `RemoveChosenKeyword` resolution.",
@@ -4673,13 +4777,13 @@
     },
     "ChooseFromZoneConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 91,
+      "line": 93,
       "doc": "Additional selection constraints for tracked-set card picks during resolution.  Internally tagged (`{ \"type\": \"DistinctCardTypes\", \"categories\": [...] }`) to match the sibling [`SearchSelectionConstraint`] convention and the frontend's `ChooseFromZoneConstraint` type, which discriminates on the `type` field. The `CardChoiceModal` confirm gate reads `constraint.type`; without the tag the default external representation (`{ \"DistinctCardTypes\": {...} }`) leaves `type` undefined and the modal can never validate a selection.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DistinctCardTypes",
-          "line": 94,
+          "line": 96,
           "kind": "struct",
           "field_names": [
             "categories"
@@ -4692,7 +4796,7 @@
     },
     "Chooser": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 35,
+      "line": 37,
       "doc": "CR 700.2: Who makes a choice during an effect's resolution.",
       "cr_refs": [
         "CR 700.2"
@@ -4700,7 +4804,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 38,
+          "line": 40,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the spell/ability makes the choice.",
@@ -4708,7 +4812,7 @@
         },
         {
           "name": "Opponent",
-          "line": 41,
+          "line": 43,
           "kind": "unit",
           "field_names": [],
           "doc": "An opponent of the controller makes the choice (CR 700.2). In 2-player, the single opponent. In multiplayer, controller chooses which opponent.",
@@ -4721,13 +4825,13 @@
     },
     "ChosenAttribute": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 685,
+      "line": 698,
       "doc": "A typed choice stored on a permanent (e.g., \"choose a color\" → Color(Red)). The variant discriminant serves as the category key.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Color",
-          "line": 686,
+          "line": 699,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4735,7 +4839,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 687,
+          "line": 700,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4743,7 +4847,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 688,
+          "line": 701,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4751,7 +4855,7 @@
         },
         {
           "name": "CardType",
-          "line": 689,
+          "line": 702,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4759,7 +4863,7 @@
         },
         {
           "name": "OddOrEven",
-          "line": 690,
+          "line": 703,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4767,7 +4871,7 @@
         },
         {
           "name": "CardName",
-          "line": 691,
+          "line": 704,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -4775,7 +4879,7 @@
         },
         {
           "name": "Number",
-          "line": 693,
+          "line": 706,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores a chosen number (e.g., \"choose a number\" for Talion).",
@@ -4783,7 +4887,7 @@
         },
         {
           "name": "Player",
-          "line": 695,
+          "line": 708,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores the chosen opponent/player ID (CR 800.4a).",
@@ -4793,7 +4897,7 @@
         },
         {
           "name": "TwoColors",
-          "line": 697,
+          "line": 710,
           "kind": "tuple",
           "field_names": [],
           "doc": "Stores two chosen colors as a pair.",
@@ -4801,7 +4905,7 @@
         },
         {
           "name": "TributeOutcome",
-          "line": 701,
+          "line": 714,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.104a + CR 702.104b: Records whether the opponent chosen for the Tribute ETB replacement paid tribute or declined. Read by the companion `TriggerCondition::TributeNotPaid` evaluator.",
@@ -4812,7 +4916,7 @@
         },
         {
           "name": "Keyword",
-          "line": 706,
+          "line": 719,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2d: Records the typed keyword chosen from a `ChoiceType::Keyword` option list (Urborg / Walking Sponge \"choose an ability the target has, remove it\"). Read by `ContinuousModification::RemoveChosenKeyword` at Layer 6 evaluation to strip the chosen keyword from the recipient.",
@@ -4822,7 +4926,7 @@
         },
         {
           "name": "Label",
-          "line": 715,
+          "line": 728,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 614.12c: Records the anchor-word label chosen as the permanent entered the battlefield (e.g. Frostcliff Siege \"Jeskai\" / \"Temur\", Khans of Tarkir Sieges \"Khans\" / \"Dragons\"). Read by `StaticCondition::ChosenLabelIs` and `TriggerCondition::ChosenLabelIs` to gate which of the two anchor-word-marked abilities (CR 607: linked abilities) functions while the permanent is on the battlefield. The label is stored case-canonicalised to match `ChoiceType::Labeled`'s capitalised option list.",
@@ -4836,13 +4940,13 @@
     },
     "ChosenSubtypeKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 850,
+      "line": 863,
       "doc": "How to specify a damage amount -- either a fixed integer or a variable reference. Which category of chosen attribute to read as a subtype. Used by `ContinuousModification::AddChosenSubtype` in layer evaluation.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CreatureType",
-          "line": 851,
+          "line": 864,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4850,7 +4954,7 @@
         },
         {
           "name": "BasicLandType",
-          "line": 852,
+          "line": 865,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4861,7 +4965,7 @@
     },
     "ClashResult": {
       "file": "crates/engine/src/types/events.rs",
-      "line": 96,
+      "line": 98,
       "doc": "CR 701.30d: Result of a clash — whether the controller won, lost, or tied.",
       "cr_refs": [
         "CR 701.30d"
@@ -4869,7 +4973,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 97,
+          "line": 99,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4877,7 +4981,7 @@
         },
         {
           "name": "Lost",
-          "line": 98,
+          "line": 100,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4885,7 +4989,7 @@
         },
         {
           "name": "Tied",
-          "line": 99,
+          "line": 101,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4896,7 +5000,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13720,
+      "line": 14656,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -4904,7 +5008,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 13721,
+          "line": 14657,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4912,7 +5016,7 @@
         },
         {
           "name": "Lost",
-          "line": 13722,
+          "line": 14658,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4923,13 +5027,13 @@
     },
     "CollectEvidenceResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1776,
+      "line": 1787,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Casting",
-          "line": 1777,
+          "line": 1788,
           "kind": "struct",
           "field_names": [
             "pending_cast"
@@ -4939,7 +5043,7 @@
         },
         {
           "name": "Effect",
-          "line": 1780,
+          "line": 1791,
           "kind": "struct",
           "field_names": [
             "pending_ability"
@@ -4952,13 +5056,13 @@
     },
     "CombatAloneAction": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 595,
+      "line": 602,
       "doc": "Which combat action the `CombatAlone` restriction governs.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Attack",
-          "line": 596,
+          "line": 603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4966,7 +5070,7 @@
         },
         {
           "name": "Block",
-          "line": 597,
+          "line": 604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -4977,13 +5081,13 @@
     },
     "CombatAloneRequirement": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 602,
+      "line": 609,
       "doc": "The polarity of a `CombatAlone` static.",
       "cr_refs": [],
       "variants": [
         {
           "name": "NeedsCompanion",
-          "line": 604,
+          "line": 611,
           "kind": "unit",
           "field_names": [],
           "doc": "\"can't X alone\" — the creature must NOT be the sole attacker/blocker.",
@@ -4991,7 +5095,7 @@
         },
         {
           "name": "MustBeSole",
-          "line": 606,
+          "line": 613,
           "kind": "unit",
           "field_names": [],
           "doc": "\"can only X alone\" — the creature must BE the sole attacker; companions are prohibited.",
@@ -5002,7 +5106,7 @@
     },
     "CombatDamageAssignmentMode": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4100,
+      "line": 4180,
       "doc": "CR 510.1c: Optional combat-damage assignment mode for attackers with text like \"you may have this creature assign its combat damage as though it weren't blocked.\"",
       "cr_refs": [
         "CR 510.1c"
@@ -5010,7 +5114,7 @@
       "variants": [
         {
           "name": "Normal",
-          "line": 4102,
+          "line": 4182,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5018,7 +5122,7 @@
         },
         {
           "name": "AsThoughUnblocked",
-          "line": 4103,
+          "line": 4183,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5029,7 +5133,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14261,
+      "line": 15212,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -5037,7 +5141,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 14262,
+          "line": 15213,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5045,7 +5149,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 14263,
+          "line": 15214,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5056,13 +5160,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2203,
+      "line": 2310,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 2205,
+          "line": 2312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -5075,13 +5179,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2210,
+      "line": 2317,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2212,
+          "line": 2319,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -5089,7 +5193,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2214,
+          "line": 2321,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -5100,7 +5204,7 @@
     },
     "CombatTaxContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2065,
+      "line": 2076,
       "doc": "CR 508.1d + CR 509.1c: Which combat step a `WaitingFor::CombatTaxPayment` belongs to.  Drives the resume branch after the tax decision — on accept, the engine submits the stored attacker / blocker declaration; on decline, the engine filters the taxed creatures out of that declaration and submits the remainder.",
       "cr_refs": [
         "CR 508.1d",
@@ -5109,7 +5213,7 @@
       "variants": [
         {
           "name": "Attacking",
-          "line": 2066,
+          "line": 2077,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5117,7 +5221,7 @@
         },
         {
           "name": "Blocking",
-          "line": 2067,
+          "line": 2078,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5128,7 +5232,7 @@
     },
     "CombatTaxPending": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2075,
+      "line": 2086,
       "doc": "CR 508.1d + CR 509.1c: The declaration that is paused awaiting a combat-tax decision. Keyed by `CombatTaxContext` — the engine resumes the matching variant on `GameAction::PayCombatTax`.",
       "cr_refs": [
         "CR 508.1d",
@@ -5137,7 +5241,7 @@
       "variants": [
         {
           "name": "Attack",
-          "line": 2076,
+          "line": 2087,
           "kind": "struct",
           "field_names": [
             "attacks",
@@ -5148,7 +5252,7 @@
         },
         {
           "name": "Block",
-          "line": 2084,
+          "line": 2095,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -5161,7 +5265,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4893,
+      "line": 5097,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -5169,7 +5273,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 4896,
+          "line": 5100,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -5180,7 +5284,7 @@
         },
         {
           "name": "Any",
-          "line": 4900,
+          "line": 5104,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -5284,13 +5388,13 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4733,
+      "line": 4937,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 4734,
+          "line": 4938,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5298,7 +5402,7 @@
         },
         {
           "name": "LT",
-          "line": 4735,
+          "line": 4939,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5306,7 +5410,7 @@
         },
         {
           "name": "GE",
-          "line": 4736,
+          "line": 4940,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5314,7 +5418,7 @@
         },
         {
           "name": "LE",
-          "line": 4737,
+          "line": 4941,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5322,7 +5426,7 @@
         },
         {
           "name": "EQ",
-          "line": 4738,
+          "line": 4942,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5330,7 +5434,7 @@
         },
         {
           "name": "NE",
-          "line": 4739,
+          "line": 4943,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5341,7 +5445,7 @@
     },
     "ConjureSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6705,
+      "line": 7116,
       "doc": "CR 707.2: Where a conjured card's identity is taken from. Untagged so the legacy named form (`{\"name\": \"X\"}`) and the duplicate form (`{\"duplicate_of\": <filter>}`) are distinguished by their disjoint keys.",
       "cr_refs": [
         "CR 707.2"
@@ -5349,7 +5453,7 @@
       "variants": [
         {
           "name": "Named",
-          "line": 6707,
+          "line": 7118,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5359,7 +5463,7 @@
         },
         {
           "name": "Duplicate",
-          "line": 6711,
+          "line": 7122,
           "kind": "struct",
           "field_names": [
             "duplicate_of"
@@ -5374,13 +5478,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14714,
+      "line": 15678,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 14715,
+          "line": 15679,
           "kind": "struct",
           "field_names": [
             "values",
@@ -5393,7 +5497,7 @@
         },
         {
           "name": "SetName",
-          "line": 14747,
+          "line": 15711,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5407,7 +5511,7 @@
         },
         {
           "name": "AddPower",
-          "line": 14750,
+          "line": 15714,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5417,7 +5521,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 14753,
+          "line": 15717,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5427,7 +5531,7 @@
         },
         {
           "name": "SetPower",
-          "line": 14756,
+          "line": 15720,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5437,7 +5541,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 14759,
+          "line": 15723,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5447,7 +5551,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 14762,
+          "line": 15726,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5457,7 +5561,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 14765,
+          "line": 15729,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5467,7 +5571,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 14768,
+          "line": 15732,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5477,7 +5581,7 @@
         },
         {
           "name": "GrantAllActivatedAbilitiesOf",
-          "line": 14780,
+          "line": 15744,
           "kind": "struct",
           "field_names": [
             "source"
@@ -5490,7 +5594,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 14787,
+          "line": 15751,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5502,7 +5606,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 14790,
+          "line": 15754,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5510,7 +5614,7 @@
         },
         {
           "name": "AddType",
-          "line": 14791,
+          "line": 15755,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5520,7 +5624,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 14794,
+          "line": 15758,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5530,7 +5634,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 14797,
+          "line": 15761,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5540,7 +5644,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 14800,
+          "line": 15764,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5550,7 +5654,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 14807,
+          "line": 15771,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -5563,7 +5667,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 14813,
+          "line": 15777,
           "kind": "struct",
           "field_names": [
             "set"
@@ -5576,7 +5680,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 14817,
+          "line": 15781,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5586,7 +5690,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 14821,
+          "line": 15785,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5596,7 +5700,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 14828,
+          "line": 15792,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5608,7 +5712,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 14833,
+          "line": 15797,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5620,7 +5724,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 14837,
+          "line": 15801,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5632,7 +5736,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 14841,
+          "line": 15805,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5644,7 +5748,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 14846,
+          "line": 15810,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -5657,7 +5761,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 14852,
+          "line": 15816,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -5665,7 +5769,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 14855,
+          "line": 15819,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -5676,7 +5780,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 14859,
+          "line": 15823,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -5688,7 +5792,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 14862,
+          "line": 15826,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -5698,7 +5802,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 14867,
+          "line": 15831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -5708,7 +5812,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 14874,
+          "line": 15838,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -5719,7 +5823,7 @@
         },
         {
           "name": "AddChosenKeyword",
-          "line": 14884,
+          "line": 15848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Grant the chosen keyword (read from the granting source's `chosen_attributes`) to the affected object. The additive counterpart of `RemoveChosenKeyword`, mirroring the `AddChosenColor` / `AddChosenSubtype` chosen-attribute family. Used by the \"choose [keyword], …; creatures you control gain that ability until end of turn\" class (Angelic Skirmisher, Linvala, Shield of Sea Gate): a preceding `Effect::Choose { ChoiceType::Keyword, persist }` stores the selection as `ChosenAttribute::Keyword`, which this modification reads at Layer 6 evaluation to install on every recipient.",
@@ -5730,7 +5834,7 @@
         },
         {
           "name": "SetColor",
-          "line": 14885,
+          "line": 15849,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -5740,7 +5844,7 @@
         },
         {
           "name": "AddColor",
-          "line": 14888,
+          "line": 15852,
           "kind": "struct",
           "field_names": [
             "color"
@@ -5750,7 +5854,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 14893,
+          "line": 15857,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -5760,7 +5864,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 14908,
+          "line": 15872,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5775,7 +5879,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 14912,
+          "line": 15876,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -5785,7 +5889,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 14915,
+          "line": 15879,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -5795,7 +5899,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 14917,
+          "line": 15881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -5805,7 +5909,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 14919,
+          "line": 15883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -5815,7 +5919,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 14922,
+          "line": 15886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -5825,7 +5929,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 14925,
+          "line": 15889,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -5837,7 +5941,7 @@
         },
         {
           "name": "SetChosenBasicLandType",
-          "line": 14939,
+          "line": 15903,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN by the granting source (e.g. Phantasmal Terrain, Convincing Mirage: \"As this Aura enters, choose a basic land type.\" + \"Enchanted land is the chosen type.\"). Mirrors `SetBasicLandType`'s replacement semantics — removes the land's old land subtypes and clears the abilities generated from its rules text — but reads the concrete subtype from the source object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer evaluation time rather than carrying a fixed type. Unit variant: the kind is implicitly `BasicLandType`. The intrinsic mana ability for the new type is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit mana grant is needed here.",
@@ -5848,7 +5952,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 14951,
+          "line": 15915,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -5860,7 +5964,7 @@
         },
         {
           "name": "RetainPrintedAbilityFromSource",
-          "line": 14964,
+          "line": 15928,
           "kind": "struct",
           "field_names": [
             "source_ability_index"
@@ -5872,7 +5976,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 14972,
+          "line": 15936,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5887,7 +5991,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 14981,
+          "line": 15945,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -5902,7 +6006,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 14995,
+          "line": 15959,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -5917,7 +6021,7 @@
         },
         {
           "name": "SetStartingLoyalty",
-          "line": 15009,
+          "line": 15973,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5930,7 +6034,7 @@
         },
         {
           "name": "RemoveManaCost",
-          "line": 15019,
+          "line": 15983,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.9 + CR 202.1b: Strip a copy's mana cost — the \"has no mana cost\" copy exception used by Embalm (CR 702.128a) and Eternalize (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy resolution, never evaluated through the layer system, so `ContinuousModification::layer()` treats it as unreachable: `token_copy.rs` bakes it into the new token's base mana cost, and `become_copy.rs` strips it from the copied values so the continuous copy carries mana value 0.",
@@ -5946,13 +6050,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2100,
+      "line": 2207,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 2101,
+          "line": 2208,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5960,7 +6064,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2102,
+          "line": 2209,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5968,7 +6072,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2105,
+          "line": 2212,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -5979,7 +6083,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 2112,
+          "line": 2219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -5992,7 +6096,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2116,
+          "line": 2223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -6003,7 +6107,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2119,
+          "line": 2226,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 108.3: Filter owner is the owner of the parent object target inherited by this chained effect (\"its owner's graveyard\").",
@@ -6014,7 +6118,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2124,
+          "line": 2231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -6025,7 +6129,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 2135,
+          "line": 2242,
           "kind": "struct",
           "field_names": [
             "index"
@@ -6038,7 +6142,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2147,
+          "line": 2254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: Filter controller is the player PERSISTED on the source via `ChosenAttribute::Player` — the player chosen by an \"as ~ enters the battlefield, choose a player\" replacement. Read at filter / layer-evaluation time from the source's `chosen_attributes` (mirrors `GameObject::protector`). Distinct from `ChosenPlayer { index }`, which is resolution-scoped (valid only mid-resolution); this is a durable characteristic readable continuously, as a CDA requires. Powers \"~'s power and toughness are each equal to the number of <X> the chosen player controls\" (Skyshroud War Beast, Lost Order of Jarkeld).",
@@ -6049,7 +6153,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2154,
+          "line": 2261,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -6130,7 +6234,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15090,
+      "line": 16054,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -6140,7 +6244,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 15093,
+          "line": 16057,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -6148,7 +6252,7 @@
         },
         {
           "name": "Finalized",
-          "line": 15095,
+          "line": 16059,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -6159,13 +6263,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6742,
+      "line": 7153,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 6743,
+          "line": 7154,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6176,7 +6280,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9397,
+      "line": 10078,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -6185,7 +6289,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 9399,
+          "line": 10080,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -6193,7 +6297,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 9401,
+          "line": 10082,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -6364,7 +6468,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6001,
+      "line": 6323,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice(_)` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -6372,7 +6476,7 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 6002,
+          "line": 6324,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6380,7 +6484,7 @@
         },
         {
           "name": "TapsSelf",
-          "line": 6003,
+          "line": 6325,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6388,7 +6492,7 @@
         },
         {
           "name": "UntapsSelf",
-          "line": 6004,
+          "line": 6326,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6396,7 +6500,7 @@
         },
         {
           "name": "SacrificesPermanent",
-          "line": 6005,
+          "line": 6327,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6404,7 +6508,7 @@
         },
         {
           "name": "PaysLife",
-          "line": 6006,
+          "line": 6328,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6412,7 +6516,7 @@
         },
         {
           "name": "PaysLoyalty",
-          "line": 6007,
+          "line": 6329,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6420,7 +6524,7 @@
         },
         {
           "name": "Discards",
-          "line": 6008,
+          "line": 6330,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6428,7 +6532,7 @@
         },
         {
           "name": "ExilesCards",
-          "line": 6009,
+          "line": 6331,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6436,7 +6540,7 @@
         },
         {
           "name": "TapsOtherCreatures",
-          "line": 6010,
+          "line": 6332,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6444,7 +6548,7 @@
         },
         {
           "name": "RemovesCounters",
-          "line": 6011,
+          "line": 6333,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6452,7 +6556,7 @@
         },
         {
           "name": "PaysEnergy",
-          "line": 6012,
+          "line": 6334,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6460,7 +6564,7 @@
         },
         {
           "name": "PaysSpeed",
-          "line": 6013,
+          "line": 6335,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6468,7 +6572,7 @@
         },
         {
           "name": "ReturnsToHand",
-          "line": 6014,
+          "line": 6336,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6476,7 +6580,7 @@
         },
         {
           "name": "Unattaches",
-          "line": 6015,
+          "line": 6337,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6484,7 +6588,7 @@
         },
         {
           "name": "Mills",
-          "line": 6016,
+          "line": 6338,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6492,7 +6596,7 @@
         },
         {
           "name": "PutsCounters",
-          "line": 6017,
+          "line": 6339,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6500,7 +6604,7 @@
         },
         {
           "name": "Reveals",
-          "line": 6018,
+          "line": 6340,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6508,7 +6612,7 @@
         },
         {
           "name": "Exerts",
-          "line": 6019,
+          "line": 6341,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6516,7 +6620,7 @@
         },
         {
           "name": "KeywordCost",
-          "line": 6020,
+          "line": 6342,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6564,7 +6668,7 @@
     },
     "CostObjectCount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5567,
+      "line": 5790,
       "doc": "CR 702.167a: Object-count requirement for costs whose text may ask for an exact number (\"two creatures\") or a minimum (\"one or more creatures\").",
       "cr_refs": [
         "CR 702.167a"
@@ -6572,7 +6676,7 @@
       "variants": [
         {
           "name": "Exactly",
-          "line": 5568,
+          "line": 5791,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6582,7 +6686,7 @@
         },
         {
           "name": "AtLeast",
-          "line": 5569,
+          "line": 5792,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6627,7 +6731,7 @@
     },
     "CostResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2474,
+      "line": 2504,
       "doc": "CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes. Determines whether the engine re-enters the spell-casting pipeline or the mana-ability pipeline.",
       "cr_refs": [
         "CR 601.2b",
@@ -6636,7 +6740,7 @@
       "variants": [
         {
           "name": "Spell",
-          "line": 2475,
+          "line": 2505,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -6646,7 +6750,7 @@
         },
         {
           "name": "SpellCost",
-          "line": 2479,
+          "line": 2509,
           "kind": "struct",
           "field_names": [
             "spell",
@@ -6658,7 +6762,7 @@
         },
         {
           "name": "ManaAbility",
-          "line": 2485,
+          "line": 2515,
           "kind": "struct",
           "field_names": [
             "mana_ability"
@@ -6671,7 +6775,7 @@
     },
     "CountScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 866,
+      "line": 879,
       "doc": "Which players' zones to count across for zone-based quantity references.  CR 608.2 + CR 109.5: `Controller` and `ScopedPlayer` are distinct axes during `player_scope` iteration. `Controller` always means the printed ability's controller (the \"you\" axis from CR 109.5). `ScopedPlayer` means the player whose iteration copy is currently running (e.g., each opponent in \"Each opponent mills half of *their* library, rounded up.\" — Maddening Cacophony's kicker mode). Outside iteration, `ScopedPlayer` falls back to `Controller`. Mirrors the `ControllerRef::You` vs `ControllerRef::ScopedPlayer` split.",
       "cr_refs": [
         "CR 109.5",
@@ -6680,7 +6784,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 868,
+          "line": 881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5: The printed ability's controller — \"you\" / \"your\" semantics.",
@@ -6690,7 +6794,7 @@
         },
         {
           "name": "Owner",
-          "line": 871,
+          "line": 884,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 404.2: The printed ability controller as owner for player-scoped queries over non-battlefield zones.",
@@ -6701,7 +6805,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 877,
+          "line": 890,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2 + CR 109.5: The currently iterated player during a `player_scope` resolution — \"they\" / \"their\" semantics relative to the iteration. Issue #310: distinguishes \"their library\" (per-iteration) from \"your library\" (always caster). Falls back to `Controller` outside iteration.",
@@ -6712,7 +6816,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 881,
+          "line": 894,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: The source's linked persisted chosen player — \"the chosen player's <zone>\" on cards whose source stored `ChosenAttribute::Player`.",
@@ -6723,7 +6827,7 @@
         },
         {
           "name": "All",
-          "line": 882,
+          "line": 895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6731,7 +6835,7 @@
         },
         {
           "name": "Opponents",
-          "line": 883,
+          "line": 896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6742,13 +6846,13 @@
     },
     "CounterCostSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5663,
+      "line": 5886,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "SingleObject",
-          "line": 5665,
+          "line": 5888,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6756,7 +6860,7 @@
         },
         {
           "name": "AmongObjects",
-          "line": 5666,
+          "line": 5889,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6794,13 +6898,13 @@
     },
     "CounterMoveSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 934,
+      "line": 947,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "StackTarget",
-          "line": 936,
+          "line": 949,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6808,7 +6912,7 @@
         },
         {
           "name": "StackTargetAnyNumber",
-          "line": 937,
+          "line": 950,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6816,7 +6920,7 @@
         },
         {
           "name": "ResolutionDistributionAnyNumber",
-          "line": 938,
+          "line": 951,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6896,7 +7000,7 @@
     },
     "CounterSourceRider": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 957,
+      "line": 970,
       "doc": "CR 701.6 + CR 608.2c: A follow-up instruction carried by `Effect::Counter` that acts on the *source permanent* of an ability countered by the effect.  The rider only fires when the countered object was an activated or triggered ability — per CR 701.8a / CR 110.1 a spell is not a permanent, so when a spell is countered there is no permanent for the rider to act on and it is skipped (the conditional \"if a permanent's ability is countered this way\" is encoded structurally by this spell-vs-ability gate, not by a separate `AbilityCondition`).  Both variants share one categorical axis — \"an effect applied to the countered ability's source permanent\" — so they live on a single enum rather than as sibling `Option` fields on `Effect::Counter` (parameterize, don't proliferate).",
       "cr_refs": [
         "CR 110.1",
@@ -6907,7 +7011,7 @@
       "variants": [
         {
           "name": "LosesAbilities",
-          "line": 961,
+          "line": 974,
           "kind": "struct",
           "field_names": [
             "static_def"
@@ -6919,7 +7023,7 @@
         },
         {
           "name": "Destroy",
-          "line": 964,
+          "line": 977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: \"destroy that permanent\" — destroys the countered ability's source permanent (Teferi's Response, Green Slime).",
@@ -6932,7 +7036,7 @@
     },
     "CounterTransferMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 926,
+      "line": 939,
       "doc": "CR 122.5 / CR 122.8: Whether a counter-transfer effect actually moves counters off the source or only puts matching counters on the destination.",
       "cr_refs": [
         "CR 122.5",
@@ -6941,7 +7045,7 @@
       "variants": [
         {
           "name": "Move",
-          "line": 928,
+          "line": 941,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.5: Remove counters from the source and put them on the target.",
@@ -6951,7 +7055,7 @@
         },
         {
           "name": "Put",
-          "line": 930,
+          "line": 943,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.8: Put matching counters on the target using source/LKI state.",
@@ -7104,9 +7208,39 @@
       ],
       "sibling_clusters": []
     },
+    "CounteredSpellDestination": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 993,
+      "doc": "CR 701.6a + CR 614.1a: \"put it <zone> instead of into that player's graveyard\" — a replacement redirect on the destination of a countered *spell* (Memory Lapse, Remand, Spell Crumple). Distinct from [`CounterSourceRider`], which acts on a countered *ability*'s source permanent.  CR 701.6a says a countered spell is put into its owner's graveyard; CR 614.1a makes the \"instead\" clause a replacement that redirects that move to the named zone. Exile is deliberately excluded — that case is already handled by the existing graveyard-exile sub-ability rider in `game::effects::counter` (Force of Negation, No More Lies).",
+      "cr_refs": [
+        "CR 614.1a",
+        "CR 701.6a"
+      ],
+      "variants": [
+        {
+          "name": "Library",
+          "line": 996,
+          "kind": "struct",
+          "field_names": [
+            "position"
+          ],
+          "doc": "\"put it on top/bottom of its owner's library\" (Memory Lapse, Spell Crumple).",
+          "cr_refs": []
+        },
+        {
+          "name": "Hand",
+          "line": 999,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "\"return it to its owner's hand\" / \"put it into its owner's hand\" (Remand).",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "CrewAction": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 587,
+      "line": 594,
       "doc": "The keyword action being performed. `StaticMode::CrewContribution` stores the exact named actions it modifies. CR 702.122 / 702.171 / 702.184.",
       "cr_refs": [
         "CR 702.122"
@@ -7114,7 +7248,7 @@
       "variants": [
         {
           "name": "Crew",
-          "line": 588,
+          "line": 595,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7122,7 +7256,7 @@
         },
         {
           "name": "Saddle",
-          "line": 589,
+          "line": 596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7130,7 +7264,7 @@
         },
         {
           "name": "Station",
-          "line": 590,
+          "line": 597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7141,7 +7275,7 @@
     },
     "CrewContributionKind": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 577,
+      "line": 584,
       "doc": "CR 702.122c: How a creature's contributed power is modified when it crews a Vehicle, saddles a Mount, or stations a permanent. See [`StaticMode::CrewContribution`].",
       "cr_refs": [
         "CR 702.122c"
@@ -7149,7 +7283,7 @@
       "variants": [
         {
           "name": "PowerDelta",
-          "line": 579,
+          "line": 586,
           "kind": "struct",
           "field_names": [
             "delta"
@@ -7159,7 +7293,7 @@
         },
         {
           "name": "ToughnessInsteadOfPower",
-          "line": 581,
+          "line": 588,
           "kind": "unit",
           "field_names": [],
           "doc": "\"using its toughness rather than its power\" — contribute `toughness`.",
@@ -7197,7 +7331,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4141,
+      "line": 4321,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -7205,7 +7339,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 4144,
+          "line": 4324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -7218,7 +7352,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2088,
+      "line": 2195,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -7226,7 +7360,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 2091,
+          "line": 2198,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -7234,7 +7368,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 2093,
+          "line": 2200,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -7244,7 +7378,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 2095,
+          "line": 2202,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -7257,7 +7391,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14132,
+      "line": 15068,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -7265,7 +7399,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 14134,
+          "line": 15070,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -7273,7 +7407,7 @@
         },
         {
           "name": "Triple",
-          "line": 14136,
+          "line": 15072,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -7281,7 +7415,7 @@
         },
         {
           "name": "Plus",
-          "line": 14138,
+          "line": 15074,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7291,7 +7425,7 @@
         },
         {
           "name": "Minus",
-          "line": 14145,
+          "line": 15081,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7304,7 +7438,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 14149,
+          "line": 15085,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -7314,7 +7448,7 @@
         },
         {
           "name": "SetTo",
-          "line": 14155,
+          "line": 15091,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7326,7 +7460,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 14161,
+          "line": 15097,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -7341,7 +7475,7 @@
     },
     "DamageRedirectTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 549,
+      "line": 562,
       "doc": "CR 614.9: Recipient of a one-shot damage-redirection effect — the battle/creature/planeswalker/player the replaced damage is dealt to instead. Resolved to a concrete object/player at effect-resolution time (see `effects::create_damage_replacement::resolve`).",
       "cr_refs": [
         "CR 614.9"
@@ -7349,7 +7483,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 552,
+          "line": 565,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to you instead\" — the replacement source's controller (Jade Monolith, Goblin Psychopath).",
@@ -7357,7 +7491,7 @@
         },
         {
           "name": "SourceObject",
-          "line": 555,
+          "line": 568,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to ~ instead\" / \"...dealt to this creature instead\" — the replacement source object itself (Beacon of Destiny).",
@@ -7365,7 +7499,7 @@
         },
         {
           "name": "ChosenObjectTarget",
-          "line": 558,
+          "line": 571,
           "kind": "unit",
           "field_names": [],
           "doc": "\"...to target creature instead\" — an object chosen as a target of the creating ability (Soltari Guerrillas).",
@@ -7376,7 +7510,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6677,
+      "line": 7047,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -7384,7 +7518,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 6679,
+          "line": 7049,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -7392,7 +7526,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 6682,
+          "line": 7052,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -7400,13 +7534,30 @@
             "CR 120.3",
             "CR 603.7c"
           ]
+        },
+        {
+          "name": "EachTarget",
+          "line": 7078,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 120.1 + CR 601.2c: Every leading object target is an independent damage source; each deals damage to the shared recipient (the final object target). The amount (`QuantityExpr::Power { scope: Target }`) is re-resolved per source so each member deals damage equal to ITS OWN power (CR 208.1: power is a modifiable characteristic; CR 608.2: read at resolution). Generalizes `Target` (one source) to the variable-count \"up to N / any number of target creatures you control each deal damage equal to their power to <recipient>\" class (Allies at Last, Coordinated Clobbering, Terrific Team-Up — Graceful Takedown's heterogeneous compound source set \"<group A> and up to one other target <group B>\" is NOT covered and is deferred at the parser; see `is_compound_source_each_power_damage`). Unlike `Target`, the recipient is `targets.last()`, not `targets[1..]`.  SCOPE — SIMULTANEOUS multi-source batch (CR 120.4a + CR 120.6 + CR 120.10). The resolver (`resolve_each_target_power_damage`) reuses the decomposed damage primitives that `combat_damage.rs`'s simultaneous combat batch is built from (`pre_replacement_damage_gate` → `replace_event` → `apply_damage_after_replacement`), running all sources as one event set against the shared recipient: each source carries its OWN `DamageContext` (per-source deathtouch/wither/lifelink/infect/toxic), all marks accumulate onto the recipient before SBAs (CR 704) so combined lethal (CR 120.6) and combined excess (CR 120.10) are correct, and a replacement pause on the recipient mid-batch resumes the remaining sources with PER-SOURCE identity preserved (`stash_remaining_each_source_damage`, no flattening to a single source id).",
+          "cr_refs": [
+            "CR 120.1",
+            "CR 120.10",
+            "CR 120.4a",
+            "CR 120.6",
+            "CR 208.1",
+            "CR 601.2c",
+            "CR 608.2",
+            "CR 704"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14249,
+      "line": 15200,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -7414,7 +7565,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 14251,
+          "line": 15202,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -7422,7 +7573,7 @@
         },
         {
           "name": "Player",
-          "line": 14253,
+          "line": 15204,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7432,7 +7583,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 14256,
+          "line": 15207,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7445,7 +7596,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14233,
+      "line": 15184,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -7453,7 +7604,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 14234,
+          "line": 15185,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7461,7 +7612,7 @@
         },
         {
           "name": "Opponent",
-          "line": 14235,
+          "line": 15186,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7469,7 +7620,7 @@
         },
         {
           "name": "Controller",
-          "line": 14238,
+          "line": 15189,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -7477,7 +7628,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 14242,
+          "line": 15193,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -7488,7 +7639,7 @@
         },
         {
           "name": "Specific",
-          "line": 14243,
+          "line": 15194,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -7526,13 +7677,13 @@
     },
     "DebugAction": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 735,
+      "line": 743,
       "doc": "Direct game-state manipulation actions for debugging, testing, and remediation. Bypasses `WaitingFor` validation — fires from any game state without disrupting the current prompt. Gated on `GameState::debug_mode`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MoveToZone",
-          "line": 740,
+          "line": 748,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7545,7 +7696,7 @@
         },
         {
           "name": "CreateCard",
-          "line": 755,
+          "line": 763,
           "kind": "struct",
           "field_names": [
             "card_name",
@@ -7561,7 +7712,7 @@
         },
         {
           "name": "RemoveObject",
-          "line": 769,
+          "line": 777,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -7571,7 +7722,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 775,
+          "line": 783,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -7583,7 +7734,7 @@
         },
         {
           "name": "DrawCards",
-          "line": 778,
+          "line": 786,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7596,7 +7747,7 @@
         },
         {
           "name": "Mill",
-          "line": 780,
+          "line": 788,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7607,7 +7758,7 @@
         },
         {
           "name": "Reveal",
-          "line": 784,
+          "line": 792,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7621,7 +7772,7 @@
         },
         {
           "name": "ShuffleLibrary",
-          "line": 786,
+          "line": 794,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -7631,7 +7782,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 789,
+          "line": 797,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -7643,7 +7794,7 @@
         },
         {
           "name": "SetBasePowerToughness",
-          "line": 793,
+          "line": 801,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7655,7 +7806,7 @@
         },
         {
           "name": "ModifyCounters",
-          "line": 800,
+          "line": 808,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7667,7 +7818,7 @@
         },
         {
           "name": "SetTapped",
-          "line": 806,
+          "line": 814,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7678,7 +7829,7 @@
         },
         {
           "name": "SetPrepared",
-          "line": 812,
+          "line": 820,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7691,7 +7842,7 @@
         },
         {
           "name": "SetController",
-          "line": 814,
+          "line": 822,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7702,7 +7853,7 @@
         },
         {
           "name": "SetSummoningSickness",
-          "line": 819,
+          "line": 827,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7713,7 +7864,7 @@
         },
         {
           "name": "SetFaceState",
-          "line": 821,
+          "line": 829,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7726,7 +7877,7 @@
         },
         {
           "name": "Attach",
-          "line": 831,
+          "line": 839,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7740,7 +7891,7 @@
         },
         {
           "name": "Detach",
-          "line": 836,
+          "line": 844,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -7750,7 +7901,7 @@
         },
         {
           "name": "GrantKeyword",
-          "line": 838,
+          "line": 846,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7761,7 +7912,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 843,
+          "line": 851,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -7772,7 +7923,7 @@
         },
         {
           "name": "SetLife",
-          "line": 850,
+          "line": 858,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7783,7 +7934,7 @@
         },
         {
           "name": "ModifyPlayerCounters",
-          "line": 852,
+          "line": 860,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7795,7 +7946,7 @@
         },
         {
           "name": "ModifyEnergy",
-          "line": 858,
+          "line": 866,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7806,7 +7957,7 @@
         },
         {
           "name": "AddMana",
-          "line": 860,
+          "line": 868,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7817,7 +7968,7 @@
         },
         {
           "name": "SetInfiniteMana",
-          "line": 869,
+          "line": 877,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -7830,7 +7981,7 @@
         },
         {
           "name": "SetPhase",
-          "line": 873,
+          "line": 881,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -7841,7 +7992,7 @@
         },
         {
           "name": "RunStateBasedActions",
-          "line": 878,
+          "line": 886,
           "kind": "unit",
           "field_names": [],
           "doc": "Explicitly run state-based actions. Use after a batch of raw mutations.",
@@ -7849,7 +8000,7 @@
         },
         {
           "name": "CreateToken",
-          "line": 896,
+          "line": 904,
           "kind": "struct",
           "field_names": [
             "request",
@@ -7864,7 +8015,7 @@
         },
         {
           "name": "CreateTokenCopy",
-          "line": 903,
+          "line": 911,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -7880,13 +8031,13 @@
     },
     "DebugTokenRequest": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 911,
+      "line": 919,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Preset",
-          "line": 912,
+          "line": 920,
           "kind": "struct",
           "field_names": [
             "preset_id",
@@ -7898,7 +8049,7 @@
         },
         {
           "name": "Custom",
-          "line": 918,
+          "line": 926,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -7941,7 +8092,7 @@
     },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1916,
+      "line": 2023,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -7949,7 +8100,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 1919,
+          "line": 2026,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -7961,7 +8112,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 1922,
+          "line": 2029,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -7972,7 +8123,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 1924,
+          "line": 2031,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -7982,7 +8133,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 1930,
+          "line": 2037,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -7994,7 +8145,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 1933,
+          "line": 2040,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8006,7 +8157,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 1936,
+          "line": 2043,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8018,7 +8169,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 1939,
+          "line": 2046,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8028,7 +8179,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 1944,
+          "line": 2051,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -8040,7 +8191,7 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 1948,
+          "line": 2055,
           "kind": "struct",
           "field_names": [
             "trigger",
@@ -8056,7 +8207,7 @@
     },
     "DevotionColors": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1045,
+      "line": 1080,
       "doc": "CR 700.5: Which color set a devotion quantity counts.",
       "cr_refs": [
         "CR 700.5"
@@ -8064,7 +8215,7 @@
       "variants": [
         {
           "name": "Fixed",
-          "line": 1047,
+          "line": 1082,
           "kind": "tuple",
           "field_names": [],
           "doc": "Count devotion to one or more fixed colors.",
@@ -8072,7 +8223,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 1050,
+          "line": 1085,
           "kind": "unit",
           "field_names": [],
           "doc": "Count devotion to the color chosen by the source's current choice effect or persisted chosen-color attribute.",
@@ -8083,7 +8234,7 @@
     },
     "DieRollModifier": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 506,
+      "line": 519,
       "doc": "CR 706.2: Modifier applied to a die roll's natural result before the effect's result table is consulted. \"Roll a d20 and add the number of cards in your hand\" → `Add(QuantityExpr::Ref(HandSize { player: Controller }))`. \"Roll a d20 and subtract the number of cards in your hand\" → `Subtract(...)`.",
       "cr_refs": [
         "CR 706.2"
@@ -8091,7 +8242,7 @@
       "variants": [
         {
           "name": "Add",
-          "line": 508,
+          "line": 521,
           "kind": "struct",
           "field_names": [
             "value"
@@ -8101,7 +8252,7 @@
         },
         {
           "name": "Subtract",
-          "line": 510,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "value"
@@ -8114,13 +8265,13 @@
     },
     "DiscardSelfScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2862,
+      "line": 3007,
       "doc": "Whether a discard cost discards the ability source itself or cards from hand.",
       "cr_refs": [],
       "variants": [
         {
           "name": "FromHand",
-          "line": 2865,
+          "line": 3010,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard from hand per `filter` / `count` (the default).",
@@ -8128,7 +8279,7 @@
         },
         {
           "name": "SourceCard",
-          "line": 2867,
+          "line": 3012,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard the source card itself (Channel's \"Discard this card\").",
@@ -8139,7 +8290,7 @@
     },
     "DistributionUnit": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4119,
+      "line": 4199,
       "doc": "CR 601.2d: What is being distributed (damage, counters, life).",
       "cr_refs": [
         "CR 601.2d"
@@ -8147,7 +8298,7 @@
       "variants": [
         {
           "name": "Damage",
-          "line": 4120,
+          "line": 4200,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8155,7 +8306,7 @@
         },
         {
           "name": "EvenSplitDamage",
-          "line": 4123,
+          "line": 4203,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2d: Even split — engine auto-computes `total / num_targets` (rounded down). No player choice needed; bypasses `WaitingFor::DistributeAmong`.",
@@ -8165,7 +8316,7 @@
         },
         {
           "name": "Counters",
-          "line": 4124,
+          "line": 4204,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8173,7 +8324,7 @@
         },
         {
           "name": "Life",
-          "line": 4125,
+          "line": 4205,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8182,9 +8333,51 @@
       ],
       "sibling_clusters": []
     },
+    "DoorLockOp": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 3481,
+      "doc": "CR 709.5f-g: Operation an [`Effect::SetRoomDoorLock`] performs on a door (half) of a Room permanent. Typed (not a bool) so serialized engine state and the door-choice prompt say which direction is being applied, and so the \"lock or unlock\" disjunction is a first-class third operation rather than an inexpressible boolean combination. Parameterizes the lock/unlock axis — both live within CR rule section 709.5 — into one effect variant instead of two sibling effects.",
+      "cr_refs": [
+        "CR 709.5f"
+      ],
+      "variants": [
+        {
+          "name": "Unlock",
+          "line": 3483,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 709.5f: choose a locked half and give it the unlocked designation.",
+          "cr_refs": [
+            "CR 709.5f"
+          ]
+        },
+        {
+          "name": "Lock",
+          "line": 3485,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 709.5g: choose an unlocked half and remove its unlocked designation.",
+          "cr_refs": [
+            "CR 709.5g"
+          ]
+        },
+        {
+          "name": "LockOrUnlock",
+          "line": 3489,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 709.5f + CR 709.5g: \"Lock or unlock a door\" — the player chooses both the operation and the eligible half at resolution (Keys to the House, Marina Vendrell).",
+          "cr_refs": [
+            "CR 709.5f",
+            "CR 709.5g"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "DoublePTMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 917,
+      "line": 930,
       "doc": "CR 701.10a: Which P/T characteristics to double.",
       "cr_refs": [
         "CR 701.10a"
@@ -8192,7 +8385,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 918,
+          "line": 931,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8200,7 +8393,7 @@
         },
         {
           "name": "Toughness",
-          "line": 919,
+          "line": 932,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8208,7 +8401,7 @@
         },
         {
           "name": "PowerAndToughness",
-          "line": 920,
+          "line": 933,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8219,7 +8412,7 @@
     },
     "DoubleTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 904,
+      "line": 917,
       "doc": "CR 701.10d-f: What aspect to double (counters, life total, or mana pool). Used by `Effect::Double` per locked decision D-05. DoublePT/DoublePTAll handle CR 701.10a-c (power/toughness) separately.",
       "cr_refs": [
         "CR 701.10a",
@@ -8228,7 +8421,7 @@
       "variants": [
         {
           "name": "Counters",
-          "line": 907,
+          "line": 920,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -8240,7 +8433,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 909,
+          "line": 922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.10d: Double a player's life total.",
@@ -8250,7 +8443,7 @@
         },
         {
           "name": "ManaPool",
-          "line": 912,
+          "line": 925,
           "kind": "struct",
           "field_names": [
             "color"
@@ -8265,13 +8458,13 @@
     },
     "Duration": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1487,
+      "line": 1552,
       "doc": "Duration for temporary effects.  Player-axis variants are parameterized by `PlayerScope` per the workspace \"Parameterize, don't proliferate\" principle. `PlayerScope::Controller` recovers the legacy \"until your next turn\" / \"controller's next step\" semantics; future `Target` / `Opponent` / `AllPlayers` readings unblock cards whose duration is bound to a non-controller player.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilEndOfTurn",
-          "line": 1489,
+          "line": 1554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of turn (cleanup step).",
@@ -8281,7 +8474,7 @@
         },
         {
           "name": "UntilEndOfCombat",
-          "line": 1491,
+          "line": 1556,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of combat phase.",
@@ -8291,7 +8484,7 @@
         },
         {
           "name": "UntilNextTurnOf",
-          "line": 1495,
+          "line": 1560,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8304,7 +8497,7 @@
         },
         {
           "name": "UntilEndOfNextTurnOf",
-          "line": 1505,
+          "line": 1570,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8316,7 +8509,7 @@
         },
         {
           "name": "UntilHostLeavesPlay",
-          "line": 1510,
+          "line": 1575,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a: Effect expires when the source object leaves the battlefield.",
@@ -8326,7 +8519,7 @@
         },
         {
           "name": "UntilNextStepOf",
-          "line": 1516,
+          "line": 1581,
           "kind": "struct",
           "field_names": [
             "step",
@@ -8342,7 +8535,7 @@
         },
         {
           "name": "ForAsLongAs",
-          "line": 1522,
+          "line": 1587,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -8354,7 +8547,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1525,
+          "line": 1590,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8417,13 +8610,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6922,
+      "line": 7333,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields.",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 6924,
+          "line": 7335,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -8435,7 +8628,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 6930,
+          "line": 7341,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -8450,7 +8643,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 6941,
+          "line": 7352,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8461,8 +8654,42 @@
           "cr_refs": []
         },
         {
+          "name": "ApplyPostReplacementDamage",
+          "line": 7367,
+          "kind": "struct",
+          "field_names": [
+            "context",
+            "target",
+            "amount",
+            "is_combat"
+          ],
+          "doc": "CR 120.3 + CR 120.4b: Internal continuation for applying a damage event that has already passed through replacement/prevention selection. This must not be emitted by the parser; it exists so a Phase C damage batch can pause on a nested life/lifelink replacement choice and resume remaining post-replacement survivors without running CR 614/615 replacement logic a second time.",
+          "cr_refs": [
+            "CR 120.3",
+            "CR 120.4b",
+            "CR 614"
+          ]
+        },
+        {
+          "name": "EachDealsDamageEqualToPower",
+          "line": 7392,
+          "kind": "struct",
+          "field_names": [
+            "sources",
+            "recipient"
+          ],
+          "doc": "CR 120.1 + CR 120.3: \"Team-up\" damage — each of up to two chosen source creatures (controlled by the caster / their team) deals damage equal to ITS OWN power to a single recipient creature, with each source creature as the damage source (CR 120.1: the object dealing the damage is its source). Both axes are TARGETED: the source set is \"up to two target creatures you control\" (CR 115.1d, 0..=2) and the recipient is one \"target creature\" (CR 115.1). Distinct from `DealDamage` because the amount and the damage source vary per source object — a single `DealDamage { amount, damage_source }` cannot express N independent (power, source) pairs aimed at one recipient.  Covers Band Together, Allies at Last, Friendly Rivalry, and Graceful Takedown — the count (\"up to two\") and the recipient's controller restriction are encoded in `sources` / `recipient` filters plus the ability's `multi_target` spec. Combo Attack (\"two target creatures *your team* controls\") is out of scope: the Two-Headed Giant team scope (CR 810) has no model, so it fails closed to `Unimplemented` rather than mis-targeting a single player's creatures.",
+          "cr_refs": [
+            "CR 115.1",
+            "CR 115.1d",
+            "CR 120.1",
+            "CR 120.3",
+            "CR 810"
+          ]
+        },
+        {
           "name": "Draw",
-          "line": 6961,
+          "line": 7412,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8478,7 +8705,7 @@
         },
         {
           "name": "Pump",
-          "line": 6967,
+          "line": 7418,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8490,7 +8717,7 @@
         },
         {
           "name": "PairWith",
-          "line": 6978,
+          "line": 7429,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8503,7 +8730,7 @@
         },
         {
           "name": "Destroy",
-          "line": 6981,
+          "line": 7432,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8514,7 +8741,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 6989,
+          "line": 7440,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8525,19 +8752,34 @@
           ]
         },
         {
+          "name": "RemoveAllDamage",
+          "line": 7450,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 120.6 + CR 120.3: Remove all damage marked on the target creature(s) (\"all damage already dealt to him is healed\"). Unlike `Regenerate`, this does not create a shield, tap, or remove from combat — it only clears marked damage (and the deathtouch flag) early, before the cleanup step (CR 514.2) at which damage would otherwise wear off. Used by Wolverine, Fierce Fighter's heal-on-damage replacement.",
+          "cr_refs": [
+            "CR 120.3",
+            "CR 120.6",
+            "CR 514.2"
+          ]
+        },
+        {
           "name": "Counter",
-          "line": 6993,
+          "line": 7454,
           "kind": "struct",
           "field_names": [
             "target",
-            "source_rider"
+            "source_rider",
+            "countered_spell_zone"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "CounterAll",
-          "line": 7014,
+          "line": 7484,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8551,7 +8793,7 @@
         },
         {
           "name": "Token",
-          "line": 7018,
+          "line": 7488,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8574,7 +8816,7 @@
         },
         {
           "name": "GainLife",
-          "line": 7056,
+          "line": 7526,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8585,7 +8827,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 7067,
+          "line": 7537,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8596,7 +8838,7 @@
         },
         {
           "name": "SetTapState",
-          "line": 7085,
+          "line": 7555,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8611,7 +8853,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 7096,
+          "line": 7566,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8623,7 +8865,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 7111,
+          "line": 7581,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8635,7 +8877,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 7132,
+          "line": 7602,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8646,7 +8888,7 @@
         },
         {
           "name": "Mill",
-          "line": 7138,
+          "line": 7608,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8658,7 +8900,7 @@
         },
         {
           "name": "Scry",
-          "line": 7155,
+          "line": 7625,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8673,7 +8915,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 7161,
+          "line": 7631,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8685,7 +8927,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7175,
+          "line": 7645,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8702,7 +8944,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7199,
+          "line": 7669,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8715,7 +8957,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7203,
+          "line": 7673,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8726,7 +8968,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7210,
+          "line": 7680,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8746,7 +8988,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7255,
+          "line": 7725,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -8764,7 +9006,7 @@
         },
         {
           "name": "Dig",
-          "line": 7300,
+          "line": 7770,
           "kind": "struct",
           "field_names": [
             "player",
@@ -8785,7 +9027,7 @@
         },
         {
           "name": "GainControl",
-          "line": 7333,
+          "line": 7803,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8795,7 +9037,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 7345,
+          "line": 7815,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8807,7 +9049,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 7349,
+          "line": 7819,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8818,7 +9060,7 @@
         },
         {
           "name": "Attach",
-          "line": 7355,
+          "line": 7825,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8829,7 +9071,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 7367,
+          "line": 7837,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -8842,7 +9084,7 @@
         },
         {
           "name": "Surveil",
-          "line": 7379,
+          "line": 7849,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8857,7 +9099,7 @@
         },
         {
           "name": "Fight",
-          "line": 7385,
+          "line": 7855,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8868,7 +9110,7 @@
         },
         {
           "name": "Bounce",
-          "line": 7393,
+          "line": 7863,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8880,7 +9122,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 7412,
+          "line": 7882,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8895,7 +9137,7 @@
         },
         {
           "name": "Explore",
-          "line": 7420,
+          "line": 7890,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8903,7 +9145,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 7424,
+          "line": 7894,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8915,7 +9157,7 @@
         },
         {
           "name": "Investigate",
-          "line": 7429,
+          "line": 7899,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -8925,7 +9167,7 @@
         },
         {
           "name": "Tribute",
-          "line": 7436,
+          "line": 7906,
           "kind": "struct",
           "field_names": [
             "count"
@@ -8938,7 +9180,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 7442,
+          "line": 7912,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -8948,7 +9190,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 7444,
+          "line": 7914,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -8957,8 +9199,19 @@
           ]
         },
         {
+          "name": "NoOp",
+          "line": 7921,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 101.3 + CR 608.2: An instruction with no game action — \"there's no effect.\" Used as the resolved outcome for a choice that has no printed clause, e.g. the losing/unlisted option of a single-conditional Will-of-the-council threshold vote (\"If guilty gets more votes, X\" — the \"innocent\"/tied outcome does nothing). Resolving this emits only an `EffectResolved` so the chain continues.",
+          "cr_refs": [
+            "CR 101.3",
+            "CR 608.2"
+          ]
+        },
+        {
           "name": "Proliferate",
-          "line": 7445,
+          "line": 7922,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8966,7 +9219,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 7452,
+          "line": 7929,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8979,7 +9232,7 @@
         },
         {
           "name": "Populate",
-          "line": 7457,
+          "line": 7934,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -8989,7 +9242,7 @@
         },
         {
           "name": "Clash",
-          "line": 7459,
+          "line": 7936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -8999,7 +9252,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 7464,
+          "line": 7941,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.1: End the turn. Exile every object on the stack, check state-based actions, remove everything from combat, then skip straight to the cleanup step. Time Stop, Sundial of the Infinite, Obeka, Glorious End, Discontinuity, Day's Undoing.",
@@ -9009,7 +9262,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 7469,
+          "line": 7946,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase. Exile every object on the stack, check state-based actions, remove everything from combat, expire \"until end of combat\" effects, and skip straight to the postcombat main phase. Does nothing outside a combat phase (CR 724.2g). Mandate of Peace.",
@@ -9020,13 +9273,14 @@
         },
         {
           "name": "Vote",
-          "line": 7484,
+          "line": 7961,
           "kind": "struct",
           "field_names": [
             "choices",
             "per_choice_effect",
             "starting_with",
-            "voter_scope"
+            "voter_scope",
+            "tally_mode"
           ],
           "doc": "CR 701.38: Vote — each player chooses one of the listed options, starting with a specified player and proceeding in turn order. After all votes are collected, the resolver runs `per_choice_effect[i]` once for each vote cast for `choices[i]`. CR 701.38d: A player with multiple votes (granted by static \"you may vote an additional time\") makes those choices at the same time they would otherwise have voted.  The starting player defaults to the ability's controller (the canonical \"Council's dilemma — starting with you\" pattern). `per_choice_effect[i]` resolves once per vote tallied for `choices[i]` (Tivit's \"for each evidence vote, investigate\" / \"for each bribery vote, create a Treasure token\"). Each per-vote sub-resolution inherits the source ability's controller and source object, identical to how `ForEach`-style replicate effects fan out.",
           "cr_refs": [
@@ -9036,7 +9290,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 7528,
+          "line": 8018,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -9056,7 +9310,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 7547,
+          "line": 8037,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9068,7 +9322,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 7551,
+          "line": 8041,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9082,7 +9336,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 7584,
+          "line": 8074,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -9095,7 +9349,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 7589,
+          "line": 8079,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9108,7 +9362,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 7600,
+          "line": 8090,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9128,7 +9382,7 @@
         },
         {
           "name": "CreateTokenCopyFromPool",
-          "line": 7655,
+          "line": 8145,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -9149,7 +9403,7 @@
         },
         {
           "name": "Myriad",
-          "line": 7686,
+          "line": 8176,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -9159,7 +9413,7 @@
         },
         {
           "name": "Encore",
-          "line": 7693,
+          "line": 8183,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.141a: Encore — for each opponent, create a token that's a copy of the (exiled) source card that must attack that opponent this turn if able. The tokens gain haste and are sacrificed at the beginning of the next end step. Resolver: `game/effects/encore.rs`. No player-selectable target (opponents and per-opponent attack binding are chosen by the effect, like `Myriad`).",
@@ -9169,7 +9423,7 @@
         },
         {
           "name": "Meld",
-          "line": 7701,
+          "line": 8191,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9184,7 +9438,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 7711,
+          "line": 8201,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9196,7 +9450,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 7720,
+          "line": 8210,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9208,7 +9462,7 @@
         },
         {
           "name": "CopyTokenBlockingAttacker",
-          "line": 7732,
+          "line": 8222,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9223,7 +9477,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 7744,
+          "line": 8234,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9239,7 +9493,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 7754,
+          "line": 8244,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -9250,7 +9504,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 7768,
+          "line": 8258,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9264,7 +9518,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 7776,
+          "line": 8266,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9278,7 +9532,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 7783,
+          "line": 8273,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9290,33 +9544,38 @@
         },
         {
           "name": "DoublePT",
-          "line": 7791,
+          "line": 8288,
           "kind": "struct",
           "field_names": [
             "mode",
-            "target"
+            "target",
+            "factor"
           ],
-          "doc": "CR 701.10a: Double power/toughness of target creature.",
+          "doc": "CR 701.10a + CR 613.4c: Multiply power/toughness of target creature by `factor` via a layer-7c continuous modification. `factor: 2` is \"double\" (CR 701.10a/b); `factor: 3` is \"triple\" (Tifa's Limit Break — Final Heaven). Higher factors compose the same way: each adds `(factor-1)x` the snapshot value (CR 701.10b templating generalized — \"double\" gives +X, \"triple\" gives +2X). The `factor` axis parameterizes the multiplier so \"double\"/\"triple\"/… share one P/T-modifying effect rather than a Double/Triple sibling cluster.",
           "cr_refs": [
-            "CR 701.10a"
+            "CR 613.4c",
+            "CR 701.10a",
+            "CR 701.10b"
           ]
         },
         {
           "name": "DoublePTAll",
-          "line": 7797,
+          "line": 8300,
           "kind": "struct",
           "field_names": [
             "mode",
-            "target"
+            "target",
+            "factor"
           ],
-          "doc": "CR 701.10a: Double power/toughness of all matching creatures.",
+          "doc": "CR 701.10a + CR 613.4c: Multiply power/toughness of all matching creatures by `factor` (see `DoublePT` for the `factor` semantics).",
           "cr_refs": [
+            "CR 613.4c",
             "CR 701.10a"
           ]
         },
         {
           "name": "MoveCounters",
-          "line": 7805,
+          "line": 8310,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9334,7 +9593,7 @@
         },
         {
           "name": "Animate",
-          "line": 7825,
+          "line": 8330,
           "kind": "struct",
           "field_names": [
             "power",
@@ -9349,7 +9608,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 7863,
+          "line": 8368,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -9373,7 +9632,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 7879,
+          "line": 8384,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -9383,7 +9642,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 7883,
+          "line": 8388,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -9395,7 +9654,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 7891,
+          "line": 8396,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -9412,7 +9671,7 @@
         },
         {
           "name": "Mana",
-          "line": 7909,
+          "line": 8414,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -9426,7 +9685,7 @@
         },
         {
           "name": "Discard",
-          "line": 7932,
+          "line": 8437,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9440,7 +9699,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 7959,
+          "line": 8464,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9450,7 +9709,7 @@
         },
         {
           "name": "Transform",
-          "line": 7963,
+          "line": 8468,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9460,7 +9719,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 7969,
+          "line": 8474,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -9476,7 +9735,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 8026,
+          "line": 8531,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9494,21 +9753,22 @@
         },
         {
           "name": "RevealHand",
-          "line": 8037,
+          "line": 8542,
           "kind": "struct",
           "field_names": [
             "target",
             "card_filter",
             "count",
             "selection",
-            "choice_optional"
+            "choice_optional",
+            "reveal"
           ],
           "doc": "",
           "cr_refs": []
         },
         {
           "name": "RevealFromHand",
-          "line": 8066,
+          "line": 8575,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9521,7 +9781,7 @@
         },
         {
           "name": "Reveal",
-          "line": 8077,
+          "line": 8586,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9534,7 +9794,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 8082,
+          "line": 8591,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9547,7 +9807,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 8091,
+          "line": 8600,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9559,7 +9819,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 8114,
+          "line": 8623,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9569,7 +9829,7 @@
         },
         {
           "name": "Choose",
-          "line": 8120,
+          "line": 8629,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -9581,7 +9841,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 8138,
+          "line": 8647,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -9594,19 +9854,33 @@
         },
         {
           "name": "Suspect",
-          "line": 8143,
+          "line": 8660,
           "kind": "struct",
           "field_names": [
-            "target"
+            "target",
+            "scope"
           ],
-          "doc": "CR 701.60a: Suspect target creature — it gains menace and \"can't block.\"",
+          "doc": "CR 701.60a: Suspect creature(s) — each gains menace and \"can't block.\"  `scope` parameterizes the \"single vs mass\" axis (mirrors `Effect::SetTapState`): `EffectScope::Single` is the targeted/anaphoric \"suspect target creature\" / \"suspect it\"; `EffectScope::All` is a non-targeting population filter (\"suspect each creature ...\") enumerated over the battlefield at resolution. No printed card uses the mass scope for Suspect yet, but the field keeps the designation/un-designation pair symmetric so the shared resolver dispatches identically.",
+          "cr_refs": [
+            "CR 701.60a"
+          ]
+        },
+        {
+          "name": "Unsuspect",
+          "line": 8680,
+          "kind": "struct",
+          "field_names": [
+            "target",
+            "scope"
+          ],
+          "doc": "CR 701.60a: Cause creature(s) to no longer be suspected — the un-designation transition (\"all suspected creatures are no longer suspected\", \"it's no longer suspected\", \"become no longer suspected\"). The designation is the source of truth, so this clears `is_suspected` and the derived menace + \"can't block\" written by `Suspect`. Sibling of `Suspect`, mirroring the `BecomePrepared` / `BecomeUnprepared` pair.  `scope` is load-bearing (CR 701.60a applies the un-designation to *each* matching permanent): `EffectScope::Single` is the targeted/anaphoric \"it's no longer suspected\" / \"~ is no longer suspected\" path that reads `ability.targets`; `EffectScope::All` is the mass \"all suspected creatures are no longer suspected\" (Absolving Lammasu) population filter that enumerates every matching battlefield permanent with no announced target.",
           "cr_refs": [
             "CR 701.60a"
           ]
         },
         {
           "name": "Connive",
-          "line": 8153,
+          "line": 8692,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9620,7 +9894,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 8161,
+          "line": 8700,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9632,7 +9906,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 8168,
+          "line": 8707,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9644,7 +9918,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 8173,
+          "line": 8712,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9656,7 +9930,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 8178,
+          "line": 8717,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9670,7 +9944,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 8187,
+          "line": 8726,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -9680,7 +9954,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 8194,
+          "line": 8733,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9692,7 +9966,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8201,
+          "line": 8740,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9703,8 +9977,21 @@
           ]
         },
         {
+          "name": "BecomeSaddled",
+          "line": 8753,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "CR 702.171b: the target permanent becomes saddled until end of turn. Distinct from the Saddle keyword's activated ability (CR 702.171a, `KeywordAction::Saddle`) which is paid by tapping creatures: this is the effect-level designation toggle used by \"becomes saddled\" instructions (Guidelight Matrix, Kolodin, Alacrian Armory) that grant the designation without paying the saddle cost. Idempotent: if already saddled, no event fires. CR 702.171b: only permanents can become saddled, the designation is cleared at end of turn / when the permanent leaves the battlefield, and it is not part of the permanent's copiable values.",
+          "cr_refs": [
+            "CR 702.171a",
+            "CR 702.171b"
+          ]
+        },
+        {
           "name": "SetClassLevel",
-          "line": 8206,
+          "line": 8758,
           "kind": "struct",
           "field_names": [
             "level"
@@ -9716,7 +10003,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 8211,
+          "line": 8763,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -9730,7 +10017,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 8241,
+          "line": 8793,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -9744,7 +10031,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 8247,
+          "line": 8799,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -9756,7 +10043,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 8252,
+          "line": 8804,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9769,7 +10056,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 8259,
+          "line": 8811,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -9783,7 +10070,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 8274,
+          "line": 8826,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9796,7 +10083,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 8282,
+          "line": 8834,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -9810,7 +10097,7 @@
         },
         {
           "name": "PayCost",
-          "line": 8297,
+          "line": 8849,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -9824,7 +10111,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 8315,
+          "line": 8867,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9844,7 +10131,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 8383,
+          "line": 8935,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9864,7 +10151,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 8418,
+          "line": 8970,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 608.2n + CR 607.2b: \"Exile it instead of putting it into a graveyard as it resolves\" — the self-replacement rider applied by a `WhenAPlayerCasts` trigger to the *triggering spell* (Rod of Absorption).  At resolution this effect does NOT move the spell (it is still on the stack); it stamps the per-object linked-source marker so the stack-resolution router sends the spell to exile (CR 614.1a replaces the normal CR 608.2n graveyard destination) when it finishes resolving. When the spell reaches exile, it is recorded as \"exiled with\" the trigger source so a linked ability (CR 607.2b — \"cards exiled with this artifact\") can later refer to the accumulating set.  Distinct from `ChangeZone { destination: Exile }` (which moves a card that is already in a zone) and from `FreeCastFromZones { exile_instead… }` (which stamps the same rider on a spell *cast during resolution*, with no linked-exile payoff). This effect is the trigger-driven, link-establishing form for the resolving spell itself.",
@@ -9876,7 +10163,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 8420,
+          "line": 8972,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9893,7 +10180,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 8465,
+          "line": 9017,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9915,7 +10202,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 8506,
+          "line": 9058,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9927,7 +10214,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 8515,
+          "line": 9067,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9939,7 +10226,7 @@
         },
         {
           "name": "RollDie",
-          "line": 8528,
+          "line": 9080,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9957,7 +10244,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 8553,
+          "line": 9105,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -9973,7 +10260,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 8573,
+          "line": 9125,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9989,7 +10276,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 8587,
+          "line": 9139,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -10001,7 +10288,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 8592,
+          "line": 9144,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -10011,7 +10298,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 8595,
+          "line": 9147,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -10021,7 +10308,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 8597,
+          "line": 9149,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -10033,7 +10320,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 8602,
+          "line": 9154,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -10044,7 +10331,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 8607,
+          "line": 9159,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 901.8 / CR 901.9c: The synthetic \"planeswalking ability.\" When a player rolls the Planeswalker symbol on the planar die, this ability triggers and is put on the stack; on resolution its controller (the roller, CR 901.8) planeswalks (CR 701.31).",
@@ -10056,7 +10343,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 8610,
+          "line": 9162,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10068,7 +10355,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 8614,
+          "line": 9166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.52: Roll to visit your Attractions.",
@@ -10078,7 +10365,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 8617,
+          "line": 9169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -10088,7 +10375,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 8620,
+          "line": 9172,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -10100,7 +10387,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 8637,
+          "line": 9189,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10120,7 +10407,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 8684,
+          "line": 9236,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10135,7 +10422,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 8697,
+          "line": 9249,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -10151,7 +10438,7 @@
         },
         {
           "name": "Exploit",
-          "line": 8712,
+          "line": 9264,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10163,7 +10450,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 8717,
+          "line": 9269,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10175,7 +10462,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 8722,
+          "line": 9274,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -10190,7 +10477,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 8734,
+          "line": 9286,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10202,7 +10489,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 8746,
+          "line": 9298,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10218,16 +10505,19 @@
         },
         {
           "name": "RevealUntil",
-          "line": 8757,
+          "line": 9309,
           "kind": "struct",
           "field_names": [
             "player",
             "filter",
+            "count",
+            "matched_disposition",
             "kept_destination",
             "rest_destination",
             "enter_tapped",
             "enters_attacking",
-            "kept_optional_to"
+            "kept_optional_to",
+            "enters_under"
           ],
           "doc": "CR 701.20a: Reveal cards from the top of a player's library one at a time until that player reveals a card matching the filter. The matching card goes to `kept_destination`, the rest go to `rest_destination`.",
           "cr_refs": [
@@ -10236,19 +10526,41 @@
         },
         {
           "name": "Discover",
-          "line": 8795,
+          "line": 9376,
           "kind": "struct",
           "field_names": [
-            "mana_value_limit"
+            "mana_value_limit",
+            "player"
           ],
-          "doc": "CR 701.57a: Discover N — exile from top until nonland with MV ≤ N, cast free or put to hand, rest to bottom in random order.",
+          "doc": "CR 701.57a: Discover N — exile from top until nonland with MV ≤ N, cast free or put to hand, rest to bottom in random order.  `player` is the player who performs the discover. CR 701.57a is written from the controller's perspective (\"exile cards from the top of *your* library\"), so the default is `TargetFilter::Controller` and existing JSON (which omits the field) keeps the controller-discovers reading. Cards like Zoyowa's Justice (\"Then *that player* discovers X\") redirect the action to another player by carrying a player `TargetFilter` here; the resolver maps it through `resolve_player_for_context_ref`.",
           "cr_refs": [
             "CR 701.57a"
           ]
         },
         {
+          "name": "Heist",
+          "line": 9398,
+          "kind": "struct",
+          "field_names": [
+            "target",
+            "look_count"
+          ],
+          "doc": "Heist — designed-for-digital (MTG Arena) keyword action. NOT in the Comprehensive Rules; operates per the Arena programmed rules (see `docs/MagicCompRules.txt` — absent). Reminder text: \"Look at three random nonland cards from target opponent's library. Exile one of them face down. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell.\"  This is the selection/look step: the resolver surfaces `WaitingFor::ChooseFromZoneChoice` over `look_count` random nonland cards from the targeted opponent's library and stashes an `Effect::HeistExile` continuation. The chosen card is finalized by `HeistExile`; the unchosen cards never leave the library. `target` is the targeted opponent player (resolved from `ability.targets`).",
+          "cr_refs": []
+        },
+        {
+          "name": "HeistExile",
+          "line": 9413,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "Heist finalizer — continuation stashed by `Effect::Heist`. The chosen card (carried on `ability.targets` by the `ChooseFromZoneChoice` answer handler) is exiled from its owner's library, turned face down (CR 406.3), linked to the source so the controller may look at it (mirrors Hideaway's `ExileLinkKind::HideawayLookable`), and granted a permanent `PlayFromExile` permission with any-type-or-color mana so it can be cast for as long as it remains exiled. Unit variant — no fields; the target is implicit in `ability.targets`.",
+          "cr_refs": [
+            "CR 406.3"
+          ]
+        },
+        {
           "name": "Cascade",
-          "line": 8807,
+          "line": 9423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -10258,7 +10570,7 @@
         },
         {
           "name": "Ripple",
-          "line": 8812,
+          "line": 9428,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10270,7 +10582,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 8818,
+          "line": 9434,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10282,7 +10594,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 8823,
+          "line": 9439,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10294,7 +10606,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 8836,
+          "line": 9452,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10306,7 +10618,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 8845,
+          "line": 9461,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10318,7 +10630,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 8854,
+          "line": 9470,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10328,7 +10640,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 8859,
+          "line": 9475,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -10338,7 +10650,7 @@
         },
         {
           "name": "Goad",
-          "line": 8865,
+          "line": 9481,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10350,7 +10662,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 8872,
+          "line": 9488,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10362,7 +10674,7 @@
         },
         {
           "name": "Detain",
-          "line": 8879,
+          "line": 9495,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10373,8 +10685,22 @@
           ]
         },
         {
+          "name": "SetRoomDoorLock",
+          "line": 9507,
+          "kind": "struct",
+          "field_names": [
+            "op",
+            "target"
+          ],
+          "doc": "CR 709.5f-g + CR 709.5j: Lock or unlock a door (half) of the targeted Room permanent. `op` fixes the direction (or `LockOrUnlock` lets the player choose); `target` selects the Room. The eligible half is chosen at resolution from the Room's runtime unlock state — locked halves for `Unlock`, unlocked halves for `Lock` — so the choice cannot be baked into static branches at parse time. Covers Ghostly Keybearer (\"unlock a locked door of up to one target Room you control\"), Keys to the House, and Marina Vendrell (\"lock or unlock a door of target Room you control\").",
+          "cr_refs": [
+            "CR 709.5f",
+            "CR 709.5j"
+          ]
+        },
+        {
           "name": "ExchangeControl",
-          "line": 8890,
+          "line": 9519,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -10388,7 +10714,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 8901,
+          "line": 9530,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10402,7 +10728,7 @@
         },
         {
           "name": "Manifest",
-          "line": 8916,
+          "line": 9545,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10417,7 +10743,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 8936,
+          "line": 9565,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -10427,7 +10753,7 @@
         },
         {
           "name": "Cloak",
-          "line": 8943,
+          "line": 9572,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10441,7 +10767,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 8955,
+          "line": 9584,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10454,7 +10780,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 8962,
+          "line": 9591,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10466,7 +10792,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 8976,
+          "line": 9605,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10479,7 +10805,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 8987,
+          "line": 9616,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10492,7 +10818,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 8997,
+          "line": 9626,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10506,7 +10832,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 9013,
+          "line": 9642,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10523,7 +10849,7 @@
         },
         {
           "name": "Double",
-          "line": 9026,
+          "line": 9655,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -10537,7 +10863,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 9034,
+          "line": 9663,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -10549,7 +10875,7 @@
         },
         {
           "name": "Incubate",
-          "line": 9040,
+          "line": 9669,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10561,7 +10887,7 @@
         },
         {
           "name": "Amass",
-          "line": 9048,
+          "line": 9677,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -10574,7 +10900,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 9056,
+          "line": 9685,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10586,7 +10912,7 @@
         },
         {
           "name": "Specialize",
-          "line": 9062,
+          "line": 9691,
           "kind": "unit",
           "field_names": [],
           "doc": "Digital-only Specialize: permanently become a color-specific face after paying the synthesized activation cost (mana + discard). Not in CR text.",
@@ -10594,7 +10920,7 @@
         },
         {
           "name": "Renown",
-          "line": 9065,
+          "line": 9694,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10606,7 +10932,7 @@
         },
         {
           "name": "Bolster",
-          "line": 9071,
+          "line": 9700,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10618,7 +10944,7 @@
         },
         {
           "name": "Adapt",
-          "line": 9077,
+          "line": 9706,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10630,7 +10956,7 @@
         },
         {
           "name": "Learn",
-          "line": 9083,
+          "line": 9712,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -10640,7 +10966,7 @@
         },
         {
           "name": "Forage",
-          "line": 9085,
+          "line": 9714,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -10650,7 +10976,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 9087,
+          "line": 9716,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10662,7 +10988,7 @@
         },
         {
           "name": "Endure",
-          "line": 9094,
+          "line": 9723,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10675,19 +11001,20 @@
         },
         {
           "name": "BlightEffect",
-          "line": 9099,
+          "line": 9738,
           "kind": "struct",
           "field_names": [
-            "count"
+            "count",
+            "player"
           ],
-          "doc": "CR 701.68a: Blight N as an effect — the controller of this ability puts N -1/-1 counters on a creature they control. Non-targeted controller choice.",
+          "doc": "CR 701.68a: Blight N as an effect — the blighting player puts N -1/-1 counters on a creature *they* control. Non-targeted: the player choosing which of their own creatures to blight is a choice, not a target (CR 701.68a — hexproof/shroud are irrelevant).  `player` is the player instructed to blight. The default `TargetFilter::Controller` keeps the common \"you blight\" reading and lets existing JSON (which omits the field) deserialize unchanged. Cards like Champion of the Weird (\"Target opponent blights 2\") redirect the action to a chosen player by carrying a player `TargetFilter` here; the resolver maps it through `resolve_player_for_context_ref` and scopes eligible creatures to that player.",
           "cr_refs": [
             "CR 701.68a"
           ]
         },
         {
           "name": "Seek",
-          "line": 9104,
+          "line": 9748,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -10701,7 +11028,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 9121,
+          "line": 9765,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10714,7 +11041,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 9136,
+          "line": 9780,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10730,7 +11057,7 @@
         },
         {
           "name": "ExchangeLifeTotals",
-          "line": 9144,
+          "line": 9788,
           "kind": "struct",
           "field_names": [
             "player_a",
@@ -10743,7 +11070,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 9152,
+          "line": 9796,
           "kind": "struct",
           "field_names": [
             "to"
@@ -10755,7 +11082,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 9157,
+          "line": 9801,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10768,7 +11095,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 9166,
+          "line": 9810,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10780,7 +11107,7 @@
         },
         {
           "name": "Conjure",
-          "line": 9173,
+          "line": 9817,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -10792,7 +11119,7 @@
         },
         {
           "name": "Intensify",
-          "line": 9185,
+          "line": 9829,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -10803,7 +11130,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 9199,
+          "line": 9843,
           "kind": "struct",
           "field_names": [
             "destination",
@@ -10814,7 +11141,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 9218,
+          "line": 9862,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10828,7 +11155,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 9229,
+          "line": 9873,
           "kind": "struct",
           "field_names": [
             "name",
@@ -10931,13 +11258,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15566,
+      "line": 16530,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 15568,
+          "line": 16532,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10945,7 +11272,7 @@
         },
         {
           "name": "InvalidParam",
-          "line": 15570,
+          "line": 16534,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10953,7 +11280,7 @@
         },
         {
           "name": "PlayerNotFound",
-          "line": 15572,
+          "line": 16536,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10961,7 +11288,7 @@
         },
         {
           "name": "ObjectNotFound",
-          "line": 15574,
+          "line": 16538,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10969,7 +11296,7 @@
         },
         {
           "name": "ChainTooDeep",
-          "line": 15576,
+          "line": 16540,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -10977,7 +11304,7 @@
         },
         {
           "name": "Unregistered",
-          "line": 15578,
+          "line": 16542,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -10988,13 +11315,13 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10849,
+      "line": 11652,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 10850,
+          "line": 11653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11002,7 +11329,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 10851,
+          "line": 11654,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11010,7 +11337,23 @@
         },
         {
           "name": "DealDamage",
-          "line": 10852,
+          "line": 11655,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ApplyPostReplacementDamage",
+          "line": 11656,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "EachDealsDamageEqualToPower",
+          "line": 11657,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11018,7 +11361,7 @@
         },
         {
           "name": "Draw",
-          "line": 10853,
+          "line": 11658,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11026,7 +11369,7 @@
         },
         {
           "name": "Pump",
-          "line": 10854,
+          "line": 11659,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11034,7 +11377,7 @@
         },
         {
           "name": "PairWith",
-          "line": 10855,
+          "line": 11660,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11042,7 +11385,7 @@
         },
         {
           "name": "Destroy",
-          "line": 10856,
+          "line": 11661,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11050,7 +11393,7 @@
         },
         {
           "name": "Counter",
-          "line": 10857,
+          "line": 11662,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11058,7 +11401,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 10858,
+          "line": 11663,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11066,7 +11409,7 @@
         },
         {
           "name": "Token",
-          "line": 10859,
+          "line": 11664,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11074,7 +11417,7 @@
         },
         {
           "name": "GainLife",
-          "line": 10860,
+          "line": 11665,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11082,7 +11425,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 10861,
+          "line": 11666,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11090,7 +11433,7 @@
         },
         {
           "name": "Tap",
-          "line": 10862,
+          "line": 11667,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11098,7 +11441,7 @@
         },
         {
           "name": "Untap",
-          "line": 10863,
+          "line": 11668,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11106,7 +11449,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 10864,
+          "line": 11669,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11114,7 +11457,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 10865,
+          "line": 11670,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11122,7 +11465,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 10866,
+          "line": 11671,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11130,7 +11473,7 @@
         },
         {
           "name": "Mill",
-          "line": 10867,
+          "line": 11672,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11138,7 +11481,7 @@
         },
         {
           "name": "Scry",
-          "line": 10868,
+          "line": 11673,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11146,7 +11489,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 10869,
+          "line": 11674,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11154,7 +11497,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 10870,
+          "line": 11675,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11162,7 +11505,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 10871,
+          "line": 11676,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11170,7 +11513,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 10872,
+          "line": 11677,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11178,7 +11521,7 @@
         },
         {
           "name": "TapAll",
-          "line": 10873,
+          "line": 11678,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11186,7 +11529,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 10874,
+          "line": 11679,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11194,7 +11537,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 10875,
+          "line": 11680,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11202,7 +11545,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 10876,
+          "line": 11681,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11210,7 +11553,7 @@
         },
         {
           "name": "Dig",
-          "line": 10877,
+          "line": 11682,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11218,7 +11561,7 @@
         },
         {
           "name": "GainControl",
-          "line": 10878,
+          "line": 11683,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11226,7 +11569,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 10879,
+          "line": 11684,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11234,7 +11577,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 10880,
+          "line": 11685,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11242,7 +11585,7 @@
         },
         {
           "name": "Attach",
-          "line": 10881,
+          "line": 11686,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11250,7 +11593,7 @@
         },
         {
           "name": "AttachAll",
-          "line": 10882,
+          "line": 11687,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11258,7 +11601,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 10883,
+          "line": 11688,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11266,7 +11609,7 @@
         },
         {
           "name": "Surveil",
-          "line": 10884,
+          "line": 11689,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11274,7 +11617,7 @@
         },
         {
           "name": "Fight",
-          "line": 10885,
+          "line": 11690,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11282,7 +11625,7 @@
         },
         {
           "name": "Bounce",
-          "line": 10886,
+          "line": 11691,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11290,7 +11633,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 10887,
+          "line": 11692,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11298,7 +11641,7 @@
         },
         {
           "name": "Explore",
-          "line": 10888,
+          "line": 11693,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11306,7 +11649,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 10889,
+          "line": 11694,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11314,7 +11657,7 @@
         },
         {
           "name": "Investigate",
-          "line": 10890,
+          "line": 11695,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11322,7 +11665,7 @@
         },
         {
           "name": "Tribute",
-          "line": 10891,
+          "line": 11696,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11330,7 +11673,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 10892,
+          "line": 11697,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11338,7 +11681,15 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 10893,
+          "line": 11698,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "NoOp",
+          "line": 11699,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11346,7 +11697,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 10894,
+          "line": 11700,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11354,7 +11705,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 10895,
+          "line": 11701,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11362,7 +11713,7 @@
         },
         {
           "name": "Populate",
-          "line": 10896,
+          "line": 11702,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11370,7 +11721,7 @@
         },
         {
           "name": "Clash",
-          "line": 10897,
+          "line": 11703,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11378,7 +11729,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 10898,
+          "line": 11704,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11386,7 +11737,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 10900,
+          "line": 11706,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase — skip to the postcombat main phase.",
@@ -11396,7 +11747,7 @@
         },
         {
           "name": "Vote",
-          "line": 10902,
+          "line": 11708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -11406,7 +11757,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 10904,
+          "line": 11710,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -11416,7 +11767,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 10905,
+          "line": 11711,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11424,7 +11775,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 10906,
+          "line": 11712,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11432,7 +11783,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 10907,
+          "line": 11713,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11440,7 +11791,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 10908,
+          "line": 11714,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11448,7 +11799,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 10909,
+          "line": 11715,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11456,7 +11807,7 @@
         },
         {
           "name": "CreateTokenCopyFromPool",
-          "line": 10910,
+          "line": 11716,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11464,7 +11815,7 @@
         },
         {
           "name": "Myriad",
-          "line": 10911,
+          "line": 11717,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11472,7 +11823,7 @@
         },
         {
           "name": "Encore",
-          "line": 10912,
+          "line": 11718,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11480,7 +11831,7 @@
         },
         {
           "name": "Meld",
-          "line": 10913,
+          "line": 11719,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11488,7 +11839,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 10914,
+          "line": 11720,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11496,7 +11847,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 10915,
+          "line": 11721,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11504,7 +11855,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 10916,
+          "line": 11722,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11512,7 +11863,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 10917,
+          "line": 11723,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11520,7 +11871,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 10918,
+          "line": 11724,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11528,7 +11879,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 10919,
+          "line": 11725,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11536,7 +11887,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 10920,
+          "line": 11726,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11544,7 +11895,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 10921,
+          "line": 11727,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11552,7 +11903,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 10922,
+          "line": 11728,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11560,7 +11911,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 10923,
+          "line": 11729,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11568,7 +11919,7 @@
         },
         {
           "name": "Animate",
-          "line": 10924,
+          "line": 11730,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11576,7 +11927,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 10925,
+          "line": 11731,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11584,7 +11935,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 10926,
+          "line": 11732,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11592,7 +11943,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 10927,
+          "line": 11733,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11600,7 +11951,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 10928,
+          "line": 11734,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11608,7 +11959,7 @@
         },
         {
           "name": "Mana",
-          "line": 10929,
+          "line": 11735,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11616,7 +11967,7 @@
         },
         {
           "name": "Discard",
-          "line": 10930,
+          "line": 11736,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11624,7 +11975,7 @@
         },
         {
           "name": "Shuffle",
-          "line": 10931,
+          "line": 11737,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11632,7 +11983,7 @@
         },
         {
           "name": "SearchLibrary",
-          "line": 10932,
+          "line": 11738,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11640,7 +11991,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 10933,
+          "line": 11739,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11648,7 +11999,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 10934,
+          "line": 11740,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11656,7 +12007,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 10935,
+          "line": 11741,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11664,7 +12015,7 @@
         },
         {
           "name": "Choose",
-          "line": 10936,
+          "line": 11742,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11672,7 +12023,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 10937,
+          "line": 11743,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11680,7 +12031,15 @@
         },
         {
           "name": "Suspect",
-          "line": 10938,
+          "line": 11744,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unsuspect",
+          "line": 11745,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11688,7 +12047,7 @@
         },
         {
           "name": "Connive",
-          "line": 10939,
+          "line": 11746,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11696,7 +12055,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 10940,
+          "line": 11747,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11704,7 +12063,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 10941,
+          "line": 11748,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11712,7 +12071,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 10942,
+          "line": 11749,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11720,7 +12079,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 10943,
+          "line": 11750,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11728,7 +12087,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 10944,
+          "line": 11751,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11736,7 +12095,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 10946,
+          "line": 11753,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -11746,7 +12105,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 10948,
+          "line": 11755,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -11755,8 +12114,18 @@
           ]
         },
         {
+          "name": "BecomeSaddled",
+          "line": 11757,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.171b: mark the target permanent as saddled until end of turn.",
+          "cr_refs": [
+            "CR 702.171b"
+          ]
+        },
+        {
           "name": "SetClassLevel",
-          "line": 10949,
+          "line": 11758,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11764,7 +12133,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 10950,
+          "line": 11759,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11772,7 +12141,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 10951,
+          "line": 11760,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11780,7 +12149,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 10952,
+          "line": 11761,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11788,7 +12157,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 10953,
+          "line": 11762,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11796,7 +12165,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 10954,
+          "line": 11763,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11804,7 +12173,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 10955,
+          "line": 11764,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11812,7 +12181,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 10956,
+          "line": 11765,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11820,7 +12189,7 @@
         },
         {
           "name": "PayCost",
-          "line": 10957,
+          "line": 11766,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11828,7 +12197,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 10958,
+          "line": 11767,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11836,7 +12205,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 10959,
+          "line": 11768,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11844,7 +12213,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 10960,
+          "line": 11769,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11852,7 +12221,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 10961,
+          "line": 11770,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11860,7 +12229,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 10962,
+          "line": 11771,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11868,7 +12237,15 @@
         },
         {
           "name": "Regenerate",
-          "line": 10963,
+          "line": 11772,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RemoveAllDamage",
+          "line": 11773,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11876,7 +12253,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 10964,
+          "line": 11774,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11884,7 +12261,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 10965,
+          "line": 11775,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11892,7 +12269,7 @@
         },
         {
           "name": "RollDie",
-          "line": 10966,
+          "line": 11776,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11900,7 +12277,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 10967,
+          "line": 11777,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11908,7 +12285,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 10968,
+          "line": 11778,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11916,7 +12293,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 10969,
+          "line": 11779,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11924,7 +12301,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 10970,
+          "line": 11780,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11932,7 +12309,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 10971,
+          "line": 11781,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11940,7 +12317,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 10972,
+          "line": 11782,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11948,7 +12325,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 10973,
+          "line": 11783,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11956,7 +12333,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 10974,
+          "line": 11784,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11964,7 +12341,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 10975,
+          "line": 11785,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11972,7 +12349,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 10976,
+          "line": 11786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11980,7 +12357,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 10977,
+          "line": 11787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11988,7 +12365,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 10978,
+          "line": 11788,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -11996,7 +12373,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 10979,
+          "line": 11789,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12004,7 +12381,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 10980,
+          "line": 11790,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12012,7 +12389,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 10981,
+          "line": 11791,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12020,7 +12397,7 @@
         },
         {
           "name": "Exploit",
-          "line": 10982,
+          "line": 11792,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12028,7 +12405,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 10983,
+          "line": 11793,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12036,7 +12413,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 10984,
+          "line": 11794,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12044,7 +12421,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 10985,
+          "line": 11795,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12052,7 +12429,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 10986,
+          "line": 11796,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12060,7 +12437,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 10987,
+          "line": 11797,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12068,7 +12445,23 @@
         },
         {
           "name": "Discover",
-          "line": 10988,
+          "line": 11798,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Heist",
+          "line": 11799,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "HeistExile",
+          "line": 11800,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12076,7 +12469,7 @@
         },
         {
           "name": "Cascade",
-          "line": 10989,
+          "line": 11801,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12084,7 +12477,7 @@
         },
         {
           "name": "Ripple",
-          "line": 10990,
+          "line": 11802,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12092,7 +12485,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 10991,
+          "line": 11803,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12100,7 +12493,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 10992,
+          "line": 11804,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12108,7 +12501,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 10993,
+          "line": 11805,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12116,7 +12509,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 10994,
+          "line": 11806,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12124,7 +12517,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 10995,
+          "line": 11807,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12132,7 +12525,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 10996,
+          "line": 11808,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12140,7 +12533,7 @@
         },
         {
           "name": "Goad",
-          "line": 10997,
+          "line": 11809,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12148,7 +12541,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 10998,
+          "line": 11810,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12156,7 +12549,15 @@
         },
         {
           "name": "Detain",
-          "line": 10999,
+          "line": 11811,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetRoomDoorLock",
+          "line": 11812,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12164,7 +12565,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 11000,
+          "line": 11813,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12172,7 +12573,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 11001,
+          "line": 11814,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12180,7 +12581,7 @@
         },
         {
           "name": "Incubate",
-          "line": 11002,
+          "line": 11815,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12188,7 +12589,7 @@
         },
         {
           "name": "Amass",
-          "line": 11003,
+          "line": 11816,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12196,7 +12597,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 11004,
+          "line": 11817,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12204,7 +12605,7 @@
         },
         {
           "name": "Specialize",
-          "line": 11005,
+          "line": 11818,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12212,7 +12613,7 @@
         },
         {
           "name": "Renown",
-          "line": 11006,
+          "line": 11819,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12220,7 +12621,7 @@
         },
         {
           "name": "Bolster",
-          "line": 11007,
+          "line": 11820,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12228,7 +12629,7 @@
         },
         {
           "name": "Adapt",
-          "line": 11008,
+          "line": 11821,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12236,7 +12637,7 @@
         },
         {
           "name": "Manifest",
-          "line": 11009,
+          "line": 11822,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12244,7 +12645,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 11010,
+          "line": 11823,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12252,7 +12653,7 @@
         },
         {
           "name": "Cloak",
-          "line": 11012,
+          "line": 11825,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.58a: Cloak (face-down 2/2 with ward {2}).",
@@ -12262,7 +12663,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 11013,
+          "line": 11826,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12270,7 +12671,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 11014,
+          "line": 11827,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12278,7 +12679,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 11015,
+          "line": 11828,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12286,7 +12687,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 11016,
+          "line": 11829,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12294,7 +12695,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 11017,
+          "line": 11830,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12302,7 +12703,7 @@
         },
         {
           "name": "Double",
-          "line": 11018,
+          "line": 11831,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12310,7 +12711,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 11019,
+          "line": 11832,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12318,7 +12719,7 @@
         },
         {
           "name": "Learn",
-          "line": 11020,
+          "line": 11833,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12326,7 +12727,7 @@
         },
         {
           "name": "Forage",
-          "line": 11021,
+          "line": 11834,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12334,7 +12735,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 11022,
+          "line": 11835,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12342,7 +12743,7 @@
         },
         {
           "name": "Endure",
-          "line": 11023,
+          "line": 11836,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12350,7 +12751,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 11024,
+          "line": 11837,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12358,7 +12759,7 @@
         },
         {
           "name": "Seek",
-          "line": 11025,
+          "line": 11838,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12366,7 +12767,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 11026,
+          "line": 11839,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12374,7 +12775,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 11027,
+          "line": 11840,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12382,7 +12783,7 @@
         },
         {
           "name": "ExchangeLifeTotals",
-          "line": 11028,
+          "line": 11841,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12390,7 +12791,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 11029,
+          "line": 11842,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12398,7 +12799,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 11030,
+          "line": 11843,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12406,7 +12807,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 11031,
+          "line": 11844,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12414,7 +12815,7 @@
         },
         {
           "name": "Conjure",
-          "line": 11032,
+          "line": 11845,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12422,7 +12823,7 @@
         },
         {
           "name": "Intensify",
-          "line": 11033,
+          "line": 11846,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12430,7 +12831,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 11034,
+          "line": 11847,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12438,7 +12839,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 11035,
+          "line": 11848,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12446,7 +12847,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 11036,
+          "line": 11849,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12454,7 +12855,7 @@
         },
         {
           "name": "Equip",
-          "line": 11038,
+          "line": 11851,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -12462,7 +12863,7 @@
         },
         {
           "name": "Crew",
-          "line": 11040,
+          "line": 11853,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -12472,7 +12873,7 @@
         },
         {
           "name": "Station",
-          "line": 11042,
+          "line": 11855,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -12482,7 +12883,7 @@
         },
         {
           "name": "Saddle",
-          "line": 11044,
+          "line": 11857,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -12492,7 +12893,7 @@
         },
         {
           "name": "Reveal",
-          "line": 11046,
+          "line": 11859,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -12500,7 +12901,7 @@
         },
         {
           "name": "Transform",
-          "line": 11047,
+          "line": 11860,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12508,7 +12909,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 11048,
+          "line": 11861,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12516,7 +12917,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 11049,
+          "line": 11862,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -12632,13 +13033,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12295,
+      "line": 13175,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 12299,
+          "line": 13179,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -12649,7 +13050,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 12302,
+          "line": 13182,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -12699,7 +13100,7 @@
     },
     "EffectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3296,
+      "line": 3451,
       "doc": "CR 701.26a / CR 701.26b: Selection scope for `Effect::SetTapState`. Picks whether the tap/untap targets a single chosen/source permanent (the legacy `Tap` / `Untap`) or every permanent matching the filter (the legacy `TapAll` / `UntapAll`). Parameterizes the structural \"single vs mass\" axis instead of proliferating sibling effect variants.",
       "cr_refs": [
         "CR 701.26a",
@@ -12708,7 +13109,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3299,
+          "line": 3454,
           "kind": "unit",
           "field_names": [],
           "doc": "One permanent — `target` is a selectable target filter (legacy `Effect::Tap` / `Effect::Untap`). `target_filter()` exposes it.",
@@ -12716,7 +13117,7 @@
         },
         {
           "name": "All",
-          "line": 3302,
+          "line": 3457,
           "kind": "unit",
           "field_names": [],
           "doc": "Every permanent matching the filter — `target` is a non-targeting population filter (legacy `Effect::TapAll` / `Effect::UntapAll`).",
@@ -12999,7 +13400,7 @@
     },
     "ExileLinkKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 723,
+      "line": 734,
       "doc": "CR 607.2a + CR 406.6: Tracks the link between an exiling source and the exiled card. When the source leaves the battlefield, the exiled card returns (CR 610.3a).",
       "cr_refs": [
         "CR 406.6",
@@ -13009,7 +13410,7 @@
       "variants": [
         {
           "name": "UntilSourceLeaves",
-          "line": 725,
+          "line": 736,
           "kind": "struct",
           "field_names": [
             "return_zone"
@@ -13021,7 +13422,7 @@
         },
         {
           "name": "TrackedBySource",
-          "line": 727,
+          "line": 738,
           "kind": "unit",
           "field_names": [],
           "doc": "Track cards \"exiled with\" a source without creating an automatic return.",
@@ -13029,7 +13430,7 @@
         },
         {
           "name": "ParadigmSource",
-          "line": 736,
+          "line": 747,
           "kind": "struct",
           "field_names": [
             "player"
@@ -13044,7 +13445,7 @@
         },
         {
           "name": "Cipher",
-          "line": 745,
+          "line": 756,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99b: Cipher — the exiled card (`exiled_id`) is *encoded* on the creature (`source_id`). While the card stays in exile and the creature stays on the battlefield, the creature has \"Whenever this creature deals combat damage to a player, its controller may cast a copy of the encoded card without paying its mana cost\" (CR 702.99c). The link is pruned automatically when the card leaves exile (`zones.rs` exile-exit) or the creature leaves the battlefield (`zones.rs` battlefield-exit, since this is not an `UntilSourceLeaves` link) — exactly CR 702.99c's lifetime.",
@@ -13055,7 +13456,7 @@
         },
         {
           "name": "Haunt",
-          "line": 756,
+          "line": 767,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.55b: Haunt — the exiled card (`exiled_id`) \"haunts\" the creature (`source_id`) targeted by its haunt ability. The link drives the card's haunt-payoff trigger, which fires from the exile zone when the haunted creature dies (CR 702.55c). Unlike `Cipher`, this link is **preserved** when the haunted creature leaves the battlefield (`zones.rs` battlefield exit) — the haunted creature's death is exactly when the payoff must read the link. The card \"haunts the creature it haunts regardless of whether or not that object is still a creature\" (CR 702.55b), so the link is pruned only when the haunting card itself leaves exile (`zones.rs` exile-exit), not when the creature changes or dies.",
@@ -13066,7 +13467,7 @@
         },
         {
           "name": "HideawayLookable",
-          "line": 768,
+          "line": 779,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.75a: Hideaway — the card (`exiled_id`) was exiled face down by the permanent (`source_id`). Like `TrackedBySource` it tracks the card so the companion \"you may play the exiled card\" ability (`TargetFilter:: ExiledBySource`, which is kind-agnostic) can later find it — but it additionally grants a *look-permission*: the player who controls the exiling permanent \"may look at this card in the exile zone\". Visibility keys the controller's face-down look-through on this kind specifically, so plain `TrackedBySource` face-down exiles that grant no such permission (Bomat Courier's \"(You can't look at it.)\", Necropotence, Asmodeus) stay redacted. Pruned on exile-exit / source-exit like `Cipher` (not an `UntilSourceLeaves` link, so no automatic return).",
@@ -13076,7 +13477,7 @@
         },
         {
           "name": "CraftMaterial",
-          "line": 780,
+          "line": 791,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.167c: Craft material — the card (`exiled_id`) was exiled to pay the craft activation cost of the permanent (`source_id`) that returns to the battlefield transformed. \"An ability of a permanent may refer to the exiled cards used to craft it.\" Unlike `TrackedBySource`, this link is **preserved** when the craft source leaves the battlefield — the source self-exiles mid-activation (CR 702.167a) and returns with the SAME ObjectId, so the link must survive its battlefield exit for the returned permanent to read it. Unlike `UntilSourceLeaves` it triggers NO automatic return (the materials stay in exile). Read by the kind-agnostic `ExiledBySource` / `CardsExiledBySource` consumers; pruned only when a material itself leaves exile (`zones.rs` exile-exit).",
@@ -13090,7 +13491,7 @@
     },
     "FaceDownBody": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6823,
+      "line": 7234,
       "doc": "CR 708.2a: Whether a face-down permanent is a creature or a non-creature.  CR 708.2a sentence 1 gives the manifest/morph default: a face-down permanent is a 2/2 *creature*. Sentence 2 (\"...unless otherwise specified by the effect that put it onto the battlefield face down\") lets an effect specify a non-creature body instead — e.g. Yedora, Grave Gardener's \"It's a Forest land.\" (It has no other types or abilities.)\". This typed discriminant replaces an implicit \"Creature is always present\" assumption so the same face-down machinery covers both classes without a raw bool.",
       "cr_refs": [
         "CR 708.2a"
@@ -13098,7 +13499,7 @@
       "variants": [
         {
           "name": "Creature",
-          "line": 6829,
+          "line": 7240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 1): the morph/manifest default — the face-down permanent has the Creature core type (always present) and defaults to 2/2 power/toughness. Any `extra_core_types` are layered on top of Creature (e.g. \"artifact creatures\").",
@@ -13108,7 +13509,7 @@
         },
         {
           "name": "Noncreature",
-          "line": 6834,
+          "line": 7245,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 2): the effect fully specifies the core types and the permanent is NOT a creature — so it has no power/toughness (CR 208.1) and gains no implicit Creature type. Used for \"It's a Forest land.\" The profile's `extra_core_types` are the complete core-type set.",
@@ -13122,13 +13523,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2220,
+      "line": 2327,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 2222,
+          "line": 2329,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -13138,7 +13539,7 @@
         },
         {
           "name": "NonToken",
-          "line": 2224,
+          "line": 2331,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -13148,7 +13549,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 2228,
+          "line": 2335,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 601.2a: Matches objects entering from being played (land play) or cast (spell), excluding tokens put directly onto the battlefield without a prior zone.",
@@ -13159,7 +13560,7 @@
         },
         {
           "name": "Attacking",
-          "line": 2231,
+          "line": 2338,
           "kind": "struct",
           "field_names": [
             "defender"
@@ -13171,7 +13572,7 @@
         },
         {
           "name": "Blocking",
-          "line": 2236,
+          "line": 2343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -13181,7 +13582,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 2239,
+          "line": 2346,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -13191,7 +13592,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 2242,
+          "line": 2349,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -13204,7 +13605,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 2247,
+          "line": 2354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -13214,7 +13615,7 @@
         },
         {
           "name": "AttackingAlone",
-          "line": 2252,
+          "line": 2359,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: Matches a creature that is (or, via the zone-change look-back snapshot, was) the sole attacker — \"attacking alone\". Live evaluation reads combat; look-back evaluation reads `ZoneChangeCombatStatus::attacking_alone`.",
@@ -13224,7 +13625,7 @@
         },
         {
           "name": "BlockingAlone",
-          "line": 2256,
+          "line": 2363,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: Matches a creature that is (or was) the sole blocker — \"blocking alone\". Look-back evaluation reads `ZoneChangeCombatStatus::blocking_alone`.",
@@ -13234,7 +13635,7 @@
         },
         {
           "name": "Tapped",
-          "line": 2257,
+          "line": 2364,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13242,7 +13643,7 @@
         },
         {
           "name": "Untapped",
-          "line": 2259,
+          "line": 2366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -13253,7 +13654,7 @@
         },
         {
           "name": "IsSaddled",
-          "line": 2261,
+          "line": 2368,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Matches permanents with the saddled designation.",
@@ -13262,8 +13663,18 @@
           ]
         },
         {
+          "name": "SaddledSource",
+          "line": 2374,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 702.171c: Matches a creature that saddled the filter source this turn (i.e. was tapped to pay the source's saddle cost — recorded in the source's `saddled_by` and cleared at end of turn). Source-relative sibling of `BlockingSource`; used by \"choose a creature that saddled it this turn\" (Calamity, Galloping Inferno).",
+          "cr_refs": [
+            "CR 702.171c"
+          ]
+        },
+        {
           "name": "ProtectorMatches",
-          "line": 2264,
+          "line": 2377,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13276,7 +13687,7 @@
         },
         {
           "name": "HasHasteOrControlledSinceTurnBegan",
-          "line": 2270,
+          "line": 2383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have haste or have been under their controller's control continuously since that player's most recent turn began. Used by Enlist's tap eligibility.",
@@ -13288,7 +13699,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 2271,
+          "line": 2384,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13298,7 +13709,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 2274,
+          "line": 2387,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13308,7 +13719,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 2279,
+          "line": 2392,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13320,7 +13731,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 2282,
+          "line": 2395,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13330,7 +13741,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 2290,
+          "line": 2403,
           "kind": "struct",
           "field_names": [
             "target"
@@ -13343,7 +13754,7 @@
         },
         {
           "name": "Counters",
-          "line": 2300,
+          "line": 2413,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -13357,7 +13768,7 @@
         },
         {
           "name": "Cmc",
-          "line": 2310,
+          "line": 2423,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -13369,8 +13780,21 @@
           ]
         },
         {
+          "name": "ManaValueParity",
+          "line": 2430,
+          "kind": "struct",
+          "field_names": [
+            "parity"
+          ],
+          "doc": "CR 202.3 + CR 608.2c: Matches objects whose mana value has the selected odd/even quality, either fixed or chosen earlier in the same resolving instruction sequence.",
+          "cr_refs": [
+            "CR 202.3",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "ManaCostIn",
-          "line": 2317,
+          "line": 2436,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -13383,7 +13807,7 @@
         },
         {
           "name": "InZone",
-          "line": 2320,
+          "line": 2439,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -13393,7 +13817,7 @@
         },
         {
           "name": "Owned",
-          "line": 2323,
+          "line": 2442,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13403,7 +13827,7 @@
         },
         {
           "name": "Foretold",
-          "line": 2329,
+          "line": 2448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -13413,7 +13837,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 2330,
+          "line": 2449,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13421,7 +13845,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 2331,
+          "line": 2450,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13429,7 +13853,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 2337,
+          "line": 2456,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -13440,7 +13864,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 2351,
+          "line": 2470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -13452,7 +13876,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 2366,
+          "line": 2485,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -13467,7 +13891,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 2383,
+          "line": 2502,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -13481,7 +13905,7 @@
         },
         {
           "name": "Another",
-          "line": 2389,
+          "line": 2508,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -13489,7 +13913,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 2391,
+          "line": 2510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -13499,7 +13923,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 2400,
+          "line": 2519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -13510,7 +13934,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2402,
+          "line": 2521,
           "kind": "struct",
           "field_names": [
             "color"
@@ -13520,7 +13944,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2429,
+          "line": 2548,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -13538,7 +13962,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2438,
+          "line": 2557,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -13548,7 +13972,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2442,
+          "line": 2561,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -13561,7 +13985,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2447,
+          "line": 2566,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13571,7 +13995,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2452,
+          "line": 2571,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -13579,7 +14003,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2465,
+          "line": 2584,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -13593,7 +14017,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2474,
+          "line": 2593,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -13601,7 +14025,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2478,
+          "line": 2597,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -13609,7 +14033,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2483,
+          "line": 2602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -13620,7 +14044,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2486,
+          "line": 2605,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -13630,7 +14054,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2489,
+          "line": 2608,
           "kind": "struct",
           "field_names": [
             "color"
@@ -13642,7 +14066,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2494,
+          "line": 2613,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13654,7 +14078,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2498,
+          "line": 2617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -13664,7 +14088,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2500,
+          "line": 2619,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -13674,7 +14098,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2502,
+          "line": 2621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -13683,8 +14107,20 @@
           ]
         },
         {
+          "name": "PowerExceedsBase",
+          "line": 2629,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 208.1 + CR 613.4a + CR 613.4b: Matches a creature whose current (post-layer) power exceeds its base power. Base power is established by layer 7a CDAs (CR 613.4a) and layer 7b set effects (CR 613.4b), before the counters and pumps applied in layers 7c–7e. True for a creature pumped above its base by +1/+1 counters, auras, or anthems; false when power == base or power < base. Consolidation target if a 3rd same-object P/T self-comparison appears: `PtSelfComparison { lhs, comparator, rhs }`.",
+          "cr_refs": [
+            "CR 208.1",
+            "CR 613.4a",
+            "CR 613.4b"
+          ]
+        },
+        {
           "name": "AnyOf",
-          "line": 2509,
+          "line": 2636,
           "kind": "struct",
           "field_names": [
             "props"
@@ -13694,7 +14130,7 @@
         },
         {
           "name": "Not",
-          "line": 2520,
+          "line": 2647,
           "kind": "struct",
           "field_names": [
             "prop"
@@ -13706,7 +14142,7 @@
         },
         {
           "name": "Modified",
-          "line": 2532,
+          "line": 2659,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -13720,7 +14156,7 @@
         },
         {
           "name": "Historic",
-          "line": 2542,
+          "line": 2669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -13731,7 +14167,7 @@
         },
         {
           "name": "NotHistoric",
-          "line": 2546,
+          "line": 2673,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: Matches objects that are not historic (negation of `Historic`). Used for \"nonhistoric\" / \"not historic\" in compound type phrases such as Desynchronization's \"nonland, nonhistoric permanent\".",
@@ -13741,7 +14177,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2550,
+          "line": 2677,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13751,7 +14187,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2555,
+          "line": 2682,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -13763,7 +14199,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2561,
+          "line": 2688,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -13775,7 +14211,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2570,
+          "line": 2697,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -13785,7 +14221,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2573,
+          "line": 2700,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -13795,7 +14231,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2578,
+          "line": 2705,
           "kind": "struct",
           "field_names": [
             "from",
@@ -13809,7 +14245,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2586,
+          "line": 2713,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -13819,7 +14255,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2589,
+          "line": 2716,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -13829,7 +14265,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2592,
+          "line": 2719,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -13839,8 +14275,24 @@
           ]
         },
         {
+          "name": "CountersPutOnThisTurn",
+          "line": 2732,
+          "kind": "struct",
+          "field_names": [
+            "actor",
+            "counters",
+            "comparator",
+            "count"
+          ],
+          "doc": "CR 122.1 + CR 122.6: Matches an object onto which `actor` put counters matching `counters` this turn, where the total count satisfies `comparator` against `count`. This is a *historical-action* predicate (CR 122.6: \"counters being put on an object\"), not a current-counter query — the object stays matched even if those counters are later removed, which is what distinguishes it from `FilterProp::Counters`. Evaluated against `GameState::counter_added_this_turn`. Covers the class \"[permanents] that [you've / an opponent has] put [one or more] [+1/+1 / any] counters on this turn\" (Kid Loki's hexproof static, and the broader counter-this-turn conditional-static class). The `actor` and `counters` axes mirror `QuantityRef::CounterAddedThisTurn` so both the count and the membership predicate share one parameterization.",
+          "cr_refs": [
+            "CR 122.1",
+            "CR 122.6"
+          ]
+        },
+        {
           "name": "FaceDown",
-          "line": 2595,
+          "line": 2740,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -13850,7 +14302,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2600,
+          "line": 2745,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13862,7 +14314,7 @@
         },
         {
           "name": "Targets",
-          "line": 2606,
+          "line": 2751,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -13875,7 +14327,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2615,
+          "line": 2760,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -13886,7 +14338,7 @@
         },
         {
           "name": "HasXInActivationCost",
-          "line": 2619,
+          "line": 2764,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 602.1: Matches activated abilities whose activation cost contains an `{X}` shard. Used for \"activate an ability with {X} in its activation cost\" on `AbilityActivated` delayed triggers (Magus Lucea Kane).",
@@ -13897,7 +14349,7 @@
         },
         {
           "name": "WasKicked",
-          "line": 2624,
+          "line": 2769,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33d: Matches spells whose kicker additional cost was paid for this cast. Used for \"the first kicked spell you cast each turn\" cost reducers (Vine Gecko). Live evaluation reads `pending_cast` / `GameObject.kickers_paid`; turn-history evaluation reads `SpellCastRecord.was_kicked`.",
@@ -13907,7 +14359,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2628,
+          "line": 2773,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -13917,7 +14369,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2632,
+          "line": 2777,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -13928,7 +14380,7 @@
         },
         {
           "name": "Named",
-          "line": 2636,
+          "line": 2781,
           "kind": "struct",
           "field_names": [
             "name"
@@ -13941,7 +14393,7 @@
         },
         {
           "name": "SameName",
-          "line": 2641,
+          "line": 2786,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -13949,7 +14401,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2654,
+          "line": 2799,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -13959,7 +14411,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 2661,
+          "line": 2806,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13972,7 +14424,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 2670,
+          "line": 2815,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -13983,7 +14435,7 @@
         },
         {
           "name": "Other",
-          "line": 2671,
+          "line": 2816,
           "kind": "struct",
           "field_names": [
             "value"
@@ -14878,8 +15330,22 @@
           ]
         },
         {
+          "name": "ChooseRoomDoor",
+          "line": 495,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "op",
+            "door"
+          ],
+          "doc": "CR 709.5f-g: Response to `WaitingFor::ChooseRoomDoor` — the player picked which door (half) of the targeted Room to act on, and the operation to apply to it. The `(op, door)` pair must be one of the prompt's `options`.",
+          "cr_refs": [
+            "CR 709.5f"
+          ]
+        },
+        {
           "name": "TapForConvoke",
-          "line": 494,
+          "line": 502,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -14893,7 +15359,7 @@
         },
         {
           "name": "HarmonizeTap",
-          "line": 500,
+          "line": 508,
           "kind": "struct",
           "field_names": [
             "creature_id"
@@ -14905,7 +15371,7 @@
         },
         {
           "name": "DeclareCompanion",
-          "line": 504,
+          "line": 512,
           "kind": "struct",
           "field_names": [
             "card_index"
@@ -14917,7 +15383,7 @@
         },
         {
           "name": "CompanionToHand",
-          "line": 509,
+          "line": 517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.139a: Pay {3} to put companion into hand (special action, see rule 116.2g).",
@@ -14927,7 +15393,7 @@
         },
         {
           "name": "DiscoverChoice",
-          "line": 511,
+          "line": 519,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -14939,7 +15405,7 @@
         },
         {
           "name": "CascadeChoice",
-          "line": 515,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -14951,7 +15417,7 @@
         },
         {
           "name": "RippleChoice",
-          "line": 519,
+          "line": 527,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -14963,7 +15429,7 @@
         },
         {
           "name": "FreeCastWindowChoice",
-          "line": 528,
+          "line": 536,
           "kind": "struct",
           "field_names": [
             "selection"
@@ -14976,7 +15442,7 @@
         },
         {
           "name": "ChooseTopOrBottom",
-          "line": 533,
+          "line": 541,
           "kind": "struct",
           "field_names": [
             "top"
@@ -14988,7 +15454,7 @@
         },
         {
           "name": "ChooseMutateMergeSide",
-          "line": 540,
+          "line": 548,
           "kind": "struct",
           "field_names": [
             "side"
@@ -15001,7 +15467,7 @@
         },
         {
           "name": "CipherEncode",
-          "line": 546,
+          "line": 554,
           "kind": "struct",
           "field_names": [
             "creature"
@@ -15013,7 +15479,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 551,
+          "line": 559,
           "kind": "struct",
           "field_names": [
             "keep"
@@ -15025,7 +15491,7 @@
         },
         {
           "name": "ChooseBattleProtector",
-          "line": 556,
+          "line": 564,
           "kind": "struct",
           "field_names": [
             "protector"
@@ -15039,7 +15505,7 @@
         },
         {
           "name": "SetAutoPass",
-          "line": 560,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -15051,7 +15517,7 @@
         },
         {
           "name": "CancelAutoPass",
-          "line": 564,
+          "line": 572,
           "kind": "unit",
           "field_names": [],
           "doc": "Cancel any active auto-pass for the acting player.",
@@ -15059,7 +15525,7 @@
         },
         {
           "name": "SetPhaseStops",
-          "line": 569,
+          "line": 577,
           "kind": "struct",
           "field_names": [
             "stops"
@@ -15069,7 +15535,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 574,
+          "line": 582,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -15084,7 +15550,7 @@
         },
         {
           "name": "AssignBlockerDamage",
-          "line": 590,
+          "line": 598,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -15097,7 +15563,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 594,
+          "line": 602,
           "kind": "struct",
           "field_names": [
             "distribution"
@@ -15109,7 +15575,7 @@
         },
         {
           "name": "ChooseCounterMoveDistribution",
-          "line": 598,
+          "line": 606,
           "kind": "struct",
           "field_names": [
             "selections"
@@ -15122,7 +15588,7 @@
         },
         {
           "name": "SubmitPayAmount",
-          "line": 604,
+          "line": 612,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -15135,7 +15601,7 @@
         },
         {
           "name": "RetargetSpell",
-          "line": 608,
+          "line": 616,
           "kind": "struct",
           "field_names": [
             "new_targets"
@@ -15147,7 +15613,7 @@
         },
         {
           "name": "LearnDecision",
-          "line": 612,
+          "line": 620,
           "kind": "struct",
           "field_names": [
             "choice"
@@ -15159,7 +15625,7 @@
         },
         {
           "name": "SelectCategoryPermanents",
-          "line": 618,
+          "line": 626,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -15172,7 +15638,7 @@
         },
         {
           "name": "ChooseX",
-          "line": 624,
+          "line": 632,
           "kind": "struct",
           "field_names": [
             "value"
@@ -15185,7 +15651,7 @@
         },
         {
           "name": "SubmitPhyrexianChoices",
-          "line": 630,
+          "line": 638,
           "kind": "struct",
           "field_names": [
             "choices"
@@ -15198,7 +15664,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 644,
+          "line": 652,
           "kind": "struct",
           "field_names": [
             "choice",
@@ -15213,7 +15679,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 654,
+          "line": 662,
           "kind": "struct",
           "field_names": [
             "payment"
@@ -15227,7 +15693,7 @@
         },
         {
           "name": "CastPreparedCopy",
-          "line": 663,
+          "line": 671,
           "kind": "struct",
           "field_names": [
             "source"
@@ -15239,7 +15705,7 @@
         },
         {
           "name": "ChooseSpecializeColor",
-          "line": 667,
+          "line": 675,
           "kind": "struct",
           "field_names": [
             "color"
@@ -15249,7 +15715,7 @@
         },
         {
           "name": "CastParadigmCopy",
-          "line": 674,
+          "line": 682,
           "kind": "struct",
           "field_names": [
             "source"
@@ -15261,7 +15727,7 @@
         },
         {
           "name": "PassParadigmOffer",
-          "line": 681,
+          "line": 689,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — decline the turn-based offer during `WaitingFor::CastOffer` (Paradigm). The exiled source stays in exile and may be offered again next turn. Assign when WotC publishes SOS CR update.",
@@ -15271,7 +15737,7 @@
         },
         {
           "name": "Debug",
-          "line": 685,
+          "line": 693,
           "kind": "tuple",
           "field_names": [],
           "doc": "Debug/remediation action — bypasses WaitingFor validation (like Concede). Gated on `GameState::debug_mode`. Rejected in multiplayer at both the WASM and server-core layers.",
@@ -15279,7 +15745,7 @@
         },
         {
           "name": "GrantDebugPermission",
-          "line": 691,
+          "line": 699,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15289,7 +15755,7 @@
         },
         {
           "name": "RevokeDebugPermission",
-          "line": 697,
+          "line": 705,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15299,7 +15765,7 @@
         },
         {
           "name": "Concede",
-          "line": 708,
+          "line": 716,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15315,13 +15781,13 @@
     },
     "GameEvent": {
       "file": "crates/engine/src/types/events.rs",
-      "line": 113,
+      "line": 115,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "GameStarted",
-          "line": 114,
+          "line": 116,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15329,7 +15795,7 @@
         },
         {
           "name": "TurnStarted",
-          "line": 115,
+          "line": 117,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15340,7 +15806,7 @@
         },
         {
           "name": "PhaseChanged",
-          "line": 119,
+          "line": 121,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -15350,7 +15816,7 @@
         },
         {
           "name": "PriorityPassed",
-          "line": 122,
+          "line": 124,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15360,7 +15826,7 @@
         },
         {
           "name": "SpellCast",
-          "line": 125,
+          "line": 127,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -15372,7 +15838,7 @@
         },
         {
           "name": "Mutated",
-          "line": 138,
+          "line": 140,
           "kind": "struct",
           "field_names": [
             "merged_id",
@@ -15389,7 +15855,7 @@
         },
         {
           "name": "SpellCopied",
-          "line": 147,
+          "line": 149,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -15404,7 +15870,7 @@
         },
         {
           "name": "XValueChosen",
-          "line": 155,
+          "line": 157,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15419,7 +15885,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 169,
+          "line": 171,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15433,7 +15899,7 @@
         },
         {
           "name": "ZoneChanged",
-          "line": 185,
+          "line": 187,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15449,7 +15915,7 @@
         },
         {
           "name": "LifeChanged",
-          "line": 194,
+          "line": 196,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15460,7 +15926,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 198,
+          "line": 200,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15473,7 +15939,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 214,
+          "line": 216,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15490,7 +15956,7 @@
         },
         {
           "name": "ManaPoolEmptied",
-          "line": 230,
+          "line": 232,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15506,7 +15972,7 @@
         },
         {
           "name": "ManaRecolored",
-          "line": 238,
+          "line": 240,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15521,7 +15987,7 @@
         },
         {
           "name": "PermanentTapped",
-          "line": 243,
+          "line": 245,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15532,7 +15998,7 @@
         },
         {
           "name": "CreatureExerted",
-          "line": 253,
+          "line": 255,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15545,7 +16011,7 @@
         },
         {
           "name": "CreatureEnlisted",
-          "line": 259,
+          "line": 261,
           "kind": "struct",
           "field_names": [
             "attacker",
@@ -15560,7 +16026,7 @@
         },
         {
           "name": "Foretold",
-          "line": 265,
+          "line": 267,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15573,7 +16039,7 @@
         },
         {
           "name": "PlayerLost",
-          "line": 269,
+          "line": 271,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15583,7 +16049,7 @@
         },
         {
           "name": "MulliganStarted",
-          "line": 272,
+          "line": 274,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -15591,7 +16057,7 @@
         },
         {
           "name": "CardsDrawn",
-          "line": 273,
+          "line": 275,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15602,7 +16068,7 @@
         },
         {
           "name": "CardDrawn",
-          "line": 277,
+          "line": 279,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15615,7 +16081,7 @@
         },
         {
           "name": "PermanentUntapped",
-          "line": 294,
+          "line": 296,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15625,7 +16091,7 @@
         },
         {
           "name": "PermanentPhasedOut",
-          "line": 300,
+          "line": 302,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15639,7 +16105,7 @@
         },
         {
           "name": "PermanentPhasedIn",
-          "line": 306,
+          "line": 308,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15651,7 +16117,7 @@
         },
         {
           "name": "PlayerPhasedOut",
-          "line": 314,
+          "line": 316,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15663,7 +16129,7 @@
         },
         {
           "name": "PlayerPhasedIn",
-          "line": 319,
+          "line": 321,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -15673,7 +16139,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 322,
+          "line": 324,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15685,7 +16151,7 @@
         },
         {
           "name": "StackPushed",
-          "line": 327,
+          "line": 329,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15695,7 +16161,7 @@
         },
         {
           "name": "StackResolved",
-          "line": 330,
+          "line": 332,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15705,7 +16171,7 @@
         },
         {
           "name": "Discarded",
-          "line": 333,
+          "line": 335,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -15717,7 +16183,7 @@
         },
         {
           "name": "DamageCleared",
-          "line": 344,
+          "line": 346,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15727,7 +16193,7 @@
         },
         {
           "name": "GameOver",
-          "line": 347,
+          "line": 349,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -15737,7 +16203,7 @@
         },
         {
           "name": "ResolutionHalted",
-          "line": 358,
+          "line": 360,
           "kind": "struct",
           "field_names": [
             "involved"
@@ -15750,7 +16216,7 @@
         },
         {
           "name": "DamageDealt",
-          "line": 361,
+          "line": 363,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -15764,7 +16230,7 @@
         },
         {
           "name": "DamagePrevented",
-          "line": 372,
+          "line": 374,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -15778,7 +16244,7 @@
         },
         {
           "name": "SpellCountered",
-          "line": 377,
+          "line": 379,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15790,7 +16256,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 385,
+          "line": 387,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15802,7 +16268,7 @@
         },
         {
           "name": "ObjectIntensified",
-          "line": 393,
+          "line": 395,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15813,7 +16279,7 @@
         },
         {
           "name": "Evolved",
-          "line": 399,
+          "line": 401,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15825,7 +16291,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 402,
+          "line": 404,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15837,7 +16303,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 407,
+          "line": 409,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15849,7 +16315,7 @@
         },
         {
           "name": "ObjectConjured",
-          "line": 418,
+          "line": 420,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15860,7 +16326,7 @@
         },
         {
           "name": "CreatureDestroyed",
-          "line": 422,
+          "line": 424,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -15870,7 +16336,7 @@
         },
         {
           "name": "PermanentSacrificed",
-          "line": 425,
+          "line": 427,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15881,7 +16347,7 @@
         },
         {
           "name": "ControllerChanged",
-          "line": 430,
+          "line": 432,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -15895,7 +16361,7 @@
         },
         {
           "name": "EffectResolved",
-          "line": 435,
+          "line": 437,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -15906,7 +16372,7 @@
         },
         {
           "name": "Unattached",
-          "line": 441,
+          "line": 443,
           "kind": "struct",
           "field_names": [
             "attachment_id",
@@ -15919,7 +16385,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 445,
+          "line": 447,
           "kind": "struct",
           "field_names": [
             "attacker_ids",
@@ -15931,7 +16397,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 452,
+          "line": 454,
           "kind": "struct",
           "field_names": [
             "assignments"
@@ -15941,7 +16407,7 @@
         },
         {
           "name": "CombatTaxPaid",
-          "line": 457,
+          "line": 459,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15955,7 +16421,7 @@
         },
         {
           "name": "CombatTaxDeclined",
-          "line": 463,
+          "line": 465,
           "kind": "struct",
           "field_names": [
             "player",
@@ -15969,7 +16435,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 467,
+          "line": 469,
           "kind": "struct",
           "field_names": [
             "target",
@@ -15980,7 +16446,7 @@
         },
         {
           "name": "VehicleCrewed",
-          "line": 473,
+          "line": 475,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -15993,7 +16459,7 @@
         },
         {
           "name": "Stationed",
-          "line": 483,
+          "line": 485,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -16007,7 +16473,7 @@
         },
         {
           "name": "Saddled",
-          "line": 493,
+          "line": 495,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -16020,7 +16486,7 @@
         },
         {
           "name": "ReplacementApplied",
-          "line": 497,
+          "line": 499,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16031,7 +16497,7 @@
         },
         {
           "name": "Transformed",
-          "line": 501,
+          "line": 503,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16041,7 +16507,7 @@
         },
         {
           "name": "Specialized",
-          "line": 505,
+          "line": 507,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16052,7 +16518,7 @@
         },
         {
           "name": "DayNightChanged",
-          "line": 509,
+          "line": 511,
           "kind": "struct",
           "field_names": [
             "new_state"
@@ -16062,7 +16528,7 @@
         },
         {
           "name": "TurnedFaceUp",
-          "line": 512,
+          "line": 514,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16072,7 +16538,7 @@
         },
         {
           "name": "CardsRevealed",
-          "line": 515,
+          "line": 517,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16084,7 +16550,7 @@
         },
         {
           "name": "CombatDamageDealtToPlayer",
-          "line": 521,
+          "line": 523,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16096,7 +16562,7 @@
         },
         {
           "name": "PlayerEliminated",
-          "line": 547,
+          "line": 549,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16106,7 +16572,7 @@
         },
         {
           "name": "CrimeCommitted",
-          "line": 550,
+          "line": 552,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16116,7 +16582,7 @@
         },
         {
           "name": "Cycled",
-          "line": 553,
+          "line": 555,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16127,7 +16593,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 557,
+          "line": 559,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16138,7 +16604,7 @@
         },
         {
           "name": "Regenerated",
-          "line": 562,
+          "line": 564,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16150,7 +16616,7 @@
         },
         {
           "name": "CreatureSuspected",
-          "line": 566,
+          "line": 568,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16161,8 +16627,20 @@
           ]
         },
         {
+          "name": "CreatureNoLongerSuspected",
+          "line": 574,
+          "kind": "struct",
+          "field_names": [
+            "object_id"
+          ],
+          "doc": "CR 701.60a: A creature is no longer suspected — the un-designation transition. Emitted only when the toggle actually flips (idempotent resolver). Mirrors `BecameUnprepared`.",
+          "cr_refs": [
+            "CR 701.60a"
+          ]
+        },
+        {
           "name": "Detained",
-          "line": 573,
+          "line": 581,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16174,7 +16652,7 @@
         },
         {
           "name": "BecamePrepared",
-          "line": 579,
+          "line": 587,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16186,7 +16664,7 @@
         },
         {
           "name": "BecameUnprepared",
-          "line": 585,
+          "line": 593,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16198,7 +16676,7 @@
         },
         {
           "name": "CaseSolved",
-          "line": 589,
+          "line": 597,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -16210,7 +16688,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 593,
+          "line": 601,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16223,7 +16701,7 @@
         },
         {
           "name": "MonarchChanged",
-          "line": 598,
+          "line": 606,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16235,7 +16713,7 @@
         },
         {
           "name": "CityBlessingGained",
-          "line": 602,
+          "line": 610,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16247,7 +16725,7 @@
         },
         {
           "name": "DieRolled",
-          "line": 608,
+          "line": 616,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16263,7 +16741,7 @@
         },
         {
           "name": "StartingPlayerContest",
-          "line": 621,
+          "line": 629,
           "kind": "struct",
           "field_names": [
             "rounds",
@@ -16277,7 +16755,7 @@
         },
         {
           "name": "CoinFlipped",
-          "line": 626,
+          "line": 634,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16290,7 +16768,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 631,
+          "line": 639,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16302,7 +16780,7 @@
         },
         {
           "name": "RoomEntered",
-          "line": 635,
+          "line": 643,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16317,7 +16795,7 @@
         },
         {
           "name": "RoomDoorUnlocked",
-          "line": 642,
+          "line": 650,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16332,7 +16810,7 @@
         },
         {
           "name": "BecomesPlotted",
-          "line": 649,
+          "line": 657,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16345,7 +16823,7 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 654,
+          "line": 662,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16358,7 +16836,7 @@
         },
         {
           "name": "Planeswalked",
-          "line": 661,
+          "line": 669,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16373,7 +16851,7 @@
         },
         {
           "name": "ChaosEnsued",
-          "line": 668,
+          "line": 676,
           "kind": "struct",
           "field_names": [
             "plane_id"
@@ -16386,7 +16864,7 @@
         },
         {
           "name": "PlanarDieRolled",
-          "line": 672,
+          "line": 680,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16399,7 +16877,7 @@
         },
         {
           "name": "SchemeSetInMotion",
-          "line": 678,
+          "line": 686,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16413,7 +16891,7 @@
         },
         {
           "name": "SchemeAbandoned",
-          "line": 684,
+          "line": 692,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16427,7 +16905,7 @@
         },
         {
           "name": "InitiativeTaken",
-          "line": 689,
+          "line": 697,
           "kind": "struct",
           "field_names": [
             "player_id"
@@ -16439,7 +16917,7 @@
         },
         {
           "name": "AttractionOpened",
-          "line": 693,
+          "line": 701,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16452,7 +16930,7 @@
         },
         {
           "name": "AttractionsRolledToVisit",
-          "line": 698,
+          "line": 706,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16465,7 +16943,7 @@
         },
         {
           "name": "AttractionVisited",
-          "line": 703,
+          "line": 711,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16480,7 +16958,7 @@
         },
         {
           "name": "Firebend",
-          "line": 709,
+          "line": 717,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16491,7 +16969,7 @@
         },
         {
           "name": "Airbend",
-          "line": 714,
+          "line": 722,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16502,7 +16980,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 719,
+          "line": 727,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16513,7 +16991,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 724,
+          "line": 732,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16524,7 +17002,7 @@
         },
         {
           "name": "CompanionRevealed",
-          "line": 729,
+          "line": 737,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16537,7 +17015,7 @@
         },
         {
           "name": "CompanionMovedToHand",
-          "line": 734,
+          "line": 742,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16550,7 +17028,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 741,
+          "line": 749,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16563,7 +17041,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 751,
+          "line": 759,
           "kind": "struct",
           "field_names": [
             "ability_tag",
@@ -16580,7 +17058,7 @@
         },
         {
           "name": "CreatureExploited",
-          "line": 759,
+          "line": 767,
           "kind": "struct",
           "field_names": [
             "exploiter",
@@ -16593,7 +17071,7 @@
         },
         {
           "name": "EnergyChanged",
-          "line": 764,
+          "line": 772,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16606,7 +17084,7 @@
         },
         {
           "name": "SpeedChanged",
-          "line": 769,
+          "line": 777,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16620,7 +17098,7 @@
         },
         {
           "name": "PlayerCounterChanged",
-          "line": 775,
+          "line": 783,
           "kind": "struct",
           "field_names": [
             "player",
@@ -16634,7 +17112,7 @@
         },
         {
           "name": "ManaExpended",
-          "line": 781,
+          "line": 789,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16648,7 +17126,7 @@
         },
         {
           "name": "Clash",
-          "line": 787,
+          "line": 795,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -16664,7 +17142,7 @@
         },
         {
           "name": "VoteCast",
-          "line": 798,
+          "line": 806,
           "kind": "struct",
           "field_names": [
             "voter",
@@ -16678,7 +17156,7 @@
         },
         {
           "name": "VoteResolved",
-          "line": 806,
+          "line": 814,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -16691,7 +17169,7 @@
         },
         {
           "name": "PowerToughnessChanged",
-          "line": 812,
+          "line": 820,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -16705,7 +17183,7 @@
         },
         {
           "name": "CascadeMissed",
-          "line": 823,
+          "line": 831,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -16719,7 +17197,7 @@
         },
         {
           "name": "DebugActionUsed",
-          "line": 831,
+          "line": 839,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -16730,7 +17208,7 @@
         },
         {
           "name": "DebugPermissionGranted",
-          "line": 837,
+          "line": 845,
           "kind": "struct",
           "field_names": [
             "host",
@@ -16741,7 +17219,7 @@
         },
         {
           "name": "DebugPermissionRevoked",
-          "line": 842,
+          "line": 850,
           "kind": "struct",
           "field_names": [
             "host",
@@ -16924,13 +17402,13 @@
     },
     "GameRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1536,
+      "line": 1601,
       "doc": "A game-level restriction that modifies how rules are applied. Stored in `GameState::restrictions` and evaluated by relevant game systems.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DamagePreventionDisabled",
-          "line": 1538,
+          "line": 1603,
           "kind": "struct",
           "field_names": [
             "source",
@@ -16944,7 +17422,7 @@
         },
         {
           "name": "ProhibitActivity",
-          "line": 1546,
+          "line": 1611,
           "kind": "struct",
           "field_names": [
             "source",
@@ -17087,13 +17565,13 @@
     },
     "IntensityScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6729,
+      "line": 7140,
       "doc": "Digital-only Alchemy: which cards an `Effect::Intensify` applies to. Every scope resolves across ALL zones (a card's intensity follows it everywhere).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 6732,
+          "line": 7143,
           "kind": "unit",
           "field_names": [],
           "doc": "\"this creature/artifact/… intensifies\" — the source object only.",
@@ -17101,7 +17579,7 @@
         },
         {
           "name": "OwnedSameName",
-          "line": 6735,
+          "line": 7146,
           "kind": "unit",
           "field_names": [],
           "doc": "\"cards you own named [this card] intensify\" — every card the source's controller owns with the source's name.",
@@ -17109,7 +17587,7 @@
         },
         {
           "name": "OwnedSubtype",
-          "line": 6738,
+          "line": 7149,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -17122,7 +17600,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12080,
+      "line": 12943,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -17131,7 +17609,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 12083,
+          "line": 12946,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -18572,8 +19050,21 @@
           ]
         },
         {
+          "name": "Teamwork",
+          "line": 826,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "Teamwork N — \"As an additional cost to cast this spell, you may tap any number of creatures you control with total power N or more.\" The spell's body then references whether this optional cost was paid (\"if this spell was cast using teamwork, ...\").  Teamwork is not yet in the printed Comprehensive Rules (Marvel Super Heroes set keyword). Its tap-any-number-with-total-power-N cost is structurally identical to Crew (CR 702.122a) and Saddle (CR 702.171a); it is an optional additional cast cost per CR 601.2b/f, and is a keyword ability per CR 702.  Runtime: `database::synthesis::synthesize_teamwork` builds an `AdditionalCost::Optional { cost: TapCreatures { requirement: Aggregate { TotalPower, GE, N }, .. } }`. Paying it sets the spell's `additional_cost_paid` flag, which the body's `AdditionalCostPaid` condition reads (mirrors Conspire).",
+          "cr_refs": [
+            "CR 601.2b",
+            "CR 702",
+            "CR 702.122a",
+            "CR 702.171a"
+          ]
+        },
+        {
           "name": "Soulshift",
-          "line": 812,
+          "line": 829,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.46: Soulshift N — when this creature dies, return target Spirit card with mana value N or less from your graveyard to your hand.",
@@ -18583,7 +19074,7 @@
         },
         {
           "name": "Backup",
-          "line": 815,
+          "line": 832,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.165: Backup N — when this creature enters, put N +1/+1 counters on target creature, which gains this creature's other abilities until EOT.",
@@ -18593,7 +19084,7 @@
         },
         {
           "name": "Squad",
-          "line": 828,
+          "line": 845,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.157a: Squad {cost} — \"As an additional cost to cast this spell, you may pay {cost} any number of times.\" \"When this creature enters, if its squad cost was paid, create a token that's a copy of it for each time its squad cost was paid.\" (CR 702.157b: each instance triggers separately.)  Runtime: `database::synthesis::synthesize_squad` builds a `AdditionalCost::Optional { repeatability: Repeatable }` additional-cost instance (origin: `AdditionalCostOrigin::Squad`) and an ETB copy trigger keyed on `QuantityRef::AdditionalCostPaymentCountFor { origin: Squad }`. `casting_costs::effective_squad_additional_cost_instances` surfaces the per-instance additional costs during casting. Fully wired.",
@@ -18604,7 +19095,7 @@
         },
         {
           "name": "Typecycling",
-          "line": 832,
+          "line": 849,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -18617,7 +19108,7 @@
         },
         {
           "name": "Firebending",
-          "line": 838,
+          "line": 855,
           "kind": "tuple",
           "field_names": [],
           "doc": "Firebending N — produces N {R} when this creature attacks (Avatar crossover).",
@@ -18625,7 +19116,7 @@
         },
         {
           "name": "Splice",
-          "line": 843,
+          "line": 860,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -18638,7 +19129,7 @@
         },
         {
           "name": "Bargain",
-          "line": 849,
+          "line": 866,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a: Bargain — you may sacrifice an artifact, enchantment, or token as an additional cost to cast this spell.",
@@ -18648,7 +19139,7 @@
         },
         {
           "name": "Sunburst",
-          "line": 856,
+          "line": 873,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.44a: Sunburst — as an object enters the battlefield as a resolving spell, it enters with a +1/+1 counter (if entering as a creature) or a charge counter (otherwise) for each color of mana spent to cast it. Wired at runtime by `synthesize_sunburst` as an ETB-counter replacement whose count is the distinct-colors-spent metric. Per CR 702.44d each instance works separately.",
@@ -18659,7 +19150,7 @@
         },
         {
           "name": "Champion",
-          "line": 861,
+          "line": 878,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.72a: Champion a [type] — exile another object of the specified type you control or sacrifice this permanent when it enters; return the exiled card when this leaves. Wired at build time by `synthesize_champion`; CR 702.72b makes the two abilities linked.",
@@ -18670,7 +19161,7 @@
         },
         {
           "name": "Training",
-          "line": 864,
+          "line": 881,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.149a: Training — whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.",
@@ -18680,7 +19171,7 @@
         },
         {
           "name": "Assist",
-          "line": 866,
+          "line": 883,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.132a: Assist — another player can help pay the generic mana cost of this spell.",
@@ -18690,7 +19181,7 @@
         },
         {
           "name": "Augment",
-          "line": 870,
+          "line": 887,
           "kind": "unit",
           "field_names": [],
           "doc": "Acorn/Un-set keyword: Augment. Runtime host-combine semantics are not implemented; the keyword identity is used for characteristic filters such as \"a card with augment\".",
@@ -18698,7 +19189,7 @@
         },
         {
           "name": "Aftermath",
-          "line": 874,
+          "line": 891,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.127a: Aftermath allows casting this half of a split card only from a graveyard, and exiles the spell any time it leaves the stack if it was cast from a graveyard.",
@@ -18708,7 +19199,7 @@
         },
         {
           "name": "JumpStart",
-          "line": 876,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.133a: Jump-start — cast from graveyard by discarding a card, then exile.",
@@ -18718,7 +19209,7 @@
         },
         {
           "name": "Cipher",
-          "line": 879,
+          "line": 896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99a: Cipher — exile this spell encoded on a creature you control; whenever that creature deals combat damage to a player, cast a copy.",
@@ -18728,7 +19219,7 @@
         },
         {
           "name": "Transmute",
-          "line": 884,
+          "line": 901,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.53a: Transmute {cost} — \"[Cost], Discard this card: Search your library for a card with the same mana value as the discarded card, reveal it, put it into your hand, then shuffle. Activate only as a sorcery.\" Runtime: `synthesize_transmute` (database/synthesis.rs).",
@@ -18738,7 +19229,7 @@
         },
         {
           "name": "Transfigure",
-          "line": 889,
+          "line": 906,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.71a: Transfigure {cost} — \"[Cost], Sacrifice this permanent: Search your library for a creature card with the same mana value as this permanent and put it onto the battlefield. Then shuffle your library. Activate only as a sorcery.\" Runtime: `synthesize_transfigure` (database/synthesis.rs).",
@@ -18748,7 +19239,7 @@
         },
         {
           "name": "Escalate",
-          "line": 892,
+          "line": 909,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.120a: Escalate [cost] — additional cost for each mode chosen beyond the first on a modal spell.",
@@ -18758,7 +19249,7 @@
         },
         {
           "name": "Recover",
-          "line": 896,
+          "line": 913,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.59a: Recover {cost} — triggered ability: when a creature is put into your graveyard from the battlefield, you may pay {cost} to return this card from your graveyard to your hand; otherwise exile it.",
@@ -18768,7 +19259,7 @@
         },
         {
           "name": "Cleave",
-          "line": 898,
+          "line": 915,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.148a: Cleave — alternative cost that removes bracketed text from Oracle text.",
@@ -18778,7 +19269,7 @@
         },
         {
           "name": "Undaunted",
-          "line": 900,
+          "line": 917,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.125a: Undaunted — costs {1} less for each opponent.",
@@ -18788,7 +19279,7 @@
         },
         {
           "name": "Paradigm",
-          "line": 908,
+          "line": 925,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Paradigm (Strixhaven) — a keyword on instants/sorceries. Reminder: \"Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.\" Runtime hooks in `stack.rs` (first-resolution arming) and `turns.rs` (first-main-phase offer) carry the semantics. Assign when WotC publishes SOS CR update.",
@@ -18798,7 +19289,7 @@
         },
         {
           "name": "Station",
-          "line": 916,
+          "line": 933,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Station — \"Tap another untapped creature you control: Put a number of charge counters on this permanent equal to the tapped creature's power. Activate only as a sorcery.\" The keyword is fixed (no parameter) — the full semantics come from the rule text. Runtime activation is handled via `GameAction::ActivateStation`, not through the generic activated-ability dispatch.",
@@ -18808,7 +19299,7 @@
         },
         {
           "name": "Replicate",
-          "line": 930,
+          "line": 947,
           "kind": "tuple",
           "field_names": [],
           "doc": "RUNTIME: `database::synthesis::synthesize_replicate` — repeatable optional additional cost (`AdditionalCost::Optional { repeatability: Repeatable }`) plus a `SpellCast` trigger whose execute is `replicate_copy_ability_definition()` (a `CopySpell` with `repeat_for = AdditionalCostPaymentCount`). CR 702.56a: Replicate {cost} — additional-cost-on-cast copy mechanic. \"As an additional cost to cast this spell, you may pay [cost] any number of times\" + \"When you cast this spell, if a replicate cost was paid for it, copy it for each time its replicate cost was paid. If the spell has any targets, you may choose new targets for any of the copies.\" Carries the per-copy mana cost.",
@@ -18818,7 +19309,7 @@
         },
         {
           "name": "Awaken",
-          "line": 943,
+          "line": 960,
           "kind": "struct",
           "field_names": [
             "count",
@@ -18834,7 +19325,7 @@
         },
         {
           "name": "ForMirrodin",
-          "line": 952,
+          "line": 969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.163a: For Mirrodin! — Equipment-only triggered ability. \"When this Equipment enters, create a 2/2 red Rebel creature token, then attach this Equipment to it.\" Bare keyword; ETB trigger semantics are synthesized in `database::synthesis`.",
@@ -18844,7 +19335,7 @@
         },
         {
           "name": "MoreThanMeetsTheEye",
-          "line": 967,
+          "line": 984,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.162a: More Than Meets the Eye {cost} — alternative cost (Transformers crossover). \"You may cast this card converted by paying [cost] rather than its mana cost.\" Follows CR 701.28 (Convert) — the permanent enters the battlefield transformed (back face up). Alternative cost rules: CR 601.2b, CR 601.2f–h, CR 118.9.  Runtime: `CastingVariant::MoreThanMeetsTheEye` + `casting::handle_mtmte_cost_choice` substitutes the MTMTE mana cost for the printed cost and routes through `continue_cast_with_alternative_spell_face`, which sets the stack spell to use back-face characteristics. On resolution, `enter_transformed` ZoneChange seed ensures the permanent enters back face up. `CastingVariant::restores_front_face_after_stack_exit` handles cleanup if the spell leaves the stack without resolving. Fully wired.",
@@ -18858,7 +19349,7 @@
         },
         {
           "name": "Freerunning",
-          "line": 983,
+          "line": 1000,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.173a: Freerunning {cost} — alternative cost. \"You may pay [cost] rather than pay this spell's mana cost if a player was dealt combat damage this turn by a creature that, at the time it dealt that damage, was an Assassin creature or a commander under your control.\" Follows CR 601.2b and CR 601.2f–h. A pure cost substitution — no resolution rider.  Runtime: The eligibility predicate is tracked in `GameState::assassin_or_commander_dealt_combat_damage_this_turn` (a `HashSet<PlayerId>` seeded by `triggers::collect_pending_triggers` when an Assassin or commander deals combat damage, per CR 702.173a). The ledger is cleared at cleanup (CR 514) by `turns::run_cleanup`. `casting::casting_variant_candidates` checks the ledger to surface `CastingVariant::Freerunning`; `casting_costs` substitutes the Freerunning cost for the printed cost. Fully wired.",
@@ -18871,7 +19362,7 @@
         },
         {
           "name": "Increment",
-          "line": 987,
+          "line": 1004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.191a: Increment — spell-cast trigger synthesized in `database::synthesis::synthesize_increment`.",
@@ -18881,7 +19372,7 @@
         },
         {
           "name": "Specialize",
-          "line": 1005,
+          "line": 1022,
           "kind": "tuple",
           "field_names": [],
           "doc": "Digital-only Specialize (Alchemy Horizons: Baldur's Gate) — not in the Comprehensive Rules; behavior follows MTG Arena. \"{cost}, Discard a colored card or a card with a basic land subtype: This permanent becomes the matching color-specialized face permanently.\" Activated ability, sorcery speed. The keyword carries only the activation mana cost; the discard filter and color selection are built at synthesis time.  Runtime: `database::synthesis::synthesize_specialize` builds a sorcery- speed `AbilityKind::Activated` with `Effect::Specialize` and `AbilityCost::Composite { Mana + Discard { filter: specialize_discard_filter } }`. `effects::specialize::resolve` reads the discarded card's LKI snapshot to determine eligible colors via `game::specialize::eligible_specialize_colors`, then either calls `specialize_permanent` directly (one option) or sets `WaitingFor::SpecializeColor` for the player to choose. `engine_resolution_choices` dispatches `GameAction::ChooseSpecializeColor` to complete the transformation. Fully wired.",
@@ -18889,7 +19380,7 @@
         },
         {
           "name": "Offering",
-          "line": 1014,
+          "line": 1031,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.48a: \"[Quality] offering\" — as an additional cost to cast this spell, you may sacrifice a [Quality] permanent. If you do, this spell's total cost is reduced by the sacrificed permanent's mana cost (CR 702.48c), and you may cast this spell any time you could cast an instant. Carries the canonical subtype string (e.g. \"Spirit\", \"Dragon\"). Runtime behavior is fully wired: timing unlock, sacrifice selection, and cost reduction in `casting_costs.rs`.",
@@ -18900,7 +19391,7 @@
         },
         {
           "name": "Unknown",
-          "line": 1017,
+          "line": 1034,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized keywords.",
@@ -18911,7 +19402,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15046,
+      "line": 16010,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -18920,7 +19411,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 15048,
+          "line": 16012,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -18933,7 +19424,7 @@
         },
         {
           "name": "Crew",
-          "line": 15054,
+          "line": 16018,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -18946,7 +19437,7 @@
         },
         {
           "name": "Saddle",
-          "line": 15060,
+          "line": 16024,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -18959,7 +19450,7 @@
         },
         {
           "name": "Station",
-          "line": 15068,
+          "line": 16032,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -20126,7 +20617,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12786,
+      "line": 13686,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -20136,7 +20627,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 12788,
+          "line": 13688,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -20146,7 +20637,7 @@
         },
         {
           "name": "Second",
-          "line": 12791,
+          "line": 13691,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -20281,7 +20772,7 @@
     },
     "LayersDirty": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1955,
+      "line": 1966,
       "doc": "Lattice tracking which battlefield objects need layer (continuous-effect) re-evaluation. Replaces the old `bool` flag so that a token / conjure / copy entry can request an INCREMENTAL re-derive of only the entering object(s) instead of a full battlefield reset+reapply.  CR 613.1: continuous effects are evaluated in layer order over the whole board. A full evaluation is always correct; the incremental path is a performance optimization that `flush_layers` only takes when it can prove (per-entered preconditions + a board-wide escalation scan) that re-deriving just the entered objects produces a board state identical to a full pass. `mark_full()` is the conservative escalation any non-entry mutation uses.",
       "cr_refs": [
         "CR 613.1"
@@ -20289,7 +20780,7 @@
       "variants": [
         {
           "name": "Clean",
-          "line": 1958,
+          "line": 1969,
           "kind": "unit",
           "field_names": [],
           "doc": "Layers are up to date; nothing to flush.",
@@ -20297,7 +20788,7 @@
         },
         {
           "name": "EnteredObjects",
-          "line": 1962,
+          "line": 1973,
           "kind": "tuple",
           "field_names": [],
           "doc": "Only these objects entered the battlefield since the last flush and no other layer-affecting mutation occurred. Candidate for the incremental fast path.",
@@ -20305,7 +20796,7 @@
         },
         {
           "name": "Full",
-          "line": 1964,
+          "line": 1975,
           "kind": "unit",
           "field_names": [],
           "doc": "A full battlefield re-evaluation is required.",
@@ -20401,7 +20892,7 @@
     },
     "LearnOption": {
       "file": "crates/engine/src/types/actions.rs",
-      "line": 716,
+      "line": 724,
       "doc": "CR 701.48a: Learn choice — rummage a specific card, or skip entirely.",
       "cr_refs": [
         "CR 701.48a"
@@ -20409,7 +20900,7 @@
       "variants": [
         {
           "name": "Rummage",
-          "line": 718,
+          "line": 726,
           "kind": "struct",
           "field_names": [
             "card_id"
@@ -20419,7 +20910,7 @@
         },
         {
           "name": "Skip",
-          "line": 720,
+          "line": 728,
           "kind": "unit",
           "field_names": [],
           "doc": "Decline to learn (skip).",
@@ -20430,13 +20921,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6663,
+      "line": 6991,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 6664,
+          "line": 6992,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20444,7 +20935,7 @@
         },
         {
           "name": "Bottom",
-          "line": 6665,
+          "line": 6993,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20452,7 +20943,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 6667,
+          "line": 6995,
           "kind": "struct",
           "field_names": [
             "n"
@@ -20465,7 +20956,7 @@
     },
     "LinkedExileScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1242,
+      "line": 1277,
       "doc": "CR 607.2a + CR 406.6 + CR 610.3: Which exile-link relation a mana ability reads when computing legal colors. Typed enum — never a bool — so future extensions (e.g. links to a different host than `~` itself) slot in cleanly.",
       "cr_refs": [
         "CR 406.6",
@@ -20475,7 +20966,7 @@
       "variants": [
         {
           "name": "ThisObject",
-          "line": 1246,
+          "line": 1281,
           "kind": "unit",
           "field_names": [],
           "doc": "Read `state.exile_links` keyed to this ability's source object (the activating permanent).",
@@ -20662,13 +21153,13 @@
     },
     "ManaAbilityResume": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1786,
+      "line": 1797,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 1787,
+          "line": 1798,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20676,7 +21167,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 1788,
+          "line": 1799,
           "kind": "struct",
           "field_names": [
             "convoke_mode"
@@ -20686,7 +21177,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 1792,
+          "line": 1803,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -20703,7 +21194,7 @@
     },
     "ManaChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1858,
+      "line": 1869,
       "doc": "CR 608.2d + CR 605.3b: Player's answer to a `ManaChoicePrompt`, carried by `GameAction::ChooseManaColor`. Shape mirrors the prompt variant.",
       "cr_refs": [
         "CR 605.3b",
@@ -20712,7 +21203,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1859,
+          "line": 1870,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20720,7 +21211,7 @@
         },
         {
           "name": "Combination",
-          "line": 1860,
+          "line": 1871,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20731,7 +21222,7 @@
     },
     "ManaChoiceContext": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1868,
+      "line": 1879,
       "doc": "CR 106.3 + CR 608.2d + CR 605.3b: What resumes after a mana-color choice. Mana abilities and resolving spell/ability effects share the same prompt and response action, but resume through different rules paths.",
       "cr_refs": [
         "CR 106.3",
@@ -20741,7 +21232,7 @@
       "variants": [
         {
           "name": "ManaAbility",
-          "line": 1869,
+          "line": 1880,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20749,7 +21240,7 @@
         },
         {
           "name": "ResolvingEffect",
-          "line": 1870,
+          "line": 1881,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -20760,7 +21251,7 @@
     },
     "ManaChoicePrompt": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1841,
+      "line": 1852,
       "doc": "CR 608.2d + CR 605.3b: The shape of the prompt surfaced via `WaitingFor::ChooseManaColor`. Typed enum rather than a bool discriminator: the continuation logic is identical (validate choice → produce mana → resume), only the option set differs.",
       "cr_refs": [
         "CR 605.3b",
@@ -20769,7 +21260,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1844,
+          "line": 1855,
           "kind": "struct",
           "field_names": [
             "options"
@@ -20779,7 +21270,7 @@
         },
         {
           "name": "Combination",
-          "line": 1846,
+          "line": 1857,
           "kind": "struct",
           "field_names": [
             "options"
@@ -20789,7 +21280,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1848,
+          "line": 1859,
           "kind": "struct",
           "field_names": [
             "count",
@@ -20852,7 +21343,7 @@
     },
     "ManaContribution": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1025,
+      "line": 1060,
       "doc": "CR 605.1a + CR 107.4a: Whether a mana-production effect is the *base* mana addition (e.g. a basic Forest tapping for `{G}`) or an *additional* mana addition that piggy-backs on another mana event (e.g. Fertile Ground's \"adds an additional one mana\"). Typed enum — never a bool — so the parser and resolver can dispatch on the contribution role without conflating it with other dimensions of mana production.",
       "cr_refs": [
         "CR 107.4a",
@@ -20861,7 +21352,7 @@
       "variants": [
         {
           "name": "Base",
-          "line": 1028,
+          "line": 1063,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition stands on its own (most mana abilities).",
@@ -20869,7 +21360,7 @@
         },
         {
           "name": "Additional",
-          "line": 1031,
+          "line": 1066,
           "kind": "unit",
           "field_names": [],
           "doc": "The mana addition is additive — it augments another mana event (Utopia Sprawl, Fertile Ground, Wild Growth, Carpet of Flowers).",
@@ -20880,13 +21371,13 @@
     },
     "ManaCost": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 878,
+      "line": 1112,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "NoCost",
-          "line": 879,
+          "line": 1113,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20894,7 +21385,7 @@
         },
         {
           "name": "Cost",
-          "line": 880,
+          "line": 1114,
           "kind": "struct",
           "field_names": [
             "shards",
@@ -20905,24 +21396,34 @@
         },
         {
           "name": "SelfManaCost",
-          "line": 885,
+          "line": 1119,
           "kind": "unit",
           "field_names": [],
           "doc": "The card's own mana cost (used for \"the flashback cost is equal to its mana cost\").",
           "cr_refs": []
+        },
+        {
+          "name": "SelfManaValue",
+          "line": 1122,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "The card's own mana value (CR 202.3), as generic mana only — used for \"encore {X}, where X is its mana value\" (Sliver Gravemother class).",
+          "cr_refs": [
+            "CR 202.3"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "ManaCostShard": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 643,
+      "line": 877,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "White",
-          "line": 645,
+          "line": 879,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20930,7 +21431,7 @@
         },
         {
           "name": "Blue",
-          "line": 646,
+          "line": 880,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20938,7 +21439,7 @@
         },
         {
           "name": "Black",
-          "line": 647,
+          "line": 881,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20946,7 +21447,7 @@
         },
         {
           "name": "Red",
-          "line": 648,
+          "line": 882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20954,7 +21455,7 @@
         },
         {
           "name": "Green",
-          "line": 649,
+          "line": 883,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20962,7 +21463,7 @@
         },
         {
           "name": "Colorless",
-          "line": 651,
+          "line": 885,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20970,7 +21471,7 @@
         },
         {
           "name": "Snow",
-          "line": 652,
+          "line": 886,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20978,7 +21479,7 @@
         },
         {
           "name": "X",
-          "line": 653,
+          "line": 887,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -20986,7 +21487,7 @@
         },
         {
           "name": "TwoOrMoreColorSource",
-          "line": 655,
+          "line": 889,
           "kind": "unit",
           "field_names": [],
           "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
@@ -20994,7 +21495,7 @@
         },
         {
           "name": "WhiteBlue",
-          "line": 657,
+          "line": 891,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21002,7 +21503,7 @@
         },
         {
           "name": "WhiteBlack",
-          "line": 658,
+          "line": 892,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21010,7 +21511,7 @@
         },
         {
           "name": "BlueBlack",
-          "line": 659,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21018,7 +21519,7 @@
         },
         {
           "name": "BlueRed",
-          "line": 660,
+          "line": 894,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21026,7 +21527,7 @@
         },
         {
           "name": "BlackRed",
-          "line": 661,
+          "line": 895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21034,7 +21535,7 @@
         },
         {
           "name": "BlackGreen",
-          "line": 662,
+          "line": 896,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21042,7 +21543,7 @@
         },
         {
           "name": "RedWhite",
-          "line": 663,
+          "line": 897,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21050,7 +21551,7 @@
         },
         {
           "name": "RedGreen",
-          "line": 664,
+          "line": 898,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21058,7 +21559,7 @@
         },
         {
           "name": "GreenWhite",
-          "line": 665,
+          "line": 899,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21066,7 +21567,7 @@
         },
         {
           "name": "GreenBlue",
-          "line": 666,
+          "line": 900,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21074,7 +21575,7 @@
         },
         {
           "name": "TwoWhite",
-          "line": 668,
+          "line": 902,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21082,7 +21583,7 @@
         },
         {
           "name": "TwoBlue",
-          "line": 669,
+          "line": 903,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21090,7 +21591,7 @@
         },
         {
           "name": "TwoBlack",
-          "line": 670,
+          "line": 904,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21098,7 +21599,7 @@
         },
         {
           "name": "TwoRed",
-          "line": 671,
+          "line": 905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21106,7 +21607,7 @@
         },
         {
           "name": "TwoGreen",
-          "line": 672,
+          "line": 906,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21114,7 +21615,7 @@
         },
         {
           "name": "PhyrexianWhite",
-          "line": 674,
+          "line": 908,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21122,7 +21623,7 @@
         },
         {
           "name": "PhyrexianBlue",
-          "line": 675,
+          "line": 909,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21130,7 +21631,7 @@
         },
         {
           "name": "PhyrexianBlack",
-          "line": 676,
+          "line": 910,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21138,7 +21639,7 @@
         },
         {
           "name": "PhyrexianRed",
-          "line": 677,
+          "line": 911,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21146,7 +21647,7 @@
         },
         {
           "name": "PhyrexianGreen",
-          "line": 678,
+          "line": 912,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21154,7 +21655,7 @@
         },
         {
           "name": "PhyrexianWhiteBlue",
-          "line": 680,
+          "line": 914,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21162,7 +21663,7 @@
         },
         {
           "name": "PhyrexianWhiteBlack",
-          "line": 681,
+          "line": 915,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21170,7 +21671,7 @@
         },
         {
           "name": "PhyrexianBlueBlack",
-          "line": 682,
+          "line": 916,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21178,7 +21679,7 @@
         },
         {
           "name": "PhyrexianBlueRed",
-          "line": 683,
+          "line": 917,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21186,7 +21687,7 @@
         },
         {
           "name": "PhyrexianBlackRed",
-          "line": 684,
+          "line": 918,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21194,7 +21695,7 @@
         },
         {
           "name": "PhyrexianBlackGreen",
-          "line": 685,
+          "line": 919,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21202,7 +21703,7 @@
         },
         {
           "name": "PhyrexianRedWhite",
-          "line": 686,
+          "line": 920,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21210,7 +21711,7 @@
         },
         {
           "name": "PhyrexianRedGreen",
-          "line": 687,
+          "line": 921,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21218,7 +21719,7 @@
         },
         {
           "name": "PhyrexianGreenWhite",
-          "line": 688,
+          "line": 922,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21226,7 +21727,7 @@
         },
         {
           "name": "PhyrexianGreenBlue",
-          "line": 689,
+          "line": 923,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21234,7 +21735,7 @@
         },
         {
           "name": "ColorlessWhite",
-          "line": 691,
+          "line": 925,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21242,7 +21743,7 @@
         },
         {
           "name": "ColorlessBlue",
-          "line": 692,
+          "line": 926,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21250,7 +21751,7 @@
         },
         {
           "name": "ColorlessBlack",
-          "line": 693,
+          "line": 927,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21258,7 +21759,7 @@
         },
         {
           "name": "ColorlessRed",
-          "line": 694,
+          "line": 928,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21266,7 +21767,7 @@
         },
         {
           "name": "ColorlessGreen",
-          "line": 695,
+          "line": 929,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21277,7 +21778,7 @@
     },
     "ManaExpiry": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 540,
+      "line": 774,
       "doc": "When mana expires — controls lifecycle beyond the normal CR 106.4 step/phase drain.",
       "cr_refs": [
         "CR 106.4"
@@ -21285,7 +21786,7 @@
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 543,
+          "line": 777,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through normal step/phase drains until the turn reaches cleanup. Used by \"Until end of turn, you don't lose this mana as steps and phases end.\"",
@@ -21293,7 +21794,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 546,
+          "line": 780,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through combat steps but drains at EndCombat → PostCombatMain. Used by Firebending and similar \"mana lasts within combat\" mechanics.",
@@ -21304,7 +21805,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14204,
+      "line": 15155,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -21313,7 +21814,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 14207,
+          "line": 15158,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -21325,7 +21826,7 @@
         },
         {
           "name": "Multiply",
-          "line": 14210,
+          "line": 15161,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -21400,13 +21901,13 @@
     },
     "ManaProduction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1092,
+      "line": 1127,
       "doc": "Mana production descriptor for `Effect::Mana`.  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"colors\":[\"White\"]}` (new) and a plain array of `ManaColor` like `[\"White\",\"Green\"]` (legacy, pre-ManaProduction refactor).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 1094,
+          "line": 1129,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -21417,7 +21918,7 @@
         },
         {
           "name": "Colorless",
-          "line": 1105,
+          "line": 1140,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21427,7 +21928,7 @@
         },
         {
           "name": "Mixed",
-          "line": 1110,
+          "line": 1145,
           "kind": "struct",
           "field_names": [
             "colorless_count",
@@ -21438,7 +21939,7 @@
         },
         {
           "name": "AnyOneColor",
-          "line": 1115,
+          "line": 1150,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21450,7 +21951,7 @@
         },
         {
           "name": "AnyCombination",
-          "line": 1128,
+          "line": 1163,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21461,7 +21962,7 @@
         },
         {
           "name": "ChosenColor",
-          "line": 1135,
+          "line": 1170,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21473,7 +21974,7 @@
         },
         {
           "name": "OpponentLandColors",
-          "line": 1152,
+          "line": 1187,
           "kind": "struct",
           "field_names": [
             "count"
@@ -21485,7 +21986,7 @@
         },
         {
           "name": "AnyTypeProduceableBy",
-          "line": 1166,
+          "line": 1201,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21500,7 +22001,7 @@
         },
         {
           "name": "ChoiceAmongExiledColors",
-          "line": 1176,
+          "line": 1211,
           "kind": "struct",
           "field_names": [
             "source"
@@ -21514,7 +22015,7 @@
         },
         {
           "name": "ChoiceAmongCombinations",
-          "line": 1186,
+          "line": 1221,
           "kind": "struct",
           "field_names": [
             "options"
@@ -21527,7 +22028,7 @@
         },
         {
           "name": "AnyInCommandersColorIdentity",
-          "line": 1196,
+          "line": 1231,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21542,7 +22043,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 1212,
+          "line": 1247,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -21556,7 +22057,7 @@
         },
         {
           "name": "AnyOneColorAmongPermanents",
-          "line": 1218,
+          "line": 1253,
           "kind": "struct",
           "field_names": [
             "count",
@@ -21572,7 +22073,7 @@
         },
         {
           "name": "TriggerEventManaType",
-          "line": 1234,
+          "line": 1269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c + CR 106.3: Produce one mana of the same type as the mana produced by the triggering `ManaAdded` event. Used by `TapsForMana` triggers of the form \"add one mana of any type that land produced\" (Vorinclex, Voice of Hunger; Dictate of Karametra). Resolves from `state.current_trigger_event` at resolution time; emits no mana if the current trigger event is absent or not a `ManaAdded` event (CR 106.5).",
@@ -21587,7 +22088,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14216,
+      "line": 15167,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -21596,7 +22097,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 14219,
+          "line": 15170,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -21604,7 +22105,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 14221,
+          "line": 15172,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -21615,13 +22116,13 @@
     },
     "ManaRestriction": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 299,
+      "line": 427,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "OnlyForSpell",
-          "line": 301,
+          "line": 429,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -21629,7 +22130,7 @@
         },
         {
           "name": "OnlyForSpellType",
-          "line": 303,
+          "line": 431,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells\" / \"only to cast artifact spells\".",
@@ -21637,7 +22138,7 @@
         },
         {
           "name": "OnlyForCreatureType",
-          "line": 306,
+          "line": 434,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" The `String` is the chosen creature type (e.g., \"Elf\").",
@@ -21645,7 +22146,7 @@
         },
         {
           "name": "SharesCreatureTypeWithCommander",
-          "line": 316,
+          "line": 444,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.6 + CR 205.3m + CR 903.3: \"a creature spell that shares a creature type with your commander\" — relational spend filter for Path of Ancestry. This is a distinct *relational-to-commander* axis, not a fixed-subtype parameterization of `OnlyForCreatureType`: the matching subtype set is computed from live commander state per spend, so it cannot be evaluated from `SpellMeta` alone. `allows_spell` returns `false` (no commander context here); the real relational evaluation happens at the `apply_mana_spell_grants` spend-check site, which has game-state access — mirroring how `OnlyForXCosts` defers full detection to its call site.",
@@ -21657,7 +22158,7 @@
         },
         {
           "name": "OnlyForTypeSpellsOrAbilities",
-          "line": 322,
+          "line": 450,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -21670,15 +22171,25 @@
         },
         {
           "name": "OnlyForActivation",
-          "line": 328,
+          "line": 456,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used for casting spells — activation-only.",
           "cr_refs": []
         },
         {
+          "name": "OnlyForTaggedActivation",
+          "line": 461,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 106.6: \"Spend this mana only to activate power-up abilities.\" Keyed on the activating ability's keyword tag (Quinjet Technician), a distinct axis from `OnlyForTypeSpellsOrAbilities` (which keys on the source permanent's type) and `OnlyForActivation` (which permits any activation).",
+          "cr_refs": [
+            "CR 106.6"
+          ]
+        },
+        {
           "name": "OnlyForXCosts",
-          "line": 331,
+          "line": 464,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -21686,7 +22197,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKind",
-          "line": 333,
+          "line": 466,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -21694,7 +22205,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKindFromZone",
-          "line": 335,
+          "line": 468,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback from a graveyard.\"",
@@ -21702,7 +22213,7 @@
         },
         {
           "name": "OnlyForSpellWithManaValue",
-          "line": 339,
+          "line": 472,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21714,8 +22225,23 @@
           ]
         },
         {
+          "name": "OnlyForSpellMatchingCostCriteria",
+          "line": 481,
+          "kind": "struct",
+          "field_names": [
+            "spell_type",
+            "criteria"
+          ],
+          "doc": "CR 106.6 + CR 107.3 + CR 202.3: \"Spend this mana only to cast [creature] spells with mana value N or greater **or** [creature] spells with {X} in their mana costs\" (Helga, Skittish Seer — creature-narrowed; Troyan, Gutsy Explorer — any spell). A spell qualifies when it matches **any** listed [`SpellCostCriterion`] (disjunction) AND, if `spell_type` is `Some`, also has that type. Parameterized over the optional type narrowing and the criteria set rather than proliferating one variant per (type × threshold × X-disjunct) combination.",
+          "cr_refs": [
+            "CR 106.6",
+            "CR 107.3",
+            "CR 202.3"
+          ]
+        },
+        {
           "name": "OnlyForSpellWithColorCount",
-          "line": 343,
+          "line": 489,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21729,18 +22255,39 @@
         },
         {
           "name": "OnlyForSpellFromZone",
-          "line": 348,
+          "line": 499,
           "kind": "tuple",
           "field_names": [],
-          "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\". Gates on the spell's cast-from zone, consulting `SpellMeta.cast_from_zone`. A distinct axis from `OnlyForSpellWithKeywordKindFromZone` (which also requires a keyword).",
+          "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\" ([`ZoneSpendPolarity::From`]) and \"from anywhere other than your hand\" ([`ZoneSpendPolarity::NotFrom`], Mm'menon, the Right Hand). Gates on the spell's cast-from zone, consulting `SpellMeta.cast_from_zone`. A distinct axis from `OnlyForSpellWithKeywordKindFromZone` (which also requires a keyword). Carried as a [`ZoneSpend`] newtype payload whose custom `Deserialize` accepts the legacy bare-`Zone` form (`{\"OnlyForSpellFromZone\":\"Graveyard\"}`) for backward compatibility, mapping it to the inclusion reading.",
           "cr_refs": [
             "CR 106.6",
             "CR 400.7"
           ]
         },
         {
+          "name": "OnlyForAny",
+          "line": 506,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 106.6: Disjunctive spend restriction — the mana may be spent on any payment that satisfies at least one inner restriction. Composition combinator (each branch is itself a full restriction), not a leaf parameterization. Models \"… to cast a Dragon spell or an Omen spell\" and \"… to cast an Assassin spell, a spell that has freerunning, or to activate an ability of an Assassin source.\"",
+          "cr_refs": [
+            "CR 106.6"
+          ]
+        },
+        {
+          "name": "OnlyForSpecialAction",
+          "line": 513,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 106.6 + CR 116.2: \"Spend this mana only to [unlock doors]\" — the special-action half of a spend restriction. Payable only for a [`PaymentContext::SpecialAction`] whose [`SpecialAction`] matches. Rejects spell casts, ability activations, and generic effect payments. Parameterized over the action class so one variant covers every restrictable special action (door unlock today; extensible).",
+          "cr_refs": [
+            "CR 106.6",
+            "CR 116.2"
+          ]
+        },
+        {
           "name": "ConvokePayment",
-          "line": 352,
+          "line": 517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51a: Internal marker for a convoke tap that substitutes for paying mana. The payment algorithm may consume it for the current spell, but cast-spent metrics and mana-added triggers must ignore it.",
@@ -21753,7 +22300,7 @@
     },
     "ManaSpellGrant": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 515,
+      "line": 749,
       "doc": "CR 106.6: Additional effect that the mana confers upon the spell it is spent on. E.g., \"that spell can't be countered\" (Cavern of Souls, Delighted Halfling).",
       "cr_refs": [
         "CR 106.6"
@@ -21761,7 +22308,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 517,
+          "line": 751,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell cast with this mana can't be countered.",
@@ -21769,7 +22316,7 @@
         },
         {
           "name": "AddKeywordUntilEndOfTurn",
-          "line": 520,
+          "line": 754,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -21783,7 +22330,7 @@
         },
         {
           "name": "TriggerOnSpend",
-          "line": 531,
+          "line": 765,
           "kind": "struct",
           "field_names": [
             "restriction",
@@ -21800,7 +22347,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1789,
+      "line": 1896,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -21808,7 +22355,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 1793,
+          "line": 1900,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -21819,13 +22366,13 @@
     },
     "ManaSpendRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1435,
+      "line": 1470,
       "doc": "Parse-time template for mana spend restrictions.  Unlike [`ManaRestriction`](super::mana::ManaRestriction) which carries concrete values on a `ManaUnit`, this enum is stored on `Effect::Mana` and resolved at production time by reading runtime state (e.g., chosen creature type from the source object).",
       "cr_refs": [],
       "variants": [
         {
           "name": "SpellOnly",
-          "line": 1437,
+          "line": 1472,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -21833,7 +22380,7 @@
         },
         {
           "name": "SpellType",
-          "line": 1439,
+          "line": 1474,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells.\"",
@@ -21841,7 +22388,7 @@
         },
         {
           "name": "ChosenCreatureType",
-          "line": 1442,
+          "line": 1477,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" Resolved at runtime from the source's `chosen_creature_type()`.",
@@ -21849,7 +22396,7 @@
         },
         {
           "name": "SpellTypeOrAbilityActivation",
-          "line": 1447,
+          "line": 1482,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -21862,15 +22409,25 @@
         },
         {
           "name": "ActivateOnly",
-          "line": 1453,
+          "line": 1488,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used to cast spells; only for ability activation costs.",
           "cr_refs": []
         },
         {
+          "name": "ActivateTagged",
+          "line": 1491,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 106.6: \"Spend this mana only to activate power-up abilities.\" Keyed on the activating ability's keyword tag (Quinjet Technician).",
+          "cr_refs": [
+            "CR 106.6"
+          ]
+        },
+        {
           "name": "XCostOnly",
-          "line": 1456,
+          "line": 1494,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -21878,7 +22435,7 @@
         },
         {
           "name": "SpellWithKeywordKind",
-          "line": 1458,
+          "line": 1496,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -21886,7 +22443,7 @@
         },
         {
           "name": "SpellWithKeywordKindFromZone",
-          "line": 1460,
+          "line": 1498,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -21897,7 +22454,7 @@
         },
         {
           "name": "SpellWithManaValue",
-          "line": 1467,
+          "line": 1505,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21909,8 +22466,23 @@
           ]
         },
         {
+          "name": "SpellMatchingCostCriteria",
+          "line": 1511,
+          "kind": "struct",
+          "field_names": [
+            "spell_type",
+            "criteria"
+          ],
+          "doc": "CR 106.6 + CR 107.3 + CR 202.3: \"Spend this mana only to cast [creature] spells with mana value N or greater **or** [creature] spells with {X} in their mana costs\" (Helga, Skittish Seer; Troyan, Gutsy Explorer). Disjunction of cost criteria with optional spell-type narrowing — see [`ManaRestriction::OnlyForSpellMatchingCostCriteria`](super::mana::ManaRestriction::OnlyForSpellMatchingCostCriteria).",
+          "cr_refs": [
+            "CR 106.6",
+            "CR 107.3",
+            "CR 202.3"
+          ]
+        },
+        {
           "name": "SpellWithColorCount",
-          "line": 1471,
+          "line": 1519,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -21924,13 +22496,35 @@
         },
         {
           "name": "SpellFromZone",
-          "line": 1476,
+          "line": 1530,
           "kind": "tuple",
           "field_names": [],
-          "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\". Gates spending on the spell's cast-from zone alone — a distinct axis from [`ManaSpendRestriction::SpellWithKeywordKindFromZone`], which additionally requires a keyword. Resolved against `SpellMeta.cast_from_zone`.",
+          "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\" ([`From`](super::mana::ZoneSpendPolarity::From)) and \"from anywhere other than your hand\" ([`NotFrom`](super::mana::ZoneSpendPolarity::NotFrom), Mm'menon, the Right Hand). Gates spending on the spell's cast-from zone alone — a distinct axis from [`ManaSpendRestriction::SpellWithKeywordKindFromZone`], which additionally requires a keyword. Resolved against `SpellMeta.cast_from_zone`. Carried as a [`ZoneSpend`] newtype payload whose custom `Deserialize` accepts the legacy bare-`Zone` serialized form for backward compatibility, mapping it to the inclusion reading.",
           "cr_refs": [
             "CR 106.6",
             "CR 400.7"
+          ]
+        },
+        {
+          "name": "UnlockDoor",
+          "line": 1538,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 106.6 + CR 116.2m + CR 709.5e: \"Spend this mana only to unlock [a ]door[s]\" — the special-action half of a spend restriction. A leaf of the [`ManaSpendRestriction::Any`] disjunction (Smoky Lounge: \"cast Room spells and unlock doors\"). Lowered to [`ManaRestriction::OnlyForSpecialAction(SpecialAction::UnlockDoor)`](super::mana::ManaRestriction::OnlyForSpecialAction), enforced when a Room's CR 709.5e unlock cost is paid through [`PaymentContext::SpecialAction`](super::mana::PaymentContext::SpecialAction).",
+          "cr_refs": [
+            "CR 106.6",
+            "CR 116.2m",
+            "CR 709.5e"
+          ]
+        },
+        {
+          "name": "Any",
+          "line": 1541,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 106.6: Disjunction of spend restrictions (\"cast X or Y or activate Z\"). Lowered to `ManaRestriction::OnlyForAny`.",
+          "cr_refs": [
+            "CR 106.6"
           ]
         }
       ],
@@ -21938,7 +22532,7 @@
     },
     "ManaSupertype": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 551,
+      "line": 785,
       "doc": "CR 205.4g: Supertype carried by produced mana (Snow today; extensible).",
       "cr_refs": [
         "CR 205.4g"
@@ -21946,7 +22540,7 @@
       "variants": [
         {
           "name": "Snow",
-          "line": 552,
+          "line": 786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22113,13 +22707,13 @@
     },
     "MayTriggerOrigin": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 575,
+      "line": 586,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Printed",
-          "line": 576,
+          "line": 587,
           "kind": "struct",
           "field_names": [
             "trigger_index"
@@ -22129,7 +22723,7 @@
         },
         {
           "name": "Keyword",
-          "line": 577,
+          "line": 588,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -22142,13 +22736,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11352,
+      "line": 12174,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 11354,
+          "line": 12176,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -22160,7 +22754,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 11357,
+          "line": 12179,
           "kind": "struct",
           "field_names": [
             "source",
@@ -22181,13 +22775,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11332,
+      "line": 12154,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 11333,
+          "line": 12155,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22195,7 +22789,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 11336,
+          "line": 12158,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -22210,7 +22804,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 11343,
+          "line": 12165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -22220,7 +22814,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 11346,
+          "line": 12168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -22321,7 +22915,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5459,
+      "line": 5678,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -22331,7 +22925,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5461,
+          "line": 5680,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -22341,7 +22935,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5463,
+          "line": 5682,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -22354,13 +22948,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4149,
+      "line": 4329,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 4150,
+          "line": 4330,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22368,7 +22962,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4151,
+          "line": 4331,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22376,7 +22970,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 4152,
+          "line": 4332,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22387,13 +22981,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3390,
+      "line": 3565,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 3396,
+          "line": 3571,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -22404,7 +22998,7 @@
         },
         {
           "name": "Target",
-          "line": 3399,
+          "line": 3574,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -22414,7 +23008,7 @@
         },
         {
           "name": "Recipient",
-          "line": 3405,
+          "line": 3580,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -22425,7 +23019,7 @@
         },
         {
           "name": "EventSource",
-          "line": 3407,
+          "line": 3582,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -22435,7 +23029,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3414,
+          "line": 3589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -22448,7 +23042,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 3430,
+          "line": 3605,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric **pronoun** (\"it\" / \"its\") whose object referent is bound at parse time. The parser rebinds this to a concrete scope wherever the enclosing clause establishes the antecedent — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\", `EventSource` when the subject is the triggering object. The rebind ([`rebind_anaphoric_object_scope`] in `parser/oracle_effect/mod.rs`) covers every per-object characteristic (power, toughness, mana value, …) — not just power — because the pronoun refers to one object and the rebind only retargets *which* object, never *which* characteristic. When no clause subject applies (triggered-ability anaphora) `Anaphoric` survives to runtime, where it resolves identically to a demonstrative (effect-context referent first; see [`ObjectScope::Demonstrative`]). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work.",
@@ -22458,7 +23052,7 @@
         },
         {
           "name": "Demonstrative",
-          "line": 3447,
+          "line": 3622,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: A **demonstrative / definite** possessive back-reference (\"that creature's\", \"that card's\", \"that spell's\", \"the creature's\") whose antecedent is a full noun phrase naming an object introduced by an earlier instruction in the same ability — *not* the grammatical subject of the clause it appears in. Unlike [`ObjectScope::Anaphoric`] (the pronoun \"its\"), the subject-injection rewrite MUST NOT rebind this — its antecedent is fixed by the Oracle text. Steadfast Armasaur (\"its toughness\", `Anaphoric` → rebound to `Source`) and Creature Bond (\"that creature's toughness\", `Demonstrative` → never rebound) parse to the same `QuantityRef` property and differ only by this scope: collapsing them caused the LKI-toughness bug. At runtime `Demonstrative` resolves identically to `Anaphoric` — `effect_context_object` (CR 608.2c instruction-order referent) first, then the trigger source (CR 608.2k), then the cost-paid object. This is the Yuriko / Dark Confidant / Mana Drain class (issue #511): a reveal/counter/reanimate earlier in the same ability binds \"that <type>'s\" to the referenced object.",
@@ -22469,7 +23063,7 @@
         },
         {
           "name": "EventTarget",
-          "line": 3456,
+          "line": 3631,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 120.1: The object that **received** the damage referenced by the current trigger event — the recipient counterpart to [`ObjectScope::EventSource`]. This is \"that creature\" in \"deals noncombat damage to a creature equal to that creature's toughness\": the antecedent is the damaged object carried by the `DamageDealt` event, not the ability source or a target. Resolved at both trigger detection and resolution (CR 603.4 intervening-if) via `extract_target_object_from_event`.",
@@ -22493,7 +23087,7 @@
     },
     "OpeningHandBottomReason": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2243,
+      "line": 2254,
       "doc": "CR 103.5 / TL:R 906.6a: Why a player is bottoming cards from an opening hand before the normal mulligan-decision step.",
       "cr_refs": [
         "CR 103.5"
@@ -22501,7 +23095,7 @@
       "variants": [
         {
           "name": "TinyLeadersMultiCommander",
-          "line": 2244,
+          "line": 2255,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22512,7 +23106,7 @@
     },
     "OpponentMayScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 183,
+      "line": 185,
       "doc": "CR 608.2d: Who may choose to perform an optional effect during resolution. Used with `AbilityDefinition::optional_for` to route the \"you may\" prompt to opponents.",
       "cr_refs": [
         "CR 608.2d"
@@ -22520,7 +23114,7 @@
       "variants": [
         {
           "name": "AnyOpponent",
-          "line": 185,
+          "line": 187,
           "kind": "unit",
           "field_names": [],
           "doc": "\"any opponent may\" — each opponent in APNAP order gets the chance; first accept wins.",
@@ -22528,7 +23122,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 187,
+          "line": 189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 101.4: \"any player may\" — every player INCLUDING the controller is offered in APNAP order; first accept wins (distinct from AnyOpponent which excludes the controller).",
@@ -22542,7 +23136,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13637,
+      "line": 14573,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -22552,7 +23146,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 13639,
+          "line": 14575,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -22560,7 +23154,7 @@
         },
         {
           "name": "Equals",
-          "line": 13641,
+          "line": 14577,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -22568,7 +23162,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 13644,
+          "line": 14580,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -22576,7 +23170,7 @@
         },
         {
           "name": "OneOf",
-          "line": 13646,
+          "line": 14582,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -22587,7 +23181,7 @@
     },
     "OutsideGameChoiceSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2193,
+      "line": 2204,
       "doc": "CR 400.11 + CR 406.3: A discriminated source for one outside-game selection. Sideboard entries (the wishboard pool) and face-up exile cards (the Karn / Coax wishboard return pool) are surfaced through one choice list so the caster picks across both pools in a single decision.  The size delta between the two variants (`Sideboard` carries a full `CardFace` so the UI can render the wishboard card without a sideboard lookup; `FaceUpExile` holds only an `ObjectId`) is intentional — `OutsideGameChoiceEntry` lists are short-lived (one entry per offered candidate while a single `WaitingFor::OutsideGameChoice` is active) and never collected by the million, so the asymmetry doesn't warrant boxing every CardFace through a heap indirection.",
       "cr_refs": [
         "CR 400.11",
@@ -22596,7 +23190,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 2195,
+          "line": 2206,
           "kind": "struct",
           "field_names": [
             "sideboard_index",
@@ -22609,7 +23203,7 @@
         },
         {
           "name": "FaceUpExile",
-          "line": 2200,
+          "line": 2211,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -22660,7 +23254,7 @@
     },
     "OutsideGameSourcePool": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 139,
+      "line": 141,
       "doc": "CR 400.11 + CR 406.3: Candidate pool for outside-game searches. The baseline pool is the player's sideboard; Karn/Coax-class text widens that pool to include owned face-up exile cards that match the same filter.",
       "cr_refs": [
         "CR 400.11",
@@ -22669,7 +23263,7 @@
       "variants": [
         {
           "name": "Sideboard",
-          "line": 142,
+          "line": 144,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a: Tournament sideboard / casual outside-the-game collection.",
@@ -22679,7 +23273,7 @@
         },
         {
           "name": "SideboardAndFaceUpExile",
-          "line": 144,
+          "line": 146,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.11a + CR 406.3: Sideboard plus matching owned face-up exile.",
@@ -22693,13 +23287,13 @@
     },
     "Parity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 486,
+      "line": 488,
       "doc": "Odd or even — used by cards like \"choose odd or even.\"",
       "cr_refs": [],
       "variants": [
         {
           "name": "Odd",
-          "line": 487,
+          "line": 489,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22707,7 +23301,7 @@
         },
         {
           "name": "Even",
-          "line": 488,
+          "line": 490,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22716,9 +23310,36 @@
       ],
       "sibling_clusters": []
     },
+    "ParitySource": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 496,
+      "doc": "Source for odd/even parity predicates over mana value.",
+      "cr_refs": [],
+      "variants": [
+        {
+          "name": "Fixed",
+          "line": 498,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "A fixed printed odd/even quality.",
+          "cr_refs": []
+        },
+        {
+          "name": "LastNamedChoice",
+          "line": 501,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 608.2c: Reads the most recent odd/even named choice made earlier in the same resolving instruction sequence.",
+          "cr_refs": [
+            "CR 608.2c"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5223,
+      "line": 5432,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -22727,7 +23348,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 5224,
+          "line": 5433,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -22737,7 +23358,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 5228,
+          "line": 5437,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -22747,7 +23368,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 5229,
+          "line": 5438,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22755,7 +23376,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 5231,
+          "line": 5440,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -22765,7 +23386,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 5232,
+          "line": 5441,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -22775,7 +23396,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 5235,
+          "line": 5444,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -22786,7 +23407,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 5239,
+          "line": 5448,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -22796,7 +23417,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 5243,
+          "line": 5452,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -22806,7 +23427,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 5245,
+          "line": 5454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -22816,7 +23437,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 5246,
+          "line": 5455,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22824,7 +23445,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 5250,
+          "line": 5459,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22837,7 +23458,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 5253,
+          "line": 5462,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -22847,7 +23468,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 5256,
+          "line": 5465,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -22857,7 +23478,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 5259,
+          "line": 5468,
           "kind": "struct",
           "field_names": [
             "color"
@@ -22867,7 +23488,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 5262,
+          "line": 5471,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22875,7 +23496,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 5263,
+          "line": 5472,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22883,7 +23504,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 5264,
+          "line": 5473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22891,7 +23512,7 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 5265,
+          "line": 5474,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22902,7 +23523,7 @@
         },
         {
           "name": "ZoneCardTypeCountAtLeast",
-          "line": 5269,
+          "line": 5478,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22913,7 +23534,7 @@
         },
         {
           "name": "ZoneCoreTypeCardCountAtLeast",
-          "line": 5273,
+          "line": 5482,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22925,7 +23546,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 5278,
+          "line": 5487,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -22937,7 +23558,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 5283,
+          "line": 5492,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22947,7 +23568,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 5286,
+          "line": 5495,
           "kind": "struct",
           "field_names": [
             "count"
@@ -22957,7 +23578,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 5289,
+          "line": 5498,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -22967,7 +23588,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 5294,
+          "line": 5503,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22979,7 +23600,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 5303,
+          "line": 5512,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -22994,7 +23615,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 5308,
+          "line": 5517,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -23004,7 +23625,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 5311,
+          "line": 5520,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23014,7 +23635,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 5314,
+          "line": 5523,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -23025,7 +23646,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 5318,
+          "line": 5527,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -23036,7 +23657,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 5322,
+          "line": 5531,
           "kind": "struct",
           "field_names": [
             "color",
@@ -23047,7 +23668,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 5326,
+          "line": 5535,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -23057,7 +23678,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 5329,
+          "line": 5538,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23065,7 +23686,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 5330,
+          "line": 5539,
           "kind": "struct",
           "field_names": [
             "name"
@@ -23075,7 +23696,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 5337,
+          "line": 5546,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -23088,7 +23709,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 5341,
+          "line": 5550,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -23098,7 +23719,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 5344,
+          "line": 5553,
           "kind": "struct",
           "field_names": [
             "power",
@@ -23109,7 +23730,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 5348,
+          "line": 5557,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23117,7 +23738,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 5349,
+          "line": 5558,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23127,7 +23748,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 5352,
+          "line": 5561,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23137,7 +23758,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 5355,
+          "line": 5564,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23147,7 +23768,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 5358,
+          "line": 5567,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23155,7 +23776,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 5359,
+          "line": 5568,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23163,17 +23784,20 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 5360,
+          "line": 5577,
           "kind": "struct",
           "field_names": [
-            "count"
+            "count",
+            "filter"
           ],
-          "doc": "",
-          "cr_refs": []
+          "doc": "CR 508.1a: True when the player declared at least `count` attackers this turn. `filter: None` counts every attacker the player declared (backed by the fast `state.attacking_creatures_this_turn` counter — \"you attacked with N+ creatures this turn\"). `filter: Some(_)` counts only attackers matching the filter from the declaration-time snapshot `state.attacker_declarations_this_turn` (Thaumaton Torpedo — \"you attacked with a Spacecraft this turn\"), so attackers that have since left the battlefield still count.",
+          "cr_refs": [
+            "CR 508.1a"
+          ]
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 5366,
+          "line": 5585,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -23181,7 +23805,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 5369,
+          "line": 5588,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23194,7 +23818,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 5373,
+          "line": 5592,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23202,7 +23826,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 5374,
+          "line": 5593,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23212,7 +23836,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 5377,
+          "line": 5596,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23220,7 +23844,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 5378,
+          "line": 5597,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23228,7 +23852,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 5379,
+          "line": 5598,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23236,7 +23860,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 5380,
+          "line": 5599,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23244,7 +23868,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 5382,
+          "line": 5601,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -23254,7 +23878,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 5383,
+          "line": 5602,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23262,7 +23886,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 5384,
+          "line": 5603,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23270,7 +23894,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 5385,
+          "line": 5604,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23278,7 +23902,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 5386,
+          "line": 5605,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23289,7 +23913,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 5390,
+          "line": 5609,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23299,7 +23923,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 5395,
+          "line": 5614,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -23312,7 +23936,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5400,
+          "line": 5619,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -23322,7 +23946,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 5408,
+          "line": 5627,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -23332,7 +23956,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 5421,
+          "line": 5640,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23346,7 +23970,7 @@
         },
         {
           "name": "And",
-          "line": 5429,
+          "line": 5648,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23359,7 +23983,7 @@
         },
         {
           "name": "Or",
-          "line": 5435,
+          "line": 5654,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -23372,7 +23996,7 @@
         },
         {
           "name": "Not",
-          "line": 5442,
+          "line": 5661,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -23459,7 +24083,7 @@
     },
     "PayCostKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2423,
+      "line": 2440,
       "doc": "CR 118.3 + CR 601.2b + CR 605.3b: Identifies the specific action to take on the objects a player selects while paying a cost.",
       "cr_refs": [
         "CR 118.3",
@@ -23469,7 +24093,7 @@
       "variants": [
         {
           "name": "Discard",
-          "line": 2424,
+          "line": 2441,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23477,7 +24101,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 2425,
+          "line": 2442,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23485,7 +24109,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 2426,
+          "line": 2443,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23493,7 +24117,7 @@
         },
         {
           "name": "ExileFromZone",
-          "line": 2428,
+          "line": 2445,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23503,7 +24127,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 2435,
+          "line": 2452,
           "kind": "struct",
           "field_names": [
             "materials"
@@ -23515,7 +24139,7 @@
         },
         {
           "name": "ExilePermanent",
-          "line": 2446,
+          "line": 2463,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -23529,7 +24153,7 @@
         },
         {
           "name": "ExileFromManaZone",
-          "line": 2450,
+          "line": 2467,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23539,7 +24163,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 2453,
+          "line": 2470,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -23551,15 +24175,22 @@
         },
         {
           "name": "TapCreatures",
-          "line": 2463,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
+          "line": 2490,
+          "kind": "struct",
+          "field_names": [
+            "aggregate"
+          ],
+          "doc": "CR 601.2b: Tap creatures as a cost. `aggregate` distinguishes the two `TapCreaturesRequirement` shapes at the interactive payment layer: `None` is the fixed-count form (player taps exactly `WaitingFor::PayCost` `count` creatures; Conspire/Convoke), while `Some(aggregate)` is the aggregate \"tap any number satisfying the constraint\" form (Crew CR 702.122a / Saddle CR 702.171a / Teamwork) — the chosen set may be any size whose total positive power (CR 208.1) satisfies `aggregate`'s comparator vs its value. Carrying the full `TapCreaturesAggregate` (not just a threshold int) keeps the payment validator honoring the advertised comparator instead of hard-coding `>=`.",
+          "cr_refs": [
+            "CR 208.1",
+            "CR 601.2b",
+            "CR 702.122a",
+            "CR 702.171a"
+          ]
         },
         {
           "name": "Behold",
-          "line": 2464,
+          "line": 2494,
           "kind": "struct",
           "field_names": [
             "action"
@@ -23572,7 +24203,7 @@
     },
     "PayableResource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4133,
+      "line": 4213,
       "doc": "CR 107.14 + CR 118.8: Resource that can be paid in a \"pay any amount of X\" prompt. Typed so the same `WaitingFor::PayAmountChoice` variant generalizes to future classes (energy, life, mana) without re-introducing boolean flags.",
       "cr_refs": [
         "CR 107.14",
@@ -23581,7 +24212,7 @@
       "variants": [
         {
           "name": "Energy",
-          "line": 4135,
+          "line": 4215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.",
@@ -23591,7 +24222,7 @@
         },
         {
           "name": "ManaGeneric",
-          "line": 4137,
+          "line": 4217,
           "kind": "struct",
           "field_names": [
             "per_x"
@@ -23604,7 +24235,7 @@
         },
         {
           "name": "Counters",
-          "line": 4142,
+          "line": 4222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c + CR 122.1: Choose how many counters to remove.",
@@ -23618,7 +24249,7 @@
     },
     "PaymentContext": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 268,
+      "line": 273,
       "doc": "CR 106.6: Context for a mana-payment decision. Distinguishes \"paying for a spell being cast\", \"paying for an ability being activated\", and paying costs during effect resolution so the restriction check can route through the correct rules category.  Casting-restricted mana (e.g., \"creature-spell-only\") must reject ability activations; activation-restricted mana (e.g., \"activate abilities only\") must reject spell casts and resolution-time effect costs. Using the correct variant per payment site is the single authority that enforces this bifurcation.",
       "cr_refs": [
         "CR 106.6"
@@ -23626,7 +24257,7 @@
       "variants": [
         {
           "name": "Spell",
-          "line": 270,
+          "line": 275,
           "kind": "tuple",
           "field_names": [],
           "doc": "Payment for a spell being cast — consult `allows_spell`.",
@@ -23634,29 +24265,44 @@
         },
         {
           "name": "Activation",
-          "line": 273,
+          "line": 279,
           "kind": "struct",
           "field_names": [
             "source_types",
-            "source_subtypes"
+            "source_subtypes",
+            "ability_tag"
           ],
-          "doc": "Payment for an activated ability — consult `allows_activation` using the source permanent's core types and subtypes.",
-          "cr_refs": []
+          "doc": "Payment for an activated ability — consult `allows_activation` using the source permanent's core types and subtypes plus the ability's keyword tag (CR 106.6, for tag-scoped restrictions like Quinjet's).",
+          "cr_refs": [
+            "CR 106.6"
+          ]
         },
         {
           "name": "Effect",
-          "line": 280,
+          "line": 287,
           "kind": "unit",
           "field_names": [],
           "doc": "Payment for a cost during spell or ability resolution. Current restriction variants name spell-casting or ability-activation use, so restricted mana is not eligible here.",
           "cr_refs": []
+        },
+        {
+          "name": "SpecialAction",
+          "line": 296,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "CR 116.2: Payment for a special action's mana cost (e.g. a Room's unlock cost, CR 116.2m / CR 709.5e). Special actions don't use the stack and are neither spell casts nor ability activations, so they need a distinct context: spell/activation-restricted mana must reject them, but special-action-restricted mana (`OnlyForSpecialAction`) must accept the matching action class. Parameterized over [`SpecialAction`] so one context variant covers every restrictable special-action class rather than a sibling per action.",
+          "cr_refs": [
+            "CR 116.2",
+            "CR 116.2m",
+            "CR 709.5e"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "PendingCoinFlipKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 909,
+      "line": 920,
       "doc": "CR 705.1 + CR 614.1a: Discriminates which multi-flip resolver paused for a Krark's Thumb keep-1 choice, carrying the loop position needed to re-enter.",
       "cr_refs": [
         "CR 614.1a",
@@ -23665,7 +24311,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 911,
+          "line": 922,
           "kind": "unit",
           "field_names": [],
           "doc": "`Effect::FlipCoin` — a single logical flip.",
@@ -23673,7 +24319,7 @@
         },
         {
           "name": "FlipN",
-          "line": 914,
+          "line": 925,
           "kind": "struct",
           "field_names": [
             "remaining"
@@ -23683,7 +24329,7 @@
         },
         {
           "name": "UntilLose",
-          "line": 917,
+          "line": 928,
           "kind": "struct",
           "field_names": [
             "wins_so_far"
@@ -23696,13 +24342,13 @@
     },
     "PendingCounterAddition": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1503,
+      "line": 1514,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 1504,
+          "line": 1515,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23715,7 +24361,7 @@
         },
         {
           "name": "Player",
-          "line": 1510,
+          "line": 1521,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23728,7 +24374,7 @@
         },
         {
           "name": "Energy",
-          "line": 1516,
+          "line": 1527,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -23743,13 +24389,13 @@
     },
     "PendingCounterPostAction": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1373,
+      "line": 1384,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "EmitEffectResolved",
-          "line": 1374,
+          "line": 1385,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -23760,7 +24406,7 @@
         },
         {
           "name": "RecordPlayerAction",
-          "line": 1378,
+          "line": 1389,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -23771,7 +24417,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 1382,
+          "line": 1393,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23782,7 +24428,7 @@
         },
         {
           "name": "InjectPredefinedTokenAbilities",
-          "line": 1386,
+          "line": 1397,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23792,7 +24438,7 @@
         },
         {
           "name": "FinalizeTokenEntry",
-          "line": 1389,
+          "line": 1400,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23807,7 +24453,7 @@
         },
         {
           "name": "ContinueTokenCreation",
-          "line": 1397,
+          "line": 1408,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -23820,7 +24466,7 @@
         },
         {
           "name": "FinalizeCopyTokenEntry",
-          "line": 1403,
+          "line": 1414,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23834,7 +24480,7 @@
         },
         {
           "name": "ContinueCopyTokenCreation",
-          "line": 1410,
+          "line": 1421,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -23848,7 +24494,7 @@
         },
         {
           "name": "ApplyCopyTokenModificationsAndFinalize",
-          "line": 1417,
+          "line": 1428,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23863,7 +24509,7 @@
         },
         {
           "name": "ClearPendingEtbCounters",
-          "line": 1425,
+          "line": 1436,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23873,7 +24519,7 @@
         },
         {
           "name": "ContinueZoneDeliveryTail",
-          "line": 1428,
+          "line": 1439,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -23890,7 +24536,7 @@
         },
         {
           "name": "RecordStationed",
-          "line": 1442,
+          "line": 1453,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -23902,7 +24548,7 @@
         },
         {
           "name": "MarkMonstrous",
-          "line": 1447,
+          "line": 1458,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23912,7 +24558,7 @@
         },
         {
           "name": "MarkRenowned",
-          "line": 1450,
+          "line": 1461,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -23925,13 +24571,13 @@
     },
     "PendingEffectResolutionEvent": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1360,
+      "line": 1371,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Emit",
-          "line": 1362,
+          "line": 1373,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23939,7 +24585,7 @@
         },
         {
           "name": "Suppress",
-          "line": 1363,
+          "line": 1374,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23950,7 +24596,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1812,
+      "line": 1919,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -23959,7 +24605,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 1815,
+          "line": 1922,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -23969,7 +24615,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 1817,
+          "line": 1924,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -23979,7 +24625,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 1819,
+          "line": 1926,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -24129,7 +24775,7 @@
     },
     "PileSide": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2330,
+      "line": 2341,
       "doc": "CR 700.3: Identifies one of the two piles produced by a `SeparateIntoPiles` partition. Typed rather than `bool` so the `GameAction::ChoosePile` payload and the engine handler share a self-documenting domain and the parser/AI cannot accidentally swap pile semantics. Pile A is the partitioner's chosen subset; pile B is `eligible \\ pile_a`.",
       "cr_refs": [
         "CR 700.3"
@@ -24137,7 +24783,7 @@
       "variants": [
         {
           "name": "A",
-          "line": 2331,
+          "line": 2342,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24145,7 +24791,7 @@
         },
         {
           "name": "B",
-          "line": 2332,
+          "line": 2343,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24161,23 +24807,15 @@
       "cr_refs": [],
       "variants": [
         {
-          "name": "SearchedLibrary",
-          "line": 82,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Scry",
+          "name": "AcceptedOptionalEffect",
           "line": 83,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
+          "doc": "A player accepted a resolution-time optional effect.",
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "SearchedLibrary",
           "line": 84,
           "kind": "unit",
           "field_names": [],
@@ -24185,7 +24823,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "Scry",
           "line": 85,
           "kind": "unit",
           "field_names": [],
@@ -24193,8 +24831,24 @@
           "cr_refs": []
         },
         {
-          "name": "ShuffledLibrary",
+          "name": "Surveil",
+          "line": 86,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "CollectEvidence",
           "line": 87,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ShuffledLibrary",
+          "line": 89,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.24a: A player shuffled their library.",
@@ -24204,7 +24858,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 89,
+          "line": 91,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.34a: A player proliferated.",
@@ -24214,7 +24868,7 @@
         },
         {
           "name": "Investigate",
-          "line": 91,
+          "line": 93,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16a: A player investigated (created a Clue token).",
@@ -24271,13 +24925,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4248,
+      "line": 4428,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 4252,
+          "line": 4432,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -24287,7 +24941,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4254,
+          "line": 4434,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -24295,7 +24949,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 4256,
+          "line": 4436,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -24305,7 +24959,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 4258,
+          "line": 4438,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -24313,7 +24967,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 4260,
+          "line": 4440,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -24321,7 +24975,7 @@
         },
         {
           "name": "HasLostTheGame",
-          "line": 4265,
+          "line": 4445,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3 + CR 104.5: Each player who has lost the game (`is_eliminated`). Quantity-only: players who lost have left the game, so this is not a live effect recipient filter. Rampant Frogantua class: \"+10/+10 for each player who has lost the game\".",
@@ -24332,7 +24986,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 4275,
+          "line": 4455,
           "kind": "struct",
           "field_names": [
             "source"
@@ -24347,7 +25001,7 @@
         },
         {
           "name": "OpponentAttacked",
-          "line": 4289,
+          "line": 4469,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -24363,7 +25017,7 @@
         },
         {
           "name": "All",
-          "line": 4294,
+          "line": 4474,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -24371,7 +25025,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 4296,
+          "line": 4476,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -24381,7 +25035,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 4299,
+          "line": 4479,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -24389,7 +25043,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 4303,
+          "line": 4483,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24403,7 +25057,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 4309,
+          "line": 4489,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -24411,7 +25065,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 4313,
+          "line": 4493,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -24422,7 +25076,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 4322,
+          "line": 4502,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -24433,7 +25087,7 @@
         },
         {
           "name": "OpponentOfTriggeringPlayerNotAttacked",
-          "line": 4328,
+          "line": 4508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking* player (resolved from the active AttackersDeclared trigger event) who is NOT in that player's attacked-this-combat set. Models \"that player has another opponent who isn't being attacked\" (Suppressor Skyguard); counted via QuantityRef::PlayerCount, gated as count >= 1.",
@@ -24445,7 +25099,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 4339,
+          "line": 4519,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -24458,7 +25112,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 4351,
+          "line": 4531,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -24469,7 +25123,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 4373,
+          "line": 4553,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24485,7 +25139,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 4399,
+          "line": 4579,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -24503,7 +25157,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 4415,
+          "line": 4595,
           "kind": "struct",
           "field_names": [
             "index"
@@ -24516,7 +25170,7 @@
         },
         {
           "name": "ParentObjectTargetOwner",
-          "line": 4425,
+          "line": 4605,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 109.4: The owner of the first object target of the resolving ability. The owner-axis sibling of `ParentObjectTargetController`, completing the owner/controller pair that `PlayerScope` (`ParentObjectTargetController`) and `TargetFilter` (`ParentTargetOwner` / `ParentTargetController`) already carry. Resolved via `ability_utils::parent_target_owner`. Powers the \"[target's owner] …, then faces a villainous choice — …\" class (This Is How It Ends) where the player facing the choice is the owner of the targeted permanent named in the prior clause, not the ability controller.",
@@ -24539,7 +25193,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4217,
+      "line": 4397,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -24549,7 +25203,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4219,
+          "line": 4399,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -24557,7 +25211,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4221,
+          "line": 4401,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -24565,7 +25219,7 @@
         },
         {
           "name": "All",
-          "line": 4223,
+          "line": 4403,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -24576,7 +25230,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3331,
+      "line": 3506,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -24586,7 +25240,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3333,
+          "line": 3508,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -24597,7 +25251,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3337,
+          "line": 3512,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -24608,7 +25262,7 @@
         },
         {
           "name": "Target",
-          "line": 3340,
+          "line": 3515,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -24620,7 +25274,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3344,
+          "line": 3519,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -24633,7 +25287,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3349,
+          "line": 3524,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -24646,7 +25300,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 3363,
+          "line": 3538,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -24657,7 +25311,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3369,
+          "line": 3544,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -24668,7 +25322,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3375,
+          "line": 3550,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -24679,7 +25333,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3382,
+          "line": 3557,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: The player PERSISTED on the source via `ChosenAttribute::Player` (an \"as ~ enters the battlefield, choose a player\" replacement). The player-scalar-axis analogue of `ControllerRef::SourceChosenPlayer`, read continuously from the source's `chosen_attributes` so a CDA P/T can track e.g. the chosen player's hand or graveyard size (Entropic Specter, Sewer Nemesis).",
@@ -24720,7 +25374,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14324,
+      "line": 15275,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -24729,7 +25383,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 14325,
+          "line": 15276,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24737,7 +25391,7 @@
         },
         {
           "name": "Resolved",
-          "line": 14326,
+          "line": 15277,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -24748,13 +25402,13 @@
     },
     "PostReplacementDrainOwner": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1488,
+      "line": 1499,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DeliveryTail",
-          "line": 1493,
+          "line": 1504,
           "kind": "unit",
           "field_names": [],
           "doc": "The shared delivery tail (`apply_zone_delivery_tail`) drains the continuation ctx-less — every direct pipeline delivery (effect moves, stack resolution, land play, destroy/sacrifice lowering).",
@@ -24762,7 +25416,7 @@
         },
         {
           "name": "CallerEpilogue",
-          "line": 1499,
+          "line": 1510,
           "kind": "unit",
           "field_names": [],
           "doc": "The caller's epilogue owns the drain; the tail skips it. Used by `engine_replacement::handle_replacement_choice`, whose post-`Execute` epilogue drains with the spell-resolution ctx and clears `post_replacement_source` for zone changes (CR 614.12a ordering: `apply_pending_spell_resolution` runs before the drain there).",
@@ -24775,7 +25429,7 @@
     },
     "PreventionAmount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 536,
+      "line": 549,
       "doc": "CR 615: How much damage to prevent.",
       "cr_refs": [
         "CR 615"
@@ -24783,7 +25437,7 @@
       "variants": [
         {
           "name": "Next",
-          "line": 538,
+          "line": 551,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Prevent the next N damage\"",
@@ -24791,7 +25445,7 @@
         },
         {
           "name": "All",
-          "line": 540,
+          "line": 553,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Prevent all damage\"",
@@ -24802,7 +25456,7 @@
     },
     "PreventionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 526,
+      "line": 539,
       "doc": "CR 615: Damage prevention scope.",
       "cr_refs": [
         "CR 615"
@@ -24810,7 +25464,7 @@
       "variants": [
         {
           "name": "AllDamage",
-          "line": 529,
+          "line": 542,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent all damage (combat + noncombat).",
@@ -24818,7 +25472,7 @@
         },
         {
           "name": "CombatDamage",
-          "line": 531,
+          "line": 544,
           "kind": "unit",
           "field_names": [],
           "doc": "Prevent only combat damage.",
@@ -24829,7 +25483,7 @@
     },
     "ProductionOverride": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1824,
+      "line": 1835,
       "doc": "CR 605.3b + CR 106.1a: A pre-resolved choice that short-circuits the normal `ChooseManaColor` prompt. Auto-tap sets this when the cost-payment planner has already determined the exact mana to produce; manual activation leaves it `None` so the player is prompted.  Typed enum (never a bool): `SingleColor` covers the one-color-repeated variants (`AnyOneColor`, `ChoiceAmongExiledColors`), while `Combination` carries the full pre-chosen multi-mana sequence for fixed combinations (`ChoiceAmongCombinations`) and free per-slot choices (`AnyCombination`).",
       "cr_refs": [
         "CR 106.1a",
@@ -24838,7 +25492,7 @@
       "variants": [
         {
           "name": "SingleColor",
-          "line": 1828,
+          "line": 1839,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked a single color; every unit of mana the ability produces becomes this color (mirrors the pre-widening `Option<ManaType>` semantics).",
@@ -24846,7 +25500,7 @@
         },
         {
           "name": "Combination",
-          "line": 1831,
+          "line": 1842,
           "kind": "tuple",
           "field_names": [],
           "doc": "The caller picked one complete mana sequence; the ability produces exactly these mana types in order.",
@@ -24857,13 +25511,13 @@
     },
     "ProhibitedActivity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1556,
+      "line": 1621,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "CastOnlyFromZones",
-          "line": 1558,
+          "line": 1623,
           "kind": "struct",
           "field_names": [
             "allowed_zones"
@@ -24876,7 +25530,7 @@
         },
         {
           "name": "CastSpells",
-          "line": 1560,
+          "line": 1625,
           "kind": "struct",
           "field_names": [
             "spell_filter"
@@ -24888,16 +25542,29 @@
         },
         {
           "name": "ActivateAbilities",
-          "line": 1566,
+          "line": 1633,
           "kind": "struct",
           "field_names": [
-            "exemption"
+            "exemption",
+            "only_tag"
           ],
-          "doc": "CR 101.2 + CR 602.5 + CR 605.1a: Prevent activating abilities, optionally exempting mana abilities.",
+          "doc": "CR 101.2 + CR 602.5 + CR 605.1a: Prevent activating abilities, optionally exempting mana abilities. `only_tag = None` prohibits all activations; `Some(tag)` scopes the prohibition to abilities carrying that keyword tag (Kang → power-up), leaving every other activation legal.",
           "cr_refs": [
             "CR 101.2",
             "CR 602.5",
             "CR 605.1a"
+          ]
+        },
+        {
+          "name": "Attack",
+          "line": 1643,
+          "kind": "struct",
+          "field_names": [
+            "defended"
+          ],
+          "doc": "CR 508.1c: A temporary effect prohibits an affected player from declaring attacks against the defended scope (\"that player can't attack you [or your permanents/planeswalkers]\"). The scope rides the shared `AttackTargetFilter` so the declare-attackers gate reuses the same defended-scope matcher as static `CantAttack` restrictions.",
+          "cr_refs": [
+            "CR 508.1c"
           ]
         }
       ],
@@ -25199,8 +25866,22 @@
           "cr_refs": []
         },
         {
+          "name": "TurnFaceUp",
+          "line": 359,
+          "kind": "struct",
+          "field_names": [
+            "object_id",
+            "applied"
+          ],
+          "doc": "CR 614.1e + CR 708.11: a permanent is being turned face up. \"As ~ is turned face up\" replacement effects apply here (megamorph/disguise).",
+          "cr_refs": [
+            "CR 614.1e",
+            "CR 708.11"
+          ]
+        },
+        {
           "name": "Destroy",
-          "line": 357,
+          "line": 363,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -25213,7 +25894,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 364,
+          "line": 370,
           "kind": "struct",
           "field_names": [
             "object_id",
@@ -25225,7 +25906,7 @@
         },
         {
           "name": "BeginTurn",
-          "line": 375,
+          "line": 381,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -25242,7 +25923,7 @@
         },
         {
           "name": "BeginPhase",
-          "line": 385,
+          "line": 391,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -25257,7 +25938,7 @@
         },
         {
           "name": "ProduceMana",
-          "line": 394,
+          "line": 400,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -25275,7 +25956,7 @@
         },
         {
           "name": "EmptyManaPool",
-          "line": 423,
+          "line": 429,
           "kind": "struct",
           "field_names": [
             "player_id",
@@ -25390,7 +26071,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4798,
+      "line": 5002,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -25398,7 +26079,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 4800,
+          "line": 5004,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -25408,7 +26089,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4802,
+          "line": 5006,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -25418,7 +26099,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 4804,
+          "line": 5008,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -25431,13 +26112,13 @@
     },
     "PtValue": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 973,
+      "line": 1008,
       "doc": "Power/toughness value -- either a fixed integer or a variable reference (e.g. \"*\", \"X\").  Custom Deserialize: accepts both the tagged format `{\"type\":\"Fixed\",\"value\":2}` (new) and plain strings like `\"2\"` or `\"*\"` (legacy card-data.json).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Fixed",
-          "line": 974,
+          "line": 1009,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25445,7 +26126,7 @@
         },
         {
           "name": "Variable",
-          "line": 975,
+          "line": 1010,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25453,7 +26134,7 @@
         },
         {
           "name": "Quantity",
-          "line": 976,
+          "line": 1011,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25464,7 +26145,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4813,
+      "line": 5017,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -25473,7 +26154,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 4816,
+          "line": 5020,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -25483,7 +26164,7 @@
         },
         {
           "name": "Base",
-          "line": 4819,
+          "line": 5023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -25496,7 +26177,7 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4437,
+      "line": 4617,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.  CR 107: `Deserialize` is hand-written below (NOT derived) so it ALSO accepts the legacy bare-integer form (`2`, `-1`) that pre-`QuantityExpr` card-data and committed game-state snapshots stored. `Serialize` stays derived, so the canonical on-disk form remains the tagged `{\"type\":\"Fixed\",\"value\":2}`.",
       "cr_refs": [
         "CR 107"
@@ -25504,7 +26185,7 @@
       "variants": [
         {
           "name": "Ref",
-          "line": 4439,
+          "line": 4619,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -25514,7 +26195,7 @@
         },
         {
           "name": "Fixed",
-          "line": 4441,
+          "line": 4621,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25524,7 +26205,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 4445,
+          "line": 4625,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25538,7 +26219,7 @@
         },
         {
           "name": "Offset",
-          "line": 4452,
+          "line": 4632,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25551,7 +26232,7 @@
         },
         {
           "name": "ClampMin",
-          "line": 4461,
+          "line": 4641,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -25564,7 +26245,7 @@
         },
         {
           "name": "Multiply",
-          "line": 4466,
+          "line": 4646,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -25575,7 +26256,7 @@
         },
         {
           "name": "Sum",
-          "line": 4475,
+          "line": 4655,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -25585,7 +26266,7 @@
         },
         {
           "name": "UpTo",
-          "line": 4500,
+          "line": 4680,
           "kind": "struct",
           "field_names": [
             "max"
@@ -25598,7 +26279,7 @@
         },
         {
           "name": "Power",
-          "line": 4506,
+          "line": 4686,
           "kind": "struct",
           "field_names": [
             "base",
@@ -25611,7 +26292,7 @@
         },
         {
           "name": "Difference",
-          "line": 4521,
+          "line": 4701,
           "kind": "struct",
           "field_names": [
             "left",
@@ -25621,29 +26302,46 @@
           "cr_refs": [
             "CR 107.1b"
           ]
+        },
+        {
+          "name": "Max",
+          "line": 4720,
+          "kind": "struct",
+          "field_names": [
+            "exprs"
+          ],
+          "doc": "The maximum of N independent quantity expressions. Powers the \"A or B, whichever is greater\" / \"the greatest of A, B, …\" Oracle templating class (Triumphant Chomp: `max(2, greatest power among Dinosaurs you control)`). A general arithmetic peer of `Sum`/`Offset`/`Multiply`/`Difference`: composes any \"greater of\" card from existing `QuantityExpr` leaves. Mirrors `Sum`'s `Vec` shape so it generalizes from two operands to N.  CR 107.1: the only numbers Magic uses are integers — this maximizes computed integer amounts. CR 120.4a / CR 120.10 establish the in-rules \"the greatest of the calculated amounts\" precedent for taking a maximum over multiple computed values. \"Whichever is greater\" itself has no dedicated CR number (cf. `Difference`, likewise an Oracle templating convention without a dedicated rule); CR 107.2 authorizes the empty fallback to 0.",
+          "cr_refs": [
+            "CR 107.1",
+            "CR 107.2",
+            "CR 120.10",
+            "CR 120.4a"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14168,
+      "line": 15104,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
       ],
       "variants": [
         {
-          "name": "Double",
-          "line": 14170,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "count * 2 — Primal Vigor, Doubling Season, Parallel Lives, Anointed Procession",
+          "name": "Times",
+          "line": 15113,
+          "kind": "struct",
+          "field_names": [
+            "factor"
+          ],
+          "doc": "count * factor — the general multiplicative replacement. `factor: 2` covers Doubling Season / Primal Vigor / Parallel Lives / Anointed Procession; `factor: 3` covers Ojer Taq, Deepest Foundation (\"three times that many of those tokens are created instead\"). Parameterized from the former `Double` (×2) so the multiplicative axis is one variant rather than a `Double` / `Triple` sibling cluster (cf. `ManaModification::Multiply { factor }`). `Times { factor: 2 }` is the canonical doubling constructor; see `QuantityModification::DOUBLE`.",
           "cr_refs": []
         },
         {
           "name": "Half",
-          "line": 14172,
+          "line": 15115,
           "kind": "unit",
           "field_names": [],
           "doc": "count / 2 rounded down — Halving Season",
@@ -25651,7 +26349,7 @@
         },
         {
           "name": "Plus",
-          "line": 14174,
+          "line": 15117,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25661,7 +26359,7 @@
         },
         {
           "name": "Minus",
-          "line": 14176,
+          "line": 15119,
           "kind": "struct",
           "field_names": [
             "value"
@@ -25671,7 +26369,7 @@
         },
         {
           "name": "Prevent",
-          "line": 14196,
+          "line": 15139,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -25688,13 +26386,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3508,
+      "line": 3683,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 3512,
+          "line": 3687,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25706,7 +26404,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 3515,
+          "line": 3690,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25718,7 +26416,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 3521,
+          "line": 3696,
           "kind": "struct",
           "field_names": [
             "player"
@@ -25730,7 +26428,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 3524,
+          "line": 3699,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -25738,7 +26436,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 3526,
+          "line": 3701,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -25748,7 +26446,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 3529,
+          "line": 3704,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25758,7 +26456,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 3546,
+          "line": 3721,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25772,7 +26470,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 3556,
+          "line": 3731,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -25787,7 +26485,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 3563,
+          "line": 3738,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25797,7 +26495,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 3584,
+          "line": 3759,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25810,7 +26508,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 3593,
+          "line": 3768,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -25823,7 +26521,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 3612,
+          "line": 3787,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -25840,7 +26538,7 @@
         },
         {
           "name": "Variable",
-          "line": 3617,
+          "line": 3792,
           "kind": "struct",
           "field_names": [
             "name"
@@ -25850,7 +26548,7 @@
         },
         {
           "name": "Power",
-          "line": 3624,
+          "line": 3799,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25864,7 +26562,7 @@
         },
         {
           "name": "Intensity",
-          "line": 3628,
+          "line": 3803,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25874,7 +26572,7 @@
         },
         {
           "name": "Toughness",
-          "line": 3633,
+          "line": 3808,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25888,7 +26586,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 3639,
+          "line": 3814,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25901,7 +26599,7 @@
         },
         {
           "name": "TargetObjectManaValue",
-          "line": 3645,
+          "line": 3820,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -25914,7 +26612,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 3651,
+          "line": 3826,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25927,7 +26625,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 3656,
+          "line": 3831,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25940,7 +26638,7 @@
         },
         {
           "name": "ObjectTypelineComponentCount",
-          "line": 3660,
+          "line": 3835,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -25954,7 +26652,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 3667,
+          "line": 3842,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -25968,7 +26666,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 3679,
+          "line": 3854,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -25980,21 +26678,21 @@
         },
         {
           "name": "Aggregate",
-          "line": 3681,
+          "line": 3861,
           "kind": "struct",
           "field_names": [
             "function",
             "property",
             "filter"
           ],
-          "doc": "CR 107.3e: Aggregate query (max/min/sum) over a property of battlefield objects.",
+          "doc": "CR 202.3: Aggregate query (max/min/sum) over a property of objects in the zones the `filter` declares (battlefield by default; e.g. an `InZone` graveyard filter aggregates over the graveyard). The resolver scans `filter.extract_zones()`, so the query is zone-general.",
           "cr_refs": [
-            "CR 107.3e"
+            "CR 202.3"
           ]
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 3698,
+          "line": 3878,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -26008,7 +26706,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 3705,
+          "line": 3885,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26018,7 +26716,7 @@
         },
         {
           "name": "Devotion",
-          "line": 3707,
+          "line": 3887,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -26030,7 +26728,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 3711,
+          "line": 3891,
           "kind": "struct",
           "field_names": [
             "source"
@@ -26042,7 +26740,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 3716,
+          "line": 3896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -26053,7 +26751,7 @@
         },
         {
           "name": "ExiledCardPower",
-          "line": 3719,
+          "line": 3899,
           "kind": "struct",
           "field_names": [
             "index"
@@ -26065,7 +26763,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 3723,
+          "line": 3903,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -26080,7 +26778,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 3732,
+          "line": 3912,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -26092,7 +26790,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 3736,
+          "line": 3916,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -26102,7 +26800,7 @@
         },
         {
           "name": "FilteredTrackedSetSize",
-          "line": 3751,
+          "line": 3931,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -26117,7 +26815,7 @@
         },
         {
           "name": "TrackedSetAggregate",
-          "line": 3765,
+          "line": 3945,
           "kind": "struct",
           "field_names": [
             "function",
@@ -26133,7 +26831,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 3774,
+          "line": 3954,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -26144,7 +26842,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 3778,
+          "line": 3958,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -26154,7 +26852,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 3793,
+          "line": 3973,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26167,7 +26865,7 @@
         },
         {
           "name": "PartySize",
-          "line": 3802,
+          "line": 3982,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26180,7 +26878,7 @@
         },
         {
           "name": "UnspentMana",
-          "line": 3811,
+          "line": 3991,
           "kind": "struct",
           "field_names": [
             "color"
@@ -26192,7 +26890,7 @@
         },
         {
           "name": "Speed",
-          "line": 3818,
+          "line": 3998,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26204,7 +26902,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 3821,
+          "line": 4001,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -26214,7 +26912,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 3829,
+          "line": 4009,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -26228,7 +26926,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 3841,
+          "line": 4021,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -26240,7 +26938,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 3844,
+          "line": 4024,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26253,7 +26951,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 3851,
+          "line": 4031,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26263,7 +26961,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 3857,
+          "line": 4037,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26276,7 +26974,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 3862,
+          "line": 4042,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -26286,7 +26984,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 3868,
+          "line": 4048,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26298,7 +26996,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 3873,
+          "line": 4053,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26310,7 +27008,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 3879,
+          "line": 4059,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26324,7 +27022,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 3887,
+          "line": 4067,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26338,7 +27036,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 3894,
+          "line": 4074,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -26348,7 +27046,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 3898,
+          "line": 4078,
           "kind": "struct",
           "field_names": [
             "from",
@@ -26363,7 +27061,7 @@
         },
         {
           "name": "ZoneChangeAggregateThisTurn",
-          "line": 3916,
+          "line": 4096,
           "kind": "struct",
           "field_names": [
             "from",
@@ -26384,7 +27082,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 3938,
+          "line": 4118,
           "kind": "struct",
           "field_names": [
             "source",
@@ -26402,7 +27100,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 3957,
+          "line": 4137,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -26410,7 +27108,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 3967,
+          "line": 4147,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26423,7 +27121,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 3974,
+          "line": 4154,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -26433,7 +27131,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 3982,
+          "line": 4162,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26447,7 +27145,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 3985,
+          "line": 4165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -26457,7 +27155,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 3999,
+          "line": 4179,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26471,7 +27169,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 4010,
+          "line": 4190,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -26486,7 +27184,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 4019,
+          "line": 4199,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26499,7 +27197,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 4024,
+          "line": 4204,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26513,7 +27211,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 4032,
+          "line": 4212,
           "kind": "struct",
           "field_names": [
             "player",
@@ -26527,7 +27225,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 4037,
+          "line": 4217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -26537,7 +27235,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 4044,
+          "line": 4224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -26547,7 +27245,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 4047,
+          "line": 4227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -26558,7 +27256,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 4051,
+          "line": 4231,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -26570,7 +27268,7 @@
         },
         {
           "name": "AdditionalCostPaymentCountFor",
-          "line": 4055,
+          "line": 4235,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -26584,7 +27282,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 4063,
+          "line": 4243,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -26594,7 +27292,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 4068,
+          "line": 4248,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26608,7 +27306,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 4079,
+          "line": 4259,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -26619,7 +27317,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 4084,
+          "line": 4264,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -26629,7 +27327,7 @@
         },
         {
           "name": "CommanderManaValue",
-          "line": 4089,
+          "line": 4269,
           "kind": "struct",
           "field_names": [
             "owner"
@@ -26641,7 +27339,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 4096,
+          "line": 4276,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26655,7 +27353,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 4105,
+          "line": 4285,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26669,7 +27367,7 @@
         },
         {
           "name": "VoteCount",
-          "line": 4112,
+          "line": 4292,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -26760,7 +27458,7 @@
     },
     "RenownSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12979,
+      "line": 13879,
       "doc": "CR 702.112: Which creature's renowned designation an `IsRenowned` condition reads.  Renowned (CR 702.112b) is a per-permanent designation other spells and abilities can identify, so a condition may reference either the ability's own permanent or a different (event-subject) creature.   - `Source` — the ability's own permanent (\"~\"), as in Renown's own     intervening-if (CR 702.112a, \"if it isn't renowned\" where \"it\" == this creature).   - `EventSubject` — the creature named by the triggering event (\"it\"), a creature     other than the source (CR 702.112b).",
       "cr_refs": [
         "CR 702.112",
@@ -26770,7 +27468,7 @@
       "variants": [
         {
           "name": "Source",
-          "line": 12980,
+          "line": 13880,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26778,7 +27476,7 @@
         },
         {
           "name": "EventSubject",
-          "line": 12981,
+          "line": 13881,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -26789,8 +27487,8 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12056,
-      "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Currently a single-variant enum: only the controller-decision form (\"you may repeat this process any number of times\") is modeled. The game-state predicate form (\"if you do, repeat this process\" — Primal Surge) is a separately-tracked deferred unit; it will add a `While(...)` variant once the optional-put pause semantics it depends on are designed.",
+      "line": 12903,
+      "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Three forms are modeled: the controller-decision form (\"you may repeat this process any number of times\", `ControllerChoice`), the stop-predicate form (\"repeat this process until …\", `UntilStopConditions`, Tainted Pact), and the game-state-predicate form (\"[if condition,] repeat this process [once]\", `WhileCondition`). The optional-put pause semantics that the `WhileCondition` loop depends on are shared with `UntilStopConditions` via the `pending_repeat_until` resume path.",
       "cr_refs": [
         "CR 107.1c",
         "CR 608.2c"
@@ -26798,7 +27496,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 12060,
+          "line": 12907,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -26808,7 +27506,7 @@
         },
         {
           "name": "UntilStopConditions",
-          "line": 12066,
+          "line": 12913,
           "kind": "struct",
           "field_names": [
             "stop_on_put_to_hand",
@@ -26819,19 +27517,32 @@
             "CR 107.1c",
             "CR 608.2c"
           ]
+        },
+        {
+          "name": "WhileCondition",
+          "line": 12928,
+          "kind": "struct",
+          "field_names": [
+            "condition",
+            "max_iterations"
+          ],
+          "doc": "CR 608.2c: \"[if <condition>,] repeat this process [once]\" — after each iteration fully resolves, the engine re-evaluates `condition` against the just-resolved game state (the same `evaluate_condition` path used by sub-ability gates) and auto-repeats while it holds. `condition` references the iteration's freshly-resolved state (e.g. `RevealedHasCardType` reads the card moved this iteration via `last_zone_changed_ids`; `QuantityCheck` reads current battlefield counts). `max_iterations` caps the number of *additional* iterations beyond the first (\"once\" → `Some(1)`, bare → `None`). Sin, Spira's Punishment (\"if the exiled card is a land card, repeat this process\"); Claim Jumper (\"if an opponent controls more lands than you, repeat this process once\").",
+          "cr_refs": [
+            "CR 608.2c"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13370,
+      "line": 14297,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 13373,
+          "line": 14300,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -26843,7 +27554,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 13379,
+          "line": 14306,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -26853,7 +27564,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 13386,
+          "line": 14313,
           "kind": "struct",
           "field_names": [
             "count",
@@ -26866,7 +27577,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 13391,
+          "line": 14318,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26878,7 +27589,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 13396,
+          "line": 14323,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -26891,7 +27602,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 13399,
+          "line": 14326,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -26903,7 +27614,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 13402,
+          "line": 14329,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -26913,7 +27624,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 13405,
+          "line": 14332,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -26924,7 +27635,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 13413,
+          "line": 14340,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26937,7 +27648,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 13427,
+          "line": 14354,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -26950,7 +27661,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 13436,
+          "line": 14363,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -26961,7 +27672,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 13439,
+          "line": 14366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -26971,7 +27682,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 13445,
+          "line": 14372,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -26983,7 +27694,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 13450,
+          "line": 14377,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -26995,7 +27706,7 @@
         },
         {
           "name": "EnteredFromZone",
-          "line": 13471,
+          "line": 14398,
           "kind": "struct",
           "field_names": [
             "origin_constraint",
@@ -27009,7 +27720,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 13486,
+          "line": 14413,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -27020,7 +27731,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 13495,
+          "line": 14422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -27032,7 +27743,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 13502,
+          "line": 14429,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -27046,7 +27757,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 13510,
+          "line": 14437,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -27056,7 +27767,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 13515,
+          "line": 14442,
           "kind": "struct",
           "field_names": [
             "source"
@@ -27070,7 +27781,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 13519,
+          "line": 14446,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -27083,7 +27794,7 @@
         },
         {
           "name": "EffectCausedDiscard",
-          "line": 13524,
+          "line": 14451,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 701.9a: Replacement applies only when the discard was caused by resolving a spell or ability effect, not by paying a cost or by a turn-based action (cleanup hand-size discard). Used by Library of Leng (\"If an effect causes you to discard a card...\").",
@@ -27094,7 +27805,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 13529,
+          "line": 14456,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -27105,7 +27816,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 13540,
+          "line": 14467,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -27117,8 +27828,21 @@
           ]
         },
         {
+          "name": "TokenCoreTypeMatches",
+          "line": 14476,
+          "kind": "struct",
+          "field_names": [
+            "core_types"
+          ],
+          "doc": "CR 614.1a + CR 111.1: Gate a `CreateToken` replacement on whether the proposed event creates a token whose core card types overlap a fixed set. Used by Divine Visitation (\"If one or more creature tokens would be created under your control, …\") — the substitution applies only to CREATURE tokens. Sibling of `TokenSubtypeMatches` but on the orthogonal core-type axis (CR 111.1 token characteristics); distinct fields, so the two are NOT a sibling-cluster smell. Matched case-exactly against the proposed `TokenSpec.characteristics.core_types`.",
+          "cr_refs": [
+            "CR 111.1",
+            "CR 614.1a"
+          ]
+        },
+        {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 13551,
+          "line": 14487,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -27130,7 +27854,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 13559,
+          "line": 14495,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -27143,7 +27867,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 13569,
+          "line": 14505,
           "kind": "struct",
           "field_names": [
             "level"
@@ -27155,7 +27879,7 @@
         },
         {
           "name": "DuringUntapStep",
-          "line": 13577,
+          "line": 14513,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 502.4: True only during the untap step. Permanents untap as a turn-based action during the untap step (502.3) and no player receives priority then (502.4), so the only `ProposedEvent::Untap` raised during this phase is the turn-based untap. Gates an untap replacement (\"if [X] would untap during [its controller's / your] untap step, [effect] instead\" — Freyalise's Winds, Edge of Malacol) so it does NOT apply to effect-untaps (\"untap target creature\") at other times.",
@@ -27166,7 +27890,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 13582,
+          "line": 14518,
           "kind": "struct",
           "field_names": [
             "text"
@@ -27585,13 +28309,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14290,
+      "line": 15241,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 14293,
+          "line": 15244,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -27599,7 +28323,7 @@
         },
         {
           "name": "Optional",
-          "line": 14295,
+          "line": 15246,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -27609,7 +28333,7 @@
         },
         {
           "name": "MayCost",
-          "line": 14302,
+          "line": 15253,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -27626,7 +28350,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14278,
+      "line": 15229,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source player. For permanents/spells this is the source's controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a make this the owner. `valid_player: None` keeps the source-player default; `Some(You)` is the explicit source-player scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 108.4a",
@@ -27636,7 +28360,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 14280,
+          "line": 15231,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source player.",
@@ -27644,7 +28368,7 @@
         },
         {
           "name": "Opponent",
-          "line": 14282,
+          "line": 15233,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source player.",
@@ -27652,7 +28376,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 14284,
+          "line": 15235,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -27663,7 +28387,7 @@
     },
     "ResolutionCastSuccessAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1886,
+      "line": 1993,
       "doc": "CR 608.2g: Follow-up after a during-resolution cast succeeds.",
       "cr_refs": [
         "CR 608.2g"
@@ -27671,7 +28395,7 @@
       "variants": [
         {
           "name": "BottomMisses",
-          "line": 1889,
+          "line": 1996,
           "kind": "unit",
           "field_names": [],
           "doc": "Cascade/Discover: cast hit is gone, so bottom the dig misses now.",
@@ -27679,7 +28403,7 @@
         },
         {
           "name": "RippleOfferRemaining",
-          "line": 1892,
+          "line": 1999,
           "kind": "struct",
           "field_names": [
             "remaining_hits"
@@ -27691,7 +28415,7 @@
         },
         {
           "name": "FreeCastOfferRemaining",
-          "line": 1901,
+          "line": 2008,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -27713,7 +28437,7 @@
     },
     "ResolutionMvRejectAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1871,
+      "line": 1978,
       "doc": "CR 608.2g: Disposition of a during-resolution card that is not cast.",
       "cr_refs": [
         "CR 608.2g"
@@ -27721,7 +28445,7 @@
       "variants": [
         {
           "name": "BottomWithMisses",
-          "line": 1873,
+          "line": 1980,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: cascade — hit joins misses on the bottom in random order.",
@@ -27731,7 +28455,7 @@
         },
         {
           "name": "ToHand",
-          "line": 1875,
+          "line": 1982,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a: discover — hit goes to its owner's hand; misses to bottom.",
@@ -27741,7 +28465,7 @@
         },
         {
           "name": "RemainExiled",
-          "line": 1880,
+          "line": 1987,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Suspend's last-counter free cast — the card has no dig misses and no resulting-MV gate, so this reject disposition is only reached if a future during-resolution free cast adds a constraint. \"If you don't [cast it], it remains exiled\" — the card stays in exile.",
@@ -27754,13 +28478,13 @@
     },
     "RestrictionExpiry": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1572,
+      "line": 1651,
       "doc": "When a game restriction expires.",
       "cr_refs": [],
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 1573,
+          "line": 1652,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27768,7 +28492,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 1574,
+          "line": 1653,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27776,26 +28500,39 @@
         },
         {
           "name": "UntilPlayerNextTurn",
-          "line": 1575,
+          "line": 1654,
           "kind": "struct",
           "field_names": [
             "player"
           ],
           "doc": "",
           "cr_refs": []
+        },
+        {
+          "name": "UntilEndOfNextTurnOf",
+          "line": 1664,
+          "kind": "struct",
+          "field_names": [
+            "player"
+          ],
+          "doc": "CR 514.2 + CR 500.7: Mirrors `Duration::UntilEndOfNextTurnOf`. Created pre-armed; at `player`'s next untap step it is CONVERTED to `RestrictionExpiry::EndOfTurn` (mirroring `prune_until_next_turn_effects`), so the existing cleanup-step prune ends it at THAT turn's cleanup — it persists through `player`'s entire next turn (Kang's extra turn). It survives the creating turn's own cleanup because that turn's untap step already passed before creation.",
+          "cr_refs": [
+            "CR 500.7",
+            "CR 514.2"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "RestrictionPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1590,
+      "line": 1681,
       "doc": "Identifies which players are affected by a temporary game restriction.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 1591,
+          "line": 1682,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27803,7 +28540,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 1592,
+          "line": 1683,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27811,7 +28548,7 @@
         },
         {
           "name": "TargetedPlayer",
-          "line": 1595,
+          "line": 1686,
           "kind": "unit",
           "field_names": [],
           "doc": "Placeholder used by parser lowering for effects that target a player. Resolved to `SpecificPlayer` by `add_restriction` at resolution time.",
@@ -27819,7 +28556,7 @@
         },
         {
           "name": "ParentTargetedPlayer",
-          "line": 1600,
+          "line": 1691,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Anaphoric \"that player\" in a sub-ability reuses a player target already chosen for an earlier instruction in the same chain. Resolved to `SpecificPlayer` by `add_restriction` after parent target propagation, without declaring a second target slot.",
@@ -27829,24 +28566,35 @@
         },
         {
           "name": "OpponentsOfSourceController",
-          "line": 1601,
+          "line": 1692,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
+        },
+        {
+          "name": "DefendingPlayer",
+          "line": 1699,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 508.5 / CR 508.5a: The defending player for the source's attack (\"Whenever ~ attacks, defending player can't cast spells this turn.\" — Xantid Swarm). Resolved to `SpecificPlayer` by `add_restriction` at resolution time via `combat::defending_player_for_attacker`, capturing the player as the restriction is created (the defending player is fixed once attackers are declared and does not change for the turn).",
+          "cr_refs": [
+            "CR 508.5",
+            "CR 508.5a"
+          ]
         }
       ],
       "sibling_clusters": []
     },
     "RestrictionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1581,
+      "line": 1672,
       "doc": "Limits the scope of a game restriction to specific sources or targets.",
       "cr_refs": [],
       "variants": [
         {
           "name": "SourcesControlledBy",
-          "line": 1582,
+          "line": 1673,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27854,7 +28602,7 @@
         },
         {
           "name": "SpecificSource",
-          "line": 1583,
+          "line": 1674,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27862,7 +28610,7 @@
         },
         {
           "name": "DamageToTarget",
-          "line": 1584,
+          "line": 1675,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27873,7 +28621,7 @@
     },
     "RetargetScope": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 4152,
+      "line": 4232,
       "doc": "CR 115.7: Scope of retargeting — single target, all targets, or forced.",
       "cr_refs": [
         "CR 115.7"
@@ -27881,7 +28629,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 4153,
+          "line": 4233,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27889,7 +28637,7 @@
         },
         {
           "name": "All",
-          "line": 4154,
+          "line": 4234,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27897,7 +28645,7 @@
         },
         {
           "name": "ForcedTo",
-          "line": 4155,
+          "line": 4235,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -27906,9 +28654,44 @@
       ],
       "sibling_clusters": []
     },
+    "RevealUntilDisposition": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 7020,
+      "doc": "CR 701.20a + CR 608.2c: How the *set* of matching cards found by an [`Effect::RevealUntil`] is dispensed once the until-loop terminates.  The default `KeepEach` preserves the historical single-hit / each-hit behavior: every matching card is routed to `kept_destination` (or paused on `WaitingFor::RevealUntilKeptChoice` when `kept_optional_to` is set) and the non-matching cards go to `rest_destination`. With the dominant `count = Fixed(1)` this is exactly \"reveal until you reveal a [filter] card\".  `ChooseAnyNumber` covers the Aurora Awakener class — \"reveal until you reveal X [filter] cards. Put any number of those [filter] cards onto the battlefield, then put the rest of the revealed cards on the bottom of your library in a random order.\" The controller selects any subset of the matched cards for `kept_destination`; every other revealed card (non-selected matches AND the interleaved non-matching cards) flows to `rest_destination`. This is the `Effect::Dig` \"put any number onto the battlefield, rest on the bottom in a random order\" disposition (`WaitingFor::DigChoice`, CR 401.4 owner-arranged random bottom placement), reused over the reveal-until matched set.",
+      "cr_refs": [
+        "CR 401.4",
+        "CR 608.2c",
+        "CR 701.20a"
+      ],
+      "variants": [
+        {
+          "name": "KeepEach",
+          "line": 7026,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.20a: Route every matched card to `kept_destination` (or `kept_optional_to`); non-matches to `rest_destination`. The legacy single-hit behavior; default so the JSON shape and every existing call site stay unchanged.",
+          "cr_refs": [
+            "CR 701.20a"
+          ]
+        },
+        {
+          "name": "ChooseAnyNumber",
+          "line": 7031,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.20a + CR 608.2c: Offer the controller a `WaitingFor::DigChoice` over the matched cards — any number go to `kept_destination`, every other revealed card goes to `rest_destination` (CR 401.4 random bottom when `rest_destination == Library`).",
+          "cr_refs": [
+            "CR 401.4",
+            "CR 608.2c",
+            "CR 701.20a"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4119,
+      "line": 4299,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -27916,7 +28699,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 4120,
+          "line": 4300,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27924,7 +28707,7 @@
         },
         {
           "name": "Down",
-          "line": 4121,
+          "line": 4301,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27935,7 +28718,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5552,
+      "line": 5775,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -27943,7 +28726,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 5554,
+          "line": 5777,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -27954,7 +28737,7 @@
     },
     "SacrificeAggregateStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5671,
+      "line": 5894,
       "doc": "CR 701.21: Aggregate statistic for a sacrifice-cost selection constraint.",
       "cr_refs": [
         "CR 701.21"
@@ -27962,7 +28745,7 @@
       "variants": [
         {
           "name": "TotalPower",
-          "line": 5672,
+          "line": 5895,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27973,7 +28756,7 @@
     },
     "SacrificeRequirement": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5678,
+      "line": 5901,
       "doc": "CR 701.21: How many permanents must be sacrificed, or what aggregate constraint the chosen set must satisfy (Phyrexian Dreadnought).",
       "cr_refs": [
         "CR 701.21"
@@ -27981,7 +28764,7 @@
       "variants": [
         {
           "name": "Count",
-          "line": 5680,
+          "line": 5903,
           "kind": "struct",
           "field_names": [
             "count"
@@ -27991,7 +28774,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 5684,
+          "line": 5907,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -28006,13 +28789,13 @@
     },
     "SearchSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 103,
+      "line": 105,
       "doc": "Selection constraint applied to multi-card library searches at the `WaitingFor::SearchChoice` step. Lives one abstraction up from `count` / `up_to` so the engine can reject illegal combinations and the AI can prune its candidate space without bespoke per-card knowledge.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 106,
+          "line": 108,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: No restriction beyond `count` (and `up_to`).",
@@ -28022,7 +28805,7 @@
         },
         {
           "name": "DistinctQualities",
-          "line": 111,
+          "line": 113,
           "kind": "struct",
           "field_names": [
             "qualities"
@@ -28034,7 +28817,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 116,
+          "line": 118,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -28048,7 +28831,7 @@
         },
         {
           "name": "MatchEachFilter",
-          "line": 121,
+          "line": 123,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -28064,7 +28847,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4204,
+      "line": 4384,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -28074,7 +28857,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 4207,
+          "line": 4387,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -28084,7 +28867,7 @@
         },
         {
           "name": "Right",
-          "line": 4210,
+          "line": 4390,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -28095,7 +28878,7 @@
     },
     "ShardChoice": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2113,
+      "line": 2124,
       "doc": "CR 107.4f + CR 601.2f: The caster's resolved choice for one Phyrexian shard.",
       "cr_refs": [
         "CR 107.4f",
@@ -28104,7 +28887,7 @@
       "variants": [
         {
           "name": "PayMana",
-          "line": 2115,
+          "line": 2126,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay one mana of the shard's color (or either component color for hybrid-Phyrexian).",
@@ -28112,7 +28895,7 @@
         },
         {
           "name": "PayLife",
-          "line": 2117,
+          "line": 2128,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay 2 life.",
@@ -28123,7 +28906,7 @@
     },
     "ShardOptions": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2101,
+      "line": 2112,
       "doc": "CR 107.4f + CR 601.2h: Which legal payments a single Phyrexian shard offers to the caster. Computed from the mana pool state (Phyrexian color availability) combined with the caster's life total and CantLoseLife status (CR 118.3 + CR 119.8).  The engine pauses at `WaitingFor::PhyrexianPayment` whenever any shard would deduct life — both `ManaOrLife` (player explicitly picks mana vs life) and `LifeOnly` (life is the only remaining payment route; player confirms or cancels via `CancelCast`). Only `ManaOnly` shards auto-resolve without surfacing the prompt, since they have no life consequence (issue #704: silent life deduction violated CR 601.2h's right to refuse the cast).",
       "cr_refs": [
         "CR 107.4f",
@@ -28134,7 +28917,7 @@
       "variants": [
         {
           "name": "ManaOrLife",
-          "line": 2103,
+          "line": 2114,
           "kind": "unit",
           "field_names": [],
           "doc": "Both mana and 2 life are legal payments; player must choose.",
@@ -28142,7 +28925,7 @@
         },
         {
           "name": "ManaOnly",
-          "line": 2105,
+          "line": 2116,
           "kind": "unit",
           "field_names": [],
           "doc": "Only mana is legal (insufficient life or CR 119.8 CantLoseLife lock).",
@@ -28152,7 +28935,7 @@
         },
         {
           "name": "LifeOnly",
-          "line": 2107,
+          "line": 2118,
           "kind": "unit",
           "field_names": [],
           "doc": "Only 2 life is legal (no mana of the shard's color available, given restrictions).",
@@ -28163,13 +28946,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2171,
+      "line": 2278,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 2173,
+          "line": 2280,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -28179,7 +28962,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 2175,
+          "line": 2282,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -28189,7 +28972,7 @@
         },
         {
           "name": "Power",
-          "line": 2177,
+          "line": 2284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -28199,7 +28982,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2179,
+          "line": 2286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -28209,7 +28992,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 2181,
+          "line": 2288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -28219,7 +29002,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 2182,
+          "line": 2289,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28227,7 +29010,7 @@
         },
         {
           "name": "Color",
-          "line": 2183,
+          "line": 2290,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28235,7 +29018,7 @@
         },
         {
           "name": "CardType",
-          "line": 2184,
+          "line": 2291,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28243,7 +29026,7 @@
         },
         {
           "name": "LandType",
-          "line": 2186,
+          "line": 2293,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -28257,13 +29040,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2191,
+      "line": 2298,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 2193,
+          "line": 2300,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28271,7 +29054,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 2194,
+          "line": 2301,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28282,13 +29065,13 @@
     },
     "ShieldKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 563,
+      "line": 576,
       "doc": "Shield type for one-shot replacement effects that expire at cleanup.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 565,
+          "line": 578,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28296,7 +29079,7 @@
         },
         {
           "name": "Regeneration",
-          "line": 567,
+          "line": 580,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19a: Regeneration shield — consumed on use, expires at cleanup.",
@@ -28306,7 +29089,7 @@
         },
         {
           "name": "Prevention",
-          "line": 569,
+          "line": 582,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -28318,7 +29101,7 @@
         },
         {
           "name": "DamageReplacementOneShot",
-          "line": 576,
+          "line": 589,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.5 + CR 614.1a: One-shot damage-amount replacement created by an effect (\"the next time ... would deal damage this turn, it deals double that damage instead\" — Desperate Gambit). Gets one opportunity to affect a damage event, is consumed on use, and expires at cleanup. Distinct from a continuous static `damage_modification` (Furnace of Rath), which keeps `ShieldKind::None` and re-applies to every damage event.",
@@ -28329,7 +29112,7 @@
         },
         {
           "name": "Redirection",
-          "line": 581,
+          "line": 594,
           "kind": "struct",
           "field_names": [
             "recipient",
@@ -28381,7 +29164,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4826,
+      "line": 5030,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -28390,7 +29173,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 4828,
+          "line": 5032,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -28402,7 +29185,7 @@
         },
         {
           "name": "Condition",
-          "line": 4838,
+          "line": 5042,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -28414,7 +29197,7 @@
         },
         {
           "name": "Text",
-          "line": 4840,
+          "line": 5044,
           "kind": "struct",
           "field_names": [
             "description"
@@ -28427,13 +29210,13 @@
     },
     "SourceExclusion": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2950,
+      "line": 3095,
       "doc": "Whether a filter predicate includes or excludes the ability source object.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Include",
-          "line": 2953,
+          "line": 3098,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object may satisfy the predicate.",
@@ -28441,7 +29224,7 @@
         },
         {
           "name": "Exclude",
-          "line": 2955,
+          "line": 3100,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object is excluded (\"another Aura/Equipment\" semantics).",
@@ -28450,9 +29233,35 @@
       ],
       "sibling_clusters": []
     },
+    "SpecialAction": {
+      "file": "crates/engine/src/types/mana.rs",
+      "line": 311,
+      "doc": "CR 116.2: A class of special action whose mana cost can be the subject of a CR 106.6 mana-spend restriction (\"Spend this mana only to unlock doors\").  Only special actions that pay a mana cost *through the mana pool* with a restriction-aware payment context belong here. CR 116.2m / CR 709.5e door unlock is the first such action (its unlock cost routes through `pay_special_action_mana_cost`). CR 116.2b turn-face-up does not yet pay its morph/disguise cost through a restriction-aware pool payment, so it is intentionally absent — its spend restriction is honest-deferred rather than silently over-permitted. New variants are added only once the corresponding special action's payment is routed through `PaymentContext::SpecialAction`.",
+      "cr_refs": [
+        "CR 106.6",
+        "CR 116.2",
+        "CR 116.2b",
+        "CR 116.2m",
+        "CR 709.5e"
+      ],
+      "variants": [
+        {
+          "name": "UnlockDoor",
+          "line": 314,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 116.2m + CR 709.5e: Paying a locked Room half's unlock cost to give the permanent the appropriate unlocked designation.",
+          "cr_refs": [
+            "CR 116.2m",
+            "CR 709.5e"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6750,
+      "line": 7161,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -28460,7 +29269,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 6752,
+          "line": 7163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -28470,7 +29279,7 @@
         },
         {
           "name": "Decrease",
-          "line": 6754,
+          "line": 7165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -28483,13 +29292,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6430,
+      "line": 6758,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 6431,
+          "line": 6759,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28497,7 +29306,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 6432,
+          "line": 6760,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28505,7 +29314,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 6433,
+          "line": 6761,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28513,7 +29322,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 6435,
+          "line": 6763,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -28524,9 +29333,46 @@
       ],
       "sibling_clusters": []
     },
+    "SpellCostCriterion": {
+      "file": "crates/engine/src/types/mana.rs",
+      "line": 405,
+      "doc": "CR 106.6 + CR 107.3 + CR 202.3: A single qualifying criterion on the cost of the spell a restricted mana may be spent on. Used by [`ManaRestriction::OnlyForSpellMatchingCostCriteria`] to express the disjunctive \"spells with mana value N or greater **or** spells with {X} in their mana costs\" reading (Helga, Skittish Seer; Troyan, Gutsy Explorer) without proliferating one variant per (threshold × X-disjunct) combination.  Both criteria are properties of the spell's *cost* (CR 202.3 mana value / CR 107.3 X symbol), so they share a single categorical axis and belong to one typed predicate rather than a raw bool flag bolted onto the mana-value variant.",
+      "cr_refs": [
+        "CR 106.6",
+        "CR 107.3",
+        "CR 202.3"
+      ],
+      "variants": [
+        {
+          "name": "ManaValue",
+          "line": 407,
+          "kind": "struct",
+          "field_names": [
+            "comparator",
+            "value"
+          ],
+          "doc": "CR 202.3: The spell's mana value satisfies `spell_mana_value <cmp> value`.",
+          "cr_refs": [
+            "CR 202.3"
+          ]
+        },
+        {
+          "name": "HasXInCost",
+          "line": 411,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 107.3 + CR 202.3e: The spell's printed mana cost contains an `{X}` symbol. Detected structurally (X contributes 0 to mana value off the stack), via `SpellMeta.has_x_in_cost`.",
+          "cr_refs": [
+            "CR 107.3",
+            "CR 202.3e"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "SpellCostSource": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2495,
+      "line": 2525,
       "doc": "CR 601.2h + CR 702.48c: Identifies which spell-cost component a `WaitingFor::PayCost` choice is paying when the same `AbilityCost` shape can come from different rules.",
       "cr_refs": [
         "CR 601.2h",
@@ -28535,7 +29381,7 @@
       "variants": [
         {
           "name": "Other",
-          "line": 2497,
+          "line": 2527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28543,7 +29389,7 @@
         },
         {
           "name": "Offering",
-          "line": 2498,
+          "line": 2528,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28551,7 +29397,7 @@
         },
         {
           "name": "Emerge",
-          "line": 2499,
+          "line": 2529,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28562,7 +29408,7 @@
     },
     "StackAbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3039,
+      "line": 3184,
       "doc": "CR 113.3b / CR 113.3c: Which stack ability kinds a `StackAbility` filter accepts.",
       "cr_refs": [
         "CR 113.3b",
@@ -28571,7 +29417,7 @@
       "variants": [
         {
           "name": "Activated",
-          "line": 3040,
+          "line": 3185,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28579,7 +29425,7 @@
         },
         {
           "name": "Triggered",
-          "line": 3041,
+          "line": 3186,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28590,13 +29436,13 @@
     },
     "StackEntryKind": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 5076,
+      "line": 5166,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 5077,
+          "line": 5167,
           "kind": "struct",
           "field_names": [
             "card_id",
@@ -28609,7 +29455,7 @@
         },
         {
           "name": "ActivatedAbility",
-          "line": 5091,
+          "line": 5181,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -28620,7 +29466,7 @@
         },
         {
           "name": "TriggeredAbility",
-          "line": 5095,
+          "line": 5185,
           "kind": "struct",
           "field_names": [
             "source_id",
@@ -28637,7 +29483,7 @@
         },
         {
           "name": "KeywordAction",
-          "line": 5138,
+          "line": 5228,
           "kind": "struct",
           "field_names": [
             "action"
@@ -28653,13 +29499,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4906,
+      "line": 5110,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 4907,
+          "line": 5111,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -28670,7 +29516,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 4911,
+          "line": 5115,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28680,7 +29526,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 4917,
+          "line": 5121,
           "kind": "struct",
           "field_names": [
             "color"
@@ -28690,7 +29536,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 4926,
+          "line": 5130,
           "kind": "struct",
           "field_names": [
             "label"
@@ -28703,7 +29549,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 4932,
+          "line": 5136,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -28715,7 +29561,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 4938,
+          "line": 5142,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -28725,7 +29571,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 4940,
+          "line": 5144,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -28738,7 +29584,7 @@
         },
         {
           "name": "And",
-          "line": 4944,
+          "line": 5148,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28748,7 +29594,7 @@
         },
         {
           "name": "Or",
-          "line": 4948,
+          "line": 5152,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -28758,7 +29604,7 @@
         },
         {
           "name": "Not",
-          "line": 4954,
+          "line": 5158,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -28768,7 +29614,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 4958,
+          "line": 5162,
           "kind": "struct",
           "field_names": [
             "state"
@@ -28780,7 +29626,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 4967,
+          "line": 5171,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28796,7 +29642,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 4977,
+          "line": 5181,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28809,7 +29655,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 4985,
+          "line": 5189,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -28824,7 +29670,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 4993,
+          "line": 5197,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28836,7 +29682,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 5000,
+          "line": 5204,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -28848,7 +29694,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 5004,
+          "line": 5208,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -28858,7 +29704,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 5008,
+          "line": 5212,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -28869,7 +29715,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 5012,
+          "line": 5216,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -28880,7 +29726,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 5016,
+          "line": 5220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -28890,7 +29736,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 5018,
+          "line": 5222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -28900,7 +29746,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 5020,
+          "line": 5224,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: True when the controller has the initiative.",
@@ -28910,7 +29756,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 5023,
+          "line": 5227,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -28920,7 +29766,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5025,
+          "line": 5229,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -28930,7 +29776,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 5028,
+          "line": 5232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -28940,7 +29786,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 5034,
+          "line": 5238,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -28952,7 +29798,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 5042,
+          "line": 5246,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28964,7 +29810,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 5046,
+          "line": 5250,
           "kind": "struct",
           "field_names": [
             "count"
@@ -28976,7 +29822,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 5071,
+          "line": 5275,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -28994,7 +29840,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 5080,
+          "line": 5284,
           "kind": "struct",
           "field_names": [
             "text"
@@ -29004,7 +29850,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 5083,
+          "line": 5287,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29012,7 +29858,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 5086,
+          "line": 5290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -29022,7 +29868,7 @@
         },
         {
           "name": "SourceHasDealtDamage",
-          "line": 5095,
+          "line": 5299,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 120.3/120.6 + CR 702.11b + CR 613.1f: True once the source permanent has actually dealt damage (combat or noncombat) since it entered the battlefield. Sticky per-object flag (set on the first nonzero amount of damage actually dealt per CR 120.3/120.6, not the would-be amount of CR 120.1a; reset when the object leaves the battlefield). Used as a Layer 6 (CR 613.1f) ability-adding gate for \"has hexproof if it hasn't dealt damage yet\" (Palladia-Mors, the Ruiner; Karakyk Guardian). The \"hasn't\" negation wraps this in `StaticCondition::Not`.",
@@ -29036,7 +29882,7 @@
         },
         {
           "name": "WasCast",
-          "line": 5100,
+          "line": 5304,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -29049,7 +29895,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 5105,
+          "line": 5309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -29059,7 +29905,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 5107,
+          "line": 5311,
           "kind": "struct",
           "field_names": [
             "level"
@@ -29071,7 +29917,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 5113,
+          "line": 5317,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -29085,7 +29931,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 5118,
+          "line": 5322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -29095,7 +29941,7 @@
         },
         {
           "name": "IsTapped",
-          "line": 5135,
+          "line": 5339,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -29109,7 +29955,7 @@
         },
         {
           "name": "SourceIsSaddled",
-          "line": 5139,
+          "line": 5343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.",
@@ -29119,7 +29965,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 5146,
+          "line": 5350,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29132,7 +29978,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 5151,
+          "line": 5355,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -29141,8 +29987,19 @@
           ]
         },
         {
+          "name": "SourceIsEnchanted",
+          "line": 5360,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 303.4: True when at least one Aura is attached to the source object. Aura-twin of `SourceIsEquipped` (CR 301.5). Used for \"as long as this creature is enchanted\" statics (Pillar of War, Thran Golem, Gate Hound, Freewind Equenaut).",
+          "cr_refs": [
+            "CR 301.5",
+            "CR 303.4"
+          ]
+        },
+        {
           "name": "SourceIsMonstrous",
-          "line": 5155,
+          "line": 5364,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -29152,7 +30009,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 5159,
+          "line": 5368,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -29163,7 +30020,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 5163,
+          "line": 5372,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29175,7 +30032,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 5175,
+          "line": 5384,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29187,7 +30044,7 @@
         },
         {
           "name": "RecipientAttackingOwnerTarget",
-          "line": 5191,
+          "line": 5400,
           "kind": "struct",
           "field_names": [
             "target"
@@ -29202,7 +30059,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 5195,
+          "line": 5404,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -29212,7 +30069,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 5198,
+          "line": 5407,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -29224,7 +30081,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 5204,
+          "line": 5413,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -29235,7 +30092,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 5209,
+          "line": 5418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -29246,7 +30103,7 @@
         },
         {
           "name": "None",
-          "line": 5210,
+          "line": 5419,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29266,13 +30123,13 @@
     },
     "StaticMode": {
       "file": "crates/engine/src/types/statics.rs",
-      "line": 612,
+      "line": 632,
       "doc": "All static ability modes from Forge's static ability registry. Matched case-sensitively against Forge mode strings.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Continuous",
-          "line": 613,
+          "line": 633,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29280,7 +30137,7 @@
         },
         {
           "name": "DamageNotRemovedDuringCleanup",
-          "line": 620,
+          "line": 640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Normally all damage marked on permanents is removed as a turn-based action during the cleanup step. This static suppresses that removal for the permanents matched by the definition's `affected` filter (\"Damage isn't removed from [filter] during cleanup steps\" — Ancient Adamantoise, Patient Zero, Uthgardt Fury, …), so their marked damage persists across turns.",
@@ -29290,7 +30147,7 @@
         },
         {
           "name": "CantAttack",
-          "line": 614,
+          "line": 641,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29298,7 +30155,7 @@
         },
         {
           "name": "CantBlock",
-          "line": 615,
+          "line": 642,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29306,27 +30163,41 @@
         },
         {
           "name": "CantAttackOrBlock",
-          "line": 616,
+          "line": 643,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "CantBecomeSuspected",
+          "line": 652,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.60a + CR 701.60d: The affected permanent can't become suspected (Airtight Alibi: \"Enchanted creature ... can't become suspected\"). A nullary marker static — the `affected` filter scopes which permanents are protected, and runtime enforcement is the suspect resolver's gate (`suspect::resolve`), which refuses to designate a permanent carrying this static. Distinct from CR 701.60d's intrinsic \"a suspected permanent can't become suspected again\": this prohibits the designation even while the permanent is NOT suspected.",
+          "cr_refs": [
+            "CR 701.60a",
+            "CR 701.60d"
+          ]
+        },
+        {
           "name": "MaxAttackersEachCombat",
-          "line": 619,
+          "line": 661,
           "kind": "struct",
           "field_names": [
-            "max"
+            "max",
+            "defender"
           ],
-          "doc": "CR 508.1d: No more than `max` creatures can be declared as attackers each combat.",
+          "doc": "CR 508.1c: No more than `max` creatures can be declared as attackers each combat. `defender` scopes *which declarations* the cap restricts: `None` is a global per-combat cap (no more than `max` creatures can attack at all); `Some(AttackDefenderScope::Controller)` is a defending-player cap (\"no more than `max` creatures can attack *you* each combat\" — Judoon Enforcers), restricting only attackers whose defending player (CR 508.5) is this static's controller, so opponents may still be attacked freely (CR 802.1 multiplayer range of influence).",
           "cr_refs": [
-            "CR 508.1d"
+            "CR 508.1c",
+            "CR 508.5",
+            "CR 802.1"
           ]
         },
         {
           "name": "MaxBlockersEachCombat",
-          "line": 624,
+          "line": 668,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29338,7 +30209,7 @@
         },
         {
           "name": "CantBeTargeted",
-          "line": 627,
+          "line": 671,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29346,7 +30217,7 @@
         },
         {
           "name": "CantBeCast",
-          "line": 630,
+          "line": 674,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29358,7 +30229,7 @@
         },
         {
           "name": "CantBeActivated",
-          "line": 656,
+          "line": 700,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29374,7 +30245,7 @@
         },
         {
           "name": "CantSearchLibrary",
-          "line": 669,
+          "line": 713,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -29387,7 +30258,7 @@
         },
         {
           "name": "CantCauseSacrificeOrExile",
-          "line": 679,
+          "line": 723,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -29400,7 +30271,7 @@
         },
         {
           "name": "CastWithFlash",
-          "line": 682,
+          "line": 726,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29408,7 +30279,7 @@
         },
         {
           "name": "GrantsExtraVote",
-          "line": 694,
+          "line": 738,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38d: While voting, the controller of this permanent may vote an additional time. Each active source grants +1 to the controller's `Player::extra_votes_per_session` snapshot taken at vote-session start (Tivit, Seller of Secrets — \"While voting, you may vote an additional time.\").  The vote-effect resolver scans the battlefield for permanents with this static at session start (CR 701.38d: extra votes happen at the same time the player would otherwise have voted). It does *not* feed into layer 7 — there is no continuous P/T or keyword grant; the static is a pure \"session-start +1 votes\" signal.",
@@ -29418,7 +30289,7 @@
         },
         {
           "name": "GrantsExtraVillainousChoice",
-          "line": 707,
+          "line": 751,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.55c: A replacement effect causes an opponent who would face a villainous choice to face that choice some number of additional times (The Valeyard — \"If an opponent would face a villainous choice, they face that choice an additional time.\"). Each active source controlled by an opponent of the facing player adds +1 additional villainous-choice instance for that player; the whole CR 701.55a process is then performed that many additional times, one at a time (CR 701.55c). Parallel to `GrantsExtraVote` (CR 701.38d), but counts a different keyword action read by a different resolver (`choose_one_of`), so the two are not unifiable (categorical-boundary rule: CR 701.55 vs CR 701.38 are separate sections). Like `GrantsExtraVote`, it does not feed into layer 7 — there is no continuous P/T or keyword grant.",
@@ -29432,7 +30303,7 @@
         },
         {
           "name": "CastWithKeyword",
-          "line": 711,
+          "line": 755,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -29444,7 +30315,7 @@
         },
         {
           "name": "CastWithAlternativeCost",
-          "line": 724,
+          "line": 768,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -29459,7 +30330,7 @@
         },
         {
           "name": "AlternativeKeywordCost",
-          "line": 739,
+          "line": 783,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -29475,7 +30346,7 @@
         },
         {
           "name": "ModifyCost",
-          "line": 749,
+          "line": 793,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -29490,7 +30361,7 @@
         },
         {
           "name": "ImposeAdditionalCost",
-          "line": 763,
+          "line": 807,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -29505,22 +30376,24 @@
         },
         {
           "name": "ReduceAbilityCost",
-          "line": 772,
+          "line": 826,
           "kind": "struct",
           "field_names": [
+            "mode",
             "keyword",
             "amount",
             "minimum_mana",
             "dynamic_count"
           ],
-          "doc": "CR 601.2f: Reduces the generic mana cost of activated abilities matching a keyword type. E.g., \"Ninjutsu abilities you activate cost {1} less to activate.\" `keyword` identifies which ability type is reduced (e.g., \"ninjutsu\", \"equip\", \"cycling\"). `amount` is the fixed generic mana reduction per activation.",
+          "doc": "CR 601.2f + CR 118.7: Modifies the generic mana cost of activated abilities matching a keyword type, in the direction given by `mode`. E.g., \"Ninjutsu abilities you activate cost {1} less to activate.\" (`Reduce`) or \"Activated abilities of sources with the chosen name cost {2} more to activate.\" (`Raise`, Skyseer's Chariot). `keyword` identifies which ability type is modified — `\"activated\"` matches every activated ability, or a tagged keyword (e.g. \"ninjutsu\", \"equip\", \"cycling\", \"power-up\") matches the activating ability's `AbilityTag`. `amount` is the fixed generic mana adjustment per activation.  Directional parameterization (not a `Raise`-only sibling): the `CostModifyMode` axis is shared with [`StaticMode::ModifyCost`] (the cast-cost analogue). `Minimum` is not meaningful here — only `Reduce` (CR 118.7) and `Raise` (CR 118.7 increase) are emitted/applied.",
           "cr_refs": [
+            "CR 118.7",
             "CR 601.2f"
           ]
         },
         {
           "name": "ModifyActivationLimit",
-          "line": 787,
+          "line": 847,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -29533,7 +30406,7 @@
         },
         {
           "name": "ActivateAsInstant",
-          "line": 797,
+          "line": 857,
           "kind": "struct",
           "field_names": [
             "cost_category"
@@ -29546,7 +30419,7 @@
         },
         {
           "name": "CantPayCost",
-          "line": 807,
+          "line": 867,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29561,7 +30434,7 @@
         },
         {
           "name": "CantGainLife",
-          "line": 811,
+          "line": 871,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29569,7 +30442,7 @@
         },
         {
           "name": "CantLoseLife",
-          "line": 812,
+          "line": 872,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29577,7 +30450,7 @@
         },
         {
           "name": "PlayerProtection",
-          "line": 821,
+          "line": 881,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.16: The scoped player(s) have protection from a quality — e.g. Serra's Emissary's \"You ... have protection from the chosen card type.\" Player scope rides on `StaticDefinition::affected` (identical to `CantGainLife`); `ProtectionTarget` is the canonical protection-quality axis. Data-carrying variant — not registry-registered (see `coverage::is_data_carrying_static`); consumed by direct pattern-match in `player_protection_from`. Only the `ChosenCardType` arm is runtime-implemented; other arms are inert.",
@@ -29587,7 +30460,7 @@
         },
         {
           "name": "MustAttack",
-          "line": 822,
+          "line": 882,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29595,7 +30468,7 @@
         },
         {
           "name": "MustAttackPlayer",
-          "line": 830,
+          "line": 890,
           "kind": "struct",
           "field_names": [
             "player"
@@ -29607,7 +30480,7 @@
         },
         {
           "name": "MustBlock",
-          "line": 833,
+          "line": 893,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29615,7 +30488,7 @@
         },
         {
           "name": "MustBlockAttacker",
-          "line": 841,
+          "line": 901,
           "kind": "struct",
           "field_names": [
             "attacker"
@@ -29628,7 +30501,7 @@
         },
         {
           "name": "CantDraw",
-          "line": 844,
+          "line": 904,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29638,7 +30511,7 @@
         },
         {
           "name": "DoubleTriggers",
-          "line": 851,
+          "line": 911,
           "kind": "struct",
           "field_names": [
             "cause"
@@ -29650,7 +30523,7 @@
         },
         {
           "name": "IgnoreHexproof",
-          "line": 854,
+          "line": 914,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29658,7 +30531,7 @@
         },
         {
           "name": "ExtraBlockers",
-          "line": 857,
+          "line": 917,
           "kind": "struct",
           "field_names": [
             "count"
@@ -29671,7 +30544,7 @@
         },
         {
           "name": "RevealTopOfLibrary",
-          "line": 862,
+          "line": 922,
           "kind": "struct",
           "field_names": [
             "all_players"
@@ -29683,7 +30556,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 867,
+          "line": 927,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29696,7 +30569,7 @@
         },
         {
           "name": "GraveyardCastPermission",
-          "line": 872,
+          "line": 932,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -29711,10 +30584,11 @@
         },
         {
           "name": "TopOfLibraryCastPermission",
-          "line": 902,
+          "line": 962,
           "kind": "struct",
           "field_names": [
             "play_mode",
+            "frequency",
             "alt_cost"
           ],
           "doc": "CR 401.5 + CR 118.9 + CR 601.2a: Static ability granting permission to play/cast the top card of the controller's library when it matches `StaticDefinition.affected`. Class members: Realmwalker (creature spells of the chosen type), Future Sight + Magus of the Future (any spell or land), Bolas's Citadel (any, with `alt_cost = pay life equal to its mana value`), Vivien on the Hunt static, etc.  Distinct from `GraveyardCastPermission`: the source object is the continually-changing top of `Player.library`, not a graveyard card. Filter eligibility is therefore re-evaluated each priority window because `casting::spell_objects_available_to_cast` is called fresh.  Casting a card via this permission moves it `Library → Stack` directly (CR 601.2a: \"moves that card from where it is to the stack\"); there is NO exile step. This separates the class cleanly from the impulse-draw class (`Effect::CastFromZone` → `CastingPermission::ExileWithAltCost`), which exiles the card before granting a permission.",
@@ -29726,7 +30600,7 @@
         },
         {
           "name": "CastFromHandFree",
-          "line": 919,
+          "line": 989,
           "kind": "struct",
           "field_names": [
             "frequency",
@@ -29740,14 +30614,16 @@
         },
         {
           "name": "ExileCastPermission",
-          "line": 950,
+          "line": 1020,
           "kind": "struct",
           "field_names": [
             "frequency",
             "play_mode",
             "cost",
             "pool",
-            "timing"
+            "timing",
+            "mana_spend_permission",
+            "grants_flash"
           ],
           "doc": "CR 601.2a + CR 113.6b + CR 118.9: Static ability granting permission to cast cards exiled with this source — restricted to cards exiled *this turn* — typically without paying the mana cost. Maralen, Fae Ascendant is the type specimen (\"Once each turn, you may cast a spell with mana value less than or equal to the number of Elves and Faeries you control from among cards exiled with Maralen this turn without paying its mana cost.\").  The source pool is the per-turn list `GameState::cards_exiled_with_source_this_turn[source_id]`. The static's `affected: TargetFilter` constrains the eligible cards (type, mana value, etc.). Per-turn frequency tracking is keyed on `source_id` in `GameState::exile_cast_permissions_used` for `OncePerTurn`; `Unlimited` skips tracking.  Distinct from `GraveyardCastPermission`: the source pool is exile (per-turn-scoped), not the controller's graveyard. Distinct from `TopOfLibraryCastPermission`: the eligible cards are a tracked exile set carved out by a prior exile-with-source effect, not the live top of library. Distinct from `Effect::CastFromZone` (Court of Locthwain, Mizzix's Mastery): that is a one-shot effect that grants per-card permissions; this is a continuous static that grants the controller a recurring per-turn cast slot.",
           "cr_refs": [
@@ -29758,7 +30634,7 @@
         },
         {
           "name": "LinkedCollectionCounterPlayPermission",
-          "line": 1003,
+          "line": 1091,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6 + CR 601.2a: Marker static identifying a source whose linked \"play a card from exile with a collection counter on it\" permission is live (Evelyn, the Covetous). Per CR 113.6, that play permission is a static ability of the source and functions only while the source is on the battlefield under the player's control; this marker is what `casting.rs::source_has_collection_counter_play_permission` consults so the per-card `CastingPermission::PlayFromExile` (collection-counter + controller provenance) is honored only while a live source remains. CR 601.2a: the permission authorizes moving a matching exiled card to the stack / battlefield (playing it).  Distinct from `ExileCastPermission`: that static is self-contained and grants the cast itself, keyed on a source-identity exile pool. This is a nullary marker; the actual permission lives on each exiled card as a `CastingPermission::PlayFromExile`, linked by the collection counter (not source identity), so the authority winks out if every source leaves but the counter persists.  RUNTIME: handled by direct match in `casting.rs::source_has_collection_counter_play_permission`; coverage support is via `is_data_carrying_static()` (mirrors the cast-permission cluster, which is also runtime-by-direct-match, not registry-keyed).",
@@ -29769,7 +30645,7 @@
         },
         {
           "name": "CountersPersistAcrossZones",
-          "line": 1020,
+          "line": 1108,
           "kind": "struct",
           "field_names": [
             "excluded_zones"
@@ -29782,7 +30658,7 @@
         },
         {
           "name": "CantBeCountered",
-          "line": 1028,
+          "line": 1116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2: This spell/permanent can't be countered.",
@@ -29792,7 +30668,7 @@
         },
         {
           "name": "CantBeCopied",
-          "line": 1031,
+          "line": 1119,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.2 + CR 707.10: This spell can't be copied by spells or abilities. Enforced in `copy_spell::resolve` when selecting the spell to copy.",
@@ -29803,7 +30679,7 @@
         },
         {
           "name": "CantEnterBattlefieldFrom",
-          "line": 1033,
+          "line": 1121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 604.3: Cards in specified zones can't enter the battlefield.",
@@ -29813,7 +30689,7 @@
         },
         {
           "name": "CantCastFrom",
-          "line": 1053,
+          "line": 1141,
           "kind": "struct",
           "field_names": [
             "who"
@@ -29827,7 +30703,7 @@
         },
         {
           "name": "CantCastDuring",
-          "line": 1059,
+          "line": 1147,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29840,7 +30716,7 @@
         },
         {
           "name": "CantActivateDuring",
-          "line": 1086,
+          "line": 1174,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29858,7 +30734,7 @@
         },
         {
           "name": "PerTurnCastLimit",
-          "line": 1096,
+          "line": 1184,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29873,7 +30749,7 @@
         },
         {
           "name": "PerTurnDrawLimit",
-          "line": 1104,
+          "line": 1192,
           "kind": "struct",
           "field_names": [
             "who",
@@ -29886,7 +30762,7 @@
         },
         {
           "name": "SuppressTriggers",
-          "line": 1131,
+          "line": 1219,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -29901,7 +30777,7 @@
         },
         {
           "name": "CantBeBlocked",
-          "line": 1138,
+          "line": 1226,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: This creature can't be blocked.",
@@ -29911,7 +30787,7 @@
         },
         {
           "name": "CantBeBlockedExceptBy",
-          "line": 1140,
+          "line": 1228,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -29923,7 +30799,7 @@
         },
         {
           "name": "CantBeBlockedBy",
-          "line": 1145,
+          "line": 1233,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29935,7 +30811,7 @@
         },
         {
           "name": "CantBeBlockedByMoreThan",
-          "line": 1153,
+          "line": 1241,
           "kind": "struct",
           "field_names": [
             "max"
@@ -29947,7 +30823,7 @@
         },
         {
           "name": "AttachmentRestriction",
-          "line": 1173,
+          "line": 1261,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29963,7 +30839,7 @@
         },
         {
           "name": "Protection",
-          "line": 1177,
+          "line": 1265,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.16: Protection prevents targeting, blocking, damage, and attachment.",
@@ -29973,7 +30849,7 @@
         },
         {
           "name": "Indestructible",
-          "line": 1179,
+          "line": 1267,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.12: Indestructible — prevents destruction by lethal damage and destroy effects.",
@@ -29983,7 +30859,7 @@
         },
         {
           "name": "CantBeDestroyed",
-          "line": 1181,
+          "line": 1269,
           "kind": "unit",
           "field_names": [],
           "doc": "Permanent cannot be destroyed (distinct from Indestructible).",
@@ -29991,7 +30867,7 @@
         },
         {
           "name": "CantBeRegenerated",
-          "line": 1193,
+          "line": 1281,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.19c: \"[Permanent] can't be regenerated [this turn].\" This does not stop regeneration abilities from being activated or shields from being created; rather, it causes regeneration shields to not be applied the next time the affected permanent would be destroyed. The per-target `StaticDefinition::affected` filter carries which permanent is marked; runtime enforcement bypasses the regen shield in `replacement.rs::destroy_applier` (CR 701.19). Distinct from `CantBeDestroyed` (which prevents destruction outright) and the inline `Effect::Destroy { cant_regenerate }` (the \"Destroy X. It can't be regenerated.\" one-shot) — this is the standalone, until-end-of-turn form (Hurr Jackal, Furnace Brood, Lim-Dûl's Cohort).",
@@ -30002,7 +30878,7 @@
         },
         {
           "name": "FlashBack",
-          "line": 1195,
+          "line": 1283,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.34: Flashback — allows casting from graveyard, exiled after resolution.",
@@ -30012,7 +30888,7 @@
         },
         {
           "name": "Shroud",
-          "line": 1197,
+          "line": 1285,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.18: Shroud — permanent cannot be the target of spells or abilities.",
@@ -30022,7 +30898,7 @@
         },
         {
           "name": "Hexproof",
-          "line": 1202,
+          "line": 1290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.11: Hexproof — affected player/permanent cannot be the target of spells or abilities an opponent controls. Applied at the player scope (\"You have hexproof.\") mirroring `Shroud`; permanent-scope hexproof grants flow through `ContinuousModification::AddKeyword` instead.",
@@ -30032,7 +30908,7 @@
         },
         {
           "name": "Vigilance",
-          "line": 1204,
+          "line": 1292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.20: Vigilance — attacking doesn't cause this creature to tap.",
@@ -30042,7 +30918,7 @@
         },
         {
           "name": "Menace",
-          "line": 1206,
+          "line": 1294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.111: Menace — can't be blocked except by two or more creatures.",
@@ -30052,7 +30928,7 @@
         },
         {
           "name": "Reach",
-          "line": 1208,
+          "line": 1296,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.17: Reach — can block creatures with flying.",
@@ -30062,7 +30938,7 @@
         },
         {
           "name": "Flying",
-          "line": 1210,
+          "line": 1298,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.9: Flying — can't be blocked except by creatures with flying or reach.",
@@ -30072,7 +30948,7 @@
         },
         {
           "name": "Trample",
-          "line": 1212,
+          "line": 1300,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.19: Trample — excess combat damage is assigned to the defending player.",
@@ -30082,7 +30958,7 @@
         },
         {
           "name": "Deathtouch",
-          "line": 1214,
+          "line": 1302,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.2: Deathtouch — any amount of damage dealt is lethal.",
@@ -30092,7 +30968,7 @@
         },
         {
           "name": "Lifelink",
-          "line": 1216,
+          "line": 1304,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.15: Lifelink — damage dealt also causes controller to gain that much life.",
@@ -30102,7 +30978,7 @@
         },
         {
           "name": "CantTap",
-          "line": 1219,
+          "line": 1307,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30110,7 +30986,7 @@
         },
         {
           "name": "CantUntap",
-          "line": 1220,
+          "line": 1308,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30118,7 +30994,7 @@
         },
         {
           "name": "MustBeBlocked",
-          "line": 1223,
+          "line": 1311,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: This creature must be blocked if able — the defending player must assign at least one legal blocker to it.",
@@ -30128,7 +31004,7 @@
         },
         {
           "name": "MustBeBlockedByAll",
-          "line": 1229,
+          "line": 1317,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1c: \"All creatures able to block this creature do so\" (Lure, Prized Unicorn, Breaker of Armies, …). Unlike [`MustBeBlocked`], this places a block requirement on *every* creature able to block it: each such untapped defender must be declared as a blocker of this attacker, not merely one.",
@@ -30138,7 +31014,7 @@
         },
         {
           "name": "Goaded",
-          "line": 1233,
+          "line": 1321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.15b: This creature is goaded for as long as the static applies. The source controller is the goading player for the \"attack another player if able\" requirement.",
@@ -30148,7 +31024,7 @@
         },
         {
           "name": "CombatAlone",
-          "line": 1241,
+          "line": 1329,
           "kind": "struct",
           "field_names": [
             "action",
@@ -30163,7 +31039,7 @@
         },
         {
           "name": "CantCrew",
-          "line": 1246,
+          "line": 1334,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122c: This creature can't crew Vehicles.",
@@ -30173,7 +31049,7 @@
         },
         {
           "name": "CrewContribution",
-          "line": 1252,
+          "line": 1340,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -30188,15 +31064,36 @@
         },
         {
           "name": "MayLookAtTopOfLibrary",
-          "line": 1256,
+          "line": 1344,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
+          "name": "MayLookAtFaceDown",
+          "line": 1355,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 708.5: Static permission to look at face-down permanents the controller would otherwise not be allowed to see. The default rule lets you look only at face-down permanents you control; this static lifts that for the permanents matched by `StaticDefinition::affected` (resolved from the static's source controller). Parameterized by scope on the affected filter — \"your opponents control\" (Found Footage → `controller: Opponent`) and \"you don't control\" (Lumbering Laundry → `Not { controller: You }`) are the same permission, differing only in the filter. The look-permission is enforced in `visibility.rs` (face-down identity redaction) and surfaced to the controller, not via layer 7.",
+          "cr_refs": [
+            "CR 708.5"
+          ]
+        },
+        {
+          "name": "CantBeTurnedFaceUp",
+          "line": 1366,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 116.2b + CR 708.7: Prohibition preventing the permanents matched by `StaticDefinition::affected` from being turned face up. Turning a face-down permanent face up is a special action (CR 116.2b) that the rules allowing it normally permit (CR 708.7); this static blocks it for the affected permanents. The optional timing window rides on `StaticDefinition::condition` (Karlov Watchdog: `DuringYourTurn` — \"Permanents your opponents control can't be turned face up during your turn\"). The affected filter is resolved from the static's source controller, so `controller: Opponent` means the source controller's opponents' permanents. Enforced in `morph::turn_face_up`.",
+          "cr_refs": [
+            "CR 116.2b",
+            "CR 708.7"
+          ]
+        },
+        {
           "name": "MayChooseNotToUntap",
-          "line": 1260,
+          "line": 1370,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3: You may choose not to untap this permanent during your untap step.",
@@ -30206,7 +31103,7 @@
         },
         {
           "name": "AdditionalLandDrop",
-          "line": 1263,
+          "line": 1373,
           "kind": "struct",
           "field_names": [
             "count"
@@ -30218,7 +31115,7 @@
         },
         {
           "name": "EmblemStatic",
-          "line": 1266,
+          "line": 1376,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30226,7 +31123,7 @@
         },
         {
           "name": "BlockRestriction",
-          "line": 1269,
+          "line": 1379,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30238,7 +31135,7 @@
         },
         {
           "name": "NoMaximumHandSize",
-          "line": 1273,
+          "line": 1383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 402.2: No maximum hand size.",
@@ -30248,7 +31145,7 @@
         },
         {
           "name": "MaximumHandSize",
-          "line": 1276,
+          "line": 1386,
           "kind": "struct",
           "field_names": [
             "modification"
@@ -30261,7 +31158,7 @@
         },
         {
           "name": "MayPlayAdditionalLand",
-          "line": 1279,
+          "line": 1389,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30269,7 +31166,7 @@
         },
         {
           "name": "CantHaveKeyword",
-          "line": 1283,
+          "line": 1393,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -30281,7 +31178,7 @@
         },
         {
           "name": "CantWinTheGame",
-          "line": 1288,
+          "line": 1398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: This player can't win the game (Platinum Angel effect).",
@@ -30291,7 +31188,7 @@
         },
         {
           "name": "CantLoseTheGame",
-          "line": 1290,
+          "line": 1400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3b: This player can't lose the game (Platinum Angel effect).",
@@ -30301,7 +31198,7 @@
         },
         {
           "name": "LegendRuleDoesntApply",
-          "line": 1299,
+          "line": 1409,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 704.5j: The \"legend rule\" doesn't apply to the affected permanents, so they are excluded from the same-name legendary grouping in the legend-rule SBA. Scope rides on `StaticDefinition::affected`: `None` = global (Mirror Gallery, \"the legend rule doesn't apply\"); a controller-scoped filter = \"doesn't apply to [permanents/tokens/Slivers/commanders] you control\" (Sakashima of a Thousand Faces, Mirror Box, Cadric, Sliver Gravemother, Try-My-Deck Elemental, ...). Enforced per-permanent in `sba.rs` via `check_static_ability` with the candidate as the target object.",
@@ -30311,7 +31208,7 @@
         },
         {
           "name": "SpeedCanIncreaseBeyondFour",
-          "line": 1301,
+          "line": 1411,
           "kind": "unit",
           "field_names": [],
           "doc": "Speed may increase beyond 4, and 4+ still counts as max speed for that player.",
@@ -30319,7 +31216,7 @@
         },
         {
           "name": "DefilerCostReduction",
-          "line": 1305,
+          "line": 1415,
           "kind": "struct",
           "field_names": [
             "color",
@@ -30333,7 +31230,7 @@
         },
         {
           "name": "SkipStep",
-          "line": 1315,
+          "line": 1425,
           "kind": "struct",
           "field_names": [
             "step"
@@ -30346,7 +31243,7 @@
         },
         {
           "name": "SpendManaAsAnyColor",
-          "line": 1320,
+          "line": 1430,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.4b: \"You may spend mana as though it were mana of any color.\" Allows the controller to pay colored mana costs with mana of any color.",
@@ -30356,7 +31253,7 @@
         },
         {
           "name": "PayLifeAsColoredMana",
-          "line": 1332,
+          "line": 1442,
           "kind": "struct",
           "field_names": [
             "color"
@@ -30368,7 +31265,7 @@
         },
         {
           "name": "StepEndUnspentMana",
-          "line": 1346,
+          "line": 1456,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -30384,7 +31281,7 @@
         },
         {
           "name": "CanAttackWithDefender",
-          "line": 1352,
+          "line": 1462,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.3b: Allows creatures with defender to attack despite having the keyword. \"can attack as though it didn't have defender\" overrides the defender restriction.",
@@ -30394,7 +31291,7 @@
         },
         {
           "name": "IgnoreLandwalkForBlocking",
-          "line": 1369,
+          "line": 1479,
           "kind": "struct",
           "field_names": [
             "qualifier"
@@ -30409,7 +31306,7 @@
         },
         {
           "name": "CanActivateAbilitiesAsThoughHaste",
-          "line": 1377,
+          "line": 1487,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5a: Bypasses the summoning-sickness gate on a creature's `{T}`/`{Q}` activated abilities — \"You may activate abilities of creatures you control as though those creatures had haste.\" This is NOT `AddKeyword(Haste)`: only the CR 602.5a activation restriction is lifted, combat attacker validation (CR 508.1a) is untouched. Canonical card: Tyvar, Jubilant Brawler.",
@@ -30420,7 +31317,7 @@
         },
         {
           "name": "CanBlockShadow",
-          "line": 1392,
+          "line": 1502,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b + CR 609.4 + CR 702.28b: Per-source block permission that lifts the shadow blocker-side restriction for the affected creature only — it may block creatures with shadow despite not having shadow itself. Shadow is the unique evasion keyword (CR 702.28b) with a symmetric \"without-shadow can't block with-shadow\" pairing, so this is keyword-specific (mirrors `CanAttackWithDefender`) rather than a generic keyword-parameterized form, which would cross keyword CR sections with distinct runtime resolvers.  Captures both printed phrasings of the same CR 509.1b outcome: \"can block creatures with shadow as though they didn't have shadow\" (Heartwood Dryad) and \"can block creatures with shadow as though it had shadow\" (Wall of Diffusion). `affected: SelfRef` (per-source, not the global rule modification `IgnoreLandwalkForBlocking` uses). Enforced inside the shadow block-legality seam in `combat.rs`, not as a layer-6 keyword grant.",
@@ -30432,7 +31329,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 1396,
+          "line": 1506,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage. Used for creatures like Ornithopter of Paradise and various Walls that can attack/block but deal 0 combat damage.",
@@ -30442,7 +31339,7 @@
         },
         {
           "name": "UntapsDuringEachOtherPlayersUntapStep",
-          "line": 1405,
+          "line": 1515,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 113.6: Continuous static that grants a second untap pass during each OTHER player's untap step. The source's controller untaps the permanents matching `StaticDefinition.affected` — NOT the active player's permanents. Canonical card: Seedborn Muse (\"Untap all permanents you control during each other player's untap step.\"). Runtime: `turns::execute_untap` runs a second pass after the active player's normal untap, scanning the battlefield for this variant on permanents whose controller != active_player.",
@@ -30453,7 +31350,7 @@
         },
         {
           "name": "MaxUntapPerType",
-          "line": 1426,
+          "line": 1536,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -30466,13 +31363,13 @@
         },
         {
           "name": "EntersWithAdditionalCounters",
-          "line": 1449,
+          "line": 1562,
           "kind": "struct",
           "field_names": [
             "counter_type",
             "count"
           ],
-          "doc": "CR 614.1c + CR 122.1: Continuous \"enters with an additional counter\" replacement static. A permanent matching `StaticDefinition::affected` (e.g. \"Other creatures you control\", \"Legendary creatures you control\", \"Nontoken creatures you control\") that would enter the battlefield does so with `count` additional counters of `counter_type` on it.  Per CR 614.1c these \"enters with …\" effects are replacement effects, not triggered abilities; the affected-permanent scope rides on `StaticDefinition::affected` (the controller-scoped \"you control\" plus any Other/Legendary/Nontoken qualifier), exactly like the anthem statics. Runtime integration lives in the battlefield-entry counter hook in `effects/change_zone.rs`, which scans active statics whose `affected` filter matches the entering object and folds `count` `counter_type` counters into the entry's counter list.  Class members (fixed-count form): Kalain, Reclusive Painter; Bard Class; Gorma the Gullet; Master Chef. The dynamic-count form (Gev, \"for each opponent who lost life\") is intentionally NOT matched by the parser and remains Unimplemented until a dynamic-count axis is added.",
+          "doc": "CR 614.1c + CR 122.1: Continuous \"enters with an additional counter\" replacement static. A permanent matching `StaticDefinition::affected` (e.g. \"Other creatures you control\", \"Legendary creatures you control\", \"Nontoken creatures you control\") that would enter the battlefield does so with `count` additional counters of `counter_type` on it.  Per CR 614.1c these \"enters with …\" effects are replacement effects, not triggered abilities; the affected-permanent scope rides on `StaticDefinition::affected` (the controller-scoped \"you control\" plus any Other/Legendary/Nontoken qualifier), exactly like the anthem statics. Runtime integration lives in the battlefield-entry counter hook in `effects/change_zone.rs`, which scans active statics whose `affected` filter matches the entering object and folds `count` `counter_type` counters into the entry's counter list.  Class members (fixed-count form): Kalain, Reclusive Painter; Bard Class; Gorma the Gullet; Master Chef. The dynamically *scaled* distributive form (Gev, Scaled Scorch — \"enter with … counter on them for each opponent who lost life this turn\") is NOT modeled here (this mode carries a fixed `count`); it routes instead to the dynamic-capable `ReplacementEvent::ChangeZone` + `Effect::PutCounter { count: QuantityExpr }` path via the enters-with-counter replacement parser.",
           "cr_refs": [
             "CR 122.1",
             "CR 614.1c"
@@ -30480,7 +31377,7 @@
         },
         {
           "name": "Other",
-          "line": 1454,
+          "line": 1567,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized static mode strings.",
@@ -30522,7 +31419,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6762,
+      "line": 7173,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -30531,7 +31428,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 6763,
+          "line": 7174,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30539,7 +31436,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 6764,
+          "line": 7175,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30550,7 +31447,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12021,
+      "line": 12866,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -30558,7 +31455,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 12029,
+          "line": 12874,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -30566,7 +31463,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 12034,
+          "line": 12879,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -30743,9 +31640,64 @@
       ],
       "sibling_clusters": []
     },
+    "TapCreaturesAggregateStat": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 5942,
+      "doc": "Aggregate statistic for a tap-creatures-cost selection constraint.  CR 208.1: power is the aggregate axis. Currently only `TotalPower` (Crew CR 702.122a, Saddle CR 702.171a, Teamwork). Mirrors `SacrificeAggregateStat`.",
+      "cr_refs": [
+        "CR 208.1",
+        "CR 702.122a",
+        "CR 702.171a"
+      ],
+      "variants": [
+        {
+          "name": "TotalPower",
+          "line": 5943,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "TapCreaturesRequirement": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 5979,
+      "doc": "How many creatures must be tapped, or what aggregate constraint the chosen set must satisfy, for a `TapCreatures` cost.  `Count { count }` is the fixed-number form (Conspire's \"tap two creatures\", Convoke-style \"tap N creatures\"). `Aggregate { stat, comparator, value }` is the \"tap any number of creatures with total power N or greater\" form used by Crew (CR 702.122a), Saddle (CR 702.171a), and Teamwork. Mirrors `SacrificeRequirement` so the two cost families share one parameterization shape.",
+      "cr_refs": [
+        "CR 702.122a",
+        "CR 702.171a"
+      ],
+      "variants": [
+        {
+          "name": "Count",
+          "line": 5981,
+          "kind": "struct",
+          "field_names": [
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Aggregate",
+          "line": 5985,
+          "kind": "struct",
+          "field_names": [
+            "stat",
+            "comparator",
+            "value"
+          ],
+          "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
     "TapStateChange": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3310,
+      "line": 3465,
       "doc": "CR 701.26a (tap) / CR 701.26b (untap): Direction of an `Effect::SetTapState`. Parameterizes the tap/untap axis so a single effect variant covers both keyword actions.",
       "cr_refs": [
         "CR 701.26a",
@@ -30754,7 +31706,7 @@
       "variants": [
         {
           "name": "Tap",
-          "line": 3312,
+          "line": 3467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26a: Turn the permanent sideways (tap it).",
@@ -30764,7 +31716,7 @@
         },
         {
           "name": "Untap",
-          "line": 3314,
+          "line": 3469,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26b: Rotate the permanent upright (untap it).",
@@ -30777,7 +31729,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 11562,
+      "line": 12407,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -30787,7 +31739,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 11564,
+          "line": 12409,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30795,7 +31747,7 @@
         },
         {
           "name": "Resolution",
-          "line": 11565,
+          "line": 12410,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30806,13 +31758,13 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3047,
+      "line": 3192,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 3048,
+          "line": 3193,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30820,7 +31772,7 @@
         },
         {
           "name": "Any",
-          "line": 3049,
+          "line": 3194,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30828,7 +31780,7 @@
         },
         {
           "name": "Player",
-          "line": 3050,
+          "line": 3195,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30836,7 +31788,7 @@
         },
         {
           "name": "Controller",
-          "line": 3051,
+          "line": 3196,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30844,7 +31796,7 @@
         },
         {
           "name": "SelfRef",
-          "line": 3052,
+          "line": 3197,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30852,7 +31804,7 @@
         },
         {
           "name": "SourceOrPaired",
-          "line": 3055,
+          "line": 3200,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -30862,7 +31814,7 @@
         },
         {
           "name": "Typed",
-          "line": 3056,
+          "line": 3201,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -30870,7 +31822,7 @@
         },
         {
           "name": "Not",
-          "line": 3057,
+          "line": 3202,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30880,7 +31832,7 @@
         },
         {
           "name": "Or",
-          "line": 3060,
+          "line": 3205,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -30890,7 +31842,7 @@
         },
         {
           "name": "And",
-          "line": 3063,
+          "line": 3208,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -30900,7 +31852,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 3073,
+          "line": 3218,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -30914,7 +31866,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 3083,
+          "line": 3228,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -30924,7 +31876,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 3087,
+          "line": 3232,
           "kind": "struct",
           "field_names": [
             "id"
@@ -30934,7 +31886,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 3095,
+          "line": 3240,
           "kind": "struct",
           "field_names": [
             "id"
@@ -30947,7 +31899,7 @@
         },
         {
           "name": "Neighbor",
-          "line": 3103,
+          "line": 3248,
           "kind": "struct",
           "field_names": [
             "direction"
@@ -30960,7 +31912,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3109,
+          "line": 3254,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -30971,7 +31923,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 3112,
+          "line": 3257,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -30979,7 +31931,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 3115,
+          "line": 3260,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -30987,7 +31939,7 @@
         },
         {
           "name": "LastRevealed",
-          "line": 3122,
+          "line": 3267,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.20e + CR 608.2c: Resolves to the most recently looked-at or revealed card(s) from a `Dig`/`RevealTop` effect in the current resolution (`state.last_revealed_ids`). Used by anaphoric \"it\" / \"that card\" references after \"look at the top card of your library\" (Amareth, the Lustrous) and by `AbilityCondition::ObjectsShareQuality` subject slots.",
@@ -30998,7 +31950,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3126,
+          "line": 3271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -31009,7 +31961,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 3129,
+          "line": 3274,
           "kind": "struct",
           "field_names": [
             "id"
@@ -31021,7 +31973,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 3156,
+          "line": 3301,
           "kind": "struct",
           "field_names": [
             "id",
@@ -31038,7 +31990,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3164,
+          "line": 3309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -31048,7 +32000,7 @@
         },
         {
           "name": "ExiledCardByIndex",
-          "line": 3170,
+          "line": 3315,
           "kind": "struct",
           "field_names": [
             "index"
@@ -31060,7 +32012,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 3174,
+          "line": 3319,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -31070,7 +32022,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 3176,
+          "line": 3321,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -31080,7 +32032,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3178,
+          "line": 3323,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -31090,7 +32042,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 3180,
+          "line": 3325,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -31099,8 +32051,20 @@
           ]
         },
         {
+          "name": "TriggeringSourceController",
+          "line": 3335,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 603.7c + CR 109.4 + CR 110.2: Resolves to the *controller* of the triggering event's source object — the player-level counterpart of `TriggeringSource`, mirroring how `TriggeringSpellController` is the controller of `StackSpell`. Used by \"the attacking player\" / \"its controller\" anaphors on `DamageReceived` triggers where the wanted player is the controller of the creature that dealt combat damage, not the damaged player (`TriggeringPlayer`). Powers Contested Game Ball (\"Whenever you're dealt combat damage, the attacking player gains control of this artifact and untaps it.\").",
+          "cr_refs": [
+            "CR 109.4",
+            "CR 110.2",
+            "CR 603.7c"
+          ]
+        },
+        {
           "name": "ParentTarget",
-          "line": 3185,
+          "line": 3340,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -31108,7 +32072,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 3190,
+          "line": 3345,
           "kind": "struct",
           "field_names": [
             "index"
@@ -31120,7 +32084,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 3196,
+          "line": 3351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -31130,7 +32094,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 3207,
+          "line": 3362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -31142,7 +32106,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3212,
+          "line": 3367,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -31153,7 +32117,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 3233,
+          "line": 3388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -31165,7 +32129,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 3252,
+          "line": 3407,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -31176,7 +32140,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 3257,
+          "line": 3412,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -31186,7 +32150,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3261,
+          "line": 3416,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -31197,7 +32161,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 3264,
+          "line": 3419,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -31205,7 +32169,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 3268,
+          "line": 3423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -31215,7 +32179,7 @@
         },
         {
           "name": "Named",
-          "line": 3271,
+          "line": 3426,
           "kind": "struct",
           "field_names": [
             "name"
@@ -31225,7 +32189,7 @@
         },
         {
           "name": "Owner",
-          "line": 3279,
+          "line": 3434,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -31235,7 +32199,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3286,
+          "line": 3441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -31266,13 +32230,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15028,
+      "line": 15992,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 15029,
+          "line": 15993,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -31280,7 +32244,7 @@
         },
         {
           "name": "Player",
-          "line": 15030,
+          "line": 15994,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -31291,13 +32255,13 @@
     },
     "TargetSelectionConstraint": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2041,
+      "line": 2052,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 2042,
+          "line": 2053,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31305,7 +32269,7 @@
         },
         {
           "name": "DifferentObjectControllers",
-          "line": 2044,
+          "line": 2055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2c: Object targets must be controlled by different players.",
@@ -31316,7 +32280,7 @@
         },
         {
           "name": "TotalManaValue",
-          "line": 2052,
+          "line": 2063,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -31335,7 +32299,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2788,
+      "line": 2933,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -31344,7 +32308,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 2791,
+          "line": 2936,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -31354,7 +32318,7 @@
         },
         {
           "name": "Random",
-          "line": 2794,
+          "line": 2939,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -31367,7 +32331,7 @@
     },
     "ThisWayCause": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3015,
+      "line": 3160,
       "doc": "CR 608.2c: Producer-action provenance for a tracked-set member — the keyword action (or one-shot zone change) that made the object part of a \"this way\" set. This is the IDENTITY of a \"<verb>ed this way\" relationship: it is the ACTION performed on the member, NOT the zone the member finally landed in.  Binding \"this way\" consumers to the action rather than the destination zone is required for two reasons (issue #2932):    1. CR 608.2c ordering — multiple distinct producer actions share the same      destination. Sacrifice (CR 701.21a), destroy (CR 701.8a), mill      (CR 701.17a), and discard (CR 701.9a) all land in the graveyard, so a      chain that mills AND sacrifices before a later \"sacrificed this way\"      consumer cannot be disambiguated by zone alone.   2. CR 614.1 / CR 614.6 replacement redirection — a replacement effect can      change a member's destination. With a Rest-in-Peace-style replacement a      sacrificed or discarded object lands in Exile, but it was still      *sacrificed / discarded this way*. The cause is the action, so it      survives the redirect; a zone binding would miss it.  Each variant cites the keyword action that produces it. `Returned` / `Bounced` are plain zone changes governed by CR 400.7 (no dedicated keyword action), distinguished by destination (battlefield vs. hand).",
       "cr_refs": [
         "CR 400.7",
@@ -31382,7 +32346,7 @@
       "variants": [
         {
           "name": "Exiled",
-          "line": 3017,
+          "line": 3162,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.13a: the member was exiled this way.",
@@ -31392,7 +32356,7 @@
         },
         {
           "name": "Sacrificed",
-          "line": 3020,
+          "line": 3165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21a: the member was sacrificed this way (cause survives a replacement that redirects the sacrifice to another zone — CR 614.6).",
@@ -31403,7 +32367,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 3022,
+          "line": 3167,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8a: the member was destroyed this way.",
@@ -31413,7 +32377,7 @@
         },
         {
           "name": "Milled",
-          "line": 3024,
+          "line": 3169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17a: the member was milled this way.",
@@ -31423,7 +32387,7 @@
         },
         {
           "name": "Discarded",
-          "line": 3027,
+          "line": 3172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: the member was discarded this way (cause survives a replacement that redirects the discard to another zone — CR 614.6).",
@@ -31434,7 +32398,7 @@
         },
         {
           "name": "Returned",
-          "line": 3030,
+          "line": 3175,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was returned (put onto the battlefield) this way by a one-shot put-onto-battlefield instruction.",
@@ -31445,7 +32409,7 @@
         },
         {
           "name": "Bounced",
-          "line": 3033,
+          "line": 3178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was bounced (returned to its owner's hand) this way by a mass-bounce instruction.",
@@ -31459,7 +32423,7 @@
     },
     "TimeTravelPhase": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2589,
+      "line": 2619,
       "doc": "CR 701.56a: Which half of a time-travel choice is currently being presented. Typed instead of boolean so serialized engine state says whether the player is adding or removing counters.",
       "cr_refs": [
         "CR 701.56a"
@@ -31467,7 +32431,7 @@
       "variants": [
         {
           "name": "Remove",
-          "line": 2590,
+          "line": 2620,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31475,7 +32439,7 @@
         },
         {
           "name": "Add",
-          "line": 2591,
+          "line": 2621,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31486,7 +32450,7 @@
     },
     "TributeOutcome": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 674,
+      "line": 687,
       "doc": "CR 702.104a + CR 702.104b: The outcome of the Tribute choice the chosen opponent made as the creature entered the battlefield. Persisted as a `ChosenAttribute` on the Tribute creature so the companion \"if tribute wasn't paid\" trigger (CR 702.104b) can read the decision. A typed enum rather than a `bool` so the absence of any `TributeOutcome` remains distinguishable from an explicit `Declined`.",
       "cr_refs": [
         "CR 702.104a",
@@ -31495,7 +32459,7 @@
       "variants": [
         {
           "name": "Paid",
-          "line": 676,
+          "line": 689,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent placed the Tribute +1/+1 counters (CR 702.104a).",
@@ -31505,7 +32469,7 @@
         },
         {
           "name": "Declined",
-          "line": 678,
+          "line": 691,
           "kind": "unit",
           "field_names": [],
           "doc": "The chosen opponent declined (CR 702.104b: \"if tribute wasn't paid\").",
@@ -31582,13 +32546,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12998,
+      "line": 13898,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 13001,
+          "line": 13901,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -31598,7 +32562,7 @@
         },
         {
           "name": "LostLife",
-          "line": 13003,
+          "line": 13903,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -31606,7 +32570,7 @@
         },
         {
           "name": "Descended",
-          "line": 13005,
+          "line": 13905,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -31614,7 +32578,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 13007,
+          "line": 13907,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31624,7 +32588,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 13009,
+          "line": 13909,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -31634,7 +32598,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 13011,
+          "line": 13911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -31644,7 +32608,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 13021,
+          "line": 13921,
           "kind": "struct",
           "field_names": [
             "player"
@@ -31657,7 +32621,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 13024,
+          "line": 13924,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -31668,7 +32632,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 13027,
+          "line": 13927,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -31678,7 +32642,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 13040,
+          "line": 13940,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -31692,7 +32656,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 13047,
+          "line": 13947,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -31702,7 +32666,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 13050,
+          "line": 13950,
           "kind": "struct",
           "field_names": [
             "level"
@@ -31714,7 +32678,7 @@
         },
         {
           "name": "AttractionVisitRoll",
-          "line": 13053,
+          "line": 13953,
           "kind": "struct",
           "field_names": [
             "min",
@@ -31728,7 +32692,7 @@
         },
         {
           "name": "WasCast",
-          "line": 13949,
+          "line": 13968,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -31745,7 +32709,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 13065,
+          "line": 13979,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -31756,7 +32720,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 13070,
+          "line": 13984,
           "kind": "struct",
           "field_names": [
             "source",
@@ -31774,7 +32738,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 13090,
+          "line": 14004,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -31784,7 +32748,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 13096,
+          "line": 14010,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31799,7 +32763,7 @@
         },
         {
           "name": "CastVariantPaidPersistent",
-          "line": 13101,
+          "line": 14015,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -31812,7 +32776,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 13105,
+          "line": 14019,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -31823,7 +32787,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 13109,
+          "line": 14023,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -31834,7 +32798,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 13114,
+          "line": 14028,
           "kind": "struct",
           "field_names": [
             "source"
@@ -31847,8 +32811,19 @@
           ]
         },
         {
+          "name": "FirstTimeObjectTappedThisTurn",
+          "line": 14035,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.26 + CR 603.4: True iff the triggering object (the permanent that became tapped) has become tapped exactly once so far this turn — i.e. this is the first time. Read from `GameState.object_tap_count_this_turn` against the tapped object's id. Per CR 603.4 it is checked at both trigger time and resolution; the count model lets the resolution-time re-check stay correct.",
+          "cr_refs": [
+            "CR 603.4",
+            "CR 701.26"
+          ]
+        },
+        {
           "name": "WasType",
-          "line": 13119,
+          "line": 14040,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -31861,7 +32836,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 13122,
+          "line": 14043,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -31873,7 +32848,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 13126,
+          "line": 14047,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -31886,7 +32861,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 13130,
+          "line": 14051,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31898,7 +32873,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 13134,
+          "line": 14055,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -31908,7 +32883,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 13137,
+          "line": 14058,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -31920,7 +32895,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 13141,
+          "line": 14062,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -31932,7 +32907,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 13144,
+          "line": 14065,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -31944,7 +32919,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 13150,
+          "line": 14071,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -31954,7 +32929,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 13153,
+          "line": 14074,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -31964,7 +32939,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 13156,
+          "line": 14077,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the controller has the initiative designation.",
@@ -31974,7 +32949,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 13159,
+          "line": 14080,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -31984,7 +32959,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 13166,
+          "line": 14087,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -31996,7 +32971,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 13171,
+          "line": 14092,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -32008,7 +32983,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 13175,
+          "line": 14096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -32018,7 +32993,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 13180,
+          "line": 14101,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -32030,7 +33005,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 13186,
+          "line": 14107,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -32040,7 +33015,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 13191,
+          "line": 14112,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -32050,7 +33025,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 13194,
+          "line": 14115,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -32060,7 +33035,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 13197,
+          "line": 14118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -32070,7 +33045,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 13199,
+          "line": 14120,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -32082,7 +33057,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 13202,
+          "line": 14123,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -32092,7 +33067,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 13206,
+          "line": 14127,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -32102,7 +33077,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 13210,
+          "line": 14131,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -32115,7 +33090,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 13213,
+          "line": 14134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -32125,7 +33100,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 13217,
+          "line": 14138,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -32138,7 +33113,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 13220,
+          "line": 14141,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -32151,7 +33126,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 13222,
+          "line": 14143,
           "kind": "struct",
           "field_names": [
             "color",
@@ -32164,7 +33139,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 13224,
+          "line": 14145,
           "kind": "struct",
           "field_names": [
             "text"
@@ -32176,7 +33151,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 13226,
+          "line": 14147,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -32188,7 +33163,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 13230,
+          "line": 14151,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -32202,7 +33177,7 @@
         },
         {
           "name": "IsRenowned",
-          "line": 13237,
+          "line": 14158,
           "kind": "struct",
           "field_names": [
             "subject"
@@ -32216,7 +33191,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 13242,
+          "line": 14163,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -32231,7 +33206,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 13253,
+          "line": 14174,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -32247,7 +33222,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 13268,
+          "line": 14189,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -32259,7 +33234,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 13271,
+          "line": 14192,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -32272,7 +33247,7 @@
         },
         {
           "name": "EventDamageSourceMatchesFilter",
-          "line": 13284,
+          "line": 14205,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -32285,7 +33260,7 @@
         },
         {
           "name": "DamagedPlayerIsEventSourceOwner",
-          "line": 13298,
+          "line": 14219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 108.3 + CR 603.4: Intervening-if predicate that holds when the player dealt the triggering damage is the OWNER of the object that dealt it (\"deals combat damage to its owner\"). Reads the triggering `GameEvent::DamageDealt`: true when `target == Player(p)` and the damage source object's `owner == p` (CR 120.1: the object that deals damage is the source of that damage). Distinct from `EventDamageSourceMatchesFilter` (which filters the damage *source* by a TargetFilter) and from `DealtDamageBySourceThisTurn` (which gates a dying creature against this-turn damage records) — this gates the recipient↔source-owner relation, which no static `TargetFilter` can express. Evaluated at both fire-time and resolution-time per CR 603.4, and per synthetic per-source event on the aggregate combat-damage path. The Beast, Deathless Prince.",
@@ -32297,7 +33272,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 13308,
+          "line": 14229,
           "kind": "struct",
           "field_names": [
             "label"
@@ -32311,7 +33286,7 @@
         },
         {
           "name": "AttackersDeclaredCount",
-          "line": 13322,
+          "line": 14243,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -32328,7 +33303,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 13336,
+          "line": 14257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -32340,7 +33315,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 13347,
+          "line": 14268,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -32351,8 +33326,22 @@
           ]
         },
         {
+          "name": "TriggeringSpellTargetsFilter",
+          "line": 14274,
+          "kind": "struct",
+          "field_names": [
+            "filter"
+          ],
+          "doc": "CR 608.2c + CR 603.2 + CR 603.4: \"if it targets [filter]\" intervening-if on a spell-cast trigger — true when the triggering spell's committed targets include at least one object matching `filter`. The trigger source is excluded when the filter carries `FilterProp::Another` / \"other\" (Orvar, the All-Form).",
+          "cr_refs": [
+            "CR 603.2",
+            "CR 603.4",
+            "CR 608.2c"
+          ]
+        },
+        {
           "name": "And",
-          "line": 13351,
+          "line": 14278,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -32362,7 +33351,7 @@
         },
         {
           "name": "Or",
-          "line": 13353,
+          "line": 14280,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -32372,7 +33361,7 @@
         },
         {
           "name": "Not",
-          "line": 13363,
+          "line": 14290,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -32388,13 +33377,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13588,
+      "line": 14524,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 13590,
+          "line": 14526,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -32402,7 +33391,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 13592,
+          "line": 14528,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -32410,7 +33399,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 13594,
+          "line": 14530,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -32418,7 +33407,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 13599,
+          "line": 14535,
           "kind": "struct",
           "field_names": [
             "n",
@@ -32429,7 +33418,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 13606,
+          "line": 14542,
           "kind": "struct",
           "field_names": [
             "n"
@@ -32439,7 +33428,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 13608,
+          "line": 14544,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -32447,7 +33436,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 13612,
+          "line": 14548,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -32457,7 +33446,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 13614,
+          "line": 14550,
           "kind": "struct",
           "field_names": [
             "level"
@@ -32469,7 +33458,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 13617,
+          "line": 14553,
           "kind": "struct",
           "field_names": [
             "max"
@@ -32481,7 +33470,7 @@
         },
         {
           "name": "OncePerOpponentPerTurn",
-          "line": 13621,
+          "line": 14557,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: \"for the first time during each of their turns\" — fires once per opponent per turn. Used by Valgavoth, Harrower of Souls: \"Whenever an opponent loses life for the first time during each of their turns, ...\"",
@@ -32491,7 +33480,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 13628,
+          "line": 14564,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -33021,8 +34010,18 @@
           ]
         },
         {
+          "name": "ConniveResolved",
+          "line": 163,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.50b: A permanent connived (the connive process — draw, discard, maybe +1/+1 — completed).",
+          "cr_refs": [
+            "CR 701.50b"
+          ]
+        },
+        {
           "name": "Exerted",
-          "line": 162,
+          "line": 165,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.43d: A creature was exerted.",
@@ -33032,7 +34031,7 @@
         },
         {
           "name": "Enlisted",
-          "line": 164,
+          "line": 167,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.154c: A creature enlisted another creature.",
@@ -33042,7 +34041,7 @@
         },
         {
           "name": "Foretold",
-          "line": 166,
+          "line": 169,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143a: A card was foretold.",
@@ -33052,7 +34051,7 @@
         },
         {
           "name": "Fight",
-          "line": 169,
+          "line": 172,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.14: A fight resolution (separate from generic deals-damage because the matcher dispatches on `EffectResolved { kind: Fight }`).",
@@ -33062,7 +34061,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 171,
+          "line": 174,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26c: A permanent phased in.",
@@ -33072,7 +34071,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 173,
+          "line": 176,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26b: A permanent phased out.",
@@ -33085,7 +34084,7 @@
     },
     "TriggerMode": {
       "file": "crates/engine/src/types/triggers.rs",
-      "line": 201,
+      "line": 210,
       "doc": "All trigger modes from Forge's TriggerType enum (CR 603).  Triggered abilities have a trigger condition and an effect, written as \"[When/Whenever/At] [trigger condition], [effect]\" (CR 603.1). When a game event matches a trigger condition, the ability automatically triggers (CR 603.2) and is placed on the stack the next time a player would receive priority (CR 603.3).  Matched case-sensitively against Forge trigger mode strings.",
       "cr_refs": [
         "CR 603",
@@ -33096,7 +34095,7 @@
       "variants": [
         {
           "name": "ChangesZone",
-          "line": 204,
+          "line": 213,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6a: Enters-the-battlefield and other zone-change triggers.",
@@ -33106,7 +34105,7 @@
         },
         {
           "name": "ChangesZoneAll",
-          "line": 206,
+          "line": 215,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6: Zone change affecting all objects matching a filter.",
@@ -33116,7 +34115,7 @@
         },
         {
           "name": "ChangesController",
-          "line": 208,
+          "line": 217,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes\" trigger — fires when control changes, not while state persists.",
@@ -33126,7 +34125,7 @@
         },
         {
           "name": "LeavesBattlefield",
-          "line": 210,
+          "line": 219,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.6c: Leaves-the-battlefield trigger — fires when a permanent moves from battlefield.",
@@ -33136,7 +34135,7 @@
         },
         {
           "name": "DamageDone",
-          "line": 214,
+          "line": 223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when a source deals damage.",
@@ -33146,7 +34145,7 @@
         },
         {
           "name": "DamageDoneOnce",
-          "line": 215,
+          "line": 224,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33154,7 +34153,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 216,
+          "line": 225,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33162,7 +34161,7 @@
         },
         {
           "name": "DamageDealtOnce",
-          "line": 217,
+          "line": 226,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33170,7 +34169,7 @@
         },
         {
           "name": "DamageDoneOnceByController",
-          "line": 218,
+          "line": 227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33178,7 +34177,7 @@
         },
         {
           "name": "DamageReceived",
-          "line": 220,
+          "line": 229,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2: Trigger when an object or player is dealt damage.",
@@ -33188,7 +34187,7 @@
         },
         {
           "name": "DamagePreventedOnce",
-          "line": 221,
+          "line": 230,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33196,7 +34195,7 @@
         },
         {
           "name": "ExcessDamage",
-          "line": 222,
+          "line": 231,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33204,7 +34203,7 @@
         },
         {
           "name": "ExcessDamageAll",
-          "line": 223,
+          "line": 232,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33212,7 +34211,7 @@
         },
         {
           "name": "SpellCast",
-          "line": 227,
+          "line": 236,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2i: Triggers when a spell becomes cast.",
@@ -33222,7 +34221,7 @@
         },
         {
           "name": "SpellCopy",
-          "line": 228,
+          "line": 237,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33230,7 +34229,7 @@
         },
         {
           "name": "SpellCastOrCopy",
-          "line": 229,
+          "line": 238,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33238,7 +34237,7 @@
         },
         {
           "name": "AbilityCast",
-          "line": 230,
+          "line": 239,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33246,7 +34245,7 @@
         },
         {
           "name": "AbilityResolves",
-          "line": 231,
+          "line": 240,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33254,7 +34253,7 @@
         },
         {
           "name": "AbilityTriggered",
-          "line": 232,
+          "line": 241,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33262,7 +34261,7 @@
         },
         {
           "name": "SpellAbilityCast",
-          "line": 233,
+          "line": 242,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33270,7 +34269,7 @@
         },
         {
           "name": "SpellAbilityCopy",
-          "line": 234,
+          "line": 243,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33278,7 +34277,7 @@
         },
         {
           "name": "Countered",
-          "line": 236,
+          "line": 245,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2g: Triggers when a spell or ability is countered (event must actually occur).",
@@ -33288,7 +34287,7 @@
         },
         {
           "name": "Attacks",
-          "line": 240,
+          "line": 249,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3a: \"Whenever [a creature] attacks\" — triggers when declared as attacker.",
@@ -33298,7 +34297,7 @@
         },
         {
           "name": "AttackersDeclared",
-          "line": 242,
+          "line": 251,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever [a player] attacks\" — triggers when one or more creatures attack.",
@@ -33308,7 +34307,7 @@
         },
         {
           "name": "YouAttack",
-          "line": 244,
+          "line": 253,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d: \"Whenever you attack\" — triggers for the attacking player.",
@@ -33318,7 +34317,7 @@
         },
         {
           "name": "YouAttackUnblocked",
-          "line": 248,
+          "line": 257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.3d + CR 509.1h: \"Whenever one or more [creatures] attack [you] and aren't blocked\" — fires after blockers are declared when at least one matching attacker was not assigned blockers.",
@@ -33329,7 +34328,7 @@
         },
         {
           "name": "AttackersDeclaredOneTarget",
-          "line": 249,
+          "line": 258,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33337,7 +34336,7 @@
         },
         {
           "name": "AttackerBlocked",
-          "line": 251,
+          "line": 260,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when an attacking creature becomes blocked.",
@@ -33347,7 +34346,7 @@
         },
         {
           "name": "AttackerBlockedOnce",
-          "line": 252,
+          "line": 261,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33355,7 +34354,7 @@
         },
         {
           "name": "AttackerBlockedByCreature",
-          "line": 254,
+          "line": 263,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Triggers when a specific creature blocks the attacker.",
@@ -33365,7 +34364,7 @@
         },
         {
           "name": "AttackerUnblocked",
-          "line": 255,
+          "line": 264,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33373,7 +34372,7 @@
         },
         {
           "name": "AttackerUnblockedOnce",
-          "line": 256,
+          "line": 265,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33381,7 +34380,7 @@
         },
         {
           "name": "Blocks",
-          "line": 260,
+          "line": 269,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: \"Whenever [a creature] blocks\" — triggers when declared as blocker.",
@@ -33391,7 +34390,7 @@
         },
         {
           "name": "BlockersDeclared",
-          "line": 262,
+          "line": 271,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.4: Triggers after all blockers are declared.",
@@ -33401,7 +34400,7 @@
         },
         {
           "name": "BecomesBlocked",
-          "line": 264,
+          "line": 273,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h + CR 603.2e: \"Becomes blocked\" trigger.",
@@ -33412,7 +34411,7 @@
         },
         {
           "name": "CounterAdded",
-          "line": 268,
+          "line": 277,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.6: Triggers when one or more counters are placed on a permanent or player.",
@@ -33422,7 +34421,7 @@
         },
         {
           "name": "CounterAddedOnce",
-          "line": 269,
+          "line": 278,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33430,7 +34429,7 @@
         },
         {
           "name": "CounterAddedAll",
-          "line": 270,
+          "line": 279,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33438,7 +34437,7 @@
         },
         {
           "name": "CounterPlayerAddedAll",
-          "line": 271,
+          "line": 280,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33446,7 +34445,7 @@
         },
         {
           "name": "CounterTypeAddedAll",
-          "line": 272,
+          "line": 281,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33454,7 +34453,7 @@
         },
         {
           "name": "CounterRemoved",
-          "line": 273,
+          "line": 282,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33462,7 +34461,7 @@
         },
         {
           "name": "CounterRemovedOnce",
-          "line": 274,
+          "line": 283,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33470,7 +34469,7 @@
         },
         {
           "name": "Sacrificed",
-          "line": 278,
+          "line": 287,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21: Triggers when a permanent is sacrificed.",
@@ -33480,7 +34479,7 @@
         },
         {
           "name": "SacrificedOnce",
-          "line": 279,
+          "line": 288,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33488,7 +34487,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 281,
+          "line": 290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8: Triggers when a permanent is destroyed.",
@@ -33498,7 +34497,7 @@
         },
         {
           "name": "Taps",
-          "line": 283,
+          "line": 292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes tapped.",
@@ -33508,7 +34507,7 @@
         },
         {
           "name": "TapsForMana",
-          "line": 285,
+          "line": 294,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.12a: Triggers when a permanent is tapped for mana.",
@@ -33518,7 +34517,7 @@
         },
         {
           "name": "TapAll",
-          "line": 286,
+          "line": 295,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33526,7 +34525,7 @@
         },
         {
           "name": "Untaps",
-          "line": 288,
+          "line": 297,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26: Triggers when a permanent becomes untapped.",
@@ -33536,7 +34535,7 @@
         },
         {
           "name": "UntapAll",
-          "line": 289,
+          "line": 298,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33544,7 +34543,7 @@
         },
         {
           "name": "BecomesTarget",
-          "line": 293,
+          "line": 302,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2e: \"Becomes the target\" trigger — fires when a spell/ability targets an object.",
@@ -33554,7 +34553,7 @@
         },
         {
           "name": "BecomesTargetOnce",
-          "line": 294,
+          "line": 303,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33562,7 +34561,7 @@
         },
         {
           "name": "Drawn",
-          "line": 298,
+          "line": 307,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1: Triggers when a player draws a card.",
@@ -33572,7 +34571,7 @@
         },
         {
           "name": "Discarded",
-          "line": 300,
+          "line": 309,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9: Triggers when a player discards a card.",
@@ -33582,7 +34581,7 @@
         },
         {
           "name": "DiscardedAll",
-          "line": 301,
+          "line": 310,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33590,7 +34589,7 @@
         },
         {
           "name": "Milled",
-          "line": 303,
+          "line": 312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17: Triggers when cards are milled (put from library into graveyard).",
@@ -33600,7 +34599,7 @@
         },
         {
           "name": "MilledOnce",
-          "line": 304,
+          "line": 313,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33608,7 +34607,7 @@
         },
         {
           "name": "MilledAll",
-          "line": 305,
+          "line": 314,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33616,7 +34615,7 @@
         },
         {
           "name": "Exiled",
-          "line": 306,
+          "line": 315,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33624,7 +34623,7 @@
         },
         {
           "name": "Revealed",
-          "line": 307,
+          "line": 316,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33632,7 +34631,7 @@
         },
         {
           "name": "Shuffled",
-          "line": 309,
+          "line": 318,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.24: Triggers when a library is shuffled.",
@@ -33642,7 +34641,7 @@
         },
         {
           "name": "LifeGained",
-          "line": 313,
+          "line": 322,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains life.",
@@ -33652,7 +34651,7 @@
         },
         {
           "name": "LifeLost",
-          "line": 315,
+          "line": 324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player loses life.",
@@ -33662,7 +34661,7 @@
         },
         {
           "name": "LifeLostAll",
-          "line": 316,
+          "line": 325,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33670,7 +34669,7 @@
         },
         {
           "name": "LifeChanged",
-          "line": 318,
+          "line": 327,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 119.3: Triggers when a player gains or loses life.",
@@ -33680,7 +34679,7 @@
         },
         {
           "name": "PayLife",
-          "line": 319,
+          "line": 328,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33688,7 +34687,7 @@
         },
         {
           "name": "PayCumulativeUpkeep",
-          "line": 321,
+          "line": 330,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.24: Cumulative upkeep trigger.",
@@ -33698,7 +34697,7 @@
         },
         {
           "name": "PayEcho",
-          "line": 323,
+          "line": 332,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30: Echo trigger.",
@@ -33708,7 +34707,7 @@
         },
         {
           "name": "TokenCreated",
-          "line": 327,
+          "line": 336,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Triggers when a token is created.",
@@ -33718,7 +34717,7 @@
         },
         {
           "name": "TokenCreatedOnce",
-          "line": 328,
+          "line": 337,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33726,7 +34725,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 332,
+          "line": 341,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.37e: Triggers when a face-down permanent is turned face up (morph/manifest/cloak).",
@@ -33736,7 +34735,7 @@
         },
         {
           "name": "Transformed",
-          "line": 334,
+          "line": 343,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27: Triggers when a permanent transforms.",
@@ -33746,7 +34745,7 @@
         },
         {
           "name": "Phase",
-          "line": 338,
+          "line": 347,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [phase/step]\" — triggers at phase start.",
@@ -33756,7 +34755,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 340,
+          "line": 349,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a phased-out permanent phases in.",
@@ -33766,7 +34765,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 342,
+          "line": 351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.26: Triggers when a permanent phases out.",
@@ -33776,7 +34775,7 @@
         },
         {
           "name": "PhaseOutAll",
-          "line": 343,
+          "line": 352,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33784,7 +34783,7 @@
         },
         {
           "name": "TurnBegin",
-          "line": 345,
+          "line": 354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2b: \"At the beginning of [a player's] turn\" trigger.",
@@ -33794,7 +34793,7 @@
         },
         {
           "name": "NewGame",
-          "line": 346,
+          "line": 355,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -33802,7 +34801,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 350,
+          "line": 359,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725: Triggers when a player becomes the monarch.",
@@ -33812,7 +34811,7 @@
         },
         {
           "name": "TakesInitiative",
-          "line": 352,
+          "line": 361,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.2: Triggers when a player takes the initiative.",
@@ -33822,7 +34821,7 @@
         },
         {
           "name": "LosesGame",
-          "line": 356,
+          "line": 365,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3a: Triggers when a player loses the game.",
@@ -33832,7 +34831,7 @@
         },
         {
           "name": "Championed",
-          "line": 360,
+          "line": 369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.72: Champion trigger.",
@@ -33842,7 +34841,7 @@
         },
         {
           "name": "Exerted",
-          "line": 362,
+          "line": 371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.43: Triggers when a creature is exerted.",
@@ -33852,7 +34851,7 @@
         },
         {
           "name": "Crewed",
-          "line": 364,
+          "line": 373,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Triggers when a Vehicle becomes crewed.",
@@ -33862,7 +34861,7 @@
         },
         {
           "name": "Crews",
-          "line": 366,
+          "line": 375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122: Actor-side crew trigger — fires when this permanent crews a Vehicle.",
@@ -33872,7 +34871,7 @@
         },
         {
           "name": "Saddled",
-          "line": 368,
+          "line": 377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Triggers when a creature becomes saddled.",
@@ -33882,7 +34881,7 @@
         },
         {
           "name": "Saddles",
-          "line": 371,
+          "line": 380,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171c: Actor-side saddle trigger — fires when this permanent saddles a Mount. Reserved — no cards today print this without the compound form.",
@@ -33892,7 +34891,7 @@
         },
         {
           "name": "SaddlesOrCrews",
-          "line": 374,
+          "line": 383,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122 + CR 702.171c: Compound actor-side trigger — fires on either saddling a Mount OR crewing a Vehicle.",
@@ -33903,7 +34902,7 @@
         },
         {
           "name": "Cycled",
-          "line": 376,
+          "line": 385,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29: Triggers when a card is cycled.",
@@ -33913,7 +34912,7 @@
         },
         {
           "name": "CycledOrDiscarded",
-          "line": 379,
+          "line": 388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29d: Triggers when a card is cycled or discarded. Fires on either event but only once per cycling action.",
@@ -33923,7 +34922,7 @@
         },
         {
           "name": "NinjutsuActivated",
-          "line": 381,
+          "line": 390,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Triggers when a player activates a ninjutsu-family ability.",
@@ -33933,7 +34932,7 @@
         },
         {
           "name": "KeywordAbilityActivated",
-          "line": 385,
+          "line": 394,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 702.107a + CR 702.142b + CR 702.177a: Triggers when a player activates a keyword ability tagged by `AbilityTag`. Parameterized to avoid per-keyword sibling proliferation: `AbilityTag::Boast`, `AbilityTag::Exhaust`, `AbilityTag::Outlast` are the current values.",
@@ -33945,7 +34944,7 @@
         },
         {
           "name": "AbilityActivated",
-          "line": 398,
+          "line": 407,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.1 + CR 605.1a: Triggers when any activated ability is activated. Listens to `GameEvent::AbilityActivated`, which is emitted only for stack-using activated abilities — by CR 605.3b, mana abilities resolve without using the stack and do not produce this event. The \"that isn't a mana ability\" qualifier on cards like Burning-Tree Shaman and Flamescroll Celebrant is thus automatically satisfied by listening here, and is additionally preserved in the AST via `TriggerCondition::ActivatedAbilityIsNonMana` for future-proofing should the event family ever widen. Player scope (`a player` / `an opponent` / `you`) lives on `valid_target` (`TargetFilter`); source-object filters (e.g., \"an ability of an artifact source\") live on `valid_card` — both reuse existing infrastructure shared with `KeywordAbilityActivated`.",
@@ -33957,7 +34956,7 @@
         },
         {
           "name": "Evolve",
-          "line": 400,
+          "line": 409,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: Evolve keyword trigger — when a creature enters with greater power/toughness.",
@@ -33967,7 +34966,7 @@
         },
         {
           "name": "Evolved",
-          "line": 402,
+          "line": 411,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100b: Triggers when a creature evolves.",
@@ -33977,7 +34976,7 @@
         },
         {
           "name": "Explored",
-          "line": 404,
+          "line": 413,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.44: Triggers when a creature explores.",
@@ -33987,7 +34986,7 @@
         },
         {
           "name": "Exploited",
-          "line": 406,
+          "line": 415,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.110: Exploit trigger — when a creature exploits another creature.",
@@ -33997,7 +34996,7 @@
         },
         {
           "name": "Enlisted",
-          "line": 408,
+          "line": 417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.154: Triggers when a creature becomes enlisted.",
@@ -34007,7 +35006,7 @@
         },
         {
           "name": "ManaAdded",
-          "line": 412,
+          "line": 421,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.4: Triggers when mana is added to a player's mana pool.",
@@ -34017,7 +35016,7 @@
         },
         {
           "name": "ManaExpend",
-          "line": 413,
+          "line": 422,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34025,7 +35024,7 @@
         },
         {
           "name": "LandPlayed",
-          "line": 417,
+          "line": 426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 505.6b: Triggers when a land is played.",
@@ -34036,7 +35035,7 @@
         },
         {
           "name": "PlayCard",
-          "line": 420,
+          "line": 429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.1a + CR 701.18b: \"Whenever you play a card\" — playing a card means playing it as a land OR casting it as a spell, so this fires on both events.",
@@ -34047,7 +35046,7 @@
         },
         {
           "name": "Attached",
-          "line": 424,
+          "line": 433,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Aura, Equipment, or Fortification becomes attached.",
@@ -34057,7 +35056,7 @@
         },
         {
           "name": "Unattach",
-          "line": 426,
+          "line": 435,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3: Triggers when an Equipment or Aura becomes unattached.",
@@ -34067,7 +35066,7 @@
         },
         {
           "name": "Adapt",
-          "line": 430,
+          "line": 439,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.46: Triggers when a creature adapts.",
@@ -34076,8 +35075,18 @@
           ]
         },
         {
+          "name": "Connives",
+          "line": 442,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.50b: Triggers when a permanent connives (after the connive process completes).",
+          "cr_refs": [
+            "CR 701.50b"
+          ]
+        },
+        {
           "name": "Foretell",
-          "line": 432,
+          "line": 444,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143: Triggers when a card is foretold.",
@@ -34087,7 +35096,7 @@
         },
         {
           "name": "Investigated",
-          "line": 434,
+          "line": 446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Triggers when a player investigates.",
@@ -34097,70 +35106,6 @@
         },
         {
           "name": "DungeonCompleted",
-          "line": 437,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RoomEntered",
-          "line": 438,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlanarDice",
-          "line": 441,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlaneswalkedFrom",
-          "line": 442,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlaneswalkedTo",
-          "line": 443,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChaosEnsues",
-          "line": 444,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RolledDie",
-          "line": 447,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RolledDieOnce",
-          "line": 448,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FlippedCoin",
           "line": 449,
           "kind": "unit",
           "field_names": [],
@@ -34168,7 +35113,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clashed",
+          "name": "RoomEntered",
           "line": 450,
           "kind": "unit",
           "field_names": [],
@@ -34176,8 +35121,72 @@
           "cr_refs": []
         },
         {
-          "name": "DayTimeChanges",
+          "name": "PlanarDice",
+          "line": 453,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PlaneswalkedFrom",
           "line": 454,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PlaneswalkedTo",
+          "line": 455,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChaosEnsues",
+          "line": 456,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RolledDie",
+          "line": 459,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RolledDieOnce",
+          "line": 460,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "FlippedCoin",
+          "line": 461,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clashed",
+          "line": 462,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DayTimeChanges",
+          "line": 466,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730: Triggers when it becomes day or night.",
@@ -34187,7 +35196,7 @@
         },
         {
           "name": "ClassLevelGained",
-          "line": 457,
+          "line": 469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34195,7 +35204,7 @@
         },
         {
           "name": "Copied",
-          "line": 460,
+          "line": 472,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34203,7 +35212,7 @@
         },
         {
           "name": "ConjureAll",
-          "line": 461,
+          "line": 473,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34211,7 +35220,7 @@
         },
         {
           "name": "Vote",
-          "line": 464,
+          "line": 476,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34219,7 +35228,7 @@
         },
         {
           "name": "BecomeRenowned",
-          "line": 468,
+          "line": 480,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112: Triggers when a creature becomes renowned.",
@@ -34229,7 +35238,7 @@
         },
         {
           "name": "BecomeMonstrous",
-          "line": 470,
+          "line": 482,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.99: Triggers when a creature becomes monstrous.",
@@ -34239,7 +35248,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 474,
+          "line": 486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.34: Triggers when a player proliferates.",
@@ -34249,7 +35258,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 475,
+          "line": 487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34257,7 +35266,7 @@
         },
         {
           "name": "Surveil",
-          "line": 479,
+          "line": 491,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.25: Triggers when a player surveils.",
@@ -34267,7 +35276,7 @@
         },
         {
           "name": "Scry",
-          "line": 481,
+          "line": 493,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.22: Triggers when a player scries.",
@@ -34277,7 +35286,7 @@
         },
         {
           "name": "PlayerPerformedAction",
-          "line": 483,
+          "line": 495,
           "kind": "unit",
           "field_names": [],
           "doc": "General typed player-action trigger for joined action lists.",
@@ -34285,7 +35294,7 @@
         },
         {
           "name": "Fight",
-          "line": 487,
+          "line": 499,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.14: Triggers when creatures fight.",
@@ -34295,86 +35304,6 @@
         },
         {
           "name": "FightOnce",
-          "line": 488,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Abandoned",
-          "line": 491,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CaseSolved",
-          "line": 492,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ClaimPrize",
-          "line": 493,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CollectEvidence",
-          "line": 494,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CommitCrime",
-          "line": 495,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CrankContraption",
-          "line": 496,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Devoured",
-          "line": 497,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Discover",
-          "line": 498,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Forage",
-          "line": 499,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "FullyUnlock",
           "line": 500,
           "kind": "unit",
           "field_names": [],
@@ -34382,23 +35311,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveGift",
-          "line": 501,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ManifestDread",
-          "line": 502,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Mentored",
+          "name": "Abandoned",
           "line": 503,
           "kind": "unit",
           "field_names": [],
@@ -34406,7 +35319,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mutates",
+          "name": "CaseSolved",
           "line": 504,
           "kind": "unit",
           "field_names": [],
@@ -34414,7 +35327,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchedLibrary",
+          "name": "ClaimPrize",
           "line": 505,
           "kind": "unit",
           "field_names": [],
@@ -34422,7 +35335,7 @@
           "cr_refs": []
         },
         {
-          "name": "SeekAll",
+          "name": "CollectEvidence",
           "line": 506,
           "kind": "unit",
           "field_names": [],
@@ -34430,7 +35343,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetInMotion",
+          "name": "CommitCrime",
           "line": 507,
           "kind": "unit",
           "field_names": [],
@@ -34438,7 +35351,7 @@
           "cr_refs": []
         },
         {
-          "name": "Specializes",
+          "name": "CrankContraption",
           "line": 508,
           "kind": "unit",
           "field_names": [],
@@ -34446,7 +35359,7 @@
           "cr_refs": []
         },
         {
-          "name": "Stationed",
+          "name": "Devoured",
           "line": 509,
           "kind": "unit",
           "field_names": [],
@@ -34454,7 +35367,7 @@
           "cr_refs": []
         },
         {
-          "name": "Trains",
+          "name": "Discover",
           "line": 510,
           "kind": "unit",
           "field_names": [],
@@ -34462,7 +35375,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnlockDoor",
+          "name": "Forage",
           "line": 511,
           "kind": "unit",
           "field_names": [],
@@ -34470,7 +35383,7 @@
           "cr_refs": []
         },
         {
-          "name": "VisitAttraction",
+          "name": "FullyUnlock",
           "line": 512,
           "kind": "unit",
           "field_names": [],
@@ -34478,7 +35391,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesCrewed",
+          "name": "GiveGift",
           "line": 513,
           "kind": "unit",
           "field_names": [],
@@ -34486,7 +35399,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesPlotted",
+          "name": "ManifestDread",
           "line": 514,
           "kind": "unit",
           "field_names": [],
@@ -34494,7 +35407,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomesSaddled",
+          "name": "Mentored",
           "line": 515,
           "kind": "unit",
           "field_names": [],
@@ -34502,7 +35415,7 @@
           "cr_refs": []
         },
         {
-          "name": "Immediate",
+          "name": "Mutates",
           "line": 516,
           "kind": "unit",
           "field_names": [],
@@ -34510,8 +35423,104 @@
           "cr_refs": []
         },
         {
-          "name": "Always",
+          "name": "SearchedLibrary",
+          "line": 517,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SeekAll",
           "line": 518,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SetInMotion",
+          "line": 519,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Specializes",
+          "line": 520,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Stationed",
+          "line": 521,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Trains",
+          "line": 522,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "UnlockDoor",
+          "line": 523,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "VisitAttraction",
+          "line": 524,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomesCrewed",
+          "line": 525,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomesPlotted",
+          "line": 526,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomesSaddled",
+          "line": 527,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Immediate",
+          "line": 528,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Always",
+          "line": 530,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.1: \"Always\" — a special trigger mode representing a continuous trigger condition.",
@@ -34521,7 +35530,7 @@
         },
         {
           "name": "EntersOrAttacks",
-          "line": 522,
+          "line": 534,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ enters or attacks\" — fires on both ETB (CR 603.6a) and attack (CR 508.3a) events.",
@@ -34532,7 +35541,7 @@
         },
         {
           "name": "AttacksOrBlocks",
-          "line": 524,
+          "line": 536,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Whenever ~ attacks or blocks\" — fires on both attack (CR 508.3a) and block (CR 509.1h) events.",
@@ -34543,7 +35552,7 @@
         },
         {
           "name": "StateCondition",
-          "line": 530,
+          "line": 542,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.8: State trigger — fires when a game-state condition becomes true, rather than in response to an event. Checked whenever a player would receive priority. The engine tracks whether the trigger is already on the stack to prevent re-triggering until the ability has resolved, been countered, or otherwise left the stack.",
@@ -34553,7 +35562,7 @@
         },
         {
           "name": "Airbend",
-          "line": 533,
+          "line": 545,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34561,7 +35570,7 @@
         },
         {
           "name": "Earthbend",
-          "line": 534,
+          "line": 546,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34569,7 +35578,7 @@
         },
         {
           "name": "Firebend",
-          "line": 535,
+          "line": 547,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34577,7 +35586,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 536,
+          "line": 548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34585,7 +35594,7 @@
         },
         {
           "name": "ElementalBend",
-          "line": 537,
+          "line": 549,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34593,7 +35602,7 @@
         },
         {
           "name": "HauntedCreatureDies",
-          "line": 545,
+          "line": 557,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.55c: Haunt payoff — \"When the creature this card haunts dies, …\". A dynamic, per-card trigger that fires while the card is in the exile zone (`trigger_zones = [Exile]`): it matches a creature's death only when that creature is the one the source card haunts, resolved through the `ExileLinkKind::Haunt` link. Matched by `game::haunt::match_haunted_creature_dies`.",
@@ -34603,7 +35612,7 @@
         },
         {
           "name": "Unknown",
-          "line": 548,
+          "line": 560,
           "kind": "tuple",
           "field_names": [],
           "doc": "Fallback for unrecognized trigger mode strings.",
@@ -34671,13 +35680,13 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2061,
+      "line": 2168,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 2062,
+          "line": 2169,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34685,7 +35694,7 @@
         },
         {
           "name": "Land",
-          "line": 2063,
+          "line": 2170,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34693,7 +35702,7 @@
         },
         {
           "name": "Artifact",
-          "line": 2064,
+          "line": 2171,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34701,7 +35710,7 @@
         },
         {
           "name": "Enchantment",
-          "line": 2065,
+          "line": 2172,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34709,7 +35718,7 @@
         },
         {
           "name": "Instant",
-          "line": 2066,
+          "line": 2173,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34717,7 +35726,7 @@
         },
         {
           "name": "Sorcery",
-          "line": 2067,
+          "line": 2174,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34725,7 +35734,7 @@
         },
         {
           "name": "Planeswalker",
-          "line": 2068,
+          "line": 2175,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34733,7 +35742,7 @@
         },
         {
           "name": "Battle",
-          "line": 2070,
+          "line": 2177,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -34743,7 +35752,7 @@
         },
         {
           "name": "Permanent",
-          "line": 2071,
+          "line": 2178,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34751,7 +35760,7 @@
         },
         {
           "name": "Card",
-          "line": 2072,
+          "line": 2179,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34759,7 +35768,7 @@
         },
         {
           "name": "Any",
-          "line": 2073,
+          "line": 2180,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34767,7 +35776,7 @@
         },
         {
           "name": "Non",
-          "line": 2076,
+          "line": 2183,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -34777,7 +35786,7 @@
         },
         {
           "name": "Subtype",
-          "line": 2079,
+          "line": 2186,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -34788,7 +35797,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2082,
+          "line": 2189,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -34867,7 +35876,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4859,
+      "line": 5063,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -34876,7 +35885,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 4861,
+          "line": 5065,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34884,7 +35893,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 4862,
+          "line": 5066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34892,7 +35901,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 4863,
+          "line": 5067,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34902,7 +35911,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 4866,
+          "line": 5070,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34912,7 +35921,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 4878,
+          "line": 5082,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -34928,7 +35937,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4174,
+      "line": 4354,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -34941,7 +35950,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 4178,
+          "line": 4358,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -34954,7 +35963,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 4182,
+          "line": 4362,
           "kind": "struct",
           "field_names": [
             "property",
@@ -34972,7 +35981,7 @@
     },
     "VoteActor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2305,
+      "line": 2316,
       "doc": "CR 101.4 + CR 608.2 (Battlebond friend-or-foe keyword action — no explicit CR section): The \"who acts\" semantic for a `WaitingFor::VoteChoice` step.  * `SubjectActs` — the player named by `player` casts the vote for   themselves. Classic Council's-dilemma (CR 701.38) is exclusively this   case: each voter acts on their own behalf and APNAP iteration changes   both subject and actor together. * `Delegated(actor)` — a fixed `actor` casts every vote on behalf of the   cycling subjects. The Battlebond friend-or-foe spell controller pins   themselves here so `player` cycles through every player in APNAP order   while authorization stays with the controller.  Stored on `WaitingFor::VoteChoice` instead of `Option<PlayerId>` so the \"is this delegated?\" discriminator is a named sum type with a meaningful pair of variant names, not a boolean-flavored optional. Callers route through [`VoteActor::resolve`] to get the authorized submitter without branching at every call site.",
       "cr_refs": [
         "CR 101.4",
@@ -34982,7 +35991,7 @@
       "variants": [
         {
           "name": "SubjectActs",
-          "line": 2306,
+          "line": 2317,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -34990,7 +35999,7 @@
         },
         {
           "name": "Delegated",
-          "line": 2307,
+          "line": 2318,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -34999,9 +36008,43 @@
       ],
       "sibling_clusters": []
     },
+    "VoteTally": {
+      "file": "crates/engine/src/types/ability.rs",
+      "line": 10358,
+      "doc": "CR 701.38a: How a completed `Effect::Vote` tally maps onto its `per_choice_effect` slots. CR 701.38 defines only the vote procedure; the strict-majority / tie-break outcome semantics below are card-defined, not a CR subrule.  `PerVote` is the Council's-dilemma family (Tivit, Capital Punishment, Expropriate, Emissary Green): every per-choice sub-effect resolves, fanning out once per vote (or once per voter / once aggregate) tallied for that choice. This is the historical `Effect::Vote` behavior and the serde default, so pre-existing serialized votes deserialize unchanged.  `Threshold` is the Will-of-the-council family (Plea for Power, Split Decision, Coercive Portal, Magister of Worth, Tyrant's Choice, Trial of a Time Lord IV): the players vote between two named outcomes and exactly ONE `per_choice_effect` resolves — the choice with strictly more votes. Ties resolve to `tie_breaker_index`, matching the Oracle phrasing \"If <B> gets more votes **or the vote is tied**, <effect-B>\".",
+      "cr_refs": [
+        "CR 701.38",
+        "CR 701.38a"
+      ],
+      "variants": [
+        {
+          "name": "PerVote",
+          "line": 10362,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "CR 701.38a: Every per-choice effect resolves, fanning out per the tally for that choice. The historical default.",
+          "cr_refs": [
+            "CR 701.38a"
+          ]
+        },
+        {
+          "name": "Threshold",
+          "line": 10368,
+          "kind": "struct",
+          "field_names": [
+            "tie_breaker_index"
+          ],
+          "doc": "CR 701.38a: The single winning choice's effect resolves once. The strict-majority rule and tie behavior are card-defined (not a CR subrule): on a tie, `tie_breaker_index` (the choice whose Oracle clause reads \"...or the vote is tied\") wins. `u8` indexes `choices`; vote cardinality is bounded by Magic card design.",
+          "cr_refs": [
+            "CR 701.38a"
+          ]
+        }
+      ],
+      "sibling_clusters": []
+    },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 9635,
+      "line": 10321,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -35010,7 +36053,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 9638,
+          "line": 10324,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -35020,7 +36063,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 9642,
+          "line": 10328,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -35030,7 +36073,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 9650,
+          "line": 10336,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -35044,13 +36087,13 @@
     },
     "WaitingFor": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 2596,
+      "line": 2626,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Priority",
-          "line": 2597,
+          "line": 2627,
           "kind": "struct",
           "field_names": [
             "player"
@@ -35060,7 +36103,7 @@
         },
         {
           "name": "MulliganDecision",
-          "line": 2613,
+          "line": 2643,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -35075,7 +36118,7 @@
         },
         {
           "name": "MulliganBottomCards",
-          "line": 2626,
+          "line": 2656,
           "kind": "struct",
           "field_names": [
             "pending"
@@ -35087,7 +36130,7 @@
         },
         {
           "name": "OpeningHandBottomCards",
-          "line": 2632,
+          "line": 2662,
           "kind": "struct",
           "field_names": [
             "pending",
@@ -35098,7 +36141,7 @@
         },
         {
           "name": "ManaPayment",
-          "line": 2636,
+          "line": 2666,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35109,7 +36152,7 @@
         },
         {
           "name": "AssistChoosePlayer",
-          "line": 2650,
+          "line": 2680,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35124,7 +36167,7 @@
         },
         {
           "name": "AssistPayment",
-          "line": 2664,
+          "line": 2694,
           "kind": "struct",
           "field_names": [
             "caster",
@@ -35139,7 +36182,7 @@
         },
         {
           "name": "ChooseXValue",
-          "line": 2686,
+          "line": 2716,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35157,7 +36200,7 @@
         },
         {
           "name": "TargetSelection",
-          "line": 2697,
+          "line": 2727,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35171,7 +36214,7 @@
         },
         {
           "name": "DeclareAttackers",
-          "line": 2713,
+          "line": 2743,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35183,7 +36226,7 @@
         },
         {
           "name": "DeclareBlockers",
-          "line": 2719,
+          "line": 2749,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35196,7 +36239,7 @@
         },
         {
           "name": "UntapChoice",
-          "line": 2735,
+          "line": 2765,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35210,7 +36253,7 @@
         },
         {
           "name": "ChooseUntapSubset",
-          "line": 2754,
+          "line": 2784,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35224,7 +36267,7 @@
         },
         {
           "name": "ExertChoice",
-          "line": 2769,
+          "line": 2799,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35239,7 +36282,7 @@
         },
         {
           "name": "EnlistChoice",
-          "line": 2780,
+          "line": 2810,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35255,7 +36298,7 @@
         },
         {
           "name": "GameOver",
-          "line": 2787,
+          "line": 2817,
           "kind": "struct",
           "field_names": [
             "winner"
@@ -35265,7 +36308,7 @@
         },
         {
           "name": "ReplacementChoice",
-          "line": 2790,
+          "line": 2820,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35277,7 +36320,7 @@
         },
         {
           "name": "OrderTriggers",
-          "line": 2803,
+          "line": 2833,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35292,7 +36335,7 @@
         },
         {
           "name": "CopyTargetChoice",
-          "line": 2809,
+          "line": 2839,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35307,7 +36350,7 @@
         },
         {
           "name": "ExploreChoice",
-          "line": 2819,
+          "line": 2849,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35323,7 +36366,7 @@
         },
         {
           "name": "ReturnAsAuraTarget",
-          "line": 2841,
+          "line": 2871,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35346,7 +36389,7 @@
         },
         {
           "name": "EquipTarget",
-          "line": 2858,
+          "line": 2888,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35358,7 +36401,7 @@
         },
         {
           "name": "CrewVehicle",
-          "line": 2864,
+          "line": 2894,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35373,7 +36416,7 @@
         },
         {
           "name": "StationTarget",
-          "line": 2875,
+          "line": 2905,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35387,7 +36430,7 @@
         },
         {
           "name": "SaddleMount",
-          "line": 2883,
+          "line": 2913,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35402,7 +36445,7 @@
         },
         {
           "name": "ScryChoice",
-          "line": 2891,
+          "line": 2921,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35413,7 +36456,7 @@
         },
         {
           "name": "CoinFlipKeepChoice",
-          "line": 2898,
+          "line": 2928,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35429,7 +36472,7 @@
         },
         {
           "name": "DigChoice",
-          "line": 2904,
+          "line": 2934,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35450,7 +36493,7 @@
         },
         {
           "name": "SurveilChoice",
-          "line": 2933,
+          "line": 2963,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35461,7 +36504,7 @@
         },
         {
           "name": "RevealChoice",
-          "line": 2937,
+          "line": 2967,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35475,7 +36518,7 @@
         },
         {
           "name": "SearchChoice",
-          "line": 2956,
+          "line": 2986,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35483,6 +36526,7 @@
             "count",
             "reveal",
             "up_to",
+            "allows_partial_find",
             "constraint",
             "split"
           ],
@@ -35491,7 +36535,7 @@
         },
         {
           "name": "SearchPartitionChoice",
-          "line": 2990,
+          "line": 3024,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35510,7 +36554,7 @@
         },
         {
           "name": "OutsideGameChoice",
-          "line": 3003,
+          "line": 3037,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35529,7 +36573,7 @@
         },
         {
           "name": "ChooseFromZoneChoice",
-          "line": 3017,
+          "line": 3051,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35546,7 +36590,7 @@
         },
         {
           "name": "ChooseOneOfBranch",
-          "line": 3029,
+          "line": 3063,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35565,7 +36609,7 @@
         },
         {
           "name": "ConniveDiscard",
-          "line": 3047,
+          "line": 3081,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35581,7 +36625,7 @@
         },
         {
           "name": "DiscardChoice",
-          "line": 3056,
+          "line": 3090,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35599,7 +36643,7 @@
         },
         {
           "name": "EffectZoneChoice",
-          "line": 3072,
+          "line": 3106,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35619,6 +36663,7 @@
             "track_exiled_by_source",
             "face_down_profile",
             "count_param",
+            "library_position",
             "is_cost_payment"
           ],
           "doc": "CR 608.2d: Player chooses object(s) from a zone during effect resolution. Generalizes the DiscardChoice pattern to sacrifice-from-battlefield and hand-to-battlefield.",
@@ -35628,7 +36673,7 @@
         },
         {
           "name": "DrawnThisTurnTopdeckChoice",
-          "line": 3130,
+          "line": 3169,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35643,7 +36688,7 @@
         },
         {
           "name": "LearnChoice",
-          "line": 3140,
+          "line": 3179,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35656,7 +36701,7 @@
         },
         {
           "name": "ManifestDreadChoice",
-          "line": 3146,
+          "line": 3185,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35670,10 +36715,13 @@
         },
         {
           "name": "TriggerTargetSelection",
-          "line": 3153,
+          "line": 3192,
           "kind": "struct",
           "field_names": [
             "player",
+            "trigger_controller",
+            "trigger_event",
+            "trigger_events",
             "target_slots",
             "mode_labels",
             "target_constraints",
@@ -35686,7 +36734,7 @@
         },
         {
           "name": "BetweenGamesSideboard",
-          "line": 3173,
+          "line": 3223,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35698,7 +36746,7 @@
         },
         {
           "name": "BetweenGamesChoosePlayDraw",
-          "line": 3178,
+          "line": 3228,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35710,7 +36758,7 @@
         },
         {
           "name": "NamedChoice",
-          "line": 3184,
+          "line": 3234,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35723,7 +36771,7 @@
         },
         {
           "name": "SpellbookDraft",
-          "line": 3195,
+          "line": 3245,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35737,7 +36785,7 @@
         },
         {
           "name": "DamageSourceChoice",
-          "line": 3205,
+          "line": 3255,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35751,7 +36799,7 @@
         },
         {
           "name": "ModeChoice",
-          "line": 3211,
+          "line": 3261,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35764,7 +36812,7 @@
         },
         {
           "name": "DiscardToHandSize",
-          "line": 3221,
+          "line": 3271,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35776,7 +36824,7 @@
         },
         {
           "name": "OptionalCostChoice",
-          "line": 3229,
+          "line": 3279,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35789,7 +36837,7 @@
         },
         {
           "name": "SpliceOffer",
-          "line": 3245,
+          "line": 3295,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35803,7 +36851,7 @@
         },
         {
           "name": "DefilerPayment",
-          "line": 3252,
+          "line": 3302,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35818,7 +36866,7 @@
         },
         {
           "name": "CastOffer",
-          "line": 3262,
+          "line": 3312,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35836,7 +36884,7 @@
         },
         {
           "name": "ModalFaceChoice",
-          "line": 3276,
+          "line": 3326,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35852,7 +36900,7 @@
         },
         {
           "name": "AlternativeCastChoice",
-          "line": 3299,
+          "line": 3349,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35878,7 +36926,7 @@
         },
         {
           "name": "MutateMergeChoice",
-          "line": 3338,
+          "line": 3388,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35895,7 +36943,7 @@
         },
         {
           "name": "CipherEncodeChoice",
-          "line": 3348,
+          "line": 3398,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35909,7 +36957,7 @@
         },
         {
           "name": "CastingVariantChoice",
-          "line": 3355,
+          "line": 3405,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35925,7 +36973,7 @@
         },
         {
           "name": "ChoosePermanentTypeSlot",
-          "line": 3367,
+          "line": 3417,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35942,7 +36990,7 @@
         },
         {
           "name": "MultiTargetSelection",
-          "line": 3378,
+          "line": 3428,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35958,7 +37006,7 @@
         },
         {
           "name": "AbilityModeChoice",
-          "line": 3389,
+          "line": 3439,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35975,7 +37023,7 @@
         },
         {
           "name": "OptionalEffectChoice",
-          "line": 3412,
+          "line": 3462,
           "kind": "struct",
           "field_names": [
             "player",
@@ -35990,7 +37038,7 @@
         },
         {
           "name": "PairChoice",
-          "line": 3423,
+          "line": 3473,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36005,7 +37053,7 @@
         },
         {
           "name": "TributeChoice",
-          "line": 3434,
+          "line": 3484,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36020,7 +37068,7 @@
         },
         {
           "name": "MiracleReveal",
-          "line": 3446,
+          "line": 3496,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36035,7 +37083,7 @@
         },
         {
           "name": "OpponentMayChoice",
-          "line": 3453,
+          "line": 3503,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36051,7 +37099,7 @@
         },
         {
           "name": "UnlessPayment",
-          "line": 3466,
+          "line": 3516,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36069,7 +37117,7 @@
         },
         {
           "name": "UnlessPaymentChooseCost",
-          "line": 3500,
+          "line": 3550,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36087,7 +37135,7 @@
         },
         {
           "name": "WardDiscardChoice",
-          "line": 3530,
+          "line": 3580,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36103,7 +37151,7 @@
         },
         {
           "name": "WardSacrificeChoice",
-          "line": 3546,
+          "line": 3596,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36119,7 +37167,7 @@
         },
         {
           "name": "UnlessBounceChoice",
-          "line": 3562,
+          "line": 3612,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36134,7 +37182,7 @@
         },
         {
           "name": "ChooseRingBearer",
-          "line": 3570,
+          "line": 3620,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36146,8 +37194,23 @@
           ]
         },
         {
+          "name": "ChooseRoomDoor",
+          "line": 3631,
+          "kind": "struct",
+          "field_names": [
+            "player",
+            "object_id",
+            "options"
+          ],
+          "doc": "CR 709.5f-g: A resolving lock/unlock-door effect needs the player to choose which door (half) of the targeted Room to act on. `options` enumerates each legal (operation, door) pair from `room::eligible_doors` — locked halves to unlock (CR 709.5f), unlocked halves to lock (CR 709.5g). For a \"lock or unlock\" effect both operations can appear, so the player chooses operation and door together. Answered with `GameAction::ChooseRoomDoor { object_id, op, door }`.",
+          "cr_refs": [
+            "CR 709.5f",
+            "CR 709.5g"
+          ]
+        },
+        {
           "name": "ChooseDungeon",
-          "line": 3575,
+          "line": 3640,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36160,7 +37223,7 @@
         },
         {
           "name": "ChooseDungeonRoom",
-          "line": 3580,
+          "line": 3645,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36175,7 +37238,7 @@
         },
         {
           "name": "SpecializeColor",
-          "line": 3587,
+          "line": 3652,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36187,7 +37250,7 @@
         },
         {
           "name": "PayCost",
-          "line": 3598,
+          "line": 3663,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36206,7 +37269,7 @@
         },
         {
           "name": "ActivationCostOneOfChoice",
-          "line": 3612,
+          "line": 3677,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36220,7 +37283,7 @@
         },
         {
           "name": "BlightChoice",
-          "line": 3618,
+          "line": 3683,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36233,7 +37296,7 @@
         },
         {
           "name": "PayManaAbilityMana",
-          "line": 3636,
+          "line": 3701,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36249,7 +37312,7 @@
         },
         {
           "name": "ChooseManaColor",
-          "line": 3646,
+          "line": 3711,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36265,7 +37328,7 @@
         },
         {
           "name": "CollectEvidenceChoice",
-          "line": 3653,
+          "line": 3718,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36281,7 +37344,7 @@
         },
         {
           "name": "HarmonizeTapChoice",
-          "line": 3662,
+          "line": 3727,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36298,7 +37361,7 @@
         },
         {
           "name": "RevealUntilKeptChoice",
-          "line": 3674,
+          "line": 3739,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36319,7 +37382,7 @@
         },
         {
           "name": "RepeatDecision",
-          "line": 3695,
+          "line": 3760,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36333,7 +37396,7 @@
         },
         {
           "name": "TopOrBottomChoice",
-          "line": 3702,
+          "line": 3767,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36346,7 +37409,7 @@
         },
         {
           "name": "PopulateChoice",
-          "line": 3707,
+          "line": 3772,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36360,7 +37423,7 @@
         },
         {
           "name": "ClashChooseOpponent",
-          "line": 3717,
+          "line": 3782,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36374,7 +37437,7 @@
         },
         {
           "name": "ClashCardPlacement",
-          "line": 3725,
+          "line": 3790,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36388,7 +37451,7 @@
         },
         {
           "name": "VoteChoice",
-          "line": 3736,
+          "line": 3801,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36401,7 +37464,8 @@
             "per_choice_effect",
             "controller",
             "source_id",
-            "actor"
+            "actor",
+            "tally_mode"
           ],
           "doc": "CR 701.38: A player is voting on the listed choices. After this player has cast all of their votes (1 + extras from \"you may vote an additional time\" static abilities), the engine advances to the next player in APNAP order until every non-eliminated player has voted, then resolves the per-choice tally sub-effects. Lives in the engine — frontend just renders the modal.",
           "cr_refs": [
@@ -36410,7 +37474,7 @@
         },
         {
           "name": "SeparatePilesPartition",
-          "line": 3795,
+          "line": 3871,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36431,7 +37495,7 @@
         },
         {
           "name": "SeparatePilesChoice",
-          "line": 3825,
+          "line": 3901,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36448,7 +37512,7 @@
         },
         {
           "name": "CompanionReveal",
-          "line": 3840,
+          "line": 3916,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36461,7 +37525,7 @@
         },
         {
           "name": "ChooseLegend",
-          "line": 3847,
+          "line": 3923,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36475,7 +37539,7 @@
         },
         {
           "name": "CommanderZoneChoice",
-          "line": 3856,
+          "line": 3932,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36489,7 +37553,7 @@
         },
         {
           "name": "BattleProtectorChoice",
-          "line": 3867,
+          "line": 3943,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36505,7 +37569,7 @@
         },
         {
           "name": "ProliferateChoice",
-          "line": 3874,
+          "line": 3950,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36518,7 +37582,7 @@
         },
         {
           "name": "TimeTravelChoice",
-          "line": 3887,
+          "line": 3963,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36532,7 +37596,7 @@
         },
         {
           "name": "ChooseObjectsSelection",
-          "line": 3897,
+          "line": 3973,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36546,7 +37610,7 @@
         },
         {
           "name": "CategoryChoice",
-          "line": 3910,
+          "line": 3986,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36570,7 +37634,7 @@
         },
         {
           "name": "CopyRetarget",
-          "line": 3947,
+          "line": 4023,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36578,7 +37642,8 @@
             "target_slots",
             "effect_kind",
             "effect_source_id",
-            "current_slot"
+            "current_slot",
+            "paradigm_remaining_offers"
           ],
           "doc": "CR 707.10c: When a spell is copied, the controller may choose new targets. Each slot shows the current target and legal alternatives.",
           "cr_refs": [
@@ -36587,7 +37652,7 @@
         },
         {
           "name": "AssignCombatDamage",
-          "line": 3962,
+          "line": 4042,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36609,7 +37674,7 @@
         },
         {
           "name": "AssignBlockerDamage",
-          "line": 3989,
+          "line": 4069,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36625,7 +37690,7 @@
         },
         {
           "name": "DistributeAmong",
-          "line": 3999,
+          "line": 4079,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36640,7 +37705,7 @@
         },
         {
           "name": "MoveCountersDistribution",
-          "line": 4007,
+          "line": 4087,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36658,7 +37723,7 @@
         },
         {
           "name": "PayAmountChoice",
-          "line": 4021,
+          "line": 4101,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36677,7 +37742,7 @@
         },
         {
           "name": "RetargetChoice",
-          "line": 4036,
+          "line": 4116,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36693,7 +37758,7 @@
         },
         {
           "name": "CombatTaxPayment",
-          "line": 4058,
+          "line": 4138,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36713,7 +37778,7 @@
         },
         {
           "name": "PhyrexianPayment",
-          "line": 4076,
+          "line": 4156,
           "kind": "struct",
           "field_names": [
             "player",
@@ -36876,13 +37941,13 @@
     },
     "ZoneDeliveryExileTracking": {
       "file": "crates/engine/src/types/game_state.rs",
-      "line": 1456,
+      "line": 1467,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 1458,
+          "line": 1469,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36890,7 +37955,7 @@
         },
         {
           "name": "TrackBySource",
-          "line": 1459,
+          "line": 1470,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36901,7 +37966,7 @@
     },
     "ZoneOwner": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 47,
+      "line": 49,
       "doc": "CR 400.1 + CR 608.2c: Which player's zone supplies cards for a direct zone choice during resolution.",
       "cr_refs": [
         "CR 400.1",
@@ -36910,7 +37975,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 50,
+          "line": 52,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the spell/ability owns the referenced zone.",
@@ -36918,7 +37983,7 @@
         },
         {
           "name": "TargetedPlayer",
-          "line": 52,
+          "line": 54,
           "kind": "unit",
           "field_names": [],
           "doc": "The first player target of the resolving spell/ability owns the referenced zone.",
@@ -36926,7 +37991,7 @@
         },
         {
           "name": "Opponent",
-          "line": 54,
+          "line": 56,
           "kind": "unit",
           "field_names": [],
           "doc": "An opponent of the controller owns the referenced zone.",
@@ -36934,7 +37999,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 59,
+          "line": 61,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38d: The scoped player (voter) owns the referenced zone. Used by per-ballot vote iteration (Expropriate) where the candidate pool is \"permanents owned by the voter\". For Battlefield, filters by `obj.owner` (ownership) rather than `obj.controller` (control).",
@@ -36944,7 +38009,7 @@
         },
         {
           "name": "EachPlayer",
-          "line": 66,
+          "line": 68,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2c: Every player owns a referenced zone, iterated in APNAP order. A `ChooseFromZone { zone_owner: EachPlayer }` parks one choice per player, drawing candidates from THAT player's zone, and accumulates each pick into the resolution chain's tracked object set. Building block for Breach the Multiverse (\"For each player, choose a creature or planeswalker card in that player's graveyard\").",
@@ -36958,13 +38023,13 @@
     },
     "ZoneRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 892,
+      "line": 905,
       "doc": "Which zone to count cards in (for `QuantityRef::ZoneCardCount`).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Graveyard",
-          "line": 893,
+          "line": 906,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36972,7 +38037,7 @@
         },
         {
           "name": "Exile",
-          "line": 894,
+          "line": 907,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36980,7 +38045,7 @@
         },
         {
           "name": "Library",
-          "line": 895,
+          "line": 908,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36988,10 +38053,38 @@
         },
         {
           "name": "Hand",
-          "line": 896,
+          "line": 909,
           "kind": "unit",
           "field_names": [],
           "doc": "",
+          "cr_refs": []
+        }
+      ],
+      "sibling_clusters": []
+    },
+    "ZoneSpendPolarity": {
+      "file": "crates/engine/src/types/mana.rs",
+      "line": 340,
+      "doc": "CR 106.6 + CR 400.7: Whether a zone-gated spend restriction names the zone a spell *must* be cast from or a zone it must *not* be cast from. This is the inclusion/exclusion axis of [`ManaRestriction::OnlyForSpellFromZone`] — \"from your graveyard\" (`From`) versus \"from anywhere other than your hand\" (`NotFrom`, Mm'menon, the Right Hand). Parameterizing the existing zone variant over this polarity keeps a single zone-spend variant rather than a `SpellFromZone` / `SpellNotFromZone` sibling pair.",
+      "cr_refs": [
+        "CR 106.6",
+        "CR 400.7"
+      ],
+      "variants": [
+        {
+          "name": "From",
+          "line": 343,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "\"from [your] <zone>\" — the spell must be cast from the named zone.",
+          "cr_refs": []
+        },
+        {
+          "name": "NotFrom",
+          "line": 347,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "\"from anywhere other than [your] <zone>\" — the spell must be cast from any zone *except* the named one. A spell with no recorded cast-from zone is treated as not satisfying the restriction (conservative).",
           "cr_refs": []
         }
       ],


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Building block: ×2 `Double` → ×N `Times { factor }`

The token / counter / life-gain replacement multiplier was hard-wired to ×2
(`QuantityModification::Double`). This PR **parameterizes** it into a single
multiplicative variant `Times { factor: u32 }`, mirroring the existing
`ManaModification::Multiply { factor }`. `Double` becomes the named constant
`QuantityModification::DOUBLE` (`Times { factor: 2 }`), and all 43 doubling call
sites migrate mechanically.

This is the right parameterization, not a sibling addition: adding a `Triple`
beside `Double` would seed exactly the `Double`/`Triple` multiplicative
sibling-cluster smell the engine guidelines warn against (cf.
`DamageModification::Double | Triple`). One `Times { factor }` covers ×2, ×3, and
every future ×N multiplier. `data/engine-inventory.json` regenerated:
`QuantityModification` now reports `[Times, Half, Plus, Minus, Prevent]` with
`sibling_clusters: []`.

### Parser (the detector)
`scan_token_multiplier_factor` recognizes `"twice that many"` (×2) and
`"<N> times that many"` (×N) via a word-boundary nom scan that delegates the
number word to the shared `parse_number` combinator — so any ×N multiplier card
parses without per-factor tags. The CR 111.1 creature-type gate
(`TokenCoreTypeMatches`) was lifted out of the substitution-only arm and now
applies to every typed token shape, so Ojer Taq's multiplier fires only on
creature tokens.

## Per-card ship / defer

| Card | Status | Rationale |
|------|--------|-----------|
| **Ojer Taq, Deepest Foundation** | ✅ Shipped | "If one or more creature tokens would be created under your control, three times that many of those tokens are created instead." → `CreateToken` replacement with `Times { factor: 3 }`, gated to creature tokens (CR 614.1a + CR 111.1). Vigilance + dies-trigger already parsed; confirmed still clean. |
| **Moonlit Meditation** | ⏸ Deferred (fail-closed) | "The first time you would create one or more tokens each turn, you may instead create that many tokens that are copies of enchanted permanent." Needs three new pieces of infra beyond the multiplier axis: a per-turn token-creation gate (state + `ReplacementCondition` + reset), an **Optional** CreateToken pipeline (today only ZoneChange/shock-land replacements decline), and a dynamic host-copy spec resolved against the Aura host. Out of scope for this parameterization; stays honestly `Effect::unimplemented`. |

## add-engine-variant verdict
`QuantityModification::Times { factor }`:
- **Stage 1 (existence):** ×N concept absent on `QuantityModification` (only ×2 `Double`); peer `ManaModification::Multiply { factor }` exists.
- **Stage 2 (parameterization):** REFACTOR_FIRST — `Double` + a hypothetical `Triple` is the multiplicative sibling smell. Collapsed to one `Times { factor }`.
- **Stage 3 (categorical boundary):** WITHIN_SECTION — the multiply axis is entirely within CR 614.1a (replacement quantity modification).

## Discriminating-test map

| Behavioral claim | Seam / fn | Production entry | Test | Revert-failing assertion | Negative / sibling |
|---|---|---|---|---|---|
| Ojer Taq triplicates creature tokens (×3) | `create_token_applier` count path + `Times` factor | `replace_event` (real pipeline) on parser output | `game::replacement::tests::ojer_taq_triplicates_creature_tokens` | `count == 6` (2×3); flips to 4 if factor→`DOUBLE`, to 2 if replacement dropped | — |
| Multiplier gated to creature tokens (CR 111.1) | `TokenCoreTypeMatches` condition | `replace_event` with an Artifact (Treasure) token | `game::replacement::tests::ojer_taq_does_not_multiply_noncreature_tokens` | `count == 2` (unchanged); without the gate it would be 6 | non-creature case |
| Line parses to `Times { factor: 3 }` + gate | `scan_token_multiplier_factor` / `parse_token_replacement` | `parse_replacement_line` | `parser::oracle_replacement::tests::ojer_taq_token_triplication_replacement` | `quantity_modification == Times { factor: 3 }` + `TokenCoreTypeMatches([Creature])` | — |
| Full card zero-unimplemented | `parse_oracle_text` | full front-face oracle | `std_longtail_e::ojer_taq_token_triplication_full_card_parses` | `assert_zero_unimplemented` + `Times { factor: 3 }` | — |
| ×2 migration preserved | `Double` → `Times { factor: 2 }` | `parse_replacement_line` | `token_doubling_via_twice_is_factor_two`, `token_doubling_replacement*` | `quantity_modification == Times { factor: 2 }` | — |
| ×N commute (CR 616.1) unchanged | `quantity_commute_class` | `replace_event` (3 doublers) | `multiple_pure_token_doublers_commute_no_prompt` | `count == 8` auto-resolved | migration regression |

The two runtime tests drive the real `replace_event` pipeline from the actual
parser output (parse → pipeline end-to-end), and the negative case reaches the
true `TokenCoreTypeMatches` arm with a non-degenerate Artifact fixture.

## Gate results
`cargo fmt` ✅ · `check-parser-combinators.sh` (and `upstream/main`) exit 0 ✅ ·
`check-engine-authorities.sh upstream/main` exit 0 ✅ · parser diff string-dispatch
grep: only the canonical word-boundary cursor `.find(' ')` (structural advance,
not dispatch — cf. `scan_for_phase`) ✅ · CR-annotation diff gate: 0 UNVERIFIED ✅ ·
`cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` exit 0 ✅ ·
`cargo coverage` exit 0 ✅ · `cargo semantic-audit` exit 0 (Ojer Taq: 0 findings) ✅ ·
`cargo test -p engine`: 13108 passed, only the known parallel-flaky
`delve_payment_skips_state_clone_per_graveyard_candidate` and
`target_selection_legal_actions_do_not_fall_back_to_stale_slot_targets` flapped —
both pass in isolation `--test-threads=1`; neither touches this diff.