### PR TITLE
feat(deck-builder): per-type sections and group-by-color mode

### DIFF
--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -56,6 +56,8 @@ export function DeckBuilder({
     setActiveSurface,
     deckView,
     setDeckView,
+    groupMode,
+    setGroupMode,
     dirty,
     cardDataCache,
     compatibility,
@@ -335,24 +337,45 @@ export function DeckBuilder({
                 </button>
               </div>
             ) : (
-              <div className="flex gap-1 rounded-lg border border-white/8 bg-black/18 p-0.5">
-                {(["list", "stack"] as const).map((view) => (
-                  <button
-                    key={view}
-                    type="button"
-                    onClick={() => setDeckView(view)}
-                    aria-label={view === "list" ? t("deck.listView") : t("deck.stackView")}
-                    aria-pressed={deckView === view}
-                    title={view === "list" ? t("deck.listView") : t("deck.stackView")}
-                    className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
-                      deckView === view
-                        ? "bg-white/14 text-white"
-                        : "text-slate-400 hover:text-slate-200"
-                    }`}
-                  >
-                    {view === "list" ? <ListViewIcon /> : <StackViewIcon />}
-                  </button>
-                ))}
+              <div className="flex items-center gap-2">
+                <div className="flex gap-1 rounded-lg border border-white/8 bg-black/18 p-0.5">
+                  {(["type", "color"] as const).map((mode) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => setGroupMode(mode)}
+                      aria-label={mode === "type" ? t("deck.groupByType") : t("deck.groupByColor")}
+                      aria-pressed={groupMode === mode}
+                      title={mode === "type" ? t("deck.groupByType") : t("deck.groupByColor")}
+                      className={`rounded-md px-2 py-1 text-xs transition-colors ${
+                        groupMode === mode
+                          ? "bg-white/14 text-white"
+                          : "text-slate-400 hover:text-slate-200"
+                      }`}
+                    >
+                      {mode === "type" ? t("deck.groupType") : t("deck.groupColor")}
+                    </button>
+                  ))}
+                </div>
+                <div className="flex gap-1 rounded-lg border border-white/8 bg-black/18 p-0.5">
+                  {(["list", "stack"] as const).map((view) => (
+                    <button
+                      key={view}
+                      type="button"
+                      onClick={() => setDeckView(view)}
+                      aria-label={view === "list" ? t("deck.listView") : t("deck.stackView")}
+                      aria-pressed={deckView === view}
+                      title={view === "list" ? t("deck.listView") : t("deck.stackView")}
+                      className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+                        deckView === view
+                          ? "bg-white/14 text-white"
+                          : "text-slate-400 hover:text-slate-200"
+                      }`}
+                    >
+                      {view === "list" ? <ListViewIcon /> : <StackViewIcon />}
+                    </button>
+                  ))}
+                </div>
               </div>
             )}
           </div>
