### PR TITLE
feat(engine): support gaining all activated abilities of target until end of turn

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2008,6 +2008,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::CopySpell { target, .. }
         | Effect::CastCopyOfCard { target, .. }
         | Effect::BecomeCopy { target, .. }
+        // CR 113.1a + CR 611.2: report the donor whose activated abilities are gained.
+        | Effect::GainActivatedAbilitiesOfTarget { target, .. }
         | Effect::Suspect { target, .. }
         | Effect::Unsuspect { target, .. }
         | Effect::Connive { target, .. }

--- a/crates/engine/src/game/effects/gain_activated_abilities.rs
+++ b/crates/engine/src/game/effects/gain_activated_abilities.rs
@@ -107,8 +107,20 @@ pub fn resolve(
             // multiple recipients (or multiple sequential grants) never collide
             // or overwrite each other (CR 611.2c fixes each affected set
             // independently).
+            //
+            // CR 112.6a: "you control" must resolve against the resolving
+            // ability's controller, not whatever player currently controls the
+            // live source object. `FilterContext::from_ability` binds
+            // `source_controller` to `ability.controller` (captured when the
+            // ability was put on the stack), so the grant still lands on the
+            // correct player's Horrors even if the source's controller has
+            // since changed or the source has left the battlefield entirely
+            // (`FilterContext::from_source` would instead read the live
+            // object's controller, or `None` if the source object no longer
+            // exists in `state.objects` — silently matching the wrong
+            // player, or no one).
             _ => {
-                let ctx = FilterContext::from_source(state, ability.source_id);
+                let ctx = FilterContext::from_ability(ability);
                 let recipient_ids: Vec<_> = state
                     .battlefield
                     .iter()
@@ -598,6 +610,158 @@ mod tests {
         assert!(
             state.objects[&bear].abilities.is_empty(),
             "the non-Horror must NOT gain the ability"
+        );
+    }
+
+    // ── Regression: group recipients must resolve against the resolving
+    // ability's controller (CR 112.6a), not the live source object's current
+    // controller. Simulates the source (Grell) leaving the battlefield before
+    // its triggered ability resolves — `state.objects` no longer holds it, so
+    // `FilterContext::from_source` would read `source_controller: None` and
+    // silently match nobody. `FilterContext::from_ability` must instead use
+    // `ability.controller`, captured when the ability was put on the stack. ──
+    #[test]
+    fn group_recipient_resolves_against_ability_controller_when_source_left_play() {
+        let mut state = GameState::new_two_player(42);
+        let donor = create_object(
+            &mut state,
+            CardId(1),
+            P1,
+            "Opponent Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&donor).unwrap();
+            obj.base_name = "Opponent Artifact".to_string();
+            obj.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec![],
+            };
+            obj.card_types = obj.base_card_types.clone();
+            obj.base_abilities = Arc::new(vec![draw_ability()]);
+        }
+
+        let horror = create_creature(&mut state, 2, P0, "Horror A");
+        {
+            let obj = state.objects.get_mut(&horror).unwrap();
+            obj.base_card_types.subtypes = vec!["Horror".to_string()];
+            obj.card_types.subtypes = vec!["Horror".to_string()];
+        }
+        let grell = create_creature(&mut state, 3, P0, "Grell Philosopher");
+        evaluate_layers(&mut state);
+
+        let horror_filter = TargetFilter::Typed(
+            TypedFilter::creature()
+                .subtype("Horror".to_string())
+                .controller(ControllerRef::You),
+        );
+        // The ability's controller is captured (P0) at trigger-resolution
+        // setup time, exactly as `ResolvedAbility::controller` would hold it
+        // on the stack — independent of whatever happens to the source object
+        // afterward.
+        let ability = make_gain_ability(
+            donor,
+            grell,
+            horror_filter,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+
+        // The source (Grell) leaves the battlefield entirely before the
+        // triggered ability resolves (e.g., destroyed in response, while its
+        // "at the beginning of your upkeep" trigger is still on the stack).
+        // `state.objects` no longer has an entry for it.
+        state.objects.remove(&grell);
+        state.battlefield.retain(|id| *id != grell);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&horror]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "CR 112.6a: the grant must still land on the ORIGINAL ability \
+             controller's (P0) Horror even though the source has left play \
+             and `state.objects` no longer has an entry for it"
+        );
+    }
+
+    // ── Regression: group recipients must use the ability's captured
+    // controller even when the live source object's controller has since
+    // changed (e.g. a control-change effect resolved between the ability
+    // being put on the stack and it resolving). ──
+    #[test]
+    fn group_recipient_resolves_against_ability_controller_when_source_controller_changed() {
+        let mut state = GameState::new_two_player(42);
+        let donor = create_object(
+            &mut state,
+            CardId(1),
+            P1,
+            "Opponent Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&donor).unwrap();
+            obj.base_name = "Opponent Artifact".to_string();
+            obj.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec![],
+            };
+            obj.card_types = obj.base_card_types.clone();
+            obj.base_abilities = Arc::new(vec![draw_ability()]);
+        }
+
+        // P0's Horror — must gain the ability, because the ability was put on
+        // the stack under P0's control.
+        let horror_p0 = create_creature(&mut state, 2, P0, "P0 Horror");
+        // P1's Horror — must NOT gain the ability, even though P1 now controls
+        // the live source object.
+        let horror_p1 = create_creature(&mut state, 3, P1, "P1 Horror");
+        for h in [horror_p0, horror_p1] {
+            let obj = state.objects.get_mut(&h).unwrap();
+            obj.base_card_types.subtypes = vec!["Horror".to_string()];
+            obj.card_types.subtypes = vec!["Horror".to_string()];
+        }
+        let grell = create_creature(&mut state, 4, P0, "Grell Philosopher");
+        evaluate_layers(&mut state);
+
+        let horror_filter = TargetFilter::Typed(
+            TypedFilter::creature()
+                .subtype("Horror".to_string())
+                .controller(ControllerRef::You),
+        );
+        let ability = make_gain_ability(
+            donor,
+            grell,
+            horror_filter,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+
+        // Control of Grell changes to P1 after the triggered ability was put
+        // on the stack (with P0 as its captured controller) but before it
+        // resolves.
+        state.objects.get_mut(&grell).unwrap().controller = P1;
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&horror_p0]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "the grant must land on the ORIGINAL ability controller's (P0) Horror"
+        );
+        assert!(
+            state.objects[&horror_p1].abilities.is_empty(),
+            "the grant must NOT follow the source's new controller (P1)"
         );
     }
 }

