### PR TITLE
fix(parser): parse negated cast-from-zone intervening-if conditions

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -16048,6 +16048,94 @@ pub mod tests {
         }
     }
 
+    /// CR 601.2 + CR 404.1 + CR 603.4: "if you cast it from your graveyard"
+    /// ("you cast it" + owner-specific zone) scopes BOTH axes — caster=you AND
+    /// origin-zone owner=you. Drives the parser-emitted condition through
+    /// `check_trigger_condition` across all four owner × caster rows relative to
+    /// the trigger controller (P0): only the row where you cast your own card
+    /// from your graveyard satisfies it. Before the scope fix the parser emitted
+    /// `controller: None, owner: None`, which wrongly passed every row.
+    #[test]
+    fn you_cast_from_your_graveyard_scopes_both_caster_and_owner() {
+        let trigger = crate::parser::oracle_trigger::parse_trigger_line(
+            "When this creature enters, if you cast it from your graveyard, put a +1/+1 counter on it.",
+            "Gravecaster",
+        );
+        let condition = trigger
+            .condition
+            .expect("scoped gravecast intervening-if must parse");
+        assert_eq!(
+            condition,
+            TriggerCondition::WasCast {
+                zone: Some(Zone::Graveyard),
+                controller: Some(ControllerRef::You),
+                owner: Some(ControllerRef::You),
+            },
+            "'you cast it from your graveyard' must scope both caster and owner to you"
+        );
+
+        // (owner, caster, expected) relative to trigger controller P0.
+        let cases = [
+            (
+                PlayerId(0),
+                PlayerId(0),
+                true,
+                "you cast your card from your graveyard",
+            ),
+            (
+                PlayerId(0),
+                PlayerId(1),
+                false,
+                "opponent cast your card from your graveyard",
+            ),
+            (
+                PlayerId(1),
+                PlayerId(0),
+                false,
+                "you cast a card from an opponent's graveyard",
+            ),
+            (
+                PlayerId(1),
+                PlayerId(1),
+                false,
+                "opponent cast their card from their graveyard",
+            ),
+        ];
+        for (owner, caster, expected, label) in cases {
+            let mut state = setup();
+            let entering = create_object(
+                &mut state,
+                CardId(1),
+                owner,
+                "Gravecaster".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&entering).unwrap();
+                obj.cast_from_zone = Some(Zone::Graveyard);
+                obj.cast_controller = Some(caster);
+            }
+            let event = zone_changed_event(
+                entering,
+                Zone::Stack,
+                Zone::Battlefield,
+                vec![CoreType::Creature],
+                Vec::new(),
+            );
+            assert_eq!(
+                check_trigger_condition(
+                    &state,
+                    &condition,
+                    PlayerId(0),
+                    Some(entering),
+                    Some(&event),
+                ),
+                expected,
+                "both-axes-scoped gravecast mismatch: {label}"
+            );
+        }
+    }
+
     /// CR 603.4 + CR 601.2h: Satoru's intervening-if must fail at resolution
     /// re-check when the entering creature was cast for mana, even after
     /// `clear_post_collection_transients` clears the transient boolean.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -770,17 +770,22 @@ pub(super) fn strip_cast_from_zone_conditional(text: &str) -> (Option<AbilityCon
     // hand/graveyard/exile" (Epochrasite, Phage the Untouchable on effect-level
     // paths). MUST precede the positive form to avoid partial prefix matching.
     if let Some((zone, rest)) = nom_on_lower(text, &lower, |input| {
+        // Decompose into prefix + zone: the prefix accepts both the ASCII
+        // (`didn't`) and curly (`didn’t`, U+2019) apostrophe used by Scryfall
+        // printings; the zone is the shared owner-specific/exile alternation.
+        let (input, _) = alt((
+            tag("if you didn't cast it from "),
+            tag("if you didn’t cast it from "),
+        ))
+        .parse(input)?;
         alt((
-            value(Zone::Hand, tag("if you didn't cast it from your hand")),
-            value(
-                Zone::Graveyard,
-                tag("if you didn't cast it from your graveyard"),
-            ),
-            value(Zone::Exile, tag("if you didn't cast it from exile")),
+            value(Zone::Hand, tag("your hand")),
+            value(Zone::Graveyard, tag("your graveyard")),
+            value(Zone::Exile, tag("exile")),
         ))
         .parse(input)
     }) {
-        let rest = rest.strip_prefix(", ").unwrap_or(rest);
+        let rest = remainder_after_optional_comma(rest);
         return (
             Some(AbilityCondition::Not {
                 condition: Box::new(AbilityCondition::CastFromZone { zone }),
@@ -797,7 +802,7 @@ pub(super) fn strip_cast_from_zone_conditional(text: &str) -> (Option<AbilityCon
         ))
         .parse(input)
     }) {
-        let rest = rest.strip_prefix(", ").unwrap_or(rest);
+        let rest = remainder_after_optional_comma(rest);
         return (
             Some(AbilityCondition::CastFromZone { zone }),
             rest.to_string(),

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -766,6 +766,29 @@ fn try_nom_condition_as_unless(
 
 pub(super) fn strip_cast_from_zone_conditional(text: &str) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
+    // CR 603.4 + CR 601.2: Negated form — "if you didn't cast it from your
+    // hand/graveyard/exile" (Epochrasite, Phage the Untouchable on effect-level
+    // paths). MUST precede the positive form to avoid partial prefix matching.
+    if let Some((zone, rest)) = nom_on_lower(text, &lower, |input| {
+        alt((
+            value(Zone::Hand, tag("if you didn't cast it from your hand")),
+            value(
+                Zone::Graveyard,
+                tag("if you didn't cast it from your graveyard"),
+            ),
+            value(Zone::Exile, tag("if you didn't cast it from exile")),
+        ))
+        .parse(input)
+    }) {
+        let rest = rest.strip_prefix(", ").unwrap_or(rest);
+        return (
+            Some(AbilityCondition::Not {
+                condition: Box::new(AbilityCondition::CastFromZone { zone }),
+            }),
+            rest.to_string(),
+        );
+    }
+    // CR 603.4 + CR 601.2: Positive form — "if you cast it from your hand/exile/graveyard".
     if let Some((zone, rest)) = nom_on_lower(text, &lower, |input| {
         alt((
             value(Zone::Hand, tag("if you cast it from your hand")),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3122,7 +3122,13 @@ fn parse_first_time_tapped_intervening_if(input: &str) -> OracleResult<'_, Trigg
 /// Epochrasite). Nom combinator consumed by `scan_preceded` in
 /// `extract_if_condition`.
 fn parse_negated_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
-    let (rest, _) = tag("if you didn't cast it from ").parse(input)?;
+    // Accept both the ASCII (`didn't`) and curly (`didn’t`, U+2019) apostrophe —
+    // Scryfall/Oracle text uses the curly form for some printings.
+    let (rest, _) = alt((
+        tag("if you didn't cast it from "),
+        tag("if you didn’t cast it from "),
+    ))
+    .parse(input)?;
     let (rest, zone) = alt((
         value(Zone::Hand, tag("your hand")),
         value(Zone::Graveyard, tag("your graveyard")),
@@ -3132,13 +3138,30 @@ fn parse_negated_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, 
     Ok((
         rest,
         TriggerCondition::Not {
-            condition: Box::new(TriggerCondition::WasCast {
-                zone: Some(zone),
-                controller: None,
-                owner: None,
-            }),
+            condition: Box::new(scoped_you_cast_from_zone(zone)),
         },
     ))
+}
+
+/// CR 601.2 + CR 400.3 + CR 404.1: Build the caster/owner-scoped `WasCast` for a
+/// "you cast it from <zone>" intervening-if. The CASTER axis is always you
+/// ("you cast it"); the ORIGIN-ZONE-OWNER axis is you only for owner-specific
+/// zones ("your hand"/"your graveyard", CR 404.1) and stays unscoped for the
+/// shared exile zone ("from exile" carries no possessive). Mirrors the scoped
+/// cast arm of `graveyard_origin_or_condition` so both axes remain separately
+/// resolvable — an opponent casting your card, or you casting from someone
+/// else's owner-specific zone, must not satisfy the scoped condition.
+fn scoped_you_cast_from_zone(zone: Zone) -> TriggerCondition {
+    // CR 400.3 + CR 404.1: hand/graveyard/library are owner-specific; exile is shared.
+    let owner = match zone {
+        Zone::Hand | Zone::Graveyard | Zone::Library => Some(ControllerRef::You),
+        _ => None,
+    };
+    TriggerCondition::WasCast {
+        zone: Some(zone),
+        controller: Some(ControllerRef::You),
+        owner,
+    }
 }
 
 /// CR 603.4 + CR 601.2: Parse "if you cast it from your hand/exile" or
@@ -3152,14 +3175,7 @@ fn parse_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerC
         value(Zone::Exile, tag("exile")),
     ))
     .parse(rest)?;
-    Ok((
-        rest,
-        TriggerCondition::WasCast {
-            zone: Some(zone),
-            controller: None,
-            owner: None,
-        },
-    ))
+    Ok((rest, scoped_you_cast_from_zone(zone)))
 }
 
 /// Extract an intervening-if condition from effect text.
@@ -16342,9 +16358,10 @@ mod tests {
         );
     }
 
-    /// CR 603.4 + CR 601.2: "if you didn't cast it from your hand" —
+    /// CR 603.4 + CR 601.2 + CR 404.1: "if you didn't cast it from your hand" —
     /// negated zone-specific cast check (Chainer, Nightmare Adept; Phage the
-    /// Untouchable). Must hoist as `Not(WasCast { zone: Hand })`.
+    /// Untouchable). Must hoist as `Not(WasCast { zone: Hand, caster=you,
+    /// owner=you })` — both the caster and owner-specific axes are scoped.
     #[test]
     fn extract_if_condition_negated_cast_from_hand() {
         let (cleaned, cond) = extract_if_condition(
@@ -16359,12 +16376,12 @@ mod tests {
                     condition.as_ref(),
                     TriggerCondition::WasCast {
                         zone: Some(Zone::Hand),
-                        controller: None,
-                        owner: None,
+                        controller: Some(ControllerRef::You),
+                        owner: Some(ControllerRef::You),
                     }
                 )
             ),
-            "expected Not(WasCast {{ zone: Hand }}), got {cond:?}",
+            "expected Not(WasCast {{ zone: Hand, you/you }}), got {cond:?}",
         );
         assert!(
             // allow-noncombinator: test assertion verifying clause excision
@@ -16373,8 +16390,9 @@ mod tests {
         );
     }
 
-    /// CR 603.4 + CR 601.2: "if you cast it from your hand" — positive
-    /// zone-specific cast check hoisted as `WasCast { zone: Hand }`.
+    /// CR 603.4 + CR 601.2 + CR 404.1: "if you cast it from your hand" — positive
+    /// zone-specific cast check hoisted as `WasCast { zone: Hand, caster=you,
+    /// owner=you }`. The owner-specific zone scopes both axes.
     #[test]
     fn extract_if_condition_cast_from_hand() {
         let (cleaned, cond) =
@@ -16384,16 +16402,35 @@ mod tests {
                 cond,
                 Some(TriggerCondition::WasCast {
                     zone: Some(Zone::Hand),
-                    controller: None,
-                    owner: None,
+                    controller: Some(ControllerRef::You),
+                    owner: Some(ControllerRef::You),
                 })
             ),
-            "expected WasCast {{ zone: Hand }}, got {cond:?}",
+            "expected WasCast {{ zone: Hand, you/you }}, got {cond:?}",
         );
         assert!(
             // allow-noncombinator: test assertion verifying clause excision
             !cleaned.contains("cast it from"),
             "intervening-if clause must be excised, got: {cleaned}",
+        );
+    }
+
+    /// CR 601.2 + CR 404.1: "if you cast it from exile" scopes the CASTER axis
+    /// to you but leaves the ORIGIN-ZONE-OWNER unscoped — exile is a shared
+    /// zone ("from exile" has no possessive), unlike hand/graveyard.
+    #[test]
+    fn extract_if_condition_cast_from_exile_owner_unscoped() {
+        let (_, cond) = extract_if_condition("if you cast it from exile, draw a card.");
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::WasCast {
+                    zone: Some(Zone::Exile),
+                    controller: Some(ControllerRef::You),
+                    owner: None,
+                })
+            ),
+            "expected WasCast {{ zone: Exile, caster=you, owner=None }}, got {cond:?}",
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14111,8 +14111,9 @@ mod tests {
     }
 
     /// Issue #3682 — Chainer, Nightmare Adept: "if you didn't cast it from your
-    /// hand" must hoist as `Not(WasCast { zone: Hand })`, NOT as
-    /// `Not(EffectOutcome(OptionalEffectPerformed))`.
+    /// hand" must hoist as `Not(WasCast { zone: Hand, caster=you, owner=you })`,
+    /// NOT as `Not(EffectOutcome(OptionalEffectPerformed))`. CR 404.1: "your
+    /// hand" scopes both the caster and the owner-specific zone to you.
     #[test]
     fn trigger_intervening_if_negated_cast_from_hand_chainer() {
         let def = parse_trigger_line(
@@ -14128,15 +14129,15 @@ mod tests {
                         condition.as_ref(),
                         TriggerCondition::WasCast {
                             zone: Some(Zone::Hand),
-                            controller: None,
-                            owner: None,
+                            controller: Some(ControllerRef::You),
+                            owner: Some(ControllerRef::You),
                         }
                     ),
-                    "expected WasCast {{ zone: Hand }}, got {:?}",
+                    "expected WasCast {{ zone: Hand, you/you }}, got {:?}",
                     condition
                 );
             }
-            other => panic!("expected Not(WasCast {{ zone: Hand }}), got {other:?}"),
+            other => panic!("expected Not(WasCast {{ zone: Hand, you/you }}), got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3116,6 +3116,52 @@ fn parse_first_time_tapped_intervening_if(input: &str) -> OracleResult<'_, Trigg
     Ok((rest, TriggerCondition::FirstTimeObjectTappedThisTurn))
 }
 
+/// CR 603.4 + CR 601.2: Parse "if you didn't cast it from your hand/exile" or
+/// "if you didn't cast it from your graveyard" — negated zone-specific cast
+/// provenance intervening-if (Chainer, Nightmare Adept; Phage the Untouchable;
+/// Epochrasite). Nom combinator consumed by `scan_preceded` in
+/// `extract_if_condition`.
+fn parse_negated_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
+    let (rest, _) = tag("if you didn't cast it from ").parse(input)?;
+    let (rest, zone) = alt((
+        value(Zone::Hand, tag("your hand")),
+        value(Zone::Graveyard, tag("your graveyard")),
+        value(Zone::Exile, tag("exile")),
+    ))
+    .parse(rest)?;
+    Ok((
+        rest,
+        TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::WasCast {
+                zone: Some(zone),
+                controller: None,
+                owner: None,
+            }),
+        },
+    ))
+}
+
+/// CR 603.4 + CR 601.2: Parse "if you cast it from your hand/exile" or
+/// "if you cast it from your graveyard" — positive zone-specific cast
+/// provenance intervening-if (Myojin cycle enters-with-counter gate).
+fn parse_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
+    let (rest, _) = tag("if you cast it from ").parse(input)?;
+    let (rest, zone) = alt((
+        value(Zone::Hand, tag("your hand")),
+        value(Zone::Graveyard, tag("your graveyard")),
+        value(Zone::Exile, tag("exile")),
+    ))
+    .parse(rest)?;
+    Ok((
+        rest,
+        TriggerCondition::WasCast {
+            zone: Some(zone),
+            controller: None,
+            owner: None,
+        },
+    ))
+}
+
 /// Extract an intervening-if condition from effect text.
 /// Returns (cleaned effect text, optional condition).
 ///
