### PR TITLE
feat(engine): compound dynamic reveal count (Klaw, Sonic Subjugator)

### DIFF
--- a/crates/engine/src/game/effects/reveal_hand.rs
+++ b/crates/engine/src/game/effects/reveal_hand.rs
@@ -304,6 +304,94 @@ mod tests {
         assert_eq!(state.revealed_cards.len(), 1);
     }
 
+    /// CR 701.20a + CR 107.1: A compound `Offset` reveal count (Klaw — "one plus
+    /// the number of creature cards in your graveyard") resolves to inner+1 and
+    /// truncates the revealed set to exactly that many cards. The controller
+    /// (PlayerId(0)) has 2 creature cards in graveyard, so the count resolves to
+    /// 2 + 1 = 3; the 5-card hand must be truncated to 3 revealed cards. Before
+    /// the parser fix this count was dropped (None) at synthesis, so the whole
+    /// hand would have been revealed — this asserts the Offset both resolves and
+    /// is consumed by the resolver.
+    #[test]
+    fn reveal_hand_offset_count_truncates_to_inner_plus_one() {
+        use crate::types::ability::{CountScope, QuantityExpr, QuantityRef, TypeFilter, ZoneRef};
+        use crate::types::card_type::CoreType;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Controller (PlayerId(0)) graveyard: 2 creature cards.
+        for cid in 10..12 {
+            let gy = create_object(
+                &mut state,
+                CardId(cid),
+                PlayerId(0),
+                "Dead Bear".to_string(),
+                Zone::Graveyard,
+            );
+            state
+                .objects
+                .get_mut(&gy)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+
+        // Target (PlayerId(1)) hand: 5 cards (M > N+1 = 3).
+        for cid in 1..6 {
+            create_object(
+                &mut state,
+                CardId(cid),
+                PlayerId(1),
+                format!("Card {cid}"),
+                Zone::Hand,
+            );
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::RevealHand {
+                target: TargetFilter::Player,
+                card_filter: TargetFilter::Any,
+                count: Some(QuantityExpr::Offset {
+                    offset: 1,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::ZoneCardCount {
+                            zone: ZoneRef::Graveyard,
+                            card_types: vec![TypeFilter::Creature],
+                            filter: None,
+                            scope: CountScope::Controller,
+                        },
+                    }),
+                }),
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                choice_optional: false,
+                reveal: true,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // 2 creatures in graveyard + 1 = 3 cards revealed (not the full 5).
+        assert_eq!(
+            state.revealed_cards.len(),
+            3,
+            "Offset count must resolve to inner(2) + 1 = 3 revealed cards"
+        );
+        match &state.waiting_for {
+            WaitingFor::RevealChoice { cards, .. } => {
+                assert_eq!(
+                    cards.len(),
+                    3,
+                    "choice set is limited to the 3 revealed cards"
+                );
+            }
+            other => panic!("Expected RevealChoice, got {other:?}"),
+        }
+    }
+
     #[test]
     fn look_at_hand_is_private_to_looker_and_skips_reveal_choice() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -2770,10 +2770,15 @@ pub(super) fn parse_hand_reveal_ast(
     {
         if let Some((_, qty_text)) = lower.split_once("equal to ") {
             let qty_text = qty_text.trim_end_matches('.');
-            if let Some(qty) = super::super::oracle_quantity::parse_quantity_ref(qty_text) {
-                return Some(HandRevealImperativeAst::RevealPartial {
-                    count: crate::types::ability::QuantityExpr::Ref { qty },
-                });
+            // CR 701.20a: "reveals a number of cards ... equal to X" — the reveal
+            // count is a full dynamic quantity expression, not just a bare ref.
+            // CR 107.1: integer arithmetic; parse_cda_quantity composes the
+            // offset/arithmetic grammar ("one plus the number of creature cards in
+            // your graveyard" -> Offset{ Ref(ZoneCardCount), +1 }, Klaw) and
+            // subsumes the single-ref case. CR 107.1b: a negative result is
+            // clamped to 0 at resolution (reveal_hand.rs .max(0)).
+            if let Some(count) = super::super::oracle_quantity::parse_cda_quantity(qty_text) {
+                return Some(HandRevealImperativeAst::RevealPartial { count });
             }
         }
     }
@@ -15728,5 +15733,101 @@ mod tests {
             }
             other => panic!("expected ExchangeLifeTotals, got {other:?}"),
         }
+    }
+
+    /// Walk an `AbilityDefinition`'s effect + sub_ability chain (descending into
+    /// `CreateDelayedTrigger`'s wrapped effect) and return the first
+    /// `Effect::RevealHand`'s `count` (cloned). Returns `None` if no RevealHand
+    /// is present.
+    fn find_reveal_hand_count(def: &AbilityDefinition) -> Option<Option<QuantityExpr>> {
+        let mut cur = Some(def);
+        while let Some(d) = cur {
+            match &*d.effect {
+                Effect::RevealHand { count, .. } => return Some(count.clone()),
+                // Klaw's ETB ability synthesizes as a CreateDelayedTrigger whose
+                // wrapped effect carries the RevealHand chain.
+                Effect::CreateDelayedTrigger { effect, .. } => {
+                    if let Some(found) = find_reveal_hand_count(effect) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+            cur = d.sub_ability.as_deref();
+        }
+        None
+    }
+
+    /// CR 701.20a + CR 107.1: Klaw's full ETB ability — "When ~ enters, target
+    /// player reveals a number of cards from their hand equal to one plus the
+    /// number of creature cards in your graveyard. You choose one of them. That
+    /// player discards that card." — must synthesize Effect::RevealHand with a
+    /// full `Offset` count. Before the fix this delegated to `parse_quantity_ref`,
+    /// which returns `None` for the compound "N plus ..." form, so the count was
+    /// dropped (count == None) — measured baseline.
+    #[test]
+    fn parse_hand_reveal_compound_offset_count() {
+        // Production entry: the full Klaw oracle flows through `parse_effect_chain`,
+        // strips the "target player" subject, and lowers to Effect::RevealHand
+        // nested in the CreateDelayedTrigger. Before the fix count was None;
+        // after, it is the full Offset.
+        let def = super::super::parse_effect_chain(
+            "When ~ enters, target player reveals a number of cards from their hand equal to one plus the number of creature cards in your graveyard. You choose one of them. That player discards that card.",
+            AbilityKind::Activated,
+        );
+        let count = find_reveal_hand_count(&def).unwrap_or_else(|| {
+            panic!("expected Effect::RevealHand in chain, got {:?}", def.effect)
+        });
+        let Some(QuantityExpr::Offset { inner, offset }) = count else {
+            panic!("expected Some(Offset) count, got {count:?}");
+        };
+        assert_eq!(offset, 1);
+        let QuantityExpr::Ref { qty } = *inner else {
+            panic!("expected Ref inner, got {inner:?}");
+        };
+        match qty {
+            QuantityRef::ZoneCardCount {
+                zone,
+                card_types,
+                scope,
+                ..
+            } => {
+                assert_eq!(zone, crate::types::ability::ZoneRef::Graveyard);
+                assert!(card_types.contains(&TypeFilter::Creature));
+                assert_eq!(scope, crate::types::ability::CountScope::Controller);
+            }
+            other => panic!("expected ZoneCardCount, got {other:?}"),
+        }
+    }
+
+    /// CR 107.1: Bare-ref subsumption regression — "equal to the number of
+    /// creature cards in your graveyard" (no offset) must still lower to
+    /// RevealPartial with a plain `Ref(ZoneCardCount)`, NOT an `Offset`. Proves
+    /// `parse_cda_quantity` still handles the single-ref case the old
+    /// `parse_quantity_ref` covered (would regress if the delegate dropped bare
+    /// refs).
+    #[test]
+    fn parse_hand_reveal_bare_ref_count_subsumed() {
+        // `parse_hand_reveal_ast` receives the verb-led clause (the "target
+        // player" subject is stripped upstream), so call it with the production
+        // input shape directly.
+        let input =
+            "reveals a number of cards from their hand equal to the number of creature cards in your graveyard";
+        let lower = input.to_lowercase();
+        let result = parse_hand_reveal_ast(input, &lower, &mut ParseContext::default());
+        let Some(HandRevealImperativeAst::RevealPartial { count }) = result else {
+            panic!("{input}: expected RevealPartial, got {result:?}");
+        };
+        let QuantityExpr::Ref { qty } = count else {
+            panic!("expected bare Ref count (not Offset), got {count:?}");
+        };
+        assert!(matches!(
+            qty,
+            QuantityRef::ZoneCardCount {
+                zone: crate::types::ability::ZoneRef::Graveyard,
+                scope: crate::types::ability::CountScope::Controller,
+                ..
+            }
+        ));
     }
 }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -6687,4 +6687,54 @@ mod tests {
             }),
         );
     }