--- a/crates/engine/src/game/effects/gain_activated_abilities.rs
+++ b/crates/engine/src/game/effects/gain_activated_abilities.rs
@@ -1,0 +1,603 @@
+use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::types::ability::{
+    AbilityKind, ContinuousModification, Duration, Effect, EffectError, EffectKind,
+    ResolvedAbility, TargetFilter, TargetRef,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+
+/// CR 113.1a + CR 113.10 + CR 611.2 + CR 611.2c + CR 613.1f: Grant the
+/// recipient(s) all activated abilities of the targeted donor object, for a
+/// duration. This is the resolution-time grant for Quicksilver Elemental
+/// ("This creature gains all activated abilities of target creature until end
+/// of turn") and Grell Philosopher ("each Horror you control gains all
+/// activated abilities of target artifact an opponent controls until end of
+/// turn").
+///
+/// CR 611.2c: the affected set and the granted-ability snapshot are fixed at
+/// the moment the effect begins. The donor's activated abilities are
+/// snapshotted ONCE, here, into concrete `ContinuousModification::GrantAbility`
+/// instances — the resolver never constructs
+/// `ContinuousModification::GrantAllActivatedAbilitiesOf` (the static-side
+/// meta-modification re-scanned every layer pass). A donor that later gains a
+/// new activated ability does NOT retroactively extend the grant.
+///
+/// CR 201.5b: a granted ability that references the donor's name (`~` /
+/// `SelfRef` in its cost/effect — e.g. "Sacrifice ~") is reinterpreted to use
+/// the recipient's identity, because the granted `GrantAbility` lands in the
+/// recipient's `obj.abilities`; when activated, its `source_id` is the
+/// recipient, so the self-reference resolves to the recipient (Quicksilver),
+/// not the donor.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (recipient, duration) = match &ability.effect {
+        Effect::GainActivatedAbilitiesOfTarget {
+            recipient,
+            duration,
+            ..
+        } => (
+            recipient.clone(),
+            duration
+                .clone()
+                .or(ability.duration.clone())
+                .unwrap_or(Duration::UntilEndOfTurn),
+        ),
+        _ => (
+            TargetFilter::SelfRef,
+            ability.duration.clone().unwrap_or(Duration::UntilEndOfTurn),
+        ),
+    };
+
+    // The donor is the single declared object target (BecomeCopy-style).
+    let donor_id = ability
+        .targets
+        .iter()
+        .find_map(|t| match t {
+            TargetRef::Object(id) => Some(*id),
+            TargetRef::Player(_) => None,
+        })
+        .ok_or_else(|| {
+            EffectError::MissingParam(
+                "GainActivatedAbilitiesOfTarget requires a target".to_string(),
+            )
+        })?;
+
+    // CR 611.2c: snapshot the donor's activated abilities exactly once, now.
+    // Read the donor's CURRENT abilities (post-layer) so abilities the donor
+    // itself has gained by this point are included, but never re-read after
+    // this point — the resulting `GrantAbility` set is frozen.
+    let modifications: Vec<ContinuousModification> = state
+        .objects
+        .get(&donor_id)
+        .map(|donor| {
+            donor
+                .abilities
+                .iter()
+                .filter(|a| a.kind == AbilityKind::Activated)
+                .map(|a| ContinuousModification::GrantAbility {
+                    definition: Box::new(a.clone()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // CR 611.2b: a grant that affects zero abilities (donor has none) is not an
+    // error — it resolves cleanly with no continuous effect registered.
+    if !modifications.is_empty() {
+        match &recipient {
+            // Quicksilver Elemental: the recipient is the source itself.
+            TargetFilter::SelfRef => {
+                state.add_transient_continuous_effect(
+                    ability.source_id,
+                    ability.controller,
+                    duration,
+                    TargetFilter::SpecificObject {
+                        id: ability.source_id,
+                    },
+                    modifications,
+                    None,
+                );
+            }
+            // Grell Philosopher: "each Horror you control" — resolve the
+            // recipient filter against the battlefield at resolution time and
+            // register one independent transient effect per matching object so
+            // multiple recipients (or multiple sequential grants) never collide
+            // or overwrite each other (CR 611.2c fixes each affected set
+            // independently).
+            _ => {
+                let ctx = FilterContext::from_source(state, ability.source_id);
+                let recipient_ids: Vec<_> = state
+                    .battlefield
+                    .iter()
+                    .copied()
+                    .filter(|id| matches_target_filter(state, *id, &recipient, &ctx))
+                    .collect();
+                for recipient_id in recipient_ids {
+                    state.add_transient_continuous_effect(
+                        ability.source_id,
+                        ability.controller,
+                        duration.clone(),
+                        TargetFilter::SpecificObject { id: recipient_id },
+                        modifications.clone(),
+                        None,
+                    );
+                }
+            }
+        }
+        crate::game::layers::flush_layers(state);
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::from(&ability.effect),
+        source_id: ability.source_id,
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::game::layers::evaluate_layers;
+    use crate::game::scenario::GameScenario;
+    use crate::game::turns::execute_cleanup;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityCost, AbilityDefinition, ControllerRef, QuantityExpr, SacrificeCost, TargetFilter,
+        TargetRef, TypedFilter,
+    };
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::identifiers::{CardId, ObjectId};
+    use crate::types::phase::Phase;
+    use crate::types::player::PlayerId;
+    use crate::types::zones::Zone;
+
+    const P0: PlayerId = PlayerId(0);
+    const P1: PlayerId = PlayerId(1);
+
+    fn create_creature(
+        state: &mut GameState,
+        card_id: u64,
+        player: PlayerId,
+        name: &str,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(card_id),
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.base_name = name.to_string();
+        obj.base_power = Some(1);
+        obj.base_toughness = Some(1);
+        obj.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+        };
+        obj.card_types = obj.base_card_types.clone();
+        id
+    }
+
+    /// A simple "{T}: Draw a card" activated ability.
+    fn draw_ability() -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(AbilityCost::Tap)
+    }
+
+    /// "Sacrifice ~: Destroy target permanent" — the cost sacrifices the
+    /// ability's own source (`SelfRef`), the CR 201.5b substitution proof.
+    fn self_sacrifice_ability() -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Destroy {
+                target: TargetFilter::Typed(TypedFilter::permanent()),
+                cant_regenerate: false,
+            },
+        )
+        .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::SelfRef,
+            1,
+        )))
+    }
+
+    fn make_gain_ability(
+        donor_id: ObjectId,
+        source_id: ObjectId,
+        recipient: TargetFilter,
+        player: PlayerId,
+        duration: Option<Duration>,
+    ) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainActivatedAbilitiesOfTarget {
+                target: TargetFilter::Any,
+                recipient,
+                duration,
+            },
+            vec![TargetRef::Object(donor_id)],
+            source_id,
+            player,
+        )
+    }
+
+    // ── Plan engine test 1: SelfRef grant copies the donor's activated ability,
+    // and activating it on the recipient produces the donor's effect sourced
+    // from the recipient. Drives the real activation pipeline.
+    #[test]
+    fn self_grant_copies_donor_ability_and_activates_from_recipient() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let donor = scenario
+            .add_creature(P0, "Donor", 1, 1)
+            .with_ability_definition(draw_ability())
+            .id();
+        let quicksilver = scenario.add_creature(P0, "Quicksilver", 1, 1).id();
+        scenario.with_library_top(P0, &["Reward Card"]);
+        let mut runner = scenario.build();
+
+        // Grant the donor's activated ability to Quicksilver.
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(runner.state_mut(), &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(runner.state_mut());
+
+        assert!(
+            runner.state().objects[&quicksilver]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "Quicksilver must gain the donor's activated ability; got {:?}",
+            runner.state().objects[&quicksilver].abilities
+        );
+
+        // Activate the granted "{T}: Draw a card" on Quicksilver. The draw
+        // resolves for Quicksilver's controller (P0) and taps Quicksilver, not
+        // the donor — proving the granted ability is sourced from the recipient.
+        let hand_before = runner.state().players[0].hand.len();
+        let ability_index = runner.state().objects[&quicksilver].abilities.len() - 1;
+        let outcome = runner.activate(quicksilver, ability_index).resolve();
+        assert_eq!(
+            outcome.state().players[0].hand.len(),
+            hand_before + 1,
+            "activating the granted ability must draw a card for the recipient's controller"
+        );
+        assert!(
+            outcome.state().objects[&quicksilver].tapped,
+            "the granted {{T}} cost must tap the recipient (Quicksilver)"
+        );
+        assert!(
+            !outcome.state().objects[&donor].tapped,
+            "the donor must NOT be tapped by the recipient's activation"
+        );
+    }
+
+    // ── Plan engine test 2: grant expires at end-of-turn cleanup ──
+    #[test]
+    fn grant_reverts_at_cleanup() {
+        let mut state = GameState::new_two_player(42);
+        let donor = create_creature(&mut state, 1, P0, "Donor");
+        state.objects.get_mut(&donor).unwrap().base_abilities = Arc::new(vec![draw_ability()]);
+        let quicksilver = create_creature(&mut state, 2, P0, "Quicksilver");
+        evaluate_layers(&mut state);
+
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects[&quicksilver].abilities.len(), 1, "granted");
+
+        execute_cleanup(&mut state, &mut events);
+        evaluate_layers(&mut state);
+        assert!(
+            state.objects[&quicksilver].abilities.is_empty(),
+            "the grant must revert at end-of-turn cleanup (CR 611.2 until-end-of-turn)"
+        );
+    }
+
+    // ── Plan engine test 3: CR 201.5b name substitution (self-sacrifice) ──
+    //
+    // The donor's "Sacrifice ~: Destroy ..." references the donor's own identity
+    // via the self-sacrifice cost. After granting to Quicksilver, the granted
+    // ability lives in Quicksilver's `abilities`; activating it (driving the
+    // real cost-payment pipeline) must sacrifice QUICKSILVER (the new source),
+    // not the donor.
+    #[test]
+    fn self_referential_cost_binds_to_recipient_not_donor() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let donor = scenario
+            .add_creature(P0, "Donor", 1, 1)
+            .with_ability_definition(self_sacrifice_ability())
+            .id();
+        let quicksilver = scenario.add_creature(P0, "Quicksilver", 1, 1).id();
+        // A bystander permanent for the granted "Destroy target permanent".
+        let bystander = scenario.add_creature(P1, "Bystander", 2, 2).id();
+        let mut runner = scenario.build();
+
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(runner.state_mut(), &ability, &mut events).unwrap();
+        crate::game::layers::evaluate_layers(runner.state_mut());
+
+        assert_eq!(
+            runner.state().objects[&quicksilver].abilities[0],
+            self_sacrifice_ability(),
+            "Quicksilver gained the self-sacrifice ability"
+        );
+
+        // Activate the granted ability ON Quicksilver, targeting the bystander.
+        // The SacrificeSelf cost is paid through the production activation
+        // pipeline against the ability's source (Quicksilver).
+        let ability_index = runner.state().objects[&quicksilver].abilities.len() - 1;
+        let outcome = runner
+            .activate(quicksilver, ability_index)
+            .target_object(bystander)
+            .resolve();
+        let state = outcome.state();
+
+        assert!(
+            !state.battlefield.contains(&quicksilver),
+            "CR 201.5b: the self-sacrifice cost must sacrifice the RECIPIENT (Quicksilver)"
+        );
+        assert!(
+            state.battlefield.contains(&donor),
+            "the donor must NOT be sacrificed by the granted self-referential cost"
+        );
+    }
+
+    // ── Plan engine test 4: donor with zero activated abilities → no-op ──
+    #[test]
+    fn donor_without_activated_abilities_resolves_cleanly() {
+        let mut state = GameState::new_two_player(42);
+        let donor = create_creature(&mut state, 1, P0, "Vanilla Donor");
+        let quicksilver = create_creature(&mut state, 2, P0, "Quicksilver");
+        evaluate_layers(&mut state);
+
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&quicksilver].abilities.is_empty(),
+            "no abilities granted when the donor has none"
+        );
+        assert!(
+            !state
+                .transient_continuous_effects
+                .iter()
+                .any(|t| t.source_id == quicksilver),
+            "no empty-modification TCE registered for a zero-ability donor"
+        );
+    }
+
+    // ── Plan engine test 5: two sequential grants from two donors stack ──
+    #[test]
+    fn two_sequential_grants_accumulate_independently() {
+        let mut state = GameState::new_two_player(42);
+        let donor_a = create_creature(&mut state, 1, P0, "Donor A");
+        state.objects.get_mut(&donor_a).unwrap().base_abilities = Arc::new(vec![draw_ability()]);
+        let donor_b = create_creature(&mut state, 2, P0, "Donor B");
+        state.objects.get_mut(&donor_b).unwrap().base_abilities =
+            Arc::new(vec![self_sacrifice_ability()]);
+        let quicksilver = create_creature(&mut state, 3, P0, "Quicksilver");
+        evaluate_layers(&mut state);
+
+        let mut events = Vec::new();
+        let ability_a = make_gain_ability(
+            donor_a,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        resolve(&mut state, &ability_a, &mut events).unwrap();
+        let ability_b = make_gain_ability(
+            donor_b,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        resolve(&mut state, &ability_b, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&quicksilver]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "first donor's ability retained after second grant"
+        );
+        assert!(
+            state.objects[&quicksilver]
+                .abilities
+                .iter()
+                .any(|a| *a == self_sacrifice_ability()),
+            "second donor's ability also gained (independent TCEs, no overwrite)"
+        );
+    }
+
+    // ── Plan engine test 6: donor controlled by an opponent still works ──
+    #[test]
+    fn donor_controlled_by_opponent_still_grants() {
+        let mut state = GameState::new_two_player(42);
+        // Donor controlled by the opponent (P1).
+        let donor = create_creature(&mut state, 1, P1, "Opponent Donor");
+        state.objects.get_mut(&donor).unwrap().base_abilities = Arc::new(vec![draw_ability()]);
+        let quicksilver = create_creature(&mut state, 2, P0, "Quicksilver");
+        evaluate_layers(&mut state);
+
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&quicksilver]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "no controller restriction on the donor target (per the card's ruling)"
+        );
+    }
+
+    // ── Plan engine test 8: CR 611.2c snapshot-once (not live rescan) ──
+    #[test]
+    fn snapshot_is_fixed_at_resolution_not_live_rescanned() {
+        let mut state = GameState::new_two_player(42);
+        let donor = create_creature(&mut state, 1, P0, "Donor");
+        state.objects.get_mut(&donor).unwrap().base_abilities = Arc::new(vec![draw_ability()]);
+        let quicksilver = create_creature(&mut state, 2, P0, "Quicksilver");
+        evaluate_layers(&mut state);
+
+        let ability = make_gain_ability(
+            donor,
+            quicksilver,
+            TargetFilter::SelfRef,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects[&quicksilver].abilities.len(), 1);
+
+        // Give the donor a NEW activated ability AFTER the grant resolved.
+        {
+            let donor_obj = state.objects.get_mut(&donor).unwrap();
+            donor_obj.base_abilities = Arc::new(vec![draw_ability(), self_sacrifice_ability()]);
+        }
+        evaluate_layers(&mut state);
+
+        // CR 611.2c: the recipient's granted set was frozen at resolution — it
+        // must NOT pick up the donor's newly added ability.
+        assert_eq!(
+            state.objects[&quicksilver].abilities.len(),
+            1,
+            "snapshot-once: recipient must not gain the donor's later-added ability"
+        );
+        assert!(
+            state.objects[&quicksilver]
+                .abilities
+                .iter()
+                .all(|a| *a == draw_ability()),
+            "only the originally-snapshotted ability remains"
+        );
+    }
+
+    // ── Plan engine test 7: group recipient ("each Horror you control") ──
+    #[test]
+    fn group_recipient_grants_to_each_matching_object_only() {
+        let mut state = GameState::new_two_player(42);
+        // Opponent's artifact donor with one activated ability.
+        let donor = create_object(
+            &mut state,
+            CardId(1),
+            P1,
+            "Opponent Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&donor).unwrap();
+            obj.base_name = "Opponent Artifact".to_string();
+            obj.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec![],
+            };
+            obj.card_types = obj.base_card_types.clone();
+            obj.base_abilities = Arc::new(vec![draw_ability()]);
+        }
+
+        // Two Horrors you control + one non-Horror you control.
+        let horror_a = create_creature(&mut state, 2, P0, "Horror A");
+        let horror_b = create_creature(&mut state, 3, P0, "Horror B");
+        for h in [horror_a, horror_b] {
+            let obj = state.objects.get_mut(&h).unwrap();
+            obj.base_card_types.subtypes = vec!["Horror".to_string()];
+            obj.card_types.subtypes = vec!["Horror".to_string()];
+        }
+        let bear = create_creature(&mut state, 4, P0, "Plain Bear");
+        let grell = create_creature(&mut state, 5, P0, "Grell Philosopher");
+        evaluate_layers(&mut state);
+
+        let horror_filter = TargetFilter::Typed(
+            TypedFilter::creature()
+                .subtype("Horror".to_string())
+                .controller(ControllerRef::You),
+        );
+        let ability = make_gain_ability(
+            donor,
+            grell,
+            horror_filter,
+            P0,
+            Some(Duration::UntilEndOfTurn),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&horror_a]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "Horror A must gain the ability"
+        );
+        assert!(
+            state.objects[&horror_b]
+                .abilities
+                .iter()
+                .any(|a| *a == draw_ability()),
+            "Horror B must gain the ability"
+        );
+        assert!(
+            state.objects[&bear].abilities.is_empty(),
+            "the non-Horror must NOT gain the ability"
+        );
+    }
+}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -109,6 +109,7 @@ pub mod forage;
 pub mod force_attack;
 pub mod force_block;
 pub mod free_cast_from_zones;
