### PR TITLE
feat(engine): equipment-attached count quantity (Winter Soldier, Whiplash)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -12525,6 +12525,100 @@ pub mod tests {
         ));
     }
 
+    /// CR 603.4 + CR 303.4: runtime gate for the enchanted intervening-if bridge on
+    /// a NON-creature source (a bare Artifact). CR 303.4 allows an Aura to enchant
+    /// any object, so the source-object-wide bridge must fire when an Aura is
+    /// attached even though the source is not a creature.
+    ///
+    /// Drives the PRODUCTION bridge
+    /// (`parser::oracle_trigger::static_condition_to_trigger_condition`) rather than
+    /// a hand-built filter, so the test discriminates against the bridge code.
+    /// Fail-before: the bridge produced `TypedFilter::creature()`, so the
+    /// non-creature artifact source failed the card-type gate and
+    /// `check_trigger_condition` returned `false` even with the Aura attached.
+    /// Hostile negatives: no attachment → false; an Equipment (wrong kind) on the
+    /// non-creature source → false.
+    #[test]
+    fn source_matches_filter_gates_on_enchanted_noncreature() {
+        let mut state = setup();
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Enchanted Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        // Artifact only — deliberately NOT a Creature.
+        state
+            .objects
+            .get_mut(&src)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+
+        let cond = crate::parser::oracle_trigger::static_condition_to_trigger_condition(
+            &StaticCondition::SourceIsEnchanted,
+        )
+        .expect("SourceIsEnchanted should bridge to a TriggerCondition");
+
+        // No attachment → does not fire.
+        assert!(!check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+
+        // Hostile: an Equipment attached to the non-creature source must NOT
+        // satisfy the Aura predicate (attachment-kind discrimination).
+        let equip = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Test Equipment".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let equip_obj = state.objects.get_mut(&equip).unwrap();
+            equip_obj.card_types.core_types.push(CoreType::Artifact);
+            equip_obj.card_types.subtypes.push("Equipment".to_string());
+            equip_obj.attached_to = Some(crate::game::game_object::AttachTarget::Object(src));
+        }
+        state.objects.get_mut(&src).unwrap().attachments.push(equip);
+        assert!(!check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+
+        // Aura attached to the non-creature source → fires (the revert-failing case).
+        let aura = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Test Aura".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let aura_obj = state.objects.get_mut(&aura).unwrap();
+            aura_obj.card_types.core_types.push(CoreType::Enchantment);
+            aura_obj.card_types.subtypes.push("Aura".to_string());
+            aura_obj.attached_to = Some(crate::game::game_object::AttachTarget::Object(src));
+        }
+        state.objects.get_mut(&src).unwrap().attachments.push(aura);
+        assert!(check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+    }
+
     // === CR 701.27g + CR 708.2: Source-state predicates (Transformed/FaceUp/FaceDown) ===
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -12436,6 +12436,95 @@ pub mod tests {
         ));
     }
 
+    /// CR 603.4 + CR 301.5a: runtime gate for the equipped intervening-if bridge
+    /// (oracle_trigger.rs `static_condition_to_trigger_condition`,
+    /// `SourceIsEquipped → SourceMatchesFilter{HasAttachment(Equipment)}`).
+    /// Discriminates: false with no attachment, false with only an Aura attached
+    /// (proves kind matters), true once an Equipment is attached.
+    #[test]
+    fn source_matches_filter_gates_on_equipped() {
+        let mut state = setup();
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Equipped Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&src)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let cond = TriggerCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::HasAttachment {
+                    kind: crate::types::ability::AttachmentKind::Equipment,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                },
+            ])),
+        };
+
+        // No attachment → does not fire.
+        assert!(!check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+
+        // Hostile: an Aura attached must NOT satisfy the Equipment predicate.
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Test Aura".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let aura_obj = state.objects.get_mut(&aura).unwrap();
+            aura_obj.card_types.core_types.push(CoreType::Enchantment);
+            aura_obj.card_types.subtypes.push("Aura".to_string());
+            aura_obj.attached_to = Some(crate::game::game_object::AttachTarget::Object(src));
+        }
+        state.objects.get_mut(&src).unwrap().attachments.push(aura);
+        assert!(!check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+
+        // Equipment attached → fires.
+        let equip = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Test Equipment".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let equip_obj = state.objects.get_mut(&equip).unwrap();
+            equip_obj.card_types.core_types.push(CoreType::Artifact);
+            equip_obj.card_types.subtypes.push("Equipment".to_string());
+            equip_obj.attached_to = Some(crate::game::game_object::AttachTarget::Object(src));
+        }
+        state.objects.get_mut(&src).unwrap().attachments.push(equip);
+        assert!(check_trigger_condition(
+            &state,
+            &cond,
+            PlayerId(0),
+            Some(src),
+            None,
+        ));
+    }
+
     // === CR 701.27g + CR 708.2: Source-state predicates (Transformed/FaceUp/FaceDown) ===
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6333,6 +6333,99 @@ mod tests {
         }
     }
 