@@ -3157,6 +3203,38 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
 
     // --- Source-referential patterns (cannot be StaticConditions) ---
     // These require trigger-source context that StaticCondition can't express.
+
+    // CR 603.4 + CR 601.2: "if you didn't cast it from your hand/graveyard/exile"
+    // — negated zone-specific cast check (Chainer, Nightmare Adept; Phage the
+    // Untouchable). The entering object must NOT have been cast from the named
+    // zone. MUST precede the zoneless "if you cast it" arm: the negated form
+    // contains "cast it from" which the zoneless arm's guard would skip, but the
+    // negated phrase would otherwise fall through to the effect parser and be
+    // misinterpreted as `Not(EffectOutcome(OptionalEffectPerformed))`.
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_negated_cast_from_zone_intervening_if)
+    {
+        let pos = before.len();
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, pos, clause_len),
+            Some(condition),
+        );
+    }
+
+    // CR 603.4 + CR 601.2: "if you cast it from your hand/graveyard/exile" —
+    // positive zone-specific cast check. The entering object must have been cast
+    // from the named zone. MUST precede the zoneless "if you cast it" arm.
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_cast_from_zone_intervening_if)
+    {
+        let pos = before.len();
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, pos, clause_len),
+            Some(condition),
+        );
+    }
 
     // CR 701.57a: "if you cast it" — zoneless cast check (Discover ETBs).
     // Guard: must not be followed by " from" (zone-specific variant).
