### PR TITLE
fix(p2p): correct reconnect dial target and stop auto-conceding dropped players

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -460,7 +460,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockGetViewerSnapshot).toHaveBeenCalledWith(2);
   });
 
-  it("starts grace-window timer on guest disconnect and auto-concedes on expiry", async () => {
+  it("holds the seat on guest disconnect and NEVER auto-concedes on grace expiry", async () => {
     const { adapter, emitConnection } = makeHost(3, 5_000);
     await adapter.initialize();
     const g1 = await joinGuest(emitConnection, {
@@ -473,30 +473,50 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     });
     await adapter.initializeGame();
 
+    // Capture g1's token before it drops, to prove the seat stays reclaimable.
+    const setup = (await g1.getSentMessages()).find(
+      (m): m is { type: "game_setup"; playerToken: string } =>
+        typeof m === "object" && m !== null && (m as { type: string }).type === "game_setup",
+    );
+    const token = setup!.playerToken;
+
     // Capture the disconnect-with-choice event.
     const events: Array<{ type: string }> = [];
     adapter.onEvent((e) => events.push(e));
 
     g1.simulateClose(); // guest 1 drops
 
-    // Adapter should have emitted the choice event and broadcast game_paused.
-    const choiceEvent = events.find(
-      (e) => e.type === "opponentDisconnectedWithChoice",
-    );
-    expect(choiceEvent).toBeDefined();
+    // Adapter emits the choice event so the host can decide — but takes no
+    // automatic action against the dropped player.
+    expect(
+      events.find((e) => e.type === "opponentDisconnectedWithChoice"),
+    ).toBeDefined();
 
-    // Advance past the grace window — auto-concede must fire.
+    // Advance well past the old grace window — a dropped player must NOT be
+    // auto-conceded. The seat is held indefinitely, waiting for them.
     mockSubmitAction.mockClear();
-    await vi.advanceTimersByTimeAsync(5_500);
-
-    // Concede submitted to engine for guest 1 (PlayerId 1).
-    expect(mockSubmitAction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "Concede",
-        data: { player_id: 1 },
-      }),
-      1,
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockSubmitAction).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "Concede" }),
+      expect.anything(),
     );