@@ -398,6 +421,8 @@ export function DeckBuilder({
                         onCardHover={onCardHover}
                         format={format}
                         compatibility={compatibility}
+                        cardDataCache={cardDataCache}
+                        groupMode={groupMode}
                         onChooseArt={handleListContextMenu}
                         onSetAsCommander={isCommander ? handleSetCommander : undefined}
                         isCommanderEligible={isCommander ? isCommanderEligible : undefined}
@@ -411,6 +436,7 @@ export function DeckBuilder({
                       deck={deck}
                       commanders={commanders}
                       cardDataCache={cardDataCache}
+                      groupMode={groupMode}
                       onAddCard={handleAddCardByName}
                       onRemoveCard={handleRemoveCard}
                       onMoveCard={handleMoveCard}

--- a/client/src/components/deck-builder/DeckList.tsx
+++ b/client/src/components/deck-builder/DeckList.tsx
@@ -4,9 +4,11 @@ import type { ParsedDeck, DeckEntry } from "../../services/deckParser";
 import { detectAndParseDeck, exportDeck, resolveCommander } from "../../services/deckParser";
 import type { ExportFormat } from "../../services/deckParser";
 import type { DeckCompatibilityResult, UnsupportedCard } from "../../services/deckCompatibility";
+import type { ScryfallCard } from "../../services/scryfall";
 
 import { MoveList } from "./MoveList";
 import { mouseHoverPreview } from "./hoverPreview";
+import { groupAccent, groupKey, groupOrder, groupTitleKey, type GroupMode } from "./deckGrouping";
 import { isMaybeboardPolicy, useSideboardPolicy } from "./useSideboardPolicy";
 
 interface DeckListProps {
@@ -33,25 +35,12 @@ interface DeckListProps {
   commanders?: string[];
   /** Demotes a commander back into the main deck. Paired with `commanders`. */
   onRemoveCommander?: (name: string) => void;
+  /** Card data used to classify each main-deck entry into its group. */
+  cardDataCache: Map<string, ScryfallCard>;
+  /** Whether the main deck is sub-grouped by card type or by color. */
+  groupMode: GroupMode;
 }
 
-
-interface GroupedEntries {
-  Creatures: DeckEntry[];
-  Spells: DeckEntry[];
-  Lands: DeckEntry[];
-}
-
-function groupByType(entries: DeckEntry[]): GroupedEntries {
-  const groups: GroupedEntries = { Creatures: [], Spells: [], Lands: [] };
-  for (const entry of entries) {
-    // Without full card data, we use name heuristics; actual categorization
-    // will be enhanced when Scryfall data is cached.
-    // For now, all go to Spells unless we integrate card type data.
-    groups.Spells.push(entry);
-  }
-  return groups;
-}
 
 function totalCards(entries: DeckEntry[]): number {
   return entries.reduce((sum, e) => sum + e.count, 0);
@@ -72,6 +61,8 @@ export function DeckList({
   onOpenArtPicker,
   commanders = [],
   onRemoveCommander,
+  cardDataCache,
+  groupMode,
 }: DeckListProps) {
   const { t } = useTranslation("deck-builder");
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -83,7 +74,16 @@ export function DeckList({
   const [viewMode, setViewMode] = useState<"main" | "sideboard">("main");
   const mainTotal = totalCards(deck.main);
   const sideTotal = totalCards(deck.sideboard);
-  const mainGroups = groupByType(deck.main);
+  const mainGroups = useMemo(() => {
+    const buckets = new Map<string, DeckEntry[]>();
+    for (const entry of deck.main) {
+      const key = groupKey(groupMode, cardDataCache.get(entry.name));
+      const bucket = buckets.get(key);
+      if (bucket) bucket.push(entry);
+      else buckets.set(key, [entry]);
+    }
+    return buckets;
+  }, [deck.main, groupMode, cardDataCache]);
 
   // CR 100.4a: Ask the engine for the format's sideboard policy rather than
   // hardcoding 15. The engine is the single authority for format rules; the
@@ -276,11 +276,12 @@ export function DeckList({
           → Maybeboard / → Main) so the move target is explicit on touch. */}
       <div>
         {viewMode === "main"
-          ? (["Creatures", "Spells", "Lands"] as const).map((group) => (
+          ? groupOrder(groupMode).map((key) => (
               <MoveList
-                key={group}
-                title={t(`deckList.group.${group}`)}
-                entries={mainGroups[group]}
+                key={key}
+                title={t(`deckList.${groupTitleKey(groupMode, key)}`)}
+                accent={groupAccent(key)}
+                entries={mainGroups.get(key) ?? []}
                 section="main"
                 onRemove={onRemoveCard}
                 onMove={onMoveCard}

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -13,6 +13,7 @@ import { BASIC_LAND_NAMES } from "../../constants/game";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
 import { mouseHoverPreview } from "./hoverPreview";
+import { groupAccent, groupKey, groupRank, groupTitleKey, type GroupMode } from "./deckGrouping";
 import { isMaybeboardPolicy, useSideboardPolicy } from "./useSideboardPolicy";
 
 interface DeckStackProps {
@@ -30,6 +31,8 @@ interface DeckStackProps {
   /** CR 100.2a / CR 903.5b: engine-backed per-card copy cap resolver. Returns
    *  the format default (4 / 1) unless the card prints an override. */
   getEffectiveCap: (name: string) => number;
+  /** Whether the main deck is sub-grouped by card type or by color. */
+  groupMode: GroupMode;
 }
 
 type DeckStackSection = "commander" | "main" | "sideboard";
@@ -38,12 +41,12 @@ interface DeckStackItem {
   count: number;
   name: string;
   section: DeckStackSection;
-  typeRank: number;
+  groupTitle: string;
   sortKey: [number, number, string];
   sourcePrinting?: SourcePrinting;
 }
 
-interface DeckStackTypeGroup {
+interface DeckStackGroup {
   key: string;
   title: string;
   entries: DeckStackItem[];
@@ -51,13 +54,6 @@ interface DeckStackTypeGroup {
 
 const CARD_HEIGHT = 156;
 const CARD_WIDTH = 112;
-
-function getTypeRank(card: ScryfallCard | undefined): number {
-  const typeLine = card?.type_line.toLowerCase() ?? "";
-  if (typeLine.includes("land")) return 2;
-  if (typeLine.includes("creature")) return 0;
-  return 1;
-}
 
 function sortDeckStackItems(items: DeckStackItem[]): DeckStackItem[] {
   const next = [...items];
@@ -75,6 +71,7 @@ function createDeckStackItems(
   deck: ParsedDeck,
   commanders: string[],
   cardDataCache: Map<string, ScryfallCard>,
+  mode: GroupMode,
 ): Record<DeckStackSection, DeckStackItem[]> {
   const commandersItems: DeckStackItem[] = [];
   for (const name of commanders) {
@@ -83,7 +80,7 @@ function createDeckStackItems(
       count: 1,
       name,
       section: "commander",
-      typeRank: 0,
+      groupTitle: "",
       sortKey: [0, card?.cmc ?? 0, name.toLowerCase()],
     });
   }
@@ -91,28 +88,26 @@ function createDeckStackItems(
   const mainItems: DeckStackItem[] = [];
   for (const entry of deck.main) {
     const card = cardDataCache.get(entry.name);
-    const typeRank = getTypeRank(card);
     mainItems.push({
       count: entry.count,
       name: entry.name,
       sourcePrinting: entry.sourcePrinting,
       section: "main",
-      typeRank,
-      sortKey: [1 + typeRank, card?.cmc ?? 0, entry.name.toLowerCase()],
+      groupTitle: groupTitleKey(mode, groupKey(mode, card)),
+      sortKey: [groupRank(mode, card), card?.cmc ?? 0, entry.name.toLowerCase()],
     });
   }
 
   const sideboardItems: DeckStackItem[] = [];
   for (const entry of deck.sideboard) {
     const card = cardDataCache.get(entry.name);
-    const typeRank = getTypeRank(card);
     sideboardItems.push({
       count: entry.count,
       name: entry.name,
       sourcePrinting: entry.sourcePrinting,
       section: "sideboard",
-      typeRank,
-      sortKey: [4 + typeRank, card?.cmc ?? 0, entry.name.toLowerCase()],
+      groupTitle: groupTitleKey(mode, groupKey(mode, card)),
+      sortKey: [groupRank(mode, card), card?.cmc ?? 0, entry.name.toLowerCase()],
     });
   }
 
@@ -127,26 +122,26 @@ function totalCards(entries: DeckEntry[]): number {
   return entries.reduce((sum, entry) => sum + entry.count, 0);
 }
 
-function buildTypeGroups(entries: DeckStackItem[]): DeckStackTypeGroup[] {
+function buildGroups(entries: DeckStackItem[]): DeckStackGroup[] {
   if (entries.length === 0) return [];
 
-  const groups: DeckStackTypeGroup[] = [];
-  let currentRank: number | null = null;
+  const groups: DeckStackGroup[] = [];
+  let currentTitle: string | null = null;
   let currentEntries: DeckStackItem[] = [];
 
   const flush = () => {
-    if (currentRank === null || currentEntries.length === 0) return;
+    if (currentTitle === null || currentEntries.length === 0) return;
     groups.push({
-      key: `type-${currentRank}`,
-      title: currentRank === 0 ? "group.Creatures" : currentRank === 1 ? "group.Spells" : "group.Lands",
+      key: `group-${currentTitle}`,
+      title: currentTitle,
       entries: currentEntries,
     });
   };
 
   for (const entry of entries) {
-    if (currentRank !== entry.typeRank) {
+    if (currentTitle !== entry.groupTitle) {
       flush();
-      currentRank = entry.typeRank;
+      currentTitle = entry.groupTitle;
       currentEntries = [entry];
       continue;
     }
@@ -330,7 +325,7 @@ function DeckStackSectionLane({
   badge,
   entries,
   emptyLabel,
-  showTypeSections = false,
+  showGroupSections = false,
   extraGroups,
   isMaybeboard,
   onAddCard,
@@ -345,10 +340,10 @@ function DeckStackSectionLane({
   badge: string;
   entries: DeckStackItem[];
   emptyLabel: string;
-  showTypeSections?: boolean;
-  /** Extra groups rendered after the type groups (e.g. Sideboard appended
+  showGroupSections?: boolean;
+  /** Extra groups rendered after the main groups (e.g. Sideboard appended
    *  to the Main Deck lane below the Lands subsection). */
-  extraGroups?: DeckStackTypeGroup[];
+  extraGroups?: DeckStackGroup[];
   isMaybeboard: boolean;
   onAddCard: (name: string) => void;
   canAddCard: (item: DeckStackItem) => boolean;
@@ -359,13 +354,13 @@ function DeckStackSectionLane({
   onContextMenu?: (cardName: string, x: number, y: number) => void;
 }) {
   const { t } = useTranslation("deck-builder");
-  const typeGroups = useMemo(() => {
-    const base = showTypeSections
-      ? buildTypeGroups(entries)
+  const groups = useMemo(() => {
+    const base = showGroupSections
+      ? buildGroups(entries)
       : [{ key: "all", title: "", entries }];
     return extraGroups && extraGroups.length > 0 ? [...base, ...extraGroups] : base;
-  }, [entries, showTypeSections, extraGroups]);
-  const showGroupHeaders = showTypeSections || (extraGroups?.length ?? 0) > 0;
+  }, [entries, showGroupSections, extraGroups]);
+  const showGroupHeaders = showGroupSections || (extraGroups?.length ?? 0) > 0;
 
   return (
     <section className="flex min-w-0 flex-col rounded-[20px] border border-white/8 bg-black/14 px-3 py-3">
@@ -383,11 +378,14 @@ function DeckStackSectionLane({
       ) : (
         <div className="pb-1">
           <div className="flex min-w-0 flex-col gap-6">
-            {typeGroups.map((group, groupIndex) => (
+            {groups.map((group, groupIndex) => (
               <div key={group.key} className={groupIndex > 0 ? "pt-1" : undefined}>
-                {showGroupHeaders && (
+                {showGroupHeaders && (() => {
+                  const accent = groupAccent(group.title);
+                  return (
                   <div className="mb-3 flex items-center gap-3">
-                    <div className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                    <span className={`h-3.5 w-1 shrink-0 rounded-full ${accent.bar}`} aria-hidden="true" />
+                    <div className={`text-[0.68rem] font-semibold uppercase tracking-[0.22em] ${accent.text}`}>
                       {t(`stack.${group.title}`)}
                     </div>
                     <div className="h-px flex-1 bg-white/8" />
@@ -397,7 +395,8 @@ function DeckStackSectionLane({
                       })}
                     </div>
                   </div>
-                )}
+                  );
+                })()}
                 <div
                   className="grid justify-start gap-4"
                   style={{ gridTemplateColumns: `repeat(auto-fill, minmax(${CARD_WIDTH}px, ${CARD_WIDTH}px))` }}
@@ -438,12 +437,13 @@ export function DeckStack({
   onCardHover,
   format,
   getEffectiveCap,
+  groupMode,
 }: DeckStackProps) {
   const { t } = useTranslation("deck-builder");
   const isMaybeboard = isMaybeboardPolicy(useSideboardPolicy(format));
   const sections = useMemo(
-    () => createDeckStackItems(deck, commanders, cardDataCache),
-    [deck, commanders, cardDataCache],
+    () => createDeckStackItems(deck, commanders, cardDataCache, groupMode),
+    [deck, commanders, cardDataCache, groupMode],
   );
   const mainDeckCount = totalCards(deck.main) + commanders.length;
   const sideboardCount = totalCards(deck.sideboard);
@@ -472,7 +472,7 @@ export function DeckStack({
   // below the Lands subsection, so it shows up naturally as you scroll the
   // visual stack. Titled "Maybeboard" for Forbidden-policy formats, else
   // "Sideboard" — consistent with the list view.
-  const sideboardGroups = useMemo<DeckStackTypeGroup[]>(
+  const sideboardGroups = useMemo<DeckStackGroup[]>(
     () =>
       sections.sideboard.length > 0
         ? [
@@ -562,7 +562,7 @@ export function DeckStack({
               }
               entries={sections.main}
               emptyLabel={t("stack.mainEmpty")}
-              showTypeSections
+              showGroupSections
               extraGroups={sideboardGroups}
               isMaybeboard={isMaybeboard}
               onAddCard={onAddCard}

--- a/client/src/components/deck-builder/MoveList.tsx
+++ b/client/src/components/deck-builder/MoveList.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import type { DeckEntry } from "../../services/deckParser";
 import type { UnsupportedCard } from "../../services/deckCompatibility";
+import type { GroupAccent } from "./deckGrouping";
 
 import { CardEntryRow } from "./CardEntryRow";
 
@@ -38,6 +39,9 @@ export interface MoveListProps {
   /** Forwarded to each row's move button as the destination label. See
    *  `CardEntryRowProps.moveTargetLabel`. */
   moveTargetLabel?: string;
+  /** Optional per-section header accent (leading bar + title tint). Omitted by
+   *  the flat sideboard/BO3-modal lists, which keep the plain gray header. */
+  accent?: GroupAccent;
 }
 
 export function MoveList({
@@ -57,6 +61,7 @@ export function MoveList({
   density = "compact",
   onOpenArtPicker,
   moveTargetLabel,
+  accent,
 }: MoveListProps) {
   const { t } = useTranslation("deck-builder");
   if (entries.length === 0 && !alwaysShow) return null;
@@ -64,8 +69,13 @@ export function MoveList({
 
   return (
     <div className="mb-2">
-      <div className="mb-1 flex justify-between text-xs font-semibold uppercase text-gray-500">
-        <span>{title}</span>
+      <div className="mb-1 flex items-center justify-between text-xs font-semibold uppercase text-gray-500">
+        <span className={`flex items-center gap-1.5 ${accent ? accent.text : ""}`}>
+          {accent && (
+            <span className={`h-3 w-1 shrink-0 rounded-full ${accent.bar}`} aria-hidden="true" />
+          )}
+          {title}
+        </span>
         <span>({count})</span>
       </div>
       {warning && (

--- a/client/src/components/deck-builder/__tests__/DeckList.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckList.test.tsx
@@ -21,6 +21,8 @@ describe("DeckList commander section", () => {
         onImport={vi.fn()}
         commanders={["Krenko, Mob Boss"]}
         onRemoveCommander={onRemoveCommander}
+        cardDataCache={new Map()}
+        groupMode="type"
       />,
     );
 
@@ -38,6 +40,8 @@ describe("DeckList commander section", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onImport={vi.fn()}
+        cardDataCache={new Map()}
+        groupMode="type"
       />,
     );
     expect(screen.queryByText(/as commander/i)).not.toBeInTheDocument();

--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -91,6 +91,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={() => 4}
+        groupMode="type"
       />,
     );
 
@@ -143,6 +144,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={() => 4}
+        groupMode="type"
       />,
     );
 
@@ -154,7 +156,7 @@ describe("DeckStack", () => {
     const plainsTile = getTileByRemoveTitle("Plains");
 
     expect(screen.getByText("Creatures")).toBeInTheDocument();
-    expect(screen.getByText("Spells")).toBeInTheDocument();
+    expect(screen.getByText("Enchantments")).toBeInTheDocument();
     expect(screen.getByText("Lands")).toBeInTheDocument();
     expect(
       screen.getByTitle("Ajani's Pridemate is at the copy limit"),
@@ -190,6 +192,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={(name) => (name === "Relentless Rats" ? Infinity : 4)}
+        groupMode="type"
       />,
     );
 
@@ -211,6 +214,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
+        groupMode="type"
       />,
     );
     expect(screen.getByTitle("Add one Seven Dwarves")).toBeEnabled();
@@ -227,6 +231,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
+        groupMode="type"
       />,
     );
     expect(
@@ -251,6 +256,7 @@ describe("DeckStack", () => {
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={() => 1}
+        groupMode="type"
       />,
     );
 
@@ -279,6 +285,7 @@ describe("DeckStack", () => {
         onMoveCard={onMoveCard}
         onRemoveCommander={vi.fn()}
         getEffectiveCap={() => 4}
+        groupMode="type"
       />,
     );
 

--- a/client/src/components/deck-builder/__tests__/deckGrouping.test.ts
+++ b/client/src/components/deck-builder/__tests__/deckGrouping.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyByColor, classifyByType, groupAccent, groupRank } from "../deckGrouping";
+import type { ScryfallCard } from "../../../services/scryfall";
+
+function makeCard(typeLine: string, colorIdentity: string[] = []): ScryfallCard {
+  return {
+    id: typeLine.toLowerCase(),
+    name: typeLine,
+    mana_cost: "",
+    cmc: 0,
+    type_line: typeLine,
+    color_identity: colorIdentity,
+    legalities: {},
+  };
+}
+
+describe("classifyByType", () => {
+  it("uses land-before-creature precedence for multi-type lines", () => {
+    expect(classifyByType(makeCard("Land Creature — Dryad Arbor"))).toBe("Lands");
+    expect(classifyByType(makeCard("Artifact Land"))).toBe("Lands");
+  });
+
+  it("classifies an artifact creature as a creature (creature precedence)", () => {
+    expect(classifyByType(makeCard("Artifact Creature — Construct"))).toBe("Creatures");
+  });
+
+  it("classifies the remaining card types", () => {
+    expect(classifyByType(makeCard("Planeswalker — Jace"))).toBe("Planeswalkers");
+    expect(classifyByType(makeCard("Instant"))).toBe("Instants");
+    expect(classifyByType(makeCard("Sorcery"))).toBe("Sorceries");
+    expect(classifyByType(makeCard("Artifact — Equipment"))).toBe("Artifacts");
+    expect(classifyByType(makeCard("Enchantment — Aura"))).toBe("Enchantments");
+    expect(classifyByType(makeCard("Battle — Siege"))).toBe("Battles");
+  });
+
+  it("falls back to Other for unknown types and undefined cards", () => {
+    expect(classifyByType(makeCard("Conspiracy"))).toBe("Other");
+    expect(classifyByType(undefined)).toBe("Other");
+  });
+});
+
+describe("classifyByColor", () => {
+  it("maps a single color identity to its color name", () => {
+    expect(classifyByColor(makeCard("Creature", ["W"]))).toBe("White");
+    expect(classifyByColor(makeCard("Creature", ["U"]))).toBe("Blue");
+    expect(classifyByColor(makeCard("Creature", ["B"]))).toBe("Black");
+    expect(classifyByColor(makeCard("Creature", ["R"]))).toBe("Red");
+    expect(classifyByColor(makeCard("Creature", ["G"]))).toBe("Green");
+  });
+
+  it("treats 2+ colors as Multicolor", () => {
+    expect(classifyByColor(makeCard("Creature", ["W", "U"]))).toBe("Multicolor");
+  });
+
+  it("treats an empty identity as Colorless", () => {
+    expect(classifyByColor(makeCard("Artifact", []))).toBe("Colorless");
+  });
+
+  it("classifies lands as Lands regardless of color identity", () => {
+    expect(classifyByColor(makeCard("Land", ["G"]))).toBe("Lands");
+    expect(classifyByColor(makeCard("Basic Land — Forest", []))).toBe("Lands");
+  });
+
+  it("treats an undefined card as Colorless", () => {
+    expect(classifyByColor(undefined)).toBe("Colorless");
+  });
+});
+
+describe("groupRank", () => {
+  it("orders type groups with Creatures before Lands before Other", () => {
+    const creature = makeCard("Creature");
+    const land = makeCard("Basic Land — Plains");
+    const other = makeCard("Conspiracy");
+    expect(groupRank("type", creature)).toBeLessThan(groupRank("type", land));
+    expect(groupRank("type", land)).toBeLessThan(groupRank("type", other));
+  });
+
+  it("orders color groups with White before Lands", () => {
+    const white = makeCard("Creature", ["W"]);
+    const land = makeCard("Land", ["W"]);
+    expect(groupRank("color", white)).toBeLessThan(groupRank("color", land));
+  });
+});
+
+describe("groupAccent", () => {
+  it("resolves a raw group key (list view) to its accent", () => {
+    expect(groupAccent("White").bar).toBe("bg-amber-200");
+    expect(groupAccent("Creatures").text).toBe("text-emerald-300");
+  });
+
+  it("resolves a prefixed title sub-path (stack view) by stripping the prefix", () => {
+    expect(groupAccent("colorGroup.White")).toEqual(groupAccent("White"));
+    expect(groupAccent("group.Lands")).toEqual(groupAccent("Lands"));
+  });
+
+  it("falls back to a neutral accent for sideboard/maybeboard and unknown keys", () => {
+    const neutral = groupAccent("sideboardGroup");
+    expect(neutral.bar).toBe("bg-white/15");
+    expect(groupAccent("maybeboardGroup")).toEqual(neutral);
+    expect(groupAccent("")).toEqual(neutral);
+  });
+});

--- a/client/src/components/deck-builder/deckGrouping.ts
+++ b/client/src/components/deck-builder/deckGrouping.ts
@@ -1,0 +1,124 @@
+import type { ScryfallCard } from "../../services/scryfall";
+
+/** How the main deck is sub-grouped: by card type or by color. Lands stay
+ *  their own section in both modes. */
+export type GroupMode = "type" | "color";
+
+export const TYPE_GROUP_ORDER = [
+  "Creatures",
+  "Planeswalkers",
+  "Instants",
+  "Sorceries",
+  "Artifacts",
+  "Enchantments",
+  "Battles",
+  "Lands",
+  "Other",
+] as const;
+
+export const COLOR_GROUP_ORDER = [
+  "White",
+  "Blue",
+  "Black",
+  "Red",
+  "Green",
+  "Multicolor",
+  "Colorless",
+  "Lands",
+] as const;
+
+const COLOR_NAMES: Record<string, string> = {
+  W: "White",
+  U: "Blue",
+  B: "Black",
+  R: "Red",
+  G: "Green",
+};
+
+/** First-match precedence: land-before-creature preserves the prior
+ *  getTypeRank precedence, and MDFC `"//"` type lines classify by the first
+ *  matching face (pre-existing behavior, intentional). */
+export function classifyByType(card: ScryfallCard | undefined): string {
+  const typeLine = card?.type_line.toLowerCase() ?? "";
+  if (typeLine.includes("land")) return "Lands";
+  if (typeLine.includes("creature")) return "Creatures";
+  if (typeLine.includes("planeswalker")) return "Planeswalkers";
+  if (typeLine.includes("instant")) return "Instants";
+  if (typeLine.includes("sorcery")) return "Sorceries";
+  if (typeLine.includes("artifact")) return "Artifacts";
+  if (typeLine.includes("enchantment")) return "Enchantments";
+  if (typeLine.includes("battle")) return "Battles";
+  return "Other";
+}
+
+export function classifyByColor(card: ScryfallCard | undefined): string {
+  if (!card) return "Colorless";
+  if (card.type_line.toLowerCase().includes("land")) return "Lands";
+  const ci = card.color_identity;
+  if (ci.length === 0) return "Colorless";
+  if (ci.length > 1) return "Multicolor";
+  return COLOR_NAMES[ci[0]] ?? "Colorless";
+}
+
+export function groupKey(mode: GroupMode, card: ScryfallCard | undefined): string {
+  return mode === "type" ? classifyByType(card) : classifyByColor(card);
+}
+
+export function groupOrder(mode: GroupMode): readonly string[] {
+  return mode === "type" ? TYPE_GROUP_ORDER : COLOR_GROUP_ORDER;
+}
+
+export function groupRank(mode: GroupMode, card: ScryfallCard | undefined): number {
+  const order = groupOrder(mode);
+  const index = order.indexOf(groupKey(mode, card));
+  return index === -1 ? order.length : index;
+}
+
+export function groupTitleKey(mode: GroupMode, key: string): string {
+  return (mode === "type" ? "group." : "colorGroup.") + key;
+}
+
+/** A section-header accent: a small leading bar color and a matching title
+ *  tint. Shared by the list and stack views so both modes' headers read the
+ *  same. Color hues follow the deck-builder color language (ManaCurve's
+ *  COLOR_MAP); type sections get distinct category accents. Classes are
+ *  enumerated as full literals so Tailwind's JIT keeps them. */
+export interface GroupAccent {
+  bar: string;
+  text: string;
+}
+
+const GROUP_ACCENTS: Record<string, GroupAccent> = {
+  // Color mode (WUBRG mirror ManaCurve's COLOR_MAP, lightened for contrast on
+  // the dark header background).
+  White: { bar: "bg-amber-200", text: "text-amber-200" },
+  Blue: { bar: "bg-blue-500", text: "text-blue-300" },
+  Black: { bar: "bg-zinc-400", text: "text-zinc-300" },
+  Red: { bar: "bg-red-500", text: "text-red-300" },
+  Green: { bar: "bg-green-500", text: "text-green-300" },
+  Multicolor: { bar: "bg-amber-400", text: "text-amber-300" },
+  Colorless: { bar: "bg-slate-400", text: "text-slate-300" },
+  // Type mode.
+  Creatures: { bar: "bg-emerald-500", text: "text-emerald-300" },
+  Planeswalkers: { bar: "bg-fuchsia-500", text: "text-fuchsia-300" },
+  Instants: { bar: "bg-sky-500", text: "text-sky-300" },
+  Sorceries: { bar: "bg-indigo-500", text: "text-indigo-300" },
+  Artifacts: { bar: "bg-slate-400", text: "text-slate-300" },
+  Enchantments: { bar: "bg-amber-300", text: "text-amber-200" },
+  Battles: { bar: "bg-orange-500", text: "text-orange-300" },
+  Other: { bar: "bg-gray-500", text: "text-gray-400" },
+  // Shared by both modes.
+  Lands: { bar: "bg-stone-500", text: "text-stone-300" },
+};
+
+/** Neutral fallback for headers with no group key (sideboard/maybeboard lanes
+ *  in the stack view) or any unrecognized key. */
+const NEUTRAL_ACCENT: GroupAccent = { bar: "bg-white/15", text: "text-slate-400" };
+
+/** Resolve a header accent. Accepts either a raw group key (`"White"`, as the
+ *  list view holds) or a title sub-path (`"colorGroup.White"` / `"group.Lands"`
+ *  / `"sideboardGroup"`, as the stack view stores on each group). */
+export function groupAccent(key: string): GroupAccent {
+  const raw = key.includes(".") ? key.slice(key.lastIndexOf(".") + 1) : key;
+  return GROUP_ACCENTS[raw] ?? NEUTRAL_ACCENT;
+}

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -21,6 +21,7 @@ import { preconDeckEntryToParsedDeck } from "../../services/preconDecks";
 import { useDeckCardData } from "../../hooks/useDeckCardData";
 import type { CardSearchFilters } from "./CardSearch";
 import { hasSearchCriteria } from "./searchFilters";
+import type { GroupMode } from "./deckGrouping";
 import type { GameFormat } from "../../adapter/types";
 import { FORMAT_REGISTRY, formatMetadata } from "../../data/formatRegistry";
 import type { CommanderBracket } from "../../types/bracket";
@@ -79,6 +80,8 @@ export function useDeckBuilder({
   const [activeSurface, setActiveSurface] = useState<"deck" | "info">("deck");
   // Visual representation of the deck within the main canvas.
   const [deckView, setDeckView] = useState<"list" | "stack">("list");
+  // How the main deck is sub-grouped within the canvas (by card type or color).
+  const [groupMode, setGroupMode] = useState<GroupMode>("type");
   // Unsaved-changes flag: set on any deck mutation, cleared on save/clone/load.
   // Drives the leave/load confirmation and the beforeunload guard.
   const [dirty, setDirty] = useState(false);
@@ -677,6 +680,8 @@ export function useDeckBuilder({
     setActiveSurface,
     deckView,
     setDeckView,
+    groupMode,
+    setGroupMode,
     dirty,
     cardDataCache,
     compatibility,

--- a/client/src/i18n/locales/de/deck-builder.json
+++ b/client/src/i18n/locales/de/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Zurück zum Deck",
     "listView": "Listenansicht",
-    "stackView": "Stapelansicht"
+    "stackView": "Stapelansicht",
+    "groupType": "Typ",
+    "groupColor": "Farbe",
+    "groupByType": "Nach Typ gruppieren",
+    "groupByColor": "Nach Farbe gruppieren"
   },
   "tabs": {
     "ariaLabel": "Deckbuilder-Oberfläche",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Fahre über eine Hauptdeck-Karte und klicke auf →, um sie hierher zu verschieben.",
     "group": {
       "Creatures": "Kreaturen",
-      "Spells": "Zaubersprüche",
+      "Planeswalkers": "Planeswalker",
+      "Instants": "Spontanzauber",
+      "Sorceries": "Hexereien",
+      "Artifacts": "Artefakte",
+      "Enchantments": "Verzauberungen",
+      "Battles": "Schlachten",
+      "Lands": "Länder",
+      "Other": "Sonstige"
+    },
+    "colorGroup": {
+      "White": "Weiß",
+      "Blue": "Blau",
+      "Black": "Schwarz",
+      "Red": "Rot",
+      "Green": "Grün",
+      "Multicolor": "Mehrfarbig",
+      "Colorless": "Farblos",
       "Lands": "Länder"
     },
     "importModalTitle": "Deck importieren",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} Karten",
     "group": {
       "Creatures": "Kreaturen",
-      "Spells": "Zaubersprüche",
+      "Planeswalkers": "Planeswalker",
+      "Instants": "Spontanzauber",
+      "Sorceries": "Hexereien",
+      "Artifacts": "Artefakte",
+      "Enchantments": "Verzauberungen",
+      "Battles": "Schlachten",
+      "Lands": "Länder",
+      "Other": "Sonstige"
+    },
+    "colorGroup": {
+      "White": "Weiß",
+      "Blue": "Blau",
+      "Black": "Schwarz",
+      "Red": "Rot",
+      "Green": "Grün",
+      "Multicolor": "Mehrfarbig",
+      "Colorless": "Farblos",
       "Lands": "Länder"
     },
     "sideboardGroup": "Sideboard",

--- a/client/src/i18n/locales/en/deck-builder.json
+++ b/client/src/i18n/locales/en/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Back to deck",
     "listView": "List view",
-    "stackView": "Stack view"
+    "stackView": "Stack view",
+    "groupType": "Type",
+    "groupColor": "Color",
+    "groupByType": "Group by type",
+    "groupByColor": "Group by color"
   },
   "tabs": {
     "ariaLabel": "Deck builder surface",
@@ -105,7 +109,23 @@
     "maybeboardEmptyHint": "Cards you're considering. Tap → Maybeboard on a deck card to park one here.",
     "group": {
       "Creatures": "Creatures",
-      "Spells": "Spells",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Instants",
+      "Sorceries": "Sorceries",
+      "Artifacts": "Artifacts",
+      "Enchantments": "Enchantments",
+      "Battles": "Battles",
+      "Lands": "Lands",
+      "Other": "Other"
+    },
+    "colorGroup": {
+      "White": "White",
+      "Blue": "Blue",
+      "Black": "Black",
+      "Red": "Red",
+      "Green": "Green",
+      "Multicolor": "Multicolor",
+      "Colorless": "Colorless",
       "Lands": "Lands"
     },
     "importModalTitle": "Import Deck",
@@ -145,7 +165,23 @@
     "groupCards_other": "{{count}} cards",
     "group": {
       "Creatures": "Creatures",
-      "Spells": "Spells",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Instants",
+      "Sorceries": "Sorceries",
+      "Artifacts": "Artifacts",
+      "Enchantments": "Enchantments",
+      "Battles": "Battles",
+      "Lands": "Lands",
+      "Other": "Other"
+    },
+    "colorGroup": {
+      "White": "White",
+      "Blue": "Blue",
+      "Black": "Black",
+      "Red": "Red",
+      "Green": "Green",
+      "Multicolor": "Multicolor",
+      "Colorless": "Colorless",
       "Lands": "Lands"
     },
     "sideboardGroup": "Sideboard",

--- a/client/src/i18n/locales/es/deck-builder.json
+++ b/client/src/i18n/locales/es/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Volver al mazo",
     "listView": "Vista de lista",
-    "stackView": "Vista de pila"
+    "stackView": "Vista de pila",
+    "groupType": "Tipo",
+    "groupColor": "Color",
+    "groupByType": "Agrupar por tipo",
+    "groupByColor": "Agrupar por color"
   },
   "tabs": {
     "ariaLabel": "Superficie del constructor de mazos",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Pasa el cursor sobre una carta del mazo principal y haz clic en → para moverla aquí.",
     "group": {
       "Creatures": "Criaturas",
-      "Spells": "Hechizos",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Instantáneos",
+      "Sorceries": "Conjuros",
+      "Artifacts": "Artefactos",
+      "Enchantments": "Encantamientos",
+      "Battles": "Batallas",
+      "Lands": "Tierras",
+      "Other": "Otros"
+    },
+    "colorGroup": {
+      "White": "Blanco",
+      "Blue": "Azul",
+      "Black": "Negro",
+      "Red": "Rojo",
+      "Green": "Verde",
+      "Multicolor": "Multicolor",
+      "Colorless": "Incoloro",
       "Lands": "Tierras"
     },
     "importModalTitle": "Importar mazo",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} cartas",
     "group": {
       "Creatures": "Criaturas",
-      "Spells": "Hechizos",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Instantáneos",
+      "Sorceries": "Conjuros",
+      "Artifacts": "Artefactos",
+      "Enchantments": "Encantamientos",
+      "Battles": "Batallas",
+      "Lands": "Tierras",
+      "Other": "Otros"
+    },
+    "colorGroup": {
+      "White": "Blanco",
+      "Blue": "Azul",
+      "Black": "Negro",
+      "Red": "Rojo",
+      "Green": "Verde",
+      "Multicolor": "Multicolor",
+      "Colorless": "Incoloro",
       "Lands": "Tierras"
     },
     "sideboardGroup": "Banquillo",

--- a/client/src/i18n/locales/fr/deck-builder.json
+++ b/client/src/i18n/locales/fr/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Retour au deck",
     "listView": "Vue en liste",
-    "stackView": "Vue en pile"
+    "stackView": "Vue en pile",
+    "groupType": "Type",
+    "groupColor": "Couleur",
+    "groupByType": "Grouper par type",
+    "groupByColor": "Grouper par couleur"
   },
   "tabs": {
     "ariaLabel": "Surface du constructeur de deck",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Survolez une carte du deck principal et cliquez sur → pour la déplacer ici.",
     "group": {
       "Creatures": "Créatures",
-      "Spells": "Sorts",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Éphémères",
+      "Sorceries": "Rituels",
+      "Artifacts": "Artefacts",
+      "Enchantments": "Enchantements",
+      "Battles": "Batailles",
+      "Lands": "Terrains",
+      "Other": "Autres"
+    },
+    "colorGroup": {
+      "White": "Blanc",
+      "Blue": "Bleu",
+      "Black": "Noir",
+      "Red": "Rouge",
+      "Green": "Vert",
+      "Multicolor": "Multicolore",
+      "Colorless": "Incolore",
       "Lands": "Terrains"
     },
     "importModalTitle": "Importer un deck",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} cartes",
     "group": {
       "Creatures": "Créatures",
-      "Spells": "Sorts",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Éphémères",
+      "Sorceries": "Rituels",
+      "Artifacts": "Artefacts",
+      "Enchantments": "Enchantements",
+      "Battles": "Batailles",
+      "Lands": "Terrains",
+      "Other": "Autres"
+    },
+    "colorGroup": {
+      "White": "Blanc",
+      "Blue": "Bleu",
+      "Black": "Noir",
+      "Red": "Rouge",
+      "Green": "Vert",
+      "Multicolor": "Multicolore",
+      "Colorless": "Incolore",
       "Lands": "Terrains"
     },
     "sideboardGroup": "Réserve",

--- a/client/src/i18n/locales/it/deck-builder.json
+++ b/client/src/i18n/locales/it/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Torna al mazzo",
     "listView": "Vista elenco",
-    "stackView": "Vista pila"
+    "stackView": "Vista pila",
+    "groupType": "Tipo",
+    "groupColor": "Colore",
+    "groupByType": "Raggruppa per tipo",
+    "groupByColor": "Raggruppa per colore"
   },
   "tabs": {
     "ariaLabel": "Superficie del costruttore di mazzi",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Passa il mouse su una carta del mazzo principale e clicca → per spostarla qui.",
     "group": {
       "Creatures": "Creature",
-      "Spells": "Magie",
+      "Planeswalkers": "Planeswalker",
+      "Instants": "Istantanei",
+      "Sorceries": "Stregonerie",
+      "Artifacts": "Artefatti",
+      "Enchantments": "Incantesimi",
+      "Battles": "Battaglie",
+      "Lands": "Terre",
+      "Other": "Altri"
+    },
+    "colorGroup": {
+      "White": "Bianco",
+      "Blue": "Blu",
+      "Black": "Nero",
+      "Red": "Rosso",
+      "Green": "Verde",
+      "Multicolor": "Multicolore",
+      "Colorless": "Incolore",
       "Lands": "Terre"
     },
     "importModalTitle": "Importa mazzo",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} carte",
     "group": {
       "Creatures": "Creature",
-      "Spells": "Magie",
+      "Planeswalkers": "Planeswalker",
+      "Instants": "Istantanei",
+      "Sorceries": "Stregonerie",
+      "Artifacts": "Artefatti",
+      "Enchantments": "Incantesimi",
+      "Battles": "Battaglie",
+      "Lands": "Terre",
+      "Other": "Altri"
+    },
+    "colorGroup": {
+      "White": "Bianco",
+      "Blue": "Blu",
+      "Black": "Nero",
+      "Red": "Rosso",
+      "Green": "Verde",
+      "Multicolor": "Multicolore",
+      "Colorless": "Incolore",
       "Lands": "Terre"
     },
     "sideboardGroup": "Sideboard",

--- a/client/src/i18n/locales/pl/deck-builder.json
+++ b/client/src/i18n/locales/pl/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Powrót do talii",
     "listView": "Widok listy",
-    "stackView": "Widok stosu"
+    "stackView": "Widok stosu",
+    "groupType": "Typ",
+    "groupColor": "Kolor",
+    "groupByType": "Grupuj według typu",
+    "groupByColor": "Grupuj według koloru"
   },
   "tabs": {
     "ariaLabel": "Powierzchnia kreatora talii",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Najedź na kartę z talii głównej i kliknij →, aby ją tu przenieść.",
     "group": {
       "Creatures": "Stwory",
-      "Spells": "Czary",
+      "Planeswalkers": "Planeswalkery",
+      "Instants": "Sztuczki",
+      "Sorceries": "Czary",
+      "Artifacts": "Artefakty",
+      "Enchantments": "Zaklęcia",
+      "Battles": "Bitwy",
+      "Lands": "Ziemie",
+      "Other": "Inne"
+    },
+    "colorGroup": {
+      "White": "Biały",
+      "Blue": "Niebieski",
+      "Black": "Czarny",
+      "Red": "Czerwony",
+      "Green": "Zielony",
+      "Multicolor": "Wielokolorowy",
+      "Colorless": "Bezbarwny",
       "Lands": "Ziemie"
     },
     "importModalTitle": "Importuj talię",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} kart",
     "group": {
       "Creatures": "Stwory",
-      "Spells": "Czary",
+      "Planeswalkers": "Planeswalkery",
+      "Instants": "Sztuczki",
+      "Sorceries": "Czary",
+      "Artifacts": "Artefakty",
+      "Enchantments": "Zaklęcia",
+      "Battles": "Bitwy",
+      "Lands": "Ziemie",
+      "Other": "Inne"
+    },
+    "colorGroup": {
+      "White": "Biały",
+      "Blue": "Niebieski",
+      "Black": "Czarny",
+      "Red": "Czerwony",
+      "Green": "Zielony",
+      "Multicolor": "Wielokolorowy",
+      "Colorless": "Bezbarwny",
       "Lands": "Ziemie"
     },
     "sideboardGroup": "Zaplecze",

--- a/client/src/i18n/locales/pt/deck-builder.json
+++ b/client/src/i18n/locales/pt/deck-builder.json
@@ -30,7 +30,11 @@
   "deck": {
     "backToDeck": "Voltar ao deck",
     "listView": "Visualização em lista",
-    "stackView": "Visualização em pilha"
+    "stackView": "Visualização em pilha",
+    "groupType": "Tipo",
+    "groupColor": "Cor",
+    "groupByType": "Agrupar por tipo",
+    "groupByColor": "Agrupar por cor"
   },
   "tabs": {
     "ariaLabel": "Superfície do construtor de decks",
@@ -99,7 +103,23 @@
     "sideboardEmptyHint": "Passe o mouse sobre uma carta do deck principal e clique em → para movê-la para cá.",
     "group": {
       "Creatures": "Criaturas",
-      "Spells": "Mágicas",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Mágicas Instantâneas",
+      "Sorceries": "Feitiços",
+      "Artifacts": "Artefatos",
+      "Enchantments": "Encantamentos",
+      "Battles": "Batalhas",
+      "Lands": "Terrenos",
+      "Other": "Outros"
+    },
+    "colorGroup": {
+      "White": "Branco",
+      "Blue": "Azul",
+      "Black": "Preto",
+      "Red": "Vermelho",
+      "Green": "Verde",
+      "Multicolor": "Multicolorido",
+      "Colorless": "Incolor",
       "Lands": "Terrenos"
     },
     "importModalTitle": "Importar Deck",
@@ -140,7 +160,23 @@
     "groupCards_other": "{{count}} cartas",
     "group": {
       "Creatures": "Criaturas",
-      "Spells": "Mágicas",
+      "Planeswalkers": "Planeswalkers",
+      "Instants": "Mágicas Instantâneas",
+      "Sorceries": "Feitiços",
+      "Artifacts": "Artefatos",
+      "Enchantments": "Encantamentos",
+      "Battles": "Batalhas",
+      "Lands": "Terrenos",
+      "Other": "Outros"
+    },
+    "colorGroup": {
+      "White": "Branco",
+      "Blue": "Azul",
+      "Black": "Preto",
+      "Red": "Vermelho",
+      "Green": "Verde",
+      "Multicolor": "Multicolorido",
+      "Colorless": "Incolor",
       "Lands": "Terrenos"
     },
     "sideboardGroup": "Sideboard",


### PR DESCRIPTION
Split the deck editor's catch-all "Spells" section into separate Creatures/Planeswalkers/Instants/Sorceries/Artifacts/Enchantments/Battles/Lands/Other sections, and add a Type/Color grouping toggle. Lands stay their own section in both modes. A shared deckGrouping module classifies cards by type or color_identity and is consumed by both the list (DeckList) and visual stack (DeckStack) views. Section headers gain a per-section accent bar + tinted title. All seven locales updated to key parity.
