### PR TITLE
fix(parser): extend grant-all-activated-abilities source-set (battlefield + graveyard filters)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -9145,6 +9145,110 @@ mod tests {
         );
     }
 
+    /// CR 613.1f + CR 603.3: Runtime zone-filter regression for battlefield
+    /// source-set grants ("all creatures your opponents control"). The parser
+    /// encodes `InZone { Battlefield }` in the source filter; this test
+    /// proves `expand_granted_activated_abilities` honours it at runtime by
+    /// building `provider_ids` from ALL objects in `state.objects` and
+    /// relying on `matches_target_filter` to exclude off-battlefield objects.
+    ///
+    /// Discriminating: an identical provider creature in HAND must not donate
+    /// its activated abilities even though it appears in `state.objects`, while
+    /// the same creature ON THE BATTLEFIELD still does.
+    ///
+    /// Reverting `InZone { Battlefield }` from the parser arm (or removing it
+    /// from the source filter here) causes the hand-provider assertion to fail,
+    /// flipping the non-donation assertion. Replacing `state.objects.keys()` in
+    /// `expand_granted_activated_abilities` with a battlefield-only scan would
+    /// trivially make this green without the filter — but that would break the
+    /// graveyard provider arms (Necrotic Ooze / "all creature cards in all
+    /// graveyards") which scan off-battlefield zones deliberately.
+    #[test]
+    fn off_battlefield_provider_does_not_donate_activated_abilities() {
+        use crate::parser::oracle::parse_oracle_text;
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr,
+        };
+
+        let mut state = setup();
+
+        // Host: a creature on the battlefield (player 0) carrying the
+        // "has all activated abilities of all creatures your opponents
+        // control" static, parsed end-to-end.
+        let host = make_creature(&mut state, "Drana and Linvala", 3, 4, PlayerId(0));
+        let parsed = parse_oracle_text(
+            "Drana and Linvala have all activated abilities of all creatures \
+             your opponents control.",
+            "Drana and Linvala",
+            &[],
+            &["Creature".into(), "Legendary".into()],
+            &[],
+        );
+        assert_eq!(
+            parsed.statics.len(),
+            1,
+            "grant-opponents-control clause parses to one static; got {:?}",
+            parsed.statics
+        );
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.static_definitions = parsed.statics.clone().into();
+        }
+
+        // Activated ability template: {T}: gain 3 life.
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 3 },
+                player: TargetFilter::Controller,
+            },
+        )
+        .cost(AbilityCost::Tap);
+
+        // BATTLEFIELD provider: opponent creature on the battlefield —
+        // InZone { Battlefield } must match → ability IS donated to host.
+        let bf_provider = make_creature(&mut state, "Battlefield Beast", 2, 2, PlayerId(1));
+        Arc::make_mut(&mut state.objects.get_mut(&bf_provider).unwrap().abilities)
+            .push(ability.clone());
+
+        // HAND provider: identical opponent creature in hand —
+        // InZone { Battlefield } must NOT match → ability is NOT donated.
+        let hand_provider = create_object(
+            &mut state,
+            CardId(902),
+            PlayerId(1),
+            "Hand Beast".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&hand_provider).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+        }
+        Arc::make_mut(&mut state.objects.get_mut(&hand_provider).unwrap().abilities)
+            .push(ability.clone());
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let host_obj = state.objects.get(&host).unwrap();
+        assert!(
+            host_obj.abilities.iter().any(|a| a == &ability),
+            "host must gain the battlefield opponent creature's activated \
+             ability (InZone{{Battlefield}} matches); got {:?}",
+            host_obj.abilities
+        );
+        // The hand provider has the same ability; if InZone{Battlefield} is not
+        // enforced at runtime, the ability would appear twice in host_obj.abilities
+        // (once per provider). We assert exactly ONE grant was applied.
+        let grant_count = host_obj.abilities.iter().filter(|a| *a == &ability).count();
+        assert_eq!(
+            grant_count, 1,
+            "hand provider must NOT donate: expected 1 grant (from bf_provider), \
+             got {grant_count} (hand_provider donated a duplicate)"
+        );
+    }
+
     #[test]
     fn emblem_static_applies_to_matching_creatures() {
         let mut state = setup();

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -755,6 +755,7 @@ fn parse_grant_all_activated_abilities_source(
 /// ability-grant-by-reference static. Each arm is a leaf of the source-set axis;
 /// adding a new referenced set is one more `alt` arm here, never a new variant.
 fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::ability::TargetFilter> {
+    use crate::types::counter::CounterType;
     alt((
         // CR 607.2a: cards exiled with the host. Optional card-type qualifier
         // narrows the granted set (Agatha grants creature cards only).
@@ -774,6 +775,75 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
                 tag("creatures you control that don't have the same name as "),
                 alt((tag("it"), tag("~"))),
             ),
+        ),
+        // CR 613.1f: "each other creature with a +1/+1 counter on it"
+        // (Experiment Kraj) — all creatures except self with at least one
+        // +1/+1 counter.
+        value(
+            TargetFilter::And {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                        FilterProp::Counters {
+                            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                            comparator: Comparator::GE,
+                            count: QuantityExpr::Fixed { value: 1 },
+                        },
+                    ])),
+                    TargetFilter::Not {
+                        filter: Box::new(TargetFilter::SelfRef),
+                    },
+                ],
+            },
+            (
+                tag("each other creature with a +1/+1 counter on "),
+                alt((tag("it"), tag("them"))),
+            ),
+        ),
+        // CR 613.1f: "all creatures your opponents control" (Drana and Linvala)
+        value(
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+            tag("all creatures your opponents control"),
+        ),
+        // CR 613.1f: "all creature cards in all graveyards" (Necrotic Ooze)
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone {
+                zone: Zone::Graveyard,
+            }])),
+            tag("all creature cards in all graveyards"),
+        ),
+        // CR 613.1f: "all land cards in all graveyards"
+        value(
+            TargetFilter::Typed(TypedFilter::land().properties(vec![FilterProp::InZone {
+                zone: Zone::Graveyard,
+            }])),
+            tag("all land cards in all graveyards"),
+        ),
+        // CR 613.1f: "all lands on the battlefield" (Manascape Refractor)
+        value(
+            TargetFilter::Typed(TypedFilter::land()),
+            tag("all lands on the battlefield"),
+        ),
+        // CR 613.1f: "all legendary creatures you control" (Robaran Mercenaries)
+        value(
+            TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::HasSupertype {
+                        value: Supertype::Legendary,
+                    }]),
+            ),
+            tag("all legendary creatures you control"),
+        ),
+        // CR 613.1f: "all artifact cards in your graveyard"
+        value(
+            TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Artifact)
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    }]),
+            ),
+            tag("all artifact cards in your graveyard"),
         ),
     ))
     .parse(input)

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -835,14 +835,17 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
             tag("all legendary creatures you control"),
         ),
         // CR 613.1f: "all artifact cards in your graveyard"
