### PR TITLE
fix(home): improve Resume Game card layout on mobile

### DIFF
--- a/client/src/components/menu/home/HomeDashboard.tsx
+++ b/client/src/components/menu/home/HomeDashboard.tsx
@@ -116,12 +116,12 @@ function ResumeHero() {
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(130%_120%_at_92%_0%,rgba(180,83,30,0.28),transparent_46%)]" />
       <img src="/logo_only.webp" alt="" aria-hidden="true" className="pointer-events-none absolute -right-10 top-1/2 w-44 -translate-y-1/2 -rotate-6 opacity-[0.06] grayscale" />
       <div className="relative flex flex-col gap-3">
-        <div className="flex items-center gap-4">
+        <div className="flex flex-col gap-3 min-[480px]:flex-row min-[480px]:items-center min-[480px]:gap-4">
           <div className="min-w-0 flex-1">
             <div className="text-[0.7rem] font-semibold uppercase tracking-[0.18em] text-ember-soft">
               {t("home.dashboard.continue")}
             </div>
-            <div className="mt-1 truncate font-display text-[clamp(1.35rem,2.4vw,1.7rem)] font-semibold tracking-[-0.02em] text-fg">
+            <div className="mt-1 font-display text-[clamp(1.35rem,2.4vw,1.7rem)] font-semibold leading-tight tracking-[-0.02em] text-fg min-[480px]:truncate">
               {primary.title}
             </div>
             <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-1.5 text-xs text-fg-muted">
@@ -135,7 +135,7 @@ function ResumeHero() {
               )}
             </div>
           </div>
-          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-ember-soft/30 bg-ember/[0.12] px-4 py-2 text-sm font-medium text-ember-text transition-colors group-hover:border-ember-soft/50">
+          <span className="inline-flex w-full shrink-0 items-center justify-center gap-1.5 rounded-full border border-ember-soft/30 bg-ember/[0.12] px-4 py-2.5 text-sm font-medium text-ember-text transition-colors group-hover:border-ember-soft/50 min-[480px]:w-auto">
             <img src="/icons/sections/resume.png" alt="" aria-hidden="true" className="h-4 w-4 opacity-80" />
             {primary.cta}
           </span>


### PR DESCRIPTION
## Summary

Fixes a mobile layout issue where the **Resume Game** card became cramped on narrow viewports, causing the format title to truncate and the CTA to compete for space with match information.

### Changes

* Stack match information and the Resume Game CTA vertically on mobile
* Allow format titles to wrap instead of truncating on narrow screens
* Make the Resume Game CTA full-width for a larger tap target
* Preserve the existing side-by-side layout on wider viewports

This is a layout-only change. Resume functionality and click behavior remain unchanged.

## Related Issues
Fixes #4151 

## Problem

The Resume Game card used a horizontal layout for the title, metadata, and CTA. On mobile widths (~390px), this caused the format name to truncate aggressively and reduced the visibility of the primary action.

## Solution

Use a responsive layout that stacks content on smaller screens while preserving the current desktop presentation, improving readability and usability without changing behavior.

## Test Plan

* [ ] Start an AI match and leave mid-game
* [ ] Open Home on a mobile-sized viewport (~390px)
* [ ] Verify the format name displays fully
* [ ] Verify the Resume Game CTA appears below the match information and spans the available width
* [ ] Verify tapping the card resumes the game as before
* [ ] Verify desktop and wider layouts remain unchanged
* [ ] Verify draft resume entries continue to open the correct draft

## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/60d448ef-94c7-4a22-ad10-6b14dc91fc1a" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/d952c20d-6b7c-4350-a8df-5c2d0dc11377" />
