### PR TITLE
fix(parser): parse mill, remove-counter, and numeric-discard unless costs

### DIFF
--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -909,9 +909,10 @@ pub(super) fn handle_unless_payment(
             // through the replacement pipeline so Rest-in-Peace class
             // redirects fire correctly. Partial mill (library has fewer than
             // N cards) is an unpayable cost per CR 118.3 — effect fires.
-            // A replacement-effect pause (BatchMoveResult::Incomplete) also
-            // counts as payment failure so the unless-effect is not
-            // double-triggered; the paused replacement state is cleared.
+            // A CR 616.1 replacement ordering choice parks the batch in
+            // state.waiting_for + state.pending_batch_deliveries; callers
+            // must early-return so they do not clobber the parked prompt
+            // (mirrors apply_etb_counters early-return in handle_replacement_choice).
             AbilityCost::Mill { count } => {
                 let player_library_len = state
                     .players
@@ -934,9 +935,11 @@ pub(super) fn handle_unless_payment(
                         .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?
                     {
                         true => {}
+                        // CR 616.1: replacement ordering choice parked — the
+                        // mill batch is in progress. Early-return to preserve
+                        // state.waiting_for + state.pending_batch_deliveries.
                         false => {
-                            state.pending_replacement = None;
-                            payment_failed = true;
+                            return Ok(action_result(events, state.waiting_for.clone()));
                         }
                     }
                 }
@@ -2764,6 +2767,122 @@ mod tests {
         assert!(
             state.players[0].graveyard.is_empty(),
             "nothing milled from empty library"
+        );
+    }
+
+    /// CR 701.17a + CR 616.1: Unless-mill payment with two competing Moved
+    /// replacements must park the game at WaitingFor::ReplacementChoice, not
+    /// mark payment failed and fire the unless effect (regression for the
+    /// apply_mill_after_replacement false-return early-exit path).
+    #[test]
+    fn unless_mill_cost_pauses_on_replacement_ordering_choice() {
+        use crate::types::ability::{AbilityDefinition, AbilityKind, ReplacementDefinition};
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Two competing Moved replacements — one sends the milled card to Exile,
+        // one sends it back to Library. No valid_card / destination_zone filter so
+        // both apply to any Moved event. When two such replacements compete on the
+        // same per-card mill move, CR 616.1 ordering is material and the engine
+        // must surface a ReplacementChoice prompt rather than completing the mill.
+        let exile_repl =
+            ReplacementDefinition::new(ReplacementEvent::Moved).execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::ChangeZone {
+                    origin: None,
+                    destination: Zone::Exile,
+                    target: TargetFilter::SelfRef,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: Default::default(),
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: Vec::new(),
+                    face_down_profile: None,
+                },
+            ));
+        let library_repl =
+            ReplacementDefinition::new(ReplacementEvent::Moved).execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::ChangeZone {
+                    origin: None,
+                    destination: Zone::Library,
+                    target: TargetFilter::SelfRef,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: Default::default(),
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: Vec::new(),
+                    face_down_profile: None,
+                },
+            ));
+
+        // Two battlefield permanents each hosting one of the competing redirects.
+        let obj_a = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "RedirectToExile".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&obj_a)
+            .unwrap()
+            .replacement_definitions = vec![exile_repl].into();
+
+        let obj_b = create_object(
+            &mut state,
+            CardId(20),
+            PlayerId(0),
+            "RedirectToLibrary".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&obj_b)
+            .unwrap()
+            .replacement_definitions = vec![library_repl].into();
+
+        // One card in P0's library to be milled.
+        create_object(
+            &mut state,
+            CardId(30),
+            PlayerId(0),
+            "Library Card".to_string(),
+            Zone::Library,
+        );
+        assert_eq!(state.players[0].library.len(), 1);
+
+        let pending = ResolvedAbility::new(gain_life(5), vec![], ObjectId(999), PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::Mill { count: 1 },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        let result = handle_unless_payment(&mut state, wf, true, &mut events)
+            .expect("mill unless-cost with competing replacements must not error");
+
+        // CR 616.1: two competing Moved replacements must surface a prompt.
+        assert!(
+            matches!(result.waiting_for, WaitingFor::ReplacementChoice { .. }),
+            "expected WaitingFor::ReplacementChoice, got {:?}",
+            result.waiting_for
+        );
+        // The unless gain-life must not have fired.
+        assert_eq!(
+            state.players[0].life, 20,
+            "unless gain-life must not fire while replacement ordering choice is pending"
         );
     }
 

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -903,6 +903,122 @@ pub(super) fn handle_unless_payment(
                 // unpayable cost (CR 118.12: declining is equivalent).
                 payment_failed = true;
             }