+    /// CR 301.5a + CR 613.4c: Winter Soldier, Icy Assassin — "Winter Soldier gets
+    /// +2/+0 for each Equipment attached to him." The source-anaphoric pronoun "him"
+    /// must resolve to AttachedToSource so the +2 boost scales dynamically with the
+    /// equipped count. Fail-before: "attached to him" was unparseable, the for-each
+    /// multiplier dropped, and the static degraded to a FIXED AddPower(2). The
+    /// graveyard-return activated ability (ChangeZone gy→battlefield) must remain.
+    #[test]
+    fn winter_soldier_equipment_count_scales_power_dynamically() {
+        use crate::types::ability::{
+            ContinuousModification, FilterProp, QuantityExpr, QuantityRef, TypeFilter, TypedFilter,
+        };
+        let parsed = parse_oracle_text(
+            "Vigilance, menace\nWinter Soldier gets +2/+0 for each Equipment attached to him.\n{3}{W}{B}: Return this card from your graveyard to the battlefield with a finality counter on him. Then you may attach an Equipment you control to him. (If a creature with a finality counter on it would die, exile it instead.)",
+            "Winter Soldier, Icy Assassin",
+            &["Vigilance".to_string(), "Menace".to_string()],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &["Human".to_string(), "Assassin".to_string()],
+        );
+        // The dynamic power modification: Multiply { factor: 2, Ref(ObjectCount{
+        // Equipment, AttachedToSource }) }.
+        let dynamic_power = parsed
+            .statics
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .find_map(|m| match m {
+                ContinuousModification::AddDynamicPower { value } => Some(value),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!("expected AddDynamicPower, got statics {:?}", parsed.statics)
+            });
+        match dynamic_power {
+            QuantityExpr::Multiply { factor, inner } => {
+                assert_eq!(*factor, 2, "power multiplier must be 2");
+                match inner.as_ref() {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter:
+                                    TargetFilter::Typed(TypedFilter {
+                                        type_filters,
+                                        properties,
+                                        ..
+                                    }),
+                            },
+                    } => {
+                        assert_eq!(*type_filters, vec![TypeFilter::Subtype("Equipment".into())]);
+                        assert!(
+                            properties.contains(&FilterProp::AttachedToSource),
+                            "must carry AttachedToSource, got {properties:?}"
+                        );
+                    }
+                    other => panic!("expected Ref(ObjectCount), got {other:?}"),
+                }
+            }
+            other => panic!("expected Multiply{{factor:2}}, got {other:?}"),
+        }
+        // "+0" toughness produces NO AddDynamicToughness (push_dynamic_pt_modifications
+        // skips a 0 component) — deviation from the original plan, which expected a
+        // factor-0 toughness mod that the architecture never emits.
+        assert!(
+            !parsed
+                .statics
+                .iter()
+                .flat_map(|s| s.modifications.iter())
+                .any(|m| matches!(m, ContinuousModification::AddDynamicToughness { .. })),
+            "no AddDynamicToughness for +0, got {:?}",
+            parsed.statics
+        );
+        // No part of the static may be a fixed AddPower (the fail-before misparse).
+        assert!(
+            !parsed
+                .statics
+                .iter()
+                .flat_map(|s| s.modifications.iter())
+                .any(|m| matches!(m, ContinuousModification::AddPower { .. })),
+            "must not degrade to a fixed AddPower, got {:?}",
+            parsed.statics
+        );
+        // Regression: the graveyard-return activated ability survives.
+        assert!(
+            parsed.abilities.iter().any(|a| matches!(
+                &*a.effect,
+                Effect::ChangeZone {
+                    destination: crate::types::zones::Zone::Battlefield,
+                    ..
+                }
+            )),
+            "graveyard-return ChangeZone activated ability must remain, got {:?}",
+            parsed.abilities
+        );
+    }
+
     /// CR 116.2b + CR 708.7: Etrata, Deadly Fugitive grants face-down creatures
     /// "{2}{U}{B}: Turn this creature face up. ...". The granted activated
     /// ability's head clause lowers to `Effect::TurnFaceUp { SelfRef }` (the

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22598,6 +22598,7 @@ fn extract_effect_verb(effect: &Effect) -> Option<&'static str> {
 mod tests {
     use super::*;
     use crate::parser::parse_oracle_text;
+    use crate::types::ability::AttachmentKind;
 
     /// CR 510.1a + CR 613.11: The Kingpin of Crime's attack ability — "Whenever you
     /// attack, you may pay 2 life. If you do, until end of turn, creatures you
@@ -24678,6 +24679,106 @@ mod tests {
                 sub.effect
             );
         }
+    }
+
+    /// MSH-A C2 — Whiplash, Vengeful Engineer. After Fix A2, the where-X clause
+    /// "where X is the number of Equipment attached to him" binds BOTH the LoseLife
+    /// and GainLife amounts to a typed `ObjectCount{Equipment, AttachedToSource}`
+    /// (fail-before: `QuantityRef::Variable("the number of Equipment attached to
+    /// him")` string fallback). This is the in-scope win.
+    ///
+    /// GATE (recorded, NOT met by parser-only A2+B1): the clean each-opponent form
+    /// Both the each-opponent form (`player_scope == Some(Opponent)`,
+    /// `LoseLife.target == None`) and the intervening-if `condition` are now
+    /// produced. The follow-up bridge maps `StaticCondition::SourceIsEquipped`
+    /// to `TriggerCondition::SourceMatchesFilter { HasAttachment(Equipment) }`
+    /// (oracle_trigger.rs `static_condition_to_trigger_condition`), so
+    /// `try_extract_intervening` succeeds, `strip_condition_clause` removes
+    /// "if he's equipped," and the body once again starts with "each opponent ",
+    /// letting `strip_each_player_subject` (lower.rs:2542) fire. This closed the
+    /// two previously recorded gaps.
+    #[test]
+    fn whiplash_where_x_binds_equipment_count_to_life_loss_and_gain() {
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        let def = parse_trigger_line(
+            "Whenever Whiplash attacks, if he's equipped, each opponent loses X life and you gain X life, where X is the number of Equipment attached to him.",
+            "Whiplash, Vengeful Engineer",
+        );
+        let execute = def.execute.expect("attack execute");
+
+        let expected_amount = QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(
+                    TypedFilter::default()
+                        .subtype("Equipment".to_string())
+                        .properties(vec![FilterProp::AttachedToSource]),
+                ),
+            },
+        };
+        // The in-scope A2 win: LoseLife amount is the typed ObjectCount, NOT Variable.
+        match &*execute.effect {
+            Effect::LoseLife { amount, target, .. } => {
+                assert_eq!(
+                    amount, &expected_amount,
+                    "LoseLife amount must bind to typed ObjectCount(Equipment+AttachedToSource)"
+                );
+                // Each-opponent form: the life loss is player-scoped, not targeted.
+                assert_eq!(
+                    target, &None,
+                    "each-opponent LoseLife must not carry a target (player_scope drives it)"
+                );
+                // Reinforce the discriminating property (AttachedToSource present).
+                match amount {
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ObjectCount {
+                                filter: TargetFilter::Typed(tf),
+                            },
+                    } => assert!(
+                        tf.properties.contains(&FilterProp::AttachedToSource),
+                        "amount filter must carry AttachedToSource, got {:?}",
+                        tf.properties
+                    ),
+                    other => panic!("expected ObjectCount amount, got {other:?}"),
+                }
+            }
+            other => panic!("expected LoseLife, got {other:?}"),
+        }
+        // The sibling GainLife shares the same typed binding (CR 107.3i).
+        let gain = execute.sub_ability.expect("gain_life sibling");
+        match &*gain.effect {
+            Effect::GainLife { amount, .. } => assert_eq!(
+                amount, &expected_amount,
+                "GainLife amount must share the typed ObjectCount binding"
+            ),
+            other => panic!("expected GainLife, got {other:?}"),
+        }
+
+        // Bridge follow-up (closed): the intervening-if condition is now carried
+        // as SourceMatchesFilter{HasAttachment(Equipment)} (CR 603.4 + CR 301.5a),
+        // and stripping it lets the each-opponent subject be recognized.
+        match def.condition {
+            Some(TriggerCondition::SourceMatchesFilter {
+                filter: TargetFilter::Typed(ref tf),
+            }) => assert!(
+                tf.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::HasAttachment {
+                        kind: AttachmentKind::Equipment,
+                        ..
+                    }
+                )),
+                "condition filter must carry HasAttachment(Equipment), got {:?}",
+                tf.properties
+            ),
+            other => panic!("expected SourceMatchesFilter(HasAttachment Equipment), got {other:?}"),
+        }
+        assert_eq!(
+            execute.player_scope,
+            Some(PlayerFilter::Opponent),
+            "each-opponent scope is now produced once the 'if he's equipped,' clause \
+             is stripped, letting strip_each_player_subject fire"
+        );
     }
 
     /// Issue #1424 — The Scarab God upkeep: opponent life loss and scry share

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1221,9 +1221,41 @@ fn parse_source_hasnt_dealt_damage(input: &str) -> OracleResult<'_, StaticCondit
     .parse(rest)
 }
 
