### PR TITLE
ci(coverage): wire parse-detail diff baseline publish + sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,68 @@ jobs:
             data/coverage-data.json \
             --fail-on-engine
 
+      - name: Parse-detail diff vs base baseline
+        # PR-only review aid (NEVER blocks — continue-on-error): surfaces the
+        # field-level parse changes this PR introduces, for the reviewing LLM.
+        # Unlike the regression check above (supported flips only), this diffs
+        # the full parse_details tree.
+        #
+        # Baseline = the PR's base.sha published coverage, fetched by its
+        # engine-source hash; head = the coverage built above from the merge
+        # commit (base.sha + PR). So head - baseline isolates EXACTLY this PR's
+        # parse changes, with no second coverage build and no cross-PR
+        # contamination — even when the PR is behind main (both sides move in
+        # lockstep). Path filter: identical engine-source hash => no parse
+        # change is possible => skip before the bin build. --features cli keeps
+        # the same [tool, cli] engine fingerprint as the steps above (lib cache
+        # hit; only the new bin links).
+        id: parsediff
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          BASE_HASH="$(./scripts/engine-source-hash.sh "$BASE_SHA")"
+          HEAD_HASH="$(./scripts/engine-source-hash.sh HEAD)"
+          if [ "$BASE_HASH" = "$HEAD_HASH" ]; then
+            echo "Engine source unchanged vs base ($BASE_HASH) — no parse change possible; skipping."
+            echo "produced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$PR_NUMBER" > pr-number.txt
+          URL="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/parse-baselines/coverage-data-${BASE_HASH}.json"
+          if curl -fsSL --retry 3 --retry-delay 2 "$URL" -o coverage-base.json; then
+            cargo run --profile tool --features cli --bin coverage-parse-diff -- \
+              coverage-base.json data/coverage-data.json \
+              --base-sha "$BASE_SHA" \
+              --markdown parse-diff.md --json parse-diff.json
+          else
+            # Baseline not published yet (base.sha only just merged) or aged out
+            # of retention. NEVER fall back to the lagging preview/ snapshot —
+            # that reintroduces cross-PR contamination. Emit a pending marker;
+            # the comment job only UPDATES an existing sticky, never creates one
+            # for a pending note.
+            printf '<!-- coverage-parse-diff -->\n### Parse changes introduced by this PR\n\n_Baseline pending for `%s` — this populates once main publishes its coverage snapshot (a few minutes after that commit landed)._\n' "$BASE_SHA" > parse-diff.md
+          fi
+          echo "produced=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload parse-diff artifact
+        # Consumed by .github/workflows/coverage-parse-diff-comment.yml, which
+        # posts the sticky PR comment from the trusted workflow_run context.
+        if: github.event_name == 'pull_request' && steps.parsediff.outputs.produced == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: parse-diff
+          if-no-files-found: ignore
+          retention-days: 3
+          path: |
+            parse-diff.md
+            parse-diff.json
+            pr-number.txt
+
       - name: Run semantic audit
         # Produces data/semantic-audit.json with structured findings for cards
         # that parse cleanly but disagree semantically with their Oracle text.
@@ -233,6 +295,28 @@ jobs:
           npx wrangler r2 object put phase-rs-data/preview/coverage-data.json --file data/coverage-data.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           npx wrangler r2 object put phase-rs-data/preview/coverage-summary.json --file data/coverage-summary.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
           npx wrangler r2 object put phase-rs-data/preview/semantic-audit.json --file data/semantic-audit.json --remote --content-type application/json --cache-control "public, max-age=60, must-revalidate"
+
+      - name: Publish immutable parse-diff baseline to R2
+        # Content-addressed sibling of the mutable preview/coverage-data.json
+        # write above: an immutable copy keyed by THIS commit's engine-source
+        # hash. The PR-side "Parse-detail diff" step fetches the copy matching
+        # its base.sha's hash, so its baseline is the exact main it forked onto
+        # — never the lagging preview/ snapshot (which mixes in other PRs'
+        # changes). Identical-source commits dedupe to one object, so storage is
+        # bounded by distinct parser states, not commit count. best-effort
+        # (continue-on-error): a missed publish just defers a PR's comment to
+        # "baseline pending" until the next main push, never wedges main.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          HASH="$(./scripts/engine-source-hash.sh HEAD)"
+          npx wrangler r2 object put "phase-rs-data/parse-baselines/coverage-data-${HASH}.json" \
+            --file data/coverage-data.json --remote --content-type application/json \
+            --cache-control "public, max-age=31536000, immutable"
 
   draft-pools:
     # Split out of card-data-gate because draft-pool-gen lives in draft-core and

