### PR TITLE
feat(engine): mana abilities with collect-evidence and pay-X-speed costs (Cryptex, Chicago Loop)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1677,7 +1677,8 @@ export type ShardChoice =
 export type PayableResource =
   | { type: "Energy" }
   | { type: "ManaGeneric"; data: { per_x: number } }
-  | { type: "Counters" };
+  | { type: "Counters" }
+  | { type: "Speed" };
 
 export type ShardOptions =
   | { type: "ManaOrLife" }

--- a/client/src/components/mana/PayAmountChoiceUI.tsx
+++ b/client/src/components/mana/PayAmountChoiceUI.tsx
@@ -37,6 +37,8 @@ export function PayAmountChoiceUI() {
         return t("mana.resourceMana");
       case "Counters":
         return t("mana.resourceCounters");
+      case "Speed":
+        return t("mana.resourceSpeed");
     }
   }, [data, t]);
 

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -422,7 +422,8 @@
     "payAmount": "{{value}} {{resource}} bezahlen",
     "resourceEnergy": "Energie",
     "resourceMana": "Mana",
-    "resourceCounters": "Marken"
+    "resourceCounters": "Marken",
+    "resourceSpeed": "Tempo"
   },
   "hand": {
     "viewFullHand_one": "Volle Hand ansehen ({{count}} Karte)",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -451,7 +451,8 @@
     "payAmount": "Pay {{value}} {{resource}}",
     "resourceEnergy": "energy",
     "resourceMana": "mana",
-    "resourceCounters": "counters"
+    "resourceCounters": "counters",
+    "resourceSpeed": "speed"
   },
   "hand": {
     "viewFullHand_one": "View full hand ({{count}} card)",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -422,7 +422,8 @@
     "payAmount": "Pagar {{value}} {{resource}}",
     "resourceEnergy": "energía",
     "resourceMana": "maná",
-    "resourceCounters": "contadores"
+    "resourceCounters": "contadores",
+    "resourceSpeed": "velocidad"
   },
   "hand": {
     "viewFullHand_one": "Ver la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -422,7 +422,8 @@
     "payAmount": "Payer {{value}} {{resource}}",
     "resourceEnergy": "énergie",
     "resourceMana": "mana",
-    "resourceCounters": "marqueurs"
+    "resourceCounters": "marqueurs",
+    "resourceSpeed": "vitesse"
   },
   "hand": {
     "viewFullHand_one": "Voir la main complète ({{count}} carte)",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -422,7 +422,8 @@
     "payAmount": "Paga {{value}} {{resource}}",
     "resourceEnergy": "energia",
     "resourceMana": "mana",
-    "resourceCounters": "segnalini"
+    "resourceCounters": "segnalini",
+    "resourceSpeed": "velocità"
   },
   "hand": {
     "viewFullHand_one": "Vedi la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -422,7 +422,8 @@
     "payAmount": "Zapłać {{value}} {{resource}}",
     "resourceEnergy": "energii",
     "resourceMana": "many",
-    "resourceCounters": "znaczników"
+    "resourceCounters": "znaczników",
+    "resourceSpeed": "prędkości"
   },
   "hand": {
     "viewFullHand_one": "Zobacz całą rękę ({{count}} karta)",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -422,7 +422,8 @@
     "payAmount": "Pagar {{value}} {{resource}}",
     "resourceEnergy": "energia",
     "resourceMana": "mana",
-    "resourceCounters": "marcadores"
+    "resourceCounters": "marcadores",
+    "resourceSpeed": "velocidade"
   },
   "hand": {
     "viewFullHand_one": "Ver mão completa ({{count}} carta)",

--- a/crates/engine/src/game/effects/collect_evidence.rs
+++ b/crates/engine/src/game/effects/collect_evidence.rs
@@ -1,6 +1,8 @@
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::{GameEvent, PlayerActionKind};
-use crate::types::game_state::{CollectEvidenceResume, GameState, PendingCast, WaitingFor};
+use crate::types::game_state::{
+    CollectEvidenceResume, GameState, PendingCast, PendingManaAbility, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
@@ -41,6 +43,27 @@ fn waiting_state(
         cards: graveyard_cards(state, player),
         resume: Box::new(resume),
     }
+}
+
+/// CR 605.2 + CR 701.59: begin collect-evidence payment for a mana ability's
+/// activation cost (Cryptex's `{T}, Collect evidence 3: Add one mana...`).
+/// Mirrors `begin_cost_payment` but resumes a parked `PendingManaAbility`
+/// rather than a `PendingCast`. Payability (CR 701.59b graveyard-MV threshold)
+/// is checked by the caller before this is reached.
+pub(crate) fn begin_cost_payment_for_mana_ability(
+    state: &GameState,
+    player: PlayerId,
+    amount: u32,
+    pending: PendingManaAbility,
+) -> WaitingFor {
+    waiting_state(
+        state,
+        player,
+        amount,
+        CollectEvidenceResume::ManaAbility {
+            pending_mana_ability: Box::new(pending),
+        },
+    )
 }
 
 /// CR 701.59a: Collect evidence N — exile graveyard cards with total mana value >= N.
@@ -202,6 +225,17 @@ pub(crate) fn handle_choice(
                 .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?;
             Ok(state.waiting_for.clone())
         }
+        // CR 605.2 + CR 701.59: Resume the parked mana-ability activation with
+        // the exiled cards stamped in. `resume` is a shared borrow, so clone the
+        // boxed pending (mirrors the `Casting` arm) — moving out of `*` would be
+        // E0507. The exile loop above already moved the chosen cards to exile.
+        CollectEvidenceResume::ManaAbility {
+            pending_mana_ability,
+        } => {
+            let mut pending = pending_mana_ability.as_ref().clone();
+            pending.collected_evidence = chosen.to_vec();
+            super::super::mana_abilities::advance_mana_ability_activation(state, pending, events)
+        }
     }
 }
 
