### PR TITLE
feat(engine): Alchemy 'perpetually' keyword action — perpetual base power/toughness

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2017,6 +2017,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         // CR 702.50a: EpicCopy's parameters live in its snapshotted ability.
         Effect::EpicCopy { .. } => {}
         Effect::Intensify { .. } => {}
+        Effect::ApplyPerpetual { .. } => {}
         Effect::TurnFaceUp { .. } => {}
         Effect::DestroyAll { target, .. }
         // CR 613.1b: mass gain-control reports its population `filter` like the

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -118,6 +118,7 @@ pub mod heist;
 pub mod hideaway;
 pub mod incubate;
 pub mod intensify;
+pub mod perpetual;
 // Tests for `heist` live in a sibling file (declared here, not in `heist.rs`,
 // so `heist.rs` stays implementation-only — no inline `#[cfg(test)]` token).
 #[cfg(test)]
@@ -2847,6 +2848,7 @@ pub fn resolve_effect(
         Effect::ProcessRadCounters => rad_counters::resolve(state, ability, events),
         Effect::Conjure { .. } => conjure::resolve(state, ability, events),
         Effect::Intensify { .. } => intensify::resolve(state, ability, events),
+        Effect::ApplyPerpetual { .. } => perpetual::resolve(state, ability, events),
         Effect::DraftFromSpellbook { .. } => spellbook::resolve(state, ability, events),
         Effect::ChooseOneOf { .. } => choose_one_of::resolve(state, ability, events),
         Effect::Unimplemented { name, .. } => {

--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -50,6 +50,12 @@ pub fn resolve(
     }
 
     if changed {
+        // CR 613.1: a perpetual edit to base power/toughness changes a
+        // characteristic that the layer pass derives live P/T from, so the board
+        // must be re-evaluated — otherwise `obj.power`/`obj.toughness` and public
+        // state stay at their pre-effect values until some unrelated future
+        // layer-dirtying event. The `Full` flush also marks public state dirty.
+        crate::game::layers::mark_layers_full(state);
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::from(&ability.effect),
             source_id: ability.source_id,
@@ -100,5 +106,51 @@ mod tests {
         assert_eq!(obj.base_power, Some(1));
         assert_eq!(obj.base_toughness, Some(1));
         assert!(obj.perpetual_mods.contains(&modification));
+    }
+
+    /// CR 613.1: the perpetual base-P/T edit must dirty layers so the live,
+    /// publicly visible `power`/`toughness` are recomputed at the next flush —
+    /// not just the persistent `base_*` fields. Mirrors the rules/display
+    /// boundary (`flush_layers`, a no-op unless `layers_dirty` is set).
+    #[test]
+    fn perpetual_base_pt_updates_live_pt_after_layer_flush() {
+        let mut state = GameState::new_two_player(7);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "High Fae Prankster".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+        }
+        // Establish the pre-effect live P/T through the normal layer pass.
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::flush_layers(&mut state);
+        assert_eq!(state.objects.get(&id).unwrap().power, Some(2));
+
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: crate::types::ability::TargetFilter::Any,
+                modification: PerpetualModification::SetBasePowerToughness {
+                    power: 4,
+                    toughness: 1,
+                },
+            },
+            vec![TargetRef::Object(id)],
+            id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        super::resolve(&mut state, &ability, &mut events).unwrap();
+
+        // The resolver must have dirtied layers; flushing recomputes live P/T.
+        crate::game::layers::flush_layers(&mut state);
+        let obj = state.objects.get(&id).unwrap();
+        assert_eq!(obj.power, Some(4));
+        assert_eq!(obj.toughness, Some(1));
     }
 }