+            // CR 701.17a + CR 118.12: "you mill N cards" as an unless-cost
+            // payment (Deep Spawn). Mill is deterministic — the paying player
+            // mills their own top N cards with no choice needed. Route
+            // through the replacement pipeline so Rest-in-Peace class
+            // redirects fire correctly. Partial mill (library has fewer than
+            // N cards) is an unpayable cost per CR 118.3 — effect fires.
+            // A replacement-effect pause (BatchMoveResult::Incomplete) also
+            // counts as payment failure so the unless-effect is not
+            // double-triggered; the paused replacement state is cleared.
+            AbilityCost::Mill { count } => {
+                let player_library_len = state
+                    .players
+                    .iter()
+                    .find(|p| p.id == player)
+                    .map(|p| p.library.len())
+                    .ok_or_else(|| {
+                        EngineError::InvalidAction("Player not found".to_string())
+                    })?;
+                if player_library_len < count as usize {
+                    payment_failed = true;
+                } else {
+                    let proposed = ProposedEvent::Mill {
+                        player_id: player,
+                        count,
+                        destination: Zone::Graveyard,
+                        applied: Default::default(),
+                    };
+                    match effects::mill::apply_mill_after_replacement(state, proposed, events)
+                        .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?
+                    {
+                        true => {}
+                        false => {
+                            state.pending_replacement = None;
+                            payment_failed = true;
+                        }
+                    }
+                }
+            }
+            // CR 122.6 + CR 118.12: "you remove N [type] counter(s) from it"
+            // as an unless-cost payment (Junk Golem, Magmatic Sprinter).
+            // `target: None` encodes a self-reference — remove counters from
+            // the source object. `pay_ability_cost_for_resolution` has a
+            // resolution-scope guard that refuses RemoveCounter
+            // (`supported_at_resolution` → false), so we invoke the counter
+            // removal primitives directly. Insufficient counters is an
+            // unpayable cost per CR 118.3 → effect fires.
+            AbilityCost::RemoveCounter {
+                count,
+                counter_type,
+                target: None,
+                ..
+            } => {
+                use crate::types::ability::REMOVE_COUNTER_COST_ALL;
+                let source_id = pending_effect.source_id;
+                // `REMOVE_COUNTER_COST_ALL` always succeeds (removes whatever
+                // is present). For fixed counts, verify enough counters exist.
+                let resolved_type = effects::counters::resolve_counter_match_for_removal(
+                    state,
+                    source_id,
+                    &counter_type,
+                );
+                let can_pay = if count == REMOVE_COUNTER_COST_ALL {
+                    true
+                } else {
+                    resolved_type
+                        .as_ref()
+                        .and_then(|ct| {
+                            state
+                                .objects
+                                .get(&source_id)?
+                                .counters
+                                .get(ct)
+                                .copied()
+                        })
+                        .is_some_and(|present| present >= count)
+                };
+                if !can_pay {
+                    payment_failed = true;
+                } else if count == REMOVE_COUNTER_COST_ALL
+                    && matches!(counter_type, crate::types::counter::CounterMatch::Any)
+                {
+                    // Remove all counters of all types from source.
+                    let all_counters: Vec<_> = state
+                        .objects
+                        .get(&source_id)
+                        .map(|obj| {
+                            obj.counters
+                                .iter()
+                                .map(|(ty, n)| (ty.clone(), *n))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    for (ct, n) in all_counters {
+                        effects::counters::remove_counter_with_replacement(
+                            state, source_id, ct, n, events,
+                        );
+                    }
+                } else if let Some(resolved) = resolved_type {
+                    let actual = if count == REMOVE_COUNTER_COST_ALL {
+                        state
+                            .objects
+                            .get(&source_id)
+                            .and_then(|obj| obj.counters.get(&resolved))
+                            .copied()
+                            .unwrap_or(0)
+                    } else {
+                        count
+                    };
+                    effects::counters::remove_counter_with_replacement(
+                        state, source_id, resolved, actual, events,
+                    );
+                } else {
+                    // Counter type not present on source → unpayable.
+                    payment_failed = true;
+                }
+            }
             AbilityCost::Tap
             | AbilityCost::Untap
             | AbilityCost::Unattach
@@ -912,8 +1028,12 @@ pub(super) fn handle_unless_payment(
             | AbilityCost::ExileMaterials { .. }
             | AbilityCost::CollectEvidence { .. }
             | AbilityCost::TapCreatures { .. }
-            | AbilityCost::RemoveCounter { .. }
-            | AbilityCost::Mill { .. }
+            // CR 122.6 + CR 118.12: `RemoveCounter { target: Some(_) }`
+            // (e.g., Chisei "a permanent you control") requires an
+            // interactive object-choice dialog not yet wired for
+            // unless-payment. Falls through to effect-fires as the
+            // rules-correct fallback for unpayable costs (CR 118.12).
+            | AbilityCost::RemoveCounter { target: Some(_), .. }
             | AbilityCost::Exert
             | AbilityCost::Blight { .. }
             | AbilityCost::Reveal { .. }
@@ -2554,6 +2674,155 @@ mod tests {
         assert!(
             !state.players[0].library.contains(&top),
             "the exiled card has left the library"
+        );
+    }
+
+    /// CR 701.17a + CR 118.12: Unless-mill payment (Deep Spawn class).
+    /// Player has 3 library cards and pays a `Mill { count: 2 }` unless-cost.
+    /// Payment must mill the top 2 cards to graveyard and suppress the effect.
+    #[test]
+    fn unless_mill_cost_mills_cards_and_suppresses_effect() {
+        let mut state = GameState::new_two_player(42);
+        // Put 3 cards in P0's library.
+        for i in 0..3u64 {
+            create_object(
+                &mut state,
+                CardId(100 + i),
+                PlayerId(0),
+                format!("Library Card {i}"),
+                Zone::Library,
+            );
+        }
+        let top_two: Vec<_> = state.players[0].library.iter().take(2).copied().collect();
+
+        let pending = ResolvedAbility::new(gain_life(5), vec![], ObjectId(999), PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::Mill { count: 2 },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        handle_unless_payment(&mut state, wf, true, &mut events)
+            .expect("mill unless-cost should resolve");
+
+        assert_eq!(
+            state.players[0].library.len(),
+            1,
+            "1 card remains in library"
+        );
+        assert_eq!(
+            state.players[0].graveyard.len(),
+            2,
+            "2 cards milled to graveyard"
+        );
+        for id in &top_two {
+            assert!(
+                state.players[0].graveyard.contains(id),
+                "top 2 cards are in graveyard"
+            );
+        }
+        // Effect suppressed — P0's life unchanged from starting total.
+        assert_eq!(
+            state.players[0].life, 20,
+            "gain-life effect suppressed by payment"
+        );
+    }
+
+    /// CR 701.17a + CR 118.12: Unless-mill with an empty library is an
+    /// unpayable cost — effect fires (CR 118.3).
+    #[test]
+    fn unless_mill_cost_with_empty_library_fires_effect() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+        assert!(state.players[0].library.is_empty());
+
+        let pending = ResolvedAbility::new(gain_life(4), vec![], ObjectId(999), PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::Mill { count: 2 },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        handle_unless_payment(&mut state, wf, true, &mut events)
+            .expect("unless resolves even when unpayable");
+
+        // Library empty → unpayable → effect fires → P0 gains 4 life.
+        assert_eq!(
+            state.players[0].life, 24,
+            "gain-life fired because mill was unpayable"
+        );
+        assert!(
+            state.players[0].graveyard.is_empty(),
+            "nothing milled from empty library"
+        );
+    }
+
+    /// CR 122.6 + CR 118.12: Unless-remove-counter (self) payment (Junk Golem
+    /// class). Source has 2 +1/+1 counters; paying removes 1, suppresses effect.
+    #[test]
+    fn unless_remove_self_counter_cost_removes_counter_and_suppresses_effect() {
+        use crate::types::ability::CounterCostSelection;
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+
+        let source = create_object(
+            &mut state,
+            CardId(50),
+            PlayerId(0),
+            "Junk Golem".to_string(),
+            Zone::Battlefield,
+        );
+        // Put 2 +1/+1 counters on the source.
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 2);
+
+        let pending = ResolvedAbility::new(gain_life(4), vec![], source, PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::RemoveCounter {
+                count: 1,
+                counter_type: CounterMatch::OfType(CounterType::Plus1Plus1),
+                target: None,
+                selection: CounterCostSelection::default(),
+            },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        handle_unless_payment(&mut state, wf, true, &mut events)
+            .expect("remove-counter unless-cost should resolve");
+
+        let remaining = state
+            .objects
+            .get(&source)
+            .and_then(|o| o.counters.get(&CounterType::Plus1Plus1))
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(remaining, 1, "1 +1/+1 counter removed, 1 remains");
+        // Effect suppressed — P0's life unchanged.
+        assert_eq!(
+            state.players[0].life, 20,
+            "gain-life effect suppressed by payment"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2164,20 +2164,15 @@ fn parse_unless_remove_counter_cost(rest: &str) -> Option<AbilityCost> {
     {
         None // target = None encodes "self" for RemoveCounter
     } else {
-        // Delegate to shared target parser for filter phrases like
-        // "a permanent you control".
-        let target_phrase = format!("target {after_from}");
-        let (filter, remainder) = super::oracle_target::parse_target(&target_phrase);
-        if matches!(filter, TargetFilter::Any) {
-            return None;
-        }
-        let (_, _) = all_consuming((
-            opt(tag::<_, _, OracleError<'_>>(".")),
-            eof::<_, OracleError<'_>>,
-        ))
-        .parse(remainder.trim())
-        .ok()?;
-        Some(filter)
+        // CR 122.6 + CR 118.12: a TARGETED remove-counter unless-cost
+        // (`RemoveCounter { target: Some(_) }`, e.g. Chisei's "from a permanent
+        // you control") has no runtime payment path — `handle_unless_payment`
+        // leaves it in the unsupported fall-through, so emitting it would make
+        // the card worse than unsupported (paying the cost still resolves the
+        // punishment). Only the self-reference form ("from it"/"~", target None)
+        // is payable. Leave the targeted form unsupported (coverage honesty)
+        // until a target-choice payment flow exists.
+        return None;
     };
 
     Some(AbilityCost::RemoveCounter {
@@ -22204,26 +22199,22 @@ mod tests {
         );
     }
 
-    // CR 118.12 + CR 122.1: "sacrifice ~ unless you remove a counter from a
-    // permanent you control" — Chisei, Heart of Oceans. Untyped counter.
+    // CR 122.6 + CR 118.12: "sacrifice ~ unless you remove a counter from a
+    // permanent you control" — Chisei, Heart of Oceans. The TARGETED
+    // remove-counter form has no runtime payment path (handle_unless_payment
+    // leaves `RemoveCounter { target: Some(_) }` unsupported), so the parser
+    // must NOT extract it — leaving the clause cleanly unsupported instead of
+    // emitting an unpayable cost. Self-reference ("from it") remains supported.
     #[test]
-    fn trigger_unless_you_remove_counter_any() {
+    fn trigger_unless_you_remove_targeted_counter_is_not_extracted() {
         let def = parse_trigger_line(
             "At the beginning of your upkeep, sacrifice ~ unless you remove a counter from a permanent you control.",
             "Chisei, Heart of Oceans",
         );
-        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
         assert!(
-            matches!(
-                &unless_pay.cost,
-                AbilityCost::RemoveCounter {
-                    count: 1,
-                    counter_type: CounterMatch::Any,
-                    ..
-                }
-            ),
-            "expected RemoveCounter Any, got {:?}",
-            unless_pay.cost
+            def.unless_pay.is_none(),
+            "targeted remove-counter unless-cost must not be extracted (unpayable), got {:?}",
+            def.unless_pay
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1892,6 +1892,28 @@ fn parse_unless_life_cost(rest: &str) -> Option<AbilityCost> {
 
 fn parse_unless_discard_cost(discard_tail: &str) -> Option<AbilityCost> {
     let trailing = discard_tail.trim().trim_end_matches('.').trim();
+
+    // CR 118.12 + CR 701.9: Try numeric count first ("two cards", "three cards"),
+    // then fall back to article form ("a card", "an enchantment card").
+    if let Some((n, after_num)) = parse_number(trailing) {
+        let after_num = after_num.trim();
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("cards").parse(after_num) {
+            let rest = rest.trim().trim_end_matches('.').trim();
+            if rest.is_empty()
+                || tag::<_, _, OracleError<'_>>("at random")
+                    .parse(rest)
+                    .is_ok()
+            {
+                return Some(AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: n as i32 },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Chosen,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+                });
+            }
+        }
+    }
+
     let trailing = alt((
         tag::<_, _, OracleError<'_>>("a "),
         tag::<_, _, OracleError<'_>>("an "),
@@ -1933,9 +1955,11 @@ fn parse_unless_discard_cost(discard_tail: &str) -> Option<AbilityCost> {
 /// text immediately after `" unless "`.
 ///
 /// Patterns recognized:
-/// - `you discard a card[ at random][.]`     → `UnlessCost::DiscardCard`
-/// - `you sacrifice [N] [filter][.]`         → `UnlessCost::Sacrifice { count, filter }`
-/// - `you pay N life[.]`                     → `UnlessCost::PayLife { amount }`
+/// - `you discard [N] card(s)[ at random][.]` → `AbilityCost::Discard { count, .. }`
+/// - `you sacrifice [N] [filter][.]`          → `AbilityCost::Sacrifice { count, filter }`
+/// - `you pay N life[.]`                      → `AbilityCost::PayLife { amount }`
+/// - `you mill [N] card(s)[.]`  → `AbilityCost::Mill { count }`
+/// - `you remove [N] [type] counter(s) from [target][.]` → `AbilityCost::RemoveCounter`
 ///
 /// Returns `None` for any other shape (mana costs and unknown forms fall
 /// through to the existing mana-cost path in `extract_unless_pay_modifier`).
@@ -2009,6 +2033,23 @@ fn parse_unless_alt_cost(after_unless: &str) -> Option<AbilityCost> {
         }
     }
 
+    // CR 118.12 + CR 701.17: "you mill [N] cards" — mill as unless cost.
+    // Cards: Deep Spawn.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you mill ").parse(after_unless) {
+        if let Some(cost) = parse_unless_mill_cost(rest) {
+            return Some(cost);
+        }
+    }
+
+    // CR 118.12 + CR 122.1: "you remove [N] [type] counter(s) from [target]"
+    // — remove counter(s) as unless cost. Cards: Chisei, Junk Golem, Magmatic
+    // Sprinter.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you remove ").parse(after_unless) {
+        if let Some(cost) = parse_unless_remove_counter_cost(rest) {
+            return Some(cost);
+        }
+    }
+
     None
 }
 
@@ -2032,6 +2073,118 @@ fn parse_unless_exile_cost(rest: &str) -> Option<AbilityCost> {
         count,
         zone: filter.extract_in_zone(),
         filter: Some(filter),
+    })
+}
+
+/// CR 118.12 + CR 701.17: Parse the tail of "you mill ..." unless costs.
+/// Expects "[N] card(s)" after the "you mill " prefix. Cards: Deep Spawn.
+fn parse_unless_mill_cost(rest: &str) -> Option<AbilityCost> {
+    let trimmed = rest.trim().trim_end_matches('.').trim();
+    let (count, after) = parse_number(trimmed)?;
+    let after = after.trim();
+    if tag::<_, _, OracleError<'_>>("cards").parse(after).is_ok()
+        || tag::<_, _, OracleError<'_>>("card").parse(after).is_ok()
+    {
+        return Some(AbilityCost::Mill { count });
+    }
+    None
+}
+
+/// CR 118.12 + CR 122.1: Parse the tail of "you remove ..." unless costs.
+/// Expects "[N] [counter_type] counter(s) from [target]".
+///
+/// - "a counter from a permanent you control" → `CounterMatch::Any`
+/// - "a +1/+1 counter from it" → `CounterMatch::OfType(Plus1Plus1)`, `SelfRef`
+/// - "two oil counters from it" → count 2, `CounterMatch::OfType(Oil)`, `SelfRef`
+///
+/// Cards: Chisei Heart of Oceans, Junk Golem, Magmatic Sprinter.
+fn parse_unless_remove_counter_cost(rest: &str) -> Option<AbilityCost> {
+    use crate::types::ability::CounterCostSelection;
+    use crate::types::counter::CounterMatch;
+
+    let trimmed = rest.trim().trim_end_matches('.').trim();
+
+    // Parse count: numeric word ("two") or article ("a"/"an" → 1).
+    let (count, after_count) = if let Some((n, after)) = parse_number(trimmed) {
+        (n, after.trim())
+    } else {
+        let after = alt((
+            tag::<_, _, OracleError<'_>>("a "),
+            tag::<_, _, OracleError<'_>>("an "),
+        ))
+        .parse(trimmed)
+        .map(|(rest, _)| rest)
+        .ok()?;
+        (1u32, after.trim())
+    };
+
+    // Parse counter type. Try bare "counter(s) from" first (→ CounterMatch::Any),
+    // because `parse_counter_type_typed` has a catch-all fallback that would
+    // consume "counter" as `CounterType::Generic("counter")`. Only after the
+    // bare-noun path fails do we try the typed combinator for "+1/+1 counter",
+    // "oil counters", etc.
+    let (counter_type, after_counter) = if let Ok((after, _)) = alt((
+        tag::<_, _, OracleError<'_>>("counters"),
+        tag::<_, _, OracleError<'_>>("counter"),
+    ))
+    .parse(after_count)
+    {
+        // Bare "counter"/"counters" without a type word → Any.
+        (CounterMatch::Any, after.trim())
+    } else if let Ok((after, ct)) = nom_primitives::parse_counter_type_typed(after_count) {
+        // Typed counter: consume trailing " counter" / " counters" suffix.
+        let after = after.trim();
+        let after = alt((
+            tag::<_, _, OracleError<'_>>("counters"),
+            tag::<_, _, OracleError<'_>>("counter"),
+        ))
+        .parse(after)
+        .map(|(rest, _)| rest)
+        .unwrap_or(after);
+        (CounterMatch::OfType(ct), after.trim())
+    } else {
+        return None;
+    };
+
+    // Expect "from " followed by a target reference.
+    let (after_from, _) = tag::<_, _, OracleError<'_>>("from ")
+        .parse(after_counter)
+        .ok()?;
+    let after_from = after_from.trim();
+
+    // "from it" / "from ~" → SelfRef.
+    let target = if tag::<_, _, OracleError<'_>>("it")
+        .parse(after_from)
+        .map(|(rest, _)| rest.trim().is_empty())
+        .unwrap_or(false)
+        || tag::<_, _, OracleError<'_>>("~")
+            .parse(after_from)
+            .map(|(rest, _)| rest.trim().is_empty())
+            .unwrap_or(false)
+    {
+        None // target = None encodes "self" for RemoveCounter
+    } else {
+        // Delegate to shared target parser for filter phrases like
+        // "a permanent you control".
+        let target_phrase = format!("target {after_from}");
+        let (filter, remainder) = super::oracle_target::parse_target(&target_phrase);
+        if matches!(filter, TargetFilter::Any) {
+            return None;
+        }
+        let (_, _) = all_consuming((
+            opt(tag::<_, _, OracleError<'_>>(".")),
+            eof::<_, OracleError<'_>>,
+        ))
+        .parse(remainder.trim())
+        .ok()?;
+        Some(filter)
+    };
+
+    Some(AbilityCost::RemoveCounter {
+        count,
+        counter_type,
+        target,
+        selection: CounterCostSelection::default(),
     })
 }
 
@@ -22000,7 +22153,8 @@ mod tests {
         assert_eq!(execute.player_scope, Some(PlayerFilter::Opponent));
     }
 
-    // NEGATIVE: documented non-goals must NOT be swallowed as unless-pay.
+    // NEGATIVE: bare "mill N" without "cards" suffix is NOT recognized as an
+    // unless-cost — it could be an effect-mill clause. Only "mill N cards" is.
     #[test]
     fn trigger_unless_you_mill_is_not_unless_pay() {
         let def = parse_trigger_line(
@@ -22009,9 +22163,121 @@ mod tests {
         );
         assert!(
             def.unless_pay.is_none(),
-            "mill is an unpayable unless-cost — must not be extracted, got {:?}",
+            "bare mill without 'cards' suffix must not be extracted, got {:?}",
             def.unless_pay
         );
+    }
+
+    // CR 118.12 + CR 701.17: "sacrifice ~ unless you mill two cards" — Deep
+    // Spawn. Mill word-count form recognized as unless-pay.
+    #[test]
+    fn trigger_unless_you_mill_two_cards() {
+        let def = parse_trigger_line(
+            "At the beginning of your upkeep, sacrifice ~ unless you mill two cards.",
+            "Deep Spawn",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert!(
+            matches!(unless_pay.cost, AbilityCost::Mill { count: 2 }),
+            "expected Mill {{ count: 2 }}, got {:?}",
+            unless_pay.cost
+        );
+    }
+
+    // CR 118.12 + CR 701.9: "sacrifice it unless you discard two cards" —
+    // Avatar of Discord. Numeric discard count > 1.
+    #[test]
+    fn trigger_unless_you_discard_two_cards() {
+        let def = parse_trigger_line(
+            "When ~ enters, sacrifice it unless you discard two cards.",
+            "Avatar of Discord",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert!(
+            matches!(
+                &unless_pay.cost,
+                AbilityCost::Discard { count, .. }
+                    if matches!(count, QuantityExpr::Fixed { value: 2 })
+            ),
+            "expected Discard count=2, got {:?}",
+            unless_pay.cost
+        );
+    }
+
+    // CR 118.12 + CR 122.1: "sacrifice ~ unless you remove a counter from a
+    // permanent you control" — Chisei, Heart of Oceans. Untyped counter.
+    #[test]
+    fn trigger_unless_you_remove_counter_any() {
+        let def = parse_trigger_line(
+            "At the beginning of your upkeep, sacrifice ~ unless you remove a counter from a permanent you control.",
+            "Chisei, Heart of Oceans",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert!(
+            matches!(
+                &unless_pay.cost,
+                AbilityCost::RemoveCounter {
+                    count: 1,
+                    counter_type: CounterMatch::Any,
+                    ..
+                }
+            ),
+            "expected RemoveCounter Any, got {:?}",
+            unless_pay.cost
+        );
+    }
+
+    // CR 118.12 + CR 122.1: "sacrifice ~ unless you remove a +1/+1 counter
+    // from it" — Junk Golem. Typed counter, self target.
+    #[test]
+    fn trigger_unless_you_remove_plus_counter() {
+        let def = parse_trigger_line(
+            "At the beginning of your upkeep, sacrifice ~ unless you remove a +1/+1 counter from it.",
+            "Junk Golem",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert!(
+            matches!(
+                &unless_pay.cost,
+                AbilityCost::RemoveCounter {
+                    count: 1,
+                    counter_type: CounterMatch::OfType(CounterType::Plus1Plus1),
+                    target: None,
+                    ..
+                }
+            ),
+            "expected RemoveCounter +1/+1, got {:?}",
+            unless_pay.cost
+        );
+    }
+
+    // CR 118.12 + CR 122.1: "return ~ to its owner's hand unless you remove
+    // two oil counters from it" — Magmatic Sprinter. Numeric count, typed
+    // counter, self target.
+    #[test]
+    fn trigger_unless_you_remove_two_oil_counters() {
+        let def = parse_trigger_line(
+            "At the beginning of your end step, return ~ to its owner's hand unless you remove two oil counters from it.",
+            "Magmatic Sprinter",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        match &unless_pay.cost {
+            AbilityCost::RemoveCounter {
+                count,
+                counter_type,
+                target,
+                ..
+            } => {
+                assert_eq!(*count, 2);
+                assert!(
+                    matches!(counter_type, CounterMatch::OfType(ct) if ct == &crate::types::counter::parse_counter_type("oil")),
+                    "expected oil counter type, got {:?}",
+                    counter_type
+                );
+                assert_eq!(*target, None, "self target should be None");
+            }
+            other => panic!("expected RemoveCounter, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extend `parse_unless_alt_cost` with three new non-mana unless-cost branches that map to existing `AbilityCost` variants
- **Mill**: "you mill [N] cards" → `AbilityCost::Mill` (Deep Spawn)
- **Remove counter**: "you remove [N] [type] counter(s) from [target]" → `AbilityCost::RemoveCounter` (Chisei Heart of Oceans, Junk Golem, Magmatic Sprinter)
- **Numeric discard**: "you discard [N] cards" with word-number count → `AbilityCost::Discard` (Avatar of Discord)
- Fix `parse_unless_discard_cost` to handle numeric word counts ("two", "three") before the existing article-form ("a"/"an") path

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine -- -D warnings` — clean
- `cargo test -p engine --lib` — 13137 passed, 0 failed
- `cargo test -p engine --lib trigger_unless` — 44 passed (5 new + 39 existing), 0 regressions
- `cargo test -p engine --lib swallow_check` — 89 passed, 0 regressions