@@ -209,7 +243,7 @@ pub(crate) fn handle_choice(
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
-    use crate::types::ability::{Effect, QuantityExpr, TargetFilter, TypedFilter};
+    use crate::types::ability::{AbilityCost, Effect, QuantityExpr, TargetFilter, TypedFilter};
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::CardId;
 
@@ -462,5 +496,83 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    fn mana_pending(source_id: ObjectId) -> PendingManaAbility {
+        PendingManaAbility {
+            player: PlayerId(0),
+            source_id,
+            ability_index: 0,
+            color_override: None,
+            resume: crate::types::game_state::ManaAbilityResume::Priority,
+            chosen_tappers: Vec::new(),
+            chosen_discards: Vec::new(),
+            chosen_mana_payment: None,
+            chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
+            chosen_exiled: Vec::new(),
+            chosen_sacrificed_battlefield: Vec::new(),
+            cost_paid_object: None,
+            batch_siblings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn collect_evidence_cost_amount_recurses_composite() {
+        use crate::game::mana_abilities;
+        // Bare collect-evidence cost.
+        assert_eq!(
+            mana_abilities::collect_evidence_cost_amount(&AbilityCost::CollectEvidence {
+                amount: 3
+            }),
+            Some(3)
+        );
+        // Composite[Tap, CollectEvidence{3}] — Cryptex's shape — recurses.
+        assert_eq!(
+            mana_abilities::collect_evidence_cost_amount(&AbilityCost::Composite {
+                costs: vec![AbilityCost::Tap, AbilityCost::CollectEvidence { amount: 3 },],
+            }),
+            Some(3)
+        );
+        // No collect-evidence component anywhere.
+        assert_eq!(
+            mana_abilities::collect_evidence_cost_amount(&AbilityCost::Composite {
+                costs: vec![AbilityCost::Tap],
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn begin_cost_payment_for_mana_ability_produces_prompt_with_cards() {
+        let mut state = GameState::new_two_player(42);
+        let a = add_graveyard_card(&mut state, PlayerId(0), 1, "One", 2);
+        let b = add_graveyard_card(&mut state, PlayerId(0), 2, "Two", 2);
+
+        let waiting = begin_cost_payment_for_mana_ability(
+            &state,
+            PlayerId(0),
+            3,
+            mana_pending(ObjectId(100)),
+        );
+
+        let (minimum_mana_value, cards, resume) = match waiting {
+            WaitingFor::CollectEvidenceChoice {
+                minimum_mana_value,
+                cards,
+                resume,
+                ..
+            } => (minimum_mana_value, cards, resume),
+            other => panic!("Expected CollectEvidenceChoice, got {:?}", other),
+        };
+
+        assert_eq!(minimum_mana_value, 3);
+        assert!(cards.contains(&a) && cards.contains(&b));
+        assert!(!cards.is_empty());
+        assert!(matches!(
+            resume.as_ref(),
+            CollectEvidenceResume::ManaAbility { .. }
+        ));
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1026,7 +1026,18 @@ pub(super) fn handle_resolution_choice(
             }
             if let Some(pending_mana_ability) = pending_mana_ability {
                 let mut pending = pending_mana_ability.as_ref().clone();
-                pending.chosen_counter_count = Some(amount);
+                // CR 107.1c / CR 107.3a: bind the announced amount to the
+                // correct mana-ability cost axis — a removed-counter count
+                // (CR 122.1) or an announced X for `Pay X speed` (CR 702.179e).
+                match resource {
+                    PayableResource::Counters => pending.chosen_counter_count = Some(amount),
+                    PayableResource::Speed => pending.chosen_x = Some(amount),
+                    other => {
+                        return Err(EngineError::InvalidAction(format!(
+                            "Unexpected pay-amount resource {other:?} for mana ability"
+                        )))
+                    }
+                }
                 let waiting_for =
                     mana_abilities::advance_mana_ability_activation(state, pending, events)?;
                 return Ok(ResolutionChoiceOutcome::WaitingFor(waiting_for));
@@ -1067,6 +1078,14 @@ pub(super) fn handle_resolution_choice(
                 PayableResource::Counters => {
                     return Err(EngineError::InvalidAction(
                         "Counter amount choices require a pending mana ability".to_string(),
+                    ));
+                }
+                PayableResource::Speed => {
+                    // CR 702.179e: `Pay X speed` only ever arises as a mana-ability
+                    // activation cost, which carries a `pending_mana_ability` and
+                    // is handled above. Reaching the standalone branch is a bug.
+                    return Err(EngineError::InvalidAction(
+                        "Speed amount choices require a pending mana ability".to_string(),
                     ));
                 }
                 PayableResource::Life => {

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1,7 +1,7 @@
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ChoiceValue, CostPaidObjectSnapshot, Effect,
-    ManaProduction, ResolvedAbility, TargetFilter, REMOVE_COUNTER_COST_ALL,
-    REMOVE_COUNTER_COST_ANY_NUMBER,
+    ManaProduction, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter,
+    REMOVE_COUNTER_COST_ALL, REMOVE_COUNTER_COST_ANY_NUMBER,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::{GameEvent, ManaTapState};
@@ -244,6 +244,11 @@ fn produce_mana_from_ability(
         source_id,
         player,
         ability_def,
+        // CR 107.3c: X is irrelevant here — `ProductionOverride::Combination`
+        // short-circuits `AnyCombination` count resolution (the produced
+        // sequence was pre-chosen by the player), and the produced count X is
+        // enforced via the prompt path's `AnyCombination { count: X }`.
+        None,
         cost_paid_object,
     );
 
@@ -333,12 +338,19 @@ fn resolved_mana_ability_for_current_state(
     source_id: ObjectId,
     player: PlayerId,
     ability_def: &AbilityDefinition,
+    chosen_x: Option<u32>,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
 ) -> ResolvedAbility {
     let mut resolved =
         super::ability_utils::build_resolved_from_def(ability_def, source_id, player);
     if let Some(snapshot) = cost_paid_object {
         resolved.set_cost_paid_object_recursive(snapshot);
+    }
+    // CR 107.3a/.3c: bind the announced X into the resolved ability so produced
+    // mana counts (`AnyCombination { count: Ref(Variable "X") }`) and any X-bearing
+    // sub-effects resolve to the chosen value (Chicago Loop's `Add X mana`).
+    if let Some(x) = chosen_x {
+        resolved.set_chosen_x_recursive(x);
     }
     apply_condition_instead_mana_swap(state, &resolved)
 }
@@ -462,6 +474,8 @@ pub fn activate_mana_ability(
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -1062,6 +1076,29 @@ fn can_activate_mana_ability_by_simulation(
     .is_ok()
 }
 
+// CR 701.59: collect-evidence amount inside a (possibly composite) mana-ability cost.
+pub(crate) fn collect_evidence_cost_amount(cost: &AbilityCost) -> Option<u32> {
+    match cost {
+        AbilityCost::CollectEvidence { amount } => Some(*amount),
+        AbilityCost::Composite { costs } => costs.iter().find_map(collect_evidence_cost_amount),
+        _ => None,
+    }
+}
+
+// CR 107.3a + CR 702.179f: a mana-ability cost of "Pay X speed".
+fn pay_speed_x_cost(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::PaySpeed {
+            amount:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { name },
+                },
+        } if name == "X" => true,
+        AbilityCost::Composite { costs } => costs.iter().any(pay_speed_x_cost),
+        _ => false,
+    }
+}
+
 pub(super) fn advance_mana_ability_activation(
     state: &mut GameState,
     mut pending: PendingManaAbility,
@@ -1073,6 +1110,32 @@ pub(super) fn advance_mana_ability_activation(
         .and_then(|obj| obj.abilities.get(pending.ability_index))
         .cloned()
         .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))?;
+
+    // CR 107.3a + CR 601.2b + CR 702.179f: A `Pay X speed` mana-ability cost
+    // (Chicago Loop's `Pay X speed: Add X mana in any combination of colors`)
+    // requires the player to announce X before any cost is paid or mana is
+    // produced. X is bound to BOTH the speed cost and the produced-mana count.
+    if pending.chosen_x.is_none() {
+        if let Some(cost) = &ability_def.cost {
+            if pay_speed_x_cost(cost) {
+                // CR 118.3: a player can't pay a cost without the resources to
+                // pay it fully, so X is bounded by the player's current speed.
+                // CR 702.179f: a player with no speed has speed 0.
+                let max = super::speed::effective_speed(state, pending.player) as u32;
+                let source_id = pending.source_id;
+                let player = pending.player;
+                return Ok(WaitingFor::PayAmountChoice {
+                    player,
+                    resource: PayableResource::Speed,
+                    min: 0,
+                    max,
+                    accumulated: 0,
+                    source_id,
+                    pending_mana_ability: Some(Box::new(pending)),
+                });
+            }
+        }
+    }
 
     if pending.chosen_discards.is_empty() {
         if let Some((count, cards)) =
@@ -1179,6 +1242,36 @@ pub(super) fn advance_mana_ability_activation(
         }
     }
 
+    // CR 605.2 + CR 701.59: "Collect evidence N" in a (possibly composite)
+    // mana-ability cost (Cryptex) requires interactively exiling graveyard
+    // cards before any mana is produced. Surface the choice via the shared
+    // CollectEvidenceChoice prompt, resuming this activation once cards are
+    // chosen. Keyed on not-yet-collected (empty selection).
+    if pending.collected_evidence.is_empty() {
+        if let Some(cost) = &ability_def.cost {
+            if let Some(amount) = collect_evidence_cost_amount(cost) {
+                // CR 605.2 + CR 605.3b: pay the ability's cost before producing mana.
+                if !super::effects::collect_evidence::can_collect_evidence(
+                    state,
+                    pending.player,
+                    amount,
+                ) {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Cannot pay collect-evidence cost for mana ability".to_string(),
+                    ));
+                }
+                return Ok(
+                    super::effects::collect_evidence::begin_cost_payment_for_mana_ability(
+                        state,
+                        pending.player,
+                        amount,
+                        pending,
+                    ),
+                );
+            }
+        }
+    }
+
     // CR 107.1c + CR 605.3a: "Remove any number of <type> counters" in a
     // mana-ability cost requires choosing the count before costs are paid and
     // mana is produced.
@@ -1247,6 +1340,7 @@ pub(super) fn advance_mana_ability_activation(
             pending.source_id,
             pending.player,
             &ability_def,
+            pending.chosen_x,
             pending.cost_paid_object.clone(),
         );
         if let Some(choice) = mana_choice_prompt(
@@ -1268,6 +1362,7 @@ pub(super) fn advance_mana_ability_activation(
                 &mut pending.chosen_sacrificed_battlefield.iter().copied(),
                 pending.chosen_mana_payment.as_deref(),
                 pending.chosen_counter_count,
+                pending.chosen_x,
             )?;
             // CR 603.2a + CR 603.2g + CR 605.3b: Cost-payment events (Tap,
             // Sacrifice, etc.) generated during a mana ability's cost step
@@ -1319,6 +1414,7 @@ pub(super) fn advance_mana_ability_activation(
         &pending.chosen_sacrificed_battlefield,
         pending.chosen_mana_payment.as_deref(),
         pending.chosen_counter_count,
+        pending.chosen_x,
         pending.cost_paid_object,
     )?;
     complete_mana_ability_activation(
@@ -1353,6 +1449,7 @@ fn pay_mana_ability_cost(
         &mut std::iter::empty(),
         None,
         None,
+        None,
     )
 }
 
@@ -1370,6 +1467,7 @@ fn resolve_mana_ability_with_selected_choices(
     sacrificed_battlefield: &[ObjectId],
     chosen_hybrid_payment: Option<&[ManaType]>,
     chosen_counter_count: Option<u32>,
+    chosen_x: Option<u32>,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
 ) -> Result<(), EngineError> {
     let mut chosen = tapped_creatures.iter().copied();
@@ -1388,6 +1486,7 @@ fn resolve_mana_ability_with_selected_choices(
         &mut sacrificed,
         chosen_hybrid_payment,
         chosen_counter_count,
+        chosen_x,
     )?;
     if chosen.next().is_some() {
         return Err(EngineError::InvalidAction(
@@ -1418,6 +1517,7 @@ fn resolve_mana_ability_with_selected_choices(
         source_id,
         player,
         ability_def,
+        chosen_x,
         cost_paid_object,
     );
 
@@ -1598,6 +1698,7 @@ fn pay_mana_ability_cost_with_choices<I, J, K, L>(
     chosen_sacrificed_battlefield: &mut L,
     chosen_hybrid_payment: Option<&[ManaType]>,
     chosen_counter_count: Option<u32>,
+    chosen_x: Option<u32>,
 ) -> Result<(), EngineError>
 where
     I: Iterator<Item = ObjectId>,
@@ -1972,6 +2073,28 @@ where
                     AbilityCost::Mill { count } => {
                         mill_for_mana_cost(state, player, *count, events)?;
                     }
+                    // CR 605.2 + CR 701.59: Collect-evidence sub-cost inside a
+                    // Composite mana-ability cost (Cryptex). The exile was
+                    // already performed interactively via the
+                    // `CollectEvidenceChoice` resume (see
+                    // `advance_mana_ability_activation`); no-op here so the cost
+                    // is neither re-paid nor errored.
+                    AbilityCost::CollectEvidence { .. } => {}
+                    // CR 107.3a/.3c + CR 702.179f: `Pay X speed` sub-cost
+                    // inside a Composite mana-ability cost. Concretize the
+                    // announced X into a Fixed cost, then delegate to the
+                    // single-authority cost payer.
+                    AbilityCost::PaySpeed { amount } => {
+                        let cost = match chosen_x {
+                            Some(x) => AbilityCost::PaySpeed {
+                                amount: QuantityExpr::Fixed { value: x as i32 },
+                            },
+                            None => AbilityCost::PaySpeed {
+                                amount: amount.clone(),
+                            },
+                        };
+                        super::costs::pay_ability_cost(state, player, source_id, &cost, events)?;
+                    }
                     // Self-contained components (Untap {Q}, Exert, PayEnergy,
                     // self-ReturnToHand, EffectCost) delegate to the
                     // single-authority cost payer alongside the tap.
@@ -1985,6 +2108,24 @@ where
                     }
                 }
             }
+        }
+        // CR 605.2 + CR 701.59: Bare collect-evidence mana-ability cost. The
+        // exile already happened interactively via the `CollectEvidenceChoice`
+        // resume; no-op so the cost is neither re-paid nor errored.
+        Some(AbilityCost::CollectEvidence { .. }) => {}
+        // CR 107.3a/.3c + CR 702.179f: Bare `Pay X speed` mana-ability cost
+        // (Chicago Loop). Concretize the announced X into a Fixed cost, then
+        // delegate to the single-authority cost payer.
+        Some(AbilityCost::PaySpeed { amount }) => {
+            let cost = match chosen_x {
+                Some(x) => AbilityCost::PaySpeed {
+                    amount: QuantityExpr::Fixed { value: x as i32 },
+                },
+                None => AbilityCost::PaySpeed {
+                    amount: amount.clone(),
+                },
+            };
+            super::costs::pay_ability_cost(state, player, source_id, &cost, events)?;
         }
         // Self-contained components (Untap, Exert, PayEnergy, self-ReturnToHand,
         // EffectCost) delegate to the single-authority cost payer.
@@ -2057,6 +2198,11 @@ fn mill_for_mana_cost(
 /// `PaySpeed` is deliberately excluded: Chicago Loop's `Pay X speed: Add X mana`
 /// couples a player-announced X to both cost and effect (CR 601.2b), which the
 /// non-announcing delegation path cannot express — it is handled on its own.
+///
+/// `CollectEvidence` is also deliberately excluded: Cryptex's `Collect evidence 3`
+/// is paid interactively via the `CollectEvidenceChoice` prompt that
+/// `advance_mana_ability_activation` surfaces before mana production (CR 701.59),
+/// so it is a no-op in the cost-payment match rather than a delegated payment.
 fn is_self_contained_mana_subcost(cost: &AbilityCost) -> bool {
     matches!(
         cost,
@@ -5909,6 +6055,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -5971,6 +6119,8 @@ mod tests {
                 chosen_discards: Vec::new(),
                 chosen_mana_payment: None,
                 chosen_counter_count: None,
+                chosen_x: None,
+                collected_evidence: Vec::new(),
                 chosen_exiled: Vec::new(),
                 chosen_sacrificed_battlefield: Vec::new(),
                 cost_paid_object: None,
@@ -6199,6 +6349,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -6300,6 +6452,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -7199,6 +7353,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -7566,6 +7722,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -8124,6 +8282,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -8192,6 +8352,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -8315,6 +8477,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -8376,6 +8540,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,
@@ -8528,6 +8694,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -947,6 +947,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1814,6 +1814,13 @@ pub enum CollectEvidenceResume {
     Effect {
         pending_ability: Box<ResolvedAbility>,
     },
+    /// CR 605.2 + CR 701.59: Collect evidence paid as a mana ability's
+    /// activation cost (Cryptex's `{T}, Collect evidence 3: Add one mana...`).
+    /// Resumes the parked mana-ability activation with the chosen cards stamped
+    /// into `PendingManaAbility::collected_evidence`, rather than a `PendingCast`.
+    ManaAbility {
+        pending_mana_ability: Box<PendingManaAbility>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1927,6 +1934,18 @@ pub struct PendingManaAbility {
     /// in a mana-ability cost. The amount is chosen before mana production.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chosen_counter_count: Option<u32>,
+    /// CR 107.3a + CR 601.2b + CR 702.179e/f: Announced value of X for a
+    /// `Pay X speed` mana-ability cost (Chicago Loop's `Pay X speed: Add X mana
+    /// in any combination of colors`). Chosen before cost payment and mana
+    /// production; bound to BOTH the speed cost and the produced-mana count via
+    /// `set_chosen_x_recursive`. `None` until the player announces X.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chosen_x: Option<u32>,
+    /// CR 605.2 + CR 701.59: Cards exiled to pay a `Collect evidence N`
+    /// mana-ability cost (Cryptex). Filled by the `CollectEvidenceChoice` resume
+    /// before mana production; empty until the player selects cards.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub collected_evidence: Vec<ObjectId>,
     /// CR 117.1 + CR 118.3: Pre-selected objects to exile as part of an
     /// `AbilityCost::Exile { filter: !SelfRef, .. }` mana ability cost. Used
     /// by Food Chain's battlefield exile cost and Titans' Nest's graveyard
@@ -4246,6 +4265,11 @@ pub enum PayableResource {
     /// CR 119.4: Pay any amount of life — N is deducted as life loss via
     /// life_costs::pay_life_as_cost (life-loss replacement pipeline + CantLoseLife).
     Life,
+    /// CR 702.179e/f: Announce X for a `Pay X speed` mana-ability cost. The chosen
+    /// amount is the announced X, bounded above by the player's current speed
+    /// (CR 702.179f: no speed counts as 0). Mana-ability only — paid via the
+    /// `PendingManaAbility::chosen_x` path, never the standalone resource branch.
+    Speed,
 }
 
 fn default_one() -> u32 {
@@ -4590,7 +4614,8 @@ impl WaitingFor {
             },
             WaitingFor::CollectEvidenceChoice { resume, .. } => match resume.as_ref() {
                 CollectEvidenceResume::Casting { pending_cast } => Some(pending_cast),
-                CollectEvidenceResume::Effect { .. } => None,
+                CollectEvidenceResume::Effect { .. }
+                | CollectEvidenceResume::ManaAbility { .. } => None,
             },
             _ => None,
         }
@@ -4621,7 +4646,8 @@ impl WaitingFor {
             },
             WaitingFor::CollectEvidenceChoice { resume, .. } => match resume.as_mut() {
                 CollectEvidenceResume::Casting { pending_cast } => Some(pending_cast),
-                CollectEvidenceResume::Effect { .. } => None,
+                CollectEvidenceResume::Effect { .. }
+                | CollectEvidenceResume::ManaAbility { .. } => None,
             },
             _ => None,
         }
@@ -8471,6 +8497,8 @@ mod tests {
                     chosen_discards: Vec::new(),
                     chosen_mana_payment: None,
                     chosen_counter_count: None,
+                    chosen_x: None,
+                    collected_evidence: Vec::new(),
                     chosen_exiled: Vec::new(),
                     chosen_sacrificed_battlefield: Vec::new(),
                     cost_paid_object: None,

--- a/crates/engine/tests/chicago_loop_pay_speed_x_mana.rs
+++ b/crates/engine/tests/chicago_loop_pay_speed_x_mana.rs
@@ -1,0 +1,244 @@
+//! Chicago Loop (#4140 deferred type 2), ability #2:
+//! `Pay X speed: Add X mana in any combination of colors.`
+//!
+//! This is a mana ability whose activation cost is `PaySpeed { amount: Ref(X) }`
+//! and whose production is `AnyCombination { count: Ref(X) }`. The player
+//! announces X (bounded above by their current speed, CR 702.179e/f), and that
+//! single value is bound to BOTH the speed cost and the produced-mana count
+//! (CR 107.3a/.3c).
+//!
+//! Drives the real activation pipeline:
+//!   ActivateAbility → PayAmountChoice{resource: Speed} (announce X)
+//!     → SubmitPayAmount → ChooseManaColor{AnyCombination count=X}
+//!       → X mana produced + X speed paid.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 107.3a: controller announces X for an activation cost with X.
+//!   - CR 107.3c: once chosen, X is fixed for both cost and effect.
+//!   - CR 702.179e: max speed bounds the declaration; CR 702.179f: no speed = 0.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{AbilityCost, QuantityExpr, QuantityRef};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, ManaChoice, PayableResource, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const CHICAGO_LOOP_PAY_SPEED: &str = "Pay X speed: Add X mana in any combination of colors.";
+
+fn pay_speed_index(state: &GameState, id: ObjectId) -> usize {
+    let obj = state.objects.get(&id).expect("Chicago Loop exists");
+    obj.abilities
+        .iter()
+        .position(|a| matches!(&a.cost, Some(cost) if cost_is_pay_speed_x(cost)))
+        .expect("Chicago Loop has a Pay X speed mana ability")
+}
+
+fn cost_is_pay_speed_x(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::PaySpeed {
+            amount:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { name },
+                },
+        } => name == "X",
+        AbilityCost::Composite { costs } => costs.iter().any(cost_is_pay_speed_x),
+        _ => false,
+    }
+}
+
+fn set_speed(runner: &mut GameRunner, player: PlayerId, speed: u8) {
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .unwrap()
+        .speed = Some(speed);
+}
+
+/// Chicago Loop is a land, not a creature. The scenario creature helper is used
+/// only to parse the ability onto a battlefield permanent; convert it to a pure
+/// land and clear P/T so the 0/0 stub is not destroyed as an SBA (CR 704.5f)
+/// after the first activation resolves (which would strand the second
+/// activation with "object not on battlefield").
+fn make_land(runner: &mut GameRunner, id: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![engine::types::card_type::CoreType::Land];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+}
+
+fn build_loop(speed: u8) -> (GameRunner, ObjectId, usize) {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Chicago Loop is a land; the creature helper is used only to parse the
+    // ability onto a battlefield permanent. The `Pay X speed` ability has no
+    // {T} component, so summoning-sickness is irrelevant.
+    let loop_id = scenario
+        .add_creature_from_oracle(P0, "Chicago Loop", 0, 0, CHICAGO_LOOP_PAY_SPEED)
+        .id();
+    let mut runner = scenario.build();
+    make_land(&mut runner, loop_id);
+    set_speed(&mut runner, P0, speed);
+    let idx = pay_speed_index(runner.state(), loop_id);
+    (runner, loop_id, idx)
+}
+
+#[test]
+fn chicago_loop_pay_speed_x_produces_x_mana_and_pays_x_speed() {
+    let (mut runner, loop_id, idx) = build_loop(2);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: loop_id,
+            ability_index: idx,
+        })
+        .expect("activation accepted");
+
+    // CR 107.3a + CR 702.179e: announce X, bounded by speed.
+    let max = match runner.state().waiting_for.clone() {
+        WaitingFor::PayAmountChoice {
+            resource: PayableResource::Speed,
+            min,
+            max,
+            ..
+        } => {
+            assert_eq!(min, 0, "X may be 0");
+            max
+        }
+        other => panic!("Expected PayAmountChoice{{Speed}}, got {other:?}"),
+    };
+    assert_eq!(max, 2, "max X bounded by current speed 2");
+
+    // Announce X = 2.
+    runner
+        .act(GameAction::SubmitPayAmount { amount: 2 })
+        .expect("X announcement accepted");
+
+    // CR 605.3b + CR 107.3c: production prompt for X=2 colors.
+    let count = match runner.state().waiting_for.clone() {
+        WaitingFor::ChooseManaColor { choice, .. } => match choice {
+            engine::types::game_state::ManaChoicePrompt::AnyCombination { count, .. } => count,
+            other => panic!("Expected AnyCombination prompt, got {other:?}"),
+        },
+        other => panic!("Expected ChooseManaColor, got {other:?}"),
+    };
+    assert_eq!(count, 2, "production count bound to announced X=2");
+
+    runner
+        .act(GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Red, ManaType::Blue]),
+            count: 1,
+        })
+        .expect("combination accepted");
+
+    // CR 107.3c: X=2 bound to BOTH axes.
+    assert_eq!(
+        runner.state().players[0].speed,
+        Some(0),
+        "speed reduced by 2 (2 → 0)"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool.mana.len(),
+        2,
+        "exactly 2 mana produced"
+    );
+}
+
+#[test]
+fn chicago_loop_pay_speed_zero_when_no_speed() {
+    let (mut runner, loop_id, idx) = build_loop(0);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: loop_id,
+            ability_index: idx,
+        })
+        .expect("activation accepted");
+
+    // CR 702.179f: no speed → max X = 0; only X=0 is legal.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::PayAmountChoice {
+            resource: PayableResource::Speed,
+            min,
+            max,
+            ..
+        } => {
+            assert_eq!(min, 0);
+            assert_eq!(max, 0, "no speed → X bounded to 0");
+        }
+        other => panic!("Expected PayAmountChoice{{Speed}}, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::SubmitPayAmount { amount: 0 })
+        .expect("X=0 accepted");
+
+    // X=0 → AnyCombination count 0 → no color prompt; activation completes with
+    // 0 mana produced and 0 speed paid (no panic).
+    assert_eq!(
+        runner.state().players[0].mana_pool.mana.len(),
+        0,
+        "X=0 produces no mana"
+    );
+    assert_eq!(runner.state().players[0].speed, Some(0), "no speed paid");
+}
+
+#[test]
+fn chicago_loop_pay_speed_x_is_per_activation() {
+    // X is per-PendingManaAbility, not a global — two sequential activations with
+    // different X produce different amounts.
+    let (mut runner, loop_id, idx) = build_loop(4);
+
+    // First activation: X = 1.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: loop_id,
+            ability_index: idx,
+        })
+        .expect("activate 1");
+    runner
+        .act(GameAction::SubmitPayAmount { amount: 1 })
+        .expect("X=1");
+    runner
+        .act(GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Green]),
+            count: 1,
+        })
+        .expect("1 color");
+    assert_eq!(
+        runner.state().players[0].mana_pool.mana.len(),
+        1,
+        "first activation: 1 mana"
+    );
+    assert_eq!(runner.state().players[0].speed, Some(3), "speed 4 → 3");
+
+    // Second activation: X = 3.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: loop_id,
+            ability_index: idx,
+        })
+        .expect("activate 2");
+    runner
+        .act(GameAction::SubmitPayAmount { amount: 3 })
+        .expect("X=3");
+    runner
+        .act(GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Red, ManaType::White, ManaType::Black]),
+            count: 1,
+        })
+        .expect("3 colors");
+    assert_eq!(
+        runner.state().players[0].mana_pool.mana.len(),
+        4,
+        "second activation adds 3 more (1 + 3 = 4 total)"
+    );
+    assert_eq!(runner.state().players[0].speed, Some(0), "speed 3 → 0");
+}

