### PR TITLE
fix(frontend): gate combat click branches on live combat WaitingFor so target clicks land

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -482,9 +482,9 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
       ) {
         toggleSelectedCard(objectId);
       }
-    } else if (combatMode === "attackers") {
+    } else if (combatMode === "attackers" && waitingFor?.type === "DeclareAttackers") {
       if (isValidAttacker) toggleAttacker(objectId);
-    } else if (combatMode === "blockers" && combatClickHandler) {
+    } else if (combatMode === "blockers" && waitingFor?.type === "DeclareBlockers" && combatClickHandler) {
       combatClickHandler(objectId);
     } else if (equipTargetChoice?.valid_targets.includes(objectId)) {
       dispatchAction({

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -329,6 +329,45 @@ describe("PermanentCard attachments", () => {
     });
   });
 
+  it("dispatches a target click even when a stale combat mode lingers during target selection", () => {
+    // Regression: a spell's TargetSelection must win over a leftover
+    // `combatMode` UI flag. PermanentCard routed combat clicks on `combatMode`
+    // alone — unlike GroupedPermanent, which also requires the matching combat
+    // WaitingFor (`waitingFor.type === "DeclareBlockers"`). So a stale
+    // `combatMode` from a just-finished combat step swallowed bounce/target
+    // clicks: targets glowed (validTargetObjectIds) but the click hit the dead
+    // blocker branch and `ChooseTarget` never fired. Reported on Chain of Vapor
+    // cast during combat.
+    const gameState = {
+      ...makeState(),
+      waiting_for: {
+        type: "TargetSelection",
+        data: {
+          pending_cast: { object_id: 99 },
+          target_slots: [],
+          selection: { current_slot: 0, current_legal_targets: [{ Object: 1 }] },
+        },
+      },
+    } as unknown as GameState;
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    const staleBlockerHandler = vi.fn();
+    useUiStore.setState({
+      combatMode: "blockers",
+      combatClickHandler: staleBlockerHandler,
+    });
+
+    const { container } = renderPermanent(new Set([1]));
+    const permanent = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.click(permanent);
+
+    expect(staleBlockerHandler).not.toHaveBeenCalled();
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "ChooseTarget",
+      data: { target: { Object: 1 } },
+    });
+  });
+
   it("submits a single battlefield sacrifice choice from the board", () => {
     const gameState = {
       ...makeState(),


### PR DESCRIPTION
PermanentCard.handleClick routed board clicks on the `combatMode` UI flag
alone, while GroupedPermanent additionally requires the matching combat
WaitingFor (`waitingFor.type === "DeclareBlockers"/"DeclareAttackers"").
When `combatMode` lingered past its combat step, a click on a valid spell
target hit the dead blocker/attacker branch and `ChooseTarget` never
dispatched — targets glowed (validTargetObjectIds) but nothing happened.
Reported casting Chain of Vapor during combat: targets shown, clicks inert.

Mirror GroupedPermanent's guard on both combat branches so an active
TargetSelection wins over a stale combat-mode flag. Strictly narrows the
combat branches (a combat click is only honored when the engine is actually
in that declaration), so it cannot regress combat selection.

Adds a discriminating regression test: stale combatMode + TargetSelection +
valid target dispatches ChooseTarget and does not call the stale blocker
handler (fails on the pre-fix routing).