+
+    // The seat is still reclaimable long after the old grace window: a
+    // reconnect with the original token still yields a reconnect_ack — proving
+    // the seat was held, not conceded or freed.
+    const g1Reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: token,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const ack = (await g1Reconnect.getSentMessages()).find(
+      (m) =>
+        typeof m === "object" &&
+        m !== null &&
+        (m as { type: string }).type === "reconnect_ack",
+    );
+    expect(ack).toBeDefined();
   });
 
   it("cancels grace timer and resumes on reconnect with valid token", async () => {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -117,14 +117,6 @@ type GameRunState = "running" | "paused-disconnect" | "paused-manual";
 
 /** Default grace window for guest auto-reconnect, in milliseconds. */
 const DEFAULT_GRACE_PERIOD_MS = 30_000;
-/**
- * Grace window applied to every persisted seat when a host resumes.
- * Wider than the in-flight default because the entire resume scenario
- * is "host was away for a while, guests may take a while to come
- * back." 5 minutes leaves headroom for browser reopen + tab warm-up +
- * reconnect backoff.
- */
-const RESUME_GRACE_PERIOD_MS = 5 * 60_000;
 
 /**
  * Guest auto-reconnect backoff schedule. Escalates briskly for early
@@ -426,24 +418,15 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   /**
-   * Open a reconnect grace window for a seat. Used only by resume
-   * rehydration to pre-seed `disconnectedSeats` — mid-game disconnects
-   * go through `handleGuestDisconnect` which carries additional
-   * broadcast and run-state responsibilities.
-   *
-   * Uses `RESUME_GRACE_PERIOD_MS` (5m) rather than the default 30s:
-   * returning guests may need to discover the host's revival through
-   * their reconnect backoff, which can take minutes.
+   * Pre-seed a persisted guest seat as disconnected on host resume, so a
+   * returning guest's token takes `handleReconnect`'s existing valid path.
+   * No grace timer is armed: consistent with the mid-game disconnect policy,
+   * a player who hasn't returned is never auto-conceded. The seat is held
+   * indefinitely (game paused) until the guest reconnects; the host may
+   * explicitly concede or kick a seat that never comes back.
    */
   private armResumeGrace(pid: PlayerId): void {
-    const timer = setTimeout(() => {
-      if (!this.playerTokens.has(pid)) return;
-      void this.concedePlayer(pid, "Resume grace expired", "conceded")
-        .catch((err) => {
-          console.error("[P2PHost] resume-grace auto-concede failed:", err);
-        });
-    }, RESUME_GRACE_PERIOD_MS);
-    this.disconnectedSeats.set(pid, { disconnectedAt: Date.now(), timer });
+    this.disconnectedSeats.set(pid, { disconnectedAt: Date.now(), timer: null });
   }
 
   /**
@@ -1275,31 +1258,16 @@ export class P2PHostAdapter implements EngineAdapter {
       return;
     }
 
-    // Mid-game disconnect: enter grace window.
-    const timer = setTimeout(() => {
-      // Grace expired without reconnect AND without host decision — auto-concede.
-      if (this.gameRunState === "paused-disconnect") {
-        this.concedePlayer(pid, "Disconnect grace expired", "conceded")
-          .then(() => {
-            // Notify remaining guests that the seat was conceded past (not kicked).
-            for (const [otherPid, s] of this.guestSessions) {
-              if (otherPid === pid) continue;
-              s.send({
-                type: "player_conceded",
-                playerId: pid,
-                reason: "Disconnect grace expired",
-              });
-            }
-          })
-          .catch((err) => {
-            console.error("[P2PHost] auto-concede failed:", err);
-          });
-      }
-    }, this.gracePeriodMs);
-
+    // Mid-game disconnect: hold the seat open indefinitely. We do NOT
+    // auto-concede a dropped player — no grace timer is armed. The game stays
+    // `paused-disconnect`, which auto-resumes the moment the player reconnects
+    // (see `handleReconnect`'s resume check). Conceding a dropped player is
+    // now ALWAYS a deliberate host action ("Continue without them" →
+    // `concedeDisconnected`, or `kickPlayer`) — never a timer. CR 104.3a
+    // concede still applies, but only on explicit host choice.
     this.disconnectedSeats.set(pid, {
       disconnectedAt: Date.now(),
-      timer,
+      timer: null,
     });
     this.gameRunState = "paused-disconnect";
 
@@ -1585,6 +1553,12 @@ export class P2PGuestAdapter implements EngineAdapter {
     existingPlayerToken?: string,
     private readonly displayName?: string,
     private readonly reservationToken?: string,
+    // IndexedDB key for the persisted reconnect token, decoupled from
+    // `hostPeerId` (the dial target). The dial target tracks the live
+    // PEER_ID_PREFIX; the storage key is held on the legacy prefix so tokens
+    // persisted before a prefix bump still resolve. Falls back to
+    // `hostPeerId` when omitted (callers that don't persist across bumps).
+    private readonly sessionKey?: string,
   ) {
     if (existingPlayerToken) {
       this.playerToken = existingPlayerToken;
@@ -1750,7 +1724,7 @@ export class P2PGuestAdapter implements EngineAdapter {
       case "game_setup": {
         this.assignedPlayerId = msg.assignedPlayerId;
         this.playerToken = msg.playerToken;
-        void saveP2PSession(this.hostPeerId, {
+        void saveP2PSession(this.sessionKey ?? this.hostPeerId, {
           playerToken: msg.playerToken,
           playerId: msg.assignedPlayerId,
         });
@@ -1763,7 +1737,7 @@ export class P2PGuestAdapter implements EngineAdapter {
       case "reconnect_ack": {
         this.assignedPlayerId = msg.assignedPlayerId;
         if (this.playerToken) {
-          void saveP2PSession(this.hostPeerId, {
+          void saveP2PSession(this.sessionKey ?? this.hostPeerId, {
             playerToken: this.playerToken,
             playerId: msg.assignedPlayerId,
           });

--- a/client/src/components/hud/DisconnectChoiceDialog.tsx
+++ b/client/src/components/hud/DisconnectChoiceDialog.tsx
@@ -28,8 +28,10 @@ interface DisconnectChoiceDialogProps {
 
 /**
  * Host-only modal shown when a guest disconnects mid-game in a 3-4p P2P
- * session. Counts down the grace window; on expiry, auto-triggers the
- * "Continue without them" path. The parent unmounts (sets `isOpen=false`)
+ * session. Counts down the grace window as an advisory timer; on expiry it
+ * defaults to WAITING — it dismisses WITHOUT conceding, never auto-eliminating
+ * a dropped player. The host can still explicitly choose "Continue without
+ * them" while the dialog is up. The parent unmounts (sets `isOpen=false`)
  * when the player reconnects, dismissing the dialog naturally.
  */
 export function DisconnectChoiceDialog({
@@ -51,17 +53,18 @@ export function DisconnectChoiceDialog({
     setSecondsRemaining(Math.ceil(gracePeriodMs / 1000));
   }, [isOpen, gracePeriodMs, playerLabel]);
 
-  // Tick the countdown. Auto-triggers continue-without when it hits zero.
+  // Tick the countdown. On expiry, default to WAITING — dismiss without
+  // conceding. A dropped player is never auto-conceded; the host keeps the
+  // explicit "Continue without them" button while the dialog is up.
   useEffect(() => {
     if (!isOpen) return;
     if (secondsRemaining <= 0) {
-      onContinueWithout();
       onDismiss();
       return;
     }
     const id = setTimeout(() => setSecondsRemaining((n) => n - 1), 1000);
     return () => clearTimeout(id);
-  }, [isOpen, secondsRemaining, onContinueWithout, onDismiss]);
+  }, [isOpen, secondsRemaining, onDismiss]);
 
   return (
     <AnimatePresence>

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -789,25 +789,31 @@ export function GameProvider({
             hostPeerHandle = peer;
             signal.throwIfAborted();
 
-            // Reconstruct the same peer id `joinRoom(code)` dialed — the
-            // IndexedDB session key for auto-reconnect is keyed on the full
-            // prefixed id, and the guest adapter uses it on reconnect to
-            // call `peer.connect(hostPeerId)`. IndexedDB (not sessionStorage)
-            // means a guest whose tab crashed can reopen and rejoin with
-            // their original seat.
-            const hostPeerId = `phase-${code}`;
-            const existing = await loadP2PSession(hostPeerId);
+            // Two deliberately-decoupled identifiers:
+            //  - dial target: `conn.peer` — the *actual* host peer id we just
+            //    connected to (= `phase2-<code>`). Auto-reconnect re-dials
+            //    this, so it must be the live id the host registered under;
+            //    reconstructing a literal prefix here is how the dial silently
+            //    broke after the PEER_ID_PREFIX bump.
+            //  - sessionKey: the IndexedDB key for the persisted reconnect
+            //    token, held on the legacy `phase-` prefix so tokens saved
+            //    before the bump still resolve. IndexedDB (not sessionStorage)
+            //    means a guest whose tab crashed can reopen and rejoin with
+            //    their original seat.
+            const sessionKey = `phase-${code}`;
+            const existing = await loadP2PSession(sessionKey);
             const reservationToken =
               window.sessionStorage.getItem(`phase-p2p-reservation:${code}`) ?? undefined;
             signal.throwIfAborted();
             const adapter = new P2PGuestAdapter(
               deckList,
               peer,
-              hostPeerId,
+              conn.peer,
               conn,
               existing?.playerToken,
               useMultiplayerStore.getState().displayName || undefined,
               reservationToken,
+              sessionKey,
             );
             p2pAdapter = adapter;
             hostPeerHandle = null;


### PR DESCRIPTION
Reconnect dial target: the guest re-dialed a stale `phase-<code>` literal
left over when PEER_ID_PREFIX was bumped to `phase2-`, so every auto-reconnect
targeted a peer no host owns. Dial `conn.peer` (the real connected host id)
instead, and decouple the IndexedDB token key into a new optional `sessionKey`
arg kept on the legacy `phase-` prefix so existing persisted tokens resolve.

Never auto-concede a dropped player: drop the grace-expiry auto-concede in
handleGuestDisconnect and the 5-minute armResumeGrace timer (and the now-dead
RESUME_GRACE_PERIOD_MS); the seat is held (paused-disconnect, auto-resumes on
reconnect). The disconnect dialog defaults to waiting at countdown-0 instead of
conceding. Conceding a dropped player is now an explicit host action only.