+/// CR 301.5a / CR 303.4 / CR 508.1k / CR 509.1g / CR 509.1h: gendered/plural
+/// contraction subject ("he's"/"she's" = "_ is", "they're" = "they are") is
+/// source-anaphoric — binds the ability source. Whiplash ("if he's equipped");
+/// The Incredible Hulk ("if he's attacking"). Composes the copula + BARE-predicate
+/// shape of `parse_recipient_is_filter_condition` (the contraction already supplies
+/// the verb, so a BARE predicate tag is matched, NOT "is equipped"). The copula is
+/// paired to its pronoun so the ungrammatical cross-products ("they's"/"he're")
+/// cannot parse. Bare "it's" is deliberately excluded (target-anaphoric in spell
+/// bodies — Awaken the Sleeper); source "it's" is handled by the context-gated
+/// SelfRef rewrite. Straight ASCII apostrophe (0x27) only.
+fn parse_contraction_source_state_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = alt((
+        preceded(alt((tag("he"), tag("she"))), tag("'s ")),
+        preceded(tag("they"), tag("'re ")),
+    ))
+    .parse(input)?;
+    alt((
+        value(StaticCondition::SourceIsEquipped, tag("equipped")),
+        value(StaticCondition::SourceIsEnchanted, tag("enchanted")),
+        value(StaticCondition::SourceIsTapped, tag("tapped")),
+        value(StaticCondition::SourceIsMonstrous, tag("monstrous")),
+        value(StaticCondition::SourceIsAttacking, tag("attacking")),
+        value(StaticCondition::SourceIsBlocking, tag("blocking")),
+        value(StaticCondition::SourceIsBlocked, tag("blocked")),
+    ))
+    .parse(rest)
+}
+
 /// CR 611.2b: Parse source-state conditions (tapped, untapped, entered this turn).
 fn parse_source_state_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
+        // CR 301.5a/303.4/508.1k/509.1g/509.1h: gendered/plural contraction subject
+        // ("he's equipped", "she's enchanted", "they're attacking"). Source-only
+        // (never target-anaphoric for a gendered/plural pronoun in MTG templates).
+        parse_contraction_source_state_condition,
         // CR 611.2b: Tapped/untapped — composed as subject × predicate.
         // Parse subject ("~ is", "this creature is", etc.) then branch on "tapped"/"untapped".
         parse_tapped_untapped,