--- a/.github/workflows/coverage-parse-diff-comment.yml
+++ b/.github/workflows/coverage-parse-diff-comment.yml
@@ -1,0 +1,124 @@
+name: Coverage parse-diff comment
+
+# Posts the parse-detail diff (built by ci.yml's "Parse-detail diff" step) as a
+# single sticky PR comment, for the reviewing LLM.
+#
+# Why workflow_run and not a step in ci.yml: the diff is computed in the
+# untrusted `pull_request` context (fork code, read-only token). Commenting
+# needs `pull-requests: write`, which fork PRs don't get. workflow_run runs in
+# the BASE repo's trusted context AFTER ci.yml finishes, and — critically — does
+# NOT check out PR code; it only consumes the uploaded artifact as data. This is
+# the safe half of the fork-comment pattern (the dangerous variant is
+# pull_request_target-with-checkout, which we deliberately avoid).
+#
+# The artifact (card names + Oracle fragments) is fork-controlled, so it is
+# treated as untrusted: its contents are read into a JS string and passed as the
+# octokit `body` param (JSON-encoded) — never concatenated into a shell/exec.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+# A new push to the same branch cancels an in-flight comment job so a slower
+# older run can't land its (stale) comment after a newer one.
+concurrency:
+  group: parse-diff-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read # download the artifact from the triggering run
+  pull-requests: write # upsert the sticky comment
+
+jobs:
+  comment:
+    name: Sticky parse-diff comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only PR-triggered CI runs produce the artifact. Skipping non-PR runs keeps
+    # this job off main/merge_group entirely.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download parse-diff artifact
+        id: dl
+        uses: actions/download-artifact@v4
+        # Absent artifact = the PR didn't change engine source (compute step
+        # skipped its upload). Nothing to comment; degrade silently.
+        continue-on-error: true
+        with:
+          name: parse-diff
+          path: parse-diff-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upsert sticky comment
+        if: steps.dl.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- coverage-parse-diff -->';
+            const dir = 'parse-diff-artifact';
+
+            // pr-number.txt is authoritative (workflow_run.pull_requests is
+            // unreliable for forks). Absent => nothing to do.
+            let prNumber;
+            try {
+              prNumber = parseInt(fs.readFileSync(`${dir}/pr-number.txt`, 'utf8').trim(), 10);
+            } catch {
+              core.info('No pr-number.txt in artifact; nothing to comment.');
+              return;
+            }
+            if (!Number.isInteger(prNumber)) {
+              core.info('pr-number.txt malformed; skipping.');
+              return;
+            }
+
+            let body;
+            try {
+              body = fs.readFileSync(`${dir}/parse-diff.md`, 'utf8');
+            } catch {
+              core.info('No parse-diff.md in artifact; nothing to comment.');
+              return;
+            }
+            if (!body.includes(MARKER)) {
+              core.info('parse-diff.md missing marker; refusing to post.');
+              return;
+            }
+
+            // Bound to GitHub's 65536-char comment limit (untrusted content can
+            // be large in pathological diffs).
+            const LIMIT = 60000;
+            if (body.length > LIMIT) {
+              body = body.slice(0, LIMIT) + '\n\n_…truncated — see the `parse-diff.json` run artifact for the full diff._\n';
+            }
+
+            // Classify: a "real changes" body carries the "signature(s)" headline;
+            // the no-change and baseline-pending bodies do not. Anti-thrash rule:
+            // only REAL changes may CREATE a comment. No-change / pending may only
+            // UPDATE an existing sticky (so a resolved diff collapses to "✓"),
+            // never spawn a fresh notification.
+            const isReal = body.includes('signature(s)');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              // EDIT in place — GitHub does not notify on edits, so re-pushes
+              // are silent. Never delete-and-recreate (that would notify).
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated sticky comment ${existing.id} on PR #${prNumber}.`);
+            } else if (isReal) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+              core.info(`Created sticky comment on PR #${prNumber}.`);
+            } else {
+              core.info('No existing sticky and nothing substantive to report; not creating one.');
+            }