+pub mod gain_activated_abilities;
 pub mod gain_control;
 pub mod gift_delivery;
 pub mod goad;
@@ -2688,6 +2689,9 @@ pub fn resolve_effect(
             copy_token_blocking::resolve(state, ability, events)
         }
         Effect::BecomeCopy { .. } => become_copy::resolve(state, ability, events),
+        Effect::GainActivatedAbilitiesOfTarget { .. } => {
+            gain_activated_abilities::resolve(state, ability, events)
+        }
         Effect::ChooseCard { .. } => choose_card::resolve(state, ability, events),
         Effect::PutCounter { .. } => counters::resolve_add(state, ability, events),
         Effect::PutCounterAll { .. } => counters::resolve_add_all(state, ability, events),

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -999,6 +999,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
+        | Effect::GainActivatedAbilitiesOfTarget { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounter { .. }
         | Effect::PutCounterAll { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -760,6 +760,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::ExileHaunting
         | EffectKind::HideawayConceal
         | EffectKind::BecomeCopy
+        | EffectKind::GainActivatedAbilitiesOfTarget
         | EffectKind::ChooseCard
         | EffectKind::PutCounter
         | EffectKind::PutCounterAll

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4713,6 +4713,56 @@ fn try_parse_gain_keyword(text: &str) -> Option<Effect> {
     })
 }
 