+        // CR 108.3: Graveyard cards are "yours" by ownership, not control —
+        // use FilterProp::Owned rather than TypedFilter::controller here.
         value(
-            TargetFilter::Typed(
-                TypedFilter::new(TypeFilter::Artifact)
-                    .controller(ControllerRef::You)
-                    .properties(vec![FilterProp::InZone {
-                        zone: Zone::Graveyard,
-                    }]),
-            ),
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact).properties(vec![
+                FilterProp::Owned {
+                    controller: ControllerRef::You,
+                },
+                FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                },
+            ])),
             tag("all artifact cards in your graveyard"),
         ),
     ))

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -800,8 +800,16 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
             ),
         ),
         // CR 613.1f: "all creatures your opponents control" (Drana and Linvala)
+        // — battlefield permanents; scope to InZone { Battlefield } so dead
+        // or exiled creatures of theirs do not donate abilities.
         value(
-            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+            TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::Opponent)
+                    .properties(vec![FilterProp::InZone {
+                        zone: Zone::Battlefield,
+                    }]),
+            ),
             tag("all creatures your opponents control"),
         ),
         // CR 613.1f: "all creature cards in all graveyards" (Necrotic Ooze)
@@ -819,18 +827,29 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
             tag("all land cards in all graveyards"),
         ),
         // CR 613.1f: "all lands on the battlefield" (Manascape Refractor)
+        // — zone is explicit in the phrase; encode it so graveyard/hand land
+        // cards are excluded from the runtime provider scan.
         value(
-            TargetFilter::Typed(TypedFilter::land()),
+            TargetFilter::Typed(TypedFilter::land().properties(vec![FilterProp::InZone {
+                zone: Zone::Battlefield,
+            }])),
             tag("all lands on the battlefield"),
         ),
         // CR 613.1f: "all legendary creatures you control" (Robaran Mercenaries)
