### PR TITLE
feat(engine): pay any amount of life

### DIFF
--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -116,6 +116,35 @@ pub fn resolve(
                 pending_mana_ability: None,
             };
         }
+        // CR 119.4 + CR 118.3 + CR 119.8: "pay any amount of life" — suspend the
+        // chain and surface a `PayAmountChoice` prompt (mirrors the energy "any
+        // amount" arm above). `max` = payer's current life, clamped to 0 when a
+        // CantLoseLife / can't-pay-life lock applies (can_pay_life_cost is false
+        // for any amount > 0). On submit the engine deducts life via
+        // `life_costs::pay_life_as_cost` and stamps `last_effect_count` so the
+        // downstream "draw/look at that many" step reads the chosen amount.
+        AbilityCost::PayLife { amount } if is_pay_any_amount(amount) => {
+            let life = state
+                .players
+                .iter()
+                .find(|p| p.id == payer)
+                .map(|p| p.life)
+                .unwrap_or(0);
+            let max = if life > 0 && crate::game::life_costs::can_pay_life_cost(state, payer, 1) {
+                u32::try_from(life).unwrap_or(0)
+            } else {
+                0
+            };
+            state.waiting_for = WaitingFor::PayAmountChoice {
+                player: payer,
+                resource: PayableResource::Life,
+                min: 0,
+                max,
+                accumulated: 0,
+                source_id: ability.source_id,
+                pending_mana_ability: None,
+            };
+        }
         // CR 107.1c + CR 107.14: A fixed-amount energy payment routes through the
         // authority, then stamps `last_effect_count` so downstream chain steps
         // that reference `QuantityRef::EventContextAmount` (e.g. "deals that much
@@ -2421,5 +2450,270 @@ mod tests {
             generic: 0,
         };
         assert_eq!(scale_mana_cost(&colored, 0), ManaCost::zero());