+/// CR 113.1a + CR 611.2: Parse "gain[s] all activated abilities of <donor>
+/// [until end of turn]" (Quicksilver Elemental, Grell Philosopher) into
+/// `Effect::GainActivatedAbilitiesOfTarget`. The fixed lead-in phrase is
+/// stripped via `TextPair::strip_prefix`, then the remaining donor noun phrase
+/// is delegated entirely to the shared `parse_target` combinator (which already
+/// handles "target creature", "target artifact an opponent controls", etc.).
+///
+/// `recipient` is left at its `SelfRef` default here (Quicksilver's implicit
+/// self-recipient); the group-recipient form ("each Horror you control gains
+/// …") is wired by the subject-application layer, which rebinds `recipient`
+/// before this effect is emitted.
+///
+/// Returns `None` (so the line falls through to the loud `Unimplemented`
+/// fallback) when the lead-in phrase is absent, when no donor target parses, or
+/// when unrecognized text remains after the target strip — never swallowing
+/// unrecognized text into a half-built effect.
+fn try_parse_gain_all_activated_abilities_of_target(text: &str) -> Option<Effect> {
+    let (text_without_duration, duration) = super::strip_trailing_duration(text);
+    let lower = text_without_duration.to_lowercase();
+    let tp = TextPair::new(text_without_duration, &lower);
+
+    // CR 113.1a: fixed lead-in. Compose the two verb forms as a single axis.
+    let after_phrase = tp
+        // allow-noncombinator: TextPair dual-string fixed lead-in strip (oracle_util convention)
+        .strip_prefix("gains all activated abilities of ")
+        // allow-noncombinator: TextPair dual-string fixed lead-in strip (oracle_util convention)
+        .or_else(|| tp.strip_prefix("gain all activated abilities of "))?;
+
+    // CR 611.2: the donor noun phrase is a normal target — delegate to the
+    // shared target combinator. No new target grammar here.
+    let donor = after_phrase.original.trim();
+    if donor.is_empty() {
+        return None;
+    }
+    let (target, rest) = parse_target(donor);
+    // `parse_target` returns the full input as `rest` (and a fallback filter)
+    // when it cannot classify the phrase. Any unconsumed trailing text means
+    // the donor phrase was not fully recognized — fall through to
+    // Unimplemented rather than mis-parse a half-built effect.
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    Some(Effect::GainActivatedAbilitiesOfTarget {
+        target,
+        recipient: TargetFilter::SelfRef,
+        duration: duration.or(Some(Duration::UntilEndOfTurn)),
+    })
+}
+
 pub(super) fn lower_imperative_ast(ast: ImperativeAst) -> Effect {
     match ast {
         ImperativeAst::Numeric(ast) => lower_numeric_imperative_ast(ast),
@@ -8015,6 +8065,12 @@ pub(super) fn parse_imperative_family_ast(
             if nom_primitives::scan_contains(lower, "control of") {
                 parse_targeted_action_ast(text, lower, ctx)
                     .map(|ast| ImperativeFamilyAst::Structured(ImperativeAst::Targeted(ast)))
+            } else if let Some(effect) = try_parse_gain_all_activated_abilities_of_target(text) {
+                // CR 113.1a + CR 611.2: "gains all activated abilities of
+                // target <donor> [until end of turn]" (Quicksilver Elemental,
+                // Grell Philosopher). Tried BEFORE the bare-keyword/quoted-ability
+                // arms so the longer, more specific phrase is not shadowed.
+                Some(ImperativeFamilyAst::GainKeyword(effect))
             } else if let Some(effect) =
                 try_parse_gain_keyword(text).or_else(|| try_parse_gain_quoted_ability(text))
             {
@@ -14481,6 +14537,235 @@ mod tests {
             try_parse_gain_quoted_ability("gain flying until end of turn").is_none(),
             "no quote marks → not a quoted-ability candidate"
         );
+    }
+
+    // ── CR 113.1a + CR 611.2: "gain[s] all activated abilities of target X" ──
+
+    /// Parser test 1: "gains all activated abilities of target creature until
+    /// end of turn" → `GainActivatedAbilitiesOfTarget` with a creature target,
+    /// `SelfRef` recipient, and `UntilEndOfTurn` duration (Quicksilver Elemental).
+    #[test]
+    fn gain_all_activated_abilities_of_target_creature() {
+        let effect = try_parse_gain_all_activated_abilities_of_target(
+            "gains all activated abilities of target creature until end of turn",
+        )
+        .expect("expected GainActivatedAbilitiesOfTarget");
+        let Effect::GainActivatedAbilitiesOfTarget {
+            target,
+            recipient,
+            duration,
+        } = effect
+        else {
+            panic!("expected GainActivatedAbilitiesOfTarget, got something else");
+        };
+        assert_eq!(recipient, TargetFilter::SelfRef, "implicit self-recipient");
+        assert_eq!(duration, Some(Duration::UntilEndOfTurn));
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected a typed creature target, got {target:?}");
+        };
+        assert!(
+            tf.type_filters
+                .iter()
+                .any(|t| matches!(t, crate::types::ability::TypeFilter::Creature)),
+            "donor target must be a creature; got {tf:?}"
+        );
+    }
+
+    /// Parser test 2: "gains all activated abilities of target artifact an
+    /// opponent controls until end of turn" → artifact + opponent-controls
+    /// donor filter (Grell Philosopher's donor phrase).
+    #[test]
+    fn gain_all_activated_abilities_of_opponent_artifact() {
+        let effect = try_parse_gain_all_activated_abilities_of_target(
+            "gains all activated abilities of target artifact an opponent controls until end of turn",
+        )
+        .expect("expected GainActivatedAbilitiesOfTarget");
+        let Effect::GainActivatedAbilitiesOfTarget { target, .. } = effect else {
+            panic!("expected GainActivatedAbilitiesOfTarget");
+        };
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected a typed artifact target, got {target:?}");
+        };
+        assert!(
+            tf.type_filters
+                .iter()
+                .any(|t| matches!(t, crate::types::ability::TypeFilter::Artifact)),
+            "donor target must be an artifact; got {tf:?}"
+        );
+        assert_eq!(
+            tf.controller,
+            Some(crate::types::ability::ControllerRef::Opponent),
+            "donor must be controlled by an opponent; got {tf:?}"
+        );
+    }
+
+    /// Parser test 3: malformed "gains all activated abilities" (no "of X") must
+    /// return `None` rather than produce a half-built effect.
+    #[test]
+    fn gain_all_activated_abilities_without_donor_returns_none() {
+        assert!(
+            try_parse_gain_all_activated_abilities_of_target("gains all activated abilities")
+                .is_none(),
+            "no donor phrase → must not produce a half-built effect"
+        );
+    }
+
+    /// Parser test 4 (dispatch-ordering guard): "gains flying until end of
+    /// turn" must route to the bare-keyword grant path, NOT the new combinator.
+    #[test]
+    fn gain_flying_is_not_captured_by_all_activated_abilities_combinator() {
+        assert!(
+            try_parse_gain_all_activated_abilities_of_target("gains flying until end of turn")
+                .is_none(),
+            "bare keyword grant must not be captured by the new combinator"
+        );
+        // And the keyword path still produces a keyword grant.
+        assert!(
+            try_parse_gain_keyword("gains flying until end of turn").is_some(),
+            "the keyword grant path must still handle bare 'gains flying'"
+        );
+    }
+
+    /// Parser test 5: full real-Oracle-text parse-through of Quicksilver
+    /// Elemental. The `{U}:` activated ability's effect must lower to
+    /// `GainActivatedAbilitiesOfTarget` (no longer `Unimplemented`), and the
+    /// untouched "spend blue mana as any color" sentence must still produce its
+    /// own ability — proving the new effect slots in without disturbing the
+    /// rest of the card.
+    #[test]
+    fn quicksilver_elemental_full_oracle_parses_gain_effect() {
+        const TEXT: &str = "{U}: This creature gains all activated abilities of target creature until end of turn. (If any of the abilities use that creature's name, use this creature's name instead.)\nYou may spend blue mana as though it were mana of any color to pay the activation costs of this creature's abilities.";
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            TEXT,
+            "Quicksilver Elemental",
+            &[],
+            &["Creature".to_string()],
+            &["Elemental".to_string()],
+        );
+
+        let gain = parsed
+            .abilities
+            .iter()
+            .find(|a| {
+                matches!(
+                    a.effect.as_ref(),
+                    Effect::GainActivatedAbilitiesOfTarget { .. }
+                )
+            })
+            .expect("the {U} ability must lower to GainActivatedAbilitiesOfTarget");
+        let Effect::GainActivatedAbilitiesOfTarget {
+            recipient,
+            duration,
+            ..
+        } = gain.effect.as_ref()
+        else {
+            unreachable!()
+        };
+        assert_eq!(*recipient, TargetFilter::SelfRef, "implicit self-recipient");
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+
+        assert!(
+            !parsed.abilities.iter().any(|a| matches!(
+                a.effect.as_ref(),
+                Effect::Unimplemented { name, .. } if name == "gain"
+            )),
+            "the 'gain' clause must no longer be Unimplemented"
+        );
+    }
+
+    /// Parser test 6: full real-Oracle-text parse-through of Grell Philosopher,
+    /// proving the GROUP-recipient rebind in `lower_subject_predicate_ast`'s
+    /// `ImperativeFallback` arm (oracle_effect/mod.rs) is reachable from the real
+    /// production parsing path. Grell's clause lives inside the "Aberrant
+    /// Tinkering — When this creature enters and at the beginning of your upkeep,
+    /// each Horror you control gains all activated abilities of target artifact
+    /// an opponent controls until end of turn." trigger sentence (the
+    /// byte-for-byte `oracle_text` from `data/card-data.json`). Test 5 uses the
+    /// full card text via `parse_oracle_text`, so this follows the same unit.
+    ///
+    /// The resolver-level `group_recipient_grants_to_each_matching_object_only`
+    /// test hand-constructs the effect and so never exercises this rebind; this
+    /// is the missing proof that production parsing threads "each Horror you
+    /// control" into `recipient` (NOT defaulting to `SelfRef`) while keeping the
+    /// opponent-controlled-artifact donor as `target`.
+    #[test]
+    fn grell_philosopher_full_oracle_rebinds_group_recipient() {
+        const TEXT: &str = "Aberrant Tinkering — When this creature enters and at the beginning of your upkeep, each Horror you control gains all activated abilities of target artifact an opponent controls until end of turn. You may spend blue mana as though it were mana of any color to activate those abilities.";
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            TEXT,
+            "Grell Philosopher",
+            &[],
+            &["Creature".to_string()],
+            &["Horror".to_string()],
+        );
+
+        // Grell's grant is the body of the "Aberrant Tinkering" triggered
+        // ability, so it lands in `parsed.triggers[*].execute` (NOT
+        // `parsed.abilities`). Walk each trigger's `execute` effect plus its
+        // `sub_ability` chain so we find it whether it is the top-level effect or
+        // a chained clause.
+        fn find_gain(def: &AbilityDefinition) -> Option<&Effect> {
+            let mut cur = Some(def);
+            while let Some(d) = cur {
+                if matches!(
+                    d.effect.as_ref(),
+                    Effect::GainActivatedAbilitiesOfTarget { .. }
+                ) {
+                    return Some(d.effect.as_ref());
+                }
+                cur = d.sub_ability.as_deref();
+            }
+            None
+        }
+        let gain = parsed
+            .triggers
+            .iter()
+            .filter_map(|t| t.execute.as_deref())
+            .find_map(find_gain)
+            .expect("Grell's trigger must lower to GainActivatedAbilitiesOfTarget");
+        let Effect::GainActivatedAbilitiesOfTarget {
+            target,
+            recipient,
+            duration,
+        } = gain
+        else {
+            unreachable!()
+        };
+
+        // Recipient must be the typed "Horror you control" group filter, NOT the
+        // default `SelfRef` — this is the rebind under test.
+        let TargetFilter::Typed(rf) = recipient else {
+            panic!("recipient must be a typed group filter, got {recipient:?}");
+        };
+        assert!(
+            rf.type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Horror")),
+            "recipient must be the Horror subtype filter; got {rf:?}"
+        );
+        assert_eq!(
+            rf.controller,
+            Some(ControllerRef::You),
+            "recipient must be controlled by you; got {rf:?}"
+        );
+
+        // Donor target must remain the opponent-controlled artifact filter.
+        let TargetFilter::Typed(tf) = target else {
+            panic!("donor target must be a typed artifact filter, got {target:?}");
+        };
+        assert!(
+            tf.type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Artifact)),
+            "donor target must be an artifact; got {tf:?}"
+        );
+        assert_eq!(
+            tf.controller,
+            Some(ControllerRef::Opponent),
+            "donor target must be controlled by an opponent; got {tf:?}"
+        );
+
+        assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
     }
 
     /// CR 122.1b: "put that many <keyword> counter(s) on <target>" must

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13368,6 +13368,17 @@ fn lower_subject_predicate_ast(
                 });
             }
             let mut clause = lower_imperative_clause(&text, ctx);