--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -1,0 +1,104 @@
+//! Digital-only Alchemy (no CR entry): `Effect::ApplyPerpetual` — apply a
+//! "perpetually" modification that permanently edits a card and follows it
+//! across every zone.
+//!
+//! Like [`super::intensify`], the change is recorded on the object
+//! (`GameObject::perpetual_mods`) and edits a persistent characteristic, so it
+//! survives zone changes and serialization. Increment 1 covers base
+//! power/toughness ("perpetually become(s)/has base power and toughness P/T",
+//! e.g. High Fae Prankster, Three Tree Battalion, Blood Age Muster).
+//!
+//! Target resolution (Increment 1): the resolved object targets, or — when the
+//! effect carries none — the source itself ("~ perpetually has ..."). Broader
+//! filter-based forms ("creatures you control perpetually gain ...") are a
+//! follow-up.
+
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetRef};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+
+/// Resolve `Effect::ApplyPerpetual`: apply `modification` to each affected card.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let modification = match &ability.effect {
+        Effect::ApplyPerpetual { modification, .. } => modification.clone(),
+        _ => return Err(EffectError::MissingParam("ApplyPerpetual".to_string())),
+    };
+
+    let mut ids: Vec<ObjectId> = ability
+        .targets
+        .iter()
+        .filter_map(|t| match t {
+            TargetRef::Object(id) => Some(*id),
+            TargetRef::Player(_) => None,
+        })
+        .collect();
+    if ids.is_empty() {
+        ids.push(ability.source_id);
+    }
+
+    let mut changed = false;
+    for id in ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            obj.apply_perpetual_modification(&modification);
+            changed = true;
+        }
+    }
+
+    if changed {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::game::zones::create_object;
+    use crate::types::ability::{Effect, PerpetualModification, ResolvedAbility, TargetRef};
+    use crate::types::game_state::GameState;
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
+    use crate::types::zones::Zone;
+
+    #[test]
+    fn perpetual_sets_base_power_toughness_and_records_it() {
+        let mut state = GameState::new_two_player(7);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Three Tree Battalion Duplicate".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().base_power = Some(5);
+        state.objects.get_mut(&id).unwrap().base_toughness = Some(5);
+
+        let modification = PerpetualModification::SetBasePowerToughness {
+            power: 1,
+            toughness: 1,
+        };
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: crate::types::ability::TargetFilter::Any,
+                modification: modification.clone(),
+            },
+            vec![TargetRef::Object(id)],
+            id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        super::resolve(&mut state, &ability, &mut events).unwrap();
+
+        let obj = state.objects.get(&id).unwrap();
+        assert_eq!(obj.base_power, Some(1));
+        assert_eq!(obj.base_toughness, Some(1));
+        assert!(obj.perpetual_mods.contains(&modification));
+    }
+}

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -394,6 +394,13 @@ pub struct GameObject {
     #[serde(default)]
     pub intensity: u32,
 
+    /// Alchemy "perpetually" modifications applied to this card (digital-only, no
+    /// CR entry). Like `intensity`, these persist across zone changes (the object
+    /// keeps its id) and serialization, so a perpetual edit follows the card
+    /// through hand/library/stack/battlefield for the rest of the game.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub perpetual_mods: Vec<crate::types::ability::PerpetualModification>,
+
     // Characteristics
     pub name: String,
     pub power: Option<i32>,
@@ -991,6 +998,27 @@ pub(crate) fn chosen_card_type_of(attrs: &[ChosenAttribute]) -> Option<CoreType>
 }
 
 impl GameObject {
+    /// Apply an Alchemy "perpetually" modification to this card: record it on the
+    /// object (so it persists across zones/serialization and can be re-applied
+    /// after a copy rebuilds base characteristics) and edit the corresponding
+    /// persistent characteristic. Increment 1: base power/toughness.
+    pub fn apply_perpetual_modification(
+        &mut self,
+        modification: &crate::types::ability::PerpetualModification,
+    ) {
+        use crate::types::ability::PerpetualModification;
+        match modification {
+            PerpetualModification::SetBasePowerToughness { power, toughness } => {
+                // The base_* fields are the persistent baseline the layer pass
+                // copies into live P/T each recalc, so editing them here makes the
+                // change permanent and zone-independent.
+                self.base_power = Some(*power);
+                self.base_toughness = Some(*toughness);
+            }
+        }
+        self.perpetual_mods.push(modification.clone());
+    }
+
     pub fn instance_payment_count(&self, origin: AdditionalCostOrigin) -> u32 {
         additional_cost_instance_payment_count(&self.additional_cost_payments, origin)
     }
@@ -1146,6 +1174,7 @@ impl GameObject {
             pair_controller: None,
             counters: HashMap::new(),
             intensity: 0,
+            perpetual_mods: Vec::new(),
             name: name.clone(),
             power: None,
             toughness: None,

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -777,6 +777,7 @@ fn walk_cost(cost: &AbilityCost, out: &mut Vec<String>) {
 fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
     match effect {
         Effect::Intensify { .. } => {}
+        Effect::ApplyPerpetual { .. } => {}
         // Heist exiles a card from an opponent's library at random; it does not
         // name a conjure card, so there is no static face to preload.
         Effect::Heist { .. } | Effect::HeistExile => {}

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -862,6 +862,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::RemoveFromCombat
         | EffectKind::Conjure
         | EffectKind::Intensify
+        | EffectKind::ApplyPerpetual
         | EffectKind::DraftFromSpellbook
         | EffectKind::ChooseOneOf
         | EffectKind::Specialize

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5703,6 +5703,12 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "[~/it/this creature] perpetually become(s)/has base
+    // power and toughness N/N" — the ApplyPerpetual keyword action (base P/T).
+    if let Some(effect) = try_parse_perpetual_base_pt(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "draft a card from [X]'s spellbook [+ destination]".
     if let Some(effect) = try_parse_spellbook_draft(tp) {
         return parsed_clause(effect);
@@ -5833,6 +5839,65 @@ fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
     tail_done(rest).then_some(Effect::Intensify {
         scope: IntensityScope::Source,
         amount,
+    })
+}
+
+/// Digital-only Alchemy: parse the self-subject base-P/T "perpetually" form —
+/// "[~ / it / this creature / …] perpetually become(s)/has base power and
+/// toughness N/N" → [`Effect::ApplyPerpetual`] with
+/// [`PerpetualModification::SetBasePowerToughness`] (High Fae Prankster).
+///
+/// Increment 1 handles only the self-subject (resolved to the source). The
+/// referenced-object forms ("the duplicate"/"its base power and toughness
+/// perpetually become …", Three Tree Battalion, Blood Age Muster) are left to
+/// `Unimplemented` until the referenced-object target wiring lands. The clause
+/// tail must be fully consumed so riders (e.g. "… and gains flying") fall
+/// through instead of being silently dropped.
+fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
+    let lower = tp.lower;
+    let after_subject = [
+        "~ ",
+        "it ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this permanent ",
+        "this token ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
+        .parse(after_subject)
+        .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("becomes "),
+        tag::<_, _, OracleError<'_>>("become "),
+        tag::<_, _, OracleError<'_>>("has "),
+        tag::<_, _, OracleError<'_>>("have "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("base power and toughness ")
+        .parse(rest)
+        .ok()?;
+    let (rest, power) = nom_primitives::parse_number(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("/").parse(rest).ok()?;
+    let (rest, toughness) = nom_primitives::parse_number(rest).ok()?;
+    if !(rest.is_empty() || rest == ".") {
+        return None;
+    }
+    Some(Effect::ApplyPerpetual {
+        target: TargetFilter::Any,
+        modification: crate::types::ability::PerpetualModification::SetBasePowerToughness {
+            power: power as i32,
+            toughness: toughness as i32,
+        },
     })
 }
 
@@ -48208,6 +48273,37 @@ mod tests {
                 ..
             } if type_filters == vec![TypeFilter::Creature]
                 && properties == vec![FilterProp::Blocking, FilterProp::Another]
+        ));
+    }
+
+    #[test]
+    fn perpetual_parser_maps_self_base_pt() {
+        use crate::types::ability::PerpetualModification;
+        // Self-subject base-P/T form (High Fae Prankster); the card's own name
+        // normalizes to `~` in Oracle text.
+        let e = parse_effect("~ perpetually has base power and toughness 4/1.");
+        assert!(matches!(
+            e,
+            Effect::ApplyPerpetual {
+                modification: PerpetualModification::SetBasePowerToughness {
+                    power: 4,
+                    toughness: 1,
+                },
+                ..
+            }
+        ));
+
+        // "become(s)" verb variant.
+        let e = parse_effect("It perpetually becomes base power and toughness 2/2.");
+        assert!(matches!(
+            e,
+            Effect::ApplyPerpetual {
+                modification: PerpetualModification::SetBasePowerToughness {
+                    power: 2,
+                    toughness: 2,
+                },
+                ..
+            }
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5855,9 +5855,13 @@ fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
 /// through instead of being silently dropped.
 fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
     let lower = tp.lower;
+    // Only unambiguous self-subjects. The anaphoric "it " is intentionally
+    // excluded: after a prior object choice it refers to that object, not the
+    // source, so accepting it here would let a referenced-object perpetual clause
+    // parse as supported while mutating the wrong object. Referenced-object forms
+    // ("the duplicate"/"its …") are deferred until real referent binding lands.
     let after_subject = [
         "~ ",
-        "it ",
         "this creature ",
         "this artifact ",
         "this enchantment ",
@@ -48293,8 +48297,9 @@ mod tests {
             }
         ));
 
-        // "become(s)" verb variant.
-        let e = parse_effect("It perpetually becomes base power and toughness 2/2.");
+        // "become(s)" verb variant. (Uses an unambiguous self-subject; the
+        // anaphoric "it" form is intentionally not accepted.)
+        let e = parse_effect("This creature perpetually becomes base power and toughness 2/2.");
         assert!(matches!(
             e,
             Effect::ApplyPerpetual {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4480,6 +4480,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::RemoveFromCombat { .. }
         | Effect::Conjure { .. }
         | Effect::Intensify { .. }
+        | Effect::ApplyPerpetual { .. }
         | Effect::DraftFromSpellbook { .. }
         | Effect::ChooseOneOf { .. }
         // CR 614.12 + CR 303.4: Return-as-Aura is its own emitted sub-effect

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7327,6 +7327,22 @@ impl FaceDownProfile {
 // carry a `QuantityExpr`; the right remedy is to box `PtValue::Quantity` (used
 // in 70+ sites), not to box individual `Effect` variants. Allow the spread here
 // until that boxing lands.
+/// Digital-only Alchemy: a modification applied by `Effect::ApplyPerpetual` that
+/// permanently edits a card and follows it across all zones (CR has no entry —
+/// matches the engine's existing `Intensify`/`Conjure` digital-only treatment).
+///
+/// Increment 1 covers base power/toughness setting; the enum is extensible to the
+/// other perpetual forms (`ModifyPowerToughness` for "perpetually gets +N/+N",
+/// `GrantAbility` for "perpetually gains ...", `Become` for type changes).
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+pub enum PerpetualModification {
+    /// "[object] perpetually become(s)/has base power and toughness P/T" — sets
+    /// the card's persistent base power and toughness (High Fae Prankster,
+    /// Three Tree Battalion, Blood Age Muster).
+    SetBasePowerToughness { power: i32, toughness: i32 },
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, strum::IntoStaticStr)]
 #[serde(tag = "type")]
@@ -9821,6 +9837,19 @@ pub enum Effect {
         #[serde(default)]
         tapped: bool,
     },
+    /// Digital-only Alchemy keyword action (no CR entry): "perpetually" applies a
+    /// modification to the matched cards that persists for the rest of the game
+    /// and follows each card across all zones — a permanent edit to the card,
+    /// unlike until-end-of-turn or while-on-battlefield continuous effects. Like
+    /// `Intensify`, the change is recorded on the object (`perpetual_mods`) so it
+    /// survives zone changes and serialization. `target` selects the affected
+    /// cards (self, a referenced object such as a conjured duplicate, or a
+    /// filter such as "creatures you control").
+    ApplyPerpetual {
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+        modification: PerpetualModification,
+    },
     /// Digital-only Alchemy keyword action (no CR entry): increase the intensity
     /// of one or more cards by `amount`. `scope` selects which cards — the source
     /// itself, every card the controller owns with the source's name, or every
@@ -10956,6 +10985,7 @@ impl Effect {
             | Effect::RuntimeHandled { .. }
             | Effect::Conjure { .. }
             | Effect::Intensify { .. }
+            | Effect::ApplyPerpetual { .. }
             | Effect::DraftFromSpellbook { .. }
             | Effect::ChooseOneOf { .. }
             | Effect::Unimplemented { .. }
@@ -11067,7 +11097,8 @@ impl Effect {
             | Effect::RevealHand { count, .. } => count.as_ref(),
 
             // --- Effects with no QuantityExpr count/amount ---
-            Effect::StartYourEngines { .. }
+            Effect::ApplyPerpetual { .. }
+            | Effect::StartYourEngines { .. }
             | Effect::ApplyPostReplacementDamage { .. }
             | Effect::Pump { .. }
             | Effect::PairWith { .. }
@@ -11280,7 +11311,8 @@ impl Effect {
             | Effect::RevealHand { count, .. } => count.as_mut(),
 
             // --- Effects with no QuantityExpr count/amount ---
-            Effect::StartYourEngines { .. }
+            Effect::ApplyPerpetual { .. }
+            | Effect::StartYourEngines { .. }
             | Effect::ApplyPostReplacementDamage { .. }
             | Effect::Pump { .. }
             | Effect::PairWith { .. }
@@ -11634,6 +11666,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::RemoveFromCombat { .. } => "RemoveFromCombat",
         Effect::Conjure { .. } => "Conjure",
         Effect::Intensify { .. } => "Intensify",
+        Effect::ApplyPerpetual { .. } => "ApplyPerpetual",
         Effect::DraftFromSpellbook { .. } => "DraftFromSpellbook",
         Effect::ChooseOneOf { .. } => "ChooseOneOf",
         Effect::Unimplemented { name, .. } => name,
@@ -11844,6 +11877,7 @@ pub enum EffectKind {
     RemoveFromCombat,
     Conjure,
     Intensify,
+    ApplyPerpetual,
     DraftFromSpellbook,
     ChooseOneOf,
     Unimplemented,
@@ -12068,6 +12102,7 @@ impl From<&Effect> for EffectKind {
             Effect::RemoveFromCombat { .. } => EffectKind::RemoveFromCombat,
             Effect::Conjure { .. } => EffectKind::Conjure,
             Effect::Intensify { .. } => EffectKind::Intensify,
+            Effect::ApplyPerpetual { .. } => EffectKind::ApplyPerpetual,
             Effect::DraftFromSpellbook { .. } => EffectKind::DraftFromSpellbook,
             Effect::ChooseOneOf { .. } => EffectKind::ChooseOneOf,
             Effect::Unimplemented { .. } => EffectKind::Unimplemented,

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -536,6 +536,7 @@ fn redundancy_delta(
         | Effect::RemoveFromCombat { .. }
         | Effect::Conjure { .. }
         | Effect::Intensify { .. }
+        | Effect::ApplyPerpetual { .. }
         | Effect::DraftFromSpellbook { .. }
         | Effect::Tribute { .. }
         | Effect::Unimplemented { .. }


### PR DESCRIPTION
Fixes #4101.

## What

Adds the Alchemy **perpetually** keyword action to the engine (digital-only, no CR entry â€” consistent with the existing `Effect::Intensify` / `Effect::Conjure` treatment). "Perpetually" applies a modification that **permanently edits a card and follows it across all zones** for the rest of the game â€” unlike until-end-of-turn or while-on-battlefield continuous effects.

This is **Increment 1: perpetual base power/toughness setting** â€” "[~ / it / this creature] perpetually become(s)/has base power and toughness N/N" (e.g. **High Fae Prankster** "perpetually has base power and toughness 4/1").

## How

Mirrors the existing Alchemy `intensity` model (`GameObject.intensity` already persists across zones + serializes):

- **`GameObject.perpetual_mods: Vec<PerpetualModification>`** â€” records the perpetual edits on the object so they persist across zone changes and serialization (basis for reapplication after copy in a follow-up).
- **`enum PerpetualModification { SetBasePowerToughness { power, toughness } }`** â€” extensible to the other forms (ModifyPT, GrantAbility, Become).
- **`Effect::ApplyPerpetual { target, modification }`** + `game::effects::perpetual::resolve` â€” applies the modification by editing the persistent `base_power`/`base_toughness` (the baseline the layer pass copies into live P/T each recalc, so the change is permanent and zone-independent), via `GameObject::apply_perpetual_modification`.
- **Parser**: `try_parse_perpetual_base_pt` (in `oracle_effect`) parses the self-subject base-P/T form into `Effect::ApplyPerpetual`. The clause tail must be fully consumed so riders fall through to `Unimplemented` rather than being silently dropped.
- New `Effect`/`EffectKind` variant registered at every exhaustive match site (dispatch, coverage, printed-cards, name/kind maps, targeting + amount-getter classifiers, dig-lookback transparency, AI redundancy policy).

## Scope

Increment 1 = the self-subject base-P/T form (resolved to the source). Deferred to follow-ups: referenced-object subjects ("the duplicate"/"its â€¦", which need object-target wiring), "perpetually gets +N/+N" (ModifyPT), "perpetually gain(s) [ability]" (the all-zones granted-ability form, the largest group), and "perpetually become(s) [type]".

## Verification

- New resolver unit test: `Effect::ApplyPerpetual` sets `base_power`/`base_toughness` and records the modification in `perpetual_mods`.
- New parser unit test: the self-subject base-P/T phrasing parses to `Effect::ApplyPerpetual { SetBasePowerToughness }`.
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) green; card-data regenerated.
