### PR TITLE
feat(engine): perpetual type-change (Alchemy 'perpetually becomes a [type] with base P/T and gains [kw]') — Second Little Pig

### DIFF
--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -41,10 +41,13 @@ pub fn resolve(
         ids.push(ability.source_id);
     }
 
+    // Cloned before the mutable object loop: a `Become` modification needs the
+    // game's creature-type set to know which existing subtypes to replace.
+    let all_creature_types = state.all_creature_types.clone();
     let mut changed = false;
     for id in ids {
         if let Some(obj) = state.objects.get_mut(&id) {
-            obj.apply_perpetual_modification(&modification);
+            obj.apply_perpetual_modification(&modification, &all_creature_types);
             changed = true;
         }
     }
@@ -152,5 +155,60 @@ mod tests {
         let obj = state.objects.get(&id).unwrap();
         assert_eq!(obj.power, Some(4));
         assert_eq!(obj.toughness, Some(1));
+    }
+
+    /// CR 613.4: a perpetual `Become` replaces creature subtypes, sets base P/T,
+    /// and grants keywords — and must dirty layers so the live, public
+    /// characteristics reflect the change after the boundary flush (Second Little
+    /// Pig: "becomes a Boar Spirit with base power and toughness 4/4 and gains
+    /// flying").
+    #[test]
+    fn perpetual_become_updates_live_types_pt_keywords_after_flush() {
+        use crate::types::card_type::CoreType;
+        use crate::types::keywords::Keyword;
+        let mut state = GameState::new_two_player(7);
+        state.all_creature_types = vec!["Boar".into(), "Spirit".into(), "Pig".into()];
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Second Little Pig".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.base_power = Some(1);
+            obj.base_toughness = Some(1);
+            obj.base_card_types.core_types = vec![CoreType::Creature];
+            obj.base_card_types.subtypes = vec!["Pig".into()];
+        }
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::flush_layers(&mut state);
+
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: crate::types::ability::TargetFilter::Any,
+                modification: PerpetualModification::Become {
+                    creature_subtypes: vec!["Boar".into(), "Spirit".into()],
+                    power: 4,
+                    toughness: 4,
+                    keywords: vec![Keyword::Flying],
+                },
+            },
+            vec![TargetRef::Object(id)],
+            id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        super::resolve(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::flush_layers(&mut state);
+
+        let obj = state.objects.get(&id).unwrap();
+        assert_eq!(obj.power, Some(4));
+        assert_eq!(obj.toughness, Some(4));
+        assert!(obj.card_types.subtypes.contains(&"Boar".to_string()));
+        assert!(obj.card_types.subtypes.contains(&"Spirit".to_string()));
+        assert!(!obj.card_types.subtypes.contains(&"Pig".to_string()));
+        assert!(obj.keywords.contains(&Keyword::Flying));
     }
 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1001,10 +1001,13 @@ impl GameObject {
     /// Apply an Alchemy "perpetually" modification to this card: record it on the
     /// object (so it persists across zones/serialization and can be re-applied
     /// after a copy rebuilds base characteristics) and edit the corresponding
-    /// persistent characteristic. Increment 1: base power/toughness.
+    /// persistent characteristic(s). `all_creature_types` is the game's known
+    /// creature-type set, used to identify which existing subtypes are creature
+    /// subtypes when a `Become` replaces them (CR 613.4).
     pub fn apply_perpetual_modification(
         &mut self,
         modification: &crate::types::ability::PerpetualModification,
+        all_creature_types: &[String],
     ) {
         use crate::types::ability::PerpetualModification;
         match modification {
@@ -1014,6 +1017,38 @@ impl GameObject {
                 // change permanent and zone-independent.
                 self.base_power = Some(*power);
                 self.base_toughness = Some(*toughness);
+            }
+            PerpetualModification::Become {
+                creature_subtypes,
+                power,
+                toughness,
+                keywords,
+            } => {
+                // CR 613.4 + CR 205.1b: "becomes a <subtypes> creature" replaces
+                // the card's creature subtypes (keeping any non-creature subtypes)
+                // and makes it a creature; the listed base P/T and keywords apply.
+                self.base_card_types
+                    .subtypes
+                    .retain(|s| !all_creature_types.iter().any(|c| c == s));
+                self.base_card_types
+                    .subtypes
+                    .extend(creature_subtypes.iter().cloned());
+                if !self
+                    .base_card_types
+                    .core_types
+                    .contains(&crate::types::card_type::CoreType::Creature)
+                {
+                    self.base_card_types
+                        .core_types
+                        .push(crate::types::card_type::CoreType::Creature);
+                }
+                self.base_power = Some(*power);
+                self.base_toughness = Some(*toughness);
+                for kw in keywords {
+                    if !self.base_keywords.contains(kw) {
+                        self.base_keywords.push(kw.clone());
+                    }
+                }
             }
         }
         self.perpetual_mods.push(modification.clone());

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5869,6 +5869,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "[~] perpetually becomes a <subtypes> with base power
+    // and toughness N/N [and gains <kw>]" — ApplyPerpetual type-change. Tried
+    // before the bare base-P/T form (more specific: requires "a <subtypes> with").
+    if let Some(effect) = try_parse_perpetual_become(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "[~/it/this creature] perpetually become(s)/has base
     // power and toughness N/N" — the ApplyPerpetual keyword action (base P/T).
     if let Some(effect) = try_parse_perpetual_base_pt(tp) {
@@ -6067,6 +6074,91 @@ fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
         modification: crate::types::ability::PerpetualModification::SetBasePowerToughness {
             power: power as i32,
             toughness: toughness as i32,
+        },
+    })
+}
+
+/// Digital-only Alchemy: parse the self-subject type-change "perpetually" form —
+/// "[~] perpetually becomes a \<subtypes\> [creature] with base power and
+/// toughness N/N [and gains \<keyword\>]" → [`Effect::ApplyPerpetual`] with
+/// [`PerpetualModification::Become`] (Second Little Pig).
+///
+/// Self-subjects only (no anaphoric "it"/"the duplicate"). The clause tail must
+/// be fully consumed, so compound riders that aren't modeled (e.g. Heir to
+/// Dragonfire's "gets +3/+3") fall through to `Unimplemented` instead of being
+/// silently dropped — Heir lacks the "with base power and toughness" segment and
+/// is rejected by the `take_until` below.
+fn try_parse_perpetual_become(tp: TextPair) -> Option<Effect> {
+    let lower = tp.lower;
+    let after_subject = [
+        "~ ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this permanent ",
+        "this token ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually becomes a ")
+        .parse(after_subject)
+        .ok()?;
+    let (rest, subtypes_phrase) =
+        take_until::<_, _, OracleError<'_>>(" with base power and toughness ")
+            .parse(rest)
+            .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" with base power and toughness ")
+        .parse(rest)
+        .ok()?;
+    let (rest, power) = nom_primitives::parse_number(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("/").parse(rest).ok()?;
+    let (rest, toughness) = nom_primitives::parse_number(rest).ok()?;
+
+    let mut keywords = Vec::new();
+    let rest = if let Ok((after, _)) = tag::<_, _, OracleError<'_>>(" and gains ").parse(rest) {
+        // allow-noncombinator: strip a trailing sentence period from the captured
+        // keyword text (punctuation cleanup, not parsing dispatch).
+        let kw_text = after.strip_suffix('.').unwrap_or(after);
+        let kw = crate::parser::oracle_keyword::parse_keyword_from_oracle(kw_text)?;
+        keywords.push(kw);
+        ""
+    } else {
+        rest
+    };
+    if !(rest.is_empty() || rest == ".") {
+        return None;
+    }
+
+    // The captured phrase ("boar spirit", optionally trailing " creature") names
+    // the creature subtypes; canonicalize each word to its capitalized subtype.
+    let phrase = subtypes_phrase
+        // allow-noncombinator: drop an optional trailing " creature" word from the
+        // captured subtype phrase (structural cleanup, not parsing dispatch).
+        .strip_suffix(" creature")
+        .unwrap_or(subtypes_phrase);
+    let creature_subtypes: Vec<String> = phrase
+        // allow-noncombinator: tokenize the captured creature-subtype phrase into
+        // its individual subtypes — structural, not parsing dispatch.
+        .split_whitespace()
+        .map(crate::parser::oracle_quantity::capitalize_first)
+        .collect();
+    if creature_subtypes.is_empty() {
+        return None;
+    }
+
+    Some(Effect::ApplyPerpetual {
+        target: TargetFilter::Any,
+        modification: crate::types::ability::PerpetualModification::Become {
+            creature_subtypes,
+            power: power as i32,
+            toughness: toughness as i32,
+            keywords,
         },
     })
 }