+
+    /// CR 107.1: "one plus the number of creature cards in your graveyard" (Klaw)
+    /// composes via integer arithmetic to `Offset { offset: 1, inner: Ref(ZoneCardCount) }`.
+    #[test]
+    fn cda_offset_plus_zone_card_count() {
+        let got = parse_cda_quantity("one plus the number of creature cards in your graveyard");
+        let Some(QuantityExpr::Offset { inner, offset }) = got else {
+            panic!("expected Offset, got {got:?}");
+        };
+        assert_eq!(offset, 1);
+        assert_eq!(
+            *inner,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ZoneCardCount {
+                    zone: ZoneRef::Graveyard,
+                    card_types: vec![TypeFilter::Creature],
+                    filter: None,
+                    scope: CountScope::Controller,
+                },
+            }
+        );
+    }
+
+    /// CR 107.1b: "one minus the number of creature cards in your graveyard"
+    /// generalizes to `Offset { offset: 1, inner: Multiply { -1, Ref(...) } }`,
+    /// proving the minus form negates the inner via the existing Multiply variant
+    /// (no new variant). A negative result is clamped to 0 at resolution.
+    #[test]
+    fn cda_offset_minus_zone_card_count() {
+        let got = parse_cda_quantity("one minus the number of creature cards in your graveyard");
+        let Some(QuantityExpr::Offset { inner, offset }) = got else {
+            panic!("expected Offset, got {got:?}");
+        };
+        assert_eq!(offset, 1);
+        let QuantityExpr::Multiply { factor, inner } = *inner else {
+            panic!("expected Multiply inner, got {inner:?}");
+        };
+        assert_eq!(factor, -1);
+        assert_eq!(
+            *inner,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ZoneCardCount {
+                    zone: ZoneRef::Graveyard,
+                    card_types: vec![TypeFilter::Creature],
+                    filter: None,
+                    scope: CountScope::Controller,
+                },
+            }
+        );
+    }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Building block: compound dynamic reveal count

