### PR TITLE
fix(engine): thread in-flight exclusion chain through costed mana-ability payment

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6687,12 +6687,23 @@ fn auto_tap_mana_sources_inner(
                 // returns, so it — and every ancestor already in
                 // `excluded_sources` — must be excluded from any nested
                 // auto-tap, or two cross-paying costed mana abilities recurse
-                // infinitely. Hoisted above the sub-cost guard so the chain is
-                // threaded into resolution even for abilities with no mana
-                // sub-cost.
-                let mut excluded = excluded_sources.clone();
-                excluded.insert(option.object_id);
-                if let Some(sub_cost) = mana_sub_cost_of(&ability_def.cost) {
+                // infinitely. The exclusion set is read only by
+                // `pay_mana_sub_cost`, reached only through the `AbilityCost::Mana`
+                // arms — exactly the costs `mana_sub_cost_of` reports `Some` for.
+                // A tap-only / sacrifice / pay-life mana ability never consumes
+                // it, so clone-and-extend only when a mana sub-cost is present and
+                // otherwise forward the caller's set unchanged — skipping a heap
+                // allocation per selected source on this auto-tap hot path.
+                let sub_cost = mana_sub_cost_of(&ability_def.cost);
+                let mut excluded_buf;
+                let excluded: &HashSet<ObjectId> = if sub_cost.is_some() {
+                    excluded_buf = excluded_sources.clone();
+                    excluded_buf.insert(option.object_id);
+                    &excluded_buf
+                } else {
+                    excluded_sources
+                };
+                if let Some(sub_cost) = sub_cost {
                     let (source_types, source_subtypes) =
                         super::casting::activation_source_types(state, option.object_id);
                     let activation_ctx = PaymentContext::Activation {
@@ -6706,7 +6717,7 @@ fn auto_tap_mana_sources_inner(
                         sub_cost,
                         events,
                         Some(option.object_id),
-                        &excluded,
+                        excluded,
                         Some(&activation_ctx),
                     );
                 }
@@ -6720,10 +6731,10 @@ fn auto_tap_mana_sources_inner(
                 // skip it silently — the player can still manually tap other sources.
                 let override_value = production_override_for_option(&ability_def, &option);
                 // CR 605.3c: Resolve via the exclusion-aware entry so the
-                // in-flight chain (`excluded`, including this source) threads
-                // into the ability's own mana sub-cost auto-tap. The public
-                // `resolve_mana_ability` would discard the chain and re-tap a
-                // suspended ancestor, recursing infinitely.
+                // in-flight chain (`excluded`, including this source when it has a
+                // mana sub-cost) threads into the ability's own mana sub-cost
+                // auto-tap. The public `resolve_mana_ability` would discard the
+                // chain and re-tap a suspended ancestor, recursing infinitely.
                 let _ = mana_abilities::resolve_mana_ability_excluding(
                     state,
                     option.object_id,
@@ -6731,7 +6742,7 @@ fn auto_tap_mana_sources_inner(
                     &ability_def,
                     events,
                     override_value,
-                    &excluded,
+                    excluded,
                 );
             }
         } else {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6679,9 +6679,20 @@ fn auto_tap_mana_sources_inner(
                 .and_then(|obj| obj.abilities.get(idx))
                 .cloned();
             if let Some(ability_def) = ability_def {
+                // CR 605.3c: Extend the in-flight exclusion chain with this
+                // source before re-entering auto-tap (pre-tap below) and before
+                // resolving the ability (which re-enters auto-tap through its
+                // mana sub-cost payment). This source's activation is suspended
+                // on the call stack until `resolve_mana_ability_excluding`
+                // returns, so it — and every ancestor already in
+                // `excluded_sources` — must be excluded from any nested
+                // auto-tap, or two cross-paying costed mana abilities recurse
+                // infinitely. Hoisted above the sub-cost guard so the chain is
+                // threaded into resolution even for abilities with no mana
+                // sub-cost.
+                let mut excluded = excluded_sources.clone();
+                excluded.insert(option.object_id);
                 if let Some(sub_cost) = mana_sub_cost_of(&ability_def.cost) {
-                    let mut excluded = excluded_sources.clone();
-                    excluded.insert(option.object_id);
                     let (source_types, source_subtypes) =
                         super::casting::activation_source_types(state, option.object_id);
                     let activation_ctx = PaymentContext::Activation {
@@ -6708,13 +6719,19 @@ fn auto_tap_mana_sources_inner(
                 // source is somehow invalid (e.g., removed by a replacement effect), we
                 // skip it silently — the player can still manually tap other sources.
                 let override_value = production_override_for_option(&ability_def, &option);
-                let _ = mana_abilities::resolve_mana_ability(
+                // CR 605.3c: Resolve via the exclusion-aware entry so the
+                // in-flight chain (`excluded`, including this source) threads
+                // into the ability's own mana sub-cost auto-tap. The public
+                // `resolve_mana_ability` would discard the chain and re-tap a
+                // suspended ancestor, recursing infinitely.
+                let _ = mana_abilities::resolve_mana_ability_excluding(
                     state,
                     option.object_id,
                     player,
                     &ability_def,
                     events,
                     override_value,
+                    &excluded,
                 );
             }
         } else {

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -15,6 +15,7 @@ use crate::types::mana::{ManaColor, ManaCost, ManaPool, ManaType, PaymentContext
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
+use std::collections::HashSet;
 
 use super::cost_payability::{eligible_exile_cost_objects, exile_cost_effective_zone};
 use super::effects::mana::resolve_restrictions;
@@ -200,9 +201,46 @@ pub fn resolve_mana_ability(
     events: &mut Vec<GameEvent>,
     color_override: Option<ProductionOverride>,
 ) -> Result<(), EngineError> {
+    // CR 605.3c: A top-level mana-ability activation has no suspended ancestor
+    // on the call stack, so the in-flight exclusion chain starts empty. The
+    // source itself is added downstream in `pay_mana_sub_cost`.
+    resolve_mana_ability_excluding(
+        state,
+        source_id,
+        player,
+        ability_def,
+        events,
+        color_override,
+        &HashSet::new(),
+    )
+}
+
+/// Resolve a mana ability while excluding an in-flight chain of ancestor
+/// mana-ability sources from the cost-payment auto-tap (CR 605.3c). Called by
+/// the casting auto-tap (`auto_tap_mana_sources_inner`) when paying one mana
+/// ability's mana sub-cost forces activation of further mana abilities: each
+/// ancestor activation is synchronously suspended mid-payment on the Rust call
+/// stack and must not be re-activated, or the auto-tap recurses infinitely
+/// (two cross-paying Signets, an N-source chain, or a self-loop).
+pub(super) fn resolve_mana_ability_excluding(
+    state: &mut GameState,
+    source_id: ObjectId,
+    player: PlayerId,
+    ability_def: &AbilityDefinition,
+    events: &mut Vec<GameEvent>,
+    color_override: Option<ProductionOverride>,
+    excluded_sources: &HashSet<ObjectId>,
+) -> Result<(), EngineError> {
     // Pay the full ability cost (tap, sacrifice, etc.)
     let waiting_before_cost = state.waiting_for.clone();
-    pay_mana_ability_cost(state, source_id, player, &ability_def.cost, events)?;
+    pay_mana_ability_cost(
+        state,
+        source_id,
+        player,
+        &ability_def.cost,
+        events,
+        excluded_sources,
+    )?;
     if state.waiting_for != waiting_before_cost {
         return Ok(());
     }
@@ -1368,6 +1406,15 @@ pub(super) fn advance_mana_ability_activation(
                 pending.chosen_mana_payment.as_deref(),
                 pending.chosen_counter_count,
                 pending.chosen_x,
+                // CR 605.3c: The interactive resume path is a fresh activation
+                // root, not a link in a suspended in-flight chain. Synchronous
+                // casting auto-tap recursion never crosses an interactive
+                // `WaitingFor` node: the instant a sub-cost needs a prompt the
+                // activation unwinds the Rust stack and serializes to
+                // `PendingManaAbility`. At resume there is therefore no ancestor
+                // activation on the call stack to exclude, so the chain is
+                // empty here.
+                &HashSet::new(),
             )?;
             if state.waiting_for != waiting_before_cost {
                 return Ok(state.waiting_for.clone());
@@ -1425,6 +1472,9 @@ pub(super) fn advance_mana_ability_activation(
         pending.chosen_counter_count,
         pending.chosen_x,
         pending.cost_paid_object,
+        // CR 605.3c: Same as the interactive cost-payment site above — resume
+        // is a fresh activation root, the suspended-ancestor chain is empty.
+        &HashSet::new(),
     )?;
     if state.waiting_for != waiting_before_cost {
         return Ok(state.waiting_for.clone());
@@ -1448,6 +1498,7 @@ fn pay_mana_ability_cost(
     player: PlayerId,
     cost: &Option<AbilityCost>,
     events: &mut Vec<GameEvent>,
+    excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError> {
     pay_mana_ability_cost_with_choices(
         state,
@@ -1462,6 +1513,7 @@ fn pay_mana_ability_cost(
         None,
         None,
         None,
+        excluded_sources,
     )
 }
 
@@ -1481,6 +1533,7 @@ fn resolve_mana_ability_with_selected_choices(
     chosen_counter_count: Option<u32>,
     chosen_x: Option<u32>,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
+    excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError> {
     let mut chosen = tapped_creatures.iter().copied();
     let mut discarded = discarded_cards.iter().copied();
@@ -1499,6 +1552,7 @@ fn resolve_mana_ability_with_selected_choices(
         chosen_hybrid_payment,
         chosen_counter_count,
         chosen_x,
+        excluded_sources,
     )?;
     if chosen.next().is_some() {
         return Err(EngineError::InvalidAction(
@@ -1711,6 +1765,7 @@ fn pay_mana_ability_cost_with_choices<I, J, K, L>(
     chosen_hybrid_payment: Option<&[ManaType]>,
     chosen_counter_count: Option<u32>,
     chosen_x: Option<u32>,
+    excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError>
 where
     I: Iterator<Item = ObjectId>,
@@ -1730,6 +1785,7 @@ where
                 cost,
                 chosen_hybrid_payment,
                 events,
+                excluded_sources,
             )?;
         }
         // CR 605.1a + CR 701.17a: Bare `Mill` mana-ability cost. The Millikin
@@ -2075,6 +2131,7 @@ where
                             cost,
                             chosen_hybrid_payment,
                             events,
+                            excluded_sources,
                         )?;
                     }
                     // CR 605.1a + CR 701.17a: `Mill` sub-cost inside a Composite
@@ -2538,9 +2595,21 @@ fn pay_mana_sub_cost(
     cost: &ManaCost,
     hybrid_plan: Option<&[ManaType]>,
     events: &mut Vec<GameEvent>,
+    excluded_sources: &HashSet<ObjectId>,
 ) -> Result<(), EngineError> {
     if hybrid_plan.is_none() {
-        let excluded_sources = std::collections::HashSet::from([source_id]);
+        // CR 605.3c: Every source already in `excluded_sources` is an ancestor
+        // mana-ability activation that is synchronously suspended on the call
+        // stack mid-payment (its cost is still being paid; it has not yet
+        // resolved). CR 605.3c ("Once a player begins to activate a mana
+        // ability, that ability can't be activated again until it has
+        // resolved") applies to each ancestor link individually, so the entire
+        // in-flight chain must be excluded from auto-tap — not just `source_id`.
+        // Extending the chain here (rather than rebuilding it from
+        // `{source_id}`) is what makes a 2-source cross-payment, an N-source
+        // chain, or a self-loop terminate instead of recursing infinitely.
+        let mut excluded_sources = excluded_sources.clone();
+        excluded_sources.insert(source_id);
         // CR 605.1a: A mana ability never carries a power-up tag (power-up
         // abilities can't produce mana), so the tag-scoped activation context is
         // `None` here — Quinjet's {R}{R} must not pay another mana ability's cost.

--- a/crates/engine/tests/costed_mana_abilities_no_recursion.rs
+++ b/crates/engine/tests/costed_mana_abilities_no_recursion.rs
@@ -1,0 +1,278 @@
+//! Two costed mana abilities (Signets) must not infinitely recurse when paying
+//! one would auto-tap the other.
+//!
+//! Regression for the auto-tap mutual-recursion stack overflow: with two
+//! Signets — each `{1}, {T}: Add <two colors>` — controlled by one player and
+//! an empty pool, activating one Signet auto-taps the other to pay its `{1}`,
+//! and paying that Signet's `{1}` auto-tapped the first right back. Pre-fix
+//! this recursed forever and SIGABRTed the process, because every
+//! `pay_mana_sub_cost` rebuilt the auto-tap exclusion set as `{source_id}`,
+//! discarding the in-flight ancestor chain.
+//!
+//! The fix threads the in-flight exclusion chain (every ancestor mana-ability
+//! activation suspended mid-payment on the call stack) through the nested
+//! auto-tap, so the chain terminates: the degenerate, externally-unfundable
+//! pair is rejected gracefully instead of overflowing, and a single Signet's
+//! payment is never starved by an over-broad exclusion.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 605.3c: "Once a player begins to activate a mana ability, that
+//!     ability can't be activated again until it has resolved." Each ancestor
+//!     activation suspended mid-payment must stay excluded from the nested
+//!     auto-tap — that is what makes the chain terminate.
+//!   - CR 605.1b: non-land permanents (Signets) can have mana abilities.
+//!   - CR 601.2g–h: a mana ability's mana sub-cost auto-taps the controller's
+//!     mana sources.
+//!
+//! This is a *class* regression: the fix applies to any pair or chain of costed
+//! mana abilities (Signets, filter lands, Pentad Prism). The two named Signets
+//! are representative; the assertions are about the general nested-sub-cost
+//! auto-tap mechanism, driven through the real activation pipeline
+//! (`GameAction::ActivateAbility` → `apply()`).
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DIMIR_SIGNET_ORACLE: &str = "{1}, {T}: Add {U}{B}.";
+const GRUUL_SIGNET_ORACLE: &str = "{1}, {T}: Add {R}{G}.";
+
+/// Signets are artifacts, not creatures. The scenario creature helper parses
+/// Oracle text onto a battlefield permanent; convert it to a pure artifact and
+/// clear P/T so the 0/0 stub is not destroyed as an SBA (CR 704.5f) before its
+/// mana ability is activated.
+fn make_artifact(runner: &mut GameRunner, id: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Artifact];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+}
+
+/// Index of the (single) mana ability on a Signet.
+fn mana_ability_index(state: &engine::types::game_state::GameState, id: ObjectId) -> usize {
+    let obj = state.objects.get(&id).expect("signet exists");
+    obj.abilities
+        .iter()
+        .position(|a| a.cost.is_some())
+        .expect("signet has a costed mana ability")
+}
+
+#[test]
+fn two_cross_paying_signets_terminate_without_recursion() {
+    // Two Signets, empty pool, NO other mana source. Activating one forces the
+    // engine to auto-tap the other to pay the `{1}`, whose own `{1}` would
+    // auto-tap the first — the mutual recursion.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+    let gruul = scenario
+        .add_creature_from_oracle(P0, "Gruul Signet", 0, 0, GRUUL_SIGNET_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    make_artifact(&mut runner, gruul);
+    let idx = mana_ability_index(runner.state(), gruul);
+
+    // CR 605.3c: PRIMARY discriminating assertion. Pre-fix this call SIGABRTs
+    // the nextest process via stack overflow (the two Signets re-tap each other
+    // forever). Post-fix the in-flight exclusion chain terminates the recursion,
+    // so the call returns. Because neither Signet can fund the other's `{1}`
+    // once both are on the in-flight chain (CR 605.3c bars re-activating a
+    // mana ability already being activated), the pair is correctly unfundable
+    // and the activation is rejected gracefully rather than producing mana.
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: gruul,
+        ability_index: idx,
+    });
+    assert!(
+        result.is_err(),
+        "the externally-unfundable Signet pair must be rejected, not partially activated"
+    );
+
+    // No partial state: neither Signet was left tapped and no mana was floated
+    // (a re-entered chain would have tapped one or both before unwinding).
+    assert!(
+        !runner.state().objects.get(&dimir).unwrap().tapped,
+        "Dimir Signet must not be tapped after a rejected activation"
+    );
+    assert!(
+        !runner.state().objects.get(&gruul).unwrap().tapped,
+        "Gruul Signet must not be tapped after a rejected activation"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        0,
+        "no mana floated by a rejected, recursion-free activation"
+    );
+}
+
+#[test]
+fn signet_activates_normally_with_a_sibling_costed_rock_present() {
+    // A second costed mana rock is present, but a bootstrap land funds the
+    // activated Signet's `{1}` — the auto-tap prefers the land over cross-paying
+    // the sibling Signet. Guards against the exclusion set over-excluding and
+    // starving a legitimate single activation when another costed rock exists.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::White);
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+    let gruul = scenario
+        .add_creature_from_oracle(P0, "Gruul Signet", 0, 0, GRUUL_SIGNET_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    make_artifact(&mut runner, gruul);
+    let idx = mana_ability_index(runner.state(), gruul);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: gruul,
+            ability_index: idx,
+        })
+        .expect("Gruul Signet activates normally with a bootstrap land available");
+
+    // Gruul tapped and produced {R}{G}; its `{1}` was paid by the land, so the
+    // sibling Dimir Signet was never cross-tapped.
+    assert!(
+        runner.state().objects.get(&gruul).unwrap().tapped,
+        "Gruul Signet activated and tapped"
+    );
+    assert!(
+        !runner.state().objects.get(&dimir).unwrap().tapped,
+        "the sibling Dimir Signet was not cross-tapped (the land funded the {{1}})"
+    );
+    // {R}{G} produced = 2 mana in the pool.
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        2,
+        "Gruul Signet produced exactly {{R}}{{G}} — exclusion did not starve the payment"
+    );
+}
+
+#[test]
+fn single_signet_activates_normally() {
+    // Baseline negative: a lone Signet with a bootstrap land activates normally.
+    // Confirms the exclusion-chain threading does not regress the common case.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::White);
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    let idx = mana_ability_index(runner.state(), dimir);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: dimir,
+            ability_index: idx,
+        })
+        .expect("lone Signet activates normally");
+
+    assert!(
+        runner.state().objects.get(&dimir).unwrap().tapped,
+        "Dimir Signet activated and tapped"
+    );
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        2,
+        "Dimir Signet produced exactly {{U}}{{B}}"
+    );
+}
+
+#[test]
+fn both_signets_and_lands_fund_a_spell_no_over_exclusion() {
+    // POSITIVE multi-source-funded assertion locking in the "no over-exclusion"
+    // guarantee. A normal board — two untapped Signets plus four basic Plains —
+    // casts a `{U}{B}` sorcery through the real cast pipeline. Plains produce only
+    // {W}, so the `{U}{B}` requirement can only be satisfied by the Dimir Signet,
+    // whose own `{1}` is auto-tapped from a Plains during cost payment. The Gruul
+    // Signet ({R}{G}) is irrelevant and must be left alone.
+    //
+    // CR 605.3c: the in-flight exclusion chain that terminates the pathological
+    // Signet-funds-Signet recursion excludes ONLY ancestor mana-ability
+    // activations, never lands. So when lands are present to fund a Signet's
+    // sub-cost, a legitimate land-funded payment is never starved by
+    // over-exclusion — the cast resolves and the cost is genuinely paid. This is
+    // the permanent guard against the exclusion chain becoming too broad.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Four untapped basic Plains: comfortably fund the activated Dimir Signet's
+    // {1} sub-cost without any Signet-funds-Signet cross-payment.
+    for _ in 0..4 {
+        scenario.add_basic_land(P0, ManaColor::White);
+    }
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+    let gruul = scenario
+        .add_creature_from_oracle(P0, "Gruul Signet", 0, 0, GRUUL_SIGNET_ORACLE)
+        .id();
+
+    // A vanilla `{U}{B}` sorcery: the Plains cannot supply {U} or {B}, so the
+    // Dimir Signet must be auto-tapped for the colored mana during cost payment,
+    // and a Plains funds the Signet's own `{1}` sub-cost.
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Two-Color Test Spell", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Black],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    make_artifact(&mut runner, gruul);
+
+    // Drive the real cast pipeline. Auto-tap funds the cost from the pool +
+    // mana-ability activations; if the exclusion chain over-excluded, the colored
+    // requirement would be unfundable and the `CastSpell` announcement would be
+    // rejected ("Cannot pay mana cost"), panicking `resolve()`'s `.expect`. A
+    // clean resolution proves the payment succeeded.
+    let outcome = runner.cast(spell).resolve();
+
+    // PRIMARY positive assertion: the cost was genuinely payable — the spell was
+    // announced, paid for, and resolved off the stack (CR 608.2m). If the fix
+    // over-excluded, the cast never reaches the stack at all.
+    let resolved_zone = outcome.zone_of(spell);
+    assert!(
+        !matches!(resolved_zone, Zone::Hand | Zone::Stack),
+        "the {{U}}{{B}} spell must have been cast and resolved off the stack, \
+         but it is still in {resolved_zone:?} — the land-funded payment was \
+         starved by over-exclusion"
+    );
+
+    // The colored mana could only have come from the Dimir Signet, so it was
+    // tapped — the legitimate, land-funded activation was NOT starved.
+    assert!(
+        outcome.state().objects.get(&dimir).unwrap().tapped,
+        "Dimir Signet was tapped to fund the {{U}}{{B}} — the land-funded \
+         activation was not over-excluded"
+    );
+    // The Gruul Signet produces the wrong colors and was never needed; the
+    // exclusion fix neither forced a wasteful tap nor blocked the real one.
+    assert!(
+        !outcome.state().objects.get(&gruul).unwrap().tapped,
+        "the irrelevant Gruul Signet was left untapped"
+    );
+}


### PR DESCRIPTION
Two costed mana abilities controlled by one player (e.g. Dimir Signet +
Gruul Signet, each {1},{T}: Add {C}{C}) caused unbounded mutual recursion
during mana auto-tap: paying Signet A's {1} auto-tapped Signet B, and
paying B's {1} re-tapped A, forever -> stack overflow -> game freeze
(observed in AI choose_action on a 4-player Commander board).

Root cause: pay_mana_sub_cost rebuilt the auto-tap exclusion set as
HashSet::from([source_id]), discarding the in-flight ancestor chain, and
casting_costs.rs resolved the mana ability via the no-exclusion entry
point. CR 605.3c: a mana ability mid-activation can't be activated again
until it resolves -- which applies to every ancestor link synchronously
suspended on the call stack, so all must be excluded from a nested
sub-cost payment, not just the immediate source.

Thread excluded_sources through resolve_mana_ability_excluding ->
pay_mana_ability_cost -> pay_mana_ability_cost_with_choices (both
AbilityCost::Mana sites) -> pay_mana_sub_cost, unioning the chain instead
of rebuilding it. Public resolve_mana_ability keeps its signature and
delegates with an empty set (top-level activations are chain roots).
Fixes the class (any pair/chain of costed mana abilities), not just two
Signets. Adds discriminating runtime regression tests.