+        // — battlefield permanents; scope to InZone { Battlefield } so
+        // legendary creature cards in hand/graveyard do not donate abilities.
         value(
             TargetFilter::Typed(
                 TypedFilter::creature()
                     .controller(ControllerRef::You)
-                    .properties(vec![FilterProp::HasSupertype {
-                        value: Supertype::Legendary,
-                    }]),
+                    .properties(vec![
+                        FilterProp::HasSupertype {
+                            value: Supertype::Legendary,
+                        },
+                        FilterProp::InZone {
+                            zone: Zone::Battlefield,
+                        },
+                    ]),
             ),
             tag("all legendary creatures you control"),
         ),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5497,6 +5497,36 @@ fn parse_grant_all_activated_abilities_legendary_creatures_you_control() {
     }
 }
 
+/// CR 613.1f + CR 108.3: "all artifact cards in your graveyard" — ownership-based
+/// graveyard filter (Necrotic Ooze variant class). Uses FilterProp::Owned rather
+/// than TypedFilter::controller because graveyard cards are "yours" by ownership.
+#[test]
+fn parse_grant_all_activated_abilities_artifact_cards_in_your_graveyard() {
+    use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypedFilter};
+    use crate::types::zones::Zone;
+    use crate::types::TypeFilter;
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact).properties(vec![
+            FilterProp::Owned {
+                controller: ControllerRef::You,
+            },
+            FilterProp::InZone {
+                zone: Zone::Graveyard,
+            },
+        ])),
+    };
+    for predicate in [
+        "all activated abilities of all artifact cards in your graveyard",
+        "has all activated abilities of all artifact cards in your graveyard",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
 /// CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" (and the
 /// has/have/are/is copula variants) maps to `AddAllBasicLandTypes`; "gain all
 /// land types" maps to `AddAllLandTypes`. Building-block coverage for the whole

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5377,6 +5377,126 @@ fn parse_continuous_modifications_grants_creatures_you_control_not_same_name() {
     }
 }
 
