### PR TITLE
fix(parser): parse negated cast-origin intervening-if condition

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7651,8 +7651,10 @@ pub(super) fn parse_imperative_family_ast(
                 None
             }
         }
+        // allow-noncombinator: first-word verb dispatch arm (sibling of "double" above)
         "proliferate" => Some(ImperativeFamilyAst::Proliferate),
         // CR 701.56a: "time travel" / "time travel N times"
+        // allow-noncombinator: first-word verb dispatch arm (sibling of "double" above)
         "time" => {
             if tag::<_, _, OracleError<'_>>("time travel")
                 .parse(lower)

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16415,7 +16415,7 @@ mod tests {
             "expected Not(WasCast {{ zone: Hand }}), got {cond:?}",
         );
         assert!(
-            !cleaned.contains("didn't cast"),
+            !cleaned.contains("didn't cast"), // allow-noncombinator: test assertion, not parsing dispatch
             "condition clause must be stripped from effect text: {cleaned}",
         );
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3209,6 +3209,23 @@ fn parse_first_time_tapped_intervening_if(input: &str) -> OracleResult<'_, Trigg
     Ok((rest, TriggerCondition::FirstTimeObjectTappedThisTurn))
 }
 
+/// CR 601.2 + CR 404.1: Build a caster/owner-scoped `WasCast` for "you cast
+/// it from <zone>" intervening-if arms. The caster axis is always you ("you
+/// cast it"). For owner-specific zones (hand, graveyard, library — CR 404.1
+/// each player has their own such zone) the origin-zone-owner is also you.
+/// Exile and the command zone are shared and carry no per-player ownership.
+fn scoped_you_cast_from_zone(zone: Option<Zone>) -> TriggerCondition {
+    let owner = zone.and_then(|z| match z {
+        Zone::Hand | Zone::Graveyard | Zone::Library => Some(ControllerRef::You),
+        _ => None,
+    });
+    TriggerCondition::WasCast {
+        zone,
+        controller: Some(ControllerRef::You),
+        owner,
+    }
+}
+
 /// Extract an intervening-if condition from effect text.
 /// Returns (cleaned effect text, optional condition).
 ///
@@ -3265,11 +3282,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         return (
             strip_condition_clause(text, before.len(), clause_len),
             Some(TriggerCondition::Not {
-                condition: Box::new(TriggerCondition::WasCast {
-                    zone,
-                    controller: None,
-                    owner: None,
-                }),
+                condition: Box::new(scoped_you_cast_from_zone(zone)),
             }),
         );
     }
@@ -3285,11 +3298,7 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
         let clause_len = lower.len() - before.len() - rest.len();
         return (
             strip_condition_clause(text, before.len(), clause_len),
-            Some(TriggerCondition::WasCast {
-                zone,
-                controller: None,
-                owner: None,
-            }),
+            Some(scoped_you_cast_from_zone(zone)),
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3251,8 +3251,49 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
     // --- Source-referential patterns (cannot be StaticConditions) ---
     // These require trigger-source context that StaticCondition can't express.
 
+    // CR 601.2a + CR 603.4: "if you didn't cast it from <zone>" — negated
+    // cast-origin intervening-if (Chainer, Nightmare Adept; Phage the
+    // Untouchable). The entering permanent must NOT have been cast from the
+    // named zone. Ordered before the positive and zoneless arms so neither
+    // shadows it.
+    if let Some((before, zone, rest)) = scan_preceded(&lower, |i: &str| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("if you didn't cast it from ").parse(i)?;
+        let (i, zone) = parse_cast_origin_zone(i)?;
+        Ok((i, zone))
+    }) {
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, before.len(), clause_len),
+            Some(TriggerCondition::Not {
+                condition: Box::new(TriggerCondition::WasCast {
+                    zone,
+                    controller: None,
+                    owner: None,
+                }),
+            }),
+        );
+    }
+
+    // CR 601.2a + CR 603.4: "if you cast it from <zone>" — zone-specific
+    // positive cast-origin intervening-if. Must precede the zoneless "if you
+    // cast it" arm below so the zone suffix is not lost.
+    if let Some((before, zone, rest)) = scan_preceded(&lower, |i: &str| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("if you cast it from ").parse(i)?;
+        let (i, zone) = parse_cast_origin_zone(i)?;
+        Ok((i, zone))
+    }) {
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, before.len(), clause_len),
+            Some(TriggerCondition::WasCast {
+                zone,
+                controller: None,
+                owner: None,
+            }),
+        );
+    }
+
     // CR 701.57a: "if you cast it" — zoneless cast check (Discover ETBs).
-    // Guard: must not be followed by " from" (zone-specific variant).
     if let Some(pos) = tp.find("if you cast it") {
         let after = &lower[pos + "if you cast it".len()..];
         if !after.starts_with(" from") {
@@ -16351,6 +16392,95 @@ mod tests {
                 })
             ),
             "expected IsRenowned {{ Source }}, got {self_cond:?}",
