### PR TITLE
fix(parser): Shelob Food-token copy drops 'except it's a Food artifact… loses all other card types'

### DIFF
--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -203,8 +203,8 @@ pub(crate) fn parse_except_body<'a>(
     // CR 707.9d: the replacement form ("… and loses all other card types")
     // must be tried before the additive form, which would otherwise leave the
     // "and loses all other card types" tail unconsumed.
-    if let Some((rest, modification)) = parse_its_a_type_loses_others(input) {
-        return Some((rest, vec![modification]));
+    if let Some((rest, modifications)) = parse_its_a_type_loses_others(input) {
+        return Some((rest, modifications));
     }
     if let Some((rest, subtype)) = parse_its_a_type_in_addition(input) {
         return Some((rest, vec![subtype]));
@@ -705,18 +705,28 @@ fn parse_its_a_type_in_addition(input: &str) -> Option<(&str, ContinuousModifica
     Some((rest, modification))
 }
 
-/// CR 205.1a + CR 613.1d + CR 707.9d: "it's a(n) {type} and loses all other
-/// card types" — REPLACES the copied card's entire core card-type set with the
-/// single named type (set-replacement, not addition). Myrkul, Lord of Bones:
-/// "create a token that's a copy of that card, except it's an enchantment and
-/// loses all other card types." Distinct from `parse_its_a_type_in_addition`
-/// (which ADDS the type, keeping the copied types); the "and loses all other
-/// card types" suffix is the replacement signal. `SetCardTypes` names only the
-/// replacement core types; supertype retention and CR 205.1a subtype
-/// correlation are applied downstream when the modification resolves. Emits
-/// [`ContinuousModification::SetCardTypes`].
-fn parse_its_a_type_loses_others(input: &str) -> Option<(&str, ContinuousModification)> {
-    let (rest, _) = alt((
+/// CR 205.1a + CR 613.1d + CR 707.9d: "it's a(n) {type words} [with
+/// "<ability>"] and [it] loses all other card types" — REPLACES the copied
+/// card's core card-type set with the named core type(s), ADDS any named
+/// subtypes, and optionally grants a quoted ability. The "loses all other card
+/// types" suffix is the replacement signal (distinct from
+/// `parse_its_a_type_in_addition`, which keeps the copied types).
+///
+/// Generalizes the single-core-type case (Myrkul, Lord of Bones: "it's an
+/// enchantment and loses all other card types") to the multi-word "Food token"
+/// shape:
+/// - Espers to Magicite: "it's an artifact and it loses all other card types"
+/// - Shelob, Child of Ungoliant: "it's a Food artifact with "{2}, {T},
+///   Sacrifice ~: You gain 3 life," and it loses all other card types"
+///
+/// Each space-delimited type word is classified as a core type (added to the
+/// `SetCardTypes` replacement set) or a subtype (emitted as `AddSubtype`).
+/// `SetCardTypes` names only the replacement core types; supertype retention
+/// and CR 205.1a subtype correlation are applied downstream when the
+/// modification resolves. The optional `with "<ability>"` clause is granted via
+/// the shared quoted-ability parser, mirroring `parse_it_has_quoted_ability`.
+fn parse_its_a_type_loses_others(input: &str) -> Option<(&str, Vec<ContinuousModification>)> {
+    let (after_article, _) = alt((
         tag::<_, _, OracleError<'_>>("it's an "),
         tag("it's a "),
         tag("it\u{2019}s an "),
@@ -724,24 +734,55 @@ fn parse_its_a_type_loses_others(input: &str) -> Option<(&str, ContinuousModific
     ))
     .parse(input)
     .ok()?;
-    let (type_word, rest) = nom_primitives::split_once_on(rest, " and loses all other card types")
-        .ok()
-        .map(|(_, pair)| pair)?;
-    let type_word = type_word.trim();
-    if type_word.is_empty() {
+    // CR 707.9d: the replacement signal. Accept the subject-repeated "and it
+    // loses" variant (Espers to Magicite, Shelob) longest-first so it is not
+    // split as the elided "and loses" variant (Myrkul) with a dangling "it".
+    let (head, rest) =
+        nom_primitives::split_once_on(after_article, " and it loses all other card types")
+            .or_else(|_| {
+                nom_primitives::split_once_on(after_article, " and loses all other card types")
+            })
+            .ok()
+            .map(|(_, pair)| pair)?;
+    // CR 707.9a: peel an optional `with <…>` clause off the head before the
+    // type list so its text is never mistaken for type words. Only the quoted
+    // form (Shelob's Food sacrifice ability) is granted; a non-quoted `with`
+    // clause (Imposter Mech's "with crew 3") is a not-yet-supported shape that
+    // is dropped fail-soft rather than parsed as bogus subtypes.
+    let (type_text, ability_mods) = match nom_primitives::split_once_on(head, " with ") {
+        Ok((_, (types, after_with))) => {
+            let mods = if after_with.trim_start().starts_with('"') {
+                split_single_quoted_ability(after_with)
+                    .map(|(quoted_text, _)| parse_quoted_ability_modifications(quoted_text))
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            (types, mods)
+        }
+        Err(_) => (head, Vec::new()),
+    };
+    // CR 205.1b + CR 707.9d: classify each type word. Core types form the
+    // replacement set; subtypes are added. "loses all other card types" is a
+    // card-type statement, so a clause naming no recognised core type has
+    // nothing to replace the set with — decline rather than guess.
+    let mut core_types = Vec::new();
+    let mut modifications = Vec::new();
+    for word in type_text.split_whitespace() {
+        let canonical = canonicalize_subtype_name(word);
+        if let Ok(core_type) = CoreType::from_str(&canonical) {
+            core_types.push(core_type);
+        } else {
+            modifications.push(ContinuousModification::AddSubtype { subtype: canonical });
+        }
+    }
+    if core_types.is_empty() {
         return None;
     }
-    // Only a recognised core type can replace the card-type set; a subtype
-    // ("loses all other card types" is a card-type statement, CR 205.1b) would
-    // be a malformed clause, so decline rather than guess.
-    let canonical = canonicalize_subtype_name(type_word);
-    let core_type = CoreType::from_str(&canonical).ok()?;
-    Some((
-        rest,
-        ContinuousModification::SetCardTypes {
-            core_types: vec![core_type],
-        },
-    ))
+    let mut result = vec![ContinuousModification::SetCardTypes { core_types }];
+    result.append(&mut modifications);
+    result.extend(ability_mods);
+    Some((rest, result))
 }
 
 /// "it has {keyword[, keyword, ...]}" — each keyword becomes `AddKeyword`.
@@ -1588,6 +1629,90 @@ mod tests {
             vec![ContinuousModification::SetCardTypes {
                 core_types: vec![CoreType::Enchantment],
             }]
+        );
+    }
+
+    /// CR 707.9d: Espers to Magicite — the subject-repeated "and it loses all
+    /// other card types" variant (vs Myrkul's elided "and loses") must also be
+    /// recognised as the replacement signal.
+    #[test]
+    fn its_an_artifact_and_it_loses_others_emits_set_card_types() {
+        let (_, mods) = parse_except_clause(
+            ", except it's an artifact and it loses all other card types",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::SetCardTypes {
+                core_types: vec![CoreType::Artifact],
+            }]
+        );
+    }
+
+    /// CR 205.1b + CR 707.9a + CR 707.9d: Shelob, Child of Ungoliant — the "Food
+    /// token" shape. "it's a Food artifact with \"<ability>\" and it loses all
+    /// other card types" must REPLACE the core types with the named core type
+    /// (Artifact), ADD the named subtype (Food), and GRANT the quoted ability.
+    #[test]
+    fn its_a_food_artifact_with_ability_loses_others_emits_full_food_token() {
+        let (_, mods) = parse_except_clause(
+            ", except it's a food artifact with \"{2}, {t}, sacrifice ~: you gain 3 life,\" and it loses all other card types",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.contains(&ContinuousModification::SetCardTypes {
+                core_types: vec![CoreType::Artifact],
+            }),
+            "must replace core types with Artifact: {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddSubtype {
+                subtype: "Food".to_string(),
+            }),
+            "must add the Food subtype: {mods:?}"
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::GrantAbility { .. })),
+            "must grant the quoted sacrifice-for-life ability: {mods:?}"
+        );
+    }
+
+    /// CR 707.9a: a non-quoted `with <…>` clause (Imposter Mech: "it's a Vehicle
+    /// artifact with crew 3 and it loses all other card types") must still yield
+    /// the clean type modifications — Vehicle subtype + Artifact replacement —
+    /// and must NOT emit bogus subtypes ("With"/"Crew"/"3") from the dropped,
+    /// not-yet-supported keyword clause.
+    #[test]
+    fn its_a_vehicle_artifact_with_crew_drops_keyword_clause_cleanly() {
+        let (_, mods) = parse_except_clause(
+            ", except it's a vehicle artifact with crew 3 and it loses all other card types",
+            "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert!(
+            mods.contains(&ContinuousModification::SetCardTypes {
+                core_types: vec![CoreType::Artifact],
+            }),
+            "must replace core types with Artifact: {mods:?}"
+        );
+        assert!(
+            mods.contains(&ContinuousModification::AddSubtype {
+                subtype: "Vehicle".to_string(),
+            }),
+            "must add the Vehicle subtype: {mods:?}"
+        );
+        assert!(
+            !mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddSubtype { subtype } if subtype != "Vehicle"
+            )),
+            "must not emit bogus subtypes from the 'with crew 3' clause: {mods:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -746,18 +746,15 @@ fn parse_its_a_type_loses_others(input: &str) -> Option<(&str, Vec<ContinuousMod
             .map(|(_, pair)| pair)?;
     // CR 707.9a: peel an optional `with <…>` clause off the head before the
     // type list so its text is never mistaken for type words. Only the quoted
-    // form (Shelob's Food sacrifice ability) is granted; a non-quoted `with`
-    // clause (Imposter Mech's "with crew 3") is a not-yet-supported shape that
-    // is dropped fail-soft rather than parsed as bogus subtypes.
+    // form (Shelob's Food sacrifice ability) is granted: `split_single_quoted_ability`
+    // trims leading whitespace and requires a leading `"`, returning `None` for a
+    // non-quoted `with` clause (Imposter Mech's "with crew 3"), which is then
+    // dropped fail-soft via `unwrap_or_default` rather than parsed as bogus subtypes.
     let (type_text, ability_mods) = match nom_primitives::split_once_on(head, " with ") {
         Ok((_, (types, after_with))) => {
-            let mods = if after_with.trim_start().starts_with('"') {
-                split_single_quoted_ability(after_with)
-                    .map(|(quoted_text, _)| parse_quoted_ability_modifications(quoted_text))
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
+            let mods = split_single_quoted_ability(after_with)
+                .map(|(quoted_text, _)| parse_quoted_ability_modifications(quoted_text))
+                .unwrap_or_default();
             (types, mods)
         }
         Err(_) => (head, Vec::new()),

--- a/crates/engine/tests/shelob_repro_token.rs
+++ b/crates/engine/tests/shelob_repro_token.rs
@@ -1,0 +1,97 @@
+//! Repro: Shelob, Child of Ungoliant must create a Food copy token when a
+//! creature dealt damage this turn by a Spider you control dies.
+//!
+//! Unlike the PR #3184 end-to-end test (which manually pushes a DamageRecord and
+//! only asserts the trigger reaches the stack), this drives the REAL damage
+//! pipeline (`deal_damage::resolve` populates `damage_dealt_this_turn`) and
+//! asserts the observable result: a Food artifact copy token of the dead
+//! creature exists under Shelob's controller.
+
+use engine::game::effects::deal_damage;
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::card_type::CoreType;
+use engine::types::zones::Zone;
+
+const SHELOB_DEATH_TRIGGER: &str = "Whenever another creature dealt damage this turn by a Spider you controlled dies, create a token that's a copy of that creature, except it's a Food artifact with \"{2}, {T}, Sacrifice ~: You gain 3 life,\" and it loses all other card types.";
+
+#[test]
+fn shelob_creates_food_copy_token_via_real_damage_pipeline() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    let _shelob = scenario
+        .add_creature_from_oracle(P0, "Shelob, Child of Ungoliant", 4, 4, SHELOB_DEATH_TRIGGER)
+        .id();
+
+    // A Spider you control deals the damage.
+    let spider = scenario.add_creature(P0, "Acid Web Spider", 3, 3).id();
+    // An opponent's creature that will be dealt lethal damage by the Spider.
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&spider)
+        .unwrap()
+        .card_types
+        .subtypes
+        .push("Spider".to_string());
+
+    // Deal lethal damage from the Spider through the production effect path so the
+    // per-turn damage ledger is populated with the real source snapshot.
+    let damage = ResolvedAbility::new(
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::Any,
+            damage_source: None,
+        },
+        vec![TargetRef::Object(victim)],
+        spider,
+        P0,
+    );
+    let mut events = Vec::new();
+    deal_damage::resolve(runner.state_mut(), &damage, &mut events).expect("spider damage resolves");
+
+    // SBA destroys the victim (lethal damage), producing the death event.
+    check_state_based_actions(runner.state_mut(), &mut events);
+    assert_eq!(
+        runner.state().objects[&victim].zone,
+        Zone::Graveyard,
+        "victim must die from the Spider's lethal damage"
+    );
+
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    // The observable effect: a Food artifact copy token of the dead creature,
+    // under Shelob's controller.
+    let token = runner.state().objects.values().find(|o| {
+        o.zone == Zone::Battlefield
+            && o.is_token
+            && o.controller == P0
+            && o.name == "Grizzly Bears"
+            && o.card_types.core_types.contains(&CoreType::Artifact)
+            && o.card_types.subtypes.iter().any(|s| s == "Food")
+    });
+
+    assert!(
+        token.is_some(),
+        "Shelob must create a Food copy token of the dead creature. \
+         Battlefield tokens: {:?}",
+        runner
+            .state()
+            .objects
+            .values()
+            .filter(|o| o.zone == Zone::Battlefield && o.is_token)
+            .map(|o| (
+                o.name.clone(),
+                o.card_types.core_types.clone(),
+                o.card_types.subtypes.clone()
+            ))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
PR #3184 fixed Shelob, Child of Ungoliant's death-trigger condition but the
copy effect parsed to a bare CopyTokenOf — the 'except it's a Food artifact
with "…," and it loses all other card types' modifier was silently dropped,
so the card produced a plain creature copy instead of a Food artifact token.

Generalize parse_its_a_type_loses_others in become_copy_except.rs from a single
core-type word to the full Food-token class: multi-word type lists (core types
-> SetCardTypes replacement, subtypes -> AddSubtype), an optional with "<quoted
ability>" grant (-> GrantAbility via the shared quoted-ability parser), and
both the 'and loses' and 'and it loses' variants. A non-quoted with-clause
(Imposter Mech 'with crew 3') is split off and dropped fail-soft rather than
mis-parsed as bogus subtypes. Also fixes Espers to Magicite ('it's an artifact
and it loses all other card types'). Myrkul's single-type case is unchanged.

CR 205.1a/205.1b + CR 613.1d + CR 707.9a/707.9d.

Adds building-block unit tests (Shelob, Espers, Imposter Mech, plus the Myrkul
regression) and a runtime regression that drives the real damage pipeline and
asserts the actual Food artifact copy token — the assertion the PR #3184
end-to-end test omitted.
