### PR TITLE
fix(engine): reserve outer-cost colors when funding costed mana-ability sub-costs

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -10693,6 +10693,7 @@ fn can_feasibly_pay_mana_cost_without_x(
         cost,
         spell_ctx.as_ref(),
         any_color,
+        None,
     );
 
     let (residual_shards, residual_generic) = match &residual {
@@ -11057,9 +11058,11 @@ pub(super) fn pay_ability_mana_cost(
         ability_tag,
         events,
         &HashSet::new(),
+        None,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn pay_ability_mana_cost_excluding(
     state: &mut GameState,
     player: PlayerId,
@@ -11068,6 +11071,11 @@ pub(super) fn pay_ability_mana_cost_excluding(
     ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
+    // CR 107.4b + CR 118.10: When this ability is paying its mana sub-cost while
+    // funding an outer cost on the call stack, the outer cost's colored shard
+    // demand is threaded so the sub-cost's generic pips are funded from
+    // non-demanded mana. `None` for ordinary top-level ability activations.
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
     pay_ability_mana_cost_with_choices_excluding(
         state,
@@ -11078,6 +11086,7 @@ pub(super) fn pay_ability_mana_cost_excluding(
         None,
         events,
         excluded_sources,
+        sub_cost_demand,
     )
 }
 
@@ -11091,6 +11100,7 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
@@ -11110,6 +11120,7 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
         phyrexian_choices,
         events,
         excluded_sources,
+        sub_cost_demand,
     )?;
 
     Ok(())
@@ -11259,6 +11270,7 @@ fn auto_tap_and_pay_cost(
         phyrexian_choices,
         events,
         &HashSet::new(),
+        None,
     )
 }
 
@@ -11272,6 +11284,7 @@ fn auto_tap_and_pay_cost_excluding(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<Vec<crate::types::mana::ManaUnit>, EngineError> {
     let events_before = events.len();
     super::casting_costs::auto_tap_mana_sources_with_context_excluding(
@@ -11309,7 +11322,25 @@ fn auto_tap_and_pay_cost_excluding(
         }
     }
 
+    // CR 107.4b + CR 601.2f: The real spend is demand-aware. The hand demand
+    // (other cards in hand needing colors) is the existing soft hybrid-resolution
+    // signal; the incoming `sub_cost_demand` is the outer cost's reserved colored
+    // shards when this payment is a nested mana sub-cost (CR 118.10). Combine the
+    // two by element-wise max so a color reserved by EITHER is deprioritized when
+    // paying a generic pip — preventing the spend from consuming a floated color
+    // the outer cost still needs (Dimir/Gruul Signet bug). Computed BEFORE the
+    // mutable pool borrow below to avoid a borrow-checker conflict (WATCH-ITEM #2).
     let hand_demand = mana_payment::compute_hand_color_demand(state, player, source_id);
+    let combined_demand: mana_payment::ColorDemand = match sub_cost_demand {
+        Some(outer) => {
+            let mut d = hand_demand;
+            for (slot, &reserved) in d.iter_mut().zip(outer.iter()) {
+                *slot = (*slot).max(reserved);
+            }
+            d
+        }
+        None => hand_demand,
+    };
     let player_data = state
         .players
         .iter_mut()
@@ -11318,7 +11349,7 @@ fn auto_tap_and_pay_cost_excluding(
     let (spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
         &mut player_data.mana_pool,
         cost,
-        Some(&hand_demand),
+        Some(&combined_demand),
         ctx,
         permissions.any_color,
         phyrexian_choices,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6308,6 +6308,7 @@ pub(super) fn auto_tap_mana_sources_excluding(
         deprioritize_source,
         excluded_sources,
         None,
+        None,
     );
 }
 
@@ -6347,9 +6348,11 @@ pub(super) fn auto_tap_mana_sources_with_context_excluding(
         deprioritize_source,
         excluded_sources,
         payment_context,
+        None,
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn auto_tap_mana_sources_inner(
     state: &mut GameState,
     player: PlayerId,
@@ -6358,6 +6361,7 @@ fn auto_tap_mana_sources_inner(
     deprioritize_source: Option<ObjectId>,
     excluded_sources: &HashSet<ObjectId>,
     payment_context: Option<&PaymentContext<'_>>,
+    sub_cost_demand: Option<&crate::game::mana_payment::ColorDemand>,
 ) {
     use crate::types::card_type::CoreType;
     use crate::types::mana::ManaCost;
@@ -6388,7 +6392,15 @@ fn auto_tap_mana_sources_inner(
         .players
         .iter()
         .find(|p| p.id == player)
-        .map(|p| mana_payment::reduce_cost_by_pool(&p.mana_pool, cost, effective_ctx, any_color))
+        .map(|p| {
+            mana_payment::reduce_cost_by_pool(
+                &p.mana_pool,
+                cost,
+                effective_ctx,
+                any_color,
+                sub_cost_demand,
+            )
+        })
         .unwrap_or_else(|| cost.clone());
 
     let (shards, generic) = match &residual {
@@ -6694,11 +6706,31 @@ fn auto_tap_mana_sources_inner(
                 // it, so clone-and-extend only when a mana sub-cost is present and
                 // otherwise forward the caller's set unchanged — skipping a heap
                 // allocation per selected source on this auto-tap hot path.
+                //
+                // CR 118.10: Each payment of a cost applies to only one spell or
+                // ability, so a source the OUTER plan reserved for the outer cost
+                // (every id in `used_sources`, a superset of `to_tap` that already
+                // contains `option.object_id`) must be excluded from the nested
+                // sub-cost auto-tap. Phase 3 does not re-verify a source is untapped
+                // before resolving, so without this the sub-cost could grab a source
+                // the outer cost still needs. Unioning `used_sources` supersedes the
+                // prior `excluded.insert(option.object_id)`.
                 let sub_cost = mana_sub_cost_of(&ability_def.cost);
-                let mut excluded_buf;
+                let excluded_buf;
+                // CR 107.4b + CR 118.10: The outer cost's colored shards are
+                // reserved; computed once (only when a mana sub-cost is present, so
+                // the `None` / no-sub-cost path adds zero work) and threaded into
+                // both the nested sub-cost auto-tap and the ability's own resolution
+                // so the sub-cost's generic pips are funded from non-demanded mana,
+                // never a floated color the outer cost still needs (the Dimir/Gruul
+                // Signet over-consumption bug).
+                let demand: Option<mana_payment::ColorDemand> =
+                    sub_cost.map(|_| mana_payment::outer_cost_color_demand(cost));
                 let excluded: &HashSet<ObjectId> = if sub_cost.is_some() {
-                    excluded_buf = excluded_sources.clone();
-                    excluded_buf.insert(option.object_id);
+                    excluded_buf = excluded_sources
+                        .union(&used_sources)
+                        .copied()
+                        .collect::<HashSet<ObjectId>>();
                     &excluded_buf
                 } else {
                     excluded_sources
@@ -6719,6 +6751,7 @@ fn auto_tap_mana_sources_inner(
                         Some(option.object_id),
                         excluded,
                         Some(&activation_ctx),
+                        demand.as_ref(),
                     );
                 }
                 // color_override tells resolve_mana_ability how to resolve the
@@ -6743,6 +6776,7 @@ fn auto_tap_mana_sources_inner(
                     events,
                     override_value,
                     excluded,
+                    demand.as_ref(),
                 );
             }
         } else {
@@ -7511,6 +7545,8 @@ pub fn finalize_mana_payment(
             super::casting::activation_ability_tag(state, pending.object_id, ability_index),
             events,
             &excluded_sources,
+            // Interactive activation resume: top-level, no outer cost on the stack.
+            None,
         )?;
         return push_activated_ability_to_stack(
             state,
@@ -7677,6 +7713,8 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             Some(phyrexian_choices),
             events,
             &excluded_sources,
+            // Interactive Phyrexian-choice resume: top-level activation, no outer cost.
+            None,
         )?;
         return push_activated_ability_to_stack(
             state,

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -487,6 +487,8 @@ fn pay_activation_costs_after_target_selection(
             super::casting::activation_ability_tag(state, pending.object_id, ability_index),
             events,
             &excluded_sources,
+            // Top-level ability activation: no outer cost on the stack.
+            None,
         )?;
     }
 

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -427,6 +427,8 @@ fn pay_ability_cost_inner(
                         *ability_tag,
                         events,
                         excluded_sources,
+                        // Top-level ability cost payment: no outer cost on the stack.
+                        None,
                     )?;
                 }
             }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -212,6 +212,7 @@ pub fn resolve_mana_ability(
         events,
         color_override,
         &HashSet::new(),
+        None,
     )
 }
 
@@ -222,6 +223,7 @@ pub fn resolve_mana_ability(
 /// ancestor activation is synchronously suspended mid-payment on the Rust call
 /// stack and must not be re-activated, or the auto-tap recurses infinitely
 /// (two cross-paying Signets, an N-source chain, or a self-loop).
+#[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_mana_ability_excluding(
     state: &mut GameState,
     source_id: ObjectId,
@@ -230,6 +232,12 @@ pub(super) fn resolve_mana_ability_excluding(
     events: &mut Vec<GameEvent>,
     color_override: Option<ProductionOverride>,
     excluded_sources: &HashSet<ObjectId>,
+    // CR 107.4b + CR 118.10: When this ability is being activated to fund an
+    // outer cost (nested Phase-3 auto-tap), the outer cost's colored shard demand
+    // is threaded here so this ability's own mana sub-cost is funded from
+    // non-demanded mana, never a floated color the outer cost still needs. `None`
+    // at the top-level entry — there is no outer cost on the stack.
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
     // Pay the full ability cost (tap, sacrifice, etc.)
     let waiting_before_cost = state.waiting_for.clone();
@@ -240,6 +248,7 @@ pub(super) fn resolve_mana_ability_excluding(
         &ability_def.cost,
         events,
         excluded_sources,
+        sub_cost_demand,
     )?;
     if state.waiting_for != waiting_before_cost {
         return Ok(());
@@ -1415,6 +1424,10 @@ pub(super) fn advance_mana_ability_activation(
                 // activation on the call stack to exclude, so the chain is
                 // empty here.
                 &HashSet::new(),
+                // CR 107.4b + CR 118.10: The interactive resume path is a
+                // top-level activation with no outer cost on the stack, so there
+                // is no colored demand to honor — `None`.
+                None,
             )?;
             if state.waiting_for != waiting_before_cost {
                 return Ok(state.waiting_for.clone());
@@ -1492,6 +1505,7 @@ pub(super) fn advance_mana_ability_activation(
 /// Pay the full cost of a mana ability. This is the single authority for mana ability
 /// cost resolution — callers dispatch activation, they never inspect individual cost
 /// components. Handles `Tap`, `Composite { Tap, Sacrifice }`, and future cost variants.
+#[allow(clippy::too_many_arguments)]
 fn pay_mana_ability_cost(
     state: &mut GameState,
     source_id: ObjectId,
@@ -1499,6 +1513,7 @@ fn pay_mana_ability_cost(
     cost: &Option<AbilityCost>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
     pay_mana_ability_cost_with_choices(
         state,
@@ -1514,6 +1529,7 @@ fn pay_mana_ability_cost(
         None,
         None,
         excluded_sources,
+        sub_cost_demand,
     )
 }
 
@@ -1553,6 +1569,9 @@ fn resolve_mana_ability_with_selected_choices(
         chosen_counter_count,
         chosen_x,
         excluded_sources,
+        // CR 107.4b + CR 118.10: Selected-choices resume is a top-level
+        // activation with no outer cost on the stack — no colored demand.
+        None,
     )?;
     if chosen.next().is_some() {
         return Err(EngineError::InvalidAction(
@@ -1766,6 +1785,7 @@ fn pay_mana_ability_cost_with_choices<I, J, K, L>(
     chosen_counter_count: Option<u32>,
     chosen_x: Option<u32>,
     excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError>
 where
     I: Iterator<Item = ObjectId>,
@@ -1786,6 +1806,7 @@ where
                 chosen_hybrid_payment,
                 events,
                 excluded_sources,
+                sub_cost_demand,
             )?;
         }
         // CR 605.1a + CR 701.17a: Bare `Mill` mana-ability cost. The Millikin
@@ -2132,6 +2153,7 @@ where
                             chosen_hybrid_payment,
                             events,
                             excluded_sources,
+                            sub_cost_demand,
                         )?;
                     }
                     // CR 605.1a + CR 701.17a: `Mill` sub-cost inside a Composite
@@ -2588,6 +2610,7 @@ fn mana_type_to_single_shard(color: ManaType) -> crate::types::mana::ManaCostSha
 /// colors chosen by `PayManaAbilityMana` and debited from the current pool.
 /// Otherwise, use the shared activation mana-payment building block so the
 /// player may activate other mana abilities while paying this activation cost.
+#[allow(clippy::too_many_arguments)]
 fn pay_mana_sub_cost(
     state: &mut GameState,
     source_id: ObjectId,
@@ -2596,6 +2619,7 @@ fn pay_mana_sub_cost(
     hybrid_plan: Option<&[ManaType]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
     if hybrid_plan.is_none() {
         // CR 605.3c: Every source already in `excluded_sources` is an ancestor
@@ -2621,6 +2645,7 @@ fn pay_mana_sub_cost(
             None,
             events,
             &excluded_sources,
+            sub_cost_demand,
         );
     }
 

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -115,6 +115,45 @@ fn mana_type_to_demand_index(mt: ManaType) -> Option<usize> {
     }
 }
 
+/// Accumulate the colored-pip demand of a single cost shard into `demand` (WUBRG).
+///
+/// CR 107.4b: Generic pips ({1}, {X}) are payable with any mana and so contribute
+/// nothing to colored demand. Only colored requirements (Single, Hybrid, the colored
+/// half of {2/C}/Phyrexian/{C/color}) increment the per-color counts. Hybrids count
+/// both halves because either color could be the one chosen to pay.
+fn accumulate_shard_demand(demand: &mut ColorDemand, shard: ManaCostShard) {
+    match shard_to_mana_type(shard) {
+        ShardRequirement::Single(mt) => {
+            if let Some(i) = mana_type_to_demand_index(mt) {
+                demand[i] += 1;
+            }
+        }
+        ShardRequirement::Hybrid(a, b) | ShardRequirement::HybridPhyrexian(a, b) => {
+            // Both colors count as demanded (either could be needed)
+            if let Some(i) = mana_type_to_demand_index(a) {
+                demand[i] += 1;
+            }
+            if let Some(i) = mana_type_to_demand_index(b) {
+                demand[i] += 1;
+            }
+        }
+        ShardRequirement::TwoGenericHybrid(mt)
+        | ShardRequirement::Phyrexian(mt)
+        | ShardRequirement::ColorlessHybrid(mt)
+        // CR 107.4f: K'rrik promotion never reaches the
+        // demand calc (shard_to_mana_type is the only
+        // producer), but the variant must be handled for
+        // exhaustiveness. Same demand shape as TwoGenericHybrid.
+        | ShardRequirement::TwoGenericHybridPhyrexian(mt) => {
+            if let Some(i) = mana_type_to_demand_index(mt) {
+                demand[i] += 1;
+            }
+        }
+        ShardRequirement::Snow | ShardRequirement::X => {}
+        ShardRequirement::TwoOrMoreColorSource => {}
+    }
+}
+
 /// Count how many colored pips the other cards in hand demand (WUBRG).
 /// Used to decide which hybrid color to spend — spend the least-demanded one.
 pub fn compute_hand_color_demand(
@@ -134,39 +173,26 @@ pub fn compute_hand_color_demand(
         if let Some(obj) = state.objects.get(&obj_id) {
             if let ManaCost::Cost { shards, .. } = &obj.mana_cost {
                 for shard in shards {
-                    match shard_to_mana_type(*shard) {
-                        ShardRequirement::Single(mt) => {
-                            if let Some(i) = mana_type_to_demand_index(mt) {
-                                demand[i] += 1;
-                            }
-                        }
-                        ShardRequirement::Hybrid(a, b)
-                        | ShardRequirement::HybridPhyrexian(a, b) => {
-                            // Both colors count as demanded (either could be needed)
-                            if let Some(i) = mana_type_to_demand_index(a) {
-                                demand[i] += 1;
-                            }
-                            if let Some(i) = mana_type_to_demand_index(b) {
-                                demand[i] += 1;
-                            }
-                        }
-                        ShardRequirement::TwoGenericHybrid(mt)
-                        | ShardRequirement::Phyrexian(mt)
-                        | ShardRequirement::ColorlessHybrid(mt)
-                        // CR 107.4f: K'rrik promotion never reaches the
-                        // demand calc (shard_to_mana_type is the only
-                        // producer), but the variant must be handled for
-                        // exhaustiveness. Same demand shape as TwoGenericHybrid.
-                        | ShardRequirement::TwoGenericHybridPhyrexian(mt) => {
-                            if let Some(i) = mana_type_to_demand_index(mt) {
-                                demand[i] += 1;
-                            }
-                        }
-                        ShardRequirement::Snow | ShardRequirement::X => {}
-                        ShardRequirement::TwoOrMoreColorSource => {}
-                    }
+                    accumulate_shard_demand(&mut demand, *shard);
                 }
             }
+        }
+    }
+    demand
+}
+
+/// Colored-pip demand of an *outer* cost still being paid (WUBRG).
+///
+/// CR 107.4b: generic pips of the outer cost contribute nothing — they can be paid
+/// with any mana, so funding a nested sub-cost from them strands no colored
+/// requirement. Only the outer cost's colored shards are "reserved": spending one of
+/// those colors on a nested mana-ability sub-cost could leave the outer cost
+/// unpayable, so the nested spend deprioritizes them. Empty for NoCost / Self* costs.
+pub(crate) fn outer_cost_color_demand(cost: &ManaCost) -> ColorDemand {
+    let mut demand = [0u32; 5];
+    if let ManaCost::Cost { shards, .. } = cost {
+        for &shard in shards {
+            accumulate_shard_demand(&mut demand, shard);
         }
     }
     demand
@@ -482,7 +508,8 @@ pub fn can_pay_for_spell(
                     ShardRequirement::Single(mt) => {
                         // CR 609.4b: When any_color is true, any mana can pay colored costs.
                         if any_color && mt != ManaType::Colorless {
-                            if spend_any_for_required_colors(&mut sim, &[mt], spell).is_none() {
+                            if spend_any_for_required_colors(&mut sim, &[mt], spell, None).is_none()
+                            {
                                 return false;
                             }
                         } else if spend_eligible(&mut sim, mt, spell).is_none() {
@@ -492,7 +519,9 @@ pub fn can_pay_for_spell(
                     // CR 107.4e: Hybrid mana — can be paid with either color.
                     ShardRequirement::Hybrid(a, b) => {
                         if any_color {
-                            if spend_any_for_required_colors(&mut sim, &[a, b], spell).is_none() {
+                            if spend_any_for_required_colors(&mut sim, &[a, b], spell, None)
+                                .is_none()
+                            {
                                 return false;
                             }
                         } else if spend_eligible(&mut sim, a, spell).is_none()
@@ -509,14 +538,16 @@ pub fn can_pay_for_spell(
                     ShardRequirement::TwoGenericHybrid(color) => {
                         // CR 609.4b: When any_color, any mana satisfies the colored half.
                         if any_color {
-                            if spend_any_for_required_colors(&mut sim, &[color], spell).is_none() {
+                            if spend_any_for_required_colors(&mut sim, &[color], spell, None)
+                                .is_none()
+                            {
                                 return false;
                             }
                         } else if spend_eligible(&mut sim, color, spell).is_none() {
-                            if spend_generic_eligible(&mut sim, spell).is_none() {
+                            if spend_generic_eligible(&mut sim, spell, None).is_none() {
                                 return false;
                             }
-                            if spend_generic_eligible(&mut sim, spell).is_none() {
+                            if spend_generic_eligible(&mut sim, spell, None).is_none() {
                                 return false;
                             }
                         }
@@ -541,6 +572,7 @@ pub fn can_pay_for_spell(
                                 &mut sim,
                                 &[ManaType::Colorless, color],
                                 spell,
+                                None,
                             )
                             .is_none()
                             {
@@ -581,14 +613,16 @@ pub fn can_pay_for_spell(
                     match deferred {
                         PhyrexianDeferred::Single(color) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*color], spell).is_some()
+                                spend_any_for_required_colors(&mut sim, &[*color], spell, None)
+                                    .is_some()
                             } else {
                                 spend_eligible(&mut sim, *color, spell).is_some()
                             }
                         }
                         PhyrexianDeferred::Hybrid(a, b) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*a, *b], spell).is_some()
+                                spend_any_for_required_colors(&mut sim, &[*a, *b], spell, None)
+                                    .is_some()
                             } else {
                                 spend_eligible(&mut sim, *a, spell).is_some()
                                     || spend_eligible(&mut sim, *b, spell).is_some()
@@ -600,13 +634,14 @@ pub fn can_pay_for_spell(
                         // still consumed via the budget arm below.
                         PhyrexianDeferred::TwoGeneric(color) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*color], spell).is_some()
+                                spend_any_for_required_colors(&mut sim, &[*color], spell, None)
+                                    .is_some()
                             } else if spend_eligible(&mut sim, *color, spell).is_some() {
                                 true
                             } else {
                                 let mut backup = sim.clone();
-                                if spend_generic_eligible(&mut backup, spell).is_some()
-                                    && spend_generic_eligible(&mut backup, spell).is_some()
+                                if spend_generic_eligible(&mut backup, spell, None).is_some()
+                                    && spend_generic_eligible(&mut backup, spell, None).is_some()
                                 {
                                     sim = backup;
                                     true
@@ -633,7 +668,7 @@ pub fn can_pay_for_spell(
 
             // Pay generic
             for _ in 0..*generic {
-                if spend_generic_eligible(&mut sim, spell).is_none() {
+                if spend_generic_eligible(&mut sim, spell, None).is_none() {
                     return false;
                 }
             }
@@ -676,6 +711,7 @@ pub(crate) fn reduce_cost_by_pool(
     cost: &ManaCost,
     spell: Option<&PaymentContext<'_>>,
     any_color: bool,
+    demand: Option<&ColorDemand>,
 ) -> ManaCost {
     let (shards, generic) = match cost {
         ManaCost::NoCost | ManaCost::SelfManaCost | ManaCost::SelfManaValue => return cost.clone(),
@@ -695,7 +731,7 @@ pub(crate) fn reduce_cost_by_pool(
             // ordering handles it downstream).
             ShardRequirement::Single(color) | ShardRequirement::Phyrexian(color) => {
                 if any_color && color != ManaType::Colorless {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
                 } else {
                     spend_eligible(&mut scratch, color, spell).is_some()
                 }
@@ -703,7 +739,7 @@ pub(crate) fn reduce_cost_by_pool(
             // CR 107.4e/f: Hybrid pays either half.
             ShardRequirement::Hybrid(a, b) | ShardRequirement::HybridPhyrexian(a, b) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[a, b], spell).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[a, b], spell, None).is_some()
                 } else {
                     spend_eligible(&mut scratch, a, spell).is_some()
                         || spend_eligible(&mut scratch, b, spell).is_some()
@@ -716,6 +752,7 @@ pub(crate) fn reduce_cost_by_pool(
                         &mut scratch,
                         &[ManaType::Colorless, color],
                         spell,
+                        None,
                     )
                     .is_some()
                 } else {
@@ -728,13 +765,13 @@ pub(crate) fn reduce_cost_by_pool(
             // afford both halves, rather than half-draining it.
             ShardRequirement::TwoGenericHybrid(color) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
                 } else if spend_eligible(&mut scratch, color, spell).is_some() {
                     true
                 } else {
                     let mut backup = scratch.clone();
-                    if spend_generic_eligible(&mut backup, spell).is_some()
-                        && spend_generic_eligible(&mut backup, spell).is_some()
+                    if spend_generic_non_demanded(&mut backup, spell, demand).is_some()
+                        && spend_generic_non_demanded(&mut backup, spell, demand).is_some()
                     {
                         scratch = backup;
                         true
@@ -759,13 +796,13 @@ pub(crate) fn reduce_cost_by_pool(
             // direct dispatch path. Pay-mana semantics mirror `TwoGenericHybrid`.
             ShardRequirement::TwoGenericHybridPhyrexian(color) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
                 } else if spend_eligible(&mut scratch, color, spell).is_some() {
                     true
                 } else {
                     let mut backup = scratch.clone();
-                    if spend_generic_eligible(&mut backup, spell).is_some()
-                        && spend_generic_eligible(&mut backup, spell).is_some()
+                    if spend_generic_non_demanded(&mut backup, spell, demand).is_some()
+                        && spend_generic_non_demanded(&mut backup, spell, demand).is_some()
                     {
                         scratch = backup;
                         true
@@ -780,9 +817,14 @@ pub(crate) fn reduce_cost_by_pool(
         }
     }
 
-    // CR 107.4b: Generic may be paid with any eligible mana.
+    // CR 107.4b: Generic may be paid with any eligible mana. When a nested
+    // sub-cost's outer-cost `demand` is supplied, a generic pip is counted
+    // covered ONLY if a non-demanded scratch unit can pay it — a demanded unit
+    // left over is reserved for the outer cost's colored shard (CR 118.10), so
+    // the pip stays in `residual_generic` and auto-tap will tap another source
+    // for it. Without `demand` the prior least-available ordering is preserved.
     for _ in 0..generic {
-        if spend_generic_eligible(&mut scratch, spell).is_some() {
+        if spend_generic_non_demanded(&mut scratch, spell, demand).is_some() {
             residual_generic = residual_generic.saturating_sub(1);
         } else {
             break;
@@ -862,7 +904,7 @@ pub fn pay_cost_with_demand_and_choices(
                     ShardRequirement::Single(mt) => {
                         // CR 609.4b: When any_color, any mana can pay colored costs.
                         if any_color && mt != ManaType::Colorless {
-                            let unit = spend_any_for_required_colors(pool, &[mt], spell)
+                            let unit = spend_any_for_required_colors(pool, &[mt], spell, None)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         } else {
@@ -874,7 +916,7 @@ pub fn pay_cost_with_demand_and_choices(
                     // CR 107.4e: Hybrid mana — pay with either half.
                     ShardRequirement::Hybrid(a, b) => {
                         if any_color {
-                            let unit = spend_any_for_required_colors(pool, &[a, b], spell)
+                            let unit = spend_any_for_required_colors(pool, &[a, b], spell, None)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         } else {
@@ -906,7 +948,7 @@ pub fn pay_cost_with_demand_and_choices(
                             }
                             Some(ShardChoice::PayMana) => {
                                 let unit = if any_color {
-                                    spend_any_for_required_colors(pool, &[color], spell)
+                                    spend_any_for_required_colors(pool, &[color], spell, None)
                                 } else {
                                     spend_eligible(pool, color, spell)
                                 }
@@ -919,7 +961,7 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_ok = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[color], spell)
+                                        spend_any_for_required_colors(pool, &[color], spell, None)
                                     } else {
                                         spend_eligible(pool, color, spell)
                                     }
@@ -937,14 +979,14 @@ pub fn pay_cost_with_demand_and_choices(
                     // CR 107.4e: Monocolored hybrid {2/C} — pay 1 colored or 2 generic.
                     ShardRequirement::TwoGenericHybrid(color) => {
                         if any_color {
-                            let unit = spend_any_for_required_colors(pool, &[color], spell)
+                            let unit = spend_any_for_required_colors(pool, &[color], spell, None)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         } else if let Some(unit) = spend_eligible(pool, color, spell) {
                             spent.push(unit);
                         } else {
                             for _ in 0..2 {
-                                let unit = spend_generic_eligible(pool, spell)
+                                let unit = spend_generic_eligible(pool, spell, None)
                                     .ok_or(PaymentError::InsufficientMana)?;
                                 spent.push(unit);
                             }
@@ -969,6 +1011,7 @@ pub fn pay_cost_with_demand_and_choices(
                                 pool,
                                 &[ManaType::Colorless, color],
                                 spell,
+                                None,
                             )
                             .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
@@ -994,7 +1037,7 @@ pub fn pay_cost_with_demand_and_choices(
                             }
                             Some(ShardChoice::PayMana) => {
                                 let unit = if any_color {
-                                    spend_any_for_required_colors(pool, &[a, b], spell)
+                                    spend_any_for_required_colors(pool, &[a, b], spell, None)
                                 } else {
                                     let remaining_pair_shards =
                                         count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1017,7 +1060,7 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_ok = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[a, b], spell)
+                                        spend_any_for_required_colors(pool, &[a, b], spell, None)
                                     } else {
                                         let remaining_pair_shards =
                                             count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1059,14 +1102,15 @@ pub fn pay_cost_with_demand_and_choices(
                             Some(ShardChoice::PayMana) => {
                                 // Mirror auto-pay preference: 1 colored, then 2 generic.
                                 if any_color {
-                                    let unit = spend_any_for_required_colors(pool, &[color], spell)
-                                        .ok_or(PaymentError::InsufficientMana)?;
+                                    let unit =
+                                        spend_any_for_required_colors(pool, &[color], spell, None)
+                                            .ok_or(PaymentError::InsufficientMana)?;
                                     spent.push(unit);
                                 } else if let Some(unit) = spend_eligible(pool, color, spell) {
                                     spent.push(unit);
                                 } else {
                                     for _ in 0..2 {
-                                        let unit = spend_generic_eligible(pool, spell)
+                                        let unit = spend_generic_eligible(pool, spell, None)
                                             .ok_or(PaymentError::InsufficientMana)?;
                                         spent.push(unit);
                                     }
@@ -1078,7 +1122,7 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_paid = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[color], spell)
+                                        spend_any_for_required_colors(pool, &[color], spell, None)
                                             .map(|u| {
                                                 spent.push(u);
                                                 true
@@ -1093,7 +1137,7 @@ pub fn pay_cost_with_demand_and_choices(
                                         let mut tmp_spent: Vec<ManaUnit> = Vec::new();
                                         let ok = (0..2).all(|_| {
                                             if let Some(u) =
-                                                spend_generic_eligible(&mut backup, spell)
+                                                spend_generic_eligible(&mut backup, spell, None)
                                             {
                                                 tmp_spent.push(u);
                                                 true
@@ -1122,10 +1166,19 @@ pub fn pay_cost_with_demand_and_choices(
             }
 
             // CR 107.4b: Generic mana can be paid with any type of mana.
-            // Prefer colorless first, then least-available color to preserve flexibility.
+            // Prefer colorless first, then a non-demanded color, then least-available
+            // color to preserve flexibility. `hand_demand` (combined upstream with the
+            // outer cost's reserved colors for nested sub-costs) softly deprioritizes
+            // a color another cost still needs (CR 118.10) without ever hard-blocking
+            // a payable spend (CR 601.2h: partial payments aren't allowed and an
+            // unpayable cost can't be paid, so a payable one must never be blocked).
+            // Note: this extends the demand signal — previously honored only by the
+            // hybrid-color path — to the generic spend, so a normal cast now also
+            // deprioritizes a hand-demanded color when filling generic. This only
+            // reorders WHICH eligible unit pays a generic pip; it never refuses one.
             for _ in 0..*generic {
-                let unit =
-                    spend_generic_eligible(pool, spell).ok_or(PaymentError::InsufficientMana)?;
+                let unit = spend_generic_eligible(pool, spell, hand_demand)
+                    .ok_or(PaymentError::InsufficientMana)?;
                 spent.push(unit);
             }
 
@@ -1179,14 +1232,14 @@ pub fn compute_phyrexian_shards(
         match effective_shard_requirement(shard_to_mana_type(shards[idx]), life_colors) {
             ShardRequirement::Single(mt) => {
                 if any_color && mt != ManaType::Colorless {
-                    let _ = spend_any_for_required_colors(&mut sim, &[mt], spell);
+                    let _ = spend_any_for_required_colors(&mut sim, &[mt], spell, None);
                 } else {
                     let _ = spend_eligible(&mut sim, mt, spell);
                 }
             }
             ShardRequirement::Hybrid(a, b) => {
                 if any_color {
-                    let _ = spend_any_for_required_colors(&mut sim, &[a, b], spell);
+                    let _ = spend_any_for_required_colors(&mut sim, &[a, b], spell, None);
                 } else {
                     let remaining_pair_shards = count_remaining_hybrid_shards(shards, idx, a, b);
                     let color = select_hybrid_payment_color(
@@ -1225,7 +1278,7 @@ pub fn compute_phyrexian_shards(
                 // if mana is unavailable or would starve generic, consume life budget.
                 if effective_mana {
                     let _ = if any_color {
-                        spend_any_for_required_colors(&mut sim, &[color], spell)
+                        spend_any_for_required_colors(&mut sim, &[color], spell, None)
                     } else {
                         spend_eligible(&mut sim, color, spell)
                     };
@@ -1235,10 +1288,10 @@ pub fn compute_phyrexian_shards(
             }
             ShardRequirement::TwoGenericHybrid(color) => {
                 if any_color {
-                    let _ = spend_any_for_required_colors(&mut sim, &[color], spell);
+                    let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None);
                 } else if spend_eligible(&mut sim, color, spell).is_none() {
                     for _ in 0..2 {
-                        let _ = spend_generic_eligible(&mut sim, spell);
+                        let _ = spend_generic_eligible(&mut sim, spell, None);
                     }
                 }
             }
@@ -1255,6 +1308,7 @@ pub fn compute_phyrexian_shards(
                         &mut sim,
                         &[ManaType::Colorless, color],
                         spell,
+                        None,
                     );
                 } else if spend_eligible(&mut sim, ManaType::Colorless, spell).is_none() {
                     let _ = spend_eligible(&mut sim, color, spell);
@@ -1287,7 +1341,7 @@ pub fn compute_phyrexian_shards(
                 });
                 if effective_mana {
                     let _ = if any_color {
-                        spend_any_for_required_colors(&mut sim, &[a, b], spell)
+                        spend_any_for_required_colors(&mut sim, &[a, b], spell, None)
                     } else {
                         let remaining_pair_shards =
                             count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1321,8 +1375,8 @@ pub fn compute_phyrexian_shards(
                         true
                     } else {
                         let mut probe = sim.clone();
-                        spend_generic_eligible(&mut probe, spell).is_some()
-                            && spend_generic_eligible(&mut probe, spell).is_some()
+                        spend_generic_eligible(&mut probe, spell, None).is_some()
+                            && spend_generic_eligible(&mut probe, spell, None).is_some()
                     }
                 };
                 // CR 107.4f + CR 118.3: Only offer mana when spending it
@@ -1345,11 +1399,11 @@ pub fn compute_phyrexian_shards(
                     // Mirror `pay_cost_with_demand_and_choices`'s preference:
                     // prefer 1 colored, then atomic 2-generic fallback.
                     if any_color {
-                        let _ = spend_any_for_required_colors(&mut sim, &[color], spell);
+                        let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None);
                     } else if spend_eligible(&mut sim, color, spell).is_none() {
                         let mut backup = sim.clone();
-                        if spend_generic_eligible(&mut backup, spell).is_some()
-                            && spend_generic_eligible(&mut backup, spell).is_some()
+                        if spend_generic_eligible(&mut backup, spell, None).is_some()
+                            && spend_generic_eligible(&mut backup, spell, None).is_some()
                         {
                             sim = backup;
                         }
@@ -1383,7 +1437,7 @@ fn sim_any_for_required_colors_available(
     required_colors: &[ManaType],
 ) -> bool {
     let mut clone = pool.clone();
-    spend_any_for_required_colors(&mut clone, required_colors, spell).is_some()
+    spend_any_for_required_colors(&mut clone, required_colors, spell, None).is_some()
 }
 
 fn sim_color_available(
@@ -1756,7 +1810,11 @@ pub(crate) fn shard_to_mana_type(shard: ManaCostShard) -> ShardRequirement {
     }
 }
 
-fn spend_any_eligible(pool: &mut ManaPool, spell: Option<&PaymentContext<'_>>) -> Option<ManaUnit> {
+fn spend_any_eligible(
+    pool: &mut ManaPool,
+    spell: Option<&PaymentContext<'_>>,
+    demand: Option<&ColorDemand>,
+) -> Option<ManaUnit> {
     match spell {
         Some(ctx) => {
             if let Some(unit) = spend_eligible(pool, ManaType::Colorless, Some(ctx)) {
@@ -1770,7 +1828,13 @@ fn spend_any_eligible(pool: &mut ManaPool, spell: Option<&PaymentContext<'_>>) -
                 ManaType::Red,
                 ManaType::Green,
             ];
-            let mut best: Option<(ManaType, usize)> = None;
+            // CR 601.2h + CR 118.10: When a `demand` is supplied, deprioritize
+            // colors the outer cost / hand still needs — but only SOFTLY: pick a
+            // demanded color when it is the only eligible one (never return `None`
+            // while payable mana exists; CR 601.2h forbids leaving a payable cost
+            // unpaid). Sort key is `(is_demanded, count)`:
+            // non-demanded colors sort first, then least-available within each tier.
+            let mut best: Option<(ManaType, bool, usize)> = None;
             for &color in &colors {
                 let count = pool
                     .mana
@@ -1782,14 +1846,21 @@ fn spend_any_eligible(pool: &mut ManaPool, spell: Option<&PaymentContext<'_>>) -
                     })
                     .count();
                 if count > 0 {
-                    match best {
-                        None => best = Some((color, count)),
-                        Some((_, best_count)) if count < best_count => best = Some((color, count)),
-                        _ => {}
+                    let is_demanded = demand
+                        .and_then(|d| mana_type_to_demand_index(color).map(|i| d[i] > 0))
+                        .unwrap_or(false);
+                    let better = match best {
+                        None => true,
+                        Some((_, best_demanded, best_count)) => {
+                            (is_demanded, count) < (best_demanded, best_count)
+                        }
+                    };
+                    if better {
+                        best = Some((color, is_demanded, count));
                     }
                 }
             }
-            best.and_then(|(color, _)| {
+            best.and_then(|(color, _, _)| {
                 spend_color_prefer_non_z(pool, color, |unit| {
                     !unit.is_convoke_payment()
                         && unit
@@ -1807,6 +1878,7 @@ fn spend_any_for_required_colors(
     pool: &mut ManaPool,
     required_colors: &[ManaType],
     spell: Option<&PaymentContext<'_>>,
+    demand: Option<&ColorDemand>,
 ) -> Option<ManaUnit> {
     for color in required_colors {
         if let Some(unit) = spend_eligible(pool, *color, spell) {
@@ -1814,12 +1886,79 @@ fn spend_any_for_required_colors(
         }
     }
 
-    spend_any_eligible(pool, spell)
+    spend_any_eligible(pool, spell, demand)
+}
+
+/// Planner-layer generic spend that respects an outer cost's colored `demand`.
+///
+/// CR 107.4b + CR 118.10: A generic pip can be paid with any mana, but when an
+/// outer cost (still being paid on the call stack) demands specific colors, a
+/// nested sub-cost must not consume those colored units — each cost payment
+/// applies to only one ability, so a unit reserved for the outer colored shard
+/// can't also fund the sub-cost's generic pip. With `demand == Some`, this spends
+/// only a NON-demanded eligible unit (a unit whose color has WUBRG demand index
+/// `0`, or colorless / convoke); if only demanded units remain it returns `None`
+/// and the pip is left in the residual so auto-tap taps a different source. With
+/// `demand == None` it is byte-identical to `spend_generic_eligible` — it never
+/// falls through to the least-available ordering when demanded units are all that
+/// is left (WATCH-ITEM #1: the planner must leave the residual, not coincidentally
+/// pay from a demanded unit).
+fn spend_generic_non_demanded(
+    pool: &mut ManaPool,
+    spell: Option<&PaymentContext<'_>>,
+    demand: Option<&ColorDemand>,
+) -> Option<ManaUnit> {
+    let Some(demand) = demand else {
+        return spend_generic_eligible(pool, spell, None);
+    };
+
+    // Convoke payment units are creature-tap stand-ins, not floated colored mana;
+    // they are never reserved for an outer colored shard, so prefer them first
+    // (mirrors `spend_generic_eligible`'s convoke-first ordering).
+    let convoke_pos = pool.mana.iter().position(|unit| {
+        unit.is_convoke_payment()
+            && spell.is_none_or(|ctx| unit.restrictions.iter().all(|r| r.allows(ctx)))
+    });
+    if let Some(pos) = convoke_pos {
+        return Some(pool.mana.swap_remove(pos));
+    }
+
+    // Among non-convoke units eligible under the spell context, pick one whose
+    // color is NOT demanded by the outer cost (colorless is never demanded).
+    // Prefer non-`Z` units within that color (mirrors `spend_color_prefer_non_z`).
+    let is_non_demanded = |unit: &ManaUnit| -> bool {
+        if unit.is_convoke_payment() {
+            return false;
+        }
+        if let Some(ctx) = spell {
+            if !unit.restrictions.iter().all(|r| r.allows(ctx)) {
+                return false;
+            }
+        }
+        match mana_type_to_demand_index(unit.color) {
+            // Colorless: index `None`, never demanded.
+            None => true,
+            Some(i) => demand[i] == 0,
+        }
+    };
+
+    if let Some(pos) = pool
+        .mana
+        .iter()
+        .position(|unit| !unit.source_could_produce_two_or_more_colors && is_non_demanded(unit))
+    {
+        return Some(pool.mana.swap_remove(pos));
+    }
+    pool.mana
+        .iter()
+        .position(is_non_demanded)
+        .map(|pos| pool.mana.swap_remove(pos))
 }
 
 fn spend_generic_eligible(
     pool: &mut ManaPool,
     spell: Option<&PaymentContext<'_>>,
+    demand: Option<&ColorDemand>,
 ) -> Option<ManaUnit> {
     if let Some(ctx) = spell {
         if let Some(pos) = pool.mana.iter().position(|unit| {
@@ -1835,7 +1974,11 @@ fn spend_generic_eligible(
         return Some(pool.mana.swap_remove(pos));
     }
 
-    spend_any_eligible(pool, spell)
+    // CR 601.2h + CR 118.10: Forward the soft color demand so the generic pip is
+    // paid from a non-demanded color when one is eligible, still spending a
+    // demanded color when it is the only payable mana (CR 601.2h: a payable cost
+    // can't be left unpaid — never false-unpayable).
+    spend_any_eligible(pool, spell, demand)
 }
 
 fn spend_any_unit(pool: &mut ManaPool) -> Option<ManaUnit> {

--- a/crates/engine/tests/costed_mana_ability_demand_aware_autotap.rs
+++ b/crates/engine/tests/costed_mana_ability_demand_aware_autotap.rs
@@ -1,0 +1,296 @@
+//! Demand-aware nested auto-tap for costed mana abilities.
+//!
+//! Regression for the false "Cannot pay mana cost" when funding a costed mana
+//! ability's generic sub-cost consumed already-floated colored mana that the
+//! OUTER cost still needed.
+//!
+//! Repro: cast a `{U}{B}{R}{G}` sorcery with a Dimir Signet (`{1},{T}: Add
+//! {U}{B}`), a Gruul Signet (`{1},{T}: Add {R}{G}`), and two Plains. The outer
+//! cost reserves both Signets for its four colored shards. Activating Dimir
+//! floats `{U}{B}` and a Plains pays its `{1}`. Pre-fix, funding Gruul's `{1}`
+//! consumed the floated `{U}` (a tie-break pick) instead of tapping the second
+//! Plains, leaving the outer `{U}{B}{R}{G}` short of `{U}` — the spell was
+//! wrongly reported unpayable.
+//!
+//! The fix is three coordinated layers plus a CR 118.10 source-exclusion fix:
+//!   - Layer A (planner): when the nested sub-cost's outer-cost colored demand
+//!     is known, a generic pip is counted covered ONLY by a non-demanded scratch
+//!     unit, so the second Plains is planned to tap.
+//!   - Layer B (real spend): the `{1}` payment softly deprioritizes a demanded
+//!     color, so it pays from `{W}` (Plains) not the reserved `{U}`.
+//!   - Layer C (exclusion): the nested sub-cost auto-tap excludes every source
+//!     the outer plan reserved (CR 118.10), so it can't grab a reserved source.
+//!
+//! All threading is `Option<&ColorDemand>` and `None` on every top-level / cast /
+//! affordability path, so non-nested behavior is byte-identical.
+//!
+//! CR references (verified against docs/MagicCompRules.txt):
+//!   - CR 107.4b: Generic mana in costs can be paid with any type of mana.
+//!   - CR 118.10: Each payment of a cost applies to only one spell or ability.
+//!   - CR 601.2h: Partial payments aren't allowed and unpayable costs can't be
+//!     paid; conversely a payable cost must never be reported unpayable.
+//!   - CR 605.1b / CR 605.3a / CR 605.3c: Signets are mana abilities; their mana
+//!     sub-cost may itself activate further mana abilities, bounded by the
+//!     in-flight exclusion chain.
+//!
+//! This is a *class* regression covering any multicolor cost funded by a mix of
+//! costed colored mana rocks and plain mana sources. Driven through the real
+//! cast / activation pipeline, not shape assertions.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DIMIR_SIGNET_ORACLE: &str = "{1}, {T}: Add {U}{B}.";
+const GRUUL_SIGNET_ORACLE: &str = "{1}, {T}: Add {R}{G}.";
+
+/// Signets are artifacts, not creatures. The scenario creature helper parses
+/// Oracle text onto a battlefield permanent; convert it to a pure artifact and
+/// clear P/T so the 0/0 stub is not destroyed as an SBA (CR 704.5f) before its
+/// mana ability is activated.
+fn make_artifact(runner: &mut GameRunner, id: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Artifact];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = None;
+    obj.toughness = None;
+    obj.base_power = None;
+    obj.base_toughness = None;
+}
+
+/// Float `count` units of `ty` into player 0's mana pool (no source modeled;
+/// mirrors the `add_mana` helper in `chord_of_calling.rs`).
+fn add_mana(runner: &mut GameRunner, ty: ManaType, count: usize) {
+    for _ in 0..count {
+        let unit = ManaUnit::new(ty, ObjectId(0), false, vec![]);
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+}
+
+/// Index of the (single) mana ability on a Signet.
+fn mana_ability_index(state: &engine::types::game_state::GameState, id: ObjectId) -> usize {
+    let obj = state.objects.get(&id).expect("signet exists");
+    obj.abilities
+        .iter()
+        .position(|a| a.cost.is_some())
+        .expect("signet has a costed mana ability")
+}
+
+#[test]
+fn wubrg_spell_funded_by_two_signets_and_two_plains_resolves() {
+    // PRIMARY discriminating test. A `{U}{B}{R}{G}` sorcery, two Signets that
+    // together supply all four colors, and exactly two Plains to fund the two
+    // `{1}` Signet sub-costs. Pre-fix, funding the second Signet's `{1}` from a
+    // floated color the outer cost still needed made `CastSpell` reject with
+    // "Cannot pay mana cost" — `resolve()`'s `.expect` panics. Post-fix the
+    // legal line (Plains -> Dimir, Plains -> Gruul, pool {U}{B}{R}{G}) resolves.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Exactly two Plains: one per Signet `{1}` sub-cost. No spare colorless or
+    // extra colored source — if a Signet's `{1}` consumes a reserved floated
+    // color, the outer cost is genuinely short and the cast fails.
+    let plains1 = scenario.add_basic_land(P0, ManaColor::White);
+    let plains2 = scenario.add_basic_land(P0, ManaColor::White);
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+    let gruul = scenario
+        .add_creature_from_oracle(P0, "Gruul Signet", 0, 0, GRUUL_SIGNET_ORACLE)
+        .id();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "WUBRG Test Spell", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Blue,
+                ManaCostShard::Black,
+                ManaCostShard::Red,
+                ManaCostShard::Green,
+            ],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    make_artifact(&mut runner, gruul);
+
+    // Drive the real cast pipeline. Auto-tap funds {U}{B}{R}{G} by activating
+    // both Signets, each `{1}` paid from a Plains. If the fix regressed, the
+    // colored requirement is unfundable and the cast never reaches the stack.
+    let outcome = runner.cast(spell).resolve();
+
+    // PRIMARY revert-failing assertion: the cost was genuinely payable and the
+    // spell resolved off the stack (CR 608.2m). Reverting any of the three
+    // layers makes funding the second Signet steal a reserved color, the cost
+    // is short, and this assertion flips (the spell stays in Hand/Stack and the
+    // cast `.expect` panics first).
+    let resolved_zone = outcome.zone_of(spell);
+    assert!(
+        !matches!(resolved_zone, Zone::Hand | Zone::Stack),
+        "the {{U}}{{B}}{{R}}{{G}} spell must have cast and resolved, but it is \
+         still in {resolved_zone:?} — a Signet `{{1}}` consumed a reserved color"
+    );
+
+    // Both Signets supplied colors the Plains cannot, so both were tapped.
+    assert!(
+        outcome.state().objects.get(&dimir).unwrap().tapped,
+        "Dimir Signet was tapped for {{U}}{{B}}"
+    );
+    assert!(
+        outcome.state().objects.get(&gruul).unwrap().tapped,
+        "Gruul Signet was tapped for {{R}}{{G}}"
+    );
+
+    // Both Plains were tapped to fund the two `{1}` sub-costs: Layer A planned
+    // the second Plains instead of consuming the reserved floated color, and
+    // Layer B paid each `{1}` from {W}, not from a color the outer cost needs.
+    assert!(
+        outcome.state().objects.get(&plains1).unwrap().tapped,
+        "the first Plains was tapped to fund a Signet `{{1}}`"
+    );
+    assert!(
+        outcome.state().objects.get(&plains2).unwrap().tapped,
+        "the second Plains was tapped — Layer A planned it instead of consuming \
+         the floated {{U}} the outer cost reserved"
+    );
+
+    // Every produced unit was spent paying the spell: the pool is empty.
+    assert_eq!(
+        outcome.state().players[0].mana_pool.total(),
+        0,
+        "the full {{U}}{{B}}{{R}}{{G}} was spent — no leftover floated mana"
+    );
+}
+
+#[test]
+fn signet_one_cost_paid_from_only_remaining_float_when_no_spare_source() {
+    // CR 601.2h float-only fallback. A Dimir Signet activated with NO untapped
+    // mana source: its `{1}` can only be paid from mana already floating in the
+    // pool. We pre-float a single {U}. Even though {U} is a color the Signet
+    // itself will produce (so a naive demand rule might refuse to spend it), the
+    // soft spend must STILL pay the `{1}` from the only available unit — never
+    // hard-block a payable cost.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+
+    // Pre-float exactly one {U} into the player's pool — the only mana available
+    // to pay the Signet's `{1}` (no untapped land or rock exists).
+    add_mana(&mut runner, ManaType::Blue, 1);
+
+    let idx = mana_ability_index(runner.state(), dimir);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: dimir,
+            ability_index: idx,
+        })
+        .expect("the Signet `{1}` must be payable from the only floated unit (CR 601.2h)");
+
+    // Revert-failing assertion: the Signet activated and produced {U}{B}. If the
+    // soft spend had hard-refused the demanded {U}, activation would error and
+    // the pool would still hold the single pre-floated {U}.
+    assert!(
+        runner.state().objects.get(&dimir).unwrap().tapped,
+        "Dimir Signet activated and tapped"
+    );
+    // Pool: started with 1 ({U}), paid the `{1}` (-1), produced {U}{B} (+2) = 2.
+    assert_eq!(
+        runner.state().players[0].mana_pool.total(),
+        2,
+        "Signet produced {{U}}{{B}} after paying its `{{1}}` from the only float"
+    );
+}
+
+#[test]
+fn reserved_sibling_rock_not_cross_tapped_for_nested_sub_cost() {
+    // Layer C reservation (CR 118.10). A `{U}{B}{R}{G}` sorcery funded by two
+    // Signets (Dimir {U}{B}, Gruul {R}{G}) and three Plains — one spare. The
+    // outer plan reserves BOTH Signets for the four colored shards. Phase 3 taps
+    // them sequentially: while Dimir resolves, the Gruul Signet is reserved for
+    // the outer cost but not yet tapped. Pre-Layer-C, Dimir's `{1}` nested
+    // auto-tap re-scanned the battlefield and could grab the still-untapped Gruul
+    // (a source the outer cost still needs) instead of a Plains, double-spending
+    // a reserved source. Layer C excludes every outer-reserved source from the
+    // nested sub-cost auto-tap, so a Plains funds the `{1}` and Gruul stays
+    // available for the outer {R}{G}. The spare third Plains proves the
+    // exclusion does not strand the payment.
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let plains: Vec<ObjectId> = (0..3)
+        .map(|_| scenario.add_basic_land(P0, ManaColor::White))
+        .collect();
+
+    let dimir = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+    let gruul = scenario
+        .add_creature_from_oracle(P0, "Gruul Signet", 0, 0, GRUUL_SIGNET_ORACLE)
+        .id();
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "WUBRG-minus-W Test Spell", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Blue,
+                ManaCostShard::Black,
+                ManaCostShard::Red,
+                ManaCostShard::Green,
+            ],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, dimir);
+    make_artifact(&mut runner, gruul);
+
+    let outcome = runner.cast(spell).resolve();
+
+    // Revert-failing assertion: the cost resolved without a false-unpayable. If
+    // Layer C let the nested sub-cost grab the reserved Gruul, the outer {R}{G}
+    // would be short and the cast would be rejected.
+    let resolved_zone = outcome.zone_of(spell);
+    assert!(
+        !matches!(resolved_zone, Zone::Hand | Zone::Stack),
+        "the four-color spell must have resolved, but it is still in \
+         {resolved_zone:?} — a reserved sibling rock was cross-tapped"
+    );
+
+    // Both Signets supplied colors the Plains cannot, so both were tapped for the
+    // OUTER cost (not consumed by a nested sub-cost).
+    for (name, id) in [("Dimir", dimir), ("Gruul", gruul)] {
+        assert!(
+            outcome.state().objects.get(&id).unwrap().tapped,
+            "{name} Signet was tapped to supply its colors for the outer cost"
+        );
+    }
+    // Exactly two of the three Plains funded the two `{1}` sub-costs; one is
+    // spare and stays untapped (the exclusion did not over-tap).
+    let tapped_plains = plains
+        .iter()
+        .filter(|id| outcome.state().objects.get(id).unwrap().tapped)
+        .count();
+    assert_eq!(
+        tapped_plains, 2,
+        "exactly two Plains funded the two Signet `{{1}}` sub-costs; one is spare"
+    );
+    assert_eq!(
+        outcome.state().players[0].mana_pool.total(),
+        0,
+        "the full {{U}}{{B}}{{R}}{{G}} was spent — no stranded leftover mana"
+    );
+}


### PR DESCRIPTION
Mana auto-tap funded a costed mana ability's generic sub-cost by consuming
already-floated colored mana the enclosing cost still needed, then reported
the (legal) spell unpayable. Repro: {U}{B}{R}{G} + Dimir Signet + Gruul
Signet + 2 Plains — Dimir floats {U}{B}, funding Gruul's {1} ate the floated
{U} instead of tapping the second Plains, so the cast failed.

Fix threads the outer cost's reserved colors (a [u32;5] ColorDemand, the
existing hand-demand vehicle) through the nested sub-cost payment in three
coordinated layers:
- Planner residual (reduce_cost_by_pool): a generic pip is covered from pool
  mana only when a non-demanded unit is eligible; otherwise it stays residual
  so the source-tapping phase taps a fresh land.
- Real spend (spend_generic_eligible/spend_any_eligible): soft deprioritize a
  demanded color, but still spend it when it is the only eligible unit, so a
  payable cost is never reported unpayable (CR 601.2h).
- Nested-frame exclusion (CR 118.10): the sub-cost auto-tap excludes the outer
  frame's reserved sources (excluded_sources union used_sources) so a source
  committed to the outer cost is never cross-tapped for the sub-cost.

All threading is Option<&ColorDemand>; every top-level/affordability/normal
cast path passes None and is behavior-preserving apart from extending the
existing hand-demand bias to the generic spend. Builds for the class (any
combination of colored costed rocks: Signets, Talismans, filter lands).

Adds crates/engine/tests/costed_mana_ability_demand_aware_autotap.rs with three
discriminating runtime tests (primary repro, CR 601.2h float-only fallback, and
a CR 118.10 contended-source case); the primary and contended-source tests fail
on the unfixed base. The costed_mana_abilities_no_recursion suite stays green.