+/// CR 613.1f: "each other creature with a +1/+1 counter on it" (Experiment Kraj)
+/// — all creatures with at least one +1/+1 counter, excluding self.
+#[test]
+fn parse_grant_all_activated_abilities_each_other_creature_with_counter() {
+    use crate::types::ability::{Comparator, FilterProp, QuantityExpr, TargetFilter, TypedFilter};
+    use crate::types::counter::{CounterMatch, CounterType};
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::And {
+            filters: vec![
+                TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                    FilterProp::Counters {
+                        counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+                        comparator: Comparator::GE,
+                        count: QuantityExpr::Fixed { value: 1 },
+                    },
+                ])),
+                TargetFilter::Not {
+                    filter: Box::new(TargetFilter::SelfRef),
+                },
+            ],
+        },
+    };
+    for predicate in [
+        "all activated abilities of each other creature with a +1/+1 counter on it",
+        "has all activated abilities of each other creature with a +1/+1 counter on it",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
+/// CR 613.1f: "all creatures your opponents control" (Drana and Linvala)
+#[test]
+fn parse_grant_all_activated_abilities_opponents_creatures() {
+    use crate::types::ability::{ControllerRef, TargetFilter, TypedFilter};
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+    };
+    for predicate in [
+        "all activated abilities of all creatures your opponents control",
+        "has all activated abilities of all creatures your opponents control",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
+/// CR 613.1f: "all creature cards in all graveyards" (Necrotic Ooze)
+#[test]
+fn parse_grant_all_activated_abilities_creature_cards_in_graveyards() {
+    use crate::types::ability::{FilterProp, TargetFilter, TypedFilter};
+    use crate::types::zones::Zone;
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone {
+            zone: Zone::Graveyard,
+        }])),
+    };
+    for predicate in [
+        "all activated abilities of all creature cards in all graveyards",
+        "has all activated abilities of all creature cards in all graveyards",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
+/// CR 613.1f: "all lands on the battlefield" (Manascape Refractor)
+#[test]
+fn parse_grant_all_activated_abilities_all_lands() {
+    use crate::types::ability::{TargetFilter, TypedFilter};
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::Typed(TypedFilter::land()),
+    };
+    for predicate in [
+        "all activated abilities of all lands on the battlefield",
+        "has all activated abilities of all lands on the battlefield",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
+/// CR 613.1f: "all legendary creatures you control" (Robaran Mercenaries)
+#[test]
+fn parse_grant_all_activated_abilities_legendary_creatures_you_control() {
+    use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypedFilter};
+    use crate::types::card_type::Supertype;
+    let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
+        source: TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::HasSupertype {
+                    value: Supertype::Legendary,
+                }]),
+        ),
+    };
+    for predicate in [
+        "all activated abilities of all legendary creatures you control",
+        "has all activated abilities of all legendary creatures you control",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![expected.clone()],
+            "predicate: {predicate}"
+        );
+    }
+}
+
 /// CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" (and the
 /// has/have/are/is copula variants) maps to `AddAllBasicLandTypes`; "gain all
 /// land types" maps to `AddAllLandTypes`. Building-block coverage for the whole

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5414,9 +5414,16 @@ fn parse_grant_all_activated_abilities_each_other_creature_with_counter() {
 /// CR 613.1f: "all creatures your opponents control" (Drana and Linvala)
 #[test]
 fn parse_grant_all_activated_abilities_opponents_creatures() {
-    use crate::types::ability::{ControllerRef, TargetFilter, TypedFilter};
+    use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypedFilter};
+    use crate::types::zones::Zone;
     let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
-        source: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+        source: TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::Opponent)
+                .properties(vec![FilterProp::InZone {
+                    zone: Zone::Battlefield,
+                }]),
+        ),
     };
     for predicate in [
         "all activated abilities of all creatures your opponents control",
@@ -5455,9 +5462,12 @@ fn parse_grant_all_activated_abilities_creature_cards_in_graveyards() {
 /// CR 613.1f: "all lands on the battlefield" (Manascape Refractor)
 #[test]
 fn parse_grant_all_activated_abilities_all_lands() {
-    use crate::types::ability::{TargetFilter, TypedFilter};
+    use crate::types::ability::{FilterProp, TargetFilter, TypedFilter};
+    use crate::types::zones::Zone;
     let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
-        source: TargetFilter::Typed(TypedFilter::land()),
+        source: TargetFilter::Typed(TypedFilter::land().properties(vec![FilterProp::InZone {
+            zone: Zone::Battlefield,
+        }])),
     };
     for predicate in [
         "all activated abilities of all lands on the battlefield",
@@ -5476,13 +5486,19 @@ fn parse_grant_all_activated_abilities_all_lands() {
 fn parse_grant_all_activated_abilities_legendary_creatures_you_control() {
     use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypedFilter};
     use crate::types::card_type::Supertype;
+    use crate::types::zones::Zone;
     let expected = ContinuousModification::GrantAllActivatedAbilitiesOf {
         source: TargetFilter::Typed(
             TypedFilter::creature()
                 .controller(ControllerRef::You)
-                .properties(vec![FilterProp::HasSupertype {
-                    value: Supertype::Legendary,
-                }]),
+                .properties(vec![
+                    FilterProp::HasSupertype {
+                        value: Supertype::Legendary,
+                    },
+                    FilterProp::InZone {
+                        zone: Zone::Battlefield,
+                    },
+                ]),
         ),
     };
     for predicate in [


### PR DESCRIPTION
Fixes #3101 (partial — remaining non-exiled source patterns)

## Summary
- Extend `grant_source_noun_phrase` in `keyword_grant.rs` with 7 new `alt` arms that produce typed `TargetFilter` values for the engine's existing `GrantAllActivatedAbilitiesOf` modification
- **New source patterns**: "each other creature with a +1/+1 counter on it" (Experiment Kraj), "all creatures your opponents control" (Drana and Linvala), "all creature cards in all graveyards" (Necrotic Ooze), "all land cards in all graveyards", "all lands on the battlefield" (Manascape Refractor), "all legendary creatures you control" (Robaran Mercenaries), "all artifact cards in your graveyard"
- No engine changes — the layer-6 `expand_granted_activated_abilities` expansion already resolves arbitrary `TargetFilter` source sets against all game objects

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine -- -D warnings` — clean
- `cargo test -p engine --lib parse_grant_all_activated` — 5 new tests passed
- `cargo test -p engine --lib oracle_static` — 865 passed, 0 regressions
- `cargo test -p engine --lib swallow_check` — 90 passed, 0 regressions
- `cargo test -p engine --lib marvin` — 1 passed (existing Marvin end-to-end)
- `cargo test -p engine --lib grants_all_activated` — 2 passed (existing layer tests)