### PR TITLE
fix(lobby): use translated AI difficulty labels in host seat picker

### DIFF
--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { FormatConfig, FormatGroup, GameFormat, MatchType } from "../../adapter/types";
+import { AI_DIFFICULTIES } from "../../constants/ai";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { FORMAT_DEFAULTS, useMultiplayerStore } from "../../stores/multiplayerStore";
 import type { AiSeatConfig, HostingSettings } from "../../stores/multiplayerStore";
@@ -9,7 +10,6 @@ import { useAiDeckCatalog } from "../../services/aiDeckCatalog";
 import { expandParsedDeck } from "../../services/deckParser";
 import { menuButtonClass } from "../menu/buttonStyles";
 import { MenuSelect, type MenuSelectGroup } from "../ui/MenuSelect";
-import { SelectField } from "../ui/SelectField";
 
 export type { AiSeatConfig };
 export type HostSettings = HostingSettings;
@@ -46,7 +46,6 @@ const GROUP_ORDER: Record<FormatGroup, number> = {
   Multiplayer: 3,
 };
 
-const DIFFICULTY_OPTIONS = ["VeryEasy", "Easy", "Medium", "Hard", "VeryHard"];
 const FFA_DECK_SIZE_OPTIONS = [60, 40] as const;
 
 /** P2P uses a hub-and-spoke topology (see `p2p-adapter.ts` `P2PHostAdapter`):
@@ -386,6 +385,14 @@ export function HostSetup({
     }
     return groups;
   }, [availableFormats]);
+  const difficultyMenuItems = useMemo(
+    () =>
+      AI_DIFFICULTIES.map(({ id }) => ({
+        value: id,
+        label: t(`menu:aiDifficulty.levels.${id}`),
+      })),
+    [t],
+  );
   const submitDisabled =
     hostDisabled || isSubmitting || hostingStatus !== "idle" || (aiSeats.length > 0 && !defaultAiDeck);
 
@@ -611,19 +618,19 @@ export function HostSetup({
                         {aiSeat ? t("hostSetup.ai") : t("hostSetup.human")}
                       </button>
                       {aiSeat ? (
-                        <SelectField
-                          chevronSize="sm"
-                          wrapperClassName="ml-auto"
-                          value={aiSeat.difficulty}
-                          onChange={(e) => setAiDifficulty(seatIndex, e.target.value)}
-                          className="rounded-[8px] border border-hairline bg-black/30 px-1.5 py-1 text-[11px] text-white outline-none"
-                        >
-                          {DIFFICULTY_OPTIONS.map((d) => (
-                            <option key={d} value={d} className="bg-[#0a0f1b] text-slate-100">
-                              {d}
-                            </option>
-                          ))}
-                        </SelectField>
+                        <MenuSelect
+                          ariaLabel={t("menu:aiDifficulty.label")}
+                          label={
+                            difficultyMenuItems.find((item) => item.value === aiSeat.difficulty)?.label ??
+                            t(`menu:aiDifficulty.levels.${aiSeat.difficulty}`)
+                          }
+                          selectedValue={aiSeat.difficulty}
+                          items={difficultyMenuItems}
+                          onSelect={(value) => setAiDifficulty(seatIndex, value)}
+                          menuLayout="dropdown"
+                          wrapperClassName="ml-auto min-w-0"
+                          className="rounded-[8px] border border-hairline bg-black/30 px-1.5 py-1 text-[11px] font-medium text-white"
+                        />
                       ) : (
                         <span className="ml-auto text-[11px] text-fg-meta">{t("hostSetup.waitingForPlayer")}</span>
                       )}

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -163,7 +163,7 @@ export function HostSetup({
   hostDisabled = false,
   hostDisabledReason,
 }: HostSetupProps) {
-  const { t } = useTranslation("multiplayer");
+  const { t } = useTranslation(["multiplayer", "menu"]);
   // Player name is edited in `PlayerIdentityBanner` above this form (see
   // MultiplayerPage). We read it here only to submit it and to seed the
   // room-name placeholder — this form itself intentionally has no

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -74,4 +74,28 @@ describe("HostSetup", () => {
       }),
     );
   });
+
+  it("renders and updates AI seat difficulty with translated labels", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <HostSetup
+        onHost={vi.fn()}
+        onBack={vi.fn()}
+        connectionMode="server"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Human" }));
+
+    const difficultyButton = screen.getByRole("button", { name: "AI difficulty" });
+    expect(difficultyButton).toHaveTextContent("Medium");
+    expect(screen.queryByText("VeryHard")).not.toBeInTheDocument();
+
+    await user.click(difficultyButton);
+    await user.click(screen.getByRole("option", { name: "Very Hard" }));
+
+    expect(difficultyButton).toHaveTextContent("Very Hard");
+    expect(screen.queryByText("VeryHard")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

* Replace the native AI difficulty `<select>` in Host Setup with `MenuSelect` for a consistent dropdown experience
* Display translated difficulty labels (e.g. **Very Easy**, **Very Hard**) instead of raw enum values
* Reuse the shared `AI_DIFFICULTIES` configuration instead of maintaining a duplicate list

## Problem

The host lobby seat picker displayed raw engine difficulty IDs such as `VeryEasy` and `VeryHard`, which are harder to read and inconsistent with other AI configuration screens. It also used a native browser select that did not match the rest of the host setup UI.

## Solution

Migrate the seat AI difficulty selector to `MenuSelect` and use localized difficulty labels via existing translations. Engine values remain unchanged while the UI now matches the format picker, AI opponent configuration, and other lobby controls.

## Test Plan

* [ ] Open **Online → Host Game** with 2+ players
* [ ] Set a seat to AI
* [ ] Open the difficulty dropdown
* [ ] Verify labels display as:

  * Very Easy
  * Easy
  * Medium
  * Hard
  * Very Hard
* [ ] Verify the selected difficulty is applied correctly when hosting
* [ ] Run:

  ```bash
  pnpm exec vitest run src/components/lobby/__tests__/HostSetup.test.tsx
  ```
  
## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/2c6181a0-8308-426a-9483-2c1c211509d3" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/e3ed258d-ebb3-45b0-b130-4148be12542e" />
