### PR TITLE
fix(engine): Summoner's Pact upkeep pay-or-lose as delayed trigger (#3871)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2738,11 +2738,12 @@ pub(crate) fn parse_oracle_ir(
         }
 
         // CR 603.7a-b: Instant/sorcery text like "Whenever [event] this turn, ..."
-        // creates a delayed triggered ability during resolution. It is not a
-        // permanent's printed triggered ability, so spell cards must get one
-        // chance to route trigger-shaped temporal text through the effect parser
-        // before generic trigger dispatch.
-        if is_spell && has_trigger_prefix(&lower) && scan_contains(&lower, "this turn") {
+        // or "At the beginning of your next upkeep, ..." creates a delayed
+        // triggered ability during resolution. It is not a permanent's printed
+        // triggered ability, so spell cards must get one chance to route
+        // trigger-shaped temporal text through the effect parser before generic
+        // trigger dispatch.
+        if is_spell && has_trigger_prefix(&lower) {
             if let Some(def) = try_parse_temporal_delayed_trigger_ability(&line, AbilityKind::Spell)
             {
                 result.abilities.push(def);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1052,8 +1052,36 @@ pub(crate) fn try_parse_temporal_delayed_trigger_ability(
     let tp = TextPair::new(text, &lower);
     let clause = try_parse_whenever_this_turn(tp)
         .or_else(|| try_parse_when_next_event(tp))
-        .or_else(|| try_parse_copy_next_spell_when_cast(tp))?;
+        .or_else(|| try_parse_copy_next_spell_when_cast(tp))
+        .or_else(|| try_parse_at_next_phase_delayed_trigger(text, kind))?;
     Some(ability_definition_from_clause(kind, clause))
+}
+
+/// CR 603.7a: Pact-cycle instants ("At the beginning of your next upkeep, pay
+/// {2}{G}{G}. If you don't, you lose the game.") install a one-shot delayed
+/// trigger when the spell resolves — not a printed battlefield Phase trigger.
+fn try_parse_at_next_phase_delayed_trigger(
+    text: &str,
+    kind: AbilityKind,
+) -> Option<ParsedEffectClause> {
+    let (effect_text, condition) = strip_temporal_prefix(text);
+    let condition = condition?;
+    let mut ctx = ParseContext::default();
+    let inner = parse_effect_chain_with_context(effect_text, kind, &mut ctx);
+    Some(ParsedEffectClause {
+        effect: Effect::CreateDelayedTrigger {
+            condition,
+            effect: Box::new(inner),
+            uses_tracked_set: false,
+        },
+        duration: None,
+        sub_ability: None,
+        distribute: None,
+        multi_target: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
 }
 
 /// CR 614.1a + CR 514.2: Detect "If [target_phrase] would die this turn, exile

--- a/crates/engine/tests/integration/issue_3871_summoners_pact.rs
+++ b/crates/engine/tests/integration/issue_3871_summoners_pact.rs
@@ -1,0 +1,54 @@
+//! Regression for issue #3871: Summoner's Pact must install a delayed trigger
+//! on resolution, not a printed battlefield upkeep trigger.
+//!
+//! https://github.com/phase-rs/phase/issues/3871
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{DelayedTriggerCondition, Effect};
+use engine::types::phase::Phase;
+
+const SUMMONERS_PACT_ORACLE: &str = "Search your library for a green creature card, reveal it, put it into your hand, then shuffle.\n\
+At the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.";
+
+#[test]
+fn summoners_pact_parses_upkeep_clause_as_delayed_trigger() {
+    let parsed = parse_oracle_text(
+        SUMMONERS_PACT_ORACLE,
+        "Summoner's Pact",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    assert!(
+        parsed.triggers.is_empty(),
+        "upkeep clause must not be a printed trigger, got {:?}",
+        parsed.triggers
+    );
+    let delayed = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::CreateDelayedTrigger { .. }));
+    let Some(ability) = delayed else {
+        panic!(
+            "expected CreateDelayedTrigger ability, got {:?}",
+            parsed
+                .abilities
+                .iter()
+                .map(|a| &*a.effect)
+                .collect::<Vec<_>>()
+        );
+    };
+    let Effect::CreateDelayedTrigger { condition, .. } = ability.effect.as_ref() else {
+        unreachable!();
+    };
+    assert!(
+        matches!(
+            condition,
+            DelayedTriggerCondition::AtNextPhaseForPlayer {
+                phase: Phase::Upkeep,
+                ..
+            }
+        ),
+        "expected controller's next upkeep delayed trigger, got {condition:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -322,6 +322,7 @@ mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;
 mod issue_3817_sheoldred_apocalypse;
 mod issue_3864_swords_two_targets;
+mod issue_3871_summoners_pact;
 mod issue_3872_tithe_taker_turn_scoped_tax;
 mod issue_3873_teferi_ageless_insight_multi_draw;
 mod issue_3874_emet_selch_optional_decline;


### PR DESCRIPTION
## Summary
- Route Pact-cycle instants' "At the beginning of your next upkeep, pay … If you don't, you lose the game" clauses through `CreateDelayedTrigger` instead of a printed battlefield `Phase` trigger.
- Add a parse regression test for Summoner's Pact.

Fixes #3871

## Test plan
- [x] `cargo test -p engine --test integration issue_3871`
- [x] `cargo clippy -p engine --tests -- -D warnings`


Made with [Cursor](https://cursor.com)