### PR TITLE
fix(engine): Sphere of Safety attack tax X concretization (#3865)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1546,7 +1546,9 @@ pub fn compute_combat_tax(
                         source_obj.controller,
                         source_id,
                     );
-                    base_cost.scaled(n.max(0) as u32)
+                    let mut cost = base_cost.clone();
+                    cost.concretize_x(n.max(0) as u32);
+                    cost
                 }
                 UnlessPayScaling::PerAffectedWithRef { quantity } => {
                     // CR 118.12a + CR 202.3e: Nils, Discipline Enforcer — "pays {X},
@@ -7472,6 +7474,52 @@ mod tests {
         });
         obj.static_definitions.push(def);
         id
+    }
+
+    fn add_sphere_of_safety(state: &mut GameState, controller: PlayerId) -> ObjectId {
+        use crate::parser::oracle_static::parse_static_line;
+
+        let def = parse_static_line(
+            "Creatures can't attack you or planeswalkers you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
+        )
+        .expect("Sphere of Safety should parse");
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            controller,
+            "Sphere of Safety".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.static_definitions.push(def);
+        id
+    }
+
+    fn create_enchantment(state: &mut GameState, controller: PlayerId, name: &str) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(state.next_object_id),
+            controller,
+            name.to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        id
+    }
+
+    #[test]
+    fn compute_attack_tax_sphere_of_safety_concretizes_x_per_attacker() {
+        let mut state = setup();
+        let _sphere = add_sphere_of_safety(&mut state, PlayerId(1));
+        let _other_ench = create_enchantment(&mut state, PlayerId(1), "Other Aura");
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let attacks = vec![(attacker, AttackTarget::Player(PlayerId(1)))];
+        let (total, per_creature) = compute_attack_tax(&state, &attacks).expect("tax applies");
+        assert_eq!(total.mana_value(), 2);
+        assert_eq!(per_creature.len(), 1);
+        assert_eq!(per_creature[0].1.mana_value(), 2);
     }
 
     #[test]

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -625,6 +625,53 @@ fn ghostly_prison_accept_pays_tax_and_attacks_proceed() {
     assert_eq!(combat.attackers.len(), 2);
 }
 
+fn add_sphere_of_safety(scenario: &mut GameScenario, player: PlayerId) -> ObjectId {
+    let def = parse_static_line(
+        "Creatures can't attack you or planeswalkers you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.",
+    )
+    .expect("Sphere of Safety should parse");
+    let mut builder = scenario.add_creature(player, "Sphere of Safety", 2, 2);
+    builder.as_enchantment().with_static_definition(def);
+    builder.id()
+}
+
+fn add_enchantment(scenario: &mut GameScenario, player: PlayerId, name: &str) -> ObjectId {
+    scenario
+        .add_creature(player, name, 2, 2)
+        .as_enchantment()
+        .id()
+}
+
+/// CR 508.1h + CR 202.3e: Sphere of Safety — {X} must be concretized from
+/// enchantment count before computing attack tax (issue #3865).
+#[test]
+fn sphere_of_safety_attack_tax_scales_with_enchantment_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let _sphere = add_sphere_of_safety(&mut scenario, P1);
+    let _other = add_enchantment(&mut scenario, P1, "Other Aura");
+    let attacker = scenario.add_creature(P0, "Bear", 2, 2).id();
+    for _ in 0..2 {
+        scenario.add_basic_land(P0, ManaColor::White);
+    }
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("Sphere of Safety should pause for combat tax");
+
+    match &runner.state().waiting_for {
+        WaitingFor::CombatTaxPayment { total_cost, .. } => {
+            assert_eq!(total_cost.mana_value(), 2, "two enchantments → X=2 tax");
+        }
+        other => panic!("expected CombatTaxPayment, got {other:?}"),
+    }
+}
+
 /// CR 508.1d + CR 509.1c: Declining the tax drops the taxed attackers. With
 /// Ghostly Prison on defender and only two taxed attackers, decline → zero
 /// attackers → combat ends (CR 508.8).


### PR DESCRIPTION
## Summary
- Fix `PerAffectedAndQuantityRef` combat tax scaling to `concretize_x` on `{X}` costs instead of `scaled()`, which left mana value at 0.
- Add unit and integration regression tests for Sphere of Safety.

Fixes #3865

## Test plan
- [x] `cargo test -p engine --lib compute_attack_tax_sphere_of_safety`
- [x] `cargo test -p engine --test integration sphere_of_safety_attack`


Made with [Cursor](https://cursor.com)