--- a/crates/engine/tests/cryptex_collect_evidence_mana_ability.rs
+++ b/crates/engine/tests/cryptex_collect_evidence_mana_ability.rs
@@ -1,0 +1,198 @@
+//! Cryptex (#4140 deferred type 1): `{T}, Collect evidence 3: Add one mana of
+//! any color. Put an unlock counter on this artifact.`
+//!
+//! This is a mana ability whose activation cost is
+//! `Composite[Tap, CollectEvidence{amount: 3}]` (CR 701.59). The interactive
+//! collect-evidence exile must be paid as a mana-ability activation cost
+//! (CR 605.2) before the mana is produced, and the `SequentialSibling`
+//! PutCounter sub-ability resolves inline once afterward.
+//!
+//! Drives the real activation pipeline:
+//!   ActivateAbility → CollectEvidenceChoice (the new mana-ability cost gate)
+//!     → SelectCards → ChooseManaColor → mana produced + unlock counter placed.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 701.59a: collect evidence N exiles graveyard cards with total MV >= N.
+//!   - CR 605.2: a mana ability's cost is paid before it produces mana.
+//!   - CR 605.3b: mana abilities resolve immediately, not on the stack.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::AbilityCost;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{ManaChoice, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaType;
+use engine::types::phase::Phase;
+
+const CRYPTEX_ORACLE: &str =
+    "{T}, Collect evidence 3: Add one mana of any color. Put an unlock counter on this artifact.";
+
+/// Find the index of the mana ability whose cost contains a CollectEvidence
+/// component (robust to ability ordering).
+fn collect_evidence_ability_index(
+    state: &engine::types::game_state::GameState,
+    id: ObjectId,
+) -> usize {
+    let obj = state.objects.get(&id).expect("Cryptex exists");
+    obj.abilities
+        .iter()
+        .position(|a| matches!(&a.cost, Some(cost) if cost_has_collect_evidence(cost)))
+        .expect("Cryptex has a collect-evidence mana ability")
+}
+
+fn cost_has_collect_evidence(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::CollectEvidence { .. } => true,
+        AbilityCost::Composite { costs } => costs.iter().any(cost_has_collect_evidence),
+        _ => false,
+    }
+}
+
+/// Cryptex is an artifact, not a creature. The scenario creature helper is used
+/// to parse Oracle text onto a battlefield permanent; convert it to a pure
+/// artifact and clear P/T so the 0/0 stub is not destroyed as an SBA (CR 704.5f)
+/// before the mana ability can be activated.
+fn make_artifact(runner: &mut GameRunner, id: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![engine::types::card_type::CoreType::Artifact];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+}
+
+#[test]
+fn cryptex_collect_evidence_mana_ability_produces_mana_and_counter() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Three cards in graveyard with total mana value >= 3 (2 + 2 = 4 >= 3).
+    scenario
+        .add_spell_to_graveyard(P0, "Opt", true)
+        .with_mana_cost(engine::types::mana::ManaCost::Cost {
+            generic: 2,
+            shards: vec![],
+        });
+    scenario
+        .add_spell_to_graveyard(P0, "Negate", true)
+        .with_mana_cost(engine::types::mana::ManaCost::Cost {
+            generic: 2,
+            shards: vec![],
+        });
+    // Cryptex is an artifact on the battlefield; place via add_creature then make
+    // it a non-summoning-sick permanent (mana ability with {T}).
+    let cryptex = scenario
+        .add_creature_from_oracle(P0, "Cryptex", 0, 0, CRYPTEX_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, cryptex);
+
+    let idx = collect_evidence_ability_index(runner.state(), cryptex);
+
+    // CR 602.2a: announce activation. A mana ability resolves immediately and
+    // surfaces the new collect-evidence cost prompt (CR 605.2 / CR 701.59).
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: cryptex,
+            ability_index: idx,
+        })
+        .expect("activation accepted");
+
+    let (legal_cards, min) = match runner.state().waiting_for.clone() {
+        WaitingFor::CollectEvidenceChoice {
+            cards,
+            minimum_mana_value,
+            ..
+        } => (cards, minimum_mana_value),
+        other => panic!("Expected CollectEvidenceChoice, got {other:?}"),
+    };
+    assert_eq!(min, 3, "collect evidence 3 threshold");
+    assert!(legal_cards.len() >= 2, "graveyard cards offered");
+
+    // Exile two graveyard cards (total MV 4 >= 3) to pay the cost.
+    let chosen: Vec<ObjectId> = legal_cards.iter().copied().take(2).collect();
+    runner
+        .act(GameAction::SelectCards {
+            cards: chosen.clone(),
+        })
+        .expect("collect-evidence selection accepted");
+
+    // CR 605.3b: production prompts for the "any color" choice.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::ChooseManaColor { .. } => {}
+        other => panic!("Expected ChooseManaColor, got {other:?}"),
+    }
+    runner
+        .act(GameAction::ChooseManaColor {
+            choice: ManaChoice::SingleColor(ManaType::Blue),
+            count: 1,
+        })
+        .expect("color choice accepted");
+
+    // Cards exiled (no longer in graveyard).
+    for id in &chosen {
+        assert_eq!(
+            runner.state().objects.get(id).unwrap().zone,
+            engine::types::zones::Zone::Exile,
+            "evidence card exiled"
+        );
+    }
+    // +1 blue mana produced.
+    let pool = &runner.state().players[0].mana_pool;
+    assert_eq!(
+        pool.mana
+            .iter()
+            .filter(|m| m.color == ManaType::Blue)
+            .count(),
+        1,
+        "exactly one blue mana produced"
+    );
+    // Exactly one unlock counter on Cryptex (the SequentialSibling PutCounter
+    // sub-ability resolved once).
+    let unlock = runner
+        .state()
+        .objects
+        .get(&cryptex)
+        .unwrap()
+        .counters
+        .get(&CounterType::Generic("unlock".to_string()))
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(unlock, 1, "exactly one unlock counter placed");
+}
+
+#[test]
+fn cryptex_collect_evidence_not_payable_below_threshold() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Only one MV-1 card in graveyard → total MV 1 < 3.
+    scenario
+        .add_spell_to_graveyard(P0, "Opt", true)
+        .with_mana_cost(engine::types::mana::ManaCost::Cost {
+            generic: 1,
+            shards: vec![],
+        });
+    let cryptex = scenario
+        .add_creature_from_oracle(P0, "Cryptex", 0, 0, CRYPTEX_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, cryptex);
+    let idx = collect_evidence_ability_index(runner.state(), cryptex);
+
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: cryptex,
+        ability_index: idx,
+    });
+    // CR 701.59b: cannot collect evidence 3 with only MV 1 in graveyard — the
+    // mana ability is not payable, so activation is rejected and no mana is
+    // produced / no counter placed.
+    assert!(
+        result.is_err()
+            || !matches!(
+                runner.state().waiting_for,
+                WaitingFor::CollectEvidenceChoice { .. } | WaitingFor::ChooseManaColor { .. }
+            ),
+        "below-threshold activation must not enter the collect-evidence flow"
+    );
+}

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1705,6 +1705,8 @@ mod tests {
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
             chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
             chosen_exiled: Vec::new(),
             chosen_sacrificed_battlefield: Vec::new(),
             cost_paid_object: None,


### PR DESCRIPTION
Closes the two mana-ability cost types deferred from the PR #4140 Millikin
cluster fix. Both were excluded from is_self_contained_mana_subcost because
they need more than a synchronous cost-payer arm.

Cryptex ({T}, Collect evidence 3: Add one mana of any color): collect-evidence
(CR 701.59) is an interactive graveyard-exile cost. New CollectEvidenceResume::
ManaAbility variant routes the existing CollectEvidenceChoice prompt back into
advance_mana_ability_activation; the exile happens once in handle_choice and the
SequentialSibling unlock-counter sub_ability resolves after mana production.

Chicago Loop (Pay X speed: Add X mana in any combination): the player-announced
X (CR 107.3a/.3c) drives both the cost and the yield. New PayableResource::Speed
surfaces a PayAmountChoice bounded by current speed (CR 118.3 / 702.179f); the
chosen X is stamped via set_chosen_x_recursive so the PaySpeed cost (concretized
to a Fixed amount and paid through the single-authority costs::pay_ability_cost)
and the AnyCombination produced count resolve to the same value.

Frontend renders the new Speed payable resource (mana.resourceSpeed across all 7
locales). All serialized additions are additive with serde default/skip guards.
