### PR TITLE
fix(parser): recognize countered_spell_zone as condition marker in swallow checker

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2033,6 +2033,12 @@ fn detect_condition_if(
         // skip_serializing_if = is_none) IS the conditional gate (Teferi's
         // Response, Green Slime, Tishana's Tidebinder).
         "\"source_rider\":",
+        // CR 701.6a: Effect::Counter.countered_spell_zone encodes the
+        // "if that spell is countered this way, put it [on top of / on
+        // the bottom of its owner's library | into its owner's hand]"
+        // destination override. Its presence IS the conditional gate
+        // (Memory Lapse, Lapse of Certainty, Remand, Spell Crumple).
+        "\"countered_spell_zone\":",
     ];
     if json_has_any(ast_json, cond_markers) {
         return;
@@ -3819,6 +3825,31 @@ mod tests {
             &["Creature"],
         );
         assert!(!has_swallowed_detector(&green_slime, "Condition_If"));
+    }
+
+    /// CR 701.6a: "If that spell is countered this way, put it [somewhere]"
+    /// — the redirect destination is encoded as `countered_spell_zone` on the
+    /// Counter effect.  Its presence IS the conditional gate (Memory Lapse,
+    /// Lapse of Certainty, Remand, Spell Crumple).
+    #[test]
+    fn condition_if_accepts_countered_spell_zone_redirect() {
+        let memory_lapse = parse_named(
+            "Counter target spell. If that spell is countered this way, \
+             put it on top of its owner's library instead of into that \
+             player's graveyard.",
+            "Memory Lapse",
+            &["Instant"],
+        );
+        assert!(!has_swallowed_detector(&memory_lapse, "Condition_If"));
+
+        let remand = parse_named(
+            "Counter target spell. If that spell is countered this way, \
+             put it into its owner's hand instead of into that player's \
+             graveyard.\nDraw a card.",
+            "Remand",
+            &["Instant"],
+        );
+        assert!(!has_swallowed_detector(&remand, "Condition_If"));
     }
 
     /// CR 702.170c + CR 608.2c: "You may exile a card … If you do, it becomes


### PR DESCRIPTION
## Summary
- Add `"countered_spell_zone":` to the `cond_markers` list in `detect_condition_if` (swallow checker) so that `Counter` effects with a redirect destination are recognized as encoding the "if that spell is countered this way" conditional gate — matching the existing `source_rider` pattern for the same effect variant.
- Promotes 4 fully-parsed cards from `supported: false` to `supported: true`: Memory Lapse, Lapse of Certainty, Remand, Spell Crumple.

## Verification
- `cargo fmt --all` — clean
- `cargo test -p engine -- swallow_check::tests::condition_if_accepts_countered_spell_zone_redirect` — passed
- `cargo coverage` before/after: all 4 cards move from unsupported to supported with zero remaining gaps