@@ -8218,6 +8250,77 @@ mod tests {
         let (rest, c) = parse_inner_condition("this creature is equipped").unwrap();
         assert_eq!(rest, "");
         assert_eq!(c, StaticCondition::SourceIsEquipped);
+    }
+
+    // CR 301.5a / CR 303.4 / CR 508.1k / CR 509.1g / CR 509.1h: gendered/plural
+    // contraction subject ("he's"/"she's"/"they're <state>") binds the ability
+    // source. Fail-before: `parse_source_subject` rejects "he's" → no Source
+    // condition (Whiplash "if he's equipped" trigger condition dropped).
+    #[test]
+    fn test_contraction_source_state_pronouns() {
+        for subj in ["he's equipped", "she's equipped", "they're equipped"] {
+            let (rest, c) = parse_inner_condition(subj)
+                .unwrap_or_else(|e| panic!("expected Ok for {subj:?}, got {e:?}"));
+            assert_eq!(rest, "", "remainder for {subj:?}");
+            assert_eq!(c, StaticCondition::SourceIsEquipped, "for {subj:?}");
+        }
+    }
+
+    // CR 508.1k / CR 303.4: the contraction combinator covers the whole source-state
+    // class, not just "equipped" (The Incredible Hulk shape "if he's attacking").
+    #[test]
+    fn test_contraction_source_state_siblings() {
+        let (rest, c) = parse_inner_condition("he's attacking").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsAttacking);
+
+        let (rest, c) = parse_inner_condition("he's enchanted").unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(c, StaticCondition::SourceIsEnchanted);
+    }
+
+    // BLOCKER-2 guard (discriminating, REACHABLE): bare "it's" is target-anaphoric
+    // in spell bodies (Awaken the Sleeper reaches this same combinator at
+    // oracle_effect/conditions.rs). It MUST NOT yield a Source condition — fails if
+    // anyone later adds a blanket "it's" source arm.
+    #[test]
+    fn test_bare_its_not_source_equipped() {
+        match parse_inner_condition("it's equipped") {
+            Err(_) => {}
+            Ok((rest, c)) => {
+                assert_ne!(
+                    c,
+                    StaticCondition::SourceIsEquipped,
+                    "bare \"it's equipped\" must not bind the source (rest={rest:?})"
+                );
+            }
+        }
+    }
+
+    // Over-acceptance guard: the copula is paired to its pronoun, so the
+    // ungrammatical cross-products "they's"/"he're" cannot parse a Source condition.
+    #[test]
+    fn test_contraction_cross_products_rejected() {
+        for subj in ["they's equipped", "he're equipped"] {
+            match parse_inner_condition(subj) {
+                Err(_) => {}
+                Ok((rest, c)) => {
+                    assert!(
+                        !matches!(
+                            c,
+                            StaticCondition::SourceIsEquipped
+                                | StaticCondition::SourceIsEnchanted
+                                | StaticCondition::SourceIsTapped
+                                | StaticCondition::SourceIsMonstrous
+                                | StaticCondition::SourceIsAttacking
+                                | StaticCondition::SourceIsBlocking
+                                | StaticCondition::SourceIsBlocked
+                        ),
+                        "ungrammatical {subj:?} must not yield a Source condition (rest={rest:?}, c={c:?})"
+                    );
+                }
+            }
+        }
     }
 
     // CR 303.4: bare SourceIsEnchanted predicate across subjects.

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3744,6 +3744,19 @@ fn parse_for_each_attached_to_source(input: &str) -> OracleResult<'_, QuantityRe
     // `FilterProp` from a typed pair.
     let (rest, prop) = alt((
         value(FilterProp::AttachedToSource, tag(" attached to ~")),
+        // CR 301.5a + CR 303.4: source-anaphoric gendered pronoun denotes the
+        // ability source (same id as `~`) — Winter Soldier, Captain America
+        // (MSH templates). Maps to AttachedToSource, identical to the `~` arm.
+        // Distinct from the recipient pronoun "it"/"that creature" arm below.
+        // Only the unambiguously source-anaphoric "him"/"her" are accepted; the
+        // singular-they "them" is excluded because it is recipient-anaphoric for
+        // player-enchanting Auras (Curse of Thirst: "Curses attached to them" =
+        // the enchanted player, not the Aura source), which would bind the wrong
+        // object set.
+        value(
+            FilterProp::AttachedToSource,
+            alt((tag(" attached to him"), tag(" attached to her"))),
+        ),
         value(
             FilterProp::AttachedToRecipient,
             alt((tag(" attached to it"), tag(" attached to that creature"))),
@@ -4475,6 +4488,86 @@ mod tests {
                 other => panic!("expected Typed filter, got {other:?}"),
             },
             other => panic!("expected ObjectCount, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_for_each_attached_to_source_gendered_animate_pronoun() {
+        // CR 301.5a + CR 303.4: MSH/Marvel templates phrase the attachment count
+        // with the source-anaphoric gendered pronoun "him"/"her"
+        // (Winter Soldier "for each Equipment attached to him"). These denote the
+        // SAME object id as `~`, so the combinator must emit `AttachedToSource`.
+        // Fail-before: no "attached to him/her" arm → Err.
+        for pronoun in ["him", "her"] {
+            let clause = format!("equipment attached to {pronoun}");
+            let (rest, q) = parse_for_each_clause_ref(&clause)
+                .unwrap_or_else(|e| panic!("expected Ok for {clause:?}, got {e:?}"));
+            assert_eq!(rest, "", "remainder for {clause:?}");
+            match q {
+                QuantityRef::ObjectCount { filter } => match filter {
+                    TargetFilter::Typed(TypedFilter {
+                        type_filters,
+                        controller,
+                        properties,
+                    }) => {
+                        assert_eq!(controller, None, "controller for {clause:?}");
+                        assert_eq!(
+                            properties,
+                            vec![FilterProp::AttachedToSource],
+                            "properties for {clause:?}"
+                        );
+                        assert_eq!(
+                            type_filters,
+                            vec![TypeFilter::Subtype("Equipment".into())],
+                            "type_filters for {clause:?}"
+                        );
+                    }
+                    other => panic!("expected Typed filter for {clause:?}, got {other:?}"),
+                },
+                other => panic!("expected ObjectCount for {clause:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_for_each_attached_to_them_not_source_bound() {
+        // CR 301.5a + CR 303.4: the singular-they "them" is recipient-anaphoric for
+        // player-enchanting Auras (Curse of Thirst: "Curses attached to them" = the
+        // enchanted player), so it must NOT bind to the source. The gendered arm
+        // deliberately omits "them"; this combinator therefore does not produce an
+        // AttachedToSource count for it (the clause is left unconsumed). Guards
+        // against a future re-add that would silently count the wrong object set.
+        let result = parse_for_each_attached_to_source("curse attached to them");
+        match result {
+            Err(_) => {}
+            Ok((rest, q)) => {
+                // If some other arm consumes it, it must not be AttachedToSource.
+                if let QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(TypedFilter { properties, .. }),
+                } = &q
+                {
+                    assert!(
+                        !properties.contains(&FilterProp::AttachedToSource),
+                        "\"attached to them\" must not bind to the source, got {q:?} (rest {rest:?})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_for_each_attached_to_recipient_it_preserved_after_gendered_arm() {
+        // Discrimination/regression: the recipient authority ("it") must stay
+        // AttachedToRecipient even with the new source-pronoun arm above it.
+        let (rest, q) = parse_for_each_clause_ref("aura attached to it").unwrap();
+        assert_eq!(rest, "");
+        match q {
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter { properties, .. }),
+            } => {
+                assert_eq!(properties, vec![FilterProp::AttachedToRecipient]);
+            }
+            other => panic!("expected recipient ObjectCount, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -505,13 +505,17 @@ pub(crate) fn parse_quantity_ref_with_context(
             return Some(qty);
         }
         // CR 301.5a + CR 303.4: "the number of <type> attached to <source>" counts
-        // objects whose `attached_to` is the source ("him"/"her"/"them"/"~" all
-        // denote the source — Whiplash's "where X is the number of Equipment
-        // attached to him"). Delegate to the shared for-each referent combinator so
-        // the source- and recipient-pronoun authorities stay in one building block;
-        // require a full consume so the generic type-phrase fall-through is unshadowed.
+        // objects whose `attached_to` is the source ("him"/"her"/"~" all denote the
+        // source — Whiplash's "where X is the number of Equipment attached to him";
+        // "them" denotes the recipient (player-enchanting Auras — see
+        // oracle_nom/quantity.rs parse_for_each_attached_to_source)). Delegate to the
+        // shared for-each referent combinator so the source- and recipient-pronoun
+        // authorities stay in one building block; require a full consume so the
+        // generic type-phrase fall-through is unshadowed.
         if let Ok((rest_after, qty)) = nom_quantity::parse_for_each_clause_ref.parse(rest) {
-            if rest_after.is_empty() {
+            // trim() matches the sibling completeness checks (470/482/489/527) and
+            // tolerates trailing whitespace.
+            if rest_after.trim().is_empty() {
                 return Some(canonicalize_quantity_ref(qty));
             }
         }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -504,6 +504,17 @@ pub(crate) fn parse_quantity_ref_with_context(
         {
             return Some(qty);
         }
+        // CR 301.5a + CR 303.4: "the number of <type> attached to <source>" counts
+        // objects whose `attached_to` is the source ("him"/"her"/"them"/"~" all
+        // denote the source — Whiplash's "where X is the number of Equipment
+        // attached to him"). Delegate to the shared for-each referent combinator so
+        // the source- and recipient-pronoun authorities stay in one building block;
+        // require a full consume so the generic type-phrase fall-through is unshadowed.
+        if let Ok((rest_after, qty)) = nom_quantity::parse_for_each_clause_ref.parse(rest) {
+            if rest_after.is_empty() {
+                return Some(canonicalize_quantity_ref(qty));
+            }
+        }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
         // CR 109.1: `parse_type_phrase_with_ctx` always returns `TargetFilter::Typed`,
         // including the empty-shaped form (no `type_filters`, no `controller`, no
@@ -3556,6 +3567,73 @@ mod tests {
             matches!(qty, QuantityRef::ObjectCount { .. }),
             "Expected ObjectCount, got {qty:?}"
         );
+    }
+
+    /// A2: CR 301.5a + CR 303.4. "the number of <type> attached to <source>" routes
+    /// through the shared for-each referent combinator to a typed ObjectCount with
+    /// `AttachedToSource` (Whiplash's "where X is the number of Equipment attached
+    /// to him"). Fail-before: `QuantityRef::Variable("the number of equipment
+    /// attached to him")` (string fallback), which is explicitly asserted-against.
+    #[test]
+    fn parse_quantity_ref_number_of_equipment_attached_to_source_pronoun() {
+        let qty = parse_quantity_ref("the number of equipment attached to him")
+            .expect("expected Some(ObjectCount)");
+        assert!(
+            !matches!(qty, QuantityRef::Variable { .. }),
+            "must not fall back to Variable, got {qty:?}"
+        );
+        match qty {
+            QuantityRef::ObjectCount {
+                filter:
+                    TargetFilter::Typed(TypedFilter {
+                        type_filters,
+                        controller,
+                        properties,
+                    }),
+            } => {
+                assert_eq!(controller, None);
+                assert_eq!(properties, vec![FilterProp::AttachedToSource]);
+                assert_eq!(type_filters, vec![TypeFilter::Subtype("Equipment".into())]);
+            }
+            other => panic!("expected ObjectCount{{AttachedToSource}}, got {other:?}"),
+        }
+    }
+
+    /// A2 NEG (multi-authority): the recipient pronoun "it" must stay
+    /// `AttachedToRecipient`, NOT collapse to the source authority.
+    #[test]
+    fn parse_quantity_ref_number_of_auras_attached_to_recipient_preserved() {
+        let qty = parse_quantity_ref("the number of auras attached to it")
+            .expect("expected Some(ObjectCount)");
+        match qty {
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter { properties, .. }),
+            } => {
+                assert_eq!(properties, vec![FilterProp::AttachedToRecipient]);
+            }
+            other => panic!("expected recipient ObjectCount, got {other:?}"),
+        }
+    }
+
+    /// A2 REGRESSION: the new for-each arm requires a full consume, so a generic
+    /// "the number of creatures you control" still falls through to the existing
+    /// type-phrase ObjectCount path (no shadowing).
+    #[test]
+    fn parse_quantity_ref_number_of_creatures_you_control_not_shadowed() {
+        let qty = parse_quantity_ref("the number of creatures you control")
+            .expect("expected Some(ObjectCount)");
+        match qty {
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(TypedFilter { properties, .. }),
+            } => {
+                assert!(
+                    !properties.contains(&FilterProp::AttachedToSource)
+                        && !properties.contains(&FilterProp::AttachedToRecipient),
+                    "generic ObjectCount must not gain an attachment prop, got {properties:?}"
+                );
+            }
+            other => panic!("expected generic ObjectCount, got {other:?}"),
+        }
     }
 
     // A1: "the number of opponents who control <filter>" → PlayerCount over the

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -721,12 +721,22 @@ fn rewrite_self_pronoun_subject(condition: &str) -> String {
     {
         // CR 508.1k / CR 509.1g / CR 509.1h: combat-state pronoun siblings of the
         // tapped/untapped rewrite. CR 700.9: "modified" is the self-state sibling
-        // for "it's modified" (Obstinate Gargoyle, Skyward Spider). Exact-match
-        // only — "attacking alone" keeps its trailing word and is left for
-        // SourceAttackingAlone; "modified creature" never hits this arm.
+        // for "it's modified" (Obstinate Gargoyle, Skyward Spider). CR 301.5a:
+        // "equipped"; CR 303.4: "enchanted" — self-state predicates for SelfRef
+        // statics (Merry "as long as it's equipped"; Fledgling Osprey "as long as
+        // it's enchanted"). Exact-match only — "attacking alone" keeps its trailing
+        // word and is left for SourceAttackingAlone; "modified creature" and
+        // "enchanted by N Auras" keep their trailing words and never hit this arm.
         if matches!(
             rest.trim(),
-            "tapped" | "untapped" | "attacking" | "blocking" | "blocked" | "modified"
+            "tapped"
+                | "untapped"
+                | "attacking"
+                | "blocking"
+                | "blocked"
+                | "modified"
+                | "equipped"
+                | "enchanted"
         ) {
             return format!("~ is {}", rest.trim());
         }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -19204,6 +19204,69 @@ fn self_pronoun_combat_state_exact_match_excludes_attacking_alone() {
 }
 
 #[test]
+fn self_static_resolves_it_pronoun_equipped_enchanted_to_source() {
+    // CR 301.5a / CR 303.4: "it" in a self-referential static gate refers to the
+    // source, so "as long as it's equipped/enchanted" must type to
+    // SourceIsEquipped/SourceIsEnchanted (Merry "as long as it's equipped";
+    // Fledgling Osprey "as long as it's enchanted"). Discriminating: before adding
+    // "equipped"/"enchanted" to the rewrite exact-match list these came back
+    // StaticCondition::Unrecognized { text: "it's equipped"/"it's enchanted" },
+    // which evaluates always-true. Fails on revert.
+    let equipped = parse_static_line("This creature gets +1/+0 as long as it's equipped.")
+        .expect("self static def");
+    assert_eq!(
+        equipped.condition,
+        Some(StaticCondition::SourceIsEquipped),
+        "expected SourceIsEquipped, got {:?}",
+        equipped.condition
+    );
+
+    let enchanted = parse_static_line("This creature has flying as long as it's enchanted.")
+        .expect("self static def");
+    assert_eq!(
+        enchanted.condition,
+        Some(StaticCondition::SourceIsEnchanted),
+        "expected SourceIsEnchanted, got {:?}",
+        enchanted.condition
+    );
+}
+
+#[test]
+fn self_static_resolves_it_pronoun_untapped_still_works() {
+    // REGRESSION: the pre-existing rewrite entries are untouched — "it's untapped"
+    // still types to Not(SourceIsTapped).
+    let def = parse_static_line("This creature has hexproof as long as it's untapped.")
+        .expect("self static def");
+    assert!(
+        matches!(
+            def.condition.as_ref(),
+            Some(StaticCondition::Not { condition })
+                if matches!(condition.as_ref(), StaticCondition::SourceIsTapped)
+        ),
+        "expected Not(SourceIsTapped), got {:?}",
+        def.condition
+    );
+}
+
+#[test]
+fn aura_static_does_not_bind_it_pronoun_equipped_enchanted_to_source() {
+    // NEG (SelfRef gate proof): a non-SelfRef attached-subject static keeps "it"
+    // bound to the recipient, so "as long as it's enchanted" must NOT collapse to
+    // SourceIsEnchanted (Awaken-the-Sleeper-class anaphor trap). Reaches the
+    // non-rewrite `else` branch (affected != SelfRef).
+    let defs = parse_static_line_multi("Enchanted creature gets +1/+1 as long as it's enchanted.");
+    assert!(!defs.is_empty(), "expected at least one static def");
+    for d in &defs {
+        assert_ne!(
+            d.condition,
+            Some(StaticCondition::SourceIsEnchanted),
+            "Aura 'it' must not resolve to the source, got {:?}",
+            d.condition
+        );
+    }
+}
+
+#[test]
 fn self_static_resolves_this_creature_is_modified_to_source_filter() {
     // CR 700.9 / CR 611.3a: "as long as this creature is modified" (Orochi
     // Merge-Keeper) must type to SourceMatchesFilter on a creature filter carrying

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2788,7 +2788,12 @@ fn remap_self_cast_scope_in_quantity(expr: &mut QuantityExpr) {
     }
 }
 
-fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<TriggerCondition> {
+// pub(crate) so the runtime gate tests in game/triggers.rs can drive the
+// production bridge directly (discriminating against this function rather than a
+// hand-built filter). Sole non-test caller remains parse_trigger_line below.
+pub(crate) fn static_condition_to_trigger_condition(
+    sc: &StaticCondition,
+) -> Option<TriggerCondition> {
     match sc {
         StaticCondition::DuringYourTurn => Some(TriggerCondition::DuringPlayersTurn {
             player: PlayerFilter::Controller,
@@ -2874,14 +2879,16 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
             })
         }
 
-        // CR 603.4 + CR 301.5a: "if [it/he/she/this creature] is equipped"
-        // intervening-if bridges to the generic source-filter matcher rather than
-        // a bespoke TriggerCondition sibling (see game/triggers.rs:5462). Runtime
-        // rechecks the source's attachment set at trigger-fire and on resolution
-        // (CR 603.4 dual-check). SourceExclusion::Include: a creature is never its
-        // own attachment.
+        // CR 603.4 + CR 301.5a: "if [it/this permanent/this artifact] is equipped"
+        // intervening-if. Source-object-wide, matching the layer evaluator
+        // (game/layers.rs SourceIsEquipped) and FilterProp::HasAttachment
+        // (game/filter.rs) — neither narrows by card type. The HasAttachment{Equipment}
+        // subtype predicate already implies a legal creature host (CR 301.5a/301.5c),
+        // so a creature() card-type gate would be redundant AND would diverge from the
+        // layer path. TypedFilter::default() -> empty type_filters -> no card-type
+        // constraint. SourceExclusion::Include: a permanent is never its own attachment.
         StaticCondition::SourceIsEquipped => Some(TriggerCondition::SourceMatchesFilter {
-            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+            filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
                 FilterProp::HasAttachment {
                     kind: AttachmentKind::Equipment,
                     controller: None,
@@ -2889,9 +2896,14 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
                 },
             ])),
         }),
-        // CR 603.4 + CR 303.4: Aura-twin of the equipped bridge.
+        // CR 603.4 + CR 303.4: "if [it/this permanent/this land] is enchanted"
+        // intervening-if. CR 303.4: an Aura enters the battlefield attached to an
+        // object OR player -- the host is NOT restricted to creatures. Source-object-wide,
+        // matching game/layers.rs SourceIsEnchanted and FilterProp::HasAttachment
+        // (game/filter.rs), neither of which narrows by card type.
+        // TypedFilter::default() -> empty type_filters -> no card-type constraint.
         StaticCondition::SourceIsEnchanted => Some(TriggerCondition::SourceMatchesFilter {
-            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+            filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
                 FilterProp::HasAttachment {
                     kind: AttachmentKind::Aura,
                     controller: None,
@@ -27510,6 +27522,82 @@ mod tests {
                 }
             )),
             "enchanted bridge must not carry the Equipment HasAttachment; got {:?}",
+            typed.properties
+        );
+    }
+
+    /// CR 603.4 + CR 303.4: the enchanted intervening-if is source-object-wide and
+    /// must NOT impose a creature card-type gate (CR 303.4 Auras may enchant any
+    /// object or player; the host is not restricted to creatures). Fail-before:
+    /// the bridge used `TypedFilter::creature()`, so `type_filters == [Creature]`
+    /// and BOTH assertions below would fail. The HasAttachment{Aura} property is
+    /// reasserted as a sibling guard so the swap to `default()` can't silently
+    /// drop the attachment predicate.
+    #[test]
+    fn bridge_source_is_enchanted_no_creature_type() {
+        let tc = static_condition_to_trigger_condition(&StaticCondition::SourceIsEnchanted)
+            .expect("SourceIsEnchanted should bridge to a TriggerCondition");
+        let TriggerCondition::SourceMatchesFilter { filter } = tc else {
+            panic!("expected SourceMatchesFilter, got {tc:?}");
+        };
+        let TargetFilter::Typed(typed) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            typed.type_filters.is_empty(),
+            "enchanted bridge must carry no card-type constraint; got {:?}",
+            typed.type_filters
+        );
+        assert!(
+            !typed.type_filters.contains(&TypeFilter::Creature),
+            "enchanted bridge must not gate on Creature; got {:?}",
+            typed.type_filters
+        );
+        assert!(
+            typed.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Aura,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                }
+            )),
+            "expected HasAttachment(Aura, None, Include); got {:?}",
+            typed.properties
+        );
+    }
+
+    /// CR 603.4 + CR 301.5a/301.5c: the equipped intervening-if is source-object-wide.
+    /// The HasAttachment{Equipment} subtype predicate already implies a legal
+    /// creature host, so a redundant `creature()` card-type gate would diverge from
+    /// the layer evaluator (game/layers.rs). Fail-before: the bridge used
+    /// `TypedFilter::creature()`, so `type_filters == [Creature]` and the empty
+    /// assertion would fail. HasAttachment{Equipment} reasserted as a sibling guard.
+    #[test]
+    fn bridge_source_is_equipped_no_creature_type() {
+        let tc = static_condition_to_trigger_condition(&StaticCondition::SourceIsEquipped)
+            .expect("SourceIsEquipped should bridge to a TriggerCondition");
+        let TriggerCondition::SourceMatchesFilter { filter } = tc else {
+            panic!("expected SourceMatchesFilter, got {tc:?}");
+        };
+        let TargetFilter::Typed(typed) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            typed.type_filters.is_empty(),
+            "equipped bridge must carry no card-type constraint; got {:?}",
+            typed.type_filters
+        );
+        assert!(
+            typed.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Equipment,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                }
+            )),
+            "expected HasAttachment(Equipment, None, Include); got {:?}",
             typed.properties
         );
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2874,6 +2874,32 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
             })
         }
 
