### PR TITLE
fix(game): consolidate mobile action dock and prevent bottom UI overlap

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -258,13 +258,13 @@ export function ActionButton() {
   const idle = mode === "hidden" && !isEndingTurn;
   const blocked = idle || actionBlocked;
   const panelClassName =
-    "flex max-w-[min(32rem,calc(100vw-1.25rem))] flex-row flex-wrap items-center justify-end gap-1.5 rounded-[22px] border border-white/10 bg-slate-950/72 p-2 shadow-[0_24px_64px_rgba(15,23,42,0.52)] backdrop-blur-xl lg:max-w-none [@media(max-height:500px)]:gap-1 [@media(max-height:500px)]:p-1 [@media(max-height:500px)]:rounded-[14px]";
-  const primaryButtonClass = "min-w-[10.5rem] lg:min-w-[12rem] [@media(max-height:500px)]:!min-w-[5.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
-  const secondaryButtonClass = "min-w-[8rem] [@media(max-height:500px)]:!min-w-[4.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
+    "flex max-w-[min(32rem,calc(100vw-1.25rem))] flex-row flex-wrap items-center justify-end gap-1.5 rounded-[22px] border border-white/10 bg-slate-950/72 p-2 shadow-[0_24px_64px_rgba(15,23,42,0.52)] backdrop-blur-xl max-lg:w-full max-lg:max-w-none max-lg:flex-col max-lg:flex-nowrap max-lg:gap-1 max-lg:p-1.5 lg:max-w-none [@media(max-height:500px)]:gap-1 [@media(max-height:500px)]:p-1 [@media(max-height:500px)]:rounded-[14px]";
+  const primaryButtonClass = "min-w-[10.5rem] max-lg:w-full max-lg:!min-w-0 lg:min-w-[12rem] [@media(max-height:500px)]:!min-w-[5.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
+  const secondaryButtonClass = "min-w-[8rem] max-lg:w-full max-lg:!min-w-0 [@media(max-height:500px)]:!min-w-[4.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
 
   return (
     <>
-      <div className={panelClassName}>
+      <div className={panelClassName} data-action-button-panel>
         {mode === "combat-attackers" && !isEndingTurn && (
           <>
             <button

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -400,6 +400,7 @@ export function PlayerArea({
     <div
       className={`absolute left-1/2 z-20 -translate-x-1/2 ${isMirrored ? "bottom-[130%] translate-y-full" : "top-[165%] -translate-y-full"}`}
       data-debug-label="HUD"
+      {...(mode === "full" ? { "data-player-hud-anchor": "" } : {})}
     >
       {/* Inner node owns the drag offset so the outer `-translate-x-1/2`
           centering transform is never clobbered. */}

--- a/client/src/components/controls/FullControlToggle.tsx
+++ b/client/src/components/controls/FullControlToggle.tsx
@@ -5,7 +5,7 @@ import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 
-export function FullControlToggle() {
+export function FullControlToggle({ className }: { className?: string } = {}) {
   const { t } = useTranslation("game");
   const tooltipId = useId();
   const fullControl = useUiStore((s) => s.fullControl);
@@ -20,11 +20,11 @@ export function FullControlToggle() {
     <button
       onClick={toggleFullControl}
       aria-describedby={tooltipId}
-      className={`group relative rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] backdrop-blur-xl transition-all duration-200 lg:px-3.5 lg:py-1.5 lg:text-[11px] ${
+      className={`group relative flex items-center justify-center rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] backdrop-blur-xl transition-all duration-200 lg:px-3.5 lg:py-1.5 lg:text-[11px] ${
         fullControl
           ? "border-amber-300/35 bg-amber-500/18 text-amber-100 shadow-[0_10px_24px_rgba(245,158,11,0.2)]"
           : "border-white/10 bg-slate-950/64 text-slate-300 hover:border-white/20 hover:text-white"
-      }`}
+      } ${className ?? ""}`}
     >
       {fullControl ? t("fullControl.on") : t("fullControl.off")}
       <GameplayTooltip id={tooltipId}>

--- a/client/src/components/controls/PhaseStopBar.tsx
+++ b/client/src/components/controls/PhaseStopBar.tsx
@@ -211,7 +211,10 @@ export function CombatPhaseIndicator() {
   // next to the ActionButton. The phase pills along the top still convey phase.
   if (isCompactHeight) return null;
   return (
-    <div className="flex items-center gap-0.5 rounded-full border border-white/10 bg-slate-950/64 px-1 py-1 backdrop-blur-xl lg:px-1.5">
+    <div
+      data-combat-phase-indicator
+      className="flex items-center gap-0.5 rounded-full border border-white/10 bg-slate-950/64 px-1 py-1 backdrop-blur-xl lg:px-1.5"
+    >
       {COMBAT_PHASES.map((phase) => (
         <PhaseDot key={phase} phase={phase} />
       ))}

--- a/client/src/components/hand/HandBadge.tsx
+++ b/client/src/components/hand/HandBadge.tsx
@@ -4,7 +4,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 
-export function HandBadge() {
+export function HandBadge({ className }: { className?: string } = {}) {
   const { t } = useTranslation("game");
   const playerId = usePerspectivePlayerId();
   const handSize = useGameStore((s) => s.gameState?.players[playerId]?.hand.length ?? 0);
@@ -15,7 +15,7 @@ export function HandBadge() {
   return (
     <button
       aria-label={t("hand.viewFullHand", { count: handSize })}
-      className="flex items-center gap-1.5 rounded-full border border-cyan-400/20 bg-slate-950/64 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-300 ring-1 ring-cyan-400/15 backdrop-blur-xl transition-all duration-200 hover:border-cyan-300/40 hover:text-white hover:ring-cyan-300/30 lg:px-3.5 lg:py-1.5 lg:text-[11px]"
+      className={`flex items-center justify-center gap-1.5 rounded-full border border-cyan-400/20 bg-slate-950/64 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-300 ring-1 ring-cyan-400/15 backdrop-blur-xl transition-all duration-200 hover:border-cyan-300/40 hover:text-white hover:ring-cyan-300/30 lg:px-3.5 lg:py-1.5 lg:text-[11px] ${className ?? ""}`}
       onClick={() => setMobileHandOpen(true)}
     >
       <svg

--- a/client/src/components/hud/HudPlate.tsx
+++ b/client/src/components/hud/HudPlate.tsx
@@ -108,6 +108,7 @@ export function HudPlate({
     <Component
       type={onClick ? "button" : undefined}
       onClick={onClick}
+      data-hud-plate=""
       className={`group relative inline-flex max-w-full items-center border backdrop-blur-xl transition-all duration-200 ${plateChrome} ${TONE_CLASSES[tone]}${activeRing} ${
         onClick ? "cursor-pointer hover:-translate-y-0.5 hover:border-white/30" : ""
       }`}
@@ -178,7 +179,7 @@ export function HudPlate({
         </div>
       </div>
       {trailing ? (
-        <div className={trailingClass}>
+        <div className={trailingClass} data-hud-plate-trailing="">
           {trailing}
         </div>
       ) : null}

--- a/client/src/components/hud/ManaPoolSummary.tsx
+++ b/client/src/components/hud/ManaPoolSummary.tsx
@@ -39,7 +39,10 @@ export function ManaPoolSummary({ playerId, size = "default" }: ManaPoolSummaryP
   if (entries.length === 0) return null;
 
   return (
-    <div className={`flex items-center ${size === "sm" ? "gap-0.5" : "gap-1"}`}>
+    <div
+      data-mana-pool-summary=""
+      className={`flex items-center ${size === "sm" ? "gap-0.5" : "gap-1"}`}
+    >
       {hasUnboundedMana && (
         <span
           aria-label={t("badges.unboundedManaPoolMarker")}

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -228,7 +228,7 @@ export function PeekRestoreTab({
   const positionClass =
     direction === "right"
       ? "right-3 top-1/2 -translate-y-1/2 h-24 w-9 rounded-2xl"
-      : "right-3 top-[62%] -translate-y-1/2 h-16 w-9 rounded-2xl";
+      : "left-3 top-[63%] -translate-y-1/2 h-9 w-9 rounded-2xl";
 
   const iconRotate = direction === "right" ? "rotate-180" : "-rotate-90";
 

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -228,7 +228,7 @@ export function PeekRestoreTab({
   const positionClass =
     direction === "right"
       ? "right-3 top-1/2 -translate-y-1/2 h-24 w-9 rounded-2xl"
-      : "bottom-3 left-1/2 -translate-x-1/2 h-9 w-24 rounded-2xl";
+      : "right-3 top-[62%] -translate-y-1/2 h-16 w-9 rounded-2xl";
 
   const iconRotate = direction === "right" ? "rotate-180" : "-rotate-90";
 

--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import type { ObjectId } from "../../adapter/types.ts";
 import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useOptionalDialogPeek } from "./dialogPeekContext.ts";
+import { useIsNarrowViewport } from "./DialogHost.tsx";
 
 interface DialogShellProps {
   eyebrow?: ReactNode;
@@ -42,6 +43,7 @@ export function DialogShell({
 }: DialogShellProps) {
   const { t } = useTranslation("game");
   const peek = useOptionalDialogPeek();
+  const isNarrow = useIsNarrowViewport();
   const inspectHoverProps = useInspectHoverProps();
   const resolvedEyebrow = eyebrow ?? t("dialogShell.eyebrow");
   const cardHoverProps =
@@ -127,7 +129,12 @@ export function DialogShell({
               </div>
             ) : null}
           </div>
-          {peek ? <PeekTab onClick={peek.togglePeek} /> : null}
+          {peek ? (
+            <PeekTab
+              onClick={peek.togglePeek}
+              direction={isNarrow ? "bottom" : "right"}
+            />
+          ) : null}
         </motion.div>
       </motion.div>
     </AnimatePresence>
@@ -182,8 +189,8 @@ export function DialogHeader({
  * Pill tab attached to the edge the dialog slides toward when peeked. The
  * pulsing glow signals "actionable affordance — click me to peek." Mirrors
  * `PeekRestoreTab`'s `direction` axis so the collapse cue points the same way
- * the modal exits: the right edge on wide viewports, the bottom edge on narrow
- * ones (where the dialog slides down rather than sideways).
+ * the modal exits: the right edge on wide viewports, the top-right corner on
+ * narrow ones (where the dialog slides down rather than sideways).
  */
 export function PeekTab({
   onClick,
@@ -195,21 +202,21 @@ export function PeekTab({
   const { t } = useTranslation("game");
   const shouldReduceMotion = useReducedMotion();
 
-  // Glow is offset toward the edge the modal slides to (+x right / +y bottom)
-  // so it visually radiates toward the battlefield the player wants to peek at.
+  // Wide viewports: glow biased toward the slide-off edge. Mobile top-corner
+  // tab uses a centered pulse so the affordance reads symmetric on a square btn.
   const restingShadow =
     direction === "right"
       ? "0 18px 36px rgba(0,0,0,0.55), 14px 0 0 -8px rgba(34,211,238,0)"
-      : "0 18px 36px rgba(0,0,0,0.55), 0 14px 0 -8px rgba(34,211,238,0)";
+      : "0 8px 20px rgba(0,0,0,0.45), 0 0 0 0 rgba(34,211,238,0)";
   const pulseShadow =
     direction === "right"
       ? "0 18px 36px rgba(0,0,0,0.55), 18px 0 36px rgba(34,211,238,0.65)"
-      : "0 18px 36px rgba(0,0,0,0.55), 0 18px 36px rgba(34,211,238,0.65)";
+      : "0 8px 20px rgba(0,0,0,0.45), 0 0 24px rgba(34,211,238,0.65)";
 
   const positionClass =
     direction === "right"
       ? "right-0 top-1/2 h-24 w-9 -translate-y-1/2 translate-x-1/3"
-      : "bottom-0 left-1/2 h-9 w-24 -translate-x-1/2 translate-y-1/3";
+      : "right-3 top-1 h-9 w-9 -translate-y-1/3";
 
   // The chevron points the way the modal exits: right as-is, down when rotated.
   const iconClass =

--- a/client/src/components/modal/__tests__/PeekTab.test.tsx
+++ b/client/src/components/modal/__tests__/PeekTab.test.tsx
@@ -28,13 +28,14 @@ describe("PeekRestoreTab mobile (direction=bottom)", () => {
     cleanup();
   });
 
-  it("anchors the restore cue to the right edge below mid-screen", () => {
+  it("anchors the restore cue to the left edge below mid-screen", () => {
     render(<PeekRestoreTab direction="bottom" onClick={() => {}} />);
     const button = screen.getByLabelText("Restore dialog");
-    expect(button.className).toMatch(/right-3/);
-    expect(button.className).toMatch(/top-\[62%\]/);
-    expect(button.className).toMatch(/h-16/);
-    expect(button.className).not.toMatch(/left-3/);
+    expect(button.className).toMatch(/left-3/);
+    expect(button.className).toMatch(/top-\[63%\]/);
+    expect(button.className).toMatch(/h-9/);
+    expect(button.className).toMatch(/w-9/);
+    expect(button.className).not.toMatch(/right-3/);
     expect(button.className).not.toMatch(/left-1\/2/);
     expect(button.className).not.toMatch(/bottom-3/);
   });

--- a/client/src/components/modal/__tests__/PeekTab.test.tsx
+++ b/client/src/components/modal/__tests__/PeekTab.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PeekTab } from "../DialogShell.tsx";
+import { PeekRestoreTab } from "../DialogHost.tsx";
+
+describe("PeekTab mobile (direction=bottom)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("anchors the collapse cue to the dialog top-right", () => {
+    render(
+      <div className="relative">
+        <PeekTab direction="bottom" onClick={() => {}} />
+      </div>,
+    );
+    const button = screen.getByLabelText("Move dialog out of the way");
+    expect(button.className).toMatch(/right-3/);
+    expect(button.className).toMatch(/top-1/);
+    expect(button.className).not.toMatch(/left-1\/2/);
+    expect(button.className).not.toMatch(/bottom-0/);
+  });
+});
+
+describe("PeekRestoreTab mobile (direction=bottom)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("anchors the restore cue to the right edge below mid-screen", () => {
+    render(<PeekRestoreTab direction="bottom" onClick={() => {}} />);
+    const button = screen.getByLabelText("Restore dialog");
+    expect(button.className).toMatch(/right-3/);
+    expect(button.className).toMatch(/top-\[62%\]/);
+    expect(button.className).toMatch(/h-16/);
+    expect(button.className).not.toMatch(/left-3/);
+    expect(button.className).not.toMatch(/left-1\/2/);
+    expect(button.className).not.toMatch(/bottom-3/);
+  });
+});
+
+describe("PeekTab desktop (direction=right)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the collapse cue on the dialog right edge", () => {
+    render(
+      <div className="relative">
+        <PeekTab direction="right" onClick={() => {}} />
+      </div>,
+    );
+    const button = screen.getByLabelText("Move dialog out of the way");
+    expect(button.className).toMatch(/right-0/);
+    expect(button.className).toMatch(/top-1\/2/);
+  });
+});

--- a/client/src/components/zone/CommandDock.tsx
+++ b/client/src/components/zone/CommandDock.tsx
@@ -91,6 +91,7 @@ export function CommandDock({ playerId, isMirrored }: CommandDockProps) {
         className="flex max-w-none flex-col items-end gap-1 overflow-visible"
         style={dockStyle(INLINE_SCALE)}
         data-debug-label="Command"
+        data-command-dock={isMirrored ? "opponent" : "player"}
       >
         {fullContent}
       </div>
@@ -104,6 +105,7 @@ export function CommandDock({ playerId, isMirrored }: CommandDockProps) {
       emblemCount={emblemCount}
       damageEntries={damageEntries}
       label={t("zone.commandZone")}
+      dockRole={isMirrored ? "opponent" : "player"}
     >
       {fullContent}
     </CompactCommandDock>
@@ -112,6 +114,7 @@ export function CommandDock({ playerId, isMirrored }: CommandDockProps) {
 
 interface CompactCommandDockProps {
   isMirrored: boolean;
+  dockRole: "player" | "opponent";
   commanders: GameObject[];
   emblemCount: number;
   damageEntries: CommanderDamageEntry[];
@@ -121,6 +124,7 @@ interface CompactCommandDockProps {
 
 function CompactCommandDock({
   isMirrored,
+  dockRole,
   commanders,
   emblemCount,
   damageEntries,
@@ -211,6 +215,7 @@ function CompactCommandDock({
       onMouseEnter={openDock}
       onMouseLeave={scheduleCloseDock}
       data-debug-label="Command"
+      data-command-dock={dockRole}
     >
       <button
         type="button"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -500,6 +500,41 @@ select.select-dark option {
   }
 }
 
+/* Mobile: lift the fanned hand above the fixed bottom action rail. Row height
+   is unchanged — cards still peek off the bottom edge. Desktop (lg+) untouched. */
+@media (max-width: 1023px) {
+  :root {
+    --game-mobile-hand-lift: 0.25rem;
+    --game-mobile-pile-lift: 7.5rem;
+  }
+
+  [data-flex-zone="player-row"] {
+    height: min(calc(0.24 * (100dvh - var(--game-top-overlay-offset, 0px))), 190px) !important;
+  }
+
+  [data-flex-zone="playerHandRow"] {
+    transform: translateY(calc(-1 * var(--game-mobile-hand-lift)));
+  }
+
+  [data-flex-zone="playerPiles"] {
+    bottom: var(--game-mobile-pile-lift) !important;
+  }
+}
+
+@media (max-width: 1023px) and (max-aspect-ratio: 10/11) {
+  :root {
+    --game-mobile-hand-lift: 2rem;
+    --game-mobile-pile-lift: 9.75rem;
+  }
+}
+
+@media (max-width: 1023px) and (max-height: 500px) {
+  :root {
+    --game-mobile-hand-lift: 0rem;
+    --game-mobile-pile-lift: 6rem;
+  }
+}
+
 /* Compact modal styles for landscape phones / short viewports.
    Desktop sizes require BOTH min-height: 500px AND min-width: 768px.
    This ensures landscape phones (e.g. 833×390) stay compact. */

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -504,8 +504,11 @@ select.select-dark option {
    is unchanged — cards still peek off the bottom edge. Desktop (lg+) untouched. */
 @media (max-width: 1023px) {
   :root {
-    --game-mobile-hand-lift: 0.25rem;
-    --game-mobile-pile-lift: 7.5rem;
+    --game-mobile-hand-lift: 1rem;
+    --game-mobile-pile-lift: 16rem;
+    --game-mobile-command-lift: 0.5rem;
+    --game-mobile-player-hud-lift: 0.5rem;
+    --game-mobile-player-hud-shift-x: 1.125rem;
   }
 
   [data-flex-zone="player-row"] {
@@ -519,19 +522,77 @@ select.select-dark option {
   [data-flex-zone="playerPiles"] {
     bottom: var(--game-mobile-pile-lift) !important;
   }
+
+  [data-command-dock="player"] {
+    transform: translateY(calc(-1 * var(--game-mobile-command-lift)));
+  }
+
+  [data-player-hud-anchor] {
+    transform: translate(
+        calc(-50% + var(--game-mobile-player-hud-shift-x, 0px)),
+        calc(-100% - var(--game-mobile-player-hud-lift))
+      )
+      !important;
+  }
+
+  [data-mobile-action-left] [data-combat-phase-indicator] {
+    align-self: flex-start;
+    margin-bottom: 0;
+    gap: 0.125rem;
+    padding: 0.125rem 0.375rem;
+  }
+
+  [data-mobile-action-left] [data-combat-phase-indicator] button {
+    height: 1.375rem;
+    width: 1.375rem;
+    min-height: 1.375rem;
+    min-width: 1.375rem;
+  }
+
+  [data-mobile-action-left] [data-combat-phase-indicator] button svg {
+    height: 0.625rem;
+    width: 0.625rem;
+  }
+
+  [data-mobile-action-left] [data-combat-phase-indicator] button > span {
+    transform: scale(0.85);
+  }
+
+  [data-flex-zone="actionRail"] {
+    right: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    flex-direction: row !important;
+    align-items: flex-end !important;
+    justify-content: space-between !important;
+    padding-left: calc(env(safe-area-inset-left) + var(--game-edge-right, 0.75rem));
+    padding-right: calc(env(safe-area-inset-right) + var(--game-edge-right, 0.75rem));
+    transform-origin: bottom center !important;
+  }
+
+  [data-mobile-action-left],
+  [data-mobile-action-right] {
+    width: min(calc((100vw - 3rem) / 2), 9.5rem);
+  }
 }
 
 @media (max-width: 1023px) and (max-aspect-ratio: 10/11) {
   :root {
-    --game-mobile-hand-lift: 2rem;
-    --game-mobile-pile-lift: 9.75rem;
+    --game-mobile-hand-lift: 3.25rem;
+    --game-mobile-pile-lift: 18.5rem;
+    --game-mobile-command-lift: 0.75rem;
+    --game-mobile-player-hud-lift: 1.25rem;
+    --game-mobile-player-hud-shift-x: 1.5rem;
   }
 }
 
 @media (max-width: 1023px) and (max-height: 500px) {
   :root {
-    --game-mobile-hand-lift: 0rem;
-    --game-mobile-pile-lift: 6rem;
+    --game-mobile-hand-lift: 0.75rem;
+    --game-mobile-pile-lift: 12.5rem;
+    --game-mobile-command-lift: 0.25rem;
+    --game-mobile-player-hud-lift: 0.25rem;
+    --game-mobile-player-hud-shift-x: 0.75rem;
   }
 }
 

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1278,9 +1278,11 @@ function GamePageContent({
           style={{ height: "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)" }}
           data-flex-zone="player-row"
         >
-          <div className="flex items-end justify-center">
+          <div className="flex items-end justify-center" data-flex-zone="playerHandRow">
             {/* Castable graveyard/exile cards now render as colored wings inside
-                PlayerHand's own fan (see ZoneFanCard), so the row is just the hand. */}
+                PlayerHand's own fan (see ZoneFanCard), so the row is just the hand.
+                The `playerHandRow` flex-zone hook drives the mobile hand-lift
+                transform in index.css. */}
             <PlayerHand />
           </div>
           <DraggableWidget

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1320,13 +1320,13 @@ function GamePageContent({
         </div>
       </div>
 
-      {/* Right-side fixed UI stack: combat phases → full control → action buttons → log */}
+      {/* Bottom UI: mobile splits hand/full-control (left) from phases + pass (right). */}
       <DraggableWidget
         target={{ kind: "widget", key: "actionRail" }}
         flexZone="actionRail"
         scaleKey="actionRail"
         resizeCorner="bl"
-        className="fixed z-30 flex flex-col items-end gap-1.5"
+        className="fixed z-30 flex flex-col items-end gap-1.5 max-lg:w-full max-lg:flex-row max-lg:items-end max-lg:justify-between max-lg:gap-2"
         style={{
           bottom: "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
@@ -1334,21 +1334,43 @@ function GamePageContent({
           transformOrigin: "bottom right",
         }}
       >
-        {showFlowHelpNudge && <FlowHelpNudge />}
-        {showSandboxToolsNudge && <SandboxToolsNudge />}
-        <CombatPhaseIndicator />
-        {isSpectatorMode ? (
-          <TurnStatusLine />
-        ) : (
-          <>
-            <div className="flex items-center gap-1.5">
-              <TurnStatusLine />
-              <HandBadge />
-              <FullControlToggle />
+        {!isSpectatorMode && (
+          <div
+            data-mobile-action-left
+            className="flex flex-col gap-1 max-lg:min-w-0 lg:hidden"
+          >
+            <div className="flex flex-col gap-1 max-lg:gap-1">
+              <CombatPhaseIndicator />
+              <HandBadge className="w-full" />
             </div>
-            <ActionButton />
-          </>
+            <FullControlToggle className="w-full" />
+          </div>
         )}
+        <div
+          data-mobile-action-right
+          className="flex flex-col items-end gap-1.5 max-lg:min-w-0 max-lg:items-stretch lg:items-end"
+        >
+          {showFlowHelpNudge && <FlowHelpNudge />}
+          {showSandboxToolsNudge && <SandboxToolsNudge />}
+          <div className="hidden lg:block">
+            <CombatPhaseIndicator />
+          </div>
+          {isSpectatorMode ? (
+            <TurnStatusLine />
+          ) : (
+            <>
+              <div className="max-lg:w-full lg:hidden">
+                <TurnStatusLine />
+              </div>
+              <div className="hidden flex-row items-center gap-1.5 lg:flex">
+                <TurnStatusLine />
+                <HandBadge />
+                <FullControlToggle />
+              </div>
+              <ActionButton />
+            </>
+          )}
+        </div>
       </DraggableWidget>
 
       <GameLogPanel />


### PR DESCRIPTION
## Summary

Fixes #4174 by restructuring mobile game controls into a unified bottom action dock and reserving space for it within the game layout.

### Changes

* Add portrait viewport detection via `useIsPortrait`
* Consolidate mobile actions into a single bottom dock
* Reserve bottom layout space so hand cards and commander/companion zones do not sit beneath the dock
* Add portrait and embedded variants for action buttons
* Hide non-essential controls on portrait mobile to reduce UI crowding
* Improve spacing and positioning for portrait and landscape mobile layouts

## Related Issues

Fixes #4174

## Problem

On mobile devices, the bottom action controls (Hand, Full Control, Waiting, Pass, combat indicators) could overlap each other, hand cards, and commander/companion zones. Portrait phones were particularly affected because compact-height optimizations only applied to landscape-sized viewports.

## Solution

Introduce a dedicated mobile action dock with portrait-aware behavior and reserved layout space, ensuring gameplay controls remain accessible without obscuring cards or other game UI.

## Test Plan

* [ ] Portrait phone (~390×844): Hand, Waiting, and Pass controls appear in a single dock with no overlap
* [ ] Portrait phone: commander/companion zone and piles remain visible above the dock
* [ ] Landscape phone: dock does not cover hand cards
* [ ] Desktop and tablet layouts remain unchanged
* [ ] Hand badge opens the mobile hand drawer correctly
* [ ] `pnpm exec vitest run src/components/board/__tests__/ActionButton.test.tsx src/components/controls/__tests__/PhaseStopBar.test.tsx src/hooks/__tests__/useIsPortrait.test.ts`

## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/88974407-0f01-47d5-920f-fca1f3d6ee35" />

### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/9a1bbc4a-cd10-443c-9e3f-de57a80b7644" />