@@ -48609,6 +48701,46 @@ mod tests {
                 ..
             } if type_filters == vec![TypeFilter::Creature]
                 && properties == vec![FilterProp::Blocking, FilterProp::Another]
+        ));
+    }
+
+    #[test]
+    fn perpetual_become_parser_maps_type_pt_keyword() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::keywords::Keyword;
+        // Second Little Pig: type-change + base P/T + gained keyword.
+        let e = parse_effect(
+            "~ perpetually becomes a Boar Spirit with base power and toughness 4/4 and gains flying.",
+        );
+        let Effect::ApplyPerpetual {
+            modification:
+                PerpetualModification::Become {
+                    creature_subtypes,
+                    power,
+                    toughness,
+                    keywords,
+                },
+            ..
+        } = e
+        else {
+            panic!("expected Become, got {e:?}");
+        };
+        assert_eq!(
+            creature_subtypes,
+            vec!["Boar".to_string(), "Spirit".to_string()]
+        );
+        assert_eq!((power, toughness), (4, 4));
+        assert_eq!(keywords, vec![Keyword::Flying]);
+
+        // Heir to Dragonfire ("becomes a Dragon, gets +3/+3, …") lacks the "with
+        // base power and toughness" segment, so it must NOT parse as Become.
+        let heir = parse_effect("~ perpetually becomes a Dragon, gets +3/+3, and gains flying.");
+        assert!(!matches!(
+            heir,
+            Effect::ApplyPerpetual {
+                modification: PerpetualModification::Become { .. },
+                ..
+            }
         ));
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7432,6 +7432,19 @@ pub enum PerpetualModification {
     /// the card's persistent base power and toughness (High Fae Prankster,
     /// Three Tree Battalion, Blood Age Muster).
     SetBasePowerToughness { power: i32, toughness: i32 },
+    /// CR 613.4 + CR 205.1b: "[object] perpetually becomes a \<subtypes\>
+    /// creature with base power and toughness P/T and gains \<keywords\>" — a
+    /// permanent type-change: the card becomes a creature whose creature
+    /// subtypes are replaced with `creature_subtypes`, with the given base P/T,
+    /// and gains `keywords` (Second Little Pig: "becomes a Boar Spirit with base
+    /// power and toughness 4/4 and gains flying").
+    Become {
+        creature_subtypes: Vec<String>,
+        power: i32,
+        toughness: i32,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        keywords: Vec<Keyword>,
+    },
 }
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
Fixes #4124.

