### PR TITLE
fix(engine): Vaultborn Tyrant dies token intervening-if (#3988)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1304,6 +1304,33 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
         }
     }
 
+    // CR 603.4 + CR 111.1: Token intervening-ifs parsed via
+    // `zone_change_object_token_condition` default to destination Battlefield
+    // (correct for ETB). On dies/leave triggers the zone-change event's `to`
+    // is Graveyard — rewrite so "if it's not a token" can match (Vaultborn
+    // Tyrant, issue #3988).
+    if def.destination == Some(Zone::Graveyard) {
+        if let Some(TriggerCondition::ZoneChangeObjectMatchesFilter {
+            destination,
+            filter,
+            ..
+        }) = def.condition.as_mut()
+        {
+            if *destination == Zone::Battlefield {
+                let is_token_predicate = matches!(
+                    filter,
+                    TargetFilter::Typed(typed)
+                        if typed.properties.iter().any(|p| {
+                            matches!(p, FilterProp::NonToken | FilterProp::Token)
+                        })
+                );
+                if is_token_predicate {
+                    *destination = Zone::Graveyard;
+                }
+            }
+        }
+    }
+
     // CR 608.2k + CR 603.7c: For event-source-bearing trigger modes, the "that
     // card / that creature / that permanent" anaphor in the effect body
     // refers to the *triggering object* carried by the event (the just-

--- a/crates/engine/tests/integration/issue_3988_vaultborn_tyrant.rs
+++ b/crates/engine/tests/integration/issue_3988_vaultborn_tyrant.rs
@@ -1,0 +1,59 @@
+//! Regression for issue #3988: Vaultborn Tyrant's dies trigger must copy itself
+//! when it's not a token.
+//!
+//! https://github.com/phase-rs/phase/issues/3988
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, FilterProp, TargetFilter, TriggerCondition};
+use engine::types::zones::Zone;
+
+const VAULTBORN_TYRANT_ORACLE: &str = "Trample\n\
+Whenever a creature you control enters, if its power is 4 or greater, you gain 3 life and draw a card.\n\
+Whenever Vaultborn Tyrant or another creature you control enters, if it's not a token, each other player creates a token that's a copy of it.\n\
+Whenever Vaultborn Tyrant or another creature you control dies, if it's not a token, you create a token that's a copy of it.";
+
+#[test]
+fn vaultborn_tyrant_dies_intervening_if_matches_graveyard_destination() {
+    let parsed = parse_oracle_text(
+        VAULTBORN_TYRANT_ORACLE,
+        "Vaultborn Tyrant",
+        &["Trample".to_string()],
+        &["Creature".to_string()],
+        &["Dinosaur".to_string()],
+    );
+    let dies = parsed
+        .triggers
+        .iter()
+        .find(|t| {
+            t.destination == Some(Zone::Graveyard)
+                && matches!(
+                    t.execute.as_ref().map(|e| e.effect.as_ref()),
+                    Some(Effect::CopyTokenOf { .. })
+                )
+        })
+        .expect("Vaultborn Tyrant must parse a dies CopyTokenOf trigger");
+    let Some(TriggerCondition::ZoneChangeObjectMatchesFilter {
+        destination,
+        filter,
+        ..
+    }) = dies.condition.as_ref()
+    else {
+        panic!(
+            "dies trigger must carry NonToken intervening-if, got {:?}",
+            dies.condition
+        );
+    };
+    assert_eq!(
+        *destination,
+        Zone::Graveyard,
+        "NonToken intervening-if on dies must match graveyard destination"
+    );
+    let TargetFilter::Typed(typed) = filter else {
+        panic!("expected typed filter, got {filter:?}");
+    };
+    assert!(
+        typed.properties.contains(&FilterProp::NonToken),
+        "expected NonToken property, got {:?}",
+        typed.properties
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -330,6 +330,7 @@ mod issue_3876_gadrak_treasure_count;
 mod issue_3878_go_shintai_combat_damage;
 mod issue_3881_feed_swarm_darksteel_mutation;
 mod issue_3883_kari_zev_ragavan;
+mod issue_3988_vaultborn_tyrant;
 mod issue_3994_malevolent_rumble;
 mod issue_3996_return_the_favor;
 mod issue_3999_latchkey_faerie_prowl_etb;


### PR DESCRIPTION
## Summary
- Rewrite token/non-token `ZoneChangeObjectMatchesFilter` intervening-ifs on dies triggers to use `Graveyard` instead of the ETB-default `Battlefield` destination.
- Add a parse regression test for Vaultborn Tyrant's dies trigger.

Fixes #3988

## Test plan
- [x] `cargo test -p engine --test integration issue_3988`
- [x] `cargo clippy -p engine --tests -- -D warnings`


Made with [Cursor](https://cursor.com)