+    }
+
+    /// CR 119.4 + CR 118.3: Install a CantLoseLife permanent for `owner`, used
+    /// to verify the "pay any amount of life" prompt clamps `max` to 0 (CR 119.8).
+    fn add_cant_lose_life_permanent(state: &mut GameState, owner: PlayerId) {
+        use crate::game::zones::create_object;
+        use crate::types::ability::{ControllerRef, StaticDefinition, TargetFilter, TypedFilter};
+        use crate::types::statics::StaticMode;
+        use crate::types::zones::Zone;
+
+        let id = create_object(
+            state,
+            CardId(900),
+            owner,
+            "Life Lock".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().static_definitions.push(
+            StaticDefinition::new(StaticMode::CantLoseLife).affected(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            )),
+        );
+    }
+
+    fn pay_any_life_ability() -> Effect {
+        Effect::PayCost {
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            },
+            scale: None,
+            payer: crate::types::ability::TargetFilter::Controller,
+        }
+    }
+
+    /// CR 119.4 + CR 118.3: "pay any amount of life" suspends on a
+    /// PayAmountChoice with `max` = current life and no life deducted yet
+    /// (mirrors `pay_any_amount_of_energy_pauses_for_choice`).
+    #[test]
+    fn pay_any_amount_of_life_pauses_for_choice() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+        let ability = make_ability(pay_any_life_ability());
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        match &state.waiting_for {
+            WaitingFor::PayAmountChoice {
+                player,
+                resource,
+                min,
+                max,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(*resource, PayableResource::Life);
+                assert_eq!(*min, 0);
+                assert_eq!(*max, 20);
+            }
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
+        assert_eq!(state.players[0].life, 20, "life must not be deducted yet");
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::LifeChanged { .. })),
+            "no LifeChanged event until the player commits an amount"
+        );
+    }
+
+    /// CR 119.8: Under a CantLoseLife lock the "pay any amount of life" prompt
+    /// clamps `max` to 0 — the player can only decline (pay 0).
+    #[test]
+    fn pay_any_amount_of_life_clamps_max_under_cant_lose_life() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+        add_cant_lose_life_permanent(&mut state, PlayerId(0));
+        let ability = make_ability(pay_any_life_ability());
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        match &state.waiting_for {
+            WaitingFor::PayAmountChoice { resource, max, .. } => {
+                assert_eq!(*resource, PayableResource::Life);
+                assert_eq!(*max, 0, "CantLoseLife clamps the payable life to 0");
+            }
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
+    }
+
+    /// CR 119.4 + CR 603.7c + CR 608.2c: Necrodominance / Plunge into Darkness
+    /// shape — optional `PayCost { PayLife, Variable X } → IfYouDo Draw
+    /// { EventContextAmount }`. Accept the optional, submit 3 life: 3 life lost
+    /// AND 3 cards drawn (the chosen amount binds the downstream count).
+    ///
+    /// Fail-on-revert: with the prompt removed the PayLife{Variable X} resolves
+    /// to 0 (no prompt), `last_effect_count` is never stamped, the Draw reads 0,
+    /// and life is unchanged.
+    #[test]
+    fn pay_any_amount_of_life_optional_then_draw_that_many() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::engine_payment_choices::handle_optional_effect_choice;
+        use crate::game::engine_resolution_choices::handle_resolution_choice;
+        use crate::game::zones::create_object;
+        use crate::types::ability::{AbilityCondition, SubAbilityLink, TargetFilter};
+        use crate::types::actions::GameAction;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Necrodominance".to_string(),
+            Zone::Battlefield,
+        );
+        // Five library cards available to draw.
+        for n in 0..5 {
+            create_object(
+                &mut state,
+                CardId(100 + n),
+                PlayerId(0),
+                format!("Card {n}"),
+                Zone::Library,
+            );
+        }
+        state.players[0].life = 20;
+
+        // IfYouDo SequentialSibling Draw { EventContextAmount } rider.
+        let mut draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        draw.condition = Some(AbilityCondition::effect_performed());
+        draw.sub_link = SubAbilityLink::SequentialSibling;
+
+        let mut pay = ResolvedAbility::new(pay_any_life_ability(), vec![], source_id, PlayerId(0));
+        pay.sub_ability = Some(Box::new(draw));
+        pay.optional = true;
+
+        let mut events = Vec::new();
+
+        // Step A: optional prompt.
+        resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
+        assert!(
+            matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. }),
+            "expected OptionalEffectChoice, got {:?}",
+            state.waiting_for
+        );
+
+        // Step B: accept → PayAmountChoice { resource: Life, max: 20 }.
+        let waiting = handle_optional_effect_choice(&mut state, true, &mut events).unwrap();
+        match &waiting {
+            WaitingFor::PayAmountChoice { resource, max, .. } => {
+                assert_eq!(*resource, PayableResource::Life);
+                assert_eq!(*max, 20);
+            }
+            other => panic!("expected PayAmountChoice after Yes, got {other:?}"),
+        }
+
+        // Step C: submit 3 → 3 life lost, 3 cards drawn, no residue.
+        handle_resolution_choice(
+            &mut state,
+            waiting,
+            GameAction::SubmitPayAmount { amount: 3 },
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(
+            state.players[0].life, 17,
+            "3 life paid via the life-loss authority"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            3,
+            "IfYouDo Draw{{EventContextAmount=3}} draws the chosen count"
+        );
+        assert!(
+            matches!(state.waiting_for, WaitingFor::Priority { .. }),
+            "chain must fully resolve, got {:?}",
+            state.waiting_for
+        );
+    }
+
+    /// CR 119.8: Under CantLoseLife the prompt clamps max=0; submitting 0
+    /// declines the payment — no life lost, the IfYouDo Draw reads 0.
+    #[test]
+    fn pay_any_amount_of_life_under_lock_submit_zero_draws_zero() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::engine_payment_choices::handle_optional_effect_choice;
+        use crate::game::engine_resolution_choices::handle_resolution_choice;
+        use crate::game::zones::create_object;
+        use crate::types::ability::{AbilityCondition, SubAbilityLink, TargetFilter};
+        use crate::types::actions::GameAction;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Necrodominance".to_string(),
+            Zone::Battlefield,
+        );
+        for n in 0..5 {
+            create_object(
+                &mut state,
+                CardId(100 + n),
+                PlayerId(0),
+                format!("Card {n}"),
+                Zone::Library,
+            );
+        }
+        state.players[0].life = 20;
+        add_cant_lose_life_permanent(&mut state, PlayerId(0));
+
+        let mut draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        draw.condition = Some(AbilityCondition::effect_performed());
+        draw.sub_link = SubAbilityLink::SequentialSibling;
+
+        let mut pay = ResolvedAbility::new(pay_any_life_ability(), vec![], source_id, PlayerId(0));
+        pay.sub_ability = Some(Box::new(draw));
+        pay.optional = true;
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
+        let waiting = handle_optional_effect_choice(&mut state, true, &mut events).unwrap();
+        match &waiting {
+            WaitingFor::PayAmountChoice { resource, max, .. } => {
+                assert_eq!(*resource, PayableResource::Life);
+                assert_eq!(*max, 0, "CantLoseLife clamps max to 0");
+            }
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
+        handle_resolution_choice(
+            &mut state,
+            waiting,
+            GameAction::SubmitPayAmount { amount: 0 },
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(state.players[0].life, 20, "no life lost under the lock");
+        assert_eq!(
+            state.players[0].hand.len(),
+            0,
+            "paying 0 life draws 0 cards"
+        );
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1041,6 +1041,19 @@ pub(super) fn handle_resolution_choice(
                         "Counter amount choices require a pending mana ability".to_string(),
                     ));
                 }