--- a/crates/engine/src/bin/coverage_parse_diff.rs
+++ b/crates/engine/src/bin/coverage_parse_diff.rs
@@ -516,7 +516,7 @@ fn render_markdown(
     let short = base_sha.get(..12).unwrap_or(base_sha);
     let _ = write!(
         s,
-        "### Parse changes introduced by this PR · {} card(s), {} signature(s)  (baseline: merge-base `{}`)\n\n",
+        "### Parse changes introduced by this PR · {} card(s), {} signature(s)  (baseline: main `{}`)\n\n",
         changed_cards,
         clusters.len(),
         short,

--- a/scripts/engine-source-hash.sh
+++ b/scripts/engine-source-hash.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Print the engine-source content hash for a given commit.
+#
+# This is the single authority for the parse-diff baseline key. The same hash
+# is computed on BOTH sides of the coverage-parse-diff flow:
+#
+#   - publish (main-push CI): hash HEAD, upload coverage-data-<hash>.json to R2.
+#   - fetch (PR CI): hash the PR's base.sha, fetch coverage-data-<hash>.json.
+#
+# Because the head coverage is built from the merge commit (base.sha + PR), a
+# baseline keyed by base.sha's hash makes `head - baseline` cancel to exactly
+# the PR's parse changes (see .github/workflows/ci.yml "Parse-detail diff").
+#
+# The fingerprint covers exactly the inputs that determine parse output and
+# mirrors the cardgen-cache key (ci.yml): the engine source tree, the engine
+# crate manifest, and the lockfile (dep pins like nom affect parsing).
+#
+# Implemented with `git ls-tree -r` rather than `hashFiles`/working-tree hashing
+# so it is computable for ANY commit straight from history — no checkout — which
+# is what lets the PR side hash base.sha without disturbing its checked-out tree.
+#
+# Usage: scripts/engine-source-hash.sh <commit-ish>
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: engine-source-hash.sh <commit-ish>" >&2
+  exit 2
+fi
+
+sha="$1"
+
+# `-r` recurses into the src tree so every file's blob hash participates; the
+# blob hashes change iff content changes. Hash the listing to a stable digest.
+# Truncated to 16 hex chars to match the card_data_hash convention (ci.yml).
+git ls-tree -r "$sha" -- \
+  crates/engine/src \
+  crates/engine/Cargo.toml \
+  Cargo.lock \
+  | sha256sum \
+  | cut -c1-16

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -140,7 +140,7 @@ META_OUTPUT_TMP="${META_OUTPUT}.tmp"
 #      set of requested --bin targets; alternating shapes (e.g. tokens-gen
 #      alone vs the others) recompiles the engine on each switch. One shape for
 #      every build keeps the warm case a true no-op.
-TOOL_BINS=(--bin tokens-gen --bin oracle-gen --bin coverage-report --bin card-data-validate)
+TOOL_BINS=(--bin tokens-gen --bin oracle-gen --bin coverage-report --bin card-data-validate --bin coverage-parse-diff)
 TOOL_BIN="target/tool"
 cargo build --profile tool --features "$FEATURES" "${TOOL_BINS[@]}"
 


### PR DESCRIPTION
Second half of the coverage-parse-diff feature. The engine bin + condition-detail enrichment landed in #4168; this wires it into CI so every parser PR gets a field-level parse-change diff posted as a sticky comment for the reviewing LLM.

## Design: clean PR-only diff with zero extra compute

`head` is the coverage `card-data-gate` already builds from the PR **merge commit** (`current main` + this PR). The architecturally consistent baseline is therefore **`base.sha` (current main)**, fetched by its engine-source content hash — `(main + PR) − main = PR`, exactly, even when the PR is behind main (both sides move in lockstep). This avoids the contamination that a `merge-base` baseline would reintroduce against a merge-commit head, and needs no second coverage build.

## Pieces

- **`scripts/engine-source-hash.sh`** — single authority for the baseline key: a `git ls-tree`-based content hash of the engine source tree + manifest + lockfile, computable for any commit straight from history. Used identically by publish and fetch sides so they can't drift. (A frontend/test/docs-only commit hashes identically to its neighbor → publish dedupes and the PR path-filter falls out for free.)
- **`ci.yml` publish (main-push)** — immutable `parse-baselines/coverage-data-<hash>.json` to R2 alongside the existing mutable `preview/` write. Identical-source commits dedupe to one object. Best-effort (`continue-on-error`).
- **`ci.yml` compute (PR-only, additive to `card-data-gate`)** — fetch baseline by `base.sha`'s hash; run the bin; upload artifact. Equal base/head hashes ⟹ no engine change ⟹ skip before the bin build. Never blocks (`continue-on-error`); never falls back to the lagging `preview/` snapshot (404 ⟹ "baseline pending" marker).
- **`coverage-parse-diff-comment.yml`** — fork-safe `workflow_run` job posting one sticky comment (marker-keyed), edited in place so re-pushes don't notify. Treats the artifact as untrusted data. Only real changes create a comment; no-change/pending only update an existing one.
- **`gen-card-data.sh`** — bin added to `TOOL_BINS` for local-dev parity.
- **bin label** — `merge-base` → `main` to match the base-tip baseline model.

## Anti-thrash guarantees
Path-filtered to engine-source changes; one sticky comment edited in place (no notification on re-push); never posts an empty/pending comment when no sticky exists; never a required/blocking check.

## Follow-up (ops, not code)
R2 lifecycle rule pruning `parse-baselines/` (~60 days) — each object is a full ~55 MB `coverage-data.json`, so retention bounds storage. A missing baseline degrades gracefully to "baseline pending", so this is non-urgent and fully decoupled from this PR.

Closes the CI half of the work planned alongside #4168.