### PR TITLE
docs(engine): correct stale spend-mana-restriction Unimplemented wording (follow-up to #4091)

### DIFF
--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1638,8 +1638,12 @@ pub enum ManaSpendRestriction {
     /// battlefield via the zone pipeline and charges no mana (the `{3}` face-down
     /// cast cost, CR 702.37c, is not yet implemented), so `SpellMeta.is_face_down`
     /// is never `true` at a payment site and the gate never over-permits. The
-    /// variant exists so the restriction is representable (the cluster's cards
-    /// parse to no `Effect::Unimplemented`); once a real face-down CAST routes its
+    /// variant exists so the restriction stays representable as a typed value even
+    /// though this leaf is dead today: the parser still recognizes the shape, but a
+    /// card whose ONLY spend restriction is this leaf is left unabsorbed at the
+    /// `Effect::Mana` seam and intentionally surfaces an `Effect::Unimplemented`
+    /// gap (honest coverage red) via `ManaSpendRestriction::has_payable_branch`.
+    /// Once a real face-down CAST routes its
     /// `{3}` cost through `PaymentContext::Spell` the gate becomes live with no
     /// type change. See
     /// [`ManaRestriction::OnlyForFaceDownSpell`](super::mana::ManaRestriction::OnlyForFaceDownSpell).

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -330,8 +330,12 @@ pub enum PaymentContext<'a> {
 /// ([`ManaRestriction::OnlyForSpecialAction(SpecialAction::TurnFaceUp)`]) can
 /// never be satisfied yet — it is honest-deferred (conservatively
 /// under-permitting) rather than silently over-permitting the mana. The variant
-/// exists so the restriction is representable (the cluster's cards parse to no
-/// `Effect::Unimplemented`); once the turn-face-up morph cost is routed through
+/// exists so the restriction stays representable as a typed value even though
+/// the `TurnFaceUp` leaf is dead today: a card whose only spend restriction is
+/// turn-face-up (Overgrown Zealot) is left unabsorbed at the `Effect::Mana`
+/// seam and intentionally surfaces an `Effect::Unimplemented` gap (honest
+/// coverage red) via `ManaSpendRestriction::has_payable_branch`. Once the
+/// turn-face-up morph cost is routed through
 /// `PaymentContext::SpecialAction(TurnFaceUp)` the gate becomes live with no
 /// type change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -548,8 +552,11 @@ pub enum ManaRestriction {
     /// mana (the `{3}` face-down cast cost, CR 702.37c, is not yet implemented).
     /// So `SpellMeta.is_face_down` is never `true` at any `PaymentContext::Spell`
     /// payment site, and this gate never over-permits — see
-    /// [`ManaRestriction::allows_spell`]. The restriction stays representable (the
-    /// cluster's cards parse to no `Effect::Unimplemented`); once a real face-down
+    /// [`ManaRestriction::allows_spell`]. The restriction stays representable as a
+    /// typed value even though it is dead today: a card whose only spend
+    /// restriction is this is left unabsorbed at the `Effect::Mana` seam and
+    /// intentionally surfaces an `Effect::Unimplemented` gap (honest coverage red)
+    /// via `ManaSpendRestriction::has_payable_branch`. Once a real face-down
     /// CAST routes its cost through `PaymentContext::Spell` with `is_face_down =
     /// true` the gate becomes live with no type change.
     OnlyForFaceDownSpell,

--- a/data/engine-inventory.json
+++ b/data/engine-inventory.json
@@ -497,7 +497,7 @@
   "enums": {
     "AbilityActivationScope": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 355,
+      "line": 359,
       "doc": "CR 106.6: The ability-activation half of a \"spend only to cast [X] spell or activate …\" restriction. Parameterizes *which* ability activations the mana may also be spent on, so the spell-type + ability-activation OR restriction needs a single variant rather than a sibling per ability scope.",
       "cr_refs": [
         "CR 106.6"
@@ -505,7 +505,7 @@
       "variants": [
         {
           "name": "OfSpellType",
-          "line": 359,
+          "line": 363,
           "kind": "unit",
           "field_names": [],
           "doc": "\"… or activate abilities of [the spell's type]\" — only abilities on a permanent whose type matches the restriction's `spell_type` (e.g. \"cast creature spells or activate abilities of creatures\").",
@@ -513,7 +513,7 @@
         },
         {
           "name": "Any",
-          "line": 362,
+          "line": 366,
           "kind": "unit",
           "field_names": [],
           "doc": "\"… or to activate an ability\" — any ability activation is permitted (e.g. Sage of the Unknowable, \"a colorless spell or to activate an ability\").",
@@ -524,13 +524,13 @@
     },
     "AbilityCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13564,
+      "line": 13568,
       "doc": "Condition on an ability within a sub_ability chain. Checked during resolve_ability_chain before executing the ability. The condition is a pure predicate — it describes WHAT to check, not the outcome. Casting-time facts needed for evaluation are stored in `SpellContext`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdditionalCostPaid",
-          "line": 13582,
+          "line": 13586,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -551,7 +551,7 @@
         },
         {
           "name": "AdditionalCostPaidInstead",
-          "line": 13613,
+          "line": 13617,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a / CR 614.15: \"Instead\" clause — a self-replacement effect that replaces the parent effect when the additional cost was paid. The resolver swaps the override sub's effect in place of the parent before resolution.",
@@ -562,7 +562,7 @@
         },
         {
           "name": "AlternativeManaCostPaid",
-          "line": 13617,
+          "line": 13621,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.9 + CR 608.2c: \"If the {COST} cost was paid\" on spells with an alternative *mana* cost (e.g. Baleful Mastery). Evaluates against `SpellContext.alternative_mana_cost_paid`, not `additional_cost_paid`.",
@@ -573,7 +573,7 @@
         },
         {
           "name": "EffectOutcome",
-          "line": 13622,
+          "line": 13626,
           "kind": "struct",
           "field_names": [
             "signal"
@@ -587,7 +587,7 @@
         },
         {
           "name": "EventOutcomeWon",
-          "line": 13627,
+          "line": 13631,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If you won\" — sub_ability executes only if this ability's controller won the triggering event, such as a clash or coin flip. Falls back to `optional_effect_performed` for in-chain clash continuations whose parent effect records the result directly.",
@@ -597,7 +597,7 @@
         },
         {
           "name": "WhenYouDo",
-          "line": 13635,
+          "line": 13639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.12: \"When you do\" — reflexive trigger that fires based on whether the parent's trigger event actually occurred. For a non-cost parent (e.g. a `BecomeCopy` reflexive or a copy/exile replacement sub-ability) the \"do\" always occurred, so this is unconditionally true. For a cost-payment parent (`Effect::PayCost`), an unpayable or declined cost is not an occurrence, so the reflexive sub-ability is skipped — `evaluate_condition` gates on `cost_payment_failed_flag` for that case (mirrors `IfYouDo`).",
@@ -607,7 +607,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 13638,
+          "line": 13642,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -619,7 +619,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 13642,
+          "line": 13646,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -632,7 +632,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 13645,
+          "line": 13649,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -645,7 +645,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 13648,
+          "line": 13652,
           "kind": "struct",
           "field_names": [
             "color",
@@ -659,7 +659,7 @@
         },
         {
           "name": "RevealedHasCardType",
-          "line": 13658,
+          "line": 13662,
           "kind": "struct",
           "field_names": [
             "card_types",
@@ -673,7 +673,7 @@
         },
         {
           "name": "ObjectsShareQuality",
-          "line": 13680,
+          "line": 13684,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -688,7 +688,7 @@
         },
         {
           "name": "TargetSharesNameWithOtherExiledThisWay",
-          "line": 13688,
+          "line": 13692,
           "kind": "struct",
           "field_names": [
             "target"
@@ -701,7 +701,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 13692,
+          "line": 13696,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: True when the source permanent entered the battlefield this turn. For the \"did not enter this turn\" sense (e.g., Moon-Circuit Hacker \"unless ~ entered this turn\"), wrap with `AbilityCondition::Not`.",
@@ -712,7 +712,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 13695,
+          "line": 13699,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -725,7 +725,7 @@
         },
         {
           "name": "CastVariantPaidInstead",
-          "line": 13700,
+          "line": 13704,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -739,7 +739,7 @@
         },
         {
           "name": "QuantityCheck",
-          "line": 13704,
+          "line": 13708,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -753,7 +753,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 13713,
+          "line": 13717,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -767,7 +767,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 13718,
+          "line": 13722,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The ability functions only while its controller has max speed.",
@@ -777,7 +777,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 13720,
+          "line": 13724,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the ability controller has the monarch designation.",
@@ -787,7 +787,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 13723,
+          "line": 13727,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the ability controller has the initiative designation.",
@@ -797,7 +797,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 13726,
+          "line": 13730,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131c: \"if you have the city's blessing\" is true when the ability controller has the city's blessing designation.",
@@ -807,7 +807,7 @@
         },
         {
           "name": "TargetHasKeywordInstead",
-          "line": 13730,
+          "line": 13734,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -819,7 +819,7 @@
         },
         {
           "name": "TargetMatchesFilter",
-          "line": 13735,
+          "line": 13739,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -833,7 +833,7 @@
         },
         {
           "name": "TriggeringSpellTargetsFilter",
-          "line": 13747,
+          "line": 13751,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -846,7 +846,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 13751,
+          "line": 13755,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -858,7 +858,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 13756,
+          "line": 13760,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -874,7 +874,7 @@
         },
         {
           "name": "ControllerControlsMatching",
-          "line": 13768,
+          "line": 13772,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -887,7 +887,7 @@
         },
         {
           "name": "ControllerControlledMatchingAsCast",
-          "line": 13772,
+          "line": 13776,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -900,7 +900,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 13776,
+          "line": 13780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: \"If it's your turn\" — gates sub_ability on whether the active player is the ability's controller. For \"if it's not your turn\", wrap with `AbilityCondition::Not`.",
@@ -910,7 +910,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 13784,
+          "line": 13788,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -923,7 +923,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 13789,
+          "line": 13793,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -936,7 +936,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 13794,
+          "line": 13798,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 608.2c: \"if it's the first combat phase of the turn\". Gates a follow-up effect on whether this is the first combat phase started this turn.",
@@ -948,7 +948,7 @@
         },
         {
           "name": "FirstEndStepOfTurn",
-          "line": 13799,
+          "line": 13803,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 513.1 + CR 608.2c: \"if it's the first end step of the turn\". Gates a follow-up effect on whether this is the first end step started this turn (Y'shtola Rhul's additional-end-step loop guard). End-step sibling of `FirstCombatPhaseOfTurn`; both read a per-turn phase-occurrence counter.",
@@ -960,7 +960,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 13805,
+          "line": 13809,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -972,7 +972,7 @@
         },
         {
           "name": "CostPaidObjectMatchesFilter",
-          "line": 13809,
+          "line": 13813,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -986,7 +986,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 13812,
+          "line": 13816,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. For the untapped sense, wrap with `AbilityCondition::Not`.",
@@ -996,7 +996,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 13820,
+          "line": 13824,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: \"if this permanent is attached to a creature you control\" — checks whether the source Aura/Equipment is currently attached to a creature controlled by the ability's controller. Used at the effect-resolution seam by optional bestow-trigger branches like Springheart Nantuko's landfall pay (the trigger itself fires regardless; only the optional payment / copy-token sub-ability is gated on attachment so the fallback Insect token branch can still resolve when the Aura is unattached).",
@@ -1007,7 +1007,7 @@
         },
         {
           "name": "ConditionInstead",
-          "line": 13829,
+          "line": 13833,
           "kind": "struct",
           "field_names": [
             "inner"
@@ -1020,7 +1020,7 @@
         },
         {
           "name": "And",
-          "line": 13834,
+          "line": 13838,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -1032,7 +1032,7 @@
         },
         {
           "name": "Or",
-          "line": 13839,
+          "line": 13843,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -1044,7 +1044,7 @@
         },
         {
           "name": "Not",
-          "line": 13847,
+          "line": 13851,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1056,7 +1056,7 @@
         },
         {
           "name": "DayNightIsNeither",
-          "line": 13851,
+          "line": 13855,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 730.2a: True when it's neither day nor night (day_night is None). Used by Daybound/Nightbound ETB initialization: \"If it's neither day nor night, it becomes day as this creature enters.\"",
@@ -1066,7 +1066,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 13853,
+          "line": 13857,
           "kind": "struct",
           "field_names": [
             "state"
@@ -1078,7 +1078,7 @@
         },
         {
           "name": "NthResolutionThisTurn",
-          "line": 13863,
+          "line": 13867,
           "kind": "struct",
           "field_names": [
             "n"
@@ -1090,7 +1090,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 13866,
+          "line": 13870,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -1102,7 +1102,7 @@
         },
         {
           "name": "ScopedPlayerMatches",
-          "line": 13886,
+          "line": 13890,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -1128,13 +1128,13 @@
     },
     "AbilityCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6321,
+      "line": 6325,
       "doc": "Cost to activate an ability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mana",
-          "line": 6322,
+          "line": 6326,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1144,7 +1144,7 @@
         },
         {
           "name": "ManaDynamic",
-          "line": 6331,
+          "line": 6335,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -1157,7 +1157,7 @@
         },
         {
           "name": "Tap",
-          "line": 6334,
+          "line": 6338,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1165,7 +1165,7 @@
         },
         {
           "name": "Untap",
-          "line": 6335,
+          "line": 6339,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1173,7 +1173,7 @@
         },
         {
           "name": "Loyalty",
-          "line": 6336,
+          "line": 6340,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1183,7 +1183,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 6339,
+          "line": 6343,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -1191,7 +1191,7 @@
         },
         {
           "name": "PayLife",
-          "line": 6345,
+          "line": 6349,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1203,7 +1203,7 @@
         },
         {
           "name": "Discard",
-          "line": 6348,
+          "line": 6352,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1216,7 +1216,7 @@
         },
         {
           "name": "Exile",
-          "line": 6359,
+          "line": 6363,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1228,7 +1228,7 @@
         },
         {
           "name": "ExileMaterials",
-          "line": 6373,
+          "line": 6377,
           "kind": "struct",
           "field_names": [
             "materials",
@@ -1241,7 +1241,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 6380,
+          "line": 6384,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1254,7 +1254,7 @@
         },
         {
           "name": "TapCreatures",
-          "line": 6389,
+          "line": 6393,
           "kind": "struct",
           "field_names": [
             "requirement",
@@ -1269,7 +1269,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 6404,
+          "line": 6408,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1285,7 +1285,7 @@
         },
         {
           "name": "PayEnergy",
-          "line": 6412,
+          "line": 6416,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1295,7 +1295,7 @@
         },
         {
           "name": "PaySpeed",
-          "line": 6416,
+          "line": 6420,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -1308,7 +1308,7 @@
         },
         {
           "name": "ReturnToHand",
-          "line": 6424,
+          "line": 6428,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1322,7 +1322,7 @@
         },
         {
           "name": "Unattach",
-          "line": 6433,
+          "line": 6437,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.3d: Unattach this Equipment from the object it is equipping. Used by activated costs such as Sunforger's \"Unattach this Equipment\".",
@@ -1332,7 +1332,7 @@
         },
         {
           "name": "Mill",
-          "line": 6434,
+          "line": 6438,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1342,7 +1342,7 @@
         },
         {
           "name": "Exert",
-          "line": 6437,
+          "line": 6441,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1350,7 +1350,7 @@
         },
         {
           "name": "Blight",
-          "line": 6440,
+          "line": 6444,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1360,7 +1360,7 @@
         },
         {
           "name": "Reveal",
-          "line": 6443,
+          "line": 6447,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1371,7 +1371,7 @@
         },
         {
           "name": "Behold",
-          "line": 6451,
+          "line": 6455,
           "kind": "struct",
           "field_names": [
             "count",
@@ -1383,7 +1383,7 @@
         },
         {
           "name": "Composite",
-          "line": 6457,
+          "line": 6461,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1393,7 +1393,7 @@
         },
         {
           "name": "OneOf",
-          "line": 6474,
+          "line": 6478,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -1406,7 +1406,7 @@
         },
         {
           "name": "Waterbend",
-          "line": 6478,
+          "line": 6482,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -1416,7 +1416,7 @@
         },
         {
           "name": "NinjutsuFamily",
-          "line": 6483,
+          "line": 6487,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -1429,7 +1429,7 @@
         },
         {
           "name": "EffectCost",
-          "line": 6490,
+          "line": 6494,
           "kind": "struct",
           "field_names": [
             "effect"
@@ -1441,7 +1441,7 @@
         },
         {
           "name": "PerCounter",
-          "line": 6506,
+          "line": 6510,
           "kind": "struct",
           "field_names": [
             "counter",
@@ -1455,7 +1455,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 6511,
+          "line": 6515,
           "kind": "struct",
           "field_names": [
             "description"
@@ -1468,13 +1468,13 @@
     },
     "AbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12451,
+      "line": 12455,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "Spell",
-          "line": 12453,
+          "line": 12457,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1482,7 +1482,7 @@
         },
         {
           "name": "Activated",
-          "line": 12454,
+          "line": 12458,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1490,7 +1490,7 @@
         },
         {
           "name": "Database",
-          "line": 12455,
+          "line": 12459,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1498,7 +1498,7 @@
         },
         {
           "name": "BeginGame",
-          "line": 12458,
+          "line": 12462,
           "kind": "unit",
           "field_names": [],
           "doc": "Pre-game abilities: \"If this card is in your opening hand, you may begin the game with...\" Fired during game setup, not during normal stack resolution.",
@@ -1506,7 +1506,7 @@
         },
         {
           "name": "Mulligan",
-          "line": 12464,
+          "line": 12468,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.5b: Mulligan-time abilities — \"Any time you could mulligan and ~ is in your hand, you may ...\" (Serum Powder, No-Regrets Egret). The player may perform the action at any point they would declare whether to take a mulligan. Like `BeginGame`, these never resolve through the normal stack; runtime dispatch lives in the mulligan flow (e.g. `MulliganChoice::UseSerumPowder` for Serum Powder).",
@@ -1519,7 +1519,7 @@
     },
     "AbilityTag": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12629,
+      "line": 12633,
       "doc": "CR 702.142b: Tag identifying the keyword origin of an ability. Used by effects that reference abilities by keyword class (e.g., \"boast abilities\", \"ninjutsu abilities\"). Survives serialization through the WASM boundary.",
       "cr_refs": [
         "CR 702.142b"
@@ -1527,7 +1527,7 @@
       "variants": [
         {
           "name": "Boast",
-          "line": 12631,
+          "line": 12635,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This ability originated from a Boast keyword definition.",
@@ -1537,7 +1537,7 @@
         },
         {
           "name": "Evolve",
-          "line": 12633,
+          "line": 12637,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.100a: This ability originated from an Evolve keyword definition.",
@@ -1547,7 +1547,7 @@
         },
         {
           "name": "Exhaust",
-          "line": 12635,
+          "line": 12639,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.177a: This ability originated from an Exhaust keyword definition.",
@@ -1557,7 +1557,7 @@
         },
         {
           "name": "Outlast",
-          "line": 12637,
+          "line": 12641,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.107a: This ability originated from an Outlast keyword definition.",
@@ -1567,7 +1567,7 @@
         },
         {
           "name": "Cycling",
-          "line": 12642,
+          "line": 12646,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.29a + CR 702.29e: This ability originated from a Cycling (or Typecycling) keyword definition. Used so the activation pipeline can emit a `GameEvent::Cycled` (CR 702.29c) that \"When you cycle this card\" triggers match.",
@@ -1579,7 +1579,7 @@
         },
         {
           "name": "Backup",
-          "line": 12644,
+          "line": 12648,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.165a: ability originated from a Backup keyword definition.",
@@ -1589,7 +1589,7 @@
         },
         {
           "name": "PowerUp",
-          "line": 12646,
+          "line": 12650,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 602.5b + CR 602.1: This ability originated from a Power-up keyword definition.",
@@ -1600,7 +1600,7 @@
         },
         {
           "name": "Equip",
-          "line": 12648,
+          "line": 12652,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.6a: This ability originated from an Equip keyword definition.",
@@ -1642,44 +1642,12 @@
     },
     "ActivationRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12675,
+      "line": 12679,
       "doc": "Structured activation-time restrictions parsed from Oracle text. These describe when an activated ability may be activated; runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 12676,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AsInstant",
-          "line": 12677,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 12678,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
-          "line": 12679,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
           "line": 12680,
           "kind": "unit",
           "field_names": [],
@@ -1687,7 +1655,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeAttackersDeclared",
+          "name": "AsInstant",
           "line": 12681,
           "kind": "unit",
           "field_names": [],
@@ -1695,7 +1663,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeCombatDamage",
+          "name": "DuringYourTurn",
           "line": 12682,
           "kind": "unit",
           "field_names": [],
@@ -1703,7 +1671,7 @@
           "cr_refs": []
         },
         {
-          "name": "OnlyOnceEachTurn",
+          "name": "DuringYourUpkeep",
           "line": 12683,
           "kind": "unit",
           "field_names": [],
@@ -1711,7 +1679,7 @@
           "cr_refs": []
         },
         {
-          "name": "OnlyOnce",
+          "name": "DuringCombat",
           "line": 12684,
           "kind": "unit",
           "field_names": [],
@@ -1719,8 +1687,40 @@
           "cr_refs": []
         },
         {
-          "name": "MaxTimesEachTurn",
+          "name": "BeforeAttackersDeclared",
           "line": 12685,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 12686,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnceEachTurn",
+          "line": 12687,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "OnlyOnce",
+          "line": 12688,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "MaxTimesEachTurn",
+          "line": 12689,
           "kind": "struct",
           "field_names": [
             "count"
@@ -1730,7 +1730,7 @@
         },
         {
           "name": "RequiresCondition",
-          "line": 12688,
+          "line": 12692,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -1740,7 +1740,7 @@
         },
         {
           "name": "IsSolved",
-          "line": 12692,
+          "line": 12696,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.3c: This ability can only be activated while the source Case is solved.",
@@ -1750,7 +1750,7 @@
         },
         {
           "name": "SourceIsHarnessed",
-          "line": 12697,
+          "line": 12701,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.64b + CR 702.186b: This ability is present only while the source permanent is harnessed, so it can only be activated while harnessed. Read from `GameObject::harnessed`. Sibling of `IsSolved` (CR 719.3c) — a per-object designation activation gate, not a parameterization of it.",
@@ -1762,7 +1762,7 @@
         },
         {
           "name": "ClassLevelIs",
-          "line": 12699,
+          "line": 12703,
           "kind": "struct",
           "field_names": [
             "level"
@@ -1774,7 +1774,7 @@
         },
         {
           "name": "LevelCounterRange",
-          "line": 12704,
+          "line": 12708,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -1788,7 +1788,7 @@
         },
         {
           "name": "CounterThreshold",
-          "line": 12715,
+          "line": 12719,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -1802,7 +1802,7 @@
         },
         {
           "name": "MatchesCardCastTiming",
-          "line": 12728,
+          "line": 12732,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: \"If you could begin to cast this card by putting it onto the stack from your hand\" — the activation is legal whenever the underlying card type's natural cast timing is legal. For a sorcery / permanent card, this is sorcery-speed; for an instant, it's instant-speed. Used by the synthesized Suspend hand-activated ability so future \"cast-timing-mirroring\" activations (Foretell, etc.) can reuse this primitive instead of special-casing card type at synthesis time.",
@@ -1815,13 +1815,13 @@
     },
     "AdditionalCost": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6736,
+      "line": 6740,
       "doc": "An additional cost that a player must decide on during casting.  This is the building block for all \"as an additional cost to cast this spell\" patterns, including kicker, blight, and other future cost mechanics.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Optional",
-          "line": 6742,
+          "line": 6746,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -1832,7 +1832,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6757,
+          "line": 6761,
           "kind": "struct",
           "field_names": [
             "costs",
@@ -1848,7 +1848,7 @@
         },
         {
           "name": "Choice",
-          "line": 6769,
+          "line": 6773,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"[cost A] or [cost B]\" — player must pay exactly one. Choosing the first cost sets `additional_cost_paid = true`.",
@@ -1856,7 +1856,7 @@
         },
         {
           "name": "Required",
-          "line": 6771,
+          "line": 6775,
           "kind": "tuple",
           "field_names": [],
           "doc": "Mandatory additional cost (e.g., \"As an additional cost, waterbend {5}\").",
@@ -1867,7 +1867,7 @@
     },
     "AdditionalCostOrigin": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6779,
+      "line": 6783,
       "doc": "CR 113.2c + CR 601.2b/f: Linked identity for one independently functioning additional-cost keyword instance. Cast-time copy triggers read their own Casualty/Replicate payments via CR 702.153b / CR 702.56b; ETB-linked Squad/Offspring triggers read their own payments via CR 607.2g.",
       "cr_refs": [
         "CR 113.2c",
@@ -1879,38 +1879,6 @@
       "variants": [
         {
           "name": "Kicker",
-          "line": 6780,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Casualty",
-          "line": 6781,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Offspring",
-          "line": 6782,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Squad",
-          "line": 6783,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Replicate",
           "line": 6784,
           "kind": "unit",
           "field_names": [],
@@ -1918,8 +1886,40 @@
           "cr_refs": []
         },
         {
+          "name": "Casualty",
+          "line": 6785,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Offspring",
+          "line": 6786,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Squad",
+          "line": 6787,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Replicate",
+          "line": 6788,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "Teamwork",
-          "line": 6790,
+          "line": 6794,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f: Teamwork's optional \"tap any number of creatures with total power N or more\" additional cost. A dedicated origin lets \"this spell was cast using teamwork\" riders test the Teamwork payment specifically (not any optional additional cost) and lets Teamwork compose with another object additional cost in the announcement queue.",
@@ -1929,7 +1929,7 @@
         },
         {
           "name": "Other",
-          "line": 6792,
+          "line": 6796,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1940,7 +1940,7 @@
     },
     "AdditionalCostPaymentSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6897,
+      "line": 6901,
       "doc": "Which casting-time payment stream an `AdditionalCostPaid` condition reads.  `Any` preserves legacy optional-additional-cost behavior. `Kicker` reads only CR 702.33 kicker payments, while `NonKicker` reads only repeatable non-kicker additional-cost payments such as Squad.",
       "cr_refs": [
         "CR 702.33"
@@ -1948,7 +1948,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 6899,
+          "line": 6903,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1956,7 +1956,7 @@
         },
         {
           "name": "Kicker",
-          "line": 6900,
+          "line": 6904,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1964,7 +1964,7 @@
         },
         {
           "name": "NonKicker",
-          "line": 6901,
+          "line": 6905,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -1975,13 +1975,13 @@
     },
     "AdditionalCostRepeatability": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3247,
+      "line": 3251,
       "doc": "Whether an optional or kicker additional cost may be paid multiple times.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Once",
-          "line": 3250,
+          "line": 3254,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay at most once (ordinary kicker / optional cost).",
@@ -1989,7 +1989,7 @@
         },
         {
           "name": "Repeatable",
-          "line": 3252,
+          "line": 3256,
           "kind": "unit",
           "field_names": [],
           "doc": "Pay any number of times (multikicker, replicate).",
@@ -2019,7 +2019,7 @@
     },
     "AggregateFunction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4505,
+      "line": 4509,
       "doc": "Reduction applied when collapsing a set of per-object values (CR 208.1 power/ toughness, CR 202.3 mana value) into a single number. The Comprehensive Rules define no standalone \"aggregate function\" rule; this enum names the reduction kind used by the various property-aggregate `QuantityRef` variants.",
       "cr_refs": [
         "CR 202.3",
@@ -2028,7 +2028,7 @@
       "variants": [
         {
           "name": "Max",
-          "line": 4506,
+          "line": 4510,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2036,7 +2036,7 @@
         },
         {
           "name": "Min",
-          "line": 4507,
+          "line": 4511,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2044,7 +2044,7 @@
         },
         {
           "name": "Sum",
-          "line": 4508,
+          "line": 4512,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2359,7 +2359,7 @@
     },
     "AttachmentKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2464,
+      "line": 2468,
       "doc": "CR 301 / CR 303: Kinds of attachments to permanents. Used by `FilterProp::HasAttachment` and `QuantityRef::AttachmentsOnLeavingObject` to parameterize attachment-predicate checks.",
       "cr_refs": [
         "CR 301",
@@ -2368,7 +2368,7 @@
       "variants": [
         {
           "name": "Aura",
-          "line": 2466,
+          "line": 2470,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: Aura — enchantment subtype that attaches via Enchant ability.",
@@ -2378,7 +2378,7 @@
         },
         {
           "name": "Equipment",
-          "line": 2468,
+          "line": 2472,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5: Equipment — artifact subtype that attaches via Equip ability.",
@@ -2413,7 +2413,7 @@
     },
     "AttackScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4614,
+      "line": 4618,
       "doc": "CR 508.6: The time window over which \"attacked [a player]\" is measured.",
       "cr_refs": [
         "CR 508.6"
@@ -2421,7 +2421,7 @@
       "variants": [
         {
           "name": "ThisTurn",
-          "line": 4616,
+          "line": 4620,
           "kind": "unit",
           "field_names": [],
           "doc": "Across the whole turn, accumulated over every combat (CR 508.5).",
@@ -2431,7 +2431,7 @@
         },
         {
           "name": "ThisCombat",
-          "line": 4618,
+          "line": 4622,
           "kind": "unit",
           "field_names": [],
           "doc": "Within the current combat only (CR 702.121a Melee).",
@@ -2444,7 +2444,7 @@
     },
     "AttackSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4605,
+      "line": 4609,
       "doc": "CR 506.2 + CR 508.1b: Whose attacks the \"opponents attacked\" player set is measured over.",
       "cr_refs": [
         "CR 506.2",
@@ -2453,7 +2453,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 4607,
+          "line": 4611,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's controller — \"opponents you attacked\".",
@@ -2461,7 +2461,7 @@
         },
         {
           "name": "Source",
-          "line": 4609,
+          "line": 4613,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source creature — \"opponents this creature attacked\".",
@@ -2550,7 +2550,7 @@
     },
     "AttackersDeclaredCountSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5172,
+      "line": 5176,
       "doc": "CR 508.1 / CR 508.1b: Subject axis for counting members of a triggering `AttackersDeclared` event.",
       "cr_refs": [
         "CR 508.1",
@@ -2559,7 +2559,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 5180,
+          "line": 5184,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -2572,7 +2572,7 @@
         },
         {
           "name": "AttackTarget",
-          "line": 5187,
+          "line": 5191,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -2816,13 +2816,13 @@
     },
     "BeholdCostAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5983,
+      "line": 5987,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "ChooseOrReveal",
-          "line": 5984,
+          "line": 5988,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2830,7 +2830,7 @@
         },
         {
           "name": "ExileChosen",
-          "line": 5985,
+          "line": 5989,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -2970,7 +2970,7 @@
     },
     "BounceSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7411,
+      "line": 7415,
       "doc": "CR 115.1: Whether the `Bounce` effect selects its affected object at cast/activation time (\"target\", locked) or at resolution time (controller- scoped filter like \"a creature you control\" — Whitemane Lion).",
       "cr_refs": [
         "CR 115.1"
@@ -2978,7 +2978,7 @@
       "variants": [
         {
           "name": "Targeted",
-          "line": 7414,
+          "line": 7418,
           "kind": "unit",
           "field_names": [],
           "doc": "Default — target chosen at cast/activation via the targeting pipeline.",
@@ -2986,7 +2986,7 @@
         },
         {
           "name": "AtResolution",
-          "line": 7416,
+          "line": 7420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Controller chooses an eligible object at resolution.",
@@ -3149,7 +3149,7 @@
     },
     "CardSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3159,
+      "line": 3163,
       "doc": "CR 701.9a: How cards are selected from a zone during an effect or cost.  Analogous to `TargetSelectionMode` but for cards from a player's hand (or other non-target zones) rather than spell/ability targets.",
       "cr_refs": [
         "CR 701.9a"
@@ -3157,7 +3157,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 3162,
+          "line": 3166,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d: The affected player or controller chooses the card(s).",
@@ -3167,7 +3167,7 @@
         },
         {
           "name": "Random",
-          "line": 3164,
+          "line": 3168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: The game selects card(s) uniformly at random.",
@@ -3180,13 +3180,13 @@
     },
     "CardTypeSetSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3833,
+      "line": 3837,
       "doc": "Source set for counting distinct card types.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Zone",
-          "line": 3835,
+          "line": 3839,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -3200,7 +3200,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3837,
+          "line": 3841,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a + CR 406.6: Cards exiled by the source's linked ability.",
@@ -3211,7 +3211,7 @@
         },
         {
           "name": "Objects",
-          "line": 3839,
+          "line": 3843,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -3223,7 +3223,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 3845,
+          "line": 3849,
           "kind": "struct",
           "field_names": [
             "caused_by"
@@ -3414,7 +3414,7 @@
     },
     "CastManaObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3853,
+      "line": 3857,
       "doc": "CR 601.2h: Which cast object a mana-spent quantity reads.",
       "cr_refs": [
         "CR 601.2h"
@@ -3422,7 +3422,7 @@
       "variants": [
         {
           "name": "SelfObject",
-          "line": 3855,
+          "line": 3859,
           "kind": "unit",
           "field_names": [],
           "doc": "The ability's source object, or the entering object in ETB replacement context.",
@@ -3430,7 +3430,7 @@
         },
         {
           "name": "TriggeringSpell",
-          "line": 3857,
+          "line": 3861,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell object referenced by the current trigger event.",
@@ -3438,7 +3438,7 @@
         },
         {
           "name": "AbilityTarget",
-          "line": 3861,
+          "line": 3865,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1 + CR 601.2h: The first object target of the resolving ability — \"it\"/\"that spell\" when the condition gates on the targeted spell (Nix: \"Counter target spell if no mana was spent to cast it\").",
@@ -3452,7 +3452,7 @@
     },
     "CastManaSpentMetric": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3867,
+      "line": 3871,
       "doc": "CR 106.3 + CR 601.2h: What to measure about mana spent to cast a spell.",
       "cr_refs": [
         "CR 106.3",
@@ -3461,7 +3461,7 @@
       "variants": [
         {
           "name": "Total",
-          "line": 3869,
+          "line": 3873,
           "kind": "unit",
           "field_names": [],
           "doc": "Total amount of mana spent.",
@@ -3469,7 +3469,7 @@
         },
         {
           "name": "DistinctColors",
-          "line": 3871,
+          "line": 3875,
           "kind": "unit",
           "field_names": [],
           "doc": "Number of distinct colors of mana spent.",
@@ -3477,7 +3477,7 @@
         },
         {
           "name": "FromSource",
-          "line": 3873,
+          "line": 3877,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -3639,7 +3639,7 @@
     },
     "CastPermissionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2135,
+      "line": 2139,
       "doc": "CR 702.85a: Typed cast-time predicates attached to an `ExileWithAltCost` permission. Extend this enum when future mechanics need cast-time gating that cannot be evaluated at permission-grant time (e.g., X-cost spells whose mana value is only known after the caster chooses X).",
       "cr_refs": [
         "CR 702.85a"
@@ -3647,7 +3647,7 @@
       "variants": [
         {
           "name": "ManaValue",
-          "line": 2138,
+          "line": 2142,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -3664,7 +3664,7 @@
     },
     "CastTimingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5953,
+      "line": 5957,
       "doc": "CR 601.3b + CR 702.8a: A timing permission actually used to cast a spell. This is separate from `CastVariantPaid`: no alternative cost was paid, but later abilities may care that normal sorcery timing was bypassed.",
       "cr_refs": [
         "CR 601.3b",
@@ -3673,7 +3673,7 @@
       "variants": [
         {
           "name": "AsThoughHadFlash",
-          "line": 5956,
+          "line": 5960,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell was cast using an effect that allowed it to be cast as though it had flash.",
@@ -3681,7 +3681,7 @@
         },
         {
           "name": "Offering",
-          "line": 5960,
+          "line": 5964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.48a: The spell was cast at instant speed by paying an Offering additional cost. When this permission is set, the Offering sacrifice is required (the player used the offering to unlock instant-speed timing).",
@@ -3694,7 +3694,7 @@
     },
     "CastVariantPaid": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5898,
+      "line": 5902,
       "doc": "CR 702.49 + CR 702.188a + CR 702.190a + CR 603.4: Which alternative-cost cast/activation variant was paid to put this permanent onto the battlefield. This is the *trigger-tag / ability-condition* layer — separate from `NinjutsuVariant` (activation-family dispatch) because it legitimately includes Sneak and Web-slinging, which are cast alt-costs rather than activated abilities.  Populated by cast alt-cost handlers and `keywords::activate_ninjutsu` into `GameObject.cast_variant_paid` as the source permanent enters the battlefield. Read by `TriggerCondition::CastVariantPaid` and `AbilityCondition::CastVariantPaid` / `CastVariantPaidInstead`.",
       "cr_refs": [
         "CR 603.4",
@@ -3705,7 +3705,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5900,
+          "line": 5904,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a / CR 702.49d: Ninjutsu (incl. commander ninjutsu) cost was paid.",
@@ -3716,7 +3716,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5903,
+          "line": 5907,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu cost was paid (distinct from Ninjutsu for parser fidelity; triggers referencing \"ninjutsu cost\" match either).",
@@ -3726,7 +3726,7 @@
         },
         {
           "name": "Sneak",
-          "line": 5905,
+          "line": 5909,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.190a: Sneak alternative cast cost was paid from hand.",
@@ -3736,7 +3736,7 @@
         },
         {
           "name": "WebSlinging",
-          "line": 5907,
+          "line": 5911,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.188a: Web-slinging alternative cast cost was paid from hand.",
@@ -3746,7 +3746,7 @@
         },
         {
           "name": "Evoke",
-          "line": 5910,
+          "line": 5914,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.74a: Evoke alternative cast cost was paid from hand. Read by the synthesized intervening-if ETB sacrifice trigger.",
@@ -3756,7 +3756,7 @@
         },
         {
           "name": "Suspend",
-          "line": 5916,
+          "line": 5920,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Cast as the suspend \"play it without paying its mana cost\" resolution after the last time counter was removed. Tagged at stack resolution; the runtime-installed haste static (creature spells only) keys off this marker so a Threaten-style control swap correctly terminates haste via `StaticCondition::SourceControllerEquals`.",
@@ -3766,7 +3766,7 @@
         },
         {
           "name": "Escape",
-          "line": 5921,
+          "line": 5925,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138a + CR 702.138b: The spell that became this permanent was cast from a graveyard via its escape alternative cost. Read by the \"unless it escaped\" intervening-if on Phlage, Titan of Fire's Fury and any future escape-gated ETB trigger.",
@@ -3777,7 +3777,7 @@
         },
         {
           "name": "Foretell",
-          "line": 5924,
+          "line": 5928,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c: The spell or permanent was a foretold card before it was cast. Read by \"if this spell was foretold\" instead/condition clauses.",
@@ -3787,7 +3787,7 @@
         },
         {
           "name": "Bestow",
-          "line": 5929,
+          "line": 5933,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.103a + CR 702.103b: The spell was cast bestowed (its bestow alternative cost was paid). Read by trigger/ability conditions for \"if its bestow cost was paid\" and by display layers that need to distinguish a bestow-cast permanent from a hard-cast creature.",
@@ -3798,7 +3798,7 @@
         },
         {
           "name": "Impending",
-          "line": 5934,
+          "line": 5938,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.176a: The spell was cast for its impending alternative cost. The permanent entered with N time counters and is not a creature while any remain. Read by the end-step counter-removal trigger and the \"not a creature\" layer fixup.",
@@ -3808,7 +3808,7 @@
         },
         {
           "name": "Surge",
-          "line": 5938,
+          "line": 5942,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.117a: Surge alternative cast cost was paid from hand. Read by the \"if its surge cost was paid\" intervening-if (Reckless Bushwhacker, Tyrant of Valakut).",
@@ -3818,7 +3818,7 @@
         },
         {
           "name": "Spectacle",
-          "line": 5942,
+          "line": 5946,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.137a: Spectacle alternative cast cost was paid from hand. Read by the \"if its spectacle cost was paid\" intervening-if (Rafter Demon) and the \"...if its spectacle cost was paid, instead\" clause (Rix Maadi Reveler).",
@@ -3828,7 +3828,7 @@
         },
         {
           "name": "Prowl",
-          "line": 5946,
+          "line": 5950,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.76a: Prowl alternative cast cost was paid from hand. Read by the \"if its prowl cost was paid\" intervening-if (Latchkey Faerie, Oona's Blackguard-style prowl payoffs).",
@@ -3841,13 +3841,13 @@
     },
     "CastingPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1893,
+      "line": 1897,
       "doc": "A permission granted to a `GameObject` allowing it to be cast under specific conditions. Stored in `GameObject::casting_permissions`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AdventureCreature",
-          "line": 1895,
+          "line": 1899,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.5: After Adventure resolves to exile, creature face castable from exile.",
@@ -3857,7 +3857,7 @@
         },
         {
           "name": "ExileWithAltCost",
-          "line": 1900,
+          "line": 1904,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3877,7 +3877,7 @@
         },
         {
           "name": "PlayFromExile",
-          "line": 1976,
+          "line": 1980,
           "kind": "struct",
           "field_names": [
             "duration",
@@ -3901,7 +3901,7 @@
         },
         {
           "name": "ExileWithEnergyCost",
-          "line": 2042,
+          "line": 2046,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.3: Cast from exile by paying {E} equal to the card's mana value. Building block for Amped Raptor and similar energy-based casting mechanics.",
@@ -3911,7 +3911,7 @@
         },
         {
           "name": "ExileWithAltAbilityCost",
-          "line": 2051,
+          "line": 2055,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -3926,7 +3926,7 @@
         },
         {
           "name": "WarpExile",
-          "line": 2069,
+          "line": 2073,
           "kind": "struct",
           "field_names": [
             "castable_after_turn"
@@ -3938,7 +3938,7 @@
         },
         {
           "name": "Plotted",
-          "line": 2079,
+          "line": 2083,
           "kind": "struct",
           "field_names": [
             "turn_plotted"
@@ -3951,7 +3951,7 @@
         },
         {
           "name": "Foretold",
-          "line": 2085,
+          "line": 2089,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -4030,44 +4030,12 @@
     },
     "CastingRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12736,
+      "line": 12740,
       "doc": "Structured spell-casting restrictions parsed from Oracle text. These describe when a spell may be cast. Runtime enforcement can be added independently of parsing/export support.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AsSorcery",
-          "line": 12737,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringCombat",
-          "line": 12738,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringOpponentsTurn",
-          "line": 12739,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourTurn",
-          "line": 12740,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DuringYourUpkeep",
           "line": 12741,
           "kind": "unit",
           "field_names": [],
@@ -4075,7 +4043,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringOpponentsUpkeep",
+          "name": "DuringCombat",
           "line": 12742,
           "kind": "unit",
           "field_names": [],
@@ -4083,7 +4051,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringAnyUpkeep",
+          "name": "DuringOpponentsTurn",
           "line": 12743,
           "kind": "unit",
           "field_names": [],
@@ -4091,7 +4059,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringYourEndStep",
+          "name": "DuringYourTurn",
           "line": 12744,
           "kind": "unit",
           "field_names": [],
@@ -4099,7 +4067,7 @@
           "cr_refs": []
         },
         {
-          "name": "DuringOpponentsEndStep",
+          "name": "DuringYourUpkeep",
           "line": 12745,
           "kind": "unit",
           "field_names": [],
@@ -4107,7 +4075,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareAttackersStep",
+          "name": "DuringOpponentsUpkeep",
           "line": 12746,
           "kind": "unit",
           "field_names": [],
@@ -4115,7 +4083,7 @@
           "cr_refs": []
         },
         {
-          "name": "DeclareBlockersStep",
+          "name": "DuringAnyUpkeep",
           "line": 12747,
           "kind": "unit",
           "field_names": [],
@@ -4123,7 +4091,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeAttackersDeclared",
+          "name": "DuringYourEndStep",
           "line": 12748,
           "kind": "unit",
           "field_names": [],
@@ -4131,7 +4099,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeBlockersDeclared",
+          "name": "DuringOpponentsEndStep",
           "line": 12749,
           "kind": "unit",
           "field_names": [],
@@ -4139,7 +4107,7 @@
           "cr_refs": []
         },
         {
-          "name": "BeforeCombatDamage",
+          "name": "DeclareAttackersStep",
           "line": 12750,
           "kind": "unit",
           "field_names": [],
@@ -4147,7 +4115,7 @@
           "cr_refs": []
         },
         {
-          "name": "AfterCombat",
+          "name": "DeclareBlockersStep",
           "line": 12751,
           "kind": "unit",
           "field_names": [],
@@ -4155,8 +4123,40 @@
           "cr_refs": []
         },
         {
-          "name": "RequiresCondition",
+          "name": "BeforeAttackersDeclared",
           "line": 12752,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeBlockersDeclared",
+          "line": 12753,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BeforeCombatDamage",
+          "line": 12754,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "AfterCombat",
+          "line": 12755,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "RequiresCondition",
+          "line": 12756,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -5110,7 +5110,7 @@
     },
     "CoinFlipResult": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15061,
+      "line": 15065,
       "doc": "CR 705.2: Typed result filter for coin-flip triggers.",
       "cr_refs": [
         "CR 705.2"
@@ -5118,7 +5118,7 @@
       "variants": [
         {
           "name": "Won",
-          "line": 15062,
+          "line": 15066,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5126,7 +5126,7 @@
         },
         {
           "name": "Lost",
-          "line": 15063,
+          "line": 15067,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5243,7 +5243,7 @@
     },
     "CombatDamageScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15617,
+      "line": 15621,
       "doc": "CR 614.1a: Restricts whether a damage replacement applies to combat, noncombat, or all damage.",
       "cr_refs": [
         "CR 614.1a"
@@ -5251,7 +5251,7 @@
       "variants": [
         {
           "name": "CombatOnly",
-          "line": 15618,
+          "line": 15622,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5259,7 +5259,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 15619,
+          "line": 15623,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5270,13 +5270,13 @@
     },
     "CombatRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2506,
+      "line": 2510,
       "doc": "Combat relationship required by `FilterProp::CombatRelation`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "BlockingOrBlockedBy",
-          "line": 2508,
+          "line": 2512,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g/509.1h: Candidate is blocking the subject or is blocked by it.",
@@ -5289,13 +5289,13 @@
     },
     "CombatRelationSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2513,
+      "line": 2517,
       "doc": "Context object for a combat relationship filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 2515,
+          "line": 2519,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object of the resolving spell or ability.",
@@ -5303,7 +5303,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 2517,
+          "line": 2521,
           "kind": "unit",
           "field_names": [],
           "doc": "The first selected object target of the resolving spell or ability.",
@@ -5375,7 +5375,7 @@
     },
     "CommanderOwnership": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5293,
+      "line": 5297,
       "doc": "Ownership scope for a commander-control condition. CR 903.3 distinguishes \"your commander\" (owner-scoped) from \"a commander\" (controller-only).",
       "cr_refs": [
         "CR 903.3"
@@ -5383,7 +5383,7 @@
       "variants": [
         {
           "name": "Own",
-          "line": 5296,
+          "line": 5300,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 109.5: \"your commander\" — the commander must be owned AND controlled by the evaluating player. Used by the Lieutenant ability word.",
@@ -5394,7 +5394,7 @@
         },
         {
           "name": "Any",
-          "line": 5300,
+          "line": 5304,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3d: \"a commander\" — any commander on the battlefield controlled by the evaluating player, regardless of owner (a stolen opponent's commander counts).",
@@ -5498,44 +5498,12 @@
     },
     "Comparator": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5133,
+      "line": 5137,
       "doc": "Comparison operator used in static conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "GT",
-          "line": 5134,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LT",
-          "line": 5135,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GE",
-          "line": 5136,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "LE",
-          "line": 5137,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "EQ",
           "line": 5138,
           "kind": "unit",
           "field_names": [],
@@ -5543,8 +5511,40 @@
           "cr_refs": []
         },
         {
-          "name": "NE",
+          "name": "LT",
           "line": 5139,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "GE",
+          "line": 5140,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "LE",
+          "line": 5141,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "EQ",
+          "line": 5142,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "NE",
+          "line": 5143,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5555,7 +5555,7 @@
     },
     "ConjureSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7318,
+      "line": 7322,
       "doc": "CR 707.2: Where a conjured card's identity is taken from. Untagged so the legacy named form (`{\"name\": \"X\"}`) and the duplicate form (`{\"duplicate_of\": <filter>}`) are distinguished by their disjoint keys.",
       "cr_refs": [
         "CR 707.2"
@@ -5563,7 +5563,7 @@
       "variants": [
         {
           "name": "Named",
-          "line": 7320,
+          "line": 7324,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5573,7 +5573,7 @@
         },
         {
           "name": "Duplicate",
-          "line": 7324,
+          "line": 7328,
           "kind": "struct",
           "field_names": [
             "duplicate_of"
@@ -5588,13 +5588,13 @@
     },
     "ContinuousModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 16083,
+      "line": 16087,
       "doc": "What modification a continuous effect applies to an object. Each variant knows its own layer implicitly.",
       "cr_refs": [],
       "variants": [
         {
           "name": "CopyValues",
-          "line": 16084,
+          "line": 16088,
           "kind": "struct",
           "field_names": [
             "values",
@@ -5607,7 +5607,7 @@
         },
         {
           "name": "SetName",
-          "line": 16116,
+          "line": 16120,
           "kind": "struct",
           "field_names": [
             "name"
@@ -5621,7 +5621,7 @@
         },
         {
           "name": "AddPower",
-          "line": 16119,
+          "line": 16123,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5631,7 +5631,7 @@
         },
         {
           "name": "AddToughness",
-          "line": 16122,
+          "line": 16126,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5641,7 +5641,7 @@
         },
         {
           "name": "SetPower",
-          "line": 16125,
+          "line": 16129,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5651,7 +5651,7 @@
         },
         {
           "name": "SetToughness",
-          "line": 16128,
+          "line": 16132,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5661,7 +5661,7 @@
         },
         {
           "name": "AddKeyword",
-          "line": 16131,
+          "line": 16135,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5671,7 +5671,7 @@
         },
         {
           "name": "RemoveKeyword",
-          "line": 16134,
+          "line": 16138,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -5681,7 +5681,7 @@
         },
         {
           "name": "GrantAbility",
-          "line": 16137,
+          "line": 16141,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5691,7 +5691,7 @@
         },
         {
           "name": "GrantAllActivatedAbilitiesOf",
-          "line": 16149,
+          "line": 16153,
           "kind": "struct",
           "field_names": [
             "source"
@@ -5704,7 +5704,7 @@
         },
         {
           "name": "GrantTrigger",
-          "line": 16156,
+          "line": 16160,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -5716,7 +5716,7 @@
         },
         {
           "name": "RemoveAllAbilities",
-          "line": 16159,
+          "line": 16163,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -5724,7 +5724,7 @@
         },
         {
           "name": "AddType",
-          "line": 16160,
+          "line": 16164,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5734,7 +5734,7 @@
         },
         {
           "name": "RemoveType",
-          "line": 16163,
+          "line": 16167,
           "kind": "struct",
           "field_names": [
             "core_type"
@@ -5744,7 +5744,7 @@
         },
         {
           "name": "AddSubtype",
-          "line": 16166,
+          "line": 16170,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5754,7 +5754,7 @@
         },
         {
           "name": "RemoveSubtype",
-          "line": 16169,
+          "line": 16173,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -5764,7 +5764,7 @@
         },
         {
           "name": "SetCardTypes",
-          "line": 16176,
+          "line": 16180,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -5777,7 +5777,7 @@
         },
         {
           "name": "RemoveAllSubtypes",
-          "line": 16182,
+          "line": 16186,
           "kind": "struct",
           "field_names": [
             "set"
@@ -5790,7 +5790,7 @@
         },
         {
           "name": "SetDynamicPower",
-          "line": 16186,
+          "line": 16190,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5800,7 +5800,7 @@
         },
         {
           "name": "SetDynamicToughness",
-          "line": 16190,
+          "line": 16194,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5810,7 +5810,7 @@
         },
         {
           "name": "SetPowerDynamic",
-          "line": 16197,
+          "line": 16201,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5822,7 +5822,7 @@
         },
         {
           "name": "SetToughnessDynamic",
-          "line": 16202,
+          "line": 16206,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5834,7 +5834,7 @@
         },
         {
           "name": "AddDynamicPower",
-          "line": 16206,
+          "line": 16210,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5846,7 +5846,7 @@
         },
         {
           "name": "AddDynamicToughness",
-          "line": 16210,
+          "line": 16214,
           "kind": "struct",
           "field_names": [
             "value"
@@ -5858,7 +5858,7 @@
         },
         {
           "name": "AddDynamicKeyword",
-          "line": 16215,
+          "line": 16219,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -5871,7 +5871,7 @@
         },
         {
           "name": "AddAllCreatureTypes",
-          "line": 16221,
+          "line": 16225,
           "kind": "unit",
           "field_names": [],
           "doc": "Grants every creature type (Changeling CDA). Expanded at runtime using `GameState::all_creature_types`.",
@@ -5879,7 +5879,7 @@
         },
         {
           "name": "AddAllBasicLandTypes",
-          "line": 16224,
+          "line": 16228,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.6 + CR 305.7: Adds all five basic land types in addition to existing types. Used by Prismatic Omen, Dryad of the Ilysian Grove.",
@@ -5890,7 +5890,7 @@
         },
         {
           "name": "AddAllLandTypes",
-          "line": 16228,
+          "line": 16232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.7: grants every land type (all 17 land subtypes) and their mana abilities, additive. Distinct from AddAllBasicLandTypes (CR 305.6, 5 basic types). Omo, Queen of Vesuva. Layer 4.",
@@ -5902,7 +5902,7 @@
         },
         {
           "name": "AddChosenSubtype",
-          "line": 16231,
+          "line": 16235,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -5912,7 +5912,7 @@
         },
         {
           "name": "AddChosenColor",
-          "line": 16236,
+          "line": 16240,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 105.3: Set the object's color to the chosen color. Reads from `chosen_attributes` at layer evaluation time.",
@@ -5922,7 +5922,7 @@
         },
         {
           "name": "RemoveChosenKeyword",
-          "line": 16243,
+          "line": 16247,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Strip the chosen keyword (read from the granting source's `chosen_attributes`) from the affected object. Mirrors `RemoveKeyword`'s discriminant-based stripping so parameterized keywords (e.g., `Landwalk(\"Swamp\")`) lose every variant sharing the same discriminant. Used by Urborg / Walking Sponge: \"target creature loses [chosen ability] until end of turn\".",
@@ -5933,7 +5933,7 @@
         },
         {
           "name": "AddChosenKeyword",
-          "line": 16253,
+          "line": 16257,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2d + CR 613.1f: Grant the chosen keyword (read from the granting source's `chosen_attributes`) to the affected object. The additive counterpart of `RemoveChosenKeyword`, mirroring the `AddChosenColor` / `AddChosenSubtype` chosen-attribute family. Used by the \"choose [keyword], …; creatures you control gain that ability until end of turn\" class (Angelic Skirmisher, Linvala, Shield of Sea Gate): a preceding `Effect::Choose { ChoiceType::Keyword, persist }` stores the selection as `ChosenAttribute::Keyword`, which this modification reads at Layer 6 evaluation to install on every recipient.",
@@ -5944,7 +5944,7 @@
         },
         {
           "name": "SetColor",
-          "line": 16254,
+          "line": 16258,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -5954,7 +5954,7 @@
         },
         {
           "name": "AddColor",
-          "line": 16257,
+          "line": 16261,
           "kind": "struct",
           "field_names": [
             "color"
@@ -5964,7 +5964,7 @@
         },
         {
           "name": "AddStaticMode",
-          "line": 16262,
+          "line": 16266,
           "kind": "struct",
           "field_names": [
             "mode"
@@ -5974,7 +5974,7 @@
         },
         {
           "name": "GrantStaticAbility",
-          "line": 16277,
+          "line": 16281,
           "kind": "struct",
           "field_names": [
             "definition"
@@ -5989,7 +5989,7 @@
         },
         {
           "name": "SwitchPowerToughness",
-          "line": 16281,
+          "line": 16285,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4d: Switch power and toughness. Applied in layer 7d.",
@@ -5999,7 +5999,7 @@
         },
         {
           "name": "AssignDamageFromToughness",
-          "line": 16284,
+          "line": 16288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage equal to its toughness rather than its power.",
@@ -6009,7 +6009,7 @@
         },
         {
           "name": "AssignDamageAsThoughUnblocked",
-          "line": 16286,
+          "line": 16290,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: This creature assigns combat damage as though it weren't blocked.",
@@ -6019,7 +6019,7 @@
         },
         {
           "name": "AssignNoCombatDamage",
-          "line": 16288,
+          "line": 16292,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1a: This creature assigns no combat damage.",
@@ -6029,7 +6029,7 @@
         },
         {
           "name": "ChangeController",
-          "line": 16291,
+          "line": 16295,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.2 (Layer 2): Change the controller of the affected object to the controller of the source permanent (e.g., Control Magic auras).",
@@ -6039,7 +6039,7 @@
         },
         {
           "name": "SetBasicLandType",
-          "line": 16294,
+          "line": 16298,
           "kind": "struct",
           "field_names": [
             "land_type"
@@ -6051,7 +6051,7 @@
         },
         {
           "name": "SetChosenBasicLandType",
-          "line": 16308,
+          "line": 16312,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.7 + CR 305.6: Sets a land's subtype to the basic land type CHOSEN by the granting source (e.g. Phantasmal Terrain, Convincing Mirage: \"As this Aura enters, choose a basic land type.\" + \"Enchanted land is the chosen type.\"). Mirrors `SetBasicLandType`'s replacement semantics — removes the land's old land subtypes and clears the abilities generated from its rules text — but reads the concrete subtype from the source object's `chosen_attributes` (`ChosenSubtypeKind::BasicLandType`) at layer evaluation time rather than carrying a fixed type. Unit variant: the kind is implicitly `BasicLandType`. The intrinsic mana ability for the new type is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit mana grant is needed here.",
@@ -6062,7 +6062,7 @@
         },
         {
           "name": "RetainPrintedTriggerFromSource",
-          "line": 16320,
+          "line": 16324,
           "kind": "struct",
           "field_names": [
             "source_trigger_index"
@@ -6074,7 +6074,7 @@
         },
         {
           "name": "RetainPrintedAbilityFromSource",
-          "line": 16333,
+          "line": 16337,
           "kind": "struct",
           "field_names": [
             "source_ability_index"
@@ -6086,7 +6086,7 @@
         },
         {
           "name": "AddSupertype",
-          "line": 16341,
+          "line": 16345,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -6101,7 +6101,7 @@
         },
         {
           "name": "RemoveSupertype",
-          "line": 16350,
+          "line": 16354,
           "kind": "struct",
           "field_names": [
             "supertype"
@@ -6116,7 +6116,7 @@
         },
         {
           "name": "AddCounterOnEnter",
-          "line": 16364,
+          "line": 16368,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -6131,7 +6131,7 @@
         },
         {
           "name": "SetStartingLoyalty",
-          "line": 16378,
+          "line": 16382,
           "kind": "struct",
           "field_names": [
             "value"
@@ -6144,7 +6144,7 @@
         },
         {
           "name": "RemoveManaCost",
-          "line": 16388,
+          "line": 16392,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.9 + CR 202.1b: Strip a copy's mana cost — the \"has no mana cost\" copy exception used by Embalm (CR 702.128a) and Eternalize (CR 702.129a). Like `AddCounterOnEnter`, this is consumed at copy resolution, never evaluated through the layer system, so `ContinuousModification::layer()` treats it as unreachable: `token_copy.rs` bakes it into the new token's base mana cost, and `become_copy.rs` strips it from the copied values so the continuous copy carries mana value 0.",
@@ -6160,13 +6160,13 @@
     },
     "ControllerRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2403,
+      "line": 2407,
       "doc": "Controller reference for filter matching.",
       "cr_refs": [],
       "variants": [
         {
           "name": "You",
-          "line": 2404,
+          "line": 2408,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6174,7 +6174,7 @@
         },
         {
           "name": "Opponent",
-          "line": 2405,
+          "line": 2409,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6182,7 +6182,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 2408,
+          "line": 2412,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: Filter controller is the current player being affected by an \"each player/opponent\" instruction during resolution.",
@@ -6193,7 +6193,7 @@
         },
         {
           "name": "TargetPlayer",
-          "line": 2415,
+          "line": 2419,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 115.1: Filter controller is the player chosen as a target of the enclosing ability (e.g., \"each creature target player controls\"). At resolution time, `filter_inner` reads the first `TargetRef::Player` from `ability.targets`. At target-selection time, `collect_target_slots` surfaces a companion `TargetFilter::Player` slot so the player is chosen as part of CR 601.2c / CR 603.3d target declaration.",
@@ -6206,7 +6206,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2419,
+          "line": 2423,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 109.4: Filter controller is the controller of the parent object target inherited by this chained effect (\"that permanent's controller may sacrifice a land\").",
@@ -6217,7 +6217,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 2422,
+          "line": 2426,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 108.3: Filter owner is the owner of the parent object target inherited by this chained effect (\"its owner's graveyard\").",
@@ -6228,7 +6228,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 2427,
+          "line": 2431,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Filter controller is the defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by intervening-if quantity checks such as \"defending player controls more lands than you.\"",
@@ -6239,7 +6239,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 2438,
+          "line": 2442,
           "kind": "struct",
           "field_names": [
             "index"
@@ -6252,7 +6252,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 2450,
+          "line": 2454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: Filter controller is the player PERSISTED on the source via `ChosenAttribute::Player` — the player chosen by an \"as ~ enters the battlefield, choose a player\" replacement. Read at filter / layer-evaluation time from the source's `chosen_attributes` (mirrors `GameObject::protector`). Distinct from `ChosenPlayer { index }`, which is resolution-scoped (valid only mid-resolution); this is a durable characteristic readable continuously, as a CDA requires. Powers \"~'s power and toughness are each equal to the number of <X> the chosen player controls\" (Skyshroud War Beast, Lost Order of Jarkeld).",
@@ -6263,7 +6263,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 2457,
+          "line": 2461,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 109.4: Filter controller is the player identified by the triggering event (the drawer, life-gainer, attacker, etc.). Resolved against `state.current_trigger_event` via `extract_player_from_event`. Mirrors `PlayerFilter::TriggeringPlayer` and `TargetFilter::TriggeringPlayer`. Used by control-relative trigger restrictions (\"an opponent who controls F draws a card\").",
@@ -6344,7 +6344,7 @@
     },
     "CopyCountStatus": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 16459,
+      "line": 16463,
       "doc": "CR 707.10 + CR 614.1a: Whether copy-count replacement effects (Twinning Staff's \"copy an additional time\") have already been folded into a `CopySpell` resolution's iteration count.  A `CopySpell` of a targeted spell pauses on `CopyRetarget` per copy; the drain driver then resumes the next iteration with a single-iteration ability. The bonus must apply to the copy *event* once (CR 614.5 — a replacement effect doesn't invoke itself repeatedly; it gets only one opportunity to affect an event), not per copy, so a resumed iteration is marked `Finalized` and the count hook skips it.",
       "cr_refs": [
         "CR 614.1a",
@@ -6354,7 +6354,7 @@
       "variants": [
         {
           "name": "Pending",
-          "line": 16462,
+          "line": 16466,
           "kind": "unit",
           "field_names": [],
           "doc": "Initial resolution — copy-count replacements not yet applied.",
@@ -6362,7 +6362,7 @@
         },
         {
           "name": "Finalized",
-          "line": 16464,
+          "line": 16468,
           "kind": "unit",
           "field_names": [],
           "doc": "Resumed iteration — the bonus is already folded into the iteration count.",
@@ -6373,13 +6373,13 @@
     },
     "CopyManaValueLimit": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7355,
+      "line": 7359,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AmountSpentToCastSource",
-          "line": 7356,
+          "line": 7360,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6390,7 +6390,7 @@
     },
     "CopyRetargetPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10415,
+      "line": 10419,
       "doc": "CR 707.10c: Whether a copy effect grants its controller the choice to pick new targets for the copy. Only effects whose Oracle text states \"you may choose new targets for the copy/copies\" permit retargeting; a bare \"copy\" keeps the original's targets unchanged (CR 115.1).",
       "cr_refs": [
         "CR 115.1",
@@ -6399,7 +6399,7 @@
       "variants": [
         {
           "name": "KeepOriginalTargets",
-          "line": 10417,
+          "line": 10421,
           "kind": "unit",
           "field_names": [],
           "doc": "No \"choose new targets\" clause — copy inherits the original's targets.",
@@ -6407,7 +6407,7 @@
         },
         {
           "name": "MayChooseNewTargets",
-          "line": 10419,
+          "line": 10423,
           "kind": "unit",
           "field_names": [],
           "doc": "Oracle text grants \"you may choose new targets for the copy.\"",
@@ -6578,7 +6578,7 @@
     },
     "CostCategory": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6525,
+      "line": 6529,
       "doc": "CR 118: Cost taxonomy — a structural classifier over `AbilityCost` variants.  Provides a single-authority view of what an ability \"does\" to pay itself without forcing callers to destructure individual cost variants. Policies, AI heuristics, and other consumers should ask `ability.cost_categories().contains(&CostCategory::SacrificesPermanent)` rather than match on `AbilityCost::Sacrifice(_)` directly. This preserves the \"single authority for ability costs\" invariant from CLAUDE.md.",
       "cr_refs": [
         "CR 118"
@@ -6586,38 +6586,6 @@
       "variants": [
         {
           "name": "ManaOnly",
-          "line": 6526,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "TapsSelf",
-          "line": 6527,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "UntapsSelf",
-          "line": 6528,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SacrificesPermanent",
-          "line": 6529,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PaysLife",
           "line": 6530,
           "kind": "unit",
           "field_names": [],
@@ -6625,7 +6593,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysLoyalty",
+          "name": "TapsSelf",
           "line": 6531,
           "kind": "unit",
           "field_names": [],
@@ -6633,7 +6601,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discards",
+          "name": "UntapsSelf",
           "line": 6532,
           "kind": "unit",
           "field_names": [],
@@ -6641,7 +6609,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExilesCards",
+          "name": "SacrificesPermanent",
           "line": 6533,
           "kind": "unit",
           "field_names": [],
@@ -6649,7 +6617,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapsOtherCreatures",
+          "name": "PaysLife",
           "line": 6534,
           "kind": "unit",
           "field_names": [],
@@ -6657,7 +6625,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemovesCounters",
+          "name": "PaysLoyalty",
           "line": 6535,
           "kind": "unit",
           "field_names": [],
@@ -6665,7 +6633,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysEnergy",
+          "name": "Discards",
           "line": 6536,
           "kind": "unit",
           "field_names": [],
@@ -6673,7 +6641,7 @@
           "cr_refs": []
         },
         {
-          "name": "PaysSpeed",
+          "name": "ExilesCards",
           "line": 6537,
           "kind": "unit",
           "field_names": [],
@@ -6681,7 +6649,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnsToHand",
+          "name": "TapsOtherCreatures",
           "line": 6538,
           "kind": "unit",
           "field_names": [],
@@ -6689,7 +6657,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unattaches",
+          "name": "RemovesCounters",
           "line": 6539,
           "kind": "unit",
           "field_names": [],
@@ -6697,7 +6665,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mills",
+          "name": "PaysEnergy",
           "line": 6540,
           "kind": "unit",
           "field_names": [],
@@ -6705,7 +6673,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutsCounters",
+          "name": "PaysSpeed",
           "line": 6541,
           "kind": "unit",
           "field_names": [],
@@ -6713,7 +6681,7 @@
           "cr_refs": []
         },
         {
-          "name": "Reveals",
+          "name": "ReturnsToHand",
           "line": 6542,
           "kind": "unit",
           "field_names": [],
@@ -6721,7 +6689,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exerts",
+          "name": "Unattaches",
           "line": 6543,
           "kind": "unit",
           "field_names": [],
@@ -6729,8 +6697,40 @@
           "cr_refs": []
         },
         {
-          "name": "KeywordCost",
+          "name": "Mills",
           "line": 6544,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PutsCounters",
+          "line": 6545,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Reveals",
+          "line": 6546,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Exerts",
+          "line": 6547,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "KeywordCost",
+          "line": 6548,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6778,7 +6778,7 @@
     },
     "CostObjectCount": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5992,
+      "line": 5996,
       "doc": "CR 702.167a: Object-count requirement for costs whose text may ask for an exact number (\"two creatures\") or a minimum (\"one or more creatures\").",
       "cr_refs": [
         "CR 702.167a"
@@ -6786,7 +6786,7 @@
       "variants": [
         {
           "name": "Exactly",
-          "line": 5993,
+          "line": 5997,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6796,7 +6796,7 @@
         },
         {
           "name": "AtLeast",
-          "line": 5994,
+          "line": 5998,
           "kind": "struct",
           "field_names": [
             "count"
@@ -6956,13 +6956,13 @@
     },
     "CounterCostSelection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6088,
+      "line": 6092,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "SingleObject",
-          "line": 6090,
+          "line": 6094,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -6970,7 +6970,7 @@
         },
         {
           "name": "AmongObjects",
-          "line": 6091,
+          "line": 6095,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7442,7 +7442,7 @@
     },
     "DamageGroupKey": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4517,
+      "line": 4521,
       "doc": "CR 120.9: Grouping key for damage-history aggregation. CR 120.9 distinguishes damage dealt \"by a specific source\" from damage in the aggregate, so any query that needs per-source partitioning before aggregation must select a key here. Today only `SourceId` is needed; future axes (e.g., per-target) fit cleanly as additional variants.",
       "cr_refs": [
         "CR 120.9"
@@ -7450,7 +7450,7 @@
       "variants": [
         {
           "name": "SourceId",
-          "line": 4520,
+          "line": 4524,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.9: Group records by `DamageRecord::source_id` so the resolver can answer \"the most damage dealt by any single source.\"",
@@ -7463,7 +7463,7 @@
     },
     "DamageKindFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2391,
+      "line": 2395,
       "doc": "Filter for damage type on trigger definitions. CR 120.3: Combat damage is dealt during the combat damage step; all other damage is noncombat.",
       "cr_refs": [
         "CR 120.3"
@@ -7471,7 +7471,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 2394,
+          "line": 2398,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches both combat and noncombat damage.",
@@ -7479,7 +7479,7 @@
         },
         {
           "name": "CombatOnly",
-          "line": 2396,
+          "line": 2400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2a: Only combat damage (dealt as a result of combat).",
@@ -7489,7 +7489,7 @@
         },
         {
           "name": "NoncombatOnly",
-          "line": 2398,
+          "line": 2402,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.2b: Only noncombat damage (dealt as an effect of a spell or ability).",
@@ -7502,7 +7502,7 @@
     },
     "DamageModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15473,
+      "line": 15477,
       "doc": "CR 614.1a: Damage modification formula for replacement effects.",
       "cr_refs": [
         "CR 614.1a"
@@ -7510,7 +7510,7 @@
       "variants": [
         {
           "name": "Double",
-          "line": 15475,
+          "line": 15479,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 2 (e.g. Furnace of Rath)",
@@ -7518,7 +7518,7 @@
         },
         {
           "name": "Triple",
-          "line": 15477,
+          "line": 15481,
           "kind": "unit",
           "field_names": [],
           "doc": "amount * 3 (e.g. Fiery Emancipation)",
@@ -7526,7 +7526,7 @@
         },
         {
           "name": "Plus",
-          "line": 15479,
+          "line": 15483,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7536,7 +7536,7 @@
         },
         {
           "name": "Minus",
-          "line": 15486,
+          "line": 15490,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7549,7 +7549,7 @@
         },
         {
           "name": "SetToSourcePower",
-          "line": 15490,
+          "line": 15494,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a: Conditional — if amount < source's power, set amount = source's power. References the replacement source's (not the damage source's) current post-layer power. Used by Ojer Axonil: \"deals damage equal to ~'s power instead.\"",
@@ -7559,7 +7559,7 @@
         },
         {
           "name": "SetTo",
-          "line": 15496,
+          "line": 15500,
           "kind": "struct",
           "field_names": [
             "value"
@@ -7571,7 +7571,7 @@
         },
         {
           "name": "LifeFloor",
-          "line": 15502,
+          "line": 15506,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -7621,7 +7621,7 @@
     },
     "DamageSource": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7249,
+      "line": 7253,
       "doc": "CR 120.3: Override for which object is the source of damage. By default, the source is the ability's source object (`ability.source_id`). `Target` means the first resolved target is the damage source (e.g., \"Target creature deals damage to itself\" — the creature, not the spell).",
       "cr_refs": [
         "CR 120.3"
@@ -7629,7 +7629,7 @@
       "variants": [
         {
           "name": "Target",
-          "line": 7251,
+          "line": 7255,
           "kind": "unit",
           "field_names": [],
           "doc": "The first resolved object target is the damage source.",
@@ -7637,7 +7637,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 7254,
+          "line": 7258,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.7c: The triggering event's source object is the damage source.",
@@ -7648,7 +7648,7 @@
         },
         {
           "name": "EachTarget",
-          "line": 7280,
+          "line": 7284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 601.2c: Every leading object target is an independent damage source; each deals damage to the shared recipient (the final object target). The amount (`QuantityExpr::Power { scope: Target }`) is re-resolved per source so each member deals damage equal to ITS OWN power (CR 208.1: power is a modifiable characteristic; CR 608.2: read at resolution). Generalizes `Target` (one source) to the variable-count \"up to N / any number of target creatures you control each deal damage equal to their power to <recipient>\" class (Allies at Last, Coordinated Clobbering, Terrific Team-Up — Graceful Takedown's heterogeneous compound source set \"<group A> and up to one other target <group B>\" is NOT covered and is deferred at the parser; see `is_compound_source_each_power_damage`). Unlike `Target`, the recipient is `targets.last()`, not `targets[1..]`.  SCOPE — SIMULTANEOUS multi-source batch (CR 120.4a + CR 120.6 + CR 120.10). The resolver (`resolve_each_target_power_damage`) reuses the decomposed damage primitives that `combat_damage.rs`'s simultaneous combat batch is built from (`pre_replacement_damage_gate` → `replace_event` → `apply_damage_after_replacement`), running all sources as one event set against the shared recipient: each source carries its OWN `DamageContext` (per-source deathtouch/wither/lifelink/infect/toxic), all marks accumulate onto the recipient before SBAs (CR 704) so combined lethal (CR 120.6) and combined excess (CR 120.10) are correct, and a replacement pause on the recipient mid-batch resumes the remaining sources with PER-SOURCE identity preserved (`stash_remaining_each_source_damage`, no flattening to a single source id).",
@@ -7668,7 +7668,7 @@
     },
     "DamageTargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15605,
+      "line": 15609,
       "doc": "CR 614.1a: Restricts which damage targets a replacement applies to. Dedicated enum because `TargetRef` can be `Player` (not handled by `matches_target_filter`).",
       "cr_refs": [
         "CR 614.1a"
@@ -7676,7 +7676,7 @@
       "variants": [
         {
           "name": "CreatureOnly",
-          "line": 15607,
+          "line": 15611,
           "kind": "unit",
           "field_names": [],
           "doc": "\"to a creature\" / \"to that creature\"",
@@ -7684,7 +7684,7 @@
         },
         {
           "name": "Player",
-          "line": 15609,
+          "line": 15613,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7694,7 +7694,7 @@
         },
         {
           "name": "PlayerOrPermanentsControlledBy",
-          "line": 15612,
+          "line": 15616,
           "kind": "struct",
           "field_names": [
             "player"
@@ -7707,7 +7707,7 @@
     },
     "DamageTargetPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15589,
+      "line": 15593,
       "doc": "CR 614.1a: Player axis for damage-recipient replacement filters.",
       "cr_refs": [
         "CR 614.1a"
@@ -7715,7 +7715,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 15590,
+          "line": 15594,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7723,7 +7723,7 @@
         },
         {
           "name": "Opponent",
-          "line": 15591,
+          "line": 15595,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -7731,7 +7731,7 @@
         },
         {
           "name": "Controller",
-          "line": 15594,
+          "line": 15598,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the replacement source. Used by Worship: \"damage that would reduce *your* life total to less than 1\".",
@@ -7739,7 +7739,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 15598,
+          "line": 15602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 614.1a: Damage recipient is the player chosen for the replacement source by a linked persisted choice, or a permanent that player controls for `PlayerOrPermanentsControlledBy`.",
@@ -7750,7 +7750,7 @@
         },
         {
           "name": "Specific",
-          "line": 15599,
+          "line": 15603,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -8203,7 +8203,7 @@
     },
     "DelayedTriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2217,
+      "line": 2221,
       "doc": "When a delayed triggered ability fires (CR 603.7).",
       "cr_refs": [
         "CR 603.7"
@@ -8211,7 +8211,7 @@
       "variants": [
         {
           "name": "AtNextPhase",
-          "line": 2220,
+          "line": 2224,
           "kind": "struct",
           "field_names": [
             "phase"
@@ -8223,7 +8223,7 @@
         },
         {
           "name": "AtNextPhaseForPlayer",
-          "line": 2223,
+          "line": 2227,
           "kind": "struct",
           "field_names": [
             "phase",
@@ -8234,7 +8234,7 @@
         },
         {
           "name": "WhenLeavesPlay",
-          "line": 2225,
+          "line": 2229,
           "kind": "struct",
           "field_names": [
             "object_id"
@@ -8244,7 +8244,7 @@
         },
         {
           "name": "WhenDies",
-          "line": 2231,
+          "line": 2235,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8256,7 +8256,7 @@
         },
         {
           "name": "WhenLeavesPlayFiltered",
-          "line": 2234,
+          "line": 2238,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8268,7 +8268,7 @@
         },
         {
           "name": "WhenEntersBattlefield",
-          "line": 2237,
+          "line": 2241,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8280,7 +8280,7 @@
         },
         {
           "name": "WhenDiesOrExiled",
-          "line": 2240,
+          "line": 2244,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -8290,7 +8290,7 @@
         },
         {
           "name": "WheneverEvent",
-          "line": 2245,
+          "line": 2249,
           "kind": "struct",
           "field_names": [
             "trigger"
@@ -8302,7 +8302,7 @@
         },
         {
           "name": "WhenNextEvent",
-          "line": 2249,
+          "line": 2253,
           "kind": "struct",
           "field_names": [
             "trigger",
@@ -8376,13 +8376,13 @@
     },
     "DiscardSelfScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3203,
+      "line": 3207,
       "doc": "Whether a discard cost discards the ability source itself or cards from hand.",
       "cr_refs": [],
       "variants": [
         {
           "name": "FromHand",
-          "line": 3206,
+          "line": 3210,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard from hand per `filter` / `count` (the default).",
@@ -8390,7 +8390,7 @@
         },
         {
           "name": "SourceCard",
-          "line": 3208,
+          "line": 3212,
           "kind": "unit",
           "field_names": [],
           "doc": "Discard the source card itself (Channel's \"Discard this card\").",
@@ -8446,7 +8446,7 @@
     },
     "DoorLockOp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3677,
+      "line": 3681,
       "doc": "CR 709.5f-g: Operation an [`Effect::SetRoomDoorLock`] performs on a door (half) of a Room permanent. Typed (not a bool) so serialized engine state and the door-choice prompt say which direction is being applied, and so the \"lock or unlock\" disjunction is a first-class third operation rather than an inexpressible boolean combination. Parameterizes the lock/unlock axis — both live within CR rule section 709.5 — into one effect variant instead of two sibling effects.",
       "cr_refs": [
         "CR 709.5f"
@@ -8454,7 +8454,7 @@
       "variants": [
         {
           "name": "Unlock",
-          "line": 3679,
+          "line": 3683,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 709.5f: choose a locked half and give it the unlocked designation.",
@@ -8464,7 +8464,7 @@
         },
         {
           "name": "Lock",
-          "line": 3681,
+          "line": 3685,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 709.5g: choose an unlocked half and remove its unlocked designation.",
@@ -8474,7 +8474,7 @@
         },
         {
           "name": "LockOrUnlock",
-          "line": 3685,
+          "line": 3689,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 709.5f + CR 709.5g: \"Lock or unlock a door\" — the player chooses both the operation and the eligible half at resolution (Keys to the House, Marina Vendrell).",
@@ -8569,13 +8569,13 @@
     },
     "Duration": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1735,
+      "line": 1739,
       "doc": "Duration for temporary effects.  Player-axis variants are parameterized by `PlayerScope` per the workspace \"Parameterize, don't proliferate\" principle. `PlayerScope::Controller` recovers the legacy \"until your next turn\" / \"controller's next step\" semantics; future `Target` / `Opponent` / `AllPlayers` readings unblock cards whose duration is bound to a non-controller player.",
       "cr_refs": [],
       "variants": [
         {
           "name": "UntilEndOfTurn",
-          "line": 1737,
+          "line": 1741,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of turn (cleanup step).",
@@ -8585,7 +8585,7 @@
         },
         {
           "name": "UntilEndOfCombat",
-          "line": 1739,
+          "line": 1743,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 514.2: Effect expires at end of combat phase.",
@@ -8595,7 +8595,7 @@
         },
         {
           "name": "UntilNextTurnOf",
-          "line": 1743,
+          "line": 1747,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8608,7 +8608,7 @@
         },
         {
           "name": "UntilEndOfNextTurnOf",
-          "line": 1753,
+          "line": 1757,
           "kind": "struct",
           "field_names": [
             "player"
@@ -8620,7 +8620,7 @@
         },
         {
           "name": "UntilHostLeavesPlay",
-          "line": 1758,
+          "line": 1762,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a: Effect expires when the source object leaves the battlefield.",
@@ -8630,7 +8630,7 @@
         },
         {
           "name": "UntilNextStepOf",
-          "line": 1764,
+          "line": 1768,
           "kind": "struct",
           "field_names": [
             "step",
@@ -8646,7 +8646,7 @@
         },
         {
           "name": "ForAsLongAs",
-          "line": 1770,
+          "line": 1774,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -8658,7 +8658,7 @@
         },
         {
           "name": "Permanent",
-          "line": 1773,
+          "line": 1777,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -8721,13 +8721,13 @@
     },
     "Effect": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7551,
+      "line": 7555,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 7553,
+          "line": 7557,
           "kind": "struct",
           "field_names": [
             "player_scope"
@@ -8739,7 +8739,7 @@
         },
         {
           "name": "ChangeSpeed",
-          "line": 7559,
+          "line": 7563,
           "kind": "struct",
           "field_names": [
             "player_scope",
@@ -8754,7 +8754,7 @@
         },
         {
           "name": "DealDamage",
-          "line": 7570,
+          "line": 7574,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8766,7 +8766,7 @@
         },
         {
           "name": "ApplyPostReplacementDamage",
-          "line": 7585,
+          "line": 7589,
           "kind": "struct",
           "field_names": [
             "context",
@@ -8783,7 +8783,7 @@
         },
         {
           "name": "EachDealsDamageEqualToPower",
-          "line": 7610,
+          "line": 7614,
           "kind": "struct",
           "field_names": [
             "sources",
@@ -8800,7 +8800,7 @@
         },
         {
           "name": "Draw",
-          "line": 7630,
+          "line": 7634,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8816,7 +8816,7 @@
         },
         {
           "name": "Pump",
-          "line": 7636,
+          "line": 7640,
           "kind": "struct",
           "field_names": [
             "power",
@@ -8828,7 +8828,7 @@
         },
         {
           "name": "PairWith",
-          "line": 7647,
+          "line": 7651,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8841,7 +8841,7 @@
         },
         {
           "name": "Destroy",
-          "line": 7650,
+          "line": 7654,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8852,7 +8852,7 @@
         },
         {
           "name": "Regenerate",
-          "line": 7658,
+          "line": 7662,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8864,7 +8864,7 @@
         },
         {
           "name": "RemoveAllDamage",
-          "line": 7668,
+          "line": 7672,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8878,7 +8878,7 @@
         },
         {
           "name": "Counter",
-          "line": 7672,
+          "line": 7676,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8890,7 +8890,7 @@
         },
         {
           "name": "CounterAll",
-          "line": 7702,
+          "line": 7706,
           "kind": "struct",
           "field_names": [
             "target"
@@ -8904,7 +8904,7 @@
         },
         {
           "name": "Token",
-          "line": 7706,
+          "line": 7710,
           "kind": "struct",
           "field_names": [
             "name",
@@ -8927,7 +8927,7 @@
         },
         {
           "name": "GainLife",
-          "line": 7744,
+          "line": 7748,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8938,7 +8938,7 @@
         },
         {
           "name": "LoseLife",
-          "line": 7755,
+          "line": 7759,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -8949,7 +8949,7 @@
         },
         {
           "name": "SetTapState",
-          "line": 7773,
+          "line": 7777,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8964,7 +8964,7 @@
         },
         {
           "name": "RemoveCounter",
-          "line": 7784,
+          "line": 7788,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -8976,7 +8976,7 @@
         },
         {
           "name": "Sacrifice",
-          "line": 7799,
+          "line": 7803,
           "kind": "struct",
           "field_names": [
             "target",
@@ -8988,7 +8988,7 @@
         },
         {
           "name": "DiscardCard",
-          "line": 7820,
+          "line": 7824,
           "kind": "struct",
           "field_names": [
             "count",
@@ -8999,7 +8999,7 @@
         },
         {
           "name": "Mill",
-          "line": 7826,
+          "line": 7830,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9011,7 +9011,7 @@
         },
         {
           "name": "Scry",
-          "line": 7843,
+          "line": 7847,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9026,7 +9026,7 @@
         },
         {
           "name": "PumpAll",
-          "line": 7849,
+          "line": 7853,
           "kind": "struct",
           "field_names": [
             "power",
@@ -9038,7 +9038,7 @@
         },
         {
           "name": "DamageAll",
-          "line": 7863,
+          "line": 7867,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9055,7 +9055,7 @@
         },
         {
           "name": "DamageEachPlayer",
-          "line": 7887,
+          "line": 7891,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -9068,7 +9068,7 @@
         },
         {
           "name": "DestroyAll",
-          "line": 7891,
+          "line": 7895,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9079,7 +9079,7 @@
         },
         {
           "name": "ChangeZone",
-          "line": 7898,
+          "line": 7902,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -9099,7 +9099,7 @@
         },
         {
           "name": "ChangeZoneAll",
-          "line": 7943,
+          "line": 7947,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -9117,7 +9117,7 @@
         },
         {
           "name": "Dig",
-          "line": 7988,
+          "line": 7992,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9138,7 +9138,7 @@
         },
         {
           "name": "GainControl",
-          "line": 8021,
+          "line": 8025,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9148,7 +9148,7 @@
         },
         {
           "name": "GainControlAll",
-          "line": 8033,
+          "line": 8037,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9160,7 +9160,7 @@
         },
         {
           "name": "ControlNextTurn",
-          "line": 8037,
+          "line": 8041,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9171,7 +9171,7 @@
         },
         {
           "name": "Attach",
-          "line": 8043,
+          "line": 8047,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -9182,7 +9182,7 @@
         },
         {
           "name": "UnattachAll",
-          "line": 8055,
+          "line": 8059,
           "kind": "struct",
           "field_names": [
             "attachment",
@@ -9195,7 +9195,7 @@
         },
         {
           "name": "Surveil",
-          "line": 8067,
+          "line": 8071,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9210,7 +9210,7 @@
         },
         {
           "name": "Fight",
-          "line": 8073,
+          "line": 8077,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9221,7 +9221,7 @@
         },
         {
           "name": "Bounce",
-          "line": 8081,
+          "line": 8085,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9233,7 +9233,7 @@
         },
         {
           "name": "BounceAll",
-          "line": 8100,
+          "line": 8104,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9248,7 +9248,7 @@
         },
         {
           "name": "Explore",
-          "line": 8108,
+          "line": 8112,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9256,7 +9256,7 @@
         },
         {
           "name": "ExploreAll",
-          "line": 8112,
+          "line": 8116,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -9268,7 +9268,7 @@
         },
         {
           "name": "Investigate",
-          "line": 8117,
+          "line": 8121,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.16: Investigate — create a Clue token.",
@@ -9278,7 +9278,7 @@
         },
         {
           "name": "Tribute",
-          "line": 8124,
+          "line": 8128,
           "kind": "struct",
           "field_names": [
             "count"
@@ -9291,7 +9291,7 @@
         },
         {
           "name": "TimeTravel",
-          "line": 8130,
+          "line": 8134,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.56a: Time travel — for each permanent you control with a time counter and each suspended card you own, you may add or remove a time counter.",
@@ -9301,7 +9301,7 @@
         },
         {
           "name": "BecomeMonarch",
-          "line": 8132,
+          "line": 8136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: Become the monarch. Sets GameState::monarch to the controller.",
@@ -9311,7 +9311,7 @@
         },
         {
           "name": "NoOp",
-          "line": 8139,
+          "line": 8143,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2: An instruction with no game action — \"there's no effect.\" Used as the resolved outcome for a choice that has no printed clause, e.g. the losing/unlisted option of a single-conditional Will-of-the-council threshold vote (\"If guilty gets more votes, X\" — the \"innocent\"/tied outcome does nothing). Resolving this emits only an `EffectResolved` so the chain continues.",
@@ -9322,7 +9322,7 @@
         },
         {
           "name": "Proliferate",
-          "line": 8140,
+          "line": 8144,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -9330,7 +9330,7 @@
         },
         {
           "name": "ProliferateTarget",
-          "line": 8147,
+          "line": 8151,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9343,7 +9343,7 @@
         },
         {
           "name": "Populate",
-          "line": 8152,
+          "line": 8156,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.36a: Choose a creature token you control, then create a copy of it.",
@@ -9353,7 +9353,7 @@
         },
         {
           "name": "Clash",
-          "line": 8154,
+          "line": 8158,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.30: Clash with an opponent — reveal top cards, compare mana values.",
@@ -9363,7 +9363,7 @@
         },
         {
           "name": "EndTheTurn",
-          "line": 8159,
+          "line": 8163,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.1: End the turn. Exile every object on the stack, check state-based actions, remove everything from combat, then skip straight to the cleanup step. Time Stop, Sundial of the Infinite, Obeka, Glorious End, Discontinuity, Day's Undoing.",
@@ -9373,7 +9373,7 @@
         },
         {
           "name": "EndCombatPhase",
-          "line": 8164,
+          "line": 8168,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase. Exile every object on the stack, check state-based actions, remove everything from combat, expire \"until end of combat\" effects, and skip straight to the postcombat main phase. Does nothing outside a combat phase (CR 724.2g). Mandate of Peace.",
@@ -9384,7 +9384,7 @@
         },
         {
           "name": "Vote",
-          "line": 8179,
+          "line": 8183,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -9401,7 +9401,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 8236,
+          "line": 8240,
           "kind": "struct",
           "field_names": [
             "partition_subject",
@@ -9421,7 +9421,7 @@
         },
         {
           "name": "SwitchPT",
-          "line": 8255,
+          "line": 8259,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9433,7 +9433,7 @@
         },
         {
           "name": "CopySpell",
-          "line": 8259,
+          "line": 8263,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9447,7 +9447,7 @@
         },
         {
           "name": "EpicCopy",
-          "line": 8292,
+          "line": 8296,
           "kind": "struct",
           "field_names": [
             "spell"
@@ -9460,7 +9460,7 @@
         },
         {
           "name": "CastCopyOfCard",
-          "line": 8297,
+          "line": 8301,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9473,7 +9473,7 @@
         },
         {
           "name": "CopyTokenOf",
-          "line": 8308,
+          "line": 8312,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9493,7 +9493,7 @@
         },
         {
           "name": "CreateTokenCopyFromPool",
-          "line": 8363,
+          "line": 8367,
           "kind": "struct",
           "field_names": [
             "owner",
@@ -9514,7 +9514,7 @@
         },
         {
           "name": "Myriad",
-          "line": 8394,
+          "line": 8398,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.116a: Myriad creates one tapped attacking copy token for each opponent other than the defending player for the source creature, then exiles those tokens at end of combat.",
@@ -9524,7 +9524,7 @@
         },
         {
           "name": "Encore",
-          "line": 8401,
+          "line": 8405,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.141a: Encore — for each opponent, create a token that's a copy of the (exiled) source card that must attack that opponent this turn if able. The tokens gain haste and are sacrificed at the beginning of the next end step. Resolver: `game/effects/encore.rs`. No player-selectable target (opponents and per-opponent attack binding are chosen by the effect, like `Myriad`).",
@@ -9534,7 +9534,7 @@
         },
         {
           "name": "Meld",
-          "line": 8409,
+          "line": 8413,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9549,7 +9549,7 @@
         },
         {
           "name": "ExileHaunting",
-          "line": 8419,
+          "line": 8423,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9561,7 +9561,7 @@
         },
         {
           "name": "HideawayConceal",
-          "line": 8428,
+          "line": 8432,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9573,7 +9573,7 @@
         },
         {
           "name": "CopyTokenBlockingAttacker",
-          "line": 8440,
+          "line": 8444,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -9588,7 +9588,7 @@
         },
         {
           "name": "BecomeCopy",
-          "line": 8452,
+          "line": 8456,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9604,7 +9604,7 @@
         },
         {
           "name": "ChooseCard",
-          "line": 8462,
+          "line": 8466,
           "kind": "struct",
           "field_names": [
             "choices",
@@ -9615,7 +9615,7 @@
         },
         {
           "name": "PutCounter",
-          "line": 8476,
+          "line": 8480,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9629,7 +9629,7 @@
         },
         {
           "name": "PutCounterAll",
-          "line": 8484,
+          "line": 8488,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9643,7 +9643,7 @@
         },
         {
           "name": "MultiplyCounter",
-          "line": 8491,
+          "line": 8495,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -9655,7 +9655,7 @@
         },
         {
           "name": "DoublePT",
-          "line": 8506,
+          "line": 8510,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9671,7 +9671,7 @@
         },
         {
           "name": "DoublePTAll",
-          "line": 8518,
+          "line": 8522,
           "kind": "struct",
           "field_names": [
             "mode",
@@ -9686,7 +9686,7 @@
         },
         {
           "name": "MoveCounters",
-          "line": 8528,
+          "line": 8532,
           "kind": "struct",
           "field_names": [
             "source",
@@ -9704,7 +9704,7 @@
         },
         {
           "name": "Animate",
-          "line": 8548,
+          "line": 8552,
           "kind": "struct",
           "field_names": [
             "power",
@@ -9719,7 +9719,7 @@
         },
         {
           "name": "ReturnAsAura",
-          "line": 8586,
+          "line": 8590,
           "kind": "struct",
           "field_names": [
             "enchant_filter",
@@ -9743,7 +9743,7 @@
         },
         {
           "name": "RegisterBending",
-          "line": 8602,
+          "line": 8606,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -9753,7 +9753,7 @@
         },
         {
           "name": "GenericEffect",
-          "line": 8606,
+          "line": 8610,
           "kind": "struct",
           "field_names": [
             "static_abilities",
@@ -9765,7 +9765,7 @@
         },
         {
           "name": "Cleanup",
-          "line": 8614,
+          "line": 8618,
           "kind": "struct",
           "field_names": [
             "clear_remembered",
@@ -9782,7 +9782,7 @@
         },
         {
           "name": "Mana",
-          "line": 8632,
+          "line": 8636,
           "kind": "struct",
           "field_names": [
             "produced",
@@ -9796,7 +9796,7 @@
         },
         {
           "name": "Discard",
-          "line": 8655,
+          "line": 8659,
           "kind": "struct",
           "field_names": [
             "count",
@@ -9810,16 +9810,6 @@
         },
         {
           "name": "Shuffle",
-          "line": 8682,
-          "kind": "struct",
-          "field_names": [
-            "target"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Transform",
           "line": 8686,
           "kind": "struct",
           "field_names": [
@@ -9829,8 +9819,18 @@
           "cr_refs": []
         },
         {
+          "name": "Transform",
+          "line": 8690,
+          "kind": "struct",
+          "field_names": [
+            "target"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
           "name": "SearchLibrary",
-          "line": 8692,
+          "line": 8696,
           "kind": "struct",
           "field_names": [
             "source_zones",
@@ -9846,7 +9846,7 @@
         },
         {
           "name": "SearchOutsideGame",
-          "line": 8749,
+          "line": 8753,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9864,7 +9864,7 @@
         },
         {
           "name": "RevealHand",
-          "line": 8760,
+          "line": 8764,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9879,7 +9879,7 @@
         },
         {
           "name": "RevealFromHand",
-          "line": 8793,
+          "line": 8797,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -9892,7 +9892,7 @@
         },
         {
           "name": "Reveal",
-          "line": 8804,
+          "line": 8808,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9905,7 +9905,7 @@
         },
         {
           "name": "RevealTop",
-          "line": 8809,
+          "line": 8813,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9918,7 +9918,7 @@
         },
         {
           "name": "ExileTop",
-          "line": 8818,
+          "line": 8822,
           "kind": "struct",
           "field_names": [
             "player",
@@ -9930,7 +9930,7 @@
         },
         {
           "name": "TargetOnly",
-          "line": 8841,
+          "line": 8845,
           "kind": "struct",
           "field_names": [
             "target"
@@ -9940,7 +9940,7 @@
         },
         {
           "name": "Choose",
-          "line": 8847,
+          "line": 8851,
           "kind": "struct",
           "field_names": [
             "choice_type",
@@ -9952,7 +9952,7 @@
         },
         {
           "name": "ChooseDamageSource",
-          "line": 8865,
+          "line": 8869,
           "kind": "struct",
           "field_names": [
             "source_filter"
@@ -9965,7 +9965,7 @@
         },
         {
           "name": "Suspect",
-          "line": 8878,
+          "line": 8882,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9978,7 +9978,7 @@
         },
         {
           "name": "Unsuspect",
-          "line": 8898,
+          "line": 8902,
           "kind": "struct",
           "field_names": [
             "target",
@@ -9991,7 +9991,7 @@
         },
         {
           "name": "Connive",
-          "line": 8910,
+          "line": 8914,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10005,7 +10005,7 @@
         },
         {
           "name": "PhaseOut",
-          "line": 8918,
+          "line": 8922,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10017,7 +10017,7 @@
         },
         {
           "name": "PhaseIn",
-          "line": 8925,
+          "line": 8929,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10029,7 +10029,7 @@
         },
         {
           "name": "ForceBlock",
-          "line": 8930,
+          "line": 8934,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10041,7 +10041,7 @@
         },
         {
           "name": "ForceAttack",
-          "line": 8935,
+          "line": 8939,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10055,7 +10055,7 @@
         },
         {
           "name": "SolveCase",
-          "line": 8944,
+          "line": 8948,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Solve the source Case — it becomes solved.",
@@ -10065,7 +10065,7 @@
         },
         {
           "name": "BecomePrepared",
-          "line": 8951,
+          "line": 8955,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10077,7 +10077,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 8958,
+          "line": 8962,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10089,7 +10089,7 @@
         },
         {
           "name": "BecomeSaddled",
-          "line": 8971,
+          "line": 8975,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10102,7 +10102,7 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 8976,
+          "line": 8980,
           "kind": "struct",
           "field_names": [
             "level"
@@ -10114,7 +10114,7 @@
         },
         {
           "name": "CreateDelayedTrigger",
-          "line": 8981,
+          "line": 8985,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -10128,7 +10128,7 @@
         },
         {
           "name": "AddTargetReplacement",
-          "line": 9011,
+          "line": 9015,
           "kind": "struct",
           "field_names": [
             "replacement",
@@ -10142,7 +10142,7 @@
         },
         {
           "name": "AddRestriction",
-          "line": 9017,
+          "line": 9021,
           "kind": "struct",
           "field_names": [
             "restriction"
@@ -10154,7 +10154,7 @@
         },
         {
           "name": "ReduceNextSpellCost",
-          "line": 9022,
+          "line": 9026,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10167,7 +10167,7 @@
         },
         {
           "name": "GrantNextSpellAbility",
-          "line": 9029,
+          "line": 9033,
           "kind": "struct",
           "field_names": [
             "modifier",
@@ -10181,7 +10181,7 @@
         },
         {
           "name": "AddPendingETBCounters",
-          "line": 9044,
+          "line": 9048,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -10194,7 +10194,7 @@
         },
         {
           "name": "CreateEmblem",
-          "line": 9052,
+          "line": 9056,
           "kind": "struct",
           "field_names": [
             "statics",
@@ -10208,7 +10208,7 @@
         },
         {
           "name": "PayCost",
-          "line": 9067,
+          "line": 9071,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -10222,7 +10222,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 9085,
+          "line": 9089,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10242,7 +10242,7 @@
         },
         {
           "name": "FreeCastFromZones",
-          "line": 9153,
+          "line": 9157,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10262,7 +10262,7 @@
         },
         {
           "name": "ExileResolvingSpellInsteadOfGraveyard",
-          "line": 9188,
+          "line": 9192,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 608.2n + CR 607.2b: \"Exile it instead of putting it into a graveyard as it resolves\" — the self-replacement rider applied by a `WhenAPlayerCasts` trigger to the *triggering spell* (Rod of Absorption).  At resolution this effect does NOT move the spell (it is still on the stack); it stamps the per-object linked-source marker so the stack-resolution router sends the spell to exile (CR 614.1a replaces the normal CR 608.2n graveyard destination) when it finishes resolving. When the spell reaches exile, it is recorded as \"exiled with\" the trigger source so a linked ability (CR 607.2b — \"cards exiled with this artifact\") can later refer to the accumulating set.  Distinct from `ChangeZone { destination: Exile }` (which moves a card that is already in a zone) and from `FreeCastFromZones { exile_instead… }` (which stamps the same rider on a spell *cast during resolution*, with no linked-exile payoff). This effect is the trigger-driven, link-establishing form for the resolving spell itself.",
@@ -10274,7 +10274,7 @@
         },
         {
           "name": "PreventDamage",
-          "line": 9190,
+          "line": 9194,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10291,7 +10291,7 @@
         },
         {
           "name": "CreateDamageReplacement",
-          "line": 9235,
+          "line": 9239,
           "kind": "struct",
           "field_names": [
             "source_filter",
@@ -10313,7 +10313,7 @@
         },
         {
           "name": "LoseTheGame",
-          "line": 9276,
+          "line": 9280,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10325,7 +10325,7 @@
         },
         {
           "name": "WinTheGame",
-          "line": 9285,
+          "line": 9289,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10337,7 +10337,7 @@
         },
         {
           "name": "RollDie",
-          "line": 9298,
+          "line": 9302,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10355,7 +10355,7 @@
         },
         {
           "name": "FlipCoin",
-          "line": 9323,
+          "line": 9327,
           "kind": "struct",
           "field_names": [
             "win_effect",
@@ -10371,7 +10371,7 @@
         },
         {
           "name": "FlipCoins",
-          "line": 9343,
+          "line": 9347,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10387,7 +10387,7 @@
         },
         {
           "name": "FlipCoinUntilLose",
-          "line": 9357,
+          "line": 9361,
           "kind": "struct",
           "field_names": [
             "win_effect"
@@ -10399,7 +10399,7 @@
         },
         {
           "name": "RingTemptsYou",
-          "line": 9362,
+          "line": 9366,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: The Ring tempts the controller. Increments ring level and prompts ring-bearer selection if the controller has creatures on the battlefield.",
@@ -10409,7 +10409,7 @@
         },
         {
           "name": "VentureIntoDungeon",
-          "line": 9365,
+          "line": 9369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.49: Venture into the dungeon. Advances the player's venture marker or starts a new dungeon if none is active.",
@@ -10419,7 +10419,7 @@
         },
         {
           "name": "VentureInto",
-          "line": 9367,
+          "line": 9371,
           "kind": "struct",
           "field_names": [
             "dungeon"
@@ -10431,7 +10431,7 @@
         },
         {
           "name": "TakeTheInitiative",
-          "line": 9372,
+          "line": 9376,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.1 + CR 726.2: Take the initiative. Grants the initiative designation and triggers venture into Undercity.",
@@ -10442,7 +10442,7 @@
         },
         {
           "name": "Planeswalk",
-          "line": 9377,
+          "line": 9381,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 901.8 / CR 901.9c: The synthetic \"planeswalking ability.\" When a player rolls the Planeswalker symbol on the planar die, this ability triggers and is put on the stack; on resolution its controller (the roller, CR 901.8) planeswalks (CR 701.31).",
@@ -10454,7 +10454,7 @@
         },
         {
           "name": "OpenAttractions",
-          "line": 9380,
+          "line": 9384,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10466,7 +10466,7 @@
         },
         {
           "name": "RollToVisitAttractions",
-          "line": 9384,
+          "line": 9388,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.52: Roll to visit your Attractions.",
@@ -10476,7 +10476,7 @@
         },
         {
           "name": "PutSticker",
-          "line": 9386,
+          "line": 9390,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10492,7 +10492,7 @@
         },
         {
           "name": "ApplySticker",
-          "line": 9404,
+          "line": 9408,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10504,7 +10504,7 @@
         },
         {
           "name": "ProcessRadCounters",
-          "line": 9413,
+          "line": 9417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 728.1: Process rad counters — mill cards equal to rad counter count, lose 1 life and remove one rad counter per nonland card milled.",
@@ -10514,7 +10514,7 @@
         },
         {
           "name": "GrantCastingPermission",
-          "line": 9416,
+          "line": 9420,
           "kind": "struct",
           "field_names": [
             "permission",
@@ -10526,7 +10526,7 @@
         },
         {
           "name": "ChooseFromZone",
-          "line": 9433,
+          "line": 9437,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10546,7 +10546,7 @@
         },
         {
           "name": "ForEachCategoryExile",
-          "line": 9491,
+          "line": 9495,
           "kind": "struct",
           "field_names": [
             "category",
@@ -10563,7 +10563,7 @@
         },
         {
           "name": "ChooseObjectsIntoTrackedSet",
-          "line": 9515,
+          "line": 9519,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -10578,7 +10578,7 @@
         },
         {
           "name": "ChooseAndSacrificeRest",
-          "line": 9528,
+          "line": 9532,
           "kind": "struct",
           "field_names": [
             "categories",
@@ -10594,7 +10594,7 @@
         },
         {
           "name": "Exploit",
-          "line": 9543,
+          "line": 9547,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10606,7 +10606,7 @@
         },
         {
           "name": "GainEnergy",
-          "line": 9548,
+          "line": 9552,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -10618,7 +10618,7 @@
         },
         {
           "name": "GivePlayerCounter",
-          "line": 9553,
+          "line": 9557,
           "kind": "struct",
           "field_names": [
             "counter_kind",
@@ -10633,7 +10633,7 @@
         },
         {
           "name": "LoseAllPlayerCounters",
-          "line": 9565,
+          "line": 9569,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10645,7 +10645,7 @@
         },
         {
           "name": "ExileFromTopUntil",
-          "line": 9577,
+          "line": 9581,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10661,7 +10661,7 @@
         },
         {
           "name": "RevealUntil",
-          "line": 9588,
+          "line": 9592,
           "kind": "struct",
           "field_names": [
             "player",
@@ -10682,7 +10682,7 @@
         },
         {
           "name": "Discover",
-          "line": 9655,
+          "line": 9659,
           "kind": "struct",
           "field_names": [
             "mana_value_limit",
@@ -10695,7 +10695,7 @@
         },
         {
           "name": "Heist",
-          "line": 9677,
+          "line": 9681,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10706,7 +10706,7 @@
         },
         {
           "name": "HeistExile",
-          "line": 9692,
+          "line": 9696,
           "kind": "unit",
           "field_names": [],
           "doc": "Heist finalizer — continuation stashed by `Effect::Heist`. The chosen card (carried on `ability.targets` by the `ChooseFromZoneChoice` answer handler) is exiled from its owner's library, turned face down (CR 406.3), linked to the source so the controller may look at it (mirrors Hideaway's `ExileLinkKind::HideawayLookable`), and granted a permanent `PlayFromExile` permission with any-type-or-color mana so it can be cast for as long as it remains exiled. Unit variant — no fields; the target is implicit in `ability.targets`.",
@@ -10716,7 +10716,7 @@
         },
         {
           "name": "Cascade",
-          "line": 9702,
+          "line": 9706,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: Cascade — when you cast a spell with cascade, exile cards from the top of your library until you exile a nonland card whose mana value is less than the cascade spell's mana value. You may cast that card without paying its mana cost. Then put all exiled non-cast cards on the bottom of your library in a random order.  The source spell's mana value is read from `ability.source_id` at resolve time (the cascade spell is on the stack when cascade resolves per CR 702.85a), so no threshold parameter is stored on the variant itself.",
@@ -10726,7 +10726,7 @@
         },
         {
           "name": "Ripple",
-          "line": 9707,
+          "line": 9711,
           "kind": "struct",
           "field_names": [
             "count"
@@ -10738,7 +10738,7 @@
         },
         {
           "name": "MiracleCast",
-          "line": 9713,
+          "line": 9717,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10750,7 +10750,7 @@
         },
         {
           "name": "MadnessCast",
-          "line": 9718,
+          "line": 9722,
           "kind": "struct",
           "field_names": [
             "cost"
@@ -10762,7 +10762,7 @@
         },
         {
           "name": "PutAtLibraryPosition",
-          "line": 9731,
+          "line": 9735,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10774,7 +10774,7 @@
         },
         {
           "name": "ChooseDrawnThisTurnPayOrTopdeck",
-          "line": 9740,
+          "line": 9744,
           "kind": "struct",
           "field_names": [
             "count",
@@ -10786,7 +10786,7 @@
         },
         {
           "name": "PutOnTopOrBottom",
-          "line": 9749,
+          "line": 9753,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10796,7 +10796,7 @@
         },
         {
           "name": "GiftDelivery",
-          "line": 9754,
+          "line": 9758,
           "kind": "struct",
           "field_names": [
             "kind"
@@ -10806,7 +10806,7 @@
         },
         {
           "name": "Goad",
-          "line": 9760,
+          "line": 9764,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10818,7 +10818,7 @@
         },
         {
           "name": "GoadAll",
-          "line": 9767,
+          "line": 9771,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10830,7 +10830,7 @@
         },
         {
           "name": "Detain",
-          "line": 9774,
+          "line": 9778,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10842,7 +10842,7 @@
         },
         {
           "name": "SetRoomDoorLock",
-          "line": 9786,
+          "line": 9790,
           "kind": "struct",
           "field_names": [
             "op",
@@ -10856,7 +10856,7 @@
         },
         {
           "name": "ExchangeControl",
-          "line": 9798,
+          "line": 9802,
           "kind": "struct",
           "field_names": [
             "target_a",
@@ -10870,7 +10870,7 @@
         },
         {
           "name": "ChangeTargets",
-          "line": 9809,
+          "line": 9813,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10884,7 +10884,7 @@
         },
         {
           "name": "Manifest",
-          "line": 9824,
+          "line": 9828,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10899,7 +10899,7 @@
         },
         {
           "name": "ManifestDread",
-          "line": 9844,
+          "line": 9848,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.62a: Manifest dread — look at top 2 cards of library, manifest one, put the rest into graveyard. Uses interactive WaitingFor::ManifestDreadChoice.",
@@ -10909,7 +10909,7 @@
         },
         {
           "name": "Cloak",
-          "line": 9851,
+          "line": 9855,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10923,7 +10923,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 9863,
+          "line": 9867,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10936,7 +10936,7 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 9870,
+          "line": 9874,
           "kind": "struct",
           "field_names": [
             "target"
@@ -10948,7 +10948,7 @@
         },
         {
           "name": "GrantExtraLoyaltyActivations",
-          "line": 9884,
+          "line": 9888,
           "kind": "struct",
           "field_names": [
             "amount",
@@ -10961,7 +10961,7 @@
         },
         {
           "name": "SkipNextTurn",
-          "line": 9895,
+          "line": 9899,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10974,7 +10974,7 @@
         },
         {
           "name": "SkipNextStep",
-          "line": 9905,
+          "line": 9909,
           "kind": "struct",
           "field_names": [
             "target",
@@ -10988,7 +10988,7 @@
         },
         {
           "name": "AdditionalPhase",
-          "line": 9921,
+          "line": 9925,
           "kind": "struct",
           "field_names": [
             "target",
@@ -11005,7 +11005,7 @@
         },
         {
           "name": "Double",
-          "line": 9934,
+          "line": 9938,
           "kind": "struct",
           "field_names": [
             "target_kind",
@@ -11019,7 +11019,7 @@
         },
         {
           "name": "RuntimeHandled",
-          "line": 9942,
+          "line": 9946,
           "kind": "struct",
           "field_names": [
             "handler"
@@ -11031,7 +11031,7 @@
         },
         {
           "name": "Incubate",
-          "line": 9948,
+          "line": 9952,
           "kind": "struct",
           "field_names": [
             "count"
@@ -11043,7 +11043,7 @@
         },
         {
           "name": "Amass",
-          "line": 9956,
+          "line": 9960,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -11056,7 +11056,7 @@
         },
         {
           "name": "Monstrosity",
-          "line": 9964,
+          "line": 9968,
           "kind": "struct",
           "field_names": [
             "count"
@@ -11068,7 +11068,7 @@
         },
         {
           "name": "Specialize",
-          "line": 9970,
+          "line": 9974,
           "kind": "unit",
           "field_names": [],
           "doc": "Digital-only Specialize: permanently become a color-specific face after paying the synthesized activation cost (mana + discard). Not in CR text.",
@@ -11076,7 +11076,7 @@
         },
         {
           "name": "Renown",
-          "line": 9973,
+          "line": 9977,
           "kind": "struct",
           "field_names": [
             "count"
@@ -11088,7 +11088,7 @@
         },
         {
           "name": "Bolster",
-          "line": 9979,
+          "line": 9983,
           "kind": "struct",
           "field_names": [
             "count"
@@ -11100,7 +11100,7 @@
         },
         {
           "name": "Adapt",
-          "line": 9985,
+          "line": 9989,
           "kind": "struct",
           "field_names": [
             "count"
@@ -11112,7 +11112,7 @@
         },
         {
           "name": "Learn",
-          "line": 9991,
+          "line": 9995,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.48a: Learn — you may discard a card to draw a card, or get a Lesson from outside the game.",
@@ -11122,7 +11122,7 @@
         },
         {
           "name": "Forage",
-          "line": 9993,
+          "line": 9997,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.",
@@ -11132,7 +11132,7 @@
         },
         {
           "name": "Harness",
-          "line": 9999,
+          "line": 10003,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.64a: Harness [this permanent] — if the source permanent isn't harnessed, it becomes harnessed. A unit keyword action (no parameters): it always designates the source permanent, mirroring `Forage`'s argument-free shape. The harnessed designation (CR 701.64b) is read by the ∞ (Infinity) ability gate via `SourceIsHarnessed`.",
@@ -11143,7 +11143,7 @@
         },
         {
           "name": "CollectEvidence",
-          "line": 10001,
+          "line": 10005,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -11155,7 +11155,7 @@
         },
         {
           "name": "Endure",
-          "line": 10008,
+          "line": 10012,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -11168,7 +11168,7 @@
         },
         {
           "name": "BlightEffect",
-          "line": 10023,
+          "line": 10027,
           "kind": "struct",
           "field_names": [
             "count",
@@ -11181,7 +11181,7 @@
         },
         {
           "name": "Seek",
-          "line": 10033,
+          "line": 10037,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -11195,7 +11195,7 @@
         },
         {
           "name": "SetLifeTotal",
-          "line": 10050,
+          "line": 10054,
           "kind": "struct",
           "field_names": [
             "target",
@@ -11208,7 +11208,7 @@
         },
         {
           "name": "ExchangeLifeWithStat",
-          "line": 10065,
+          "line": 10069,
           "kind": "struct",
           "field_names": [
             "player",
@@ -11224,7 +11224,7 @@
         },
         {
           "name": "ExchangeLifeTotals",
-          "line": 10073,
+          "line": 10077,
           "kind": "struct",
           "field_names": [
             "player_a",
@@ -11237,7 +11237,7 @@
         },
         {
           "name": "SetDayNight",
-          "line": 10081,
+          "line": 10085,
           "kind": "struct",
           "field_names": [
             "to"
@@ -11249,7 +11249,7 @@
         },
         {
           "name": "GiveControl",
-          "line": 10086,
+          "line": 10090,
           "kind": "struct",
           "field_names": [
             "target",
@@ -11262,7 +11262,7 @@
         },
         {
           "name": "RemoveFromCombat",
-          "line": 10095,
+          "line": 10099,
           "kind": "struct",
           "field_names": [
             "target"
@@ -11274,7 +11274,7 @@
         },
         {
           "name": "Conjure",
-          "line": 10102,
+          "line": 10106,
           "kind": "struct",
           "field_names": [
             "cards",
@@ -11286,7 +11286,7 @@
         },
         {
           "name": "ApplyPerpetual",
-          "line": 10117,
+          "line": 10121,
           "kind": "struct",
           "field_names": [
             "target",
@@ -11297,7 +11297,7 @@
         },
         {
           "name": "Intensify",
-          "line": 10127,
+          "line": 10131,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -11308,7 +11308,7 @@
         },
         {
           "name": "DraftFromSpellbook",
-          "line": 10141,
+          "line": 10145,
           "kind": "struct",
           "field_names": [
             "destination",
@@ -11319,7 +11319,7 @@
         },
         {
           "name": "ChooseOneOf",
-          "line": 10160,
+          "line": 10164,
           "kind": "struct",
           "field_names": [
             "chooser",
@@ -11333,7 +11333,7 @@
         },
         {
           "name": "Unimplemented",
-          "line": 10171,
+          "line": 10175,
           "kind": "struct",
           "field_names": [
             "name",
@@ -11436,13 +11436,13 @@
     },
     "EffectError": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 16935,
+      "line": 16939,
       "doc": "Error type for effect handler failures.",
       "cr_refs": [],
       "variants": [
         {
           "name": "MissingParam",
-          "line": 16937,
+          "line": 16941,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -11450,22 +11450,6 @@
         },
         {
           "name": "InvalidParam",
-          "line": 16939,
-          "kind": "tuple",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PlayerNotFound",
-          "line": 16941,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ObjectNotFound",
           "line": 16943,
           "kind": "tuple",
           "field_names": [],
@@ -11473,7 +11457,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChainTooDeep",
+          "name": "PlayerNotFound",
           "line": 16945,
           "kind": "unit",
           "field_names": [],
@@ -11481,8 +11465,24 @@
           "cr_refs": []
         },
         {
-          "name": "Unregistered",
+          "name": "ObjectNotFound",
           "line": 16947,
+          "kind": "tuple",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChainTooDeep",
+          "line": 16949,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unregistered",
+          "line": 16951,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -11493,44 +11493,12 @@
     },
     "EffectKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12009,
+      "line": 12013,
       "doc": "Typed tag carried by `GameEvent::EffectResolved`. Replaces the former `api_type: String` field with a compile-time-checked enum. Variants mirror `Effect` variants 1:1, plus a few engine-level emits (Equip) and trigger-condition placeholders (Reveal, Transform, TurnFaceUp, DayTimeChange).",
       "cr_refs": [],
       "variants": [
         {
           "name": "StartYourEngines",
-          "line": 12010,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ChangeSpeed",
-          "line": 12011,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "DealDamage",
-          "line": 12012,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ApplyPostReplacementDamage",
-          "line": 12013,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "EachDealsDamageEqualToPower",
           "line": 12014,
           "kind": "unit",
           "field_names": [],
@@ -11538,7 +11506,7 @@
           "cr_refs": []
         },
         {
-          "name": "Draw",
+          "name": "ChangeSpeed",
           "line": 12015,
           "kind": "unit",
           "field_names": [],
@@ -11546,7 +11514,7 @@
           "cr_refs": []
         },
         {
-          "name": "Pump",
+          "name": "DealDamage",
           "line": 12016,
           "kind": "unit",
           "field_names": [],
@@ -11554,7 +11522,7 @@
           "cr_refs": []
         },
         {
-          "name": "PairWith",
+          "name": "ApplyPostReplacementDamage",
           "line": 12017,
           "kind": "unit",
           "field_names": [],
@@ -11562,7 +11530,7 @@
           "cr_refs": []
         },
         {
-          "name": "Destroy",
+          "name": "EachDealsDamageEqualToPower",
           "line": 12018,
           "kind": "unit",
           "field_names": [],
@@ -11570,7 +11538,7 @@
           "cr_refs": []
         },
         {
-          "name": "Counter",
+          "name": "Draw",
           "line": 12019,
           "kind": "unit",
           "field_names": [],
@@ -11578,7 +11546,7 @@
           "cr_refs": []
         },
         {
-          "name": "CounterAll",
+          "name": "Pump",
           "line": 12020,
           "kind": "unit",
           "field_names": [],
@@ -11586,7 +11554,7 @@
           "cr_refs": []
         },
         {
-          "name": "Token",
+          "name": "PairWith",
           "line": 12021,
           "kind": "unit",
           "field_names": [],
@@ -11594,7 +11562,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainLife",
+          "name": "Destroy",
           "line": 12022,
           "kind": "unit",
           "field_names": [],
@@ -11602,7 +11570,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseLife",
+          "name": "Counter",
           "line": 12023,
           "kind": "unit",
           "field_names": [],
@@ -11610,7 +11578,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tap",
+          "name": "CounterAll",
           "line": 12024,
           "kind": "unit",
           "field_names": [],
@@ -11618,7 +11586,7 @@
           "cr_refs": []
         },
         {
-          "name": "Untap",
+          "name": "Token",
           "line": 12025,
           "kind": "unit",
           "field_names": [],
@@ -11626,7 +11594,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveCounter",
+          "name": "GainLife",
           "line": 12026,
           "kind": "unit",
           "field_names": [],
@@ -11634,7 +11602,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sacrifice",
+          "name": "LoseLife",
           "line": 12027,
           "kind": "unit",
           "field_names": [],
@@ -11642,7 +11610,7 @@
           "cr_refs": []
         },
         {
-          "name": "DiscardCard",
+          "name": "Tap",
           "line": 12028,
           "kind": "unit",
           "field_names": [],
@@ -11650,7 +11618,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mill",
+          "name": "Untap",
           "line": 12029,
           "kind": "unit",
           "field_names": [],
@@ -11658,7 +11626,7 @@
           "cr_refs": []
         },
         {
-          "name": "Scry",
+          "name": "RemoveCounter",
           "line": 12030,
           "kind": "unit",
           "field_names": [],
@@ -11666,7 +11634,7 @@
           "cr_refs": []
         },
         {
-          "name": "PumpAll",
+          "name": "Sacrifice",
           "line": 12031,
           "kind": "unit",
           "field_names": [],
@@ -11674,7 +11642,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageAll",
+          "name": "DiscardCard",
           "line": 12032,
           "kind": "unit",
           "field_names": [],
@@ -11682,7 +11650,7 @@
           "cr_refs": []
         },
         {
-          "name": "DamageEachPlayer",
+          "name": "Mill",
           "line": 12033,
           "kind": "unit",
           "field_names": [],
@@ -11690,7 +11658,7 @@
           "cr_refs": []
         },
         {
-          "name": "DestroyAll",
+          "name": "Scry",
           "line": 12034,
           "kind": "unit",
           "field_names": [],
@@ -11698,7 +11666,7 @@
           "cr_refs": []
         },
         {
-          "name": "TapAll",
+          "name": "PumpAll",
           "line": 12035,
           "kind": "unit",
           "field_names": [],
@@ -11706,7 +11674,7 @@
           "cr_refs": []
         },
         {
-          "name": "UntapAll",
+          "name": "DamageAll",
           "line": 12036,
           "kind": "unit",
           "field_names": [],
@@ -11714,7 +11682,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZone",
+          "name": "DamageEachPlayer",
           "line": 12037,
           "kind": "unit",
           "field_names": [],
@@ -11722,7 +11690,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeZoneAll",
+          "name": "DestroyAll",
           "line": 12038,
           "kind": "unit",
           "field_names": [],
@@ -11730,7 +11698,7 @@
           "cr_refs": []
         },
         {
-          "name": "Dig",
+          "name": "TapAll",
           "line": 12039,
           "kind": "unit",
           "field_names": [],
@@ -11738,7 +11706,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControl",
+          "name": "UntapAll",
           "line": 12040,
           "kind": "unit",
           "field_names": [],
@@ -11746,7 +11714,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainControlAll",
+          "name": "ChangeZone",
           "line": 12041,
           "kind": "unit",
           "field_names": [],
@@ -11754,7 +11722,7 @@
           "cr_refs": []
         },
         {
-          "name": "ControlNextTurn",
+          "name": "ChangeZoneAll",
           "line": 12042,
           "kind": "unit",
           "field_names": [],
@@ -11762,7 +11730,7 @@
           "cr_refs": []
         },
         {
-          "name": "Attach",
+          "name": "Dig",
           "line": 12043,
           "kind": "unit",
           "field_names": [],
@@ -11770,7 +11738,7 @@
           "cr_refs": []
         },
         {
-          "name": "AttachAll",
+          "name": "GainControl",
           "line": 12044,
           "kind": "unit",
           "field_names": [],
@@ -11778,7 +11746,7 @@
           "cr_refs": []
         },
         {
-          "name": "UnattachAll",
+          "name": "GainControlAll",
           "line": 12045,
           "kind": "unit",
           "field_names": [],
@@ -11786,7 +11754,7 @@
           "cr_refs": []
         },
         {
-          "name": "Surveil",
+          "name": "ControlNextTurn",
           "line": 12046,
           "kind": "unit",
           "field_names": [],
@@ -11794,7 +11762,7 @@
           "cr_refs": []
         },
         {
-          "name": "Fight",
+          "name": "Attach",
           "line": 12047,
           "kind": "unit",
           "field_names": [],
@@ -11802,7 +11770,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bounce",
+          "name": "AttachAll",
           "line": 12048,
           "kind": "unit",
           "field_names": [],
@@ -11810,7 +11778,7 @@
           "cr_refs": []
         },
         {
-          "name": "BounceAll",
+          "name": "UnattachAll",
           "line": 12049,
           "kind": "unit",
           "field_names": [],
@@ -11818,7 +11786,7 @@
           "cr_refs": []
         },
         {
-          "name": "Explore",
+          "name": "Surveil",
           "line": 12050,
           "kind": "unit",
           "field_names": [],
@@ -11826,7 +11794,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExploreAll",
+          "name": "Fight",
           "line": 12051,
           "kind": "unit",
           "field_names": [],
@@ -11834,7 +11802,7 @@
           "cr_refs": []
         },
         {
-          "name": "Investigate",
+          "name": "Bounce",
           "line": 12052,
           "kind": "unit",
           "field_names": [],
@@ -11842,7 +11810,7 @@
           "cr_refs": []
         },
         {
-          "name": "Tribute",
+          "name": "BounceAll",
           "line": 12053,
           "kind": "unit",
           "field_names": [],
@@ -11850,7 +11818,7 @@
           "cr_refs": []
         },
         {
-          "name": "TimeTravel",
+          "name": "Explore",
           "line": 12054,
           "kind": "unit",
           "field_names": [],
@@ -11858,7 +11826,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeMonarch",
+          "name": "ExploreAll",
           "line": 12055,
           "kind": "unit",
           "field_names": [],
@@ -11866,7 +11834,7 @@
           "cr_refs": []
         },
         {
-          "name": "NoOp",
+          "name": "Investigate",
           "line": 12056,
           "kind": "unit",
           "field_names": [],
@@ -11874,7 +11842,7 @@
           "cr_refs": []
         },
         {
-          "name": "Proliferate",
+          "name": "Tribute",
           "line": 12057,
           "kind": "unit",
           "field_names": [],
@@ -11882,7 +11850,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProliferateTarget",
+          "name": "TimeTravel",
           "line": 12058,
           "kind": "unit",
           "field_names": [],
@@ -11890,7 +11858,7 @@
           "cr_refs": []
         },
         {
-          "name": "Populate",
+          "name": "BecomeMonarch",
           "line": 12059,
           "kind": "unit",
           "field_names": [],
@@ -11898,7 +11866,7 @@
           "cr_refs": []
         },
         {
-          "name": "Clash",
+          "name": "NoOp",
           "line": 12060,
           "kind": "unit",
           "field_names": [],
@@ -11906,7 +11874,7 @@
           "cr_refs": []
         },
         {
-          "name": "EndTheTurn",
+          "name": "Proliferate",
           "line": 12061,
           "kind": "unit",
           "field_names": [],
@@ -11914,8 +11882,40 @@
           "cr_refs": []
         },
         {
-          "name": "EndCombatPhase",
+          "name": "ProliferateTarget",
+          "line": 12062,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Populate",
           "line": 12063,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Clash",
+          "line": 12064,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "EndTheTurn",
+          "line": 12065,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "EndCombatPhase",
+          "line": 12067,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 724.2: End the combat phase — skip to the postcombat main phase.",
@@ -11925,7 +11925,7 @@
         },
         {
           "name": "Vote",
-          "line": 12065,
+          "line": 12069,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38: Vote — interactive APNAP-ordered choice with per-choice tally effects.",
@@ -11935,7 +11935,7 @@
         },
         {
           "name": "SeparateIntoPiles",
-          "line": 12067,
+          "line": 12071,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.3: SeparateIntoPiles — partition objects into two piles, another player chooses one, sub-effect applies.",
@@ -11945,38 +11945,6 @@
         },
         {
           "name": "SwitchPT",
-          "line": 12068,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopySpell",
-          "line": 12069,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "EpicCopy",
-          "line": 12070,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CastCopyOfCard",
-          "line": 12071,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CopyTokenOf",
           "line": 12072,
           "kind": "unit",
           "field_names": [],
@@ -11984,7 +11952,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateTokenCopyFromPool",
+          "name": "CopySpell",
           "line": 12073,
           "kind": "unit",
           "field_names": [],
@@ -11992,7 +11960,7 @@
           "cr_refs": []
         },
         {
-          "name": "Myriad",
+          "name": "EpicCopy",
           "line": 12074,
           "kind": "unit",
           "field_names": [],
@@ -12000,7 +11968,7 @@
           "cr_refs": []
         },
         {
-          "name": "Encore",
+          "name": "CastCopyOfCard",
           "line": 12075,
           "kind": "unit",
           "field_names": [],
@@ -12008,7 +11976,7 @@
           "cr_refs": []
         },
         {
-          "name": "Meld",
+          "name": "CopyTokenOf",
           "line": 12076,
           "kind": "unit",
           "field_names": [],
@@ -12016,7 +11984,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileHaunting",
+          "name": "CreateTokenCopyFromPool",
           "line": 12077,
           "kind": "unit",
           "field_names": [],
@@ -12024,7 +11992,7 @@
           "cr_refs": []
         },
         {
-          "name": "HideawayConceal",
+          "name": "Myriad",
           "line": 12078,
           "kind": "unit",
           "field_names": [],
@@ -12032,7 +12000,7 @@
           "cr_refs": []
         },
         {
-          "name": "BecomeCopy",
+          "name": "Encore",
           "line": 12079,
           "kind": "unit",
           "field_names": [],
@@ -12040,7 +12008,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseCard",
+          "name": "Meld",
           "line": 12080,
           "kind": "unit",
           "field_names": [],
@@ -12048,7 +12016,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutCounter",
+          "name": "ExileHaunting",
           "line": 12081,
           "kind": "unit",
           "field_names": [],
@@ -12056,7 +12024,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutCounterAll",
+          "name": "HideawayConceal",
           "line": 12082,
           "kind": "unit",
           "field_names": [],
@@ -12064,7 +12032,7 @@
           "cr_refs": []
         },
         {
-          "name": "MultiplyCounter",
+          "name": "BecomeCopy",
           "line": 12083,
           "kind": "unit",
           "field_names": [],
@@ -12072,7 +12040,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePT",
+          "name": "ChooseCard",
           "line": 12084,
           "kind": "unit",
           "field_names": [],
@@ -12080,7 +12048,7 @@
           "cr_refs": []
         },
         {
-          "name": "DoublePTAll",
+          "name": "PutCounter",
           "line": 12085,
           "kind": "unit",
           "field_names": [],
@@ -12088,7 +12056,7 @@
           "cr_refs": []
         },
         {
-          "name": "MoveCounters",
+          "name": "PutCounterAll",
           "line": 12086,
           "kind": "unit",
           "field_names": [],
@@ -12096,7 +12064,7 @@
           "cr_refs": []
         },
         {
-          "name": "Animate",
+          "name": "MultiplyCounter",
           "line": 12087,
           "kind": "unit",
           "field_names": [],
@@ -12104,7 +12072,7 @@
           "cr_refs": []
         },
         {
-          "name": "ReturnAsAura",
+          "name": "DoublePT",
           "line": 12088,
           "kind": "unit",
           "field_names": [],
@@ -12112,7 +12080,7 @@
           "cr_refs": []
         },
         {
-          "name": "RegisterBending",
+          "name": "DoublePTAll",
           "line": 12089,
           "kind": "unit",
           "field_names": [],
@@ -12120,7 +12088,7 @@
           "cr_refs": []
         },
         {
-          "name": "GenericEffect",
+          "name": "MoveCounters",
           "line": 12090,
           "kind": "unit",
           "field_names": [],
@@ -12128,7 +12096,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cleanup",
+          "name": "Animate",
           "line": 12091,
           "kind": "unit",
           "field_names": [],
@@ -12136,7 +12104,7 @@
           "cr_refs": []
         },
         {
-          "name": "Mana",
+          "name": "ReturnAsAura",
           "line": 12092,
           "kind": "unit",
           "field_names": [],
@@ -12144,7 +12112,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discard",
+          "name": "RegisterBending",
           "line": 12093,
           "kind": "unit",
           "field_names": [],
@@ -12152,7 +12120,7 @@
           "cr_refs": []
         },
         {
-          "name": "Shuffle",
+          "name": "GenericEffect",
           "line": 12094,
           "kind": "unit",
           "field_names": [],
@@ -12160,7 +12128,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchLibrary",
+          "name": "Cleanup",
           "line": 12095,
           "kind": "unit",
           "field_names": [],
@@ -12168,7 +12136,7 @@
           "cr_refs": []
         },
         {
-          "name": "SearchOutsideGame",
+          "name": "Mana",
           "line": 12096,
           "kind": "unit",
           "field_names": [],
@@ -12176,7 +12144,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileTop",
+          "name": "Discard",
           "line": 12097,
           "kind": "unit",
           "field_names": [],
@@ -12184,7 +12152,7 @@
           "cr_refs": []
         },
         {
-          "name": "TargetOnly",
+          "name": "Shuffle",
           "line": 12098,
           "kind": "unit",
           "field_names": [],
@@ -12192,7 +12160,7 @@
           "cr_refs": []
         },
         {
-          "name": "Choose",
+          "name": "SearchLibrary",
           "line": 12099,
           "kind": "unit",
           "field_names": [],
@@ -12200,7 +12168,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDamageSource",
+          "name": "SearchOutsideGame",
           "line": 12100,
           "kind": "unit",
           "field_names": [],
@@ -12208,7 +12176,7 @@
           "cr_refs": []
         },
         {
-          "name": "Suspect",
+          "name": "ExileTop",
           "line": 12101,
           "kind": "unit",
           "field_names": [],
@@ -12216,7 +12184,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unsuspect",
+          "name": "TargetOnly",
           "line": 12102,
           "kind": "unit",
           "field_names": [],
@@ -12224,7 +12192,7 @@
           "cr_refs": []
         },
         {
-          "name": "Connive",
+          "name": "Choose",
           "line": 12103,
           "kind": "unit",
           "field_names": [],
@@ -12232,7 +12200,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseOut",
+          "name": "ChooseDamageSource",
           "line": 12104,
           "kind": "unit",
           "field_names": [],
@@ -12240,7 +12208,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhaseIn",
+          "name": "Suspect",
           "line": 12105,
           "kind": "unit",
           "field_names": [],
@@ -12248,7 +12216,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceBlock",
+          "name": "Unsuspect",
           "line": 12106,
           "kind": "unit",
           "field_names": [],
@@ -12256,7 +12224,7 @@
           "cr_refs": []
         },
         {
-          "name": "ForceAttack",
+          "name": "Connive",
           "line": 12107,
           "kind": "unit",
           "field_names": [],
@@ -12264,7 +12232,7 @@
           "cr_refs": []
         },
         {
-          "name": "SolveCase",
+          "name": "PhaseOut",
           "line": 12108,
           "kind": "unit",
           "field_names": [],
@@ -12272,8 +12240,40 @@
           "cr_refs": []
         },
         {
-          "name": "BecomePrepared",
+          "name": "PhaseIn",
+          "line": 12109,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceBlock",
           "line": 12110,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ForceAttack",
+          "line": 12111,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SolveCase",
+          "line": 12112,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BecomePrepared",
+          "line": 12114,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — mark target creature as prepared.",
@@ -12283,7 +12283,7 @@
         },
         {
           "name": "BecomeUnprepared",
-          "line": 12112,
+          "line": 12116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.xxx: Prepare (Strixhaven) — clear prepared state on target.",
@@ -12293,7 +12293,7 @@
         },
         {
           "name": "BecomeSaddled",
-          "line": 12114,
+          "line": 12118,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: mark the target permanent as saddled until end of turn.",
@@ -12303,38 +12303,6 @@
         },
         {
           "name": "SetClassLevel",
-          "line": 12115,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "CreateDelayedTrigger",
-          "line": 12116,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddTargetReplacement",
-          "line": 12117,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AddRestriction",
-          "line": 12118,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ReduceNextSpellCost",
           "line": 12119,
           "kind": "unit",
           "field_names": [],
@@ -12342,7 +12310,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantNextSpellAbility",
+          "name": "CreateDelayedTrigger",
           "line": 12120,
           "kind": "unit",
           "field_names": [],
@@ -12350,7 +12318,7 @@
           "cr_refs": []
         },
         {
-          "name": "AddPendingETBCounters",
+          "name": "AddTargetReplacement",
           "line": 12121,
           "kind": "unit",
           "field_names": [],
@@ -12358,7 +12326,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateEmblem",
+          "name": "AddRestriction",
           "line": 12122,
           "kind": "unit",
           "field_names": [],
@@ -12366,7 +12334,7 @@
           "cr_refs": []
         },
         {
-          "name": "PayCost",
+          "name": "ReduceNextSpellCost",
           "line": 12123,
           "kind": "unit",
           "field_names": [],
@@ -12374,7 +12342,7 @@
           "cr_refs": []
         },
         {
-          "name": "CastFromZone",
+          "name": "GrantNextSpellAbility",
           "line": 12124,
           "kind": "unit",
           "field_names": [],
@@ -12382,7 +12350,7 @@
           "cr_refs": []
         },
         {
-          "name": "FreeCastFromZones",
+          "name": "AddPendingETBCounters",
           "line": 12125,
           "kind": "unit",
           "field_names": [],
@@ -12390,7 +12358,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileResolvingSpellInsteadOfGraveyard",
+          "name": "CreateEmblem",
           "line": 12126,
           "kind": "unit",
           "field_names": [],
@@ -12398,7 +12366,7 @@
           "cr_refs": []
         },
         {
-          "name": "PreventDamage",
+          "name": "PayCost",
           "line": 12127,
           "kind": "unit",
           "field_names": [],
@@ -12406,7 +12374,7 @@
           "cr_refs": []
         },
         {
-          "name": "CreateDamageReplacement",
+          "name": "CastFromZone",
           "line": 12128,
           "kind": "unit",
           "field_names": [],
@@ -12414,7 +12382,7 @@
           "cr_refs": []
         },
         {
-          "name": "Regenerate",
+          "name": "FreeCastFromZones",
           "line": 12129,
           "kind": "unit",
           "field_names": [],
@@ -12422,7 +12390,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveAllDamage",
+          "name": "ExileResolvingSpellInsteadOfGraveyard",
           "line": 12130,
           "kind": "unit",
           "field_names": [],
@@ -12430,7 +12398,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseTheGame",
+          "name": "PreventDamage",
           "line": 12131,
           "kind": "unit",
           "field_names": [],
@@ -12438,7 +12406,7 @@
           "cr_refs": []
         },
         {
-          "name": "WinTheGame",
+          "name": "CreateDamageReplacement",
           "line": 12132,
           "kind": "unit",
           "field_names": [],
@@ -12446,7 +12414,7 @@
           "cr_refs": []
         },
         {
-          "name": "RollDie",
+          "name": "Regenerate",
           "line": 12133,
           "kind": "unit",
           "field_names": [],
@@ -12454,7 +12422,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoin",
+          "name": "RemoveAllDamage",
           "line": 12134,
           "kind": "unit",
           "field_names": [],
@@ -12462,7 +12430,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoins",
+          "name": "LoseTheGame",
           "line": 12135,
           "kind": "unit",
           "field_names": [],
@@ -12470,7 +12438,7 @@
           "cr_refs": []
         },
         {
-          "name": "FlipCoinUntilLose",
+          "name": "WinTheGame",
           "line": 12136,
           "kind": "unit",
           "field_names": [],
@@ -12478,7 +12446,7 @@
           "cr_refs": []
         },
         {
-          "name": "RingTemptsYou",
+          "name": "RollDie",
           "line": 12137,
           "kind": "unit",
           "field_names": [],
@@ -12486,7 +12454,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureIntoDungeon",
+          "name": "FlipCoin",
           "line": 12138,
           "kind": "unit",
           "field_names": [],
@@ -12494,7 +12462,7 @@
           "cr_refs": []
         },
         {
-          "name": "VentureInto",
+          "name": "FlipCoins",
           "line": 12139,
           "kind": "unit",
           "field_names": [],
@@ -12502,7 +12470,7 @@
           "cr_refs": []
         },
         {
-          "name": "TakeTheInitiative",
+          "name": "FlipCoinUntilLose",
           "line": 12140,
           "kind": "unit",
           "field_names": [],
@@ -12510,7 +12478,7 @@
           "cr_refs": []
         },
         {
-          "name": "Planeswalk",
+          "name": "RingTemptsYou",
           "line": 12141,
           "kind": "unit",
           "field_names": [],
@@ -12518,7 +12486,7 @@
           "cr_refs": []
         },
         {
-          "name": "OpenAttractions",
+          "name": "VentureIntoDungeon",
           "line": 12142,
           "kind": "unit",
           "field_names": [],
@@ -12526,7 +12494,7 @@
           "cr_refs": []
         },
         {
-          "name": "RollToVisitAttractions",
+          "name": "VentureInto",
           "line": 12143,
           "kind": "unit",
           "field_names": [],
@@ -12534,7 +12502,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutSticker",
+          "name": "TakeTheInitiative",
           "line": 12144,
           "kind": "unit",
           "field_names": [],
@@ -12542,7 +12510,7 @@
           "cr_refs": []
         },
         {
-          "name": "ApplySticker",
+          "name": "Planeswalk",
           "line": 12145,
           "kind": "unit",
           "field_names": [],
@@ -12550,7 +12518,7 @@
           "cr_refs": []
         },
         {
-          "name": "ProcessRadCounters",
+          "name": "OpenAttractions",
           "line": 12146,
           "kind": "unit",
           "field_names": [],
@@ -12558,7 +12526,7 @@
           "cr_refs": []
         },
         {
-          "name": "GrantCastingPermission",
+          "name": "RollToVisitAttractions",
           "line": 12147,
           "kind": "unit",
           "field_names": [],
@@ -12566,7 +12534,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseFromZone",
+          "name": "PutSticker",
           "line": 12148,
           "kind": "unit",
           "field_names": [],
@@ -12574,7 +12542,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseObjectsIntoTrackedSet",
+          "name": "ApplySticker",
           "line": 12149,
           "kind": "unit",
           "field_names": [],
@@ -12582,7 +12550,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseAndSacrificeRest",
+          "name": "ProcessRadCounters",
           "line": 12150,
           "kind": "unit",
           "field_names": [],
@@ -12590,7 +12558,7 @@
           "cr_refs": []
         },
         {
-          "name": "Exploit",
+          "name": "GrantCastingPermission",
           "line": 12151,
           "kind": "unit",
           "field_names": [],
@@ -12598,7 +12566,7 @@
           "cr_refs": []
         },
         {
-          "name": "GainEnergy",
+          "name": "ChooseFromZone",
           "line": 12152,
           "kind": "unit",
           "field_names": [],
@@ -12606,7 +12574,7 @@
           "cr_refs": []
         },
         {
-          "name": "GivePlayerCounter",
+          "name": "ChooseObjectsIntoTrackedSet",
           "line": 12153,
           "kind": "unit",
           "field_names": [],
@@ -12614,7 +12582,7 @@
           "cr_refs": []
         },
         {
-          "name": "LoseAllPlayerCounters",
+          "name": "ChooseAndSacrificeRest",
           "line": 12154,
           "kind": "unit",
           "field_names": [],
@@ -12622,7 +12590,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExileFromTopUntil",
+          "name": "Exploit",
           "line": 12155,
           "kind": "unit",
           "field_names": [],
@@ -12630,7 +12598,7 @@
           "cr_refs": []
         },
         {
-          "name": "RevealUntil",
+          "name": "GainEnergy",
           "line": 12156,
           "kind": "unit",
           "field_names": [],
@@ -12638,7 +12606,7 @@
           "cr_refs": []
         },
         {
-          "name": "Discover",
+          "name": "GivePlayerCounter",
           "line": 12157,
           "kind": "unit",
           "field_names": [],
@@ -12646,7 +12614,7 @@
           "cr_refs": []
         },
         {
-          "name": "Heist",
+          "name": "LoseAllPlayerCounters",
           "line": 12158,
           "kind": "unit",
           "field_names": [],
@@ -12654,7 +12622,7 @@
           "cr_refs": []
         },
         {
-          "name": "HeistExile",
+          "name": "ExileFromTopUntil",
           "line": 12159,
           "kind": "unit",
           "field_names": [],
@@ -12662,7 +12630,7 @@
           "cr_refs": []
         },
         {
-          "name": "Cascade",
+          "name": "RevealUntil",
           "line": 12160,
           "kind": "unit",
           "field_names": [],
@@ -12670,7 +12638,7 @@
           "cr_refs": []
         },
         {
-          "name": "Ripple",
+          "name": "Discover",
           "line": 12161,
           "kind": "unit",
           "field_names": [],
@@ -12678,7 +12646,7 @@
           "cr_refs": []
         },
         {
-          "name": "MiracleCast",
+          "name": "Heist",
           "line": 12162,
           "kind": "unit",
           "field_names": [],
@@ -12686,7 +12654,7 @@
           "cr_refs": []
         },
         {
-          "name": "MadnessCast",
+          "name": "HeistExile",
           "line": 12163,
           "kind": "unit",
           "field_names": [],
@@ -12694,7 +12662,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutAtLibraryPosition",
+          "name": "Cascade",
           "line": 12164,
           "kind": "unit",
           "field_names": [],
@@ -12702,7 +12670,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseDrawnThisTurnPayOrTopdeck",
+          "name": "Ripple",
           "line": 12165,
           "kind": "unit",
           "field_names": [],
@@ -12710,7 +12678,7 @@
           "cr_refs": []
         },
         {
-          "name": "PutOnTopOrBottom",
+          "name": "MiracleCast",
           "line": 12166,
           "kind": "unit",
           "field_names": [],
@@ -12718,7 +12686,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiftDelivery",
+          "name": "MadnessCast",
           "line": 12167,
           "kind": "unit",
           "field_names": [],
@@ -12726,7 +12694,7 @@
           "cr_refs": []
         },
         {
-          "name": "Goad",
+          "name": "PutAtLibraryPosition",
           "line": 12168,
           "kind": "unit",
           "field_names": [],
@@ -12734,7 +12702,7 @@
           "cr_refs": []
         },
         {
-          "name": "GoadAll",
+          "name": "ChooseDrawnThisTurnPayOrTopdeck",
           "line": 12169,
           "kind": "unit",
           "field_names": [],
@@ -12742,7 +12710,7 @@
           "cr_refs": []
         },
         {
-          "name": "Detain",
+          "name": "PutOnTopOrBottom",
           "line": 12170,
           "kind": "unit",
           "field_names": [],
@@ -12750,7 +12718,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetRoomDoorLock",
+          "name": "GiftDelivery",
           "line": 12171,
           "kind": "unit",
           "field_names": [],
@@ -12758,7 +12726,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeControl",
+          "name": "Goad",
           "line": 12172,
           "kind": "unit",
           "field_names": [],
@@ -12766,7 +12734,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChangeTargets",
+          "name": "GoadAll",
           "line": 12173,
           "kind": "unit",
           "field_names": [],
@@ -12774,7 +12742,7 @@
           "cr_refs": []
         },
         {
-          "name": "Incubate",
+          "name": "Detain",
           "line": 12174,
           "kind": "unit",
           "field_names": [],
@@ -12782,7 +12750,7 @@
           "cr_refs": []
         },
         {
-          "name": "Amass",
+          "name": "SetRoomDoorLock",
           "line": 12175,
           "kind": "unit",
           "field_names": [],
@@ -12790,7 +12758,7 @@
           "cr_refs": []
         },
         {
-          "name": "Monstrosity",
+          "name": "ExchangeControl",
           "line": 12176,
           "kind": "unit",
           "field_names": [],
@@ -12798,7 +12766,7 @@
           "cr_refs": []
         },
         {
-          "name": "Specialize",
+          "name": "ChangeTargets",
           "line": 12177,
           "kind": "unit",
           "field_names": [],
@@ -12806,7 +12774,7 @@
           "cr_refs": []
         },
         {
-          "name": "Renown",
+          "name": "Incubate",
           "line": 12178,
           "kind": "unit",
           "field_names": [],
@@ -12814,7 +12782,7 @@
           "cr_refs": []
         },
         {
-          "name": "Bolster",
+          "name": "Amass",
           "line": 12179,
           "kind": "unit",
           "field_names": [],
@@ -12822,7 +12790,7 @@
           "cr_refs": []
         },
         {
-          "name": "Adapt",
+          "name": "Monstrosity",
           "line": 12180,
           "kind": "unit",
           "field_names": [],
@@ -12830,7 +12798,7 @@
           "cr_refs": []
         },
         {
-          "name": "Manifest",
+          "name": "Specialize",
           "line": 12181,
           "kind": "unit",
           "field_names": [],
@@ -12838,7 +12806,7 @@
           "cr_refs": []
         },
         {
-          "name": "ManifestDread",
+          "name": "Renown",
           "line": 12182,
           "kind": "unit",
           "field_names": [],
@@ -12846,8 +12814,40 @@
           "cr_refs": []
         },
         {
-          "name": "Cloak",
+          "name": "Bolster",
+          "line": 12183,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Adapt",
           "line": 12184,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Manifest",
+          "line": 12185,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ManifestDread",
+          "line": 12186,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Cloak",
+          "line": 12188,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.58a: Cloak (face-down 2/2 with ward {2}).",
@@ -12857,38 +12857,6 @@
         },
         {
           "name": "ExtraTurn",
-          "line": 12185,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "GrantExtraLoyaltyActivations",
-          "line": 12186,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SkipNextTurn",
-          "line": 12187,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SkipNextStep",
-          "line": 12188,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "AdditionalPhase",
           "line": 12189,
           "kind": "unit",
           "field_names": [],
@@ -12896,7 +12864,7 @@
           "cr_refs": []
         },
         {
-          "name": "Double",
+          "name": "GrantExtraLoyaltyActivations",
           "line": 12190,
           "kind": "unit",
           "field_names": [],
@@ -12904,7 +12872,7 @@
           "cr_refs": []
         },
         {
-          "name": "RuntimeHandled",
+          "name": "SkipNextTurn",
           "line": 12191,
           "kind": "unit",
           "field_names": [],
@@ -12912,7 +12880,7 @@
           "cr_refs": []
         },
         {
-          "name": "Learn",
+          "name": "SkipNextStep",
           "line": 12192,
           "kind": "unit",
           "field_names": [],
@@ -12920,7 +12888,7 @@
           "cr_refs": []
         },
         {
-          "name": "Forage",
+          "name": "AdditionalPhase",
           "line": 12193,
           "kind": "unit",
           "field_names": [],
@@ -12928,7 +12896,7 @@
           "cr_refs": []
         },
         {
-          "name": "Harness",
+          "name": "Double",
           "line": 12194,
           "kind": "unit",
           "field_names": [],
@@ -12936,7 +12904,7 @@
           "cr_refs": []
         },
         {
-          "name": "CollectEvidence",
+          "name": "RuntimeHandled",
           "line": 12195,
           "kind": "unit",
           "field_names": [],
@@ -12944,7 +12912,7 @@
           "cr_refs": []
         },
         {
-          "name": "Endure",
+          "name": "Learn",
           "line": 12196,
           "kind": "unit",
           "field_names": [],
@@ -12952,7 +12920,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlightEffect",
+          "name": "Forage",
           "line": 12197,
           "kind": "unit",
           "field_names": [],
@@ -12960,7 +12928,7 @@
           "cr_refs": []
         },
         {
-          "name": "Seek",
+          "name": "Harness",
           "line": 12198,
           "kind": "unit",
           "field_names": [],
@@ -12968,7 +12936,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetLifeTotal",
+          "name": "CollectEvidence",
           "line": 12199,
           "kind": "unit",
           "field_names": [],
@@ -12976,7 +12944,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeWithStat",
+          "name": "Endure",
           "line": 12200,
           "kind": "unit",
           "field_names": [],
@@ -12984,7 +12952,7 @@
           "cr_refs": []
         },
         {
-          "name": "ExchangeLifeTotals",
+          "name": "BlightEffect",
           "line": 12201,
           "kind": "unit",
           "field_names": [],
@@ -12992,7 +12960,7 @@
           "cr_refs": []
         },
         {
-          "name": "SetDayNight",
+          "name": "Seek",
           "line": 12202,
           "kind": "unit",
           "field_names": [],
@@ -13000,7 +12968,7 @@
           "cr_refs": []
         },
         {
-          "name": "GiveControl",
+          "name": "SetLifeTotal",
           "line": 12203,
           "kind": "unit",
           "field_names": [],
@@ -13008,7 +12976,7 @@
           "cr_refs": []
         },
         {
-          "name": "RemoveFromCombat",
+          "name": "ExchangeLifeWithStat",
           "line": 12204,
           "kind": "unit",
           "field_names": [],
@@ -13016,7 +12984,7 @@
           "cr_refs": []
         },
         {
-          "name": "Conjure",
+          "name": "ExchangeLifeTotals",
           "line": 12205,
           "kind": "unit",
           "field_names": [],
@@ -13024,7 +12992,7 @@
           "cr_refs": []
         },
         {
-          "name": "Intensify",
+          "name": "SetDayNight",
           "line": 12206,
           "kind": "unit",
           "field_names": [],
@@ -13032,7 +13000,7 @@
           "cr_refs": []
         },
         {
-          "name": "ApplyPerpetual",
+          "name": "GiveControl",
           "line": 12207,
           "kind": "unit",
           "field_names": [],
@@ -13040,7 +13008,7 @@
           "cr_refs": []
         },
         {
-          "name": "DraftFromSpellbook",
+          "name": "RemoveFromCombat",
           "line": 12208,
           "kind": "unit",
           "field_names": [],
@@ -13048,7 +13016,7 @@
           "cr_refs": []
         },
         {
-          "name": "ChooseOneOf",
+          "name": "Conjure",
           "line": 12209,
           "kind": "unit",
           "field_names": [],
@@ -13056,7 +13024,7 @@
           "cr_refs": []
         },
         {
-          "name": "Unimplemented",
+          "name": "Intensify",
           "line": 12210,
           "kind": "unit",
           "field_names": [],
@@ -13064,8 +13032,40 @@
           "cr_refs": []
         },
         {
-          "name": "Equip",
+          "name": "ApplyPerpetual",
+          "line": 12211,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "DraftFromSpellbook",
           "line": 12212,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ChooseOneOf",
+          "line": 12213,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Unimplemented",
+          "line": 12214,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Equip",
+          "line": 12216,
           "kind": "unit",
           "field_names": [],
           "doc": "Engine-level equip action (not via an Effect handler).",
@@ -13073,7 +13073,7 @@
         },
         {
           "name": "Crew",
-          "line": 12214,
+          "line": 12218,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.122a: Engine-level crew action (not via an Effect handler).",
@@ -13083,7 +13083,7 @@
         },
         {
           "name": "Station",
-          "line": 12216,
+          "line": 12220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.184a: Engine-level station action (not via an Effect handler).",
@@ -13093,7 +13093,7 @@
         },
         {
           "name": "Saddle",
-          "line": 12218,
+          "line": 12222,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171a: Engine-level saddle action (not via an Effect handler).",
@@ -13103,7 +13103,7 @@
         },
         {
           "name": "Reveal",
-          "line": 12220,
+          "line": 12224,
           "kind": "unit",
           "field_names": [],
           "doc": "Trigger-condition placeholders — emitters not yet implemented.",
@@ -13111,7 +13111,7 @@
         },
         {
           "name": "Transform",
-          "line": 12221,
+          "line": 12225,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13119,7 +13119,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 12222,
+          "line": 12226,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13127,7 +13127,7 @@
         },
         {
           "name": "DayTimeChange",
-          "line": 12223,
+          "line": 12227,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13243,13 +13243,13 @@
     },
     "EffectOutcomeSignal": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13548,
+      "line": 13552,
       "doc": "Which previous-effect outcome a conditional sub-ability asks about.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OptionalEffectPerformed",
-          "line": 13552,
+          "line": 13556,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c / CR 608.2d: \"if you do\", \"if that player does\", and \"if a player does\" all read whether the prompted optional effect was performed.",
@@ -13260,7 +13260,7 @@
         },
         {
           "name": "CurrentScopeSucceeded",
-          "line": 13555,
+          "line": 13559,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.3 + CR 608.2c: \"for each opponent who can't\" reads whether the current player-scope iteration's mandatory instruction succeeded.",
@@ -13310,7 +13310,7 @@
     },
     "EffectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3647,
+      "line": 3651,
       "doc": "CR 701.26a / CR 701.26b: Selection scope for `Effect::SetTapState`. Picks whether the tap/untap targets a single chosen/source permanent (the legacy `Tap` / `Untap`) or every permanent matching the filter (the legacy `TapAll` / `UntapAll`). Parameterizes the structural \"single vs mass\" axis instead of proliferating sibling effect variants.",
       "cr_refs": [
         "CR 701.26a",
@@ -13319,7 +13319,7 @@
       "variants": [
         {
           "name": "Single",
-          "line": 3650,
+          "line": 3654,
           "kind": "unit",
           "field_names": [],
           "doc": "One permanent — `target` is a selectable target filter (legacy `Effect::Tap` / `Effect::Untap`). `target_filter()` exposes it.",
@@ -13327,7 +13327,7 @@
         },
         {
           "name": "All",
-          "line": 3653,
+          "line": 3657,
           "kind": "unit",
           "field_names": [],
           "doc": "Every permanent matching the filter — `target` is a non-targeting population filter (legacy `Effect::TapAll` / `Effect::UntapAll`).",
@@ -13701,7 +13701,7 @@
     },
     "FaceDownBody": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7436,
+      "line": 7440,
       "doc": "CR 708.2a: Whether a face-down permanent is a creature or a non-creature.  CR 708.2a sentence 1 gives the manifest/morph default: a face-down permanent is a 2/2 *creature*. Sentence 2 (\"...unless otherwise specified by the effect that put it onto the battlefield face down\") lets an effect specify a non-creature body instead — e.g. Yedora, Grave Gardener's \"It's a Forest land.\" (It has no other types or abilities.)\". This typed discriminant replaces an implicit \"Creature is always present\" assumption so the same face-down machinery covers both classes without a raw bool.",
       "cr_refs": [
         "CR 708.2a"
@@ -13709,7 +13709,7 @@
       "variants": [
         {
           "name": "Creature",
-          "line": 7442,
+          "line": 7446,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 1): the morph/manifest default — the face-down permanent has the Creature core type (always present) and defaults to 2/2 power/toughness. Any `extra_core_types` are layered on top of Creature (e.g. \"artifact creatures\").",
@@ -13719,7 +13719,7 @@
         },
         {
           "name": "Noncreature",
-          "line": 7447,
+          "line": 7451,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2a (sentence 2): the effect fully specifies the core types and the permanent is NOT a creature — so it has no power/toughness (CR 208.1) and gains no implicit Creature type. Used for \"It's a Forest land.\" The profile's `extra_core_types` are the complete core-type set.",
@@ -13733,13 +13733,13 @@
     },
     "FilterProp": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2523,
+      "line": 2527,
       "doc": "Individual filter properties that can be combined in a Typed filter.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Token",
-          "line": 2525,
+          "line": 2529,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are tokens.",
@@ -13749,7 +13749,7 @@
         },
         {
           "name": "NonToken",
-          "line": 2527,
+          "line": 2531,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 111.1: Matches objects that are not tokens.",
@@ -13759,7 +13759,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 2531,
+          "line": 2535,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 601.2a: Matches objects entering from being played (land play) or cast (spell), excluding tokens put directly onto the battlefield without a prior zone.",
@@ -13770,7 +13770,7 @@
         },
         {
           "name": "Attacking",
-          "line": 2534,
+          "line": 2538,
           "kind": "struct",
           "field_names": [
             "defender"
@@ -13782,7 +13782,7 @@
         },
         {
           "name": "Blocking",
-          "line": 2539,
+          "line": 2543,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Matches creatures that are blocking.",
@@ -13792,7 +13792,7 @@
         },
         {
           "name": "BlockingSource",
-          "line": 2542,
+          "line": 2546,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g: Matches creatures currently blocking the filter source. Used for \"creature(s) blocking it\" source-relative quantities and filters.",
@@ -13802,7 +13802,7 @@
         },
         {
           "name": "CombatRelation",
-          "line": 2545,
+          "line": 2549,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -13815,7 +13815,7 @@
         },
         {
           "name": "Unblocked",
-          "line": 2550,
+          "line": 2554,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: Matches attacking creatures with no blockers assigned.",
@@ -13825,7 +13825,7 @@
         },
         {
           "name": "AttackingAlone",
-          "line": 2555,
+          "line": 2559,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: Matches a creature that is (or, via the zone-change look-back snapshot, was) the sole attacker — \"attacking alone\". Live evaluation reads combat; look-back evaluation reads `ZoneChangeCombatStatus::attacking_alone`.",
@@ -13835,7 +13835,7 @@
         },
         {
           "name": "BlockingAlone",
-          "line": 2559,
+          "line": 2563,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: Matches a creature that is (or was) the sole blocker — \"blocking alone\". Look-back evaluation reads `ZoneChangeCombatStatus::blocking_alone`.",
@@ -13845,7 +13845,7 @@
         },
         {
           "name": "Tapped",
-          "line": 2560,
+          "line": 2564,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -13853,7 +13853,7 @@
         },
         {
           "name": "Untapped",
-          "line": 2562,
+          "line": 2566,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 / CR 110.5: Untapped status as targeting qualifier.",
@@ -13864,7 +13864,7 @@
         },
         {
           "name": "IsSaddled",
-          "line": 2564,
+          "line": 2568,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: Matches permanents with the saddled designation.",
@@ -13874,7 +13874,7 @@
         },
         {
           "name": "SaddledSource",
-          "line": 2570,
+          "line": 2574,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171c: Matches a creature that saddled the filter source this turn (i.e. was tapped to pay the source's saddle cost — recorded in the source's `saddled_by` and cleared at end of turn). Source-relative sibling of `BlockingSource`; used by \"choose a creature that saddled it this turn\" (Calamity, Galloping Inferno).",
@@ -13884,7 +13884,7 @@
         },
         {
           "name": "ProtectorMatches",
-          "line": 2573,
+          "line": 2577,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -13897,7 +13897,7 @@
         },
         {
           "name": "HasHasteOrControlledSinceTurnBegan",
-          "line": 2579,
+          "line": 2583,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6 + CR 702.10b + CR 702.154a: Matches creatures that either have haste or have been under their controller's control continuously since that player's most recent turn began. Used by Enlist's tap eligibility.",
@@ -13909,7 +13909,7 @@
         },
         {
           "name": "WithKeyword",
-          "line": 2580,
+          "line": 2584,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13919,7 +13919,7 @@
         },
         {
           "name": "HasKeywordKind",
-          "line": 2583,
+          "line": 2587,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13929,7 +13929,7 @@
         },
         {
           "name": "WithoutKeyword",
-          "line": 2588,
+          "line": 2592,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13941,7 +13941,7 @@
         },
         {
           "name": "WithoutKeywordKind",
-          "line": 2591,
+          "line": 2595,
           "kind": "struct",
           "field_names": [
             "value"
@@ -13951,7 +13951,7 @@
         },
         {
           "name": "CanEnchant",
-          "line": 2599,
+          "line": 2603,
           "kind": "struct",
           "field_names": [
             "target"
@@ -13964,7 +13964,7 @@
         },
         {
           "name": "Counters",
-          "line": 2609,
+          "line": 2613,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -13978,7 +13978,7 @@
         },
         {
           "name": "Cmc",
-          "line": 2619,
+          "line": 2623,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -13991,7 +13991,7 @@
         },
         {
           "name": "ManaValueParity",
-          "line": 2626,
+          "line": 2630,
           "kind": "struct",
           "field_names": [
             "parity"
@@ -14004,7 +14004,7 @@
         },
         {
           "name": "ManaCostIn",
-          "line": 2632,
+          "line": 2636,
           "kind": "struct",
           "field_names": [
             "costs"
@@ -14017,7 +14017,7 @@
         },
         {
           "name": "InZone",
-          "line": 2635,
+          "line": 2639,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -14027,7 +14027,7 @@
         },
         {
           "name": "Owned",
-          "line": 2638,
+          "line": 2642,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -14037,7 +14037,7 @@
         },
         {
           "name": "Foretold",
-          "line": 2644,
+          "line": 2648,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.143c-d: Matches cards in exile that have the foretold designation. This is a status of the exiled card, not equivalent to having the Foretell keyword or a generic exile casting permission.",
@@ -14047,7 +14047,7 @@
         },
         {
           "name": "EnchantedBy",
-          "line": 2645,
+          "line": 2649,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14055,7 +14055,7 @@
         },
         {
           "name": "EquippedBy",
-          "line": 2646,
+          "line": 2650,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -14063,7 +14063,7 @@
         },
         {
           "name": "AttachedToSource",
-          "line": 2652,
+          "line": 2656,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the matched object's `attached_to` field equals the filter source's object ID. Inverse of `EnchantedBy`/`EquippedBy`, which check whether the source has an attachment. Used for \"Aura and Equipment attached to ~\" quantity clauses (Kellan, the Fae-Blooded) and for any compound filter whose subject is \"attached to <self>\".",
@@ -14074,7 +14074,7 @@
         },
         {
           "name": "AttachedToRecipient",
-          "line": 2666,
+          "line": 2670,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4 + CR 613.4c: True when the matched object's `attached_to` field equals the *recipient* of the resolving effect (the per-object `id` in a layer's affected list). Distinct from `AttachedToSource` — for an Aura/Equipment static \"Enchanted/Equipped creature gets +N/+M for each X attached to it\", the pronoun \"it\" refers to the affected creature, not to the static's source object. The recipient is supplied through `FilterContext::recipient_id`; when recipient is unknown (no per-recipient context), this prop evaluates to false. Covers ~25 cards: Strong Back, Mantle of the Ancients, Auramancer's Guise, Champion of the Flame, Bruenor Battlehammer's \"Each creature you control gets +2/+0 for each Equipment attached to it\", and the broader \"<subject> gets +N/+M for each Aura/Equipment attached to it\" family.",
@@ -14086,7 +14086,7 @@
         },
         {
           "name": "HasAttachment",
-          "line": 2681,
+          "line": 2685,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -14101,7 +14101,7 @@
         },
         {
           "name": "HasAnyAttachmentOf",
-          "line": 2698,
+          "line": 2702,
           "kind": "struct",
           "field_names": [
             "kinds",
@@ -14115,7 +14115,7 @@
         },
         {
           "name": "Another",
-          "line": 2704,
+          "line": 2708,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches any object that is NOT the trigger source (for \"another creature\" triggers).",
@@ -14123,7 +14123,7 @@
         },
         {
           "name": "Unpaired",
-          "line": 2706,
+          "line": 2710,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Matches objects that are not paired with another creature.",
@@ -14133,7 +14133,7 @@
         },
         {
           "name": "OtherThanTriggerObject",
-          "line": 2715,
+          "line": 2719,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 109.3: Matches any object that is NOT the object that caused the currently-evaluating trigger to fire (the \"triggering object\"). Distinct from `Another`, which excludes the *ability source*. Used for intervening-if count predicates like Valakut, the Molten Pinnacle's \"if you control at least five other Mountains\" — here \"other\" means \"other than the newly- entered Mountain,\" not \"other than Valakut.\" Resolves against `FilterContext::triggering_object_id`, populated at trigger-condition evaluation from the current `GameEvent`.",
@@ -14144,7 +14144,7 @@
         },
         {
           "name": "HasColor",
-          "line": 2717,
+          "line": 2721,
           "kind": "struct",
           "field_names": [
             "color"
@@ -14154,7 +14154,7 @@
         },
         {
           "name": "PtComparison",
-          "line": 2744,
+          "line": 2748,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -14172,7 +14172,7 @@
         },
         {
           "name": "PowerGTSource",
-          "line": 2753,
+          "line": 2757,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1b: Matches objects whose power is strictly greater than the source object's power. Used for \"creatures with greater power\" blocking restrictions (relative comparison).",
@@ -14182,7 +14182,7 @@
         },
         {
           "name": "ColorCount",
-          "line": 2757,
+          "line": 2761,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -14195,7 +14195,7 @@
         },
         {
           "name": "HasSupertype",
-          "line": 2762,
+          "line": 2766,
           "kind": "struct",
           "field_names": [
             "value"
@@ -14205,7 +14205,7 @@
         },
         {
           "name": "IsChosenCreatureType",
-          "line": 2767,
+          "line": 2771,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose subtypes include the source object's chosen creature type. Used for \"of the chosen type\" patterns (Cavern of Souls, Metallic Mimic).",
@@ -14213,7 +14213,7 @@
         },
         {
           "name": "MostPrevalentCreatureTypeIn",
-          "line": 2780,
+          "line": 2784,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -14227,7 +14227,7 @@
         },
         {
           "name": "IsChosenColor",
-          "line": 2789,
+          "line": 2793,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose colors include the source object's chosen color. Used for \"of the chosen color\" patterns (Hall of Triumph, Runed Stalactite). Reads `ChosenAttribute::Color` from the source permanent.",
@@ -14235,7 +14235,7 @@
         },
         {
           "name": "IsChosenCardType",
-          "line": 2793,
+          "line": 2797,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose core type includes the source object's chosen card type. Used for \"spells of the chosen type\" patterns (Archon of Valor's Reach). Reads `ChosenAttribute::CardType` from the source permanent.",
@@ -14243,7 +14243,7 @@
         },
         {
           "name": "IsChosenLandOrNonlandKind",
-          "line": 2798,
+          "line": 2802,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.2 + CR 608.2c: Matches objects by the transient \"land or nonland\" choice made earlier in the same resolving instruction sequence. Used by \"of the chosen kind\" library filters, where \"Land\" means cards with the land card type and \"Nonland\" means cards without it.",
@@ -14254,7 +14254,7 @@
         },
         {
           "name": "HasSingleTarget",
-          "line": 2801,
+          "line": 2805,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.7: Matches stack entries that have exactly one target. Used for \"with a single target\" qualifiers on retarget effects.",
@@ -14264,7 +14264,7 @@
         },
         {
           "name": "NotColor",
-          "line": 2804,
+          "line": 2808,
           "kind": "struct",
           "field_names": [
             "color"
@@ -14276,7 +14276,7 @@
         },
         {
           "name": "NotSupertype",
-          "line": 2809,
+          "line": 2813,
           "kind": "struct",
           "field_names": [
             "value"
@@ -14288,7 +14288,7 @@
         },
         {
           "name": "Suspected",
-          "line": 2813,
+          "line": 2817,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.60b: Matches suspected creatures.",
@@ -14298,7 +14298,7 @@
         },
         {
           "name": "Renowned",
-          "line": 2815,
+          "line": 2819,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.112b: Matches permanents with the renowned designation.",
@@ -14308,7 +14308,7 @@
         },
         {
           "name": "ToughnessGTPower",
-          "line": 2817,
+          "line": 2821,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1c: Matches creatures whose toughness is greater than their power.",
@@ -14318,7 +14318,7 @@
         },
         {
           "name": "PowerExceedsBase",
-          "line": 2825,
+          "line": 2829,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1 + CR 613.4a + CR 613.4b: Matches a creature whose current (post-layer) power exceeds its base power. Base power is established by layer 7a CDAs (CR 613.4a) and layer 7b set effects (CR 613.4b), before the counters and pumps applied in layers 7c–7e. True for a creature pumped above its base by +1/+1 counters, auras, or anthems; false when power == base or power < base. Consolidation target if a 3rd same-object P/T self-comparison appears: `PtSelfComparison { lhs, comparator, rhs }`.",
@@ -14330,7 +14330,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2832,
+          "line": 2836,
           "kind": "struct",
           "field_names": [
             "props"
@@ -14340,7 +14340,7 @@
         },
         {
           "name": "Not",
-          "line": 2843,
+          "line": 2847,
           "kind": "struct",
           "field_names": [
             "prop"
@@ -14352,7 +14352,7 @@
         },
         {
           "name": "Modified",
-          "line": 2855,
+          "line": 2859,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.9: A permanent is modified if it has one or more counters on it (CR 122), if it is equipped (CR 301.5), or if it is enchanted by an Aura that is controlled by that permanent's controller (CR 303.4).  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.9 names \"modified\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Modified` for \"modified creature(s)\" subjects, analogous to how `FilterProp::Suspected` models CR 701.60b's \"suspected\" status.",
@@ -14366,7 +14366,7 @@
         },
         {
           "name": "Historic",
-          "line": 2865,
+          "line": 2869,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: An object is historic if it has the legendary supertype, the artifact card type, or the Saga subtype.  Modeled as a first-class typed predicate rather than an `AnyOf` composite because CR 700.6 names \"historic\" as a distinct concept and the three legs share a single runtime match arm. Parser dispatch emits `FilterProp::Historic` for \"historic permanent\" / \"historic spell\" / \"historic card\" subjects, mirroring `FilterProp::Modified` for CR 700.9's \"modified\" predicate.",
@@ -14377,7 +14377,7 @@
         },
         {
           "name": "NotHistoric",
-          "line": 2869,
+          "line": 2873,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.6: Matches objects that are not historic (negation of `Historic`). Used for \"nonhistoric\" / \"not historic\" in compound type phrases such as Desynchronization's \"nonland, nonhistoric permanent\".",
@@ -14387,7 +14387,7 @@
         },
         {
           "name": "DifferentNameFrom",
-          "line": 2873,
+          "line": 2877,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -14397,7 +14397,7 @@
         },
         {
           "name": "InAnyZone",
-          "line": 2878,
+          "line": 2882,
           "kind": "struct",
           "field_names": [
             "zones"
@@ -14409,7 +14409,7 @@
         },
         {
           "name": "SharesQuality",
-          "line": 2884,
+          "line": 2888,
           "kind": "struct",
           "field_names": [
             "quality",
@@ -14421,7 +14421,7 @@
         },
         {
           "name": "WasDealtDamageThisTurn",
-          "line": 2893,
+          "line": 2897,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 510.1: Object was dealt damage during this turn. Checks `damage_marked > 0` (damage persists until cleanup step).",
@@ -14431,7 +14431,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 2896,
+          "line": 2900,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: Object entered the battlefield during this turn. Checks `entered_battlefield_turn == Some(current_turn)`.",
@@ -14441,7 +14441,7 @@
         },
         {
           "name": "ZoneChangedThisTurn",
-          "line": 2901,
+          "line": 2905,
           "kind": "struct",
           "field_names": [
             "from",
@@ -14455,7 +14455,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 2909,
+          "line": 2913,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: Creature was declared as an attacker this turn. Checks `creatures_attacked_this_turn` tracking set on GameState.",
@@ -14465,7 +14465,7 @@
         },
         {
           "name": "BlockedThisTurn",
-          "line": 2912,
+          "line": 2916,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1a: Creature was declared as a blocker this turn. Checks `creatures_blocked_this_turn` tracking set on GameState.",
@@ -14475,7 +14475,7 @@
         },
         {
           "name": "AttackedOrBlockedThisTurn",
-          "line": 2915,
+          "line": 2919,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a + CR 509.1a: Creature attacked or blocked this turn. Compound check used by \"that attacked or blocked this turn\" Oracle text.",
@@ -14486,7 +14486,7 @@
         },
         {
           "name": "CountersPutOnThisTurn",
-          "line": 2928,
+          "line": 2932,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -14502,7 +14502,7 @@
         },
         {
           "name": "FaceDown",
-          "line": 2936,
+          "line": 2940,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 707.2: Matches face-down objects on the battlefield. Used for \"face-down creature\" trigger subjects.",
@@ -14512,7 +14512,7 @@
         },
         {
           "name": "TargetsOnly",
-          "line": 2941,
+          "line": 2945,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -14524,7 +14524,7 @@
         },
         {
           "name": "Targets",
-          "line": 2947,
+          "line": 2951,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -14537,7 +14537,7 @@
         },
         {
           "name": "HasXInManaCost",
-          "line": 2956,
+          "line": 2960,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.1: Matches spells/objects whose printed mana cost contains an `{X}` shard. Used for \"spell with {X} in its mana cost\" qualifier on spell-cast triggers (Lattice Library, Nev the Practical Dean, Owlin Spiralmancer, Brass Infiniscope, Elementalist's Palette). Evaluated against `SpellCastRecord.has_x_in_cost` in the spell-history filter path and against `cost_has_x(&obj.mana_cost)` for live objects.",
@@ -14548,7 +14548,7 @@
         },
         {
           "name": "HasXInActivationCost",
-          "line": 2960,
+          "line": 2964,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 602.1: Matches activated abilities whose activation cost contains an `{X}` shard. Used for \"activate an ability with {X} in its activation cost\" on `AbilityActivated` delayed triggers (Magus Lucea Kane).",
@@ -14559,7 +14559,7 @@
         },
         {
           "name": "WasKicked",
-          "line": 2965,
+          "line": 2969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33d: Matches spells whose kicker additional cost was paid for this cast. Used for \"the first kicked spell you cast each turn\" cost reducers (Vine Gecko). Live evaluation reads `pending_cast` / `GameObject.kickers_paid`; turn-history evaluation reads `SpellCastRecord.was_kicked`.",
@@ -14569,7 +14569,7 @@
         },
         {
           "name": "HasManaAbility",
-          "line": 2969,
+          "line": 2973,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1: Matches objects that have at least one ability classified as a mana ability by the engine's authoritative mana-ability classifier. Used for library filters such as \"artifact card with a mana ability\".",
@@ -14579,7 +14579,7 @@
         },
         {
           "name": "HasNoAbilities",
-          "line": 2973,
+          "line": 2977,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.1 + CR 113.3: Matches objects that currently have no abilities: no keyword, activated, triggered, replacement, or static abilities. Used for library filters such as \"creature card with no abilities\".",
@@ -14590,7 +14590,7 @@
         },
         {
           "name": "Named",
-          "line": 2977,
+          "line": 2981,
           "kind": "struct",
           "field_names": [
             "name"
@@ -14603,7 +14603,7 @@
         },
         {
           "name": "SameName",
-          "line": 2982,
+          "line": 2986,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects with the same name as a previously-referenced card. Used for \"search your library for a card with that name\" patterns.",
@@ -14611,7 +14611,7 @@
         },
         {
           "name": "SameNameAsParentTarget",
-          "line": 2995,
+          "line": 2999,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: Matches objects whose name equals the name of the resolving ability's first object target. Used by chained sub-abilities where a prior step targeted/exiled a card and the next step references \"cards with that name\" — e.g., Deadly Cover-Up's \"search ... for any number of cards with that name and exile them\" (the \"that name\" is the name of the card exiled by the immediately preceding effect, which is inherited as the first target via `TargetFilter::ParentTarget`).  Differs from `SameName` (which reads the source object's name): this reads from `ability.targets[0]` when that target is `TargetRef::Object`, looking up the name from `state.objects` (or `lki_cache` if the target has already left its zone).",
@@ -14621,7 +14621,7 @@
         },
         {
           "name": "NameMatchesAnyPermanent",
-          "line": 3002,
+          "line": 3006,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -14634,7 +14634,7 @@
         },
         {
           "name": "IsCommander",
-          "line": 3011,
+          "line": 3015,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.3 + CR 903.3d: Matches permanents on the battlefield that are a commander. Reads `GameObject::is_commander`, set during deck construction per CR 903.3 (the legendary card designated as that deck's commander). Used for \"commander(s) you control\", \"your commander\" subject phrases and for \"target commander\" in commander-format effects (Codsworth, Falthis, Anara, Champions of Archery, etc.).",
@@ -14645,7 +14645,7 @@
         },
         {
           "name": "Other",
-          "line": 3012,
+          "line": 3016,
           "kind": "struct",
           "field_names": [
             "value"
@@ -17624,13 +17624,13 @@
     },
     "GameRestriction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1784,
+      "line": 1788,
       "doc": "A game-level restriction that modifies how rules are applied. Stored in `GameState::restrictions` and evaluated by relevant game systems.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DamagePreventionDisabled",
-          "line": 1786,
+          "line": 1790,
           "kind": "struct",
           "field_names": [
             "source",
@@ -17644,7 +17644,7 @@
         },
         {
           "name": "ProhibitActivity",
-          "line": 1794,
+          "line": 1798,
           "kind": "struct",
           "field_names": [
             "source",
@@ -17787,13 +17787,13 @@
     },
     "IntensityScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7342,
+      "line": 7346,
       "doc": "Digital-only Alchemy: which cards an `Effect::Intensify` applies to. Every scope resolves across ALL zones (a card's intensity follows it everywhere).",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 7345,
+          "line": 7349,
           "kind": "unit",
           "field_names": [],
           "doc": "\"this creature/artifact/… intensifies\" — the source object only.",
@@ -17801,7 +17801,7 @@
         },
         {
           "name": "OwnedSameName",
-          "line": 7348,
+          "line": 7352,
           "kind": "unit",
           "field_names": [],
           "doc": "\"cards you own named [this card] intensify\" — every card the source's controller owns with the source's name.",
@@ -17809,7 +17809,7 @@
         },
         {
           "name": "OwnedSubtype",
-          "line": 7351,
+          "line": 7355,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -17855,7 +17855,7 @@
     },
     "IterationKindBinding": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13316,
+      "line": 13320,
       "doc": "CR 608.2c + CR 122.1: tags a `ChooseOneOf` branch whose effect must be rebound to the current counter-kind iteration before resolving. Used when a `repeat_for: DistinctCounterKindsAmong` loop drives a \"put your choice of a fixed counter or a counter of that kind\" choice — the dynamic branch carries `RebindToIteratedKind` so the loop rewrites its `PutCounter` counter type to the iteration's kind. Typed (not a bool) so future binding modes can extend.",
       "cr_refs": [
         "CR 122.1",
@@ -17864,7 +17864,7 @@
       "variants": [
         {
           "name": "RebindToIteratedKind",
-          "line": 13319,
+          "line": 13323,
           "kind": "unit",
           "field_names": [],
           "doc": "Rebind this branch's `PutCounter` counter type to the current iterated counter kind.",
@@ -19657,7 +19657,7 @@
     },
     "KeywordAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 16415,
+      "line": 16419,
       "doc": "Typed payload for activated keyword abilities resolved from the stack.  CR 113.3b requires activated abilities to go on the stack. CR 113.7a requires last-known-information carry-through when the source leaves its zone. Cost-payment snapshots (e.g. `Station::snapshot_power`) are captured at announcement time so resolution is safe even if the paid creature leaves the battlefield.",
       "cr_refs": [
         "CR 113.3b",
@@ -19666,7 +19666,7 @@
       "variants": [
         {
           "name": "Equip",
-          "line": 16417,
+          "line": 16421,
           "kind": "struct",
           "field_names": [
             "equipment_id",
@@ -19679,7 +19679,7 @@
         },
         {
           "name": "Crew",
-          "line": 16423,
+          "line": 16427,
           "kind": "struct",
           "field_names": [
             "vehicle_id",
@@ -19692,7 +19692,7 @@
         },
         {
           "name": "Saddle",
-          "line": 16429,
+          "line": 16433,
           "kind": "struct",
           "field_names": [
             "mount_id",
@@ -19705,7 +19705,7 @@
         },
         {
           "name": "Station",
-          "line": 16437,
+          "line": 16441,
           "kind": "struct",
           "field_names": [
             "spacecraft_id",
@@ -20872,7 +20872,7 @@
     },
     "KickerVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14059,
+      "line": 14063,
       "doc": "CR 702.33f: Discriminator for which kicker cost was paid on a spell that has more than one kicker cost (\"Kicker {A} and/or {B}\"). Per CR 702.33f, the abilities that gate on a specific kicker reference the kickers by *position* on the card (\"its [A] kicker\" / \"its [B] kicker\"), so the discriminator is the position, not the cost text.  For single-kicker spells (CR 702.33a) and multikicker (CR 702.33c), only `First` is meaningful — there is no second kicker cost. Multikicker count is expressed via `Vec<KickerVariant>` length on `SpellContext.kickers_paid` (each repeated payment pushes another `First` entry).",
       "cr_refs": [
         "CR 702.33a",
@@ -20882,7 +20882,7 @@
       "variants": [
         {
           "name": "First",
-          "line": 14061,
+          "line": 14065,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: First kicker cost as listed on the card.",
@@ -20892,7 +20892,7 @@
         },
         {
           "name": "Second",
-          "line": 14064,
+          "line": 14068,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33f: Second kicker cost as listed on the card. Only present when the card has \"Kicker {A} and/or {B}\" (CR 702.33b).",
@@ -21176,13 +21176,13 @@
     },
     "LibraryPosition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7193,
+      "line": 7197,
       "doc": "Specific position within a library for placement effects. Top and Bottom use move_to_library_position; NthFromTop inserts at index n-1.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Top",
-          "line": 7194,
+          "line": 7198,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21190,7 +21190,7 @@
         },
         {
           "name": "Bottom",
-          "line": 7195,
+          "line": 7199,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21198,7 +21198,7 @@
         },
         {
           "name": "NthFromTop",
-          "line": 7197,
+          "line": 7201,
           "kind": "struct",
           "field_names": [
             "n"
@@ -21626,13 +21626,13 @@
     },
     "ManaCost": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 1186,
+      "line": 1193,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "NoCost",
-          "line": 1187,
+          "line": 1194,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -21640,7 +21640,7 @@
         },
         {
           "name": "Cost",
-          "line": 1188,
+          "line": 1195,
           "kind": "struct",
           "field_names": [
             "shards",
@@ -21651,7 +21651,7 @@
         },
         {
           "name": "SelfManaCost",
-          "line": 1193,
+          "line": 1200,
           "kind": "unit",
           "field_names": [],
           "doc": "The card's own mana cost (used for \"the flashback cost is equal to its mana cost\").",
@@ -21659,7 +21659,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 1196,
+          "line": 1203,
           "kind": "unit",
           "field_names": [],
           "doc": "The card's own mana value (CR 202.3), as generic mana only — used for \"encore {X}, where X is its mana value\" (Sliver Gravemother class).",
@@ -21672,60 +21672,12 @@
     },
     "ManaCostShard": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 951,
+      "line": 958,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "White",
-          "line": 953,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Blue",
-          "line": 954,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Black",
-          "line": 955,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Red",
-          "line": 956,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Green",
-          "line": 957,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Colorless",
-          "line": 959,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Snow",
           "line": 960,
           "kind": "unit",
           "field_names": [],
@@ -21733,7 +21685,7 @@
           "cr_refs": []
         },
         {
-          "name": "X",
+          "name": "Blue",
           "line": 961,
           "kind": "unit",
           "field_names": [],
@@ -21741,23 +21693,31 @@
           "cr_refs": []
         },
         {
-          "name": "TwoOrMoreColorSource",
-          "line": 963,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
-          "cr_refs": []
-        },
-        {
-          "name": "WhiteBlue",
-          "line": 965,
+          "name": "Black",
+          "line": 962,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
-          "name": "WhiteBlack",
+          "name": "Red",
+          "line": 963,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Green",
+          "line": 964,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Colorless",
           "line": 966,
           "kind": "unit",
           "field_names": [],
@@ -21765,7 +21725,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlueBlack",
+          "name": "Snow",
           "line": 967,
           "kind": "unit",
           "field_names": [],
@@ -21773,7 +21733,7 @@
           "cr_refs": []
         },
         {
-          "name": "BlueRed",
+          "name": "X",
           "line": 968,
           "kind": "unit",
           "field_names": [],
@@ -21781,31 +21741,15 @@
           "cr_refs": []
         },
         {
-          "name": "BlackRed",
-          "line": 969,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "BlackGreen",
+          "name": "TwoOrMoreColorSource",
           "line": 970,
           "kind": "unit",
           "field_names": [],
-          "doc": "",
+          "doc": "`{Z}`: one mana from a source that could produce two or more colors.",
           "cr_refs": []
         },
         {
-          "name": "RedWhite",
-          "line": 971,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "RedGreen",
+          "name": "WhiteBlue",
           "line": 972,
           "kind": "unit",
           "field_names": [],
@@ -21813,7 +21757,7 @@
           "cr_refs": []
         },
         {
-          "name": "GreenWhite",
+          "name": "WhiteBlack",
           "line": 973,
           "kind": "unit",
           "field_names": [],
@@ -21821,7 +21765,7 @@
           "cr_refs": []
         },
         {
-          "name": "GreenBlue",
+          "name": "BlueBlack",
           "line": 974,
           "kind": "unit",
           "field_names": [],
@@ -21829,7 +21773,15 @@
           "cr_refs": []
         },
         {
-          "name": "TwoWhite",
+          "name": "BlueRed",
+          "line": 975,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "BlackRed",
           "line": 976,
           "kind": "unit",
           "field_names": [],
@@ -21837,7 +21789,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoBlue",
+          "name": "BlackGreen",
           "line": 977,
           "kind": "unit",
           "field_names": [],
@@ -21845,7 +21797,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoBlack",
+          "name": "RedWhite",
           "line": 978,
           "kind": "unit",
           "field_names": [],
@@ -21853,7 +21805,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoRed",
+          "name": "RedGreen",
           "line": 979,
           "kind": "unit",
           "field_names": [],
@@ -21861,7 +21813,7 @@
           "cr_refs": []
         },
         {
-          "name": "TwoGreen",
+          "name": "GreenWhite",
           "line": 980,
           "kind": "unit",
           "field_names": [],
@@ -21869,15 +21821,15 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhite",
-          "line": 982,
+          "name": "GreenBlue",
+          "line": 981,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlue",
+          "name": "TwoWhite",
           "line": 983,
           "kind": "unit",
           "field_names": [],
@@ -21885,7 +21837,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlack",
+          "name": "TwoBlue",
           "line": 984,
           "kind": "unit",
           "field_names": [],
@@ -21893,7 +21845,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRed",
+          "name": "TwoBlack",
           "line": 985,
           "kind": "unit",
           "field_names": [],
@@ -21901,7 +21853,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreen",
+          "name": "TwoRed",
           "line": 986,
           "kind": "unit",
           "field_names": [],
@@ -21909,15 +21861,15 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlue",
-          "line": 988,
+          "name": "TwoGreen",
+          "line": 987,
           "kind": "unit",
           "field_names": [],
           "doc": "",
           "cr_refs": []
         },
         {
-          "name": "PhyrexianWhiteBlack",
+          "name": "PhyrexianWhite",
           "line": 989,
           "kind": "unit",
           "field_names": [],
@@ -21925,7 +21877,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueBlack",
+          "name": "PhyrexianBlue",
           "line": 990,
           "kind": "unit",
           "field_names": [],
@@ -21933,7 +21885,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlueRed",
+          "name": "PhyrexianBlack",
           "line": 991,
           "kind": "unit",
           "field_names": [],
@@ -21941,7 +21893,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackRed",
+          "name": "PhyrexianRed",
           "line": 992,
           "kind": "unit",
           "field_names": [],
@@ -21949,7 +21901,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianBlackGreen",
+          "name": "PhyrexianGreen",
           "line": 993,
           "kind": "unit",
           "field_names": [],
@@ -21957,15 +21909,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianRedWhite",
-          "line": 994,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "PhyrexianRedGreen",
+          "name": "PhyrexianWhiteBlue",
           "line": 995,
           "kind": "unit",
           "field_names": [],
@@ -21973,7 +21917,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenWhite",
+          "name": "PhyrexianWhiteBlack",
           "line": 996,
           "kind": "unit",
           "field_names": [],
@@ -21981,7 +21925,7 @@
           "cr_refs": []
         },
         {
-          "name": "PhyrexianGreenBlue",
+          "name": "PhyrexianBlueBlack",
           "line": 997,
           "kind": "unit",
           "field_names": [],
@@ -21989,7 +21933,15 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessWhite",
+          "name": "PhyrexianBlueRed",
+          "line": 998,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianBlackRed",
           "line": 999,
           "kind": "unit",
           "field_names": [],
@@ -21997,7 +21949,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlue",
+          "name": "PhyrexianBlackGreen",
           "line": 1000,
           "kind": "unit",
           "field_names": [],
@@ -22005,7 +21957,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessBlack",
+          "name": "PhyrexianRedWhite",
           "line": 1001,
           "kind": "unit",
           "field_names": [],
@@ -22013,7 +21965,7 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessRed",
+          "name": "PhyrexianRedGreen",
           "line": 1002,
           "kind": "unit",
           "field_names": [],
@@ -22021,8 +21973,56 @@
           "cr_refs": []
         },
         {
-          "name": "ColorlessGreen",
+          "name": "PhyrexianGreenWhite",
           "line": 1003,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "PhyrexianGreenBlue",
+          "line": 1004,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessWhite",
+          "line": 1006,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlue",
+          "line": 1007,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessBlack",
+          "line": 1008,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessRed",
+          "line": 1009,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ColorlessGreen",
+          "line": 1010,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -22033,7 +22033,7 @@
     },
     "ManaExpiry": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 848,
+      "line": 855,
       "doc": "When mana expires — controls lifecycle beyond the normal CR 106.4 step/phase drain.",
       "cr_refs": [
         "CR 106.4"
@@ -22041,7 +22041,7 @@
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 851,
+          "line": 858,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through normal step/phase drains until the turn reaches cleanup. Used by \"Until end of turn, you don't lose this mana as steps and phases end.\"",
@@ -22049,7 +22049,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 854,
+          "line": 861,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana persists through combat steps but drains at EndCombat → PostCombatMain. Used by Firebending and similar \"mana lasts within combat\" mechanics.",
@@ -22060,7 +22060,7 @@
     },
     "ManaModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15560,
+      "line": 15564,
       "doc": "CR 106.3 + CR 614.1a: Mana-production replacement payload. Used by `ReplacementEvent::ProduceMana` to describe HOW the produced mana should be modified before entering the player's mana pool.",
       "cr_refs": [
         "CR 106.3",
@@ -22069,7 +22069,7 @@
       "variants": [
         {
           "name": "ReplaceWith",
-          "line": 15563,
+          "line": 15567,
           "kind": "struct",
           "field_names": [
             "mana_type"
@@ -22081,7 +22081,7 @@
         },
         {
           "name": "Multiply",
-          "line": 15566,
+          "line": 15570,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -22343,7 +22343,7 @@
     },
     "ManaReplacementScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15572,
+      "line": 15576,
       "doc": "CR 106.12b + CR 614.1a: Event scope for mana-production replacements.",
       "cr_refs": [
         "CR 106.12b",
@@ -22352,7 +22352,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 15575,
+          "line": 15579,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies to any mana-production event.",
@@ -22360,7 +22360,7 @@
         },
         {
           "name": "TappedForMana",
-          "line": 15577,
+          "line": 15581,
           "kind": "unit",
           "field_names": [],
           "doc": "Applies only when a permanent is tapped for mana.",
@@ -22371,13 +22371,13 @@
     },
     "ManaRestriction": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 460,
+      "line": 464,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "OnlyForSpell",
-          "line": 462,
+          "line": 466,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells.\"",
@@ -22385,7 +22385,7 @@
         },
         {
           "name": "OnlyForSpellType",
-          "line": 464,
+          "line": 468,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast creature spells\" / \"only to cast artifact spells\".",
@@ -22393,7 +22393,7 @@
         },
         {
           "name": "OnlyForCreatureType",
-          "line": 467,
+          "line": 471,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast a creature spell of the chosen type.\" The `String` is the chosen creature type (e.g., \"Elf\").",
@@ -22401,7 +22401,7 @@
         },
         {
           "name": "SharesCreatureTypeWithCommander",
-          "line": 477,
+          "line": 481,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.6 + CR 205.3m + CR 903.3: \"a creature spell that shares a creature type with your commander\" — relational spend filter for Path of Ancestry. This is a distinct *relational-to-commander* axis, not a fixed-subtype parameterization of `OnlyForCreatureType`: the matching subtype set is computed from live commander state per spend, so it cannot be evaluated from `SpellMeta` alone. `allows_spell` returns `false` (no commander context here); the real relational evaluation happens at the `apply_mana_spell_grants` spend-check site, which has game-state access — mirroring how `OnlyForXCosts` defers full detection to its call site.",
@@ -22413,7 +22413,7 @@
         },
         {
           "name": "OnlyForTypeSpellsOrAbilities",
-          "line": 483,
+          "line": 487,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -22426,7 +22426,7 @@
         },
         {
           "name": "OnlyForActivation",
-          "line": 489,
+          "line": 493,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only to activate abilities.\" Cannot be used for casting spells — activation-only.",
@@ -22434,7 +22434,7 @@
         },
         {
           "name": "OnlyForTaggedActivation",
-          "line": 494,
+          "line": 498,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6: \"Spend this mana only to activate power-up abilities.\" Keyed on the activating ability's keyword tag (Quinjet Technician), a distinct axis from `OnlyForTypeSpellsOrAbilities` (which keys on the source permanent's type) and `OnlyForActivation` (which permits any activation).",
@@ -22444,7 +22444,7 @@
         },
         {
           "name": "OnlyForXCosts",
-          "line": 497,
+          "line": 501,
           "kind": "unit",
           "field_names": [],
           "doc": "\"Spend this mana only on costs that include {X}.\" Only permits spending on spells or abilities with {X} in their cost.",
@@ -22452,7 +22452,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKind",
-          "line": 499,
+          "line": 503,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback.\"",
@@ -22460,7 +22460,7 @@
         },
         {
           "name": "OnlyForSpellWithKeywordKindFromZone",
-          "line": 501,
+          "line": 505,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"Spend this mana only to cast spells with flashback from a graveyard.\"",
@@ -22468,7 +22468,7 @@
         },
         {
           "name": "OnlyForSpellWithManaValue",
-          "line": 505,
+          "line": 509,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -22481,7 +22481,7 @@
         },
         {
           "name": "OnlyForSpellMatchingCostCriteria",
-          "line": 514,
+          "line": 518,
           "kind": "struct",
           "field_names": [
             "spell_type",
@@ -22496,7 +22496,7 @@
         },
         {
           "name": "OnlyForSpellWithColorCount",
-          "line": 522,
+          "line": 526,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -22510,7 +22510,7 @@
         },
         {
           "name": "OnlyForSpellFromZone",
-          "line": 532,
+          "line": 536,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6 + CR 400.7: \"Spend this mana only to cast spells from your graveyard\" / \"from exile\" ([`ZoneSpendPolarity::From`]) and \"from anywhere other than your hand\" ([`ZoneSpendPolarity::NotFrom`], Mm'menon, the Right Hand). Gates on the spell's cast-from zone, consulting `SpellMeta.cast_from_zone`. A distinct axis from `OnlyForSpellWithKeywordKindFromZone` (which also requires a keyword). Carried as a [`ZoneSpend`] newtype payload whose custom `Deserialize` accepts the legacy bare-`Zone` form (`{\"OnlyForSpellFromZone\":\"Graveyard\"}`) for backward compatibility, mapping it to the inclusion reading.",
@@ -22521,10 +22521,10 @@
         },
         {
           "name": "OnlyForFaceDownSpell",
-          "line": 555,
+          "line": 562,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 106.6 + CR 708.4: \"Spend this mana only to cast face-down spells\" (Tin Street Gossip). Gates spending on whether the spell is being CAST face down (morph/disguise/cloak), consulting `SpellMeta.is_face_down`. Rejects normal face-up casts, ability activations, and special actions.  The gate reads `meta.is_face_down`, which `build_spell_meta` sources from the cast's face-down intent — NOT from `obj.face_down`. That distinction matters: exile/library concealment (foretell, hideaway) sets `obj.face_down = true` for a card that is nonetheless CAST FACE UP (CR 702.143c), so the gate correctly REJECTS those concealment casts.  The gate is also fail-closed today: no production path casts a face-down spell *through spell payment* in this engine. CR 708.4 face-down play is modeled by [`GameAction::PlayFaceDown`] → `game::morph::play_face_down`, which moves the card hand→battlefield via the zone pipeline and charges no mana (the `{3}` face-down cast cost, CR 702.37c, is not yet implemented). So `SpellMeta.is_face_down` is never `true` at any `PaymentContext::Spell` payment site, and this gate never over-permits — see [`ManaRestriction::allows_spell`]. The restriction stays representable (the cluster's cards parse to no `Effect::Unimplemented`); once a real face-down CAST routes its cost through `PaymentContext::Spell` with `is_face_down = true` the gate becomes live with no type change.",
+          "doc": "CR 106.6 + CR 708.4: \"Spend this mana only to cast face-down spells\" (Tin Street Gossip). Gates spending on whether the spell is being CAST face down (morph/disguise/cloak), consulting `SpellMeta.is_face_down`. Rejects normal face-up casts, ability activations, and special actions.  The gate reads `meta.is_face_down`, which `build_spell_meta` sources from the cast's face-down intent — NOT from `obj.face_down`. That distinction matters: exile/library concealment (foretell, hideaway) sets `obj.face_down = true` for a card that is nonetheless CAST FACE UP (CR 702.143c), so the gate correctly REJECTS those concealment casts.  The gate is also fail-closed today: no production path casts a face-down spell *through spell payment* in this engine. CR 708.4 face-down play is modeled by [`GameAction::PlayFaceDown`] → `game::morph::play_face_down`, which moves the card hand→battlefield via the zone pipeline and charges no mana (the `{3}` face-down cast cost, CR 702.37c, is not yet implemented). So `SpellMeta.is_face_down` is never `true` at any `PaymentContext::Spell` payment site, and this gate never over-permits — see [`ManaRestriction::allows_spell`]. The restriction stays representable as a typed value even though it is dead today: a card whose only spend restriction is this is left unabsorbed at the `Effect::Mana` seam and intentionally surfaces an `Effect::Unimplemented` gap (honest coverage red) via `ManaSpendRestriction::has_payable_branch`. Once a real face-down CAST routes its cost through `PaymentContext::Spell` with `is_face_down = true` the gate becomes live with no type change.",
           "cr_refs": [
             "CR 106.6",
             "CR 702.143c",
@@ -22534,7 +22534,7 @@
         },
         {
           "name": "OnlyForAny",
-          "line": 562,
+          "line": 569,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6: Disjunctive spend restriction — the mana may be spent on any payment that satisfies at least one inner restriction. Composition combinator (each branch is itself a full restriction), not a leaf parameterization. Models \"… to cast a Dragon spell or an Omen spell\" and \"… to cast an Assassin spell, a spell that has freerunning, or to activate an ability of an Assassin source.\"",
@@ -22544,7 +22544,7 @@
         },
         {
           "name": "OnlyForSpecialAction",
-          "line": 569,
+          "line": 576,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6 + CR 116.2: \"Spend this mana only to [unlock doors]\" — the special-action half of a spend restriction. Payable only for a [`PaymentContext::SpecialAction`] whose [`SpecialAction`] matches. Rejects spell casts, ability activations, and generic effect payments. Parameterized over the action class so one variant covers every restrictable special action (door unlock today; extensible).",
@@ -22555,7 +22555,7 @@
         },
         {
           "name": "ConvokePayment",
-          "line": 573,
+          "line": 580,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51a: Internal marker for a convoke tap that substitutes for paying mana. The payment algorithm may consume it for the current spell, but cast-spent metrics and mana-added triggers must ignore it.",
@@ -22568,7 +22568,7 @@
     },
     "ManaSpellGrant": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 823,
+      "line": 830,
       "doc": "CR 106.6: Additional effect that the mana confers upon the spell it is spent on. E.g., \"that spell can't be countered\" (Cavern of Souls, Delighted Halfling).",
       "cr_refs": [
         "CR 106.6"
@@ -22576,7 +22576,7 @@
       "variants": [
         {
           "name": "CantBeCountered",
-          "line": 825,
+          "line": 832,
           "kind": "unit",
           "field_names": [],
           "doc": "The spell cast with this mana can't be countered.",
@@ -22584,7 +22584,7 @@
         },
         {
           "name": "AddKeywordUntilEndOfTurn",
-          "line": 828,
+          "line": 835,
           "kind": "struct",
           "field_names": [
             "keyword",
@@ -22598,7 +22598,7 @@
         },
         {
           "name": "TriggerOnSpend",
-          "line": 839,
+          "line": 846,
           "kind": "struct",
           "field_names": [
             "restriction",
@@ -22615,7 +22615,7 @@
     },
     "ManaSpendPermission": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2090,
+      "line": 2094,
       "doc": "CR 609.4b: Permission modifying how mana may be spent to pay a cost.",
       "cr_refs": [
         "CR 609.4b"
@@ -22623,7 +22623,7 @@
       "variants": [
         {
           "name": "AnyTypeOrColor",
-          "line": 2094,
+          "line": 2098,
           "kind": "unit",
           "field_names": [],
           "doc": "Mana may be spent as though it were mana of any type or color for this payment. This preserves the Oracle distinction without changing the actual mana spent.",
@@ -22787,10 +22787,10 @@
         },
         {
           "name": "FaceDownSpell",
-          "line": 1646,
+          "line": 1650,
           "kind": "unit",
           "field_names": [],
-          "doc": "CR 106.6 + CR 708.4: \"Spend this mana only to cast face-down spells\" (Tin Street Gossip). Lowered to [`ManaRestriction::OnlyForFaceDownSpell`](super::mana::ManaRestriction::OnlyForFaceDownSpell), gated on `SpellMeta.is_face_down` at the spell-payment site.  The runtime gate reads `SpellMeta.is_face_down`, sourced from the cast's face-down intent (`build_spell_meta`) rather than `obj.face_down`, so it correctly REJECTS exile-concealment casts (foretell/hideaway) whose `obj.face_down = true` but which are cast face up (CR 702.143c). It is also fail-closed: no production path casts a face-down spell *through spell payment* in this engine — CR 708.4 face-down play (`GameAction::PlayFaceDown` → `game::morph::play_face_down`) enters the battlefield via the zone pipeline and charges no mana (the `{3}` face-down cast cost, CR 702.37c, is not yet implemented), so `SpellMeta.is_face_down` is never `true` at a payment site and the gate never over-permits. The variant exists so the restriction is representable (the cluster's cards parse to no `Effect::Unimplemented`); once a real face-down CAST routes its `{3}` cost through `PaymentContext::Spell` the gate becomes live with no type change. See [`ManaRestriction::OnlyForFaceDownSpell`](super::mana::ManaRestriction::OnlyForFaceDownSpell).",
+          "doc": "CR 106.6 + CR 708.4: \"Spend this mana only to cast face-down spells\" (Tin Street Gossip). Lowered to [`ManaRestriction::OnlyForFaceDownSpell`](super::mana::ManaRestriction::OnlyForFaceDownSpell), gated on `SpellMeta.is_face_down` at the spell-payment site.  The runtime gate reads `SpellMeta.is_face_down`, sourced from the cast's face-down intent (`build_spell_meta`) rather than `obj.face_down`, so it correctly REJECTS exile-concealment casts (foretell/hideaway) whose `obj.face_down = true` but which are cast face up (CR 702.143c). It is also fail-closed: no production path casts a face-down spell *through spell payment* in this engine — CR 708.4 face-down play (`GameAction::PlayFaceDown` → `game::morph::play_face_down`) enters the battlefield via the zone pipeline and charges no mana (the `{3}` face-down cast cost, CR 702.37c, is not yet implemented), so `SpellMeta.is_face_down` is never `true` at a payment site and the gate never over-permits. The variant exists so the restriction stays representable as a typed value even though this leaf is dead today: the parser still recognizes the shape, but a card whose ONLY spend restriction is this leaf is left unabsorbed at the `Effect::Mana` seam and intentionally surfaces an `Effect::Unimplemented` gap (honest coverage red) via `ManaSpendRestriction::has_payable_branch`. Once a real face-down CAST routes its `{3}` cost through `PaymentContext::Spell` the gate becomes live with no type change. See [`ManaRestriction::OnlyForFaceDownSpell`](super::mana::ManaRestriction::OnlyForFaceDownSpell).",
           "cr_refs": [
             "CR 106.6",
             "CR 702.143c",
@@ -22800,7 +22800,7 @@
         },
         {
           "name": "TurnPermanentFaceUp",
-          "line": 1657,
+          "line": 1661,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 106.6 + CR 116.2b + CR 702.37e: \"Spend this mana only to turn permanents face up\" / \"turn creatures face up\" — the morph/disguise turn-face-up special-action half of a spend restriction (Overgrown Zealot; Tin Street Gossip). A leaf of the [`ManaSpendRestriction::Any`] disjunction. Lowered to [`ManaRestriction::OnlyForSpecialAction(SpecialAction::TurnFaceUp)`](super::mana::ManaRestriction::OnlyForSpecialAction). The runtime gate is honest-deferred: no payment site emits `PaymentContext::SpecialAction(TurnFaceUp)` yet (turn-face-up charges no mana in this engine), so such mana is conservatively unspendable rather than over-permitted — see [`SpecialAction::TurnFaceUp`](super::mana::SpecialAction::TurnFaceUp).",
@@ -22812,7 +22812,7 @@
         },
         {
           "name": "Any",
-          "line": 1660,
+          "line": 1664,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 106.6: Disjunction of spend restrictions (\"cast X or Y or activate Z\"). Lowered to `ManaRestriction::OnlyForAny`.",
@@ -22825,7 +22825,7 @@
     },
     "ManaSupertype": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 859,
+      "line": 866,
       "doc": "CR 205.4g: Supertype carried by produced mana (Snow today; extensible).",
       "cr_refs": [
         "CR 205.4g"
@@ -22833,7 +22833,7 @@
       "variants": [
         {
           "name": "Snow",
-          "line": 860,
+          "line": 867,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23029,13 +23029,13 @@
     },
     "ModalSelectionCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12542,
+      "line": 12546,
       "doc": "Casting-time condition used by modal choice headers.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Static",
-          "line": 12544,
+          "line": 12548,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -23047,7 +23047,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 12547,
+          "line": 12551,
           "kind": "struct",
           "field_names": [
             "source",
@@ -23068,13 +23068,13 @@
     },
     "ModalSelectionConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12522,
+      "line": 12526,
       "doc": "Selection constraints attached to a modal choice header.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DifferentTargetPlayers",
-          "line": 12523,
+          "line": 12527,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23082,7 +23082,7 @@
         },
         {
           "name": "ConditionalMaxChoices",
-          "line": 12526,
+          "line": 12530,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -23097,7 +23097,7 @@
         },
         {
           "name": "NoRepeatThisTurn",
-          "line": 12533,
+          "line": 12537,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once per turn for this source. Oracle text: \"choose one that hasn't been chosen this turn\"",
@@ -23107,7 +23107,7 @@
         },
         {
           "name": "NoRepeatThisGame",
-          "line": 12536,
+          "line": 12540,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.2: Each mode may only be chosen once total for this source. Oracle text: \"choose one that hasn't been chosen\"",
@@ -23208,7 +23208,7 @@
     },
     "NinjutsuVariant": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5880,
+      "line": 5884,
       "doc": "CR 702.49: Ninjutsu-family keyword variants that share the \"activate to swap a creature in combat\" pattern. This enum is the *activation-family dispatch* layer — it is used only by `activate_ninjutsu` and its supporting helpers (`ninjutsu_timing_ok`, `returnable_creatures_for_variant`, etc.) to pick the correct activation behavior. Sneak (CR 702.190a) and Web-slinging (CR 702.188a) are NOT activated abilities and therefore do not appear here; see `CastVariantPaid` for the trigger-tag layer that does include them.",
       "cr_refs": [
         "CR 702.188a",
@@ -23218,7 +23218,7 @@
       "variants": [
         {
           "name": "Ninjutsu",
-          "line": 5882,
+          "line": 5886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49a: Return unblocked attacker, declare blockers or later.",
@@ -23228,7 +23228,7 @@
         },
         {
           "name": "CommanderNinjutsu",
-          "line": 5884,
+          "line": 5888,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.49d: Commander ninjutsu — activate from hand or command zone.",
@@ -23241,13 +23241,13 @@
     },
     "ObjectProperty": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4525,
+      "line": 4529,
       "doc": "A measurable property of a game object for aggregate queries.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Power",
-          "line": 4526,
+          "line": 4530,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23255,7 +23255,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4527,
+          "line": 4531,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23263,7 +23263,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 4528,
+          "line": 4532,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23274,13 +23274,13 @@
     },
     "ObjectScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3761,
+      "line": 3765,
       "doc": "Scope selector for object-axis quantities (Round Π-5). Picks WHICH object to read from when a `QuantityRef` (and future per-object conditions) is per-object. Mirrors `PlayerScope` for the player axis.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Source",
-          "line": 3767,
+          "line": 3771,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.7 + CR 113.7a: The source object of the resolving ability — \"this creature\", \"~\", \"it\" (when \"it\" anaphors back to the source). CR 113.7 defines the source as the object that generated the ability; CR 113.7a keeps the ability (and thus its source reference) valid on the stack even after the source leaves its expected zone, via LKI.",
@@ -23291,7 +23291,7 @@
         },
         {
           "name": "Target",
-          "line": 3770,
+          "line": 3774,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The first object target of the resolving ability — \"that creature\", \"the creature\", \"it\" (when \"it\" anaphors back to a target).",
@@ -23301,7 +23301,7 @@
         },
         {
           "name": "Recipient",
-          "line": 3776,
+          "line": 3780,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4c + CR 115.10: The object currently receiving an effect. In layer evaluation this is the per-object recipient. Outside layers, it resolves to the first object target when present, then to the source. Used for recipient-relative \"its colors\" boosts such as Blessing of the Nephilim and Civic Saber.",
@@ -23312,7 +23312,7 @@
         },
         {
           "name": "EventSource",
-          "line": 3778,
+          "line": 3782,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: The object referenced by the current trigger event.",
@@ -23322,7 +23322,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3785,
+          "line": 3789,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: The specific untargeted object previously referred to by this ability's cost OR trigger condition. Resolved (first match wins) via `ResolvedAbility.cost_paid_object` → trigger-event source → `effect_context_object`. Subsumes the former `EventContextSource*` trio (CR 117.1 + CR 400.7j cost referent and CR 603.2 trigger referent are the two enumerated members of CR 608.2k's single clause).",
@@ -23335,7 +23335,7 @@
         },
         {
           "name": "Anaphoric",
-          "line": 3801,
+          "line": 3805,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2k: A deferred anaphoric **pronoun** (\"it\" / \"its\") whose object referent is bound at parse time. The parser rebinds this to a concrete scope wherever the enclosing clause establishes the antecedent — `Source` when the clause subject is the ability source, `Target` when the recipient is \"itself\", `EventSource` when the subject is the triggering object. The rebind ([`rebind_anaphoric_object_scope`] in `parser/oracle_effect/mod.rs`) covers every per-object characteristic (power, toughness, mana value, …) — not just power — because the pronoun refers to one object and the rebind only retargets *which* object, never *which* characteristic. When no clause subject applies (triggered-ability anaphora) `Anaphoric` survives to runtime, where it resolves identically to a demonstrative (effect-context referent first; see [`ObjectScope::Demonstrative`]). General rules-correct runtime resolution of triggered-ability anaphora (e.g. \"its mana value\" after a reveal — see issue #511) is separate per-card parser work.",
@@ -23345,7 +23345,7 @@
         },
         {
           "name": "Demonstrative",
-          "line": 3818,
+          "line": 3822,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: A **demonstrative / definite** possessive back-reference (\"that creature's\", \"that card's\", \"that spell's\", \"the creature's\") whose antecedent is a full noun phrase naming an object introduced by an earlier instruction in the same ability — *not* the grammatical subject of the clause it appears in. Unlike [`ObjectScope::Anaphoric`] (the pronoun \"its\"), the subject-injection rewrite MUST NOT rebind this — its antecedent is fixed by the Oracle text. Steadfast Armasaur (\"its toughness\", `Anaphoric` → rebound to `Source`) and Creature Bond (\"that creature's toughness\", `Demonstrative` → never rebound) parse to the same `QuantityRef` property and differ only by this scope: collapsing them caused the LKI-toughness bug. At runtime `Demonstrative` resolves identically to `Anaphoric` — `effect_context_object` (CR 608.2c instruction-order referent) first, then the trigger source (CR 608.2k), then the cost-paid object. This is the Yuriko / Dark Confidant / Mana Drain class (issue #511): a reveal/counter/reanimate earlier in the same ability binds \"that <type>'s\" to the referenced object.",
@@ -23356,7 +23356,7 @@
         },
         {
           "name": "EventTarget",
-          "line": 3827,
+          "line": 3831,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2 + CR 120.1: The object that **received** the damage referenced by the current trigger event — the recipient counterpart to [`ObjectScope::EventSource`]. This is \"that creature\" in \"deals noncombat damage to a creature equal to that creature's toughness\": the antecedent is the damaged object carried by the `DamageDealt` event, not the ability source or a target. Resolved at both trigger detection and resolution (CR 603.4 intervening-if) via `extract_target_object_from_event`.",
@@ -23429,7 +23429,7 @@
     },
     "OriginConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14978,
+      "line": 14982,
       "doc": "CR 603.6c: source-zone constraint for one clause of a zone-change trigger. CR 400.1 enumerates the seven zones; a zone-change event's `from` field is `Some(zone)` for an object that moved between zones and `None` for an object created directly in its destination (CR 111.1 token creation).",
       "cr_refs": [
         "CR 111.1",
@@ -23439,7 +23439,7 @@
       "variants": [
         {
           "name": "Any",
-          "line": 14980,
+          "line": 14984,
           "kind": "unit",
           "field_names": [],
           "doc": "No source-zone restriction. Matches any `from`, including `None`.",
@@ -23447,7 +23447,7 @@
         },
         {
           "name": "Equals",
-          "line": 14982,
+          "line": 14986,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches only when the object moved from exactly this zone.",
@@ -23455,7 +23455,7 @@
         },
         {
           "name": "NotEquals",
-          "line": 14985,
+          "line": 14989,
           "kind": "tuple",
           "field_names": [],
           "doc": "\"from anywhere other than the battlefield\" — matches any source zone except this one. An object with `from = None` does not match.",
@@ -23463,7 +23463,7 @@
         },
         {
           "name": "OneOf",
-          "line": 14987,
+          "line": 14991,
           "kind": "tuple",
           "field_names": [],
           "doc": "Matches when the source zone is one of these. Subsumes inclusion sets.",
@@ -23632,7 +23632,7 @@
     },
     "ParsedCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5634,
+      "line": 5638,
       "doc": "CR 601.3 / CR 602.5: A fully typed condition for casting/activation restrictions. Parsed at Oracle parse time to eliminate runtime reparsing. `Option<ParsedCondition>` is used at storage sites — `None` means the parser could not decompose the condition (permissive fallback: evaluates to `true`).",
       "cr_refs": [
         "CR 601.3",
@@ -23641,7 +23641,7 @@
       "variants": [
         {
           "name": "SourceInZone",
-          "line": 5635,
+          "line": 5639,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -23651,7 +23651,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 5639,
+          "line": 5643,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1a: The source creature is currently attacking.",
@@ -23661,7 +23661,7 @@
         },
         {
           "name": "SourceIsAttackingOrBlocking",
-          "line": 5640,
+          "line": 5644,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23669,7 +23669,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 5642,
+          "line": 5646,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: The source creature is blocked.",
@@ -23679,7 +23679,7 @@
         },
         {
           "name": "SourcePowerAtLeast",
-          "line": 5643,
+          "line": 5647,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -23689,7 +23689,7 @@
         },
         {
           "name": "SourceHasCounterAtLeast",
-          "line": 5646,
+          "line": 5650,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -23700,7 +23700,7 @@
         },
         {
           "name": "SourceHasNoCounter",
-          "line": 5650,
+          "line": 5654,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -23710,7 +23710,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 5654,
+          "line": 5658,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 302.6: Source entered the battlefield this turn.",
@@ -23720,7 +23720,7 @@
         },
         {
           "name": "SourceAttackedThisTurn",
-          "line": 5656,
+          "line": 5660,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.142a: This creature attacked this turn (Boast activation restriction).",
@@ -23730,7 +23730,7 @@
         },
         {
           "name": "SourceIsCreature",
-          "line": 5657,
+          "line": 5661,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23738,7 +23738,7 @@
         },
         {
           "name": "SourceAttachedTo",
-          "line": 5661,
+          "line": 5665,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -23751,7 +23751,7 @@
         },
         {
           "name": "SourceUntappedAttachedTo",
-          "line": 5664,
+          "line": 5668,
           "kind": "struct",
           "field_names": [
             "required_type"
@@ -23761,7 +23761,7 @@
         },
         {
           "name": "SourceLacksKeyword",
-          "line": 5667,
+          "line": 5671,
           "kind": "struct",
           "field_names": [
             "keyword"
@@ -23771,7 +23771,7 @@
         },
         {
           "name": "SourceIsColor",
-          "line": 5670,
+          "line": 5674,
           "kind": "struct",
           "field_names": [
             "color"
@@ -23781,7 +23781,7 @@
         },
         {
           "name": "FirstSpellThisGame",
-          "line": 5673,
+          "line": 5677,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23789,7 +23789,7 @@
         },
         {
           "name": "OpponentSearchedLibraryThisTurn",
-          "line": 5674,
+          "line": 5678,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23797,7 +23797,7 @@
         },
         {
           "name": "BeenAttackedThisStep",
-          "line": 5675,
+          "line": 5679,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23805,17 +23805,6 @@
         },
         {
           "name": "ZoneCardCountAtLeast",
-          "line": 5676,
-          "kind": "struct",
-          "field_names": [
-            "zone",
-            "count"
-          ],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "ZoneCardTypeCountAtLeast",
           "line": 5680,
           "kind": "struct",
           "field_names": [
@@ -23826,8 +23815,19 @@
           "cr_refs": []
         },
         {
-          "name": "ZoneCoreTypeCardCountAtLeast",
+          "name": "ZoneCardTypeCountAtLeast",
           "line": 5684,
+          "kind": "struct",
+          "field_names": [
+            "zone",
+            "count"
+          ],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "ZoneCoreTypeCardCountAtLeast",
+          "line": 5688,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -23839,7 +23839,7 @@
         },
         {
           "name": "ZoneSubtypeCardCountAtLeast",
-          "line": 5689,
+          "line": 5693,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -23851,7 +23851,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 5694,
+          "line": 5698,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23861,7 +23861,7 @@
         },
         {
           "name": "HandSizeExact",
-          "line": 5697,
+          "line": 5701,
           "kind": "struct",
           "field_names": [
             "count"
@@ -23871,7 +23871,7 @@
         },
         {
           "name": "HandSizeOneOf",
-          "line": 5700,
+          "line": 5704,
           "kind": "struct",
           "field_names": [
             "counts"
@@ -23881,7 +23881,7 @@
         },
         {
           "name": "QuantityVsEachOpponent",
-          "line": 5705,
+          "line": 5709,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23893,7 +23893,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 5714,
+          "line": 5718,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -23908,7 +23908,7 @@
         },
         {
           "name": "CreaturesYouControlTotalPowerAtLeast",
-          "line": 5719,
+          "line": 5723,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -23918,7 +23918,7 @@
         },
         {
           "name": "YouControlLandSubtypeAny",
-          "line": 5722,
+          "line": 5726,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -23928,7 +23928,7 @@
         },
         {
           "name": "YouControlSubtypeCountAtLeast",
-          "line": 5725,
+          "line": 5729,
           "kind": "struct",
           "field_names": [
             "subtype",
@@ -23939,7 +23939,7 @@
         },
         {
           "name": "YouControlCoreTypeCountAtLeast",
-          "line": 5729,
+          "line": 5733,
           "kind": "struct",
           "field_names": [
             "core_type",
@@ -23950,7 +23950,7 @@
         },
         {
           "name": "YouControlColorPermanentCountAtLeast",
-          "line": 5733,
+          "line": 5737,
           "kind": "struct",
           "field_names": [
             "color",
@@ -23961,7 +23961,7 @@
         },
         {
           "name": "YouControlSubtypeOrGraveyardCardSubtype",
-          "line": 5737,
+          "line": 5741,
           "kind": "struct",
           "field_names": [
             "subtype"
@@ -23971,7 +23971,7 @@
         },
         {
           "name": "YouControlLegendaryCreature",
-          "line": 5740,
+          "line": 5744,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -23979,7 +23979,7 @@
         },
         {
           "name": "YouControlNamedPlaneswalker",
-          "line": 5741,
+          "line": 5745,
           "kind": "struct",
           "field_names": [
             "name"
@@ -23989,7 +23989,7 @@
         },
         {
           "name": "ControlsCreatureWithKeyword",
-          "line": 5748,
+          "line": 5752,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -24002,7 +24002,7 @@
         },
         {
           "name": "YouControlCreatureWithPowerAtLeast",
-          "line": 5752,
+          "line": 5756,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -24012,7 +24012,7 @@
         },
         {
           "name": "YouControlCreatureWithPt",
-          "line": 5755,
+          "line": 5759,
           "kind": "struct",
           "field_names": [
             "power",
@@ -24023,7 +24023,7 @@
         },
         {
           "name": "YouControlAnotherColorlessCreature",
-          "line": 5759,
+          "line": 5763,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24031,7 +24031,7 @@
         },
         {
           "name": "YouControlSnowPermanentCountAtLeast",
-          "line": 5760,
+          "line": 5764,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24041,7 +24041,7 @@
         },
         {
           "name": "YouControlDifferentPowerCreatureCountAtLeast",
-          "line": 5763,
+          "line": 5767,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24051,7 +24051,7 @@
         },
         {
           "name": "YouControlLandsWithSameNameAtLeast",
-          "line": 5766,
+          "line": 5770,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24061,7 +24061,7 @@
         },
         {
           "name": "YouControlNoCreatures",
-          "line": 5769,
+          "line": 5773,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24069,7 +24069,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 5770,
+          "line": 5774,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24077,7 +24077,7 @@
         },
         {
           "name": "YouAttackedWithAtLeast",
-          "line": 5779,
+          "line": 5783,
           "kind": "struct",
           "field_names": [
             "count",
@@ -24090,7 +24090,7 @@
         },
         {
           "name": "YouPlayedLandThisTurn",
-          "line": 5787,
+          "line": 5791,
           "kind": "unit",
           "field_names": [],
           "doc": "True when the player has already used at least one land play this turn. The count is tracked on `Player::lands_played_this_turn` from `GameEvent::LandPlayed`.",
@@ -24098,7 +24098,7 @@
         },
         {
           "name": "YouCastSpellThisTurn",
-          "line": 5790,
+          "line": 5794,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24111,7 +24111,7 @@
         },
         {
           "name": "YouCastNoncreatureSpellThisTurn",
-          "line": 5794,
+          "line": 5798,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24119,7 +24119,7 @@
         },
         {
           "name": "YouCastSpellCountAtLeast",
-          "line": 5795,
+          "line": 5799,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24129,7 +24129,7 @@
         },
         {
           "name": "YouGainedLifeThisTurn",
-          "line": 5798,
+          "line": 5802,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24137,7 +24137,7 @@
         },
         {
           "name": "YouCreatedTokenThisTurn",
-          "line": 5799,
+          "line": 5803,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24145,7 +24145,7 @@
         },
         {
           "name": "YouDiscardedCardThisTurn",
-          "line": 5800,
+          "line": 5804,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24153,7 +24153,7 @@
         },
         {
           "name": "YouSacrificedArtifactThisTurn",
-          "line": 5801,
+          "line": 5805,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24161,7 +24161,7 @@
         },
         {
           "name": "CreatureDiedThisTurn",
-          "line": 5803,
+          "line": 5807,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4: A creature moved from battlefield to graveyard this turn.",
@@ -24171,7 +24171,7 @@
         },
         {
           "name": "YouHadCreatureEnterThisTurn",
-          "line": 5804,
+          "line": 5808,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24179,7 +24179,7 @@
         },
         {
           "name": "YouHadAngelOrBerserkerEnterThisTurn",
-          "line": 5805,
+          "line": 5809,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24187,7 +24187,7 @@
         },
         {
           "name": "YouHadArtifactEnterThisTurn",
-          "line": 5806,
+          "line": 5810,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -24195,7 +24195,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 5807,
+          "line": 5811,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24206,7 +24206,7 @@
         },
         {
           "name": "CardsLeftYourGraveyardThisTurnAtLeast",
-          "line": 5811,
+          "line": 5815,
           "kind": "struct",
           "field_names": [
             "count"
@@ -24216,7 +24216,7 @@
         },
         {
           "name": "PlayerCountAtLeast",
-          "line": 5816,
+          "line": 5820,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -24229,7 +24229,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5821,
+          "line": 5825,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the activating player has the city's blessing.",
@@ -24239,7 +24239,7 @@
         },
         {
           "name": "IsYourTurn",
-          "line": 5829,
+          "line": 5833,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 102.1: \"The active player is the player whose turn it is.\" True when the scoped player is the active player — gates a casting/restriction predicate on \"if it's your turn\". For \"if it's not your turn\" the parser wraps this leaf with `ParsedCondition::Not`. Mirrors `AbilityCondition::IsYourTurn` (the structural analogue at the ability-resolution layer), the same way `ParsedCondition::And` mirrors `AbilityCondition::And`.",
@@ -24249,7 +24249,7 @@
         },
         {
           "name": "SpellTargetsFilter",
-          "line": 5842,
+          "line": 5846,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -24263,7 +24263,7 @@
         },
         {
           "name": "And",
-          "line": 5850,
+          "line": 5854,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24276,7 +24276,7 @@
         },
         {
           "name": "Or",
-          "line": 5856,
+          "line": 5860,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -24289,7 +24289,7 @@
         },
         {
           "name": "Not",
-          "line": 5863,
+          "line": 5867,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -24899,7 +24899,7 @@
     },
     "PermissionGrantee": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2113,
+      "line": 2117,
       "doc": "CR 611.2a + CR 108.3: Identifies which player a `CastingPermission` is granted to at resolution time. Resolved to a concrete `PlayerId` by `grant_permission::resolve` before the permission is written to the target `GameObject`. Drives both `granted_to` binding and, for durations scoped to that player (e.g., `UntilNextTurnOf`), the prune step in `layers.rs`.  Default is `AbilityController` for all pre-existing parser call sites. Additional variants support compound-exile patterns where multiple objects are granted distinct permissions tied to different players: - `ObjectOwner` — Suspend Aggression: \"its owner may play it\". Each object   in the tracked set is granted to its own owner (CR 108.3). - `ParentTargetController` — Expedited Inheritance: \"its controller may   exile [N] ... They may play those cards\". The grant is tied to the   parent effect's player target rather than the triggered-ability controller.",
       "cr_refs": [
         "CR 108.3",
@@ -24908,7 +24908,7 @@
       "variants": [
         {
           "name": "AbilityController",
-          "line": 2116,
+          "line": 2120,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 611.2a default — the controller of the effect that created the grant.",
@@ -24918,7 +24918,7 @@
         },
         {
           "name": "ObjectOwner",
-          "line": 2118,
+          "line": 2122,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 — each iterated object's owner (per-object binding).",
@@ -24928,7 +24928,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 2120,
+          "line": 2124,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 — the player target of the parent effect in the chain.",
@@ -24941,13 +24941,13 @@
     },
     "PerpetualModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7541,
+      "line": 7545,
       "doc": "The typed effect enum. Each variant corresponds to an effect handler. Zero HashMap<String, String> fields. Digital-only Alchemy: a modification applied by `Effect::ApplyPerpetual` that permanently edits a card and follows it across all zones (CR has no entry — matches the engine's existing `Intensify`/`Conjure` digital-only treatment).  Increment 1 covers base power/toughness setting; the enum is extensible to the other perpetual forms (`ModifyPowerToughness` for \"perpetually gets +N/+N\", `GrantAbility` for \"perpetually gains ...\", `Become` for type changes).",
       "cr_refs": [],
       "variants": [
         {
           "name": "SetBasePowerToughness",
-          "line": 7545,
+          "line": 7549,
           "kind": "struct",
           "field_names": [
             "power",
@@ -25248,13 +25248,13 @@
     },
     "PlayerFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4624,
+      "line": 4628,
       "doc": "A filter matching players by game-state conditions.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Controller",
-          "line": 4628,
+          "line": 4632,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity. CR 700.2a: the default chooser for any modal/effect player reference.",
@@ -25264,7 +25264,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4630,
+          "line": 4634,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -25272,7 +25272,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 4632,
+          "line": 4636,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2: The defending player for the source creature's attack.",
@@ -25282,7 +25282,7 @@
         },
         {
           "name": "OpponentLostLife",
-          "line": 4634,
+          "line": 4638,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who lost life this turn (life_lost_this_turn > 0).",
@@ -25290,7 +25290,7 @@
         },
         {
           "name": "OpponentGainedLife",
-          "line": 4636,
+          "line": 4640,
           "kind": "unit",
           "field_names": [],
           "doc": "Each opponent who gained life this turn (life_gained_this_turn > 0).",
@@ -25298,7 +25298,7 @@
         },
         {
           "name": "HasLostTheGame",
-          "line": 4641,
+          "line": 4645,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 104.3 + CR 104.5: Each player who has lost the game (`is_eliminated`). Quantity-only: players who lost have left the game, so this is not a live effect recipient filter. Rampant Frogantua class: \"+10/+10 for each player who has lost the game\".",
@@ -25309,7 +25309,7 @@
         },
         {
           "name": "OpponentDealtCombatDamage",
-          "line": 4651,
+          "line": 4655,
           "kind": "struct",
           "field_names": [
             "source"
@@ -25324,7 +25324,7 @@
         },
         {
           "name": "OpponentAttacked",
-          "line": 4665,
+          "line": 4669,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -25340,7 +25340,7 @@
         },
         {
           "name": "All",
-          "line": 4670,
+          "line": 4674,
           "kind": "unit",
           "field_names": [],
           "doc": "All players.",
@@ -25348,7 +25348,7 @@
         },
         {
           "name": "HighestSpeed",
-          "line": 4672,
+          "line": 4676,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f: Each player whose speed is tied for the highest speed among players.",
@@ -25358,7 +25358,7 @@
         },
         {
           "name": "ZoneChangedThisWay",
-          "line": 4675,
+          "line": 4679,
           "kind": "unit",
           "field_names": [],
           "doc": "\"each player who [verb]ed a card this way\" — scoped to players who owned objects that changed zones in the preceding effect (tracked via `last_zone_changed_ids`).",
@@ -25366,7 +25366,7 @@
         },
         {
           "name": "PerformedActionThisWay",
-          "line": 4679,
+          "line": 4683,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -25380,7 +25380,7 @@
         },
         {
           "name": "OwnersOfCardsExiledBySource",
-          "line": 4685,
+          "line": 4689,
           "kind": "unit",
           "field_names": [],
           "doc": "Each owner of a card currently exiled with the ability's source. Used by linked-exile follow-ups like Skyclave Apparition's leaves trigger.",
@@ -25388,7 +25388,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 4689,
+          "line": 4693,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.3c + CR 603.2: The player identified by `state.current_trigger_event`. Used to route \"they [verb]\" effects on triggers whose subject is a player (e.g. Firemane Commando's \"another player ... they draw a card\").",
@@ -25399,7 +25399,7 @@
         },
         {
           "name": "OpponentOtherThanTriggering",
-          "line": 4698,
+          "line": 4702,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.3 + CR 603.2c: Each opponent other than the player identified by `state.current_trigger_event`. Used by \"each other opponent\" phrasing on damage triggers — the triggering opponent has already received the source's damage in the same chain (e.g. Hydra Omnivore's \"Whenever ~ deals combat damage to an opponent, it deals that much damage to each other opponent.\"). The \"other\" anaphors back to the triggering opponent named in the trigger event clause. Falls back to plain `Opponent` semantics when no trigger event is in scope (i.e. only excludes the controller).",
@@ -25410,7 +25410,7 @@
         },
         {
           "name": "OpponentOfTriggeringPlayerNotAttacked",
-          "line": 4704,
+          "line": 4708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking* player (resolved from the active AttackersDeclared trigger event) who is NOT in that player's attacked-this-combat set. Models \"that player has another opponent who isn't being attacked\" (Suppressor Skyguard); counted via QuantityRef::PlayerCount, gated as count >= 1.",
@@ -25422,7 +25422,7 @@
         },
         {
           "name": "VotedFor",
-          "line": 4715,
+          "line": 4719,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -25435,7 +25435,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 4727,
+          "line": 4731,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"reduce that opponent's speed\" anaphoring the controller of a bounced creature). The `PlayerFilter`-axis analogue of `PlayerScope::ParentObjectTargetController` and `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -25446,7 +25446,7 @@
         },
         {
           "name": "ControlsCount",
-          "line": 4749,
+          "line": 4753,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -25462,7 +25462,7 @@
         },
         {
           "name": "PlayerAttribute",
-          "line": 4775,
+          "line": 4779,
           "kind": "struct",
           "field_names": [
             "relation",
@@ -25480,7 +25480,7 @@
         },
         {
           "name": "ChosenPlayer",
-          "line": 4791,
+          "line": 4795,
           "kind": "struct",
           "field_names": [
             "index"
@@ -25493,7 +25493,7 @@
         },
         {
           "name": "ParentObjectTargetOwner",
-          "line": 4801,
+          "line": 4805,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 109.4: The owner of the first object target of the resolving ability. The owner-axis sibling of `ParentObjectTargetController`, completing the owner/controller pair that `PlayerScope` (`ParentObjectTargetController`) and `TargetFilter` (`ParentTargetOwner` / `ParentTargetController`) already carry. Resolved via `ability_utils::parent_target_owner`. Powers the \"[target's owner] …, then faces a villainous choice — …\" class (This Is How It Ends) where the player facing the choice is the owner of the targeted permanent named in the prior clause, not the ability controller.",
@@ -25516,7 +25516,7 @@
     },
     "PlayerRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4593,
+      "line": 4597,
       "doc": "CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that compose with an independent condition.",
       "cr_refs": [
         "CR 102.1",
@@ -25526,7 +25526,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 4595,
+          "line": 4599,
           "kind": "unit",
           "field_names": [],
           "doc": "The controller of the effect or quantity.",
@@ -25534,7 +25534,7 @@
         },
         {
           "name": "Opponent",
-          "line": 4597,
+          "line": 4601,
           "kind": "unit",
           "field_names": [],
           "doc": "All opponents of the controller.",
@@ -25542,7 +25542,7 @@
         },
         {
           "name": "All",
-          "line": 4599,
+          "line": 4603,
           "kind": "unit",
           "field_names": [],
           "doc": "All players in the game.",
@@ -25553,7 +25553,7 @@
     },
     "PlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3702,
+      "line": 3706,
       "doc": "CR 102 + CR 119 + CR 402: Player axis for player-scoped quantity references.  Parameterizes the player whose hand size, life total, or other per-player scalar is being read. Replaces sibling enum variants like `LifeTotal` / `TargetLifeTotal` / `OpponentLifeTotal` and `HandSize` / `OpponentHandSize` with a single parameterized form.  Categorical-boundary check (per the \"Parameterize, don't proliferate\" principle): every variant is a player-relativity choice within a single CR section. Aggregate scopes (`Opponent`, `AllPlayers`) compose `AggregateFunction` to express max/min/sum across a population — they do not introduce a new abstraction layer.",
       "cr_refs": [
         "CR 102",
@@ -25563,7 +25563,7 @@
       "variants": [
         {
           "name": "Controller",
-          "line": 3704,
+          "line": 3708,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 / CR 113.6: The controller of the source ability or effect.",
@@ -25574,7 +25574,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3708,
+          "line": 3712,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This keeps \"their\" quantities separate from \"you\" quantities.",
@@ -25585,7 +25585,7 @@
         },
         {
           "name": "Target",
-          "line": 3711,
+          "line": 3715,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 113.6 + CR 115.1: The first player target of the resolving ability (read from `ability.targets`).",
@@ -25597,7 +25597,7 @@
         },
         {
           "name": "Opponent",
-          "line": 3715,
+          "line": 3719,
           "kind": "struct",
           "field_names": [
             "aggregate"
@@ -25610,7 +25610,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3720,
+          "line": 3724,
           "kind": "struct",
           "field_names": [
             "aggregate",
@@ -25623,7 +25623,7 @@
         },
         {
           "name": "RecipientController",
-          "line": 3734,
+          "line": 3738,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4m + CR 613.4c: The controller of the object currently receiving a layer effect. Used for Aura/Equipment statics such as \"enchanted creature gets +1/+1 for each card in its controller's hand\", where \"its\" refers to the enchanted creature, not the Aura.",
@@ -25634,7 +25634,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3740,
+          "line": 3744,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source attacking creature, resolved per attacker through `combat::defending_player_for_attacker`. Used by attack-trigger intervening-if quantities such as \"no opponent has more life than that player.\"",
@@ -25645,7 +25645,7 @@
         },
         {
           "name": "ParentObjectTargetController",
-          "line": 3746,
+          "line": 3750,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.4 + CR 608.2c: The controller of the first object target of the resolving ability (\"that opponent\" anaphoring the controller of a bounced/destroyed creature). The player-scalar-axis analogue of `ControllerRef::ParentTargetController`. Resolved via `ability_utils::parent_target_controller`.",
@@ -25656,7 +25656,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3753,
+          "line": 3757,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.1 + CR 109.4: The player PERSISTED on the source via `ChosenAttribute::Player` (an \"as ~ enters the battlefield, choose a player\" replacement). The player-scalar-axis analogue of `ControllerRef::SourceChosenPlayer`, read continuously from the source's `chosen_attributes` so a CDA P/T can track e.g. the chosen player's hand or graveyard size (Entropic Specter, Sewer Nemesis).",
@@ -25697,7 +25697,7 @@
     },
     "PostReplacementContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15680,
+      "line": 15684,
       "doc": "CR 614.12a + CR 615.5: Continuation effect that runs after a replacement effect's modifications complete. Stashed by the replacement pipeline, drained by callers (`engine_replacement`, `stack`, `deal_damage`, `engine`).  Two binding states share one slot: - `Template`: an `AbilityDefinition` AST that needs the replacement   source for resolution context (e.g. \"As ~ enters, choose a basic land   type\" — controller and source come from the resolving permanent). - `Resolved`: a `ResolvedAbility` that already carries selected targets   and resolution-time context, ready for direct dispatch (e.g. Phyrexian   Hydra's prevented-damage follow-up captures the source and counter   quantity from the resolution that created the prevention shield).",
       "cr_refs": [
         "CR 614.12a",
@@ -25706,7 +25706,7 @@
       "variants": [
         {
           "name": "Template",
-          "line": 15681,
+          "line": 15685,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25714,7 +25714,7 @@
         },
         {
           "name": "Resolved",
-          "line": 15682,
+          "line": 15686,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -25834,13 +25834,13 @@
     },
     "ProhibitedActivity": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1804,
+      "line": 1808,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "CastOnlyFromZones",
-          "line": 1806,
+          "line": 1810,
           "kind": "struct",
           "field_names": [
             "allowed_zones"
@@ -25853,7 +25853,7 @@
         },
         {
           "name": "CastSpells",
-          "line": 1808,
+          "line": 1812,
           "kind": "struct",
           "field_names": [
             "spell_filter"
@@ -25865,7 +25865,7 @@
         },
         {
           "name": "ActivateAbilities",
-          "line": 1816,
+          "line": 1820,
           "kind": "struct",
           "field_names": [
             "exemption",
@@ -25880,7 +25880,7 @@
         },
         {
           "name": "Attack",
-          "line": 1826,
+          "line": 1830,
           "kind": "struct",
           "field_names": [
             "defended"
@@ -26394,7 +26394,7 @@
     },
     "PtStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5198,
+      "line": 5202,
       "doc": "CR 208: Selects which creature P/T metric a `FilterProp::PtComparison` reads. Power, toughness, and their total are all derived from the same CR 208 characteristic pair, so they are a leaf-level parameterization axis, not a cross-section conflation.",
       "cr_refs": [
         "CR 208"
@@ -26402,7 +26402,7 @@
       "variants": [
         {
           "name": "Power",
-          "line": 5200,
+          "line": 5204,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's power (first number).",
@@ -26412,7 +26412,7 @@
         },
         {
           "name": "Toughness",
-          "line": 5202,
+          "line": 5206,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The creature's toughness (second number).",
@@ -26422,7 +26422,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 5204,
+          "line": 5208,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: The sum of the creature's power and toughness.",
@@ -26468,7 +26468,7 @@
     },
     "PtValueScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5213,
+      "line": 5217,
       "doc": "CR 208.4b: Selects whether a `FilterProp::PtComparison` reads the creature's current power/toughness (after all continuous effects) or its base power/toughness. Per CR 613.4b, base values are those set in layer 7b (after CDAs in 7a and set effects, but before counters and modifying effects in 7c). A 1/1 with a +1/+1 counter has base power 1 but current power 2.",
       "cr_refs": [
         "CR 208.4b",
@@ -26477,7 +26477,7 @@
       "variants": [
         {
           "name": "Current",
-          "line": 5216,
+          "line": 5220,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 613.4: The fully-modified value after applying every layer-7 sublayer.",
@@ -26487,7 +26487,7 @@
         },
         {
           "name": "Base",
-          "line": 5219,
+          "line": 5223,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.4b: The value after layer 7b only — ignores counters (7c) and other modifying effects.",
@@ -26500,7 +26500,7 @@
     },
     "QuantityExpr": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4813,
+      "line": 4817,
       "doc": "An expression that produces an integer for quantity comparisons. Either a dynamic game-state lookup or a literal constant.  CR 107: `Deserialize` is hand-written below (NOT derived) so it ALSO accepts the legacy bare-integer form (`2`, `-1`) that pre-`QuantityExpr` card-data and committed game-state snapshots stored. `Serialize` stays derived, so the canonical on-disk form remains the tagged `{\"type\":\"Fixed\",\"value\":2}`.",
       "cr_refs": [
         "CR 107"
@@ -26508,7 +26508,7 @@
       "variants": [
         {
           "name": "Ref",
-          "line": 4815,
+          "line": 4819,
           "kind": "struct",
           "field_names": [
             "qty"
@@ -26518,7 +26518,7 @@
         },
         {
           "name": "Fixed",
-          "line": 4817,
+          "line": 4821,
           "kind": "struct",
           "field_names": [
             "value"
@@ -26528,7 +26528,7 @@
         },
         {
           "name": "DivideRounded",
-          "line": 4821,
+          "line": 4825,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -26542,7 +26542,7 @@
         },
         {
           "name": "Offset",
-          "line": 4828,
+          "line": 4832,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -26555,7 +26555,7 @@
         },
         {
           "name": "ClampMin",
-          "line": 4837,
+          "line": 4841,
           "kind": "struct",
           "field_names": [
             "inner",
@@ -26568,7 +26568,7 @@
         },
         {
           "name": "Multiply",
-          "line": 4842,
+          "line": 4846,
           "kind": "struct",
           "field_names": [
             "factor",
@@ -26579,7 +26579,7 @@
         },
         {
           "name": "Sum",
-          "line": 4851,
+          "line": 4855,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -26589,7 +26589,7 @@
         },
         {
           "name": "UpTo",
-          "line": 4876,
+          "line": 4880,
           "kind": "struct",
           "field_names": [
             "max"
@@ -26602,7 +26602,7 @@
         },
         {
           "name": "Power",
-          "line": 4882,
+          "line": 4886,
           "kind": "struct",
           "field_names": [
             "base",
@@ -26615,7 +26615,7 @@
         },
         {
           "name": "Difference",
-          "line": 4897,
+          "line": 4901,
           "kind": "struct",
           "field_names": [
             "left",
@@ -26628,7 +26628,7 @@
         },
         {
           "name": "Max",
-          "line": 4916,
+          "line": 4920,
           "kind": "struct",
           "field_names": [
             "exprs"
@@ -26646,7 +26646,7 @@
     },
     "QuantityModification": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15509,
+      "line": 15513,
       "doc": "CR 614.1a: Quantity modification for replacement effects (tokens, counters). Modeled after DamageModification but for non-damage quantities.",
       "cr_refs": [
         "CR 614.1a"
@@ -26654,7 +26654,7 @@
       "variants": [
         {
           "name": "Times",
-          "line": 15518,
+          "line": 15522,
           "kind": "struct",
           "field_names": [
             "factor"
@@ -26664,7 +26664,7 @@
         },
         {
           "name": "Half",
-          "line": 15520,
+          "line": 15524,
           "kind": "unit",
           "field_names": [],
           "doc": "count / 2 rounded down — Halving Season",
@@ -26672,7 +26672,7 @@
         },
         {
           "name": "Plus",
-          "line": 15522,
+          "line": 15526,
           "kind": "struct",
           "field_names": [
             "value"
@@ -26682,7 +26682,7 @@
         },
         {
           "name": "Minus",
-          "line": 15524,
+          "line": 15528,
           "kind": "struct",
           "field_names": [
             "value"
@@ -26692,7 +26692,7 @@
         },
         {
           "name": "Prevent",
-          "line": 15544,
+          "line": 15548,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 113.6i + CR 614.17 + CR 614.6 + CR 614.7 + CR 122.1: Fully replace the quantity event with nothing — the proposed `AddCounter` / `CreateToken` event \"never happens\" (CR 614.6).  CR 113.6i is the *authorizing* rule for permanent-scoped counter prohibitions (\"an object's ability that states counters can't be put on that object functions as that object is entering the battlefield in addition to functioning while that object is on the battlefield\"). CR 614.17 is the framework for \"can't\" effects — they aren't replacement effects but follow similar rules — which is why we model the prohibition through the replacement pipeline. CR 122.1 (\"a counter is a marker placed on an object or player\") identifies the placement event the prohibition suppresses; CR 614.6/614.7 govern the resulting \"event never happens\" outcome.  Used by self-targeted counter-prohibition replacements (\"~ can't have counters put on it.\" — Melira's Keepers). Composes with `valid_card: SelfRef` for permanent-scoped protection and with player-scope filters for the future Solemnity-class global variant.",
@@ -26709,13 +26709,13 @@
     },
     "QuantityRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3879,
+      "line": 3883,
       "doc": "A dynamic game quantity — a runtime lookup into the game state.",
       "cr_refs": [],
       "variants": [
         {
           "name": "HandSize",
-          "line": 3883,
+          "line": 3887,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26727,7 +26727,7 @@
         },
         {
           "name": "LifeTotal",
-          "line": 3886,
+          "line": 3890,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26739,7 +26739,7 @@
         },
         {
           "name": "GraveyardSize",
-          "line": 3892,
+          "line": 3896,
           "kind": "struct",
           "field_names": [
             "player"
@@ -26751,7 +26751,7 @@
         },
         {
           "name": "LifeAboveStarting",
-          "line": 3895,
+          "line": 3899,
           "kind": "unit",
           "field_names": [],
           "doc": "Controller's life total minus the format's starting life total. Used for \"N or more life more than your starting life total\" conditions.",
@@ -26759,7 +26759,7 @@
         },
         {
           "name": "StartingLifeTotal",
-          "line": 3897,
+          "line": 3901,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 103.4: The format's starting life total (20 for Standard, 40 for Commander, etc.).",
@@ -26769,7 +26769,7 @@
         },
         {
           "name": "ObjectCount",
-          "line": 3900,
+          "line": 3904,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26779,7 +26779,7 @@
         },
         {
           "name": "ObjectCountDistinct",
-          "line": 3917,
+          "line": 3921,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -26793,7 +26793,7 @@
         },
         {
           "name": "ObjectCountBySharedQuality",
-          "line": 3927,
+          "line": 3931,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -26808,7 +26808,7 @@
         },
         {
           "name": "PlayerCount",
-          "line": 3934,
+          "line": 3938,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26818,7 +26818,7 @@
         },
         {
           "name": "CountersOn",
-          "line": 3955,
+          "line": 3959,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26831,7 +26831,7 @@
         },
         {
           "name": "CountersOnObjects",
-          "line": 3964,
+          "line": 3968,
           "kind": "struct",
           "field_names": [
             "counter_type",
@@ -26844,7 +26844,7 @@
         },
         {
           "name": "PlayerCounter",
-          "line": 3983,
+          "line": 3987,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -26861,7 +26861,7 @@
         },
         {
           "name": "Variable",
-          "line": 3988,
+          "line": 3992,
           "kind": "struct",
           "field_names": [
             "name"
@@ -26871,7 +26871,7 @@
         },
         {
           "name": "Power",
-          "line": 3995,
+          "line": 3999,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26885,7 +26885,7 @@
         },
         {
           "name": "Intensity",
-          "line": 3999,
+          "line": 4003,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26895,7 +26895,7 @@
         },
         {
           "name": "Toughness",
-          "line": 4004,
+          "line": 4008,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26909,7 +26909,7 @@
         },
         {
           "name": "ObjectManaValue",
-          "line": 4010,
+          "line": 4014,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26922,7 +26922,7 @@
         },
         {
           "name": "TargetObjectManaValue",
-          "line": 4016,
+          "line": 4020,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -26935,7 +26935,7 @@
         },
         {
           "name": "ObjectColorCount",
-          "line": 4022,
+          "line": 4026,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26948,7 +26948,7 @@
         },
         {
           "name": "ObjectNameWordCount",
-          "line": 4027,
+          "line": 4031,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26961,7 +26961,7 @@
         },
         {
           "name": "ObjectTypelineComponentCount",
-          "line": 4031,
+          "line": 4035,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -26975,7 +26975,7 @@
         },
         {
           "name": "ManaSymbolsInManaCost",
-          "line": 4038,
+          "line": 4042,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -26989,7 +26989,7 @@
         },
         {
           "name": "SelfManaValue",
-          "line": 4050,
+          "line": 4054,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: The mana value of the source object — i.e. the object passed as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this is the spell-being-cast, so \"pay life equal to its mana value\" reads the right value at cost-payment time. Distinct from `ObjectManaValue { scope: CostPaidObject }` (which reads the cost-paid / trigger-referenced object per CR 608.2k); that ref returns 0 outside cost/trigger resolution, whereas this one is correct any time the resolver has a `source_id` (cost payment, ability resolution, etc.).",
@@ -27001,7 +27001,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 4057,
+          "line": 4061,
           "kind": "struct",
           "field_names": [
             "function",
@@ -27015,7 +27015,7 @@
         },
         {
           "name": "ControlledByEachPlayer",
-          "line": 4074,
+          "line": 4078,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -27029,7 +27029,7 @@
         },
         {
           "name": "TargetZoneCardCount",
-          "line": 4081,
+          "line": 4085,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -27039,7 +27039,7 @@
         },
         {
           "name": "Devotion",
-          "line": 4083,
+          "line": 4087,
           "kind": "struct",
           "field_names": [
             "colors"
@@ -27051,7 +27051,7 @@
         },
         {
           "name": "DistinctCardTypes",
-          "line": 4087,
+          "line": 4091,
           "kind": "struct",
           "field_names": [
             "source"
@@ -27063,7 +27063,7 @@
         },
         {
           "name": "CardsExiledBySource",
-          "line": 4092,
+          "line": 4096,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 406.6 + CR 607.1: Count of cards currently in exile that are linked to the source via its exile-linked ability. Used by \"as long as there are N or more cards exiled with ~\" conditional statics (Veteran Survivor, etc.) — composes with `StaticCondition::QuantityComparison` rather than requiring a dedicated variant.",
@@ -27074,7 +27074,7 @@
         },
         {
           "name": "ExiledCardPower",
-          "line": 4095,
+          "line": 4099,
           "kind": "struct",
           "field_names": [
             "index"
@@ -27086,7 +27086,7 @@
         },
         {
           "name": "ZoneCardCount",
-          "line": 4099,
+          "line": 4103,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -27101,7 +27101,7 @@
         },
         {
           "name": "BasicLandTypeCount",
-          "line": 4108,
+          "line": 4112,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -27113,7 +27113,7 @@
         },
         {
           "name": "TrackedSetSize",
-          "line": 4112,
+          "line": 4116,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Count of objects moved by the preceding effect in the sub_ability chain. Only valid during sub-ability chain resolution; returns 0 outside that context. The caller (token resolver) is responsible for consuming the tracked set after use.",
@@ -27123,7 +27123,7 @@
         },
         {
           "name": "FilteredTrackedSetSize",
-          "line": 4127,
+          "line": 4131,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -27138,7 +27138,7 @@
         },
         {
           "name": "TrackedSetAggregate",
-          "line": 4141,
+          "line": 4145,
           "kind": "struct",
           "field_names": [
             "function",
@@ -27154,7 +27154,7 @@
         },
         {
           "name": "ExiledFromHandThisResolution",
-          "line": 4150,
+          "line": 4154,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's \"draws a card for each card exiled from their hand this way.\" The counter is tracked in `state.exiled_from_hand_this_resolution` and reset at the top of each player action and at the start of each top-level ability chain.",
@@ -27165,7 +27165,7 @@
         },
         {
           "name": "PreviousEffectAmount",
-          "line": 4154,
+          "line": 4158,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.3: Numeric amount produced by the preceding effect in the sub_ability chain. Used for patterns where a sub_ability references the parent effect's numeric result (life lost, damage dealt, counters removed).",
@@ -27175,7 +27175,7 @@
         },
         {
           "name": "LifeLostThisTurn",
-          "line": 4169,
+          "line": 4173,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27188,7 +27188,7 @@
         },
         {
           "name": "PartySize",
-          "line": 4178,
+          "line": 4182,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27201,7 +27201,7 @@
         },
         {
           "name": "UnspentMana",
-          "line": 4187,
+          "line": 4191,
           "kind": "struct",
           "field_names": [
             "color"
@@ -27213,7 +27213,7 @@
         },
         {
           "name": "Speed",
-          "line": 4194,
+          "line": 4198,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27225,7 +27225,7 @@
         },
         {
           "name": "EventContextAmount",
-          "line": 4197,
+          "line": 4201,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Numeric value from the triggering event. Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.",
@@ -27235,7 +27235,7 @@
         },
         {
           "name": "AttachmentsOnLeavingObject",
-          "line": 4205,
+          "line": 4209,
           "kind": "struct",
           "field_names": [
             "kind",
@@ -27249,7 +27249,7 @@
         },
         {
           "name": "EventContextSourceCostX",
-          "line": 4217,
+          "line": 4221,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3a + CR 601.2b + CR 603.2: The announced value of `{X}` for the triggering spell. Reads `GameObject::cost_x_paid` on the spell object referenced by `current_trigger_event` (populated during `determine_total_cost` and persisted through stack → battlefield). Used by triggers of the form \"whenever you cast your first spell with {X} in its mana cost each turn, [do something with X]\" (e.g. Nev the Practical Dean's \"put X +1/+1 counters on Nev\").",
@@ -27261,7 +27261,7 @@
         },
         {
           "name": "SpellsCastThisTurn",
-          "line": 4220,
+          "line": 4224,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27274,7 +27274,7 @@
         },
         {
           "name": "EnteredThisTurn",
-          "line": 4227,
+          "line": 4231,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27284,7 +27284,7 @@
         },
         {
           "name": "SacrificedThisTurn",
-          "line": 4233,
+          "line": 4237,
           "kind": "struct",
           "field_names": [
             "player",
@@ -27297,7 +27297,7 @@
         },
         {
           "name": "CrimesCommittedThisTurn",
-          "line": 4238,
+          "line": 4242,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 710.2: Number of crimes the controller has committed this turn.",
@@ -27307,7 +27307,7 @@
         },
         {
           "name": "LifeGainedThisTurn",
-          "line": 4244,
+          "line": 4248,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27319,7 +27319,7 @@
         },
         {
           "name": "CardsDrawnThisTurn",
-          "line": 4249,
+          "line": 4253,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27331,7 +27331,7 @@
         },
         {
           "name": "BattlefieldEntriesThisTurn",
-          "line": 4255,
+          "line": 4259,
           "kind": "struct",
           "field_names": [
             "player",
@@ -27345,7 +27345,7 @@
         },
         {
           "name": "LandsPlayedThisTurn",
-          "line": 4263,
+          "line": 4267,
           "kind": "struct",
           "field_names": [
             "player",
@@ -27359,7 +27359,7 @@
         },
         {
           "name": "TurnsTaken",
-          "line": 4270,
+          "line": 4274,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500: Number of turns this player has taken so far in the game. Resolved against the controller/scope player.",
@@ -27369,7 +27369,7 @@
         },
         {
           "name": "ZoneChangeCountThisTurn",
-          "line": 4274,
+          "line": 4278,
           "kind": "struct",
           "field_names": [
             "from",
@@ -27384,7 +27384,7 @@
         },
         {
           "name": "ZoneChangeAggregateThisTurn",
-          "line": 4292,
+          "line": 4296,
           "kind": "struct",
           "field_names": [
             "from",
@@ -27405,7 +27405,7 @@
         },
         {
           "name": "DamageDealtThisTurn",
-          "line": 4314,
+          "line": 4318,
           "kind": "struct",
           "field_names": [
             "source",
@@ -27423,7 +27423,7 @@
         },
         {
           "name": "ChosenNumber",
-          "line": 4333,
+          "line": 4337,
           "kind": "unit",
           "field_names": [],
           "doc": "A number chosen as the source entered the battlefield (e.g., Talion, the Kindly Lord). Resolved from the source object's `ChosenAttribute::Number`.",
@@ -27431,7 +27431,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 4343,
+          "line": 4347,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27444,7 +27444,7 @@
         },
         {
           "name": "DescendedThisTurn",
-          "line": 4350,
+          "line": 4354,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: Whether the controller descended this turn (permanent card entered graveyard).",
@@ -27454,7 +27454,7 @@
         },
         {
           "name": "LoyaltyAbilitiesActivatedThisTurn",
-          "line": 4358,
+          "line": 4362,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27468,7 +27468,7 @@
         },
         {
           "name": "SpellsCastLastTurn",
-          "line": 4361,
+          "line": 4365,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 117.1: Number of spells cast last turn (by any player). Used for werewolf transform conditions.",
@@ -27478,7 +27478,7 @@
         },
         {
           "name": "SpellsCastThisGame",
-          "line": 4375,
+          "line": 4379,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27492,7 +27492,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 4386,
+          "line": 4390,
           "kind": "struct",
           "field_names": [
             "actor",
@@ -27507,7 +27507,7 @@
         },
         {
           "name": "CardsDiscardedThisTurn",
-          "line": 4395,
+          "line": 4399,
           "kind": "struct",
           "field_names": [
             "player"
@@ -27520,7 +27520,7 @@
         },
         {
           "name": "TokensCreatedThisTurn",
-          "line": 4400,
+          "line": 4404,
           "kind": "struct",
           "field_names": [
             "player",
@@ -27534,7 +27534,7 @@
         },
         {
           "name": "PlayerActionsThisTurn",
-          "line": 4408,
+          "line": 4412,
           "kind": "struct",
           "field_names": [
             "player",
@@ -27548,7 +27548,7 @@
         },
         {
           "name": "DungeonsCompleted",
-          "line": 4413,
+          "line": 4417,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: Number of dungeons the controller has completed.",
@@ -27558,7 +27558,7 @@
         },
         {
           "name": "CostXPaid",
-          "line": 4420,
+          "line": 4424,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3m: The value of X paid for the spell that produced the source object. Survives the stack → battlefield transition (stored on the GameObject as `cost_x_paid`), so ETB replacement effects (\"enters with X counters\") and ETB triggered abilities referring to X resolve against the actual paid amount. Distinct from `Variable { name: \"X\" }` which only resolves while the ability is on the stack with `chosen_x` set.",
@@ -27568,7 +27568,7 @@
         },
         {
           "name": "KickerCount",
-          "line": 4423,
+          "line": 4427,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.33b + CR 702.33c: Number of kicker costs paid for the source spell. For multikicker, each repeated payment contributes one entry.",
@@ -27579,7 +27579,7 @@
         },
         {
           "name": "AdditionalCostPaymentCount",
-          "line": 4427,
+          "line": 4431,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 601.2b/f/h + CR 702.157a: Number of non-kicker additional-cost payments made for the source spell. Used by Squad so its payment count remains distinct from Kicker's CR 702.33 payment model.",
@@ -27591,7 +27591,7 @@
         },
         {
           "name": "AdditionalCostPaymentCountFor",
-          "line": 4431,
+          "line": 4435,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -27605,7 +27605,7 @@
         },
         {
           "name": "ConvokedCreatureCount",
-          "line": 4439,
+          "line": 4443,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.51c: Number of creatures that convoked the source spell or the spell that became the source permanent. Reads `GameObject::convoked_creatures`; ETB replacement contexts resolve against the entering object.",
@@ -27615,7 +27615,7 @@
         },
         {
           "name": "ManaSpentToCast",
-          "line": 4444,
+          "line": 4448,
           "kind": "struct",
           "field_names": [
             "scope",
@@ -27629,7 +27629,7 @@
         },
         {
           "name": "ColorsInCommandersColorIdentity",
-          "line": 4455,
+          "line": 4459,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.4 + CR 903.4f: Number of distinct colors in the controller's commander(s)' combined color identity. Color identity is the union of every commander's mana-cost colors plus color indicator/CDA colors. Resolves to 0 when the controller has no commander (CR 903.4f: \"that quality is undefined if that player doesn't have a commander\"). Used by War Room's \"pay life equal to the number of colors in your commanders' color identity\" activation cost.",
@@ -27640,7 +27640,7 @@
         },
         {
           "name": "CommanderCastFromCommandZoneCount",
-          "line": 4460,
+          "line": 4464,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 903.8: Number of times the controller has cast their commander(s) from the command zone this game. Used by commander storm effects such as \"copy it for each time you've cast your commander from the command zone this game.\"",
@@ -27650,7 +27650,7 @@
         },
         {
           "name": "CommanderManaValue",
-          "line": 4465,
+          "line": 4469,
           "kind": "struct",
           "field_names": [
             "owner"
@@ -27662,7 +27662,7 @@
         },
         {
           "name": "DistinctColorsAmongPermanents",
-          "line": 4472,
+          "line": 4476,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27676,7 +27676,7 @@
         },
         {
           "name": "DistinctCounterKindsAmong",
-          "line": 4481,
+          "line": 4485,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27690,7 +27690,7 @@
         },
         {
           "name": "VoteCount",
-          "line": 4488,
+          "line": 4492,
           "kind": "struct",
           "field_names": [
             "choice_index"
@@ -27781,7 +27781,7 @@
     },
     "RenownSubject": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14252,
+      "line": 14256,
       "doc": "CR 702.112: Which creature's renowned designation an `IsRenowned` condition reads.  Renowned (CR 702.112b) is a per-permanent designation other spells and abilities can identify, so a condition may reference either the ability's own permanent or a different (event-subject) creature.   - `Source` — the ability's own permanent (\"~\"), as in Renown's own     intervening-if (CR 702.112a, \"if it isn't renowned\" where \"it\" == this creature).   - `EventSubject` — the creature named by the triggering event (\"it\"), a creature     other than the source (CR 702.112b).",
       "cr_refs": [
         "CR 702.112",
@@ -27791,7 +27791,7 @@
       "variants": [
         {
           "name": "Source",
-          "line": 14253,
+          "line": 14257,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27799,7 +27799,7 @@
         },
         {
           "name": "EventSubject",
-          "line": 14254,
+          "line": 14258,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -27810,7 +27810,7 @@
     },
     "RepeatContinuation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13276,
+      "line": 13280,
       "doc": "CR 608.2c + CR 107.1c: how a \"repeat this process\" loop decides whether to run another iteration. The non-count companion to `AbilityDefinition`'s `repeat_for` (a fixed `QuantityExpr` count) — this predicate decides per-iteration whether to re-follow the resolving ability's instructions.  Three forms are modeled: the controller-decision form (\"you may repeat this process any number of times\", `ControllerChoice`), the stop-predicate form (\"repeat this process until …\", `UntilStopConditions`, Tainted Pact), and the game-state-predicate form (\"[if condition,] repeat this process [once]\", `WhileCondition`). The optional-put pause semantics that the `WhileCondition` loop depends on are shared with `UntilStopConditions` via the `pending_repeat_until` resume path.",
       "cr_refs": [
         "CR 107.1c",
@@ -27819,7 +27819,7 @@
       "variants": [
         {
           "name": "ControllerChoice",
-          "line": 13280,
+          "line": 13284,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.1c: \"you may repeat this process [any number of times]\" — after each iteration fully resolves, the controller is prompted (`WaitingFor::RepeatDecision`) to repeat or stop.",
@@ -27829,7 +27829,7 @@
         },
         {
           "name": "UntilStopConditions",
-          "line": 13286,
+          "line": 13290,
           "kind": "struct",
           "field_names": [
             "stop_on_put_to_hand",
@@ -27843,7 +27843,7 @@
         },
         {
           "name": "WhileCondition",
-          "line": 13301,
+          "line": 13305,
           "kind": "struct",
           "field_names": [
             "condition",
@@ -27859,13 +27859,13 @@
     },
     "ReplacementCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14676,
+      "line": 14680,
       "doc": "Condition that gates whether a replacement effect applies. Checked when determining if the replacement is a candidate for an event.",
       "cr_refs": [],
       "variants": [
         {
           "name": "And",
-          "line": 14679,
+          "line": 14683,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -27877,7 +27877,7 @@
         },
         {
           "name": "UnlessControlsSubtype",
-          "line": 14685,
+          "line": 14689,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -27887,7 +27887,7 @@
         },
         {
           "name": "UnlessControlsOtherLeq",
-          "line": 14692,
+          "line": 14696,
           "kind": "struct",
           "field_names": [
             "count",
@@ -27900,7 +27900,7 @@
         },
         {
           "name": "UnlessControlsMatching",
-          "line": 14697,
+          "line": 14701,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -27912,7 +27912,7 @@
         },
         {
           "name": "UnlessControlsCountMatching",
-          "line": 14702,
+          "line": 14706,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -27925,7 +27925,7 @@
         },
         {
           "name": "UnlessPlayerLifeAtMost",
-          "line": 14705,
+          "line": 14709,
           "kind": "struct",
           "field_names": [
             "amount"
@@ -27937,7 +27937,7 @@
         },
         {
           "name": "UnlessMultipleOpponents",
-          "line": 14708,
+          "line": 14712,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless you have two or more opponents\" CR 614.1d — Battlebond lands (Luxury Suite, etc.)",
@@ -27947,7 +27947,7 @@
         },
         {
           "name": "UnlessYourTurn",
-          "line": 14711,
+          "line": 14715,
           "kind": "unit",
           "field_names": [],
           "doc": "\"unless it's your turn\" CR 614.1d + CR 500 — Replacement suppressed when active player is the controller.",
@@ -27958,7 +27958,7 @@
         },
         {
           "name": "UnlessQuantity",
-          "line": 14719,
+          "line": 14723,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -27971,7 +27971,7 @@
         },
         {
           "name": "OnlyIfQuantity",
-          "line": 14733,
+          "line": 14737,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -27984,7 +27984,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 14742,
+          "line": 14746,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a + CR 702.179e: \"Max speed — [replacement]\" applies only while the replacement source's controller has max speed.",
@@ -27995,7 +27995,7 @@
         },
         {
           "name": "CastViaEscape",
-          "line": 14745,
+          "line": 14749,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.138c: \"escapes with\" — replacement applies only when the creature entered the battlefield via escape.",
@@ -28005,7 +28005,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 14751,
+          "line": 14755,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -28017,7 +28017,7 @@
         },
         {
           "name": "CastFromZone",
-          "line": 14756,
+          "line": 14760,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -28029,7 +28029,7 @@
         },
         {
           "name": "EnteredFromZone",
-          "line": 14777,
+          "line": 14781,
           "kind": "struct",
           "field_names": [
             "origin_constraint",
@@ -28043,7 +28043,7 @@
         },
         {
           "name": "YouAttackedThisTurn",
-          "line": 14792,
+          "line": 14796,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 207.2c (Raid ability word) + CR 614.1c: \"if you attacked this turn\" — replacement applies only when the controller attacked with a creature earlier this turn. Evaluated against `state.creatures_attacked_this_turn` for the controller.",
@@ -28054,7 +28054,7 @@
         },
         {
           "name": "OpponentDamagedThisTurn",
-          "line": 14801,
+          "line": 14805,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.54a (Bloodthirst) + CR 614.1c: \"if an opponent was dealt damage this turn\" — replacement applies only when any opponent of the replacement's controller was the target of a damage event recorded in `state.damage_dealt_this_turn` earlier this turn. The damage need not have originated from the controller; ANY source dealing damage to ANY opponent satisfies CR 702.54a. Tracking is cleared at turn start via `start_next_turn` (CR 514.2 cleanup is one earlier mechanism; the per-turn store is cleared on the active player's next turn-start).",
@@ -28066,7 +28066,7 @@
         },
         {
           "name": "CastViaKicker",
-          "line": 14808,
+          "line": 14812,
           "kind": "struct",
           "field_names": [
             "variant",
@@ -28080,7 +28080,7 @@
         },
         {
           "name": "SourceTappedState",
-          "line": 14816,
+          "line": 14820,
           "kind": "struct",
           "field_names": [
             "tapped"
@@ -28090,7 +28090,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 14821,
+          "line": 14825,
           "kind": "struct",
           "field_names": [
             "source"
@@ -28104,7 +28104,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 14825,
+          "line": 14829,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -28117,7 +28117,7 @@
         },
         {
           "name": "EffectCausedDiscard",
-          "line": 14830,
+          "line": 14834,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 614.1a + CR 701.9a: Replacement applies only when the discard was caused by resolving a spell or ability effect, not by paying a cost or by a turn-based action (cleanup hand-size discard). Used by Library of Leng (\"If an effect causes you to discard a card...\").",
@@ -28128,7 +28128,7 @@
         },
         {
           "name": "OnlyExtraTurn",
-          "line": 14835,
+          "line": 14839,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.7 + CR 614.10: Replacement applies only when the triggering event is an *extra* turn (granted by an effect, not a natural turn). Used by Stranglehold (\"If a player would begin an extra turn...\"). Evaluated by `begin_turn_matcher` against `ProposedEvent::BeginTurn`.",
@@ -28139,7 +28139,7 @@
         },
         {
           "name": "TokenSubtypeMatches",
-          "line": 14846,
+          "line": 14850,
           "kind": "struct",
           "field_names": [
             "subtypes"
@@ -28152,7 +28152,7 @@
         },
         {
           "name": "TokenCoreTypeMatches",
-          "line": 14855,
+          "line": 14859,
           "kind": "struct",
           "field_names": [
             "core_types"
@@ -28165,7 +28165,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 14866,
+          "line": 14870,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 614.6: \"except the first one you draw in each of your draw steps\" — the replacement applies to every card-draw EXCEPT the draw step's mandatory first draw (the active player's CR 504.1 turn-based action). Used by Alhammarret's Archive (\"If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead.\"). Evaluated against `ProposedEvent::Draw`: returns `false` (suppress) when the drawing player is the active player, the current phase is the draw step, AND the player has not yet drawn a card during this step (`cards_drawn_this_step == 0`); otherwise `true` (apply replacement).",
@@ -28177,7 +28177,7 @@
         },
         {
           "name": "IfControlsMatching",
-          "line": 14874,
+          "line": 14878,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -28190,7 +28190,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 14884,
+          "line": 14888,
           "kind": "struct",
           "field_names": [
             "level"
@@ -28202,7 +28202,7 @@
         },
         {
           "name": "DuringUntapStep",
-          "line": 14892,
+          "line": 14896,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 502.3 + CR 502.4: True only during the untap step. Permanents untap as a turn-based action during the untap step (502.3) and no player receives priority then (502.4), so the only `ProposedEvent::Untap` raised during this phase is the turn-based untap. Gates an untap replacement (\"if [X] would untap during [its controller's / your] untap step, [effect] instead\" — Freyalise's Winds, Edge of Malacol) so it does NOT apply to effect-untaps (\"untap target creature\") at other times.",
@@ -28213,7 +28213,7 @@
         },
         {
           "name": "ControllerControlsSource",
-          "line": 14915,
+          "line": 14919,
           "kind": "struct",
           "field_names": [
             "source",
@@ -28228,7 +28228,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 14923,
+          "line": 14927,
           "kind": "struct",
           "field_names": [
             "text"
@@ -28647,13 +28647,13 @@
     },
     "ReplacementMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15646,
+      "line": 15650,
       "doc": "Whether a replacement effect is mandatory or offers the affected player a choice.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Mandatory",
-          "line": 15649,
+          "line": 15653,
           "kind": "unit",
           "field_names": [],
           "doc": "Always applies (default). Used for \"enters tapped\", \"prevent damage\", etc.",
@@ -28661,7 +28661,7 @@
         },
         {
           "name": "Optional",
-          "line": 15651,
+          "line": 15655,
           "kind": "struct",
           "field_names": [
             "decline"
@@ -28671,7 +28671,7 @@
         },
         {
           "name": "MayCost",
-          "line": 15658,
+          "line": 15662,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -28688,7 +28688,7 @@
     },
     "ReplacementPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 15634,
+      "line": 15638,
       "doc": "CR 614.1a: Which player(s) a replacement effect applies to, scoped relative to the replacement source player. For permanents/spells this is the source's controller; for cards outside the battlefield/stack, CR 109.4 + CR 108.4a make this the owner. `valid_player: None` keeps the source-player default; `Some(You)` is the explicit source-player scope, `Some(Opponent)` an opponent-scoped replacement (Tainted Remedy), and `Some(AnyPlayer)` a global all-players replacement (Rain of Gore).  Serialized as a bare string (no `#[serde(tag)]`) to match the prior `Option<ControllerRef>` field encoding — existing persisted / in-flight `valid_player` values (`\"You\"` / `\"Opponent\"`) deserialize unchanged.",
       "cr_refs": [
         "CR 108.4a",
@@ -28698,7 +28698,7 @@
       "variants": [
         {
           "name": "You",
-          "line": 15636,
+          "line": 15640,
           "kind": "unit",
           "field_names": [],
           "doc": "The replacement source player.",
@@ -28706,7 +28706,7 @@
         },
         {
           "name": "Opponent",
-          "line": 15638,
+          "line": 15642,
           "kind": "unit",
           "field_names": [],
           "doc": "Any opponent of the replacement source player.",
@@ -28714,7 +28714,7 @@
         },
         {
           "name": "AnyPlayer",
-          "line": 15640,
+          "line": 15644,
           "kind": "unit",
           "field_names": [],
           "doc": "Every player in the game, regardless of who controls the source.",
@@ -28725,7 +28725,7 @@
     },
     "ResolutionCastSuccessAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2187,
+      "line": 2191,
       "doc": "CR 608.2g: Follow-up after a during-resolution cast succeeds.",
       "cr_refs": [
         "CR 608.2g"
@@ -28733,7 +28733,7 @@
       "variants": [
         {
           "name": "BottomMisses",
-          "line": 2190,
+          "line": 2194,
           "kind": "unit",
           "field_names": [],
           "doc": "Cascade/Discover: cast hit is gone, so bottom the dig misses now.",
@@ -28741,7 +28741,7 @@
         },
         {
           "name": "RippleOfferRemaining",
-          "line": 2193,
+          "line": 2197,
           "kind": "struct",
           "field_names": [
             "remaining_hits"
@@ -28753,7 +28753,7 @@
         },
         {
           "name": "FreeCastOfferRemaining",
-          "line": 2202,
+          "line": 2206,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -28775,7 +28775,7 @@
     },
     "ResolutionMvRejectAction": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2172,
+      "line": 2176,
       "doc": "CR 608.2g: Disposition of a during-resolution card that is not cast.",
       "cr_refs": [
         "CR 608.2g"
@@ -28783,7 +28783,7 @@
       "variants": [
         {
           "name": "BottomWithMisses",
-          "line": 2174,
+          "line": 2178,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.85a: cascade — hit joins misses on the bottom in random order.",
@@ -28793,7 +28793,7 @@
         },
         {
           "name": "ToHand",
-          "line": 2176,
+          "line": 2180,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.57a: discover — hit goes to its owner's hand; misses to bottom.",
@@ -28803,7 +28803,7 @@
         },
         {
           "name": "RemainExiled",
-          "line": 2181,
+          "line": 2185,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.62a: Suspend's last-counter free cast — the card has no dig misses and no resulting-MV gate, so this reject disposition is only reached if a future during-resolution free cast adds a constraint. \"If you don't [cast it], it remains exiled\" — the card stays in exile.",
@@ -28816,13 +28816,13 @@
     },
     "RestrictionExpiry": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1834,
+      "line": 1838,
       "doc": "When a game restriction expires.",
       "cr_refs": [],
       "variants": [
         {
           "name": "EndOfTurn",
-          "line": 1835,
+          "line": 1839,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28830,7 +28830,7 @@
         },
         {
           "name": "EndOfCombat",
-          "line": 1836,
+          "line": 1840,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28838,7 +28838,7 @@
         },
         {
           "name": "UntilPlayerNextTurn",
-          "line": 1837,
+          "line": 1841,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28848,7 +28848,7 @@
         },
         {
           "name": "UntilEndOfNextTurnOf",
-          "line": 1847,
+          "line": 1851,
           "kind": "struct",
           "field_names": [
             "player"
@@ -28864,13 +28864,13 @@
     },
     "RestrictionPlayerScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1864,
+      "line": 1868,
       "doc": "Identifies which players are affected by a temporary game restriction.",
       "cr_refs": [],
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 1865,
+          "line": 1869,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28878,7 +28878,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 1866,
+          "line": 1870,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28886,7 +28886,7 @@
         },
         {
           "name": "TargetedPlayer",
-          "line": 1869,
+          "line": 1873,
           "kind": "unit",
           "field_names": [],
           "doc": "Placeholder used by parser lowering for effects that target a player. Resolved to `SpecificPlayer` by `add_restriction` at resolution time.",
@@ -28894,7 +28894,7 @@
         },
         {
           "name": "ParentTargetedPlayer",
-          "line": 1874,
+          "line": 1878,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Anaphoric \"that player\" in a sub-ability reuses a player target already chosen for an earlier instruction in the same chain. Resolved to `SpecificPlayer` by `add_restriction` after parent target propagation, without declaring a second target slot.",
@@ -28904,7 +28904,7 @@
         },
         {
           "name": "OpponentsOfSourceController",
-          "line": 1875,
+          "line": 1879,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -28912,7 +28912,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 1882,
+          "line": 1886,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: The defending player for the source's attack (\"Whenever ~ attacks, defending player can't cast spells this turn.\" — Xantid Swarm). Resolved to `SpecificPlayer` by `add_restriction` at resolution time via `combat::defending_player_for_attacker`, capturing the player as the restriction is created (the defending player is fixed once attackers are declared and does not change for the turn).",
@@ -28926,13 +28926,13 @@
     },
     "RestrictionScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 1855,
+      "line": 1859,
       "doc": "Limits the scope of a game restriction to specific sources or targets.",
       "cr_refs": [],
       "variants": [
         {
           "name": "SourcesControlledBy",
-          "line": 1856,
+          "line": 1860,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28940,7 +28940,7 @@
         },
         {
           "name": "SpecificSource",
-          "line": 1857,
+          "line": 1861,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28948,7 +28948,7 @@
         },
         {
           "name": "DamageToTarget",
-          "line": 1858,
+          "line": 1862,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -28994,7 +28994,7 @@
     },
     "RevealUntilDisposition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7222,
+      "line": 7226,
       "doc": "CR 701.20a + CR 608.2c: How the *set* of matching cards found by an [`Effect::RevealUntil`] is dispensed once the until-loop terminates.  The default `KeepEach` preserves the historical single-hit / each-hit behavior: every matching card is routed to `kept_destination` (or paused on `WaitingFor::RevealUntilKeptChoice` when `kept_optional_to` is set) and the non-matching cards go to `rest_destination`. With the dominant `count = Fixed(1)` this is exactly \"reveal until you reveal a [filter] card\".  `ChooseAnyNumber` covers the Aurora Awakener class — \"reveal until you reveal X [filter] cards. Put any number of those [filter] cards onto the battlefield, then put the rest of the revealed cards on the bottom of your library in a random order.\" The controller selects any subset of the matched cards for `kept_destination`; every other revealed card (non-selected matches AND the interleaved non-matching cards) flows to `rest_destination`. This is the `Effect::Dig` \"put any number onto the battlefield, rest on the bottom in a random order\" disposition (`WaitingFor::DigChoice`, CR 401.4 owner-arranged random bottom placement), reused over the reveal-until matched set.",
       "cr_refs": [
         "CR 401.4",
@@ -29004,7 +29004,7 @@
       "variants": [
         {
           "name": "KeepEach",
-          "line": 7228,
+          "line": 7232,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.20a: Route every matched card to `kept_destination` (or `kept_optional_to`); non-matches to `rest_destination`. The legacy single-hit behavior; default so the JSON shape and every existing call site stay unchanged.",
@@ -29014,7 +29014,7 @@
         },
         {
           "name": "ChooseAnyNumber",
-          "line": 7233,
+          "line": 7237,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.20a + CR 608.2c: Offer the controller a `WaitingFor::DigChoice` over the matched cards — any number go to `kept_destination`, every other revealed card goes to `rest_destination` (CR 401.4 random bottom when `rest_destination == Library`).",
@@ -29029,7 +29029,7 @@
     },
     "RoundingMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4495,
+      "line": 4499,
       "doc": "CR 107.1a: Rounding direction for fractional Oracle-text expressions. Every \"half X\" phrase in Oracle text specifies whether to round up or down; this enum records that choice verbatim so resolution is deterministic.",
       "cr_refs": [
         "CR 107.1a"
@@ -29037,7 +29037,7 @@
       "variants": [
         {
           "name": "Up",
-          "line": 4496,
+          "line": 4500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29045,7 +29045,7 @@
         },
         {
           "name": "Down",
-          "line": 4497,
+          "line": 4501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29056,7 +29056,7 @@
     },
     "RuntimeHandler": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5977,
+      "line": 5981,
       "doc": "CR 702.49: Identifies which dedicated engine path handles a RuntimeHandled ability.",
       "cr_refs": [
         "CR 702.49"
@@ -29064,7 +29064,7 @@
       "variants": [
         {
           "name": "NinjutsuFamily",
-          "line": 5979,
+          "line": 5983,
           "kind": "unit",
           "field_names": [],
           "doc": "Handled by GameAction::ActivateNinjutsu path.",
@@ -29075,7 +29075,7 @@
     },
     "SacrificeAggregateStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6096,
+      "line": 6100,
       "doc": "CR 701.21: Aggregate statistic for a sacrifice-cost selection constraint.",
       "cr_refs": [
         "CR 701.21"
@@ -29083,7 +29083,7 @@
       "variants": [
         {
           "name": "TotalPower",
-          "line": 6097,
+          "line": 6101,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29094,7 +29094,7 @@
     },
     "SacrificeRequirement": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6103,
+      "line": 6107,
       "doc": "CR 701.21: How many permanents must be sacrificed, or what aggregate constraint the chosen set must satisfy (Phyrexian Dreadnought).",
       "cr_refs": [
         "CR 701.21"
@@ -29102,7 +29102,7 @@
       "variants": [
         {
           "name": "Count",
-          "line": 6105,
+          "line": 6109,
           "kind": "struct",
           "field_names": [
             "count"
@@ -29112,7 +29112,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 6109,
+          "line": 6113,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -29185,7 +29185,7 @@
     },
     "SeatDirection": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4580,
+      "line": 4584,
       "doc": "CR 102.1 + CR 103.1: Seating direction relative to a player. The game's default turn order proceeds clockwise (CR 103.1); the next player in turn order is seated to the active player's left (CR 101.4). Thus walking forward through `seat_order` is `Left`, and walking backward is `Right`.",
       "cr_refs": [
         "CR 101.4",
@@ -29195,7 +29195,7 @@
       "variants": [
         {
           "name": "Left",
-          "line": 4583,
+          "line": 4587,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's left — the next player in turn order (CR 101.4). Forward through `seat_order`.",
@@ -29205,7 +29205,7 @@
         },
         {
           "name": "Right",
-          "line": 4586,
+          "line": 4590,
           "kind": "unit",
           "field_names": [],
           "doc": "The living player seated immediately to the controller's right — the previous player in turn order. Backward through `seat_order`.",
@@ -29284,13 +29284,13 @@
     },
     "SharedQuality": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2474,
+      "line": 2478,
       "doc": "Qualities that can be shared across multi-target selections. Used by `FilterProp::SharesQuality` for group constraint validation at resolution time.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Name",
-          "line": 2476,
+          "line": 2480,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 201.2: object names compared by shared name.",
@@ -29300,7 +29300,7 @@
         },
         {
           "name": "ManaValue",
-          "line": 2478,
+          "line": 2482,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 202.3: mana value.",
@@ -29310,7 +29310,7 @@
         },
         {
           "name": "Power",
-          "line": 2480,
+          "line": 2484,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: power.",
@@ -29320,7 +29320,7 @@
         },
         {
           "name": "Toughness",
-          "line": 2482,
+          "line": 2486,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: toughness.",
@@ -29330,7 +29330,7 @@
         },
         {
           "name": "TotalPowerToughness",
-          "line": 2484,
+          "line": 2488,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 208.1: sum of power and toughness.",
@@ -29340,7 +29340,7 @@
         },
         {
           "name": "CreatureType",
-          "line": 2485,
+          "line": 2489,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29348,7 +29348,7 @@
         },
         {
           "name": "Color",
-          "line": 2486,
+          "line": 2490,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29356,7 +29356,7 @@
         },
         {
           "name": "CardType",
-          "line": 2487,
+          "line": 2491,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29364,7 +29364,7 @@
         },
         {
           "name": "LandType",
-          "line": 2489,
+          "line": 2493,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 205.3i + CR 305.6: land subtypes, including the five basic land types.",
@@ -29378,13 +29378,13 @@
     },
     "SharedQualityRelation": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2494,
+      "line": 2498,
       "doc": "Relationship required by `FilterProp::SharesQuality`.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Shares",
-          "line": 2496,
+          "line": 2500,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29392,7 +29392,7 @@
         },
         {
           "name": "DoesNotShare",
-          "line": 2497,
+          "line": 2501,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29502,7 +29502,7 @@
     },
     "SolveCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5226,
+      "line": 5230,
       "doc": "CR 719.1: Condition that must be met for a Case to become solved. Evaluated by the auto-solve trigger at end step (CR 719.2).",
       "cr_refs": [
         "CR 719.1",
@@ -29511,7 +29511,7 @@
       "variants": [
         {
           "name": "ObjectCount",
-          "line": 5228,
+          "line": 5232,
           "kind": "struct",
           "field_names": [
             "filter",
@@ -29523,7 +29523,7 @@
         },
         {
           "name": "Condition",
-          "line": 5238,
+          "line": 5242,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -29535,7 +29535,7 @@
         },
         {
           "name": "Text",
-          "line": 5240,
+          "line": 5244,
           "kind": "struct",
           "field_names": [
             "description"
@@ -29548,13 +29548,13 @@
     },
     "SourceExclusion": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3291,
+      "line": 3295,
       "doc": "Whether a filter predicate includes or excludes the ability source object.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Include",
-          "line": 3294,
+          "line": 3298,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object may satisfy the predicate.",
@@ -29562,7 +29562,7 @@
         },
         {
           "name": "Exclude",
-          "line": 3296,
+          "line": 3300,
           "kind": "unit",
           "field_names": [],
           "doc": "The source object is excluded (\"another Aura/Equipment\" semantics).",
@@ -29573,8 +29573,8 @@
     },
     "SpecialAction": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 338,
-      "doc": "CR 116.2: A class of special action whose mana cost can be the subject of a CR 106.6 mana-spend restriction (\"Spend this mana only to unlock doors\").  Only special actions that pay a mana cost *through the mana pool* with a restriction-aware payment context belong here. CR 116.2m / CR 709.5e door unlock is the first such action (its unlock cost routes through `pay_special_action_mana_cost`). CR 116.2b turn-face-up's morph/disguise cost is not yet paid through a restriction-aware pool payment in this engine (`game::morph::turn_face_up` flips the permanent without charging the cost), so a `TurnFaceUp`-restricted mana's runtime gate ([`ManaRestriction::OnlyForSpecialAction(SpecialAction::TurnFaceUp)`]) can never be satisfied yet — it is honest-deferred (conservatively under-permitting) rather than silently over-permitting the mana. The variant exists so the restriction is representable (the cluster's cards parse to no `Effect::Unimplemented`); once the turn-face-up morph cost is routed through `PaymentContext::SpecialAction(TurnFaceUp)` the gate becomes live with no type change.",
+      "line": 342,
+      "doc": "CR 116.2: A class of special action whose mana cost can be the subject of a CR 106.6 mana-spend restriction (\"Spend this mana only to unlock doors\").  Only special actions that pay a mana cost *through the mana pool* with a restriction-aware payment context belong here. CR 116.2m / CR 709.5e door unlock is the first such action (its unlock cost routes through `pay_special_action_mana_cost`). CR 116.2b turn-face-up's morph/disguise cost is not yet paid through a restriction-aware pool payment in this engine (`game::morph::turn_face_up` flips the permanent without charging the cost), so a `TurnFaceUp`-restricted mana's runtime gate ([`ManaRestriction::OnlyForSpecialAction(SpecialAction::TurnFaceUp)`]) can never be satisfied yet — it is honest-deferred (conservatively under-permitting) rather than silently over-permitting the mana. The variant exists so the restriction stays representable as a typed value even though the `TurnFaceUp` leaf is dead today: a card whose only spend restriction is turn-face-up (Overgrown Zealot) is left unabsorbed at the `Effect::Mana` seam and intentionally surfaces an `Effect::Unimplemented` gap (honest coverage red) via `ManaSpendRestriction::has_payable_branch`. Once the turn-face-up morph cost is routed through `PaymentContext::SpecialAction(TurnFaceUp)` the gate becomes live with no type change.",
       "cr_refs": [
         "CR 106.6",
         "CR 116.2",
@@ -29585,7 +29585,7 @@
       "variants": [
         {
           "name": "UnlockDoor",
-          "line": 341,
+          "line": 345,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 116.2m + CR 709.5e: Paying a locked Room half's unlock cost to give the permanent the appropriate unlocked designation.",
@@ -29596,7 +29596,7 @@
         },
         {
           "name": "TurnFaceUp",
-          "line": 347,
+          "line": 351,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 116.2b + CR 702.37e: Paying a face-down permanent's morph/disguise cost to turn it face up. No payment site emits `PaymentContext::SpecialAction(TurnFaceUp)` yet (turn-face-up is free in this engine), so a mana restricted to this action is conservatively unspendable rather than over-permitted — see the type-level note above.",
@@ -29610,7 +29610,7 @@
     },
     "SpeedDelta": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7363,
+      "line": 7367,
       "doc": "CR 702.179c-d: Direction of a speed change. Typed (not a bool) so the `Effect::ChangeSpeed` handler dispatches exhaustively.",
       "cr_refs": [
         "CR 702.179c"
@@ -29618,7 +29618,7 @@
       "variants": [
         {
           "name": "Increase",
-          "line": 7365,
+          "line": 7369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179c-d: increase speed (capped at 4 by the speed rules).",
@@ -29628,7 +29628,7 @@
         },
         {
           "name": "Decrease",
-          "line": 7367,
+          "line": 7371,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.179f-consistent: decrease speed, treating no speed as 0.",
@@ -29641,13 +29641,13 @@
     },
     "SpellCastingOptionKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6960,
+      "line": 6964,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "AlternativeCost",
-          "line": 6961,
+          "line": 6965,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29655,7 +29655,7 @@
         },
         {
           "name": "CastWithoutManaCost",
-          "line": 6962,
+          "line": 6966,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29663,7 +29663,7 @@
         },
         {
           "name": "AsThoughHadFlash",
-          "line": 6963,
+          "line": 6967,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29671,7 +29671,7 @@
         },
         {
           "name": "CastAdventure",
-          "line": 6965,
+          "line": 6969,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 715.3a: Cast the Adventure half of an Adventure card.",
@@ -29684,7 +29684,7 @@
     },
     "SpellCostCriterion": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 438,
+      "line": 442,
       "doc": "CR 106.6 + CR 107.3 + CR 202.3: A single qualifying criterion on the cost of the spell a restricted mana may be spent on. Used by [`ManaRestriction::OnlyForSpellMatchingCostCriteria`] to express the disjunctive \"spells with mana value N or greater **or** spells with {X} in their mana costs\" reading (Helga, Skittish Seer; Troyan, Gutsy Explorer) without proliferating one variant per (threshold × X-disjunct) combination.  Both criteria are properties of the spell's *cost* (CR 202.3 mana value / CR 107.3 X symbol), so they share a single categorical axis and belong to one typed predicate rather than a raw bool flag bolted onto the mana-value variant.",
       "cr_refs": [
         "CR 106.6",
@@ -29694,7 +29694,7 @@
       "variants": [
         {
           "name": "ManaValue",
-          "line": 440,
+          "line": 444,
           "kind": "struct",
           "field_names": [
             "comparator",
@@ -29707,7 +29707,7 @@
         },
         {
           "name": "HasXInCost",
-          "line": 444,
+          "line": 448,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 107.3 + CR 202.3e: The spell's printed mana cost contains an `{X}` symbol. Detected structurally (X contributes 0 to mana value off the stack), via `SpellMeta.has_x_in_cost`.",
@@ -29757,7 +29757,7 @@
     },
     "StackAbilityKind": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3380,
+      "line": 3384,
       "doc": "CR 113.3b / CR 113.3c: Which stack ability kinds a `StackAbility` filter accepts.",
       "cr_refs": [
         "CR 113.3b",
@@ -29766,7 +29766,7 @@
       "variants": [
         {
           "name": "Activated",
-          "line": 3381,
+          "line": 3385,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29774,7 +29774,7 @@
         },
         {
           "name": "Triggered",
-          "line": 3382,
+          "line": 3386,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -29848,13 +29848,13 @@
     },
     "StaticCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5306,
+      "line": 5310,
       "doc": "Condition for static ability applicability.",
       "cr_refs": [],
       "variants": [
         {
           "name": "DevotionGE",
-          "line": 5307,
+          "line": 5311,
           "kind": "struct",
           "field_names": [
             "colors",
@@ -29865,7 +29865,7 @@
         },
         {
           "name": "IsPresent",
-          "line": 5311,
+          "line": 5315,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -29875,7 +29875,7 @@
         },
         {
           "name": "ChosenColorIs",
-          "line": 5317,
+          "line": 5321,
           "kind": "struct",
           "field_names": [
             "color"
@@ -29885,7 +29885,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 5326,
+          "line": 5330,
           "kind": "struct",
           "field_names": [
             "label"
@@ -29898,7 +29898,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 5332,
+          "line": 5336,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -29910,7 +29910,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 5338,
+          "line": 5342,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The relevant player has max speed.",
@@ -29920,7 +29920,7 @@
         },
         {
           "name": "SpeedGE",
-          "line": 5340,
+          "line": 5344,
           "kind": "struct",
           "field_names": [
             "threshold"
@@ -29933,7 +29933,7 @@
         },
         {
           "name": "And",
-          "line": 5344,
+          "line": 5348,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -29943,7 +29943,7 @@
         },
         {
           "name": "Or",
-          "line": 5348,
+          "line": 5352,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -29953,7 +29953,7 @@
         },
         {
           "name": "Not",
-          "line": 5354,
+          "line": 5358,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -29963,7 +29963,7 @@
         },
         {
           "name": "DayNightIs",
-          "line": 5358,
+          "line": 5362,
           "kind": "struct",
           "field_names": [
             "state"
@@ -29975,7 +29975,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 5367,
+          "line": 5371,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -29991,7 +29991,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 5377,
+          "line": 5381,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -30004,7 +30004,7 @@
         },
         {
           "name": "RecipientHasCounters",
-          "line": 5385,
+          "line": 5389,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -30019,7 +30019,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 5393,
+          "line": 5397,
           "kind": "struct",
           "field_names": [
             "level"
@@ -30031,7 +30031,7 @@
         },
         {
           "name": "DefendingPlayerControls",
-          "line": 5400,
+          "line": 5404,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30043,7 +30043,7 @@
         },
         {
           "name": "SourceAttackingAlone",
-          "line": 5404,
+          "line": 5408,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 506.5: True when the source creature is the only attacking creature.",
@@ -30053,7 +30053,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 5408,
+          "line": 5412,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.1k + CR 506.4: True when the source creature is currently an attacking creature. CR 508.1k defines \"attacking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being an attacker.",
@@ -30064,7 +30064,7 @@
         },
         {
           "name": "SourceIsBlocking",
-          "line": 5412,
+          "line": 5416,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1g + CR 506.4: True when the source creature is currently a blocking creature. CR 509.1g defines \"blocking creature\" (becomes one when declared, remains until removed or combat ends). CR 506.4 defines when a creature stops being a blocker.",
@@ -30075,7 +30075,7 @@
         },
         {
           "name": "SourceIsBlocked",
-          "line": 5416,
+          "line": 5420,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 509.1h: True when the source creature has been blocked this combat. Once a creature is blocked, it remains blocked for the rest of combat even if all its blockers leave — mirrors `AttackerInfo.blocked` (sticky flag).",
@@ -30085,7 +30085,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 5418,
+          "line": 5422,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when the controller is the monarch.",
@@ -30095,7 +30095,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 5420,
+          "line": 5424,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: True when the controller has the initiative.",
@@ -30105,7 +30105,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 5423,
+          "line": 5427,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: True when no player holds the monarch designation. Distinct from `Not(IsMonarch)`, which is also true when an opponent is monarch.",
@@ -30115,7 +30115,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 5425,
+          "line": 5429,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: True when the controller has the city's blessing (Ascend).",
@@ -30125,7 +30125,7 @@
         },
         {
           "name": "CompletedADungeon",
-          "line": 5428,
+          "line": 5432,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 309.7: True when the controller has completed at least one dungeon. Used by \"as long as you've completed a dungeon\" statics (Nadaar, etc.).",
@@ -30135,7 +30135,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 5434,
+          "line": 5438,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -30147,7 +30147,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 5442,
+          "line": 5446,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -30159,7 +30159,7 @@
         },
         {
           "name": "OpponentPoisonAtLeast",
-          "line": 5446,
+          "line": 5450,
           "kind": "struct",
           "field_names": [
             "count"
@@ -30171,7 +30171,7 @@
         },
         {
           "name": "UnlessPay",
-          "line": 5471,
+          "line": 5475,
           "kind": "struct",
           "field_names": [
             "cost",
@@ -30189,7 +30189,7 @@
         },
         {
           "name": "Unrecognized",
-          "line": 5480,
+          "line": 5484,
           "kind": "struct",
           "field_names": [
             "text"
@@ -30199,7 +30199,7 @@
         },
         {
           "name": "DuringYourTurn",
-          "line": 5483,
+          "line": 5487,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -30207,7 +30207,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 5486,
+          "line": 5490,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7: True when the source permanent entered the battlefield this turn. Used for \"as long as this [permanent] entered this turn\" conditional statics.",
@@ -30217,7 +30217,7 @@
         },
         {
           "name": "SourceHasDealtDamage",
-          "line": 5495,
+          "line": 5499,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 120.3/120.6 + CR 702.11b + CR 613.1f: True once the source permanent has actually dealt damage (combat or noncombat) since it entered the battlefield. Sticky per-object flag (set on the first nonzero amount of damage actually dealt per CR 120.3/120.6, not the would-be amount of CR 120.1a; reset when the object leaves the battlefield). Used as a Layer 6 (CR 613.1f) ability-adding gate for \"has hexproof if it hasn't dealt damage yet\" (Palladia-Mors, the Ruiner; Karakyk Guardian). The \"hasn't\" negation wraps this in `StaticCondition::Not`.",
@@ -30231,7 +30231,7 @@
         },
         {
           "name": "WasCast",
-          "line": 5500,
+          "line": 5504,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -30244,7 +30244,7 @@
         },
         {
           "name": "IsRingBearer",
-          "line": 5505,
+          "line": 5509,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.54a: True when this creature is the ring-bearer for its controller.",
@@ -30254,7 +30254,7 @@
         },
         {
           "name": "RingLevelAtLeast",
-          "line": 5507,
+          "line": 5511,
           "kind": "struct",
           "field_names": [
             "level"
@@ -30266,7 +30266,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 5513,
+          "line": 5517,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -30280,7 +30280,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 5518,
+          "line": 5522,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: True when the source object is tapped. Used for \"for as long as ~ remains tapped\" duration conditions.",
@@ -30290,7 +30290,7 @@
         },
         {
           "name": "IsTapped",
-          "line": 5535,
+          "line": 5539,
           "kind": "struct",
           "field_names": [
             "scope"
@@ -30304,7 +30304,7 @@
         },
         {
           "name": "SourceIsSaddled",
-          "line": 5539,
+          "line": 5543,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.171b: True when the source permanent is saddled. Negation via Not { SourceIsSaddled }.",
@@ -30314,7 +30314,7 @@
         },
         {
           "name": "SourceControllerEquals",
-          "line": 5546,
+          "line": 5550,
           "kind": "struct",
           "field_names": [
             "player"
@@ -30327,7 +30327,7 @@
         },
         {
           "name": "SourceIsEquipped",
-          "line": 5551,
+          "line": 5555,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5a: True when at least one Equipment is attached to the source object. Used for \"as long as ~ is equipped\" statics (Auriok Steelshaper, etc.).",
@@ -30337,7 +30337,7 @@
         },
         {
           "name": "SourceIsEnchanted",
-          "line": 5556,
+          "line": 5560,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 303.4: True when at least one Aura is attached to the source object. Aura-twin of `SourceIsEquipped` (CR 301.5). Used for \"as long as this creature is enchanted\" statics (Pillar of War, Thran Golem, Gate Hound, Freewind Equenaut).",
@@ -30348,7 +30348,7 @@
         },
         {
           "name": "SourceIsMonstrous",
-          "line": 5560,
+          "line": 5564,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.37: True when the source permanent is monstrous. Read from `GameObject::monstrous` (existing bool field). Used for \"as long as this creature is monstrous\" statics (Fleecemane Lion, etc.).",
@@ -30358,7 +30358,7 @@
         },
         {
           "name": "SourceIsHarnessed",
-          "line": 5566,
+          "line": 5570,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.64b + CR 702.186b: True when the source permanent is harnessed. Read from `GameObject::harnessed`. This is the ∞ (Infinity) ability gate: \"∞ — [Ability]\" grants [Ability] only while the permanent is harnessed. Sibling of `SourceIsMonstrous` — a distinct CR designation marker, not a parameterization of it (each marker is its own CR 701.x designation).",
@@ -30370,7 +30370,7 @@
         },
         {
           "name": "SourceAttachedToCreature",
-          "line": 5570,
+          "line": 5574,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 301.5 + CR 303.4: True when the source Aura/Equipment is attached to a creature. All observed Oracle text uses \"attached to a creature\"; no filter parameter needed. Used for \"as long as this Equipment is attached to a creature\" statics (Pact Weapon, etc.).",
@@ -30381,7 +30381,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 5574,
+          "line": 5578,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30393,7 +30393,7 @@
         },
         {
           "name": "RecipientMatchesFilter",
-          "line": 5586,
+          "line": 5590,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -30405,7 +30405,7 @@
         },
         {
           "name": "RecipientAttackingOwnerTarget",
-          "line": 5602,
+          "line": 5606,
           "kind": "struct",
           "field_names": [
             "target"
@@ -30420,7 +30420,7 @@
         },
         {
           "name": "SourceIsPaired",
-          "line": 5606,
+          "line": 5610,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: True while the source object is paired with another creature.",
@@ -30430,7 +30430,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 5609,
+          "line": 5613,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -30442,7 +30442,7 @@
         },
         {
           "name": "EnchantedIsFaceDown",
-          "line": 5615,
+          "line": 5619,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2 + CR 707.2: True when the creature this Aura/Equipment is attached to is face-down. Resolves against the attached-to object's `face_down` status. Used by \"as long as enchanted creature is face down\" gated statics (Unable to Scream, etc.).",
@@ -30453,7 +30453,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 5620,
+          "line": 5624,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.166a + CR 601.2f: True when an optional additional cost (Bargain) was paid for the spell currently being cast. Gates self-spell `ModifyCost` statics like Hamlet Glutton's \"This spell costs {2} less to cast if it's bargained.\" Evaluated against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).",
@@ -30464,7 +30464,7 @@
         },
         {
           "name": "None",
-          "line": 5621,
+          "line": 5625,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31784,7 +31784,7 @@
     },
     "StepSkipTarget": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 7375,
+      "line": 7379,
       "doc": "CR 500.11 + CR 614.10a: A one-shot skip can name either a single step or a whole phase. Keep whole-phase skips distinct from their first step so \"skip your next beginning of combat step\" remains representable.",
       "cr_refs": [
         "CR 500.11",
@@ -31793,7 +31793,7 @@
       "variants": [
         {
           "name": "Step",
-          "line": 7376,
+          "line": 7380,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -31801,7 +31801,7 @@
         },
         {
           "name": "CombatPhase",
-          "line": 7377,
+          "line": 7381,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31855,13 +31855,13 @@
     },
     "StickerTicketCostPayment": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10180,
+      "line": 10184,
       "doc": "",
       "cr_refs": [],
       "variants": [
         {
           "name": "PayNormally",
-          "line": 10182,
+          "line": 10186,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31869,7 +31869,7 @@
         },
         {
           "name": "WithoutPaying",
-          "line": 10183,
+          "line": 10187,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -31880,7 +31880,7 @@
     },
     "SubAbilityLink": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 13239,
+      "line": 13243,
       "doc": "CR 608.2c: How a `sub_ability` relates to its parent in the resolution chain. Determines whether the sub is part of the parent's action (skipped when an optional parent is declined) or an independent following instruction (always resolves). Derived at parse time from the `ClauseBoundary` separating the two clauses in the printed Oracle text.",
       "cr_refs": [
         "CR 608.2c"
@@ -31888,7 +31888,7 @@
       "variants": [
         {
           "name": "ContinuationStep",
-          "line": 13247,
+          "line": 13251,
           "kind": "unit",
           "field_names": [],
           "doc": "Within-sentence continuation (comma / \"then\" joined). The sub is a resolution step of the parent's instruction — Squadron Hawk \"...put them into your hand, then shuffle.\" Skipped when an optional parent is declined. This is the default: an unmarked sub is a continuation, preserving today's runtime behavior for every existing chain.",
@@ -31896,7 +31896,7 @@
         },
         {
           "name": "SequentialSibling",
-          "line": 13252,
+          "line": 13256,
           "kind": "unit",
           "field_names": [],
           "doc": "Separate-sentence sibling instruction (sentence boundary). The sub is the NEXT printed instruction, independent of the parent — Ponder \"You may shuffle.\" \"Draw a card.\" Always resolves, even when an optional parent is declined (CR 608.2c \"in the order written\").",
@@ -32075,7 +32075,7 @@
     },
     "TapCreaturesAggregateStat": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6144,
+      "line": 6148,
       "doc": "Aggregate statistic for a tap-creatures-cost selection constraint.  CR 208.1: power is the aggregate axis. Currently only `TotalPower` (Crew CR 702.122a, Saddle CR 702.171a, Teamwork). Mirrors `SacrificeAggregateStat`.",
       "cr_refs": [
         "CR 208.1",
@@ -32085,7 +32085,7 @@
       "variants": [
         {
           "name": "TotalPower",
-          "line": 6145,
+          "line": 6149,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32096,7 +32096,7 @@
     },
     "TapCreaturesRequirement": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 6181,
+      "line": 6185,
       "doc": "How many creatures must be tapped, or what aggregate constraint the chosen set must satisfy, for a `TapCreatures` cost.  `Count { count }` is the fixed-number form (Conspire's \"tap two creatures\", Convoke-style \"tap N creatures\"). `Aggregate { stat, comparator, value }` is the \"tap any number of creatures with total power N or greater\" form used by Crew (CR 702.122a), Saddle (CR 702.171a), and Teamwork. Mirrors `SacrificeRequirement` so the two cost families share one parameterization shape.",
       "cr_refs": [
         "CR 702.122a",
@@ -32105,7 +32105,7 @@
       "variants": [
         {
           "name": "Count",
-          "line": 6183,
+          "line": 6187,
           "kind": "struct",
           "field_names": [
             "count"
@@ -32115,7 +32115,7 @@
         },
         {
           "name": "Aggregate",
-          "line": 6187,
+          "line": 6191,
           "kind": "struct",
           "field_names": [
             "stat",
@@ -32130,7 +32130,7 @@
     },
     "TapStateChange": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3661,
+      "line": 3665,
       "doc": "CR 701.26a (tap) / CR 701.26b (untap): Direction of an `Effect::SetTapState`. Parameterizes the tap/untap axis so a single effect variant covers both keyword actions.",
       "cr_refs": [
         "CR 701.26a",
@@ -32139,7 +32139,7 @@
       "variants": [
         {
           "name": "Tap",
-          "line": 3663,
+          "line": 3667,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26a: Turn the permanent sideways (tap it).",
@@ -32149,7 +32149,7 @@
         },
         {
           "name": "Untap",
-          "line": 3665,
+          "line": 3669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26b: Rotate the permanent upright (untap it).",
@@ -32162,7 +32162,7 @@
     },
     "TargetChoiceTiming": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 12780,
+      "line": 12784,
       "doc": "CR 601.2c + CR 603.3d + CR 608.2d: Whether object/player choices for an ability are announced while casting/putting the ability on the stack, or chosen later during resolution by the resolving instruction.",
       "cr_refs": [
         "CR 601.2c",
@@ -32172,7 +32172,7 @@
       "variants": [
         {
           "name": "Stack",
-          "line": 12782,
+          "line": 12786,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32180,7 +32180,7 @@
         },
         {
           "name": "Resolution",
-          "line": 12783,
+          "line": 12787,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -32191,44 +32191,12 @@
     },
     "TargetFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3388,
+      "line": 3392,
       "doc": "Typed target filter replacing all Forge filter strings and TargetSpec.",
       "cr_refs": [],
       "variants": [
         {
           "name": "None",
-          "line": 3389,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Any",
-          "line": 3390,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Player",
-          "line": 3391,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Controller",
-          "line": 3392,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "SelfRef",
           "line": 3393,
           "kind": "unit",
           "field_names": [],
@@ -32236,8 +32204,40 @@
           "cr_refs": []
         },
         {
-          "name": "SourceOrPaired",
+          "name": "Any",
+          "line": 3394,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Player",
+          "line": 3395,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Controller",
           "line": 3396,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SelfRef",
+          "line": 3397,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "SourceOrPaired",
+          "line": 3400,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.95b: Resolves to the source object and the creature it is paired with. If the source is not paired, this matches no objects.",
@@ -32247,7 +32247,7 @@
         },
         {
           "name": "Typed",
-          "line": 3397,
+          "line": 3401,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -32255,7 +32255,7 @@
         },
         {
           "name": "Not",
-          "line": 3398,
+          "line": 3402,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -32265,7 +32265,7 @@
         },
         {
           "name": "Or",
-          "line": 3401,
+          "line": 3405,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -32275,7 +32275,7 @@
         },
         {
           "name": "And",
-          "line": 3404,
+          "line": 3408,
           "kind": "struct",
           "field_names": [
             "filters"
@@ -32285,7 +32285,7 @@
         },
         {
           "name": "StackAbility",
-          "line": 3414,
+          "line": 3418,
           "kind": "struct",
           "field_names": [
             "controller",
@@ -32299,7 +32299,7 @@
         },
         {
           "name": "StackSpell",
-          "line": 3424,
+          "line": 3428,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches spells on the stack (not activated/triggered abilities). CR 115.1a: Used by \"becomes the target of a spell\" triggers to filter source type.",
@@ -32309,7 +32309,7 @@
         },
         {
           "name": "SpecificObject",
-          "line": 3428,
+          "line": 3432,
           "kind": "struct",
           "field_names": [
             "id"
@@ -32319,7 +32319,7 @@
         },
         {
           "name": "SpecificPlayer",
-          "line": 3436,
+          "line": 3440,
           "kind": "struct",
           "field_names": [
             "id"
@@ -32332,7 +32332,7 @@
         },
         {
           "name": "Neighbor",
-          "line": 3444,
+          "line": 3448,
           "kind": "struct",
           "field_names": [
             "direction"
@@ -32345,7 +32345,7 @@
         },
         {
           "name": "ScopedPlayer",
-          "line": 3450,
+          "line": 3454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.10 + CR 608.2c: The current player being affected by an \"each player/opponent\" instruction during resolution. This is not the ability controller; \"you\" and \"your\" still refer to `controller`.",
@@ -32356,7 +32356,7 @@
         },
         {
           "name": "AttachedTo",
-          "line": 3453,
+          "line": 3457,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches the permanent that the trigger source (Equipment/Aura) is attached to. Used for \"equipped creature\" / \"enchanted creature\" trigger subjects.",
@@ -32364,7 +32364,7 @@
         },
         {
           "name": "LastCreated",
-          "line": 3456,
+          "line": 3460,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the most recently created token(s) from Effect::Token. Used for \"create X and [verb] it\" patterns (e.g. \"create a token and suspect it\").",
@@ -32372,7 +32372,7 @@
         },
         {
           "name": "LastRevealed",
-          "line": 3463,
+          "line": 3467,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.20e + CR 608.2c: Resolves to the most recently looked-at or revealed card(s) from a `Dig`/`RevealTop` effect in the current resolution (`state.last_revealed_ids`). Used by anaphoric \"it\" / \"that card\" references after \"look at the top card of your library\" (Amareth, the Lustrous) and by `AbilityCondition::ObjectsShareQuality` subject slots.",
@@ -32383,7 +32383,7 @@
         },
         {
           "name": "CostPaidObject",
-          "line": 3467,
+          "line": 3471,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the resolving spell or ability. Used by effects such as \"the exiled card\" after an exile-as-cost clause.",
@@ -32394,7 +32394,7 @@
         },
         {
           "name": "TrackedSet",
-          "line": 3470,
+          "line": 3474,
           "kind": "struct",
           "field_names": [
             "id"
@@ -32406,7 +32406,7 @@
         },
         {
           "name": "TrackedSetFiltered",
-          "line": 3497,
+          "line": 3501,
           "kind": "struct",
           "field_names": [
             "id",
@@ -32423,7 +32423,7 @@
         },
         {
           "name": "ExiledBySource",
-          "line": 3505,
+          "line": 3509,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2a: Cards exiled by a specific source via \"exile until ~ leaves\" links. Resolves via relational `state.exile_links` lookup, not intrinsic object properties.",
@@ -32433,7 +32433,7 @@
         },
         {
           "name": "ExiledCardByIndex",
-          "line": 3511,
+          "line": 3515,
           "kind": "struct",
           "field_names": [
             "index"
@@ -32445,7 +32445,7 @@
         },
         {
           "name": "TriggeringSpellController",
-          "line": 3515,
+          "line": 3519,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the controller of the spell/ability that triggered this.",
@@ -32455,7 +32455,7 @@
         },
         {
           "name": "TriggeringSpellOwner",
-          "line": 3517,
+          "line": 3521,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the owner of the spell/ability that triggered this.",
@@ -32465,7 +32465,7 @@
         },
         {
           "name": "TriggeringPlayer",
-          "line": 3519,
+          "line": 3523,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the player involved in the triggering event.",
@@ -32475,7 +32475,7 @@
         },
         {
           "name": "TriggeringSource",
-          "line": 3521,
+          "line": 3525,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c: Resolves to the source object of the triggering event.",
@@ -32485,7 +32485,7 @@
         },
         {
           "name": "TriggeringSourceController",
-          "line": 3531,
+          "line": 3535,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.7c + CR 109.4 + CR 110.2: Resolves to the *controller* of the triggering event's source object — the player-level counterpart of `TriggeringSource`, mirroring how `TriggeringSpellController` is the controller of `StackSpell`. Used by \"the attacking player\" / \"its controller\" anaphors on `DamageReceived` triggers where the wanted player is the controller of the creature that dealt combat damage, not the damaged player (`TriggeringPlayer`). Powers Contested Game Ball (\"Whenever you're dealt combat damage, the attacking player gains control of this artifact and untaps it.\").",
@@ -32497,7 +32497,7 @@
         },
         {
           "name": "ParentTarget",
-          "line": 3536,
+          "line": 3540,
           "kind": "unit",
           "field_names": [],
           "doc": "Resolves to the same target(s) as the parent ability. Used for anaphoric \"it\"/\"that creature\"/\"that player\" in compound effects (e.g., \"tap target creature and put a stun counter on it\"). At resolution time, the sub_ability chain inherits parent targets automatically.",
@@ -32505,7 +32505,7 @@
         },
         {
           "name": "ParentTargetSlot",
-          "line": 3541,
+          "line": 3545,
           "kind": "struct",
           "field_names": [
             "index"
@@ -32517,7 +32517,7 @@
         },
         {
           "name": "ParentTargetController",
-          "line": 3547,
+          "line": 3551,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c: Resolves to the controller of the parent ability's target object. Used for \"its controller\" in compound effects (e.g., \"counter target spell. Its controller loses 2 life.\"). At resolution time, looks up the controller of the first parent target.",
@@ -32527,7 +32527,7 @@
         },
         {
           "name": "ParentTargetOwner",
-          "line": 3558,
+          "line": 3562,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 108.3 + CR 608.2c: Resolves to the *owner* of the parent ability's target object. Used for \"its owner\" anaphoric references where the acting player is the owner of a previously-mentioned permanent — e.g., Enslave's \"enchanted creature deals 1 damage to its owner\" or Bomb Squad's \"that creature deals 4 damage to its owner\". Resolution mirrors `ParentTargetController` (parent target slot → trigger-event source → AttachedTo host on source for Aura phase triggers), but returns the resolved object's `owner` rather than `controller` per CR 108.3.  Distinct from `Owner` (which always reads the source object's owner) and `ParentTargetController` (which returns the controller per CR 109.4).",
@@ -32539,7 +32539,7 @@
         },
         {
           "name": "SourceChosenPlayer",
-          "line": 3563,
+          "line": 3567,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 607.2d + CR 608.2c: Resolves to the player chosen for the source by a linked persisted choice (\"the chosen player\"). This is not a target slot and is distinct from `ControllerRef::ChosenPlayer`, which is resolution-scoped to the current ability chain.",
@@ -32550,7 +32550,7 @@
         },
         {
           "name": "OriginalController",
-          "line": 3584,
+          "line": 3588,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 109.5 + CR 608.2c: Resolves to the ability's *original* controller — the player who put the spell or ability on the stack — even when a surrounding `player_scope` iteration has rebound `ResolvedAbility::controller` to a different player for the current per-player iteration.  At resolution time, returns `ability.original_controller.unwrap_or(ability.controller)`. This mirrors the quantity-layer behavior in `resolve_quantity_with_targets`, where \"you\" / \"your\" quantities always read the original controller.  Used by parser-level distribution of compound subjects like \"you and that player each Y\" — the first half (\"you\") MUST resolve to the printed ability controller, not the iterated voter, even when the parent ability has `player_scope: PlayerFilter::VotedFor` (Master of Ceremonies pattern, CR 800.4g).  Distinct from `Controller` (which resolves to `ability.controller` and is rebound per-iteration by the player_scope driver in `resolve_ability_chain`). Distinct from `ParentTargetController` (parent's target's controller) and `PostReplacementSourceController` (replacement-context source's controller).",
@@ -32562,7 +32562,7 @@
         },
         {
           "name": "PostReplacementSourceController",
-          "line": 3603,
+          "line": 3607,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5 + CR 609.7: Resolves to the controller of the *prevented event's* damage source. Used by prevention follow-up sentences such as \"the source's controller draws cards equal to the damage prevented this way\" (Swans of Bryn Argoll) and \"deals damage to that source's controller\" (Deflecting Palm class). At resolution time, looks up `state.post_replacement_event_source` and returns its controller.  Distinct from `ParentTargetController` (which resolves via the parent ability's target slot) and `TriggeringSpellController` (which resolves via `state.current_trigger_event`, which is `None` during post-replacement resolution). Architectural twin of the quantity-side `last_effect_count` fallback at `replacement.rs:317` — both stash event context that lives outside the trigger window. The parser never emits this variant directly; the prevention follow-up call site rewrites `ParentTargetController` → `PostReplacementSourceController` via `each_target_filter_mut` after `parse_effect_chain` returns, so the surface phrase \"the source's controller\" can stay consolidated in `parse_target` for non-prevention callers.",
@@ -32573,7 +32573,7 @@
         },
         {
           "name": "PostReplacementDamageTarget",
-          "line": 3608,
+          "line": 3612,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 615.5: Resolves to the player or permanent that was the target of the prevented damage event. Used by prevention follow-up sentences such as \"that player exiles that many cards\" where the affected player is the damage recipient, not the replacement source or damage source.",
@@ -32583,7 +32583,7 @@
         },
         {
           "name": "DefendingPlayer",
-          "line": 3612,
+          "line": 3616,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 508.5 / CR 508.5a: Resolves to the defending player for the source attacking creature, looked up per attacker through `combat::defending_player_for_attacker`.",
@@ -32594,7 +32594,7 @@
         },
         {
           "name": "HasChosenName",
-          "line": 3615,
+          "line": 3619,
           "kind": "unit",
           "field_names": [],
           "doc": "Matches objects whose name equals the source's ChosenAttribute::CardName. Used for \"card with the chosen name\" patterns.",
@@ -32602,7 +32602,7 @@
         },
         {
           "name": "ChosenDamageSource",
-          "line": 3619,
+          "line": 3623,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 609.7a: Matches the object stored as the source's chosen damage source. Resolution-time prevention effects should resolve this to `SpecificObject` when the shield is created so global shields do not depend on a live source.",
@@ -32612,7 +32612,7 @@
         },
         {
           "name": "Named",
-          "line": 3622,
+          "line": 3626,
           "kind": "struct",
           "field_names": [
             "name"
@@ -32622,7 +32622,7 @@
         },
         {
           "name": "Owner",
-          "line": 3630,
+          "line": 3634,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.3: Resolves to the owner of the object referenced by `source_id`. Used for \"its owner's library/hand/graveyard\" phrasings where the acting player must be the card's owner, not its current controller (e.g., Nexus of Fate's shuffle-back replacement when the card is under opposing control via Mind Control).",
@@ -32632,7 +32632,7 @@
         },
         {
           "name": "AllPlayers",
-          "line": 3637,
+          "line": 3641,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 118.12a: Every player in the game (controller + opponents), polled in APNAP order. The unless-payer population for \"[Effect] unless any player pays ...\" clauses (Cleansing, Rhystic cycle, Soul Strings). Resolution is a sequential poll — the first player to pay prevents the effect — so this variant is only valid as an `UnlessPayModifier.payer`; it is never used as a target or affected filter.",
@@ -32663,13 +32663,13 @@
     },
     "TargetRef": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 16397,
+      "line": 16401,
       "doc": "Unified target reference for creatures and players.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Object",
-          "line": 16398,
+          "line": 16402,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -32677,7 +32677,7 @@
         },
         {
           "name": "Player",
-          "line": 16399,
+          "line": 16403,
           "kind": "tuple",
           "field_names": [],
           "doc": "",
@@ -32732,7 +32732,7 @@
     },
     "TargetSelectionMode": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3129,
+      "line": 3133,
       "doc": "CR 115.1 + CR 701.9b: How a target slot's referent is selected.  CR 115.1: Default — the spell/ability's controller chooses each target. CR 701.9b: Some effects override the controller-choice default by requiring the game to make the selection (analogous to \"random discard\" — the affected player does not choose). Magic Oracle text expresses this with the modifier \"random target [predicate]\" appearing immediately before the target word (Mana Clash, Goblin Lyre, Pixie Queen, Vexing Sphinx, Maddening Hex, etc.).  Categorical-boundary check (per CLAUDE.md \"Parameterize, don't proliferate\"): this enum is the *selection-mode* axis — one level above the predicate (`TargetFilter`) and orthogonal to slot count (`MultiTargetSpec`). It does not belong on `TargetFilter` (which captures *what* matches), nor on `MultiTargetSpec` (which captures *how many*). It captures *who selects*.",
       "cr_refs": [
         "CR 115.1",
@@ -32741,7 +32741,7 @@
       "variants": [
         {
           "name": "Chosen",
-          "line": 3132,
+          "line": 3136,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 115.1: The spell or ability's controller chooses each target.",
@@ -32751,7 +32751,7 @@
         },
         {
           "name": "Random",
-          "line": 3135,
+          "line": 3139,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9b (analogous): The game selects each target uniformly at random from the legal-target set. The controller does not choose.",
@@ -32764,7 +32764,7 @@
     },
     "ThisWayCause": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 3356,
+      "line": 3360,
       "doc": "CR 608.2c: Producer-action provenance for a tracked-set member — the keyword action (or one-shot zone change) that made the object part of a \"this way\" set. This is the IDENTITY of a \"<verb>ed this way\" relationship: it is the ACTION performed on the member, NOT the zone the member finally landed in.  Binding \"this way\" consumers to the action rather than the destination zone is required for two reasons (issue #2932):    1. CR 608.2c ordering — multiple distinct producer actions share the same      destination. Sacrifice (CR 701.21a), destroy (CR 701.8a), mill      (CR 701.17a), and discard (CR 701.9a) all land in the graveyard, so a      chain that mills AND sacrifices before a later \"sacrificed this way\"      consumer cannot be disambiguated by zone alone.   2. CR 614.1 / CR 614.6 replacement redirection — a replacement effect can      change a member's destination. With a Rest-in-Peace-style replacement a      sacrificed or discarded object lands in Exile, but it was still      *sacrificed / discarded this way*. The cause is the action, so it      survives the redirect; a zone binding would miss it.  Each variant cites the keyword action that produces it. `Returned` / `Bounced` are plain zone changes governed by CR 400.7 (no dedicated keyword action), distinguished by destination (battlefield vs. hand).",
       "cr_refs": [
         "CR 400.7",
@@ -32779,7 +32779,7 @@
       "variants": [
         {
           "name": "Exiled",
-          "line": 3358,
+          "line": 3362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.13a: the member was exiled this way.",
@@ -32789,7 +32789,7 @@
         },
         {
           "name": "Sacrificed",
-          "line": 3361,
+          "line": 3365,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.21a: the member was sacrificed this way (cause survives a replacement that redirects the sacrifice to another zone — CR 614.6).",
@@ -32800,7 +32800,7 @@
         },
         {
           "name": "Destroyed",
-          "line": 3363,
+          "line": 3367,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.8a: the member was destroyed this way.",
@@ -32810,7 +32810,7 @@
         },
         {
           "name": "Milled",
-          "line": 3365,
+          "line": 3369,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.17a: the member was milled this way.",
@@ -32820,7 +32820,7 @@
         },
         {
           "name": "Discarded",
-          "line": 3368,
+          "line": 3372,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.9a: the member was discarded this way (cause survives a replacement that redirects the discard to another zone — CR 614.6).",
@@ -32831,7 +32831,7 @@
         },
         {
           "name": "Returned",
-          "line": 3371,
+          "line": 3375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was returned (put onto the battlefield) this way by a one-shot put-onto-battlefield instruction.",
@@ -32842,7 +32842,7 @@
         },
         {
           "name": "Bounced",
-          "line": 3374,
+          "line": 3378,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 608.2c + CR 400.7: the member was bounced (returned to its owner's hand) this way by a mass-bounce instruction.",
@@ -32979,13 +32979,13 @@
     },
     "TriggerCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14271,
+      "line": 14275,
       "doc": "Intervening-if condition for triggered abilities. Checked both when the trigger would fire and when it resolves on the stack.  Predicates are leaf conditions (\"you gained life\", \"you descended\"). `And`/`Or` compose multiple predicates for compound conditions (\"if you gained and lost life this turn\").  Adding a new condition: 1. Add a variant here with the predicate's natural subject baked in 2. Add a match arm in `check_trigger_condition` (game/triggers.rs) 3. Add parser support in `extract_if_condition` (parser/oracle_trigger.rs) 4. Add any per-turn tracking fields to `Player` / `GameState` if needed",
       "cr_refs": [],
       "variants": [
         {
           "name": "GainedLife",
-          "line": 14274,
+          "line": 14278,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -32995,7 +32995,7 @@
         },
         {
           "name": "LostLife",
-          "line": 14276,
+          "line": 14280,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you lost life this turn\"",
@@ -33003,7 +33003,7 @@
         },
         {
           "name": "Descended",
-          "line": 14278,
+          "line": 14282,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if you descended this turn\" (a permanent card was put into your graveyard)",
@@ -33011,7 +33011,7 @@
         },
         {
           "name": "ControlsType",
-          "line": 14280,
+          "line": 14284,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33021,7 +33021,7 @@
         },
         {
           "name": "NoSpellsCastLastTurn",
-          "line": 14282,
+          "line": 14286,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if no spells were cast last turn\" — werewolf transform condition.",
@@ -33031,7 +33031,7 @@
         },
         {
           "name": "TwoOrMoreSpellsCastLastTurn",
-          "line": 14284,
+          "line": 14288,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if two or more spells were cast last turn\" — werewolf reverse transform.",
@@ -33041,7 +33041,7 @@
         },
         {
           "name": "DuringPlayersTurn",
-          "line": 14294,
+          "line": 14298,
           "kind": "struct",
           "field_names": [
             "player"
@@ -33054,7 +33054,7 @@
         },
         {
           "name": "SourceEnteredThisTurn",
-          "line": 14297,
+          "line": 14301,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 400.7 + CR 603.4: True when the source permanent entered the battlefield this turn.",
@@ -33065,7 +33065,7 @@
         },
         {
           "name": "EchoDue",
-          "line": 14300,
+          "line": 14304,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.30a: Echo intervening-if for a permanent that has not yet had its next-controller-upkeep echo payment handled.",
@@ -33075,7 +33075,7 @@
         },
         {
           "name": "MinCoAttackers",
-          "line": 14313,
+          "line": 14317,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -33089,7 +33089,7 @@
         },
         {
           "name": "SolveConditionMet",
-          "line": 14320,
+          "line": 14324,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 719.2: Intervening-if for Case auto-solve. True when the source Case is unsolved AND its solve condition is met.",
@@ -33099,7 +33099,7 @@
         },
         {
           "name": "ClassLevelGE",
-          "line": 14323,
+          "line": 14327,
           "kind": "struct",
           "field_names": [
             "level"
@@ -33111,7 +33111,7 @@
         },
         {
           "name": "SourceIsHarnessed",
-          "line": 14329,
+          "line": 14333,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.64b + CR 702.186b: True when the source permanent is harnessed. The intervening-if counterpart of `StaticCondition::SourceIsHarnessed` — gates an ∞ (Infinity) triggered ability so it only fires while the permanent is harnessed. Mirrors `ClassLevelGE`'s \"active only past a per-object designation\" gating.",
@@ -33122,7 +33122,7 @@
         },
         {
           "name": "AttractionVisitRoll",
-          "line": 14332,
+          "line": 14336,
           "kind": "struct",
           "field_names": [
             "min",
@@ -33136,7 +33136,7 @@
         },
         {
           "name": "WasCast",
-          "line": 14347,
+          "line": 14351,
           "kind": "struct",
           "field_names": [
             "zone",
@@ -33153,7 +33153,7 @@
         },
         {
           "name": "WasPlayed",
-          "line": 14358,
+          "line": 14362,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 305.1 + CR 603.4: Intervening/event condition for zone-change triggers whose subject must have been played as a land. Negation (\"without being played\") is expressed via `Not { Box::new(WasPlayed) }`.",
@@ -33164,7 +33164,7 @@
         },
         {
           "name": "AdditionalCostPaid",
-          "line": 14363,
+          "line": 14367,
           "kind": "struct",
           "field_names": [
             "source",
@@ -33182,7 +33182,7 @@
         },
         {
           "name": "SourceIsAttacking",
-          "line": 14383,
+          "line": 14387,
           "kind": "unit",
           "field_names": [],
           "doc": "\"if it's attacking\" — true when the trigger source object is currently an attacker. CR 508.1: Used by ninjutsu ETB triggers (e.g., Thousand-Faced Shadow).",
@@ -33192,7 +33192,7 @@
         },
         {
           "name": "CastVariantPaid",
-          "line": 14389,
+          "line": 14393,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -33207,7 +33207,7 @@
         },
         {
           "name": "CastVariantPaidPersistent",
-          "line": 14394,
+          "line": 14398,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -33220,7 +33220,7 @@
         },
         {
           "name": "ActivatedAbilityIsNonMana",
-          "line": 14398,
+          "line": 14402,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 605.1a + CR 603.4: Event qualifier for \"that isn't a mana ability\" on activated-ability trigger events.",
@@ -33231,7 +33231,7 @@
         },
         {
           "name": "DealtDamageBySourceThisTurn",
-          "line": 14402,
+          "line": 14406,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 700.4 + CR 120.1: \"a creature dealt damage by ~ this turn dies\" — death trigger gated on the dying creature having been dealt damage by the trigger source this turn.",
@@ -33242,7 +33242,7 @@
         },
         {
           "name": "DealtDamageThisTurnBySource",
-          "line": 14407,
+          "line": 14411,
           "kind": "struct",
           "field_names": [
             "source"
@@ -33256,7 +33256,7 @@
         },
         {
           "name": "FirstTimeObjectTappedThisTurn",
-          "line": 14414,
+          "line": 14418,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.26 + CR 603.4: True iff the triggering object (the permanent that became tapped) has become tapped exactly once so far this turn — i.e. this is the first time. Read from `GameState.object_tap_count_this_turn` against the tapped object's id. Per CR 603.4 it is checked at both trigger time and resolution; the count model lets the resolution-time re-check stay correct.",
@@ -33267,7 +33267,7 @@
         },
         {
           "name": "WasType",
-          "line": 14419,
+          "line": 14423,
           "kind": "struct",
           "field_names": [
             "card_type"
@@ -33280,7 +33280,7 @@
         },
         {
           "name": "LifeTotalGE",
-          "line": 14422,
+          "line": 14426,
           "kind": "struct",
           "field_names": [
             "minimum"
@@ -33292,7 +33292,7 @@
         },
         {
           "name": "ControlCount",
-          "line": 14426,
+          "line": 14430,
           "kind": "struct",
           "field_names": [
             "minimum",
@@ -33305,7 +33305,7 @@
         },
         {
           "name": "ControlsNone",
-          "line": 14430,
+          "line": 14434,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33317,7 +33317,7 @@
         },
         {
           "name": "AttackedThisTurn",
-          "line": 14434,
+          "line": 14438,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if you attacked this turn\" — true when the controller declared attackers during this turn's combat phase.",
@@ -33327,7 +33327,7 @@
         },
         {
           "name": "FirstCombatPhaseOfTurn",
-          "line": 14437,
+          "line": 14441,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 500.8 + CR 506.1 + CR 603.4: \"if it's the first combat phase of the turn\". True during the first combat phase started this turn, including its steps.",
@@ -33339,7 +33339,7 @@
         },
         {
           "name": "CastSpellThisTurn",
-          "line": 14441,
+          "line": 14445,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33351,7 +33351,7 @@
         },
         {
           "name": "QuantityComparison",
-          "line": 14444,
+          "line": 14448,
           "kind": "struct",
           "field_names": [
             "lhs",
@@ -33363,7 +33363,7 @@
         },
         {
           "name": "HasMaxSpeed",
-          "line": 14450,
+          "line": 14454,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.178a: The trigger functions only while its controller has max speed.",
@@ -33373,7 +33373,7 @@
         },
         {
           "name": "IsMonarch",
-          "line": 14453,
+          "line": 14457,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if you're the monarch\" is true when the controller is the monarch.",
@@ -33383,7 +33383,7 @@
         },
         {
           "name": "IsInitiative",
-          "line": 14456,
+          "line": 14460,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 726.3: \"if you have the initiative\" is true when the controller has the initiative designation.",
@@ -33393,7 +33393,7 @@
         },
         {
           "name": "NoMonarch",
-          "line": 14459,
+          "line": 14463,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 725.1: \"if there is no monarch\" is true when no player holds the monarch designation. Distinct from `Not(IsMonarch)`.",
@@ -33403,7 +33403,7 @@
         },
         {
           "name": "WasStartingPlayer",
-          "line": 14466,
+          "line": 14470,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -33415,7 +33415,7 @@
         },
         {
           "name": "SpellCastWithVariantThisTurn",
-          "line": 14471,
+          "line": 14475,
           "kind": "struct",
           "field_names": [
             "variant"
@@ -33427,7 +33427,7 @@
         },
         {
           "name": "HasCityBlessing",
-          "line": 14475,
+          "line": 14479,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.131a: \"if you have the city's blessing\" — true when the controller has Ascend.",
@@ -33437,7 +33437,7 @@
         },
         {
           "name": "CompletedDungeon",
-          "line": 14480,
+          "line": 14484,
           "kind": "struct",
           "field_names": [
             "specific"
@@ -33449,7 +33449,7 @@
         },
         {
           "name": "SourceIsTapped",
-          "line": 14486,
+          "line": 14490,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 110.5b: \"if this [permanent] is tapped\" — checks the source's tapped status. Negation (\"untapped\") is expressed via `Not { Box::new(SourceIsTapped) }`.",
@@ -33459,7 +33459,7 @@
         },
         {
           "name": "SourceIsTransformed",
-          "line": 14491,
+          "line": 14495,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.27g: \"if this [permanent] is transformed\" — checks the source's transformed status. A \"transformed permanent\" is a double-faced permanent on the battlefield with its back face up. Negation (\"not transformed\") is expressed via `Not { Box::new(SourceIsTransformed) }`.",
@@ -33469,7 +33469,7 @@
         },
         {
           "name": "SourceIsFaceUp",
-          "line": 14494,
+          "line": 14498,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-up\" — checks the source's face-up status. Negation (\"face-down\") is expressed via `Not { Box::new(SourceIsFaceUp) }`.",
@@ -33479,7 +33479,7 @@
         },
         {
           "name": "SourceIsFaceDown",
-          "line": 14497,
+          "line": 14501,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 708.2: \"if this [permanent] is face-down\" — checks the source's face-down status. Negation (\"face-up\") is expressed via `Not { Box::new(SourceIsFaceDown) }`.",
@@ -33489,7 +33489,7 @@
         },
         {
           "name": "SourceInZone",
-          "line": 14499,
+          "line": 14503,
           "kind": "struct",
           "field_names": [
             "zone"
@@ -33501,7 +33501,7 @@
         },
         {
           "name": "CounterAddedThisTurn",
-          "line": 14502,
+          "line": 14506,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 122.1: \"if you put a counter on a permanent this turn\" — true when the controller added any counter to any permanent this turn.",
@@ -33511,7 +33511,7 @@
         },
         {
           "name": "LostLifeLastTurn",
-          "line": 14506,
+          "line": 14510,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4: \"if an opponent lost life this turn\" / \"if that player lost life this turn\" — checks whether a specific player reference lost life (this turn or last turn).",
@@ -33521,7 +33521,7 @@
         },
         {
           "name": "DefendingPlayerControlsNone",
-          "line": 14510,
+          "line": 14514,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33534,7 +33534,7 @@
         },
         {
           "name": "TributeNotPaid",
-          "line": 14513,
+          "line": 14517,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 702.104a: \"if tribute wasn't paid\" — Tribute mechanic intervening-if.",
@@ -33544,7 +33544,7 @@
         },
         {
           "name": "CastDuringPhase",
-          "line": 14517,
+          "line": 14521,
           "kind": "struct",
           "field_names": [
             "phases"
@@ -33557,7 +33557,7 @@
         },
         {
           "name": "CastTimingPermission",
-          "line": 14520,
+          "line": 14524,
           "kind": "struct",
           "field_names": [
             "permission"
@@ -33570,7 +33570,7 @@
         },
         {
           "name": "ManaColorSpent",
-          "line": 14522,
+          "line": 14526,
           "kind": "struct",
           "field_names": [
             "color",
@@ -33583,7 +33583,7 @@
         },
         {
           "name": "ManaSpentCondition",
-          "line": 14524,
+          "line": 14528,
           "kind": "struct",
           "field_names": [
             "text"
@@ -33595,7 +33595,7 @@
         },
         {
           "name": "HadCounters",
-          "line": 14526,
+          "line": 14530,
           "kind": "struct",
           "field_names": [
             "counter_type"
@@ -33607,7 +33607,7 @@
         },
         {
           "name": "ControlsCommander",
-          "line": 14530,
+          "line": 14534,
           "kind": "struct",
           "field_names": [
             "ownership"
@@ -33621,7 +33621,7 @@
         },
         {
           "name": "IsRenowned",
-          "line": 14537,
+          "line": 14541,
           "kind": "struct",
           "field_names": [
             "subject"
@@ -33635,7 +33635,7 @@
         },
         {
           "name": "HasCounters",
-          "line": 14542,
+          "line": 14546,
           "kind": "struct",
           "field_names": [
             "counters",
@@ -33650,7 +33650,7 @@
         },
         {
           "name": "ZoneChangeObjectMatchesFilter",
-          "line": 14553,
+          "line": 14557,
           "kind": "struct",
           "field_names": [
             "origin",
@@ -33666,7 +33666,7 @@
         },
         {
           "name": "ZoneChangeObjectIsTapped",
-          "line": 14568,
+          "line": 14572,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 110.5b: Intervening-if for an \"enters tapped\" rider whose subject is the permanent named by the trigger event (the entering permanent), NOT the permanent that owns the ability. Distinct from `SourceIsTapped`, which checks the ability's own source. Used by \"Whenever a [filter] enters tapped\" observer triggers (Amulet of Vigor, Tiller Engine) and, via `Not`, \"enters untapped\" (Charismatic Conqueror). Mirrors the source-vs-event-object split already established by `SourceMatchesFilter` / `ZoneChangeObjectMatchesFilter`.",
@@ -33678,7 +33678,7 @@
         },
         {
           "name": "SourceMatchesFilter",
-          "line": 14571,
+          "line": 14575,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33691,7 +33691,7 @@
         },
         {
           "name": "EventDamageSourceMatchesFilter",
-          "line": 14584,
+          "line": 14588,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33704,7 +33704,7 @@
         },
         {
           "name": "DamagedPlayerIsEventSourceOwner",
-          "line": 14598,
+          "line": 14602,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 120.1 + CR 108.3 + CR 603.4: Intervening-if predicate that holds when the player dealt the triggering damage is the OWNER of the object that dealt it (\"deals combat damage to its owner\"). Reads the triggering `GameEvent::DamageDealt`: true when `target == Player(p)` and the damage source object's `owner == p` (CR 120.1: the object that deals damage is the source of that damage). Distinct from `EventDamageSourceMatchesFilter` (which filters the damage *source* by a TargetFilter) and from `DealtDamageBySourceThisTurn` (which gates a dying creature against this-turn damage records) — this gates the recipient↔source-owner relation, which no static `TargetFilter` can express. Evaluated at both fire-time and resolution-time per CR 603.4, and per synthetic per-source event on the aggregate combat-damage path. The Beast, Deathless Prince.",
@@ -33716,7 +33716,7 @@
         },
         {
           "name": "ChosenLabelIs",
-          "line": 14608,
+          "line": 14612,
           "kind": "struct",
           "field_names": [
             "label"
@@ -33730,7 +33730,7 @@
         },
         {
           "name": "AttackersDeclaredCount",
-          "line": 14622,
+          "line": 14626,
           "kind": "struct",
           "field_names": [
             "subject",
@@ -33747,7 +33747,7 @@
         },
         {
           "name": "ExceptFirstDrawInDrawStep",
-          "line": 14636,
+          "line": 14640,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 121.1 + CR 504.1 + CR 603.4: \"except the first one [you|they] draw in each of [your|their] draw steps\" — the trigger fires for every card-draw EXCEPT the draw step's mandatory first draw. Used by Orcish Bowmasters (\"Whenever an opponent draws a card except the first one they draw in each of their draw steps, ~ deals 1 damage to any target.\"). Reads the `nth_in_step` ordinal embedded in the `GameEvent::CardDrawn` event: returns `false` when the drawing player is the active player, the current phase is the draw step, AND `nth_in_step == 1`; otherwise `true`.",
@@ -33759,7 +33759,7 @@
         },
         {
           "name": "PlacedByAbilitySource",
-          "line": 14647,
+          "line": 14651,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.4 + CR 603.6a + CR 400.7: \"if it was put onto the battlefield with this ability\" — true when the triggering zone-change object's `entered_via_ability_source` equals the trigger's own source id (i.e. THIS ability placed it). Used by anti-recursion ETB guards (Kodama of the East Tree). The negation (\"if it wasn't ... with this ability\") wraps via `Not { condition: Box::new(PlacedByAbilitySource) }`, mirroring `Not(WasCast)` — no `negated: bool`. Resolves the entering object from the `GameEvent::ZoneChanged` event, falling back to the trigger source for self-referential cases.",
@@ -33771,7 +33771,7 @@
         },
         {
           "name": "TriggeringSpellTargetsFilter",
-          "line": 14653,
+          "line": 14657,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -33785,7 +33785,7 @@
         },
         {
           "name": "And",
-          "line": 14657,
+          "line": 14661,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -33795,7 +33795,7 @@
         },
         {
           "name": "Or",
-          "line": 14659,
+          "line": 14663,
           "kind": "struct",
           "field_names": [
             "conditions"
@@ -33805,7 +33805,7 @@
         },
         {
           "name": "Not",
-          "line": 14669,
+          "line": 14673,
           "kind": "struct",
           "field_names": [
             "condition"
@@ -33821,13 +33821,13 @@
     },
     "TriggerConstraint": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 14929,
+      "line": 14933,
       "doc": "Rate-limiting constraint for triggered abilities.",
       "cr_refs": [],
       "variants": [
         {
           "name": "OncePerTurn",
-          "line": 14931,
+          "line": 14935,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once each turn.\"",
@@ -33835,7 +33835,7 @@
         },
         {
           "name": "OncePerGame",
-          "line": 14933,
+          "line": 14937,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only once.\"",
@@ -33843,7 +33843,7 @@
         },
         {
           "name": "OnlyDuringYourTurn",
-          "line": 14935,
+          "line": 14939,
           "kind": "unit",
           "field_names": [],
           "doc": "\"This ability triggers only during your turn.\"",
@@ -33851,7 +33851,7 @@
         },
         {
           "name": "NthSpellThisTurn",
-          "line": 14940,
+          "line": 14944,
           "kind": "struct",
           "field_names": [
             "n",
@@ -33862,7 +33862,7 @@
         },
         {
           "name": "NthDrawThisTurn",
-          "line": 14947,
+          "line": 14951,
           "kind": "struct",
           "field_names": [
             "n"
@@ -33872,7 +33872,7 @@
         },
         {
           "name": "OnlyDuringOpponentsTurn",
-          "line": 14949,
+          "line": 14953,
           "kind": "unit",
           "field_names": [],
           "doc": "\"At the beginning of each opponent's [phase]\"",
@@ -33880,7 +33880,7 @@
         },
         {
           "name": "OnlyDuringYourMainPhase",
-          "line": 14953,
+          "line": 14957,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 505.1: Trigger fires only during the controller's main phase (precombat or postcombat). Used by cards that print \"during your main phase\" as a trigger timing restriction.",
@@ -33890,7 +33890,7 @@
         },
         {
           "name": "AtClassLevel",
-          "line": 14955,
+          "line": 14959,
           "kind": "struct",
           "field_names": [
             "level"
@@ -33902,7 +33902,7 @@
         },
         {
           "name": "MaxTimesPerTurn",
-          "line": 14958,
+          "line": 14962,
           "kind": "struct",
           "field_names": [
             "max"
@@ -33914,7 +33914,7 @@
         },
         {
           "name": "OncePerOpponentPerTurn",
-          "line": 14962,
+          "line": 14966,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 603.2: \"for the first time during each of their turns\" — fires once per opponent per turn. Used by Valgavoth, Harrower of Souls: \"Whenever an opponent loses life for the first time during each of their turns, ...\"",
@@ -33924,7 +33924,7 @@
         },
         {
           "name": "EventSourceControlledBy",
-          "line": 14969,
+          "line": 14973,
           "kind": "struct",
           "field_names": [
             "controller"
@@ -36124,44 +36124,12 @@
     },
     "TypeFilter": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 2362,
+      "line": 2366,
       "doc": "Type filter for card type matching in filters.",
       "cr_refs": [],
       "variants": [
         {
           "name": "Creature",
-          "line": 2363,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Land",
-          "line": 2364,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Artifact",
-          "line": 2365,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Enchantment",
-          "line": 2366,
-          "kind": "unit",
-          "field_names": [],
-          "doc": "",
-          "cr_refs": []
-        },
-        {
-          "name": "Instant",
           "line": 2367,
           "kind": "unit",
           "field_names": [],
@@ -36169,7 +36137,7 @@
           "cr_refs": []
         },
         {
-          "name": "Sorcery",
+          "name": "Land",
           "line": 2368,
           "kind": "unit",
           "field_names": [],
@@ -36177,7 +36145,7 @@
           "cr_refs": []
         },
         {
-          "name": "Planeswalker",
+          "name": "Artifact",
           "line": 2369,
           "kind": "unit",
           "field_names": [],
@@ -36185,8 +36153,40 @@
           "cr_refs": []
         },
         {
-          "name": "Battle",
+          "name": "Enchantment",
+          "line": 2370,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Instant",
           "line": 2371,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Sorcery",
+          "line": 2372,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Planeswalker",
+          "line": 2373,
+          "kind": "unit",
+          "field_names": [],
+          "doc": "",
+          "cr_refs": []
+        },
+        {
+          "name": "Battle",
+          "line": 2375,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 310: Battle — a permanent type introduced in March of the Machine.",
@@ -36196,7 +36196,7 @@
         },
         {
           "name": "Kindred",
-          "line": 2373,
+          "line": 2377,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 308.1: Kindred — each kindred card has another card type; matched via CoreType::Kindred.",
@@ -36206,7 +36206,7 @@
         },
         {
           "name": "Permanent",
-          "line": 2374,
+          "line": 2378,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36214,7 +36214,7 @@
         },
         {
           "name": "Card",
-          "line": 2375,
+          "line": 2379,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36222,7 +36222,7 @@
         },
         {
           "name": "Any",
-          "line": 2376,
+          "line": 2380,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36230,7 +36230,7 @@
         },
         {
           "name": "Non",
-          "line": 2379,
+          "line": 2383,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.4b: Negation — matches objects whose type does NOT match the inner filter. \"noncreature\" → `Non(Box::new(Creature))`, \"non-Human\" → `Non(Box::new(Subtype(\"Human\")))`",
@@ -36240,7 +36240,7 @@
         },
         {
           "name": "Subtype",
-          "line": 2382,
+          "line": 2386,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.). String because MTG has 250+ creature subtypes (CR 205.3m) with new ones each set.",
@@ -36251,7 +36251,7 @@
         },
         {
           "name": "AnyOf",
-          "line": 2385,
+          "line": 2389,
           "kind": "tuple",
           "field_names": [],
           "doc": "CR 608.2b: Disjunction — matches if ANY inner filter matches. \"creature or enchantment\" → `AnyOf(vec![Creature, Enchantment])`",
@@ -36330,7 +36330,7 @@
     },
     "UnlessPayScaling": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 5259,
+      "line": 5263,
       "doc": "CR 508.1h + CR 509.1d: How an `UnlessPay` combat-tax cost scales when multiple creatures are covered by the restriction.  - `Flat`: the cost is paid once regardless of how many affected creatures there are   (e.g., Brainwash — a single enchanted creature, cost {3}). - `PerAffectedCreature`: the cost is paid per creature that the restriction applies   to in the declared attack/block (e.g., Ghostly Prison — \"pays {2} for each creature   they control that's attacking you\"). - `PerQuantityRef`: the cost is paid once, scaled by the resolved value of the   dynamic `QuantityRef` (useful for \"{X}\" where X is defined as a game-state count   without a per-creature multiplier). - `PerAffectedAndQuantityRef`: the cost is multiplied by the resolved quantity AND   paid once per affected creature (e.g., Sphere of Safety — \"pays {X} for each of   those creatures, where X is the number of enchantments you control\").",
       "cr_refs": [
         "CR 508.1h",
@@ -36339,7 +36339,7 @@
       "variants": [
         {
           "name": "Flat",
-          "line": 5261,
+          "line": 5265,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36347,7 +36347,7 @@
         },
         {
           "name": "PerAffectedCreature",
-          "line": 5262,
+          "line": 5266,
           "kind": "unit",
           "field_names": [],
           "doc": "",
@@ -36355,7 +36355,7 @@
         },
         {
           "name": "PerQuantityRef",
-          "line": 5263,
+          "line": 5267,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -36365,7 +36365,7 @@
         },
         {
           "name": "PerAffectedAndQuantityRef",
-          "line": 5266,
+          "line": 5270,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -36375,7 +36375,7 @@
         },
         {
           "name": "PerAffectedWithRef",
-          "line": 5278,
+          "line": 5282,
           "kind": "struct",
           "field_names": [
             "quantity"
@@ -36391,7 +36391,7 @@
     },
     "UntilCondition": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 4550,
+      "line": 4554,
       "doc": "CR 701.13a + CR 608.2c: Termination predicate for an iterative exile-from-top loop. The loop exiles one card at a time off the top of a library and checks the predicate after each exile; the loop ends as soon as the predicate is satisfied (or the library is empty).  This parameterizes `Effect::ExileFromTopUntil` so that the same iteration engine handles two distinct stop-condition families:  * `NextMatches(filter)` — stop once the most-recently-exiled card matches a   filter. Covers Etali / Cascade / Discover-shape patterns where a single   \"hit\" card is selected (see CR 702.85a, CR 701.57a). * `CumulativeThreshold { .. }` — stop once the running aggregate over every   card exiled this resolution satisfies the comparator vs the threshold.   Covers Tasha's Hideous Laughter, Dream Harvest, Improvisation Capstone   (\"…until that player has exiled cards with total mana value N or   greater\") — CR 202.3 supplies the per-card mana value, CR 107.3e the   summation.",
       "cr_refs": [
         "CR 107.3e",
@@ -36404,7 +36404,7 @@
       "variants": [
         {
           "name": "NextMatches",
-          "line": 4554,
+          "line": 4558,
           "kind": "struct",
           "field_names": [
             "filter"
@@ -36417,7 +36417,7 @@
         },
         {
           "name": "CumulativeThreshold",
-          "line": 4558,
+          "line": 4562,
           "kind": "struct",
           "field_names": [
             "property",
@@ -36464,7 +36464,7 @@
     },
     "VoteTally": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10695,
+      "line": 10699,
       "doc": "CR 701.38a: How a completed `Effect::Vote` tally maps onto its `per_choice_effect` slots. CR 701.38 defines only the vote procedure; the strict-majority / tie-break outcome semantics below are card-defined, not a CR subrule.  `PerVote` is the Council's-dilemma family (Tivit, Capital Punishment, Expropriate, Emissary Green): every per-choice sub-effect resolves, fanning out once per vote (or once per voter / once aggregate) tallied for that choice. This is the historical `Effect::Vote` behavior and the serde default, so pre-existing serialized votes deserialize unchanged.  `Threshold` is the Will-of-the-council family (Plea for Power, Split Decision, Coercive Portal, Magister of Worth, Tyrant's Choice, Trial of a Time Lord IV): the players vote between two named outcomes and exactly ONE `per_choice_effect` resolves — the choice with strictly more votes. Ties resolve to `tie_breaker_index`, matching the Oracle phrasing \"If <B> gets more votes **or the vote is tied**, <effect-B>\".",
       "cr_refs": [
         "CR 701.38",
@@ -36473,7 +36473,7 @@
       "variants": [
         {
           "name": "PerVote",
-          "line": 10699,
+          "line": 10703,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 701.38a: Every per-choice effect resolves, fanning out per the tally for that choice. The historical default.",
@@ -36483,7 +36483,7 @@
         },
         {
           "name": "Threshold",
-          "line": 10705,
+          "line": 10709,
           "kind": "struct",
           "field_names": [
             "tie_breaker_index"
@@ -36498,7 +36498,7 @@
     },
     "VoterScope": {
       "file": "crates/engine/src/types/ability.rs",
-      "line": 10658,
+      "line": 10662,
       "doc": "CR 701.38a + CR 800.4g: Which players cast votes for an `Effect::Vote`.  `AllPlayers` is the classic Council's-dilemma shape (\"starting with you, each player votes for...\"). `EachOpponent` covers \"each opponent chooses...\" patterns (Master of Ceremonies, etc.) where the source's controller does NOT vote — they instead receive a per-choice effect via `PlayerFilter::VotedFor` (\"you and that player each ...\").  Per CR 800.4g, when every opponent has left the game in a multiplayer session, an `EachOpponent` vote produces an empty voter queue and the resolver emits `EffectResolved` with no tally instead of waiting forever on a non-existent voter.",
       "cr_refs": [
         "CR 701.38a",
@@ -36507,7 +36507,7 @@
       "variants": [
         {
           "name": "AllPlayers",
-          "line": 10661,
+          "line": 10665,
           "kind": "unit",
           "field_names": [],
           "doc": "Every non-eliminated player votes, in APNAP order from `starting_with`. CR 701.38a — the canonical Council's-dilemma voter set.",
@@ -36517,7 +36517,7 @@
         },
         {
           "name": "EachOpponent",
-          "line": 10665,
+          "line": 10669,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 800.4g: Every non-eliminated opponent of the ability controller votes. The controller does not vote — they receive per-choice sub-effects via `PlayerFilter::VotedFor` against the recorded ballots.",
@@ -36527,7 +36527,7 @@
         },
         {
           "name": "ControllerLabels",
-          "line": 10673,
+          "line": 10677,
           "kind": "unit",
           "field_names": [],
           "doc": "CR 101.4 + CR 608.2: Battlebond's friend-or-foe keyword action has no dedicated CR section. The spell controller alone makes one choice per non-eliminated player, in APNAP order from the controller. The \"voter\" slot in each ballot records the LABELED player (subject), not the actor — the actor is always the controller. Used by Pir's Whim, Khorvath's Fury, Regna's Sanction, Virtus's Maneuver, and Zndrsplt's Judgment.",
@@ -38530,7 +38530,7 @@
     },
     "ZoneSpendPolarity": {
       "file": "crates/engine/src/types/mana.rs",
-      "line": 373,
+      "line": 377,
       "doc": "CR 106.6 + CR 400.7: Whether a zone-gated spend restriction names the zone a spell *must* be cast from or a zone it must *not* be cast from. This is the inclusion/exclusion axis of [`ManaRestriction::OnlyForSpellFromZone`] — \"from your graveyard\" (`From`) versus \"from anywhere other than your hand\" (`NotFrom`, Mm'menon, the Right Hand). Parameterizing the existing zone variant over this polarity keeps a single zone-spend variant rather than a `SpellFromZone` / `SpellNotFromZone` sibling pair.",
       "cr_refs": [
         "CR 106.6",
@@ -38539,7 +38539,7 @@
       "variants": [
         {
           "name": "From",
-          "line": 376,
+          "line": 380,
           "kind": "unit",
           "field_names": [],
           "doc": "\"from [your] <zone>\" — the spell must be cast from the named zone.",
@@ -38547,7 +38547,7 @@
         },
         {
           "name": "NotFrom",
-          "line": 380,
+          "line": 384,
           "kind": "unit",
           "field_names": [],
           "doc": "\"from anywhere other than [your] <zone>\" — the spell must be cast from any zone *except* the named one. A spell with no recorded cast-from zone is treated as not satisfying the restriction (conservative).",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up documentation nitpick to the now-merged #4091 (spend-mana restriction: face-down casts, turn-face-up).

In the review on #4091, the maintainer noted that a couple of the new variant docs still used the pre-liveness-gate phrasing claiming the cluster's cards "parse to no `Effect::Unimplemented`":

> One minor cleanup to fold into the rebase if you touch the docs/comments anyway: a couple of the new variant docs still use the old phrasing that the cluster's cards parse to no `Effect::Unimplemented`; after this fix, the dead-only full-card cases intentionally do produce an `Unimplemented` gap. The behavior is correct; that wording is now stale.

That wording was stale by the time #4091 merged: the `ManaSpendRestriction::has_payable_branch` liveness gate (CR 106.6) means the `Effect::Mana` parser seam (`oracle_effect/sequence.rs`) absorbs a parsed restriction **only** when at least one branch is payable. A card whose only spend restriction is an all-dead leaf (`FaceDownSpell` / `TurnPermanentFaceUp` / `XCostOnly`) is left **unabsorbed** and intentionally lowers to `Effect::Unimplemented` (honest coverage red). The typed *variant* stays representable (the parser still recognizes the restriction shape); only the dead-only *full card* surfaces the gap.

### What this PR does (documentation-only, zero behavior change)
Rewords three doc comments to draw that type-vs-card distinction and reference the `has_payable_branch` gate:
- `ManaSpendRestriction::FaceDownSpell` (`types/ability.rs`)
- `ManaRestriction::OnlyForFaceDownSpell` (`types/mana.rs`)
- `SpecialAction` class-level doc / `TurnFaceUp` (`types/mana.rs`)

Then regenerates `data/engine-inventory.json` so its serialized copies of those doc strings follow (the only non-doc churn in that file is `"line":` renumbering from the added doc lines — verified no variant adds/drops, no `"name"` changes).

Card→variant attribution corrected: the `FaceDownSpell` rationale no longer presents Tin Street Gossip as a pure-`FaceDownSpell` card (it is `Any([FaceDownSpell, TurnPermanentFaceUp])`); the standalone `TurnPermanentFaceUp` example is Overgrown Zealot. The variant-header clause attribution `"...cast face-down spells" (Tin Street Gossip)` is retained intentionally — that clause is the genuine `FaceDownSpell` source within the card's `Any`.

No types, parser logic, engine logic, tests, or CR annotations change. The `has_payable_branch` gate and the `is_face_down`-from-cast-intent fix from #4091 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