@@ -14016,6 +14094,36 @@ mod tests {
         }
     }
 
+    /// Issue #3682 — Chainer, Nightmare Adept: "if you didn't cast it from your
+    /// hand" must hoist as `Not(WasCast { zone: Hand })`, NOT as
+    /// `Not(EffectOutcome(OptionalEffectPerformed))`.
+    #[test]
+    fn trigger_intervening_if_negated_cast_from_hand_chainer() {
+        let def = parse_trigger_line(
+            "Whenever a nontoken creature you control enters, if you didn't cast it from your hand, it gains haste until your next turn.",
+            "Chainer, Nightmare Adept",
+        );
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.destination, Some(Zone::Battlefield));
+        match &def.condition {
+            Some(TriggerCondition::Not { condition }) => {
+                assert!(
+                    matches!(
+                        condition.as_ref(),
+                        TriggerCondition::WasCast {
+                            zone: Some(Zone::Hand),
+                            controller: None,
+                            owner: None,
+                        }
+                    ),
+                    "expected WasCast {{ zone: Hand }}, got {:?}",
+                    condition
+                );
+            }
+            other => panic!("expected Not(WasCast {{ zone: Hand }}), got {other:?}"),
+        }
+    }
+
     #[test]
     fn trigger_intervening_if_spell_from_hand_this_turn_attaches_condition() {
         let def = parse_trigger_line(
@@ -16230,6 +16338,61 @@ mod tests {
         assert!(
             // allow-noncombinator: test assertion verifying clause excision, not parsing dispatch
             !cleaned.contains("put onto the battlefield with this ability"),
+            "intervening-if clause must be excised, got: {cleaned}",
+        );
+    }
+
+    /// CR 603.4 + CR 601.2: "if you didn't cast it from your hand" —
+    /// negated zone-specific cast check (Chainer, Nightmare Adept; Phage the
+    /// Untouchable). Must hoist as `Not(WasCast { zone: Hand })`.
+    #[test]
+    fn extract_if_condition_negated_cast_from_hand() {
+        let (cleaned, cond) = extract_if_condition(
+            "if you didn't cast it from your hand, it gains haste until your next turn.",
+        );
+        assert!(
+            matches!(
+                &cond,
+                Some(TriggerCondition::Not {
+                    condition
+                }) if matches!(
+                    condition.as_ref(),
+                    TriggerCondition::WasCast {
+                        zone: Some(Zone::Hand),
+                        controller: None,
+                        owner: None,
+                    }
+                )
+            ),
+            "expected Not(WasCast {{ zone: Hand }}), got {cond:?}",
+        );
+        assert!(
+            // allow-noncombinator: test assertion verifying clause excision
+            !cleaned.contains("didn't cast"),
+            "intervening-if clause must be excised, got: {cleaned}",
+        );
+    }
+
+    /// CR 603.4 + CR 601.2: "if you cast it from your hand" — positive
+    /// zone-specific cast check hoisted as `WasCast { zone: Hand }`.
+    #[test]
+    fn extract_if_condition_cast_from_hand() {
+        let (cleaned, cond) =
+            extract_if_condition("if you cast it from your hand, put a counter on it.");
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::WasCast {
+                    zone: Some(Zone::Hand),
+                    controller: None,
+                    owner: None,
+                })
+            ),
+            "expected WasCast {{ zone: Hand }}, got {cond:?}",
+        );
+        assert!(
+            // allow-noncombinator: test assertion verifying clause excision
+            !cleaned.contains("cast it from"),
             "intervening-if clause must be excised, got: {cleaned}",
         );
     }


### PR DESCRIPTION
Fixes #3682

## Summary
- Add nom combinators `parse_negated_cast_from_zone_intervening_if` and `parse_cast_from_zone_intervening_if` for trigger-level "if you (didn't) cast it from your hand/graveyard/exile" intervening-if patterns — covers the entire class of negated and positive zone-specific cast-provenance conditions
- Extend `strip_cast_from_zone_conditional` with the negated form for effect-level paths (Epochrasite-style trailing conditions)
- Fixes Chainer, Nightmare Adept's haste grant and Phage the Untouchable's lose-the-game trigger, which were misinterpreted as `Not(EffectOutcome(OptionalEffectPerformed))` instead of `Not(WasCast { zone: Hand })`

## Verification
- `cargo fmt --all` — clean
- `parser::oracle_trigger::tests` — 788 passed, 0 failed
- `parser::oracle_effect` — 2104 passed, 0 failed
- `snapshot` — 312 passed, 0 failed