This PR fixes **Klaw, Sonic Subjugator** — "Sonic Attack — When Klaw enters, target player reveals a number of cards from their hand equal to **one plus the number of creature cards in your graveyard**. You choose one of them. That player discards that card." The dynamic reveal count was being dropped (`Effect::RevealHand.count = null`; `supported: false`, `gap_count: 1`). The whole reveal → choose → discard structure already parsed — only the count was swallowed.

**No new engine variant** (the `add-engine-variant` gate returned EXISTS_AS_PARAMETER). The fix is a single-site parser change.

### Root cause + fix

In `oracle_effect/imperative.rs` (`parse_hand_reveal_ast`), the "reveals a number of cards ... equal to X" reveal-count parser delegated to `parse_quantity_ref`, which only recognizes a **bare** `QuantityRef` and returns `None` for a compound quantity — silently dropping the count. The fix delegates to `parse_cda_quantity` instead — the offset/arithmetic-aware entry that returns a full `QuantityExpr` and is a **strict superset** of `parse_quantity_ref` (its final arm wraps `parse_quantity_ref` in `Ref`, so every bare-ref form still parses) — and stores the `QuantityExpr` directly (no `Ref` wrapper).

"one plus the number of creature cards in your graveyard" now lowers to:

```
QuantityExpr::Offset {
  offset: 1,
  inner: Ref(QuantityRef::ZoneCardCount {
    zone: Graveyard, card_types: [Creature], scope: Controller,
  }),
}
```

reusing the existing `QuantityExpr::Offset` variant (resolver `game/quantity.rs`: `Offset { inner, offset } => recurse(inner) + offset`) and `RevealHand.count` (already `Option<QuantityExpr>`; consumed at `reveal_hand.rs` with a `.max(0)` negative clamp). No engine, type, or runtime change.

### Class this generalizes

The fix covers the whole "reveals a number of cards ... equal to `<compound dynamic quantity>`" class — offset ("N plus/minus the number of …"), fraction, multiply, binary arithmetic — plus every bare-ref form the old call handled. Klaw is the driver; future reveal-count cards with compound quantities are covered with no new code.

### CR references (verified against the Comprehensive Rules)

- **CR 107.1** — the only numbers Magic uses are integers (the reveal count is integer arithmetic).
- **CR 107.1b** — a calculation that yields a negative result uses zero instead (the `.max(0)` clamp at resolution).
- **CR 701.20a** — definition of "reveal a card".

### Tests (non-vacuous + discriminating, verified via revert-probe)

- Card-synthesis through the full `parse_effect_chain` on Klaw's oracle → `RevealHand.count == Some(Offset{1, Ref(ZoneCardCount{Graveyard,[Creature],Controller})})`; the `ChooseFromZone{count:1}` / `DiscardCard` sub-chain intact. Fail-before: `count == None`.
- Bare-ref subsumption: "equal to the number of creature cards in your graveyard" still parses to `Ref(ZoneCardCount)`, not `Offset` (proves no regression on the single-ref case).
- Combinator plus/minus offset shape.
- Runtime: 2 creature cards in the controller's graveyard + a 5-card hand → exactly **3** cards revealed. Discriminating: dropping `+offset` reveals 2, disabling the truncate reveals 5 — so the count provably drives runtime behavior end-to-end.

`mtgish/` untouched. No new serialized surface.