## What

Follow-up to the Alchemy **perpetually** mechanic (#4104). Adds the **perpetual type-change** form â€” "[~] perpetually becomes a \<subtypes\> creature with base power and toughness N/N and gains \<keyword\>".

Card fixed (Scryfall-verified):

- **Second Little Pig** â€” "{2}{W/B}{W/B}: Second Little Pig perpetually becomes a Boar Spirit with base power and toughness 4/4 and gains flying. Activate only if Second Little Pig isn't a Spirit."

## How

Reuses the merged `perpetual_mods` / base-edit pattern â€” no new layer machinery. Adds `PerpetualModification::Become { creature_subtypes, power, toughness, keywords }`:

- **Resolver** (`apply_perpetual_modification`): replaces the card's **creature** subtypes (keeps any non-creature subtypes, classified via `state.all_creature_types` â€” CR 613.4), ensures it is a creature, sets base power/toughness, grants the keywords â€” all on the persistent `base_*` fields, then `mark_layers_full` so the live/public characteristics recompute at the next flush (the issue matthewevans flagged on #4104).
- **Parser** (`try_parse_perpetual_become`, tried before the bare base-P/T form): self-subjects only (no anaphoric "it"/"the duplicate"). The clause tail must be fully consumed, so compound riders that aren't modeled (e.g. Heir to Dragonfire's "gets +3/+3") fall through to `Unimplemented` rather than being silently dropped.

## Verification

- Parser unit test: the Second Little Pig phrasing â†’ `Become { [Boar, Spirit], 4/4, [Flying] }`; Heir to Dragonfire's "becomes a Dragon, gets +3/+3" does **not** parse as `Become`.
- Resolver runtime regression: after resolution + `flush_layers`, the live `card_types.subtypes` (Boar/Spirit, not Pig), `power`/`toughness` (4/4), and `keywords` (flying) reflect the change â€” not just the base fields.
- `cargo fmt`, the parser-combinator gate, and `clippy -D warnings` (engine + phase-ai) green; card-data regenerated.

## Scope

Self-subject "becomes a \<subtypes\> with base P/T N/N [and gains \<kw\>]" only. Deferred: "gets +N/+N" perpetual P/T modifier (Heir to Dragonfire, Jaheira â€” needs P/T-modifier layer integration), referenced-object subjects ("the duplicate"/"its"), and "perpetually gains [ability]".

CR 613.4 (type-changing), CR 205.1b (subtypes).