+        // CR 603.4 + CR 301.5a: "if [it/he/she/this creature] is equipped"
+        // intervening-if bridges to the generic source-filter matcher rather than
+        // a bespoke TriggerCondition sibling (see game/triggers.rs:5462). Runtime
+        // rechecks the source's attachment set at trigger-fire and on resolution
+        // (CR 603.4 dual-check). SourceExclusion::Include: a creature is never its
+        // own attachment.
+        StaticCondition::SourceIsEquipped => Some(TriggerCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Equipment,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                },
+            ])),
+        }),
+        // CR 603.4 + CR 303.4: Aura-twin of the equipped bridge.
+        StaticCondition::SourceIsEnchanted => Some(TriggerCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Aura,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                },
+            ])),
+        }),
+
         // Not combinator — handle common negation patterns.
         StaticCondition::Not { condition } => match condition.as_ref() {
             StaticCondition::DuringYourTurn => Some(TriggerCondition::Not {
@@ -3028,8 +3054,6 @@ fn static_condition_to_trigger_condition(sc: &StaticCondition) -> Option<Trigger
         | StaticCondition::SourceIsAttacking
         | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
-        | StaticCondition::SourceIsEquipped
-        | StaticCondition::SourceIsEnchanted
         | StaticCondition::SourceIsPaired
         | StaticCondition::SourceIsMonstrous
         // CR 110.5b + CR 611.2b: `IsTapped { scope }` is a duration-only
@@ -27421,6 +27445,72 @@ mod tests {
                 filter: filter.clone(),
             }),
             Some(TriggerCondition::SourceMatchesFilter { filter }),
+        );
+    }
+
+    /// CR 603.4 + CR 301.5a: the equipped intervening-if must bridge to a
+    /// SourceMatchesFilter carrying a creature HasAttachment(Equipment) predicate.
+    /// Fail-before: `SourceIsEquipped` was in the `=> None` arm, so `.expect`
+    /// would panic on `None`.
+    #[test]
+    fn bridge_source_is_equipped_to_has_attachment() {
+        let tc = static_condition_to_trigger_condition(&StaticCondition::SourceIsEquipped)
+            .expect("SourceIsEquipped should bridge to a TriggerCondition");
+        let TriggerCondition::SourceMatchesFilter { filter } = tc else {
+            panic!("expected SourceMatchesFilter, got {tc:?}");
+        };
+        let TargetFilter::Typed(typed) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            typed.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Equipment,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                }
+            )),
+            "expected HasAttachment(Equipment, None, Include); got {:?}",
+            typed.properties
+        );
+    }
+
+    /// CR 603.4 + CR 303.4: the enchanted intervening-if bridges to an Aura
+    /// HasAttachment predicate, and crucially must NOT carry the Equipment
+    /// variant (discriminates attachment kind).
+    #[test]
+    fn bridge_source_is_enchanted_to_has_attachment() {
+        let tc = static_condition_to_trigger_condition(&StaticCondition::SourceIsEnchanted)
+            .expect("SourceIsEnchanted should bridge to a TriggerCondition");
+        let TriggerCondition::SourceMatchesFilter { filter } = tc else {
+            panic!("expected SourceMatchesFilter, got {tc:?}");
+        };
+        let TargetFilter::Typed(typed) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            typed.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Aura,
+                    controller: None,
+                    exclude_source: crate::types::ability::SourceExclusion::Include,
+                }
+            )),
+            "expected HasAttachment(Aura, None, Include); got {:?}",
+            typed.properties
+        );
+        assert!(
+            !typed.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::HasAttachment {
+                    kind: AttachmentKind::Equipment,
+                    ..
+                }
+            )),
+            "enchanted bridge must not carry the Equipment HasAttachment; got {:?}",
+            typed.properties
         );
     }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Building block: source-anaphoric "Equipment/Aura attached to {source}" count