+                PayableResource::Life => {
+                    // CR 119.4: pay N life via the life-loss-as-cost authority
+                    // (replacement pipeline + CantLoseLife) — NOT inline life
+                    // subtraction.
+                    match crate::game::life_costs::pay_life_as_cost(state, player, amount, events) {
+                        crate::game::life_costs::PayLifeCostResult::Paid { .. } => {}
+                        _ => {
+                            return Err(EngineError::InvalidAction(format!(
+                                "Player {player:?} cannot pay {amount} life"
+                            )))
+                        }
+                    }
+                }
             }
             // CR 603.7c: Bind the paid amount for downstream chain steps that
             // read `QuantityRef::EventContextAmount` (e.g. "deals that much

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6442,6 +6442,30 @@ pub(super) fn parse_cost_resource_ast(
                 },
             });
         }
+        // CR 119.4 + CR 107.1c: "pay any amount of life" → variable life payment;
+        // the amount paid binds X for the downstream "draw/look at that many"
+        // step. The word-boundary guard (eof or " .,") blocks "lifelink" /
+        // "lifeforce" from false-matching.
+        if terminated(
+            tag::<_, _, OracleError<'_>>("any amount of life"),
+            peek(alt((
+                value((), eof),
+                value((), nom::combinator::recognize(one_of(" .,"))),
+            ))),
+        )
+        .parse(rest)
+        .is_ok()
+        {
+            return Some(CostResourceImperativeAst::Pay {
+                cost: AbilityCost::PayLife {
+                    amount: QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                },
+            });
+        }
         // CR 118.1 + CR 107.3: "pay any amount of mana" → variable generic
         // mana payment. Join forces uses the total paid this way as X for the
         // following effect chain.
@@ -12367,6 +12391,34 @@ mod tests {
             ),
             "expected half-life DivideRounded, got {amount:?}"
         );