+        );
+    }
+
+    /// CR 601.2a + CR 603.4: "if you didn't cast it from your hand" —
+    /// negated cast-origin intervening-if (Chainer, Nightmare Adept; Phage
+    /// the Untouchable). Must produce `Not(WasCast { zone: Hand })`.
+    #[test]
+    fn extract_if_condition_didnt_cast_from_hand() {
+        let (cleaned, cond) = extract_if_condition(
+            "if you didn't cast it from your hand, it gains haste until your next turn.",
+        );
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::Not { ref condition })
+                    if matches!(
+                        **condition,
+                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                    )
+            ),
+            "expected Not(WasCast {{ zone: Hand }}), got {cond:?}",
+        );
+        assert!(
+            !cleaned.contains("didn't cast"),
+            "condition clause must be stripped from effect text: {cleaned}",
+        );
+    }
+
+    /// CR 601.2a + CR 603.4: "if you cast it from your hand" — positive
+    /// zone-specific cast-origin intervening-if.
+    #[test]
+    fn extract_if_condition_cast_from_zone() {
+        let (_, cond) = extract_if_condition(
+            "if you cast it from your graveyard, create a 2/2 black zombie creature token.",
+        );
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::WasCast {
+                    zone: Some(Zone::Graveyard),
+                    ..
+                })
+            ),
+            "expected WasCast {{ zone: Graveyard }}, got {cond:?}",
+        );
+    }
+
+    /// CR 601.2a + CR 603.4: Full Chainer, Nightmare Adept trigger parse —
+    /// the trigger condition must be `Not(WasCast { zone: Hand })` and the
+    /// effect target must be the entering creature (not the source).
+    #[test]
+    fn chainer_nightmare_adept_trigger_condition() {
+        let def = parse_trigger_line(
+            "Whenever a nontoken creature you control enters, if you didn't cast it from your hand, it gains haste until your next turn.",
+            "Chainer, Nightmare Adept",
+        );
+        assert!(
+            matches!(
+                def.condition,
+                Some(TriggerCondition::Not { ref condition })
+                    if matches!(
+                        **condition,
+                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                    )
+            ),
+            "expected Not(WasCast {{ zone: Hand }}), got {:?}",
+            def.condition,
+        );
+    }
+
+    /// CR 603.4: Phage the Untouchable trigger parse — "if you didn't cast it
+    /// from your hand, you lose the game" must attach `Not(WasCast { zone: Hand })`.
+    #[test]
+    fn phage_the_untouchable_trigger_condition() {
+        let def = parse_trigger_line(
+            "When ~ enters, if you didn't cast it from your hand, you lose the game.",
+            "Phage the Untouchable",
+        );
+        assert!(
+            matches!(
+                def.condition,
+                Some(TriggerCondition::Not { ref condition })
+                    if matches!(
+                        **condition,
+                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                    )
+            ),
+            "expected Not(WasCast {{ zone: Hand }}), got {:?}",
+            def.condition,
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16406,7 +16406,10 @@ mod tests {
 
     /// CR 601.2a + CR 603.4: "if you didn't cast it from your hand" —
     /// negated cast-origin intervening-if (Chainer, Nightmare Adept; Phage
-    /// the Untouchable). Must produce `Not(WasCast { zone: Hand })`.
+    /// the Untouchable). Must produce `Not(WasCast { zone: Hand, controller:
+    /// You, owner: You })` — all three axes must be pinned so that an opponent
+    /// casting the card from their own hand, or you casting it from an
+    /// opponent's hand, do not satisfy the inner condition.
     #[test]
     fn extract_if_condition_didnt_cast_from_hand() {
         let (cleaned, cond) = extract_if_condition(
@@ -16418,10 +16421,14 @@ mod tests {
                 Some(TriggerCondition::Not { ref condition })
                     if matches!(
                         **condition,
-                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                        TriggerCondition::WasCast {
+                            zone: Some(Zone::Hand),
+                            controller: Some(ControllerRef::You),
+                            owner: Some(ControllerRef::You),
+                        }
                     )
             ),
-            "expected Not(WasCast {{ zone: Hand }}), got {cond:?}",
+            "expected Not(WasCast {{ zone: Hand, controller: You, owner: You }}), got {cond:?}",
         );
         assert!(
             !cleaned.contains("didn't cast"), // allow-noncombinator: test assertion, not parsing dispatch
@@ -16430,7 +16437,29 @@ mod tests {
     }
 
     /// CR 601.2a + CR 603.4: "if you cast it from your hand" — positive
-    /// zone-specific cast-origin intervening-if.
+    /// zone-specific cast-origin intervening-if. All three axes (zone, caster,
+    /// zone-owner) must be pinned: zone=Hand, controller=You, owner=You.
+    #[test]
+    fn extract_if_condition_cast_from_hand() {
+        let (_, cond) = extract_if_condition(
+            "if you cast it from your hand, it enters with a +1/+1 counter on it.",
+        );
+        assert!(
+            matches!(
+                cond,
+                Some(TriggerCondition::WasCast {
+                    zone: Some(Zone::Hand),
+                    controller: Some(ControllerRef::You),
+                    owner: Some(ControllerRef::You),
+                })
+            ),
+            "expected WasCast {{ zone: Hand, controller: You, owner: You }}, got {cond:?}",
+        );
+    }
+
+    /// CR 601.2a + CR 603.4: "if you cast it from your graveyard" — positive
+    /// zone-specific cast-origin. Graveyard is owner-scoped (CR 404.1), so
+    /// owner must be You; controller must also be You ("you cast it").
     #[test]
     fn extract_if_condition_cast_from_zone() {
         let (_, cond) = extract_if_condition(
@@ -16441,16 +16470,18 @@ mod tests {
                 cond,
                 Some(TriggerCondition::WasCast {
                     zone: Some(Zone::Graveyard),
-                    ..
+                    controller: Some(ControllerRef::You),
+                    owner: Some(ControllerRef::You),
                 })
             ),
-            "expected WasCast {{ zone: Graveyard }}, got {cond:?}",
+            "expected WasCast {{ zone: Graveyard, controller: You, owner: You }}, got {cond:?}",
         );
     }
 
     /// CR 601.2a + CR 603.4: Full Chainer, Nightmare Adept trigger parse —
-    /// the trigger condition must be `Not(WasCast { zone: Hand })` and the
-    /// effect target must be the entering creature (not the source).
+    /// the trigger condition must be `Not(WasCast { zone: Hand, controller:
+    /// You, owner: You })` and the effect target must be the entering creature
+    /// (not the source). All three axes must be pinned to prevent false matches.
     #[test]
     fn chainer_nightmare_adept_trigger_condition() {
         let def = parse_trigger_line(
@@ -16463,16 +16494,21 @@ mod tests {
                 Some(TriggerCondition::Not { ref condition })
                     if matches!(
                         **condition,
-                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                        TriggerCondition::WasCast {
+                            zone: Some(Zone::Hand),
+                            controller: Some(ControllerRef::You),
+                            owner: Some(ControllerRef::You),
+                        }
                     )
             ),
-            "expected Not(WasCast {{ zone: Hand }}), got {:?}",
+            "expected Not(WasCast {{ zone: Hand, controller: You, owner: You }}), got {:?}",
             def.condition,
         );
     }
 
     /// CR 603.4: Phage the Untouchable trigger parse — "if you didn't cast it
-    /// from your hand, you lose the game" must attach `Not(WasCast { zone: Hand })`.
+    /// from your hand, you lose the game" must attach `Not(WasCast { zone:
+    /// Hand, controller: You, owner: You })`. All three axes pinned.
     #[test]
     fn phage_the_untouchable_trigger_condition() {
         let def = parse_trigger_line(
@@ -16485,10 +16521,14 @@ mod tests {
                 Some(TriggerCondition::Not { ref condition })
                     if matches!(
                         **condition,
-                        TriggerCondition::WasCast { zone: Some(Zone::Hand), .. }
+                        TriggerCondition::WasCast {
+                            zone: Some(Zone::Hand),
+                            controller: Some(ControllerRef::You),
+                            owner: Some(ControllerRef::You),
+                        }
                     )
             ),
-            "expected Not(WasCast {{ zone: Hand }}), got {:?}",
+            "expected Not(WasCast {{ zone: Hand, controller: You, owner: You }}), got {:?}",
             def.condition,
         );
     }


### PR DESCRIPTION
Fixes #3682

## Summary
- Add two new `extract_if_condition` arms for zone-specific active-voice cast-origin conditions using `scan_preceded` + the existing `parse_cast_origin_zone` combinator:
  - `"if you didn't cast it from <zone>"` → `Not(WasCast { zone })`
  - `"if you cast it from <zone>"` → `WasCast { zone }`
- Previously, "if you didn't cast it from your hand" fell through to the effect-level generic "you didn't" handler, producing `Not(OptionalEffectPerformed)` instead of `Not(WasCast { zone: Hand })` — Chainer granted haste to itself instead of the entering creature because the condition never matched

## Cards unlocked
- Chainer, Nightmare Adept — trigger condition now correctly gates on cast-from-hand
- Phage the Untouchable — "you lose the game" ETB trigger now correctly gates on cast-from-hand
- Epochrasite — enters-with-counters condition (same pattern, static path)

## Verification
- `cargo fmt --all` — clean
- `cargo test -p engine --lib -- oracle_trigger::tests::extract_if_condition_didnt_cast` — passed
- `cargo test -p engine --lib -- oracle_trigger::tests::extract_if_condition_cast_from_zone` — passed
- `cargo test -p engine --lib -- oracle_trigger::tests::chainer_nightmare_adept` — passed
- `cargo test -p engine --lib -- oracle_trigger::tests::phage_the_untouchable` — passed
- `cargo test -p engine --lib -- oracle_trigger::tests::` (791 tests) — all passed
- `cargo test -p engine --lib -- oracle_effect::tests::` (1152 tests) — all passed