### PR TITLE
Fix Selvala, Explorer Returned parley mana (fixes #841)

### DIFF
--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2027,6 +2027,28 @@ fn parse_destroyed_or_sacrificed_this_way_filter(
     None
 }
 
+fn parse_filtered_revealed_this_way(lower: &str) -> Option<QuantityRef> {
+    for suffix in [" revealed this way", "revealed this way"] {
+        let result: OracleResult<'_, &str> =
+            terminated(take_until(suffix), tag(suffix)).parse(lower);
+        if let Ok(("", filter_phrase)) = result {
+            let (filter, remainder) =
+                crate::parser::oracle_target::parse_type_phrase(filter_phrase.trim());
+            if !remainder.trim().is_empty() {
+                continue;
+            }
+            if filter_is_nontrivial_for_tracked_set(&filter) {
+                return Some(QuantityRef::FilteredTrackedSetSize {
+                    filter: Box::new(filter),
+                    caused_by: None,
+                });
+            }
+            return Some(QuantityRef::TrackedSetSize);
+        }
+    }
+    None
+}
+
 fn parse_filtered_destroyed_this_way(lower: &str) -> Option<QuantityRef> {
     match parse_destroyed_or_sacrificed_this_way_filter(lower)? {
         (Some(filter), cause) if filter_is_nontrivial_for_tracked_set(&filter) => {
@@ -2573,6 +2595,9 @@ fn parse_for_each_clause_with_they_controller(
         // Only emit `FilteredTrackedSetSize` when the filter restricts the
         // tracked set. Bare "destroyed this way" still falls through to the
         // unfiltered `TrackedSetSize`.
+        if let Some(qty) = parse_filtered_revealed_this_way(&lower) {
+            return Some(qty);
+        }
         if let Some(qty) = parse_filtered_destroyed_this_way(&lower) {
             return Some(qty);
         }
@@ -6276,6 +6301,30 @@ mod tests {
                                 .as_ref()
                                 .is_some_and(|c| matches!(c, ControllerRef::You)),
                             "filter must require controller=You"
+                        );
+                    }
+                    other => panic!("expected Typed filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
+        }
+    }
+
+    /// CR 608.2c + CR 701.20b: "nonland card revealed this way" (Selvala,
+    /// Explorer Returned parley) must emit `FilteredTrackedSetSize` with a
+    /// nonland filter and no producer-action binding.
+    #[test]
+    fn nonland_card_revealed_this_way_uses_filtered_tracked_set_nonland() {
+        let qty = parse_for_each_clause("nonland card revealed this way").expect("must parse");
+        match qty {
+            QuantityRef::FilteredTrackedSetSize { filter, caused_by } => {
+                assert_eq!(caused_by, None, "revealed-this-way is action-agnostic");
+                match *filter {
+                    TargetFilter::Typed(ref tf) => {
+                        assert!(
+                            tf.type_filters
+                                .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))),
+                            "filter must include NonLand; got {tf:?}"
                         );
                     }
                     other => panic!("expected Typed filter, got {other:?}"),

--- a/crates/engine/tests/integration/issue_841_selvala_explorer_returned.rs
+++ b/crates/engine/tests/integration/issue_841_selvala_explorer_returned.rs
@@ -9,9 +9,17 @@ use engine::types::phase::Phase;
 
 const SELVALA_ORACLE: &str = "Parley — {T}: Each player reveals the top card of their library. For each nonland card revealed this way, add {G} and you gain 1 life. Then each player draws a card.";
 
-fn stamp_library_top(runner: &mut engine::game::scenario::GameRunner, player: engine::types::PlayerId, core_type: CoreType) {
+fn stamp_library_top(
+    runner: &mut engine::game::scenario::GameRunner,
+    player: engine::types::PlayerId,
+    core_type: CoreType,
+) {
     let top = runner.state().players[player.0 as usize].library[0];
-    let obj = runner.state_mut().objects.get_mut(&top).expect("library top");
+    let obj = runner
+        .state_mut()
+        .objects
+        .get_mut(&top)
+        .expect("library top");
     obj.card_types.core_types.push(core_type);
     obj.base_card_types = obj.card_types.clone();
 }
@@ -41,7 +49,9 @@ fn selvala_parley_adds_green_only_for_nonland_reveals() {
     runner.advance_until_stack_empty();
 
     assert_eq!(
-        runner.state().players[P0.0 as usize].mana_pool.count_color(ManaType::Green),
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(ManaType::Green),
         1,
         "one nonland reveal across both players must produce exactly one green mana"
     );

--- a/crates/engine/tests/integration/issue_841_selvala_explorer_returned.rs
+++ b/crates/engine/tests/integration/issue_841_selvala_explorer_returned.rs
@@ -1,0 +1,53 @@
+//! Issue #841 — Selvala, Explorer Returned parley must add {G} only for nonland reveals.
+//!
+//! https://github.com/phase-rs/phase/issues/841
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::card_type::CoreType;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+
+const SELVALA_ORACLE: &str = "Parley — {T}: Each player reveals the top card of their library. For each nonland card revealed this way, add {G} and you gain 1 life. Then each player draws a card.";
+
+fn stamp_library_top(runner: &mut engine::game::scenario::GameRunner, player: engine::types::PlayerId, core_type: CoreType) {
+    let top = runner.state().players[player.0 as usize].library[0];
+    let obj = runner.state_mut().objects.get_mut(&top).expect("library top");
+    obj.card_types.core_types.push(core_type);
+    obj.base_card_types = obj.card_types.clone();
+}
+
+#[test]
+fn selvala_parley_adds_green_only_for_nonland_reveals() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Grizzly Bears", "Library Bottom"]);
+    scenario.with_library_top(P1, &["Forest", "Library Bottom"]);
+    scenario.add_creature_from_oracle(P0, "Selvala, Explorer Returned", 2, 3, SELVALA_ORACLE);
+
+    let mut runner = scenario.build();
+    stamp_library_top(&mut runner, P0, CoreType::Creature);
+    stamp_library_top(&mut runner, P1, CoreType::Land);
+
+    let selvala_id = runner
+        .state()
+        .battlefield
+        .iter()
+        .find(|id| runner.state().objects[id].name == "Selvala, Explorer Returned")
+        .copied()
+        .expect("Selvala on battlefield");
+    let life_before = runner.state().players[P0.0 as usize].life;
+
+    runner.activate(selvala_id, 0).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].mana_pool.count_color(ManaType::Green),
+        1,
+        "one nonland reveal across both players must produce exactly one green mana"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before + 1,
+        "Selvala must gain 1 life per nonland card revealed"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -345,6 +345,7 @@ mod issue_688_mind_into_matter;
 mod issue_689_resonating_lute_hand_size;
 mod issue_691_sheoldred_saga_lore;
 mod issue_709_regression;
+mod issue_841_selvala_explorer_returned;
 mod issue_859_weathered_wayfarer;
 mod issue_860_luminarch_aspirant;
 mod issue_861_first_sliver_cascade;


### PR DESCRIPTION
## Summary
- Parse `for each nonland card revealed this way` as `FilteredTrackedSetSize` with a nonland filter instead of unfiltered `TrackedSetSize`.
- Add parser and integration tests for Selvala, Explorer Returned's parley ability.

## Root cause
The `for each … this way` path only recognized producer-action suffixes like `discarded this way`. Reveal sets use an action-agnostic tracked set, so `nonland card revealed this way` fell through to counting every revealed card — including lands.

## Test plan
- [x] `cargo test -p engine --lib nonland_card_revealed_this_way`
- [x] `cargo test -p engine --test integration selvala_parley`

Fixes #841

Made with [Cursor](https://cursor.com)