+    }
+
+    #[test]
+    fn parse_pay_any_amount_of_life_as_variable_life_cost() {
+        // CR 119.4 + CR 107.1c: "pay any amount of life" → PayLife with a
+        // Variable("X") amount; the chosen amount binds X for the downstream
+        // "draw/look at that many" step (Necrodominance, Plunge into Darkness).
+        for text in [
+            "pay any amount of life",
+            "pay any amount of life, then look at that many cards",
+        ] {
+            let lower = text.to_lowercase();
+            let Some(CostResourceImperativeAst::Pay {
+                cost: AbilityCost::PayLife { amount },
+            }) = parse_cost_resource_ast(text, &lower, &mut ParseContext::default())
+            else {
+                panic!("expected PayLife variable cost for {text:?}");
+            };
+            assert!(
+                matches!(
+                    amount,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { ref name },
+                    } if name == "X"
+                ),
+                "expected Variable(X) life amount for {text:?}, got {amount:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4220,6 +4220,9 @@ pub enum PayableResource {
     },
     /// CR 107.1c + CR 122.1: Choose how many counters to remove.
     Counters,
+    /// CR 119.4: Pay any amount of life — N is deducted as life loss via
+    /// life_costs::pay_life_as_cost (life-loss replacement pipeline + CantLoseLife).
+    Life,
 }
 
 fn default_one() -> u32 {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -401,6 +401,7 @@ mod multi_upkeep_triggers_suspend;
 mod mycoloth_upkeep_trigger;
 mod mystic_forge_regression;
 mod narset_jeskai_waymaster_draw_spells_cast;
+mod necrodominance_pay_any_life_draw;
 mod ninjutsu_cluster;
 mod nix_counter_no_mana_spent;
 mod ob_nixilis_captive_kingpin_life_loss;

--- a/crates/engine/tests/integration/necrodominance_pay_any_life_draw.rs
+++ b/crates/engine/tests/integration/necrodominance_pay_any_life_draw.rs
@@ -1,0 +1,121 @@
+//! Necrodominance — "At the beginning of your end step, you may pay any amount
+//! of life. If you do, draw that many cards."
+//!
+//! Exercises the new `PayableResource::Life` interactive subsystem end-to-end:
+//! the end-step trigger fires, the controller accepts the optional "you may",
+//! commits an amount via `SubmitPayAmount`, the life-loss authority deducts that
+//! many life, and the `EventContextAmount`-counted Draw rider draws that many
+//! cards.
+//!
+//! Discriminating: starting at P0's pre-combat main, the next end step reached
+//! is P0's own. The controller pays 3 life and must draw exactly 3 cards.
+//! Pre-fix, "pay any amount of life" lowered to `Effect::Unimplemented`, so no
+//! prompt surfaced, no life was lost, and the IfYouDo Draw read 0.
+
+use engine::game::scenario::GameScenario;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+// Only the pay-life trigger clause — the "no maximum hand size" / draw-replacement
+// clauses are orthogonal to the feature under test and kept out of the scenario.
+const ORACLE: &str = "At the beginning of your end step, you may pay any amount of life. \
+                      If you do, draw that many cards.";
+
+fn hand_size(runner: &engine::game::scenario::GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.hand.len())
+        .unwrap_or(0)
+}
+
+#[test]
+fn necrodominance_pay_any_life_draws_that_many() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Stock libraries so the end step / draw steps never deck anyone out and so
+    // there are cards to draw when the trigger resolves.
+    for &pid in &[P0, P1] {
+        scenario.with_library_top(pid, &["Lib A", "Lib B", "Lib C", "Lib D", "Lib E"]);
+    }
+    // Necrodominance on P0's battlefield, parsed from real Oracle text. Card type
+    // is irrelevant to the end-step trigger, so a minimal body suffices.
+    scenario.add_creature_from_oracle(P0, "Necrodominance", 0, 1, ORACLE);
+
+    let mut runner = scenario.build();
+    let life_before = runner.life(P0);
+    let hand_before = hand_size(&runner, P0);
+
+    // Roll forward into P0's end step, answering the trigger: accept the optional
+    // "you may" then pay 3 life. Pass priority elsewhere and declare no
+    // attackers/blockers so combat never stalls.
+    let mut drew = false;
+    for _ in 0..400 {
+        match &runner.state().waiting_for {
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                let player = *player;
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept optional pay-life");
+                assert_eq!(player, P0, "the optional belongs to the controller");
+            }
+            WaitingFor::PayAmountChoice { player, max, .. } => {
+                assert_eq!(*player, P0);
+                assert!(*max >= 3, "P0 has ≥3 life to pay, got max {max}");
+                runner
+                    .act(GameAction::SubmitPayAmount { amount: 3 })
+                    .expect("submit 3 life");
+                drew = true;
+                // Let the IfYouDo Draw rider resolve, then stop.
+                let _ = runner.act(GameAction::PassPriority);
+                break;
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                if runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                if runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    assert!(drew, "the end-step trigger must surface a PayAmountChoice");
+    assert_eq!(
+        runner.life(P0),
+        life_before - 3,
+        "paying 3 life via the life-loss authority deducts 3 life"
+    );
+    assert_eq!(
+        hand_size(&runner, P0),
+        hand_before + 3,
+        "the IfYouDo Draw must draw the chosen amount (3 cards)"
+    );
+}


### PR DESCRIPTION
Fixes #4106.

## Summary

"Pay any amount of life" was dropped to `Effect::Unimplemented`, so the whole effect did nothing — **Necrodominance** ("you may pay any amount of life. If you do, draw that many cards"), **Plunge into Darkness** ("pay any amount of life, then look at that many cards..."), **Vizkopa Confessor** (ETB pay clause).

## Root cause

The engine already implements the interactive "pay any amount" subsystem (`WaitingFor::PayAmountChoice` → `SubmitPayAmount` → `last_effect_count` → `QuantityRef::EventContextAmount`) for **Energy** and **generic mana**, but there was no `PayableResource::Life` — so "pay any amount of life" had no interactive path.

## Implementation (new `PayableResource::Life`, end-to-end, mirroring the energy path)

- **Parser** (`oracle_effect/imperative.rs`): recognize "pay any amount of life" → `AbilityCost::PayLife` with a variable amount, word-boundary-guarded so "lifelink"/"lifeforce" don't false-match.
- **Resolver** (`effects/pay.rs`): park on `WaitingFor::PayAmountChoice { resource: Life, max }` where `max` = the payer's current life, clamped to 0 under a CantLoseLife lock (CR 119.8).
- **Submit** (`engine_resolution_choices.rs`): deduct the chosen amount via the life-loss-as-cost authority (`life_costs::pay_life_as_cost`, CR 119.4 — runs the life-loss replacement pipeline), then stamp `last_effect_count` so the downstream "draw/look at that many" binds the paid amount.

No new `Effect` variant (reuses `Effect::PayCost` + `AbilityCost::PayLife`). No AI change (`PayAmountChoice` is resource-agnostic). The "As ~ enters, pay any amount of life" CDA cards (Phyrexian Processor, etc.) and Plague of Vermin's multi-player loop are out of scope. CR 119.4 / 118.3 / 119.8 / 107.1c.

## Tests

- Discriminating runtime (fail-on-revert): Necrodominance-shaped optional chain — pay 3 life → controller's life −3 **and** draws exactly 3 (without the fix it's `Unimplemented` → no prompt, draws 0); plus an end-to-end integration card-test parsing Necrodominance's real Oracle.
- CantLoseLife lock → max payable 0 → submit 0 → no life lost, draws 0.
- Resolver parks on `PayAmountChoice{Life}`; AST: "pay any amount of life" → `PayLife{Variable}`; the existing negative test (no "lifelink"/"lifeforce" match) stays green.

## Verification

`cargo +nightly test -p engine`: lib 13118 passed (incl. the new tests); the only lib failure was the pre-existing flaky `ai_support::tests::delve_payment_skips_state_clone_per_graveyard_candidate` (perf-counter race, passes in isolation). `--test integration`: harness 1456 passed; the 2 `anaphoric_scope_allowlist_guard` failures are pre-existing on the base (orthogonal, verified). `cargo check --workspace`, `clippy --workspace --all-targets --features engine/proptest -D warnings`, parser-combinator gate, rustfmt: clean.