This PR builds the reusable count for **"the number of Equipment/Aura attached to {the source}"** and wires two MSH cards end-to-end. **No new engine enum variant** — the quantity reuses the existing `QuantityRef::ObjectCount { filter }` + `FilterProp::AttachedToSource`, and the dynamic P/T scaling reuses `ContinuousModification::AddDynamicPower`/`AddDynamicToughness` (the same shape Armament Master already produces). The work is parser wiring plus one trigger-condition bridge, built for the **class**, not the card.

### What changed (parser, build-for-the-class)

- **Attachment-count referent (`oracle_nom/quantity.rs`).** `parse_for_each_attached_to_source` now accepts the source-anaphoric gendered pronoun `"him"`/`"her"` (`" attached to him"`) → `AttachedToSource`, alongside the existing `"~"` arm. The recipient pronoun `"it"`/`"that creature"` → `AttachedToRecipient` is preserved unchanged. The singular-they `"them"` is **deliberately excluded** because it is recipient-anaphoric for player-enchanting Auras (e.g. *Curse of Thirst* — "Curses attached to them" = the enchanted **player**, not the Aura source), which would bind the wrong object set.
- **Quantity path (`oracle_quantity.rs`).** The `"the number of <type> attached to <source>"` block delegates to the same combinator, so `"where X is the number of Equipment attached to him"` lowers to the typed `ObjectCount` instead of the `Variable` string fallback.
- **Contraction source-state conditions (`oracle_nom/condition.rs`).** New `parse_contraction_source_state_condition`: `"he's"/"she's"/"they're" + <state>` (equipped / enchanted / tapped / monstrous / attacking / blocking / blocked) → the matching `Source*` condition. Bare `"it's"` is **excluded** (target-anaphoric in spell bodies, e.g. *Awaken the Sleeper* "Gain control of target creature … if it's equipped"). Modeled on the existing `parse_recipient_is_filter_condition` copula-then-bare-predicate shape.
- **Self-ref static rewrite (`oracle_static/anthem.rs`).** `rewrite_self_pronoun_subject` (SelfRef-gated) gains `"equipped"`/`"enchanted"`, so self-ref statics `"… as long as it's equipped/enchanted"` bind to the source.
- **Trigger-condition bridge (`oracle_trigger.rs`).** `StaticCondition::SourceIsEquipped`/`SourceIsEnchanted` intervening-ifs now bridge to the existing generic `TriggerCondition::SourceMatchesFilter { filter: creature + HasAttachment(Equipment/Aura) }` (the runtime handler doc explicitly anticipates this: "so properties such as enchanted/equipped … do not need bespoke TriggerCondition siblings") instead of being dropped to `None`. This carries Whiplash's `"if he's equipped"` gate; with the gate-clause stripped, the each-opponent subject strip fires.