+            // CR 113.1a + CR 611.2: "each <type> you control gains all activated
+            // abilities of target <donor>" (Grell Philosopher). The imperative
+            // path lowered the verb to `GainActivatedAbilitiesOfTarget` with the
+            // default `SelfRef` recipient; rebind the recipient to the subject's
+            // resolved group filter so the grant lands on each matching object
+            // rather than the spell source. The donor `target` and `duration`
+            // were already parsed by the imperative combinator.
+            if let Effect::GainActivatedAbilitiesOfTarget { recipient, .. } = &mut clause.effect {
+                *recipient = subject.affected.clone();
+                return clause;
+            }
             if matches!(
                 &clause.effect,
                 Effect::ChooseFromZone {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4369,6 +4369,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::HideawayConceal { .. }
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
+        | Effect::GainActivatedAbilitiesOfTarget { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounter { .. }
         | Effect::PutCounterAll { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8487,6 +8487,37 @@ pub enum Effect {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         additional_modifications: Vec<ContinuousModification>,
     },
+    /// CR 113.1a + CR 113.10 + CR 611.2 + CR 611.2c + CR 613.1f: Grant the
+    /// recipient(s) all activated abilities of a chosen target object, for a
+    /// duration. Unlike the static-side `ContinuousModification::GrantAllActivatedAbilitiesOf`
+    /// (re-scanned every layer pass against a structural source filter, correct
+    /// for CR 604/611.3 always-on statics), this is a CR 611.2c resolution-time
+    /// grant: the donor's activated abilities are snapshotted ONCE, when this
+    /// effect resolves, into concrete `ContinuousModification::GrantAbility`
+    /// instances — never the `GrantAllActivatedAbilitiesOf` meta-modification.
+    ///
+    /// **Invariant**: the resolver must never construct
+    /// `ContinuousModification::GrantAllActivatedAbilitiesOf` — doing so would
+    /// silently reintroduce live-rescan semantics into the transient path, since
+    /// `gather_transient_continuous_effects` has no special-case handling for
+    /// that meta-modification (only the static-side gather does) and the CR
+    /// 611.2c "won't change" guarantee would silently break.
+    ///
+    /// CR 201.5b: a granted ability that references the donor's name (`~` /
+    /// `SelfRef` in its cost/effect) is reinterpreted to use the recipient's
+    /// own identity — handled by the granted `GrantAbility` definition binding
+    /// the recipient as its source at activation time.
+    GainActivatedAbilitiesOfTarget {
+        /// The donor, chosen via targeting (BecomeCopy-style).
+        #[serde(default = "default_target_filter_any")]
+        target: TargetFilter,
+        /// Who receives the abilities: `SelfRef` (Quicksilver Elemental) or a
+        /// typed group filter (Grell Philosopher: each Horror you control).
+        #[serde(default = "default_target_filter_self_ref")]
+        recipient: TargetFilter,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration: Option<Duration>,
+    },
     ChooseCard {
         #[serde(default)]
         choices: Vec<String>,
@@ -11002,6 +11033,7 @@ impl Effect {
             | Effect::CopySpell { target, .. }
             | Effect::CastCopyOfCard { target, .. }
             | Effect::BecomeCopy { target, .. }
+            | Effect::GainActivatedAbilitiesOfTarget { target, .. }
             | Effect::ChooseCard { target, .. }
             | Effect::PutCounter { target, .. }
             | Effect::MultiplyCounter { target, .. }
@@ -11490,6 +11522,7 @@ impl Effect {
             | Effect::HideawayConceal { .. }
             | Effect::CopyTokenBlockingAttacker { .. }
             | Effect::BecomeCopy { .. }
+            | Effect::GainActivatedAbilitiesOfTarget { .. }
             | Effect::ChooseCard { .. }
             | Effect::MultiplyCounter { .. }
             | Effect::DoublePT { .. }
@@ -11710,6 +11743,7 @@ impl Effect {
             | Effect::HideawayConceal { .. }
             | Effect::CopyTokenBlockingAttacker { .. }
             | Effect::BecomeCopy { .. }
+            | Effect::GainActivatedAbilitiesOfTarget { .. }
             | Effect::ChooseCard { .. }
             | Effect::MultiplyCounter { .. }
             | Effect::DoublePT { .. }
@@ -11897,6 +11931,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::HideawayConceal { .. } => "HideawayConceal",
         Effect::CopyTokenBlockingAttacker { .. } => "CopyTokenBlockingAttacker",
         Effect::BecomeCopy { .. } => "BecomeCopy",
+        Effect::GainActivatedAbilitiesOfTarget { .. } => "GainActivatedAbilitiesOfTarget",
         Effect::ChooseCard { .. } => "ChooseCard",
         Effect::PutCounter { .. } => "PutCounter",
         Effect::PutCounterAll { .. } => "PutCounterAll",
@@ -12116,6 +12151,7 @@ pub enum EffectKind {
     ExileHaunting,
     HideawayConceal,
     BecomeCopy,
+    GainActivatedAbilitiesOfTarget,
     ChooseCard,
     PutCounter,
     PutCounterAll,
@@ -12344,6 +12380,9 @@ impl From<&Effect> for EffectKind {
             // is bookkeeping layered on top of the same token-copy creation.
             Effect::CopyTokenBlockingAttacker { .. } => EffectKind::CopyTokenOf,
             Effect::BecomeCopy { .. } => EffectKind::BecomeCopy,
+            Effect::GainActivatedAbilitiesOfTarget { .. } => {
+                EffectKind::GainActivatedAbilitiesOfTarget
+            }
             Effect::ChooseCard { .. } => EffectKind::ChooseCard,
             Effect::PutCounter { .. } => EffectKind::PutCounter,
             Effect::PutCounterAll { .. } => EffectKind::PutCounterAll,

--- a/crates/phase-ai/src/cast_facts.rs
+++ b/crates/phase-ai/src/cast_facts.rs
@@ -373,6 +373,9 @@ fn effect_requires_targets(effect: &Effect) -> bool {
         | Effect::DoublePT { target, .. }
         | Effect::PreventDamage { target, .. }
         | Effect::Animate { target, .. }
+        // CR 113.1a + CR 611.2: the donor whose activated abilities are gained
+        // (Quicksilver Elemental) is a real declared target.
+        | Effect::GainActivatedAbilitiesOfTarget { target, .. }
         | Effect::PutCounter { target, .. } => !matches!(target, TargetFilter::None),
         Effect::RevealHand { target, .. } => !matches!(target, TargetFilter::None),
         // CR 701.26a/b: only single-permanent tap/untap declares a target. The

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -438,6 +438,7 @@ fn redundancy_delta(
         | Effect::ExileResolvingSpellInsteadOfGraveyard
         | Effect::CopyTokenBlockingAttacker { .. }
         | Effect::BecomeCopy { .. }
+        | Effect::GainActivatedAbilitiesOfTarget { .. }
         | Effect::ChooseCard { .. }
         | Effect::PutCounterAll { .. }
         | Effect::MultiplyCounter { .. }


### PR DESCRIPTION
## Summary
- Adds `Effect::GainActivatedAbilitiesOfTarget`, a CR 611.2c resolution-time
  ability grant: snapshot a chosen target's activated abilities once, grant
  them to a recipient (self, or a filtered group) until end of turn.
- Unblocks Quicksilver Elemental (`{U}: ... gains all activated abilities of
  target creature until end of turn`) and Grell Philosopher (`each Horror you
  control gains all activated abilities of target artifact an opponent
  controls until end of turn`) — built as one general primitive rather than
  a single-card special case, per CLAUDE.md's "build for the class" rule.
- Self-references in granted abilities correctly rebind to the recipient
  (CR 201.5b), proven by a sacrifice-cost test that sacrifices the recipient,
  not the donor.

## Test plan
- [x] 8 new engine tests in `gain_activated_abilities.rs` (self-grant, EOT
      expiry, CR 201.5b name substitution, empty-donor no-op, multi-grant
      stacking, uncontrolled-donor targeting, group recipient, CR 611.2c
      snapshot-not-live-rescan regression)
- [x] 6 new parser tests in `imperative.rs` (both card phrasings, malformed
      input falls through to `Unimplemented`, dispatch-ordering regression
      vs. bare "gains flying", full real-Oracle-text parse-through for both
      cards including the group-recipient rebind)
- [x] `cargo fmt --all`, `cargo clippy -p engine -p phase-ai --all-targets -- -D warnings` clean
- [x] Two independent `/review-impl` rounds (one fix round: corrected a CR
      citation 707.9a→201.5b, added missing parser-level coverage for Grell
      Philosopher's group-recipient path)

Fixes #2913