### Class this unlocks

The source-pronoun count + condition handling covers the "for each Equipment/Aura attached to {source}" + "<source-pronoun>'s equipped/enchanted/…" family beyond the two cards below — e.g. Captain America, Liberator (attachment count), and the self-ref static `"as long as it's equipped/enchanted"` cards (Merry, Esquire of Rohan; Fledgling Osprey; Skyrider Trainee; Metathran Elite). The bare-`"it's"` trigger cases (Tetsuo, Krond, etc.) remain gapped on a **separate** self-ref normalization issue, not on this bridge.

### Cards shipped

- **Winter Soldier, Icy Assassin** — "Winter Soldier gets +2/+0 for each Equipment attached to him." The static now scales power dynamically (`AddDynamicPower(Multiply{2, ObjectCount{Equipment + AttachedToSource}})`) instead of misparsing to a fixed +2/+0. The +0 toughness component is correctly omitted (a +0 dynamic mod is a layer no-op). The graveyard-return activated ability is unchanged.
- **Whiplash, Vengeful Engineer** — "Whenever Whiplash attacks, if he's equipped, each opponent loses X life and you gain X life, where X is the number of Equipment attached to him." Now parses with the `"if he's equipped"` intervening-if (bridged to `SourceMatchesFilter{HasAttachment(Equipment)}`), `X = ObjectCount{Equipment + AttachedToSource}` on both LoseLife/GainLife, and the each-opponent form (`player_scope = Opponent`, no explicit target).

### CR references (verified against the Comprehensive Rules)

- **CR 301.5a** — Equipment / "equipped creature".
- **CR 303.4** — Aura / enchanted.
- **CR 603.4** — intervening-"if" clause (checked at trigger and rechecked on resolution; drives the bridged source-state gate).
- **CR 508.1k / 509.1g / 509.1h** — combat-state predicates (attacking/blocking/blocked arms).

### Tests (non-vacuous + discriminating)

- Card-synthesis for both cards (fail-before: fixed +2/+0; `Variable` X with null condition / empty target).
- Combinator-level positive + regression + negative: `"attached to it"` → recipient (preserved); `"the number of creatures you control"` → generic `ObjectCount` (not shadowed); `"it's equipped"` NOT a source condition (Awaken-the-Sleeper guard); `"they's"/"he're"` rejected; `"attached to them"` NOT source-bound (Curse-of-Thirst guard).
- Runtime gating test proving the bridged condition fires only when the source actually has an Equipment attached (false with no attachment, false with an Aura only, true with an Equipment).

No new serialized surface (maps to existing `TriggerCondition`/`FilterProp` variants). `mtgish/` untouched.
