### PR TITLE
feat(deck-builder): folders + stars for organizing saved decks

### DIFF
--- a/client/src/components/deck-builder/DeckBuilderToolbar.tsx
+++ b/client/src/components/deck-builder/DeckBuilderToolbar.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameFormat } from "../../adapter/types";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { FormatFilter } from "./FormatFilter";
-import { MenuSelect } from "../ui/MenuSelect";
+import { MenuSelect, type MenuSelectGroup } from "../ui/MenuSelect";
+import { useDeckFolders } from "../../hooks/useDeckFolders";
 
 function PencilIcon({ className }: { className?: string }) {
   return (
@@ -49,6 +51,31 @@ export function DeckBuilderToolbar({
     value,
     label,
   }));
+
+  // Folder-aware deck switcher: group the saved decks the same way the library
+  // does so jumping between decks while editing mirrors the library structure.
+  const { group } = useDeckFolders();
+  const grouped = useMemo(() => group(savedDecks), [group, savedDecks]);
+  const isOrganized =
+    grouped.starred.length > 0 || grouped.folders.some((entry) => entry.decks.length > 0);
+  const deckGroups = useMemo<MenuSelectGroup[]>(() => {
+    const toItems = (names: string[]) => names.map((name) => ({ value: name, label: name }));
+    const result: MenuSelectGroup[] = [];
+    if (grouped.starred.length > 0) {
+      result.push({ label: t("switcher.starred"), items: toItems(grouped.starred) });
+    }
+    for (const { folder, decks } of grouped.folders) {
+      if (decks.length > 0) result.push({ label: folder.name, items: toItems(decks) });
+    }
+    if (grouped.unfiled.length > 0) {
+      result.push({ label: t("switcher.unfiled"), items: toItems(grouped.unfiled) });
+    }
+    return result;
+  }, [grouped, t]);
+  const flatDeckItems = useMemo(
+    () => savedDecks.map((name) => ({ value: name, label: name })),
+    [savedDecks],
+  );
 
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-white/8 bg-black/18 px-3 py-2 backdrop-blur-md lg:px-4">
@@ -125,7 +152,12 @@ export function DeckBuilderToolbar({
         {savedDecks.length > 0 && (
           <MenuSelect
             label={t("toolbar.loadDeck")}
-            items={savedDecks.map((name) => ({ value: name, label: name }))}
+            items={isOrganized ? undefined : flatDeckItems}
+            groups={isOrganized ? deckGroups : undefined}
+            selectedValue={deckName}
+            filterable={savedDecks.length > 8}
+            filterPlaceholder={t("switcher.searchPlaceholder")}
+            noMatchesLabel={t("switcher.noMatches")}
             onSelect={onLoad}
             wrapperClassName="min-w-0 w-full lg:w-auto lg:shrink-0"
           />

--- a/client/src/components/deck-builder/__tests__/DeckBuilder.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckBuilder.test.tsx
@@ -7,7 +7,14 @@ import { DeckBuilder } from "../DeckBuilder";
 import { loadPreconDeckMap } from "../../../hooks/useDecks";
 import { resolveCommander } from "../../../services/deckParser";
 import { useIsMobile } from "../../../hooks/useIsMobile";
-import { ACTIVE_DECK_KEY, STORAGE_KEY_PREFIX } from "../../../constants/storage";
+import {
+  ACTIVE_DECK_KEY,
+  STORAGE_KEY_PREFIX,
+  createFolder,
+  getDeckMeta,
+  setDeckFolder,
+  toggleDeckStar,
+} from "../../../constants/storage";
 import { useAppNotificationStore } from "../../../stores/appToastStore";
 
 const cacheCardsMock = vi.fn();
@@ -217,6 +224,48 @@ describe("DeckBuilder", () => {
     });
   });
 
+  it("preserves folder and star membership across a rename", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      STORAGE_KEY_PREFIX + "Old Deck",
+      JSON.stringify({
+        main: [{ name: "Lightning Bolt", count: 4 }],
+        sideboard: [],
+        format: "Standard",
+      }),
+    );
+    localStorage.setItem(ACTIVE_DECK_KEY, "Old Deck");
+    const folder = createFolder("Aggro")!;
+    setDeckFolder("Old Deck", folder.id);
+    toggleDeckStar("Old Deck");
+
+    render(
+      <DeckBuilder
+        format="Standard"
+        onFormatChange={vi.fn()}
+        initialDeckName="Old Deck"
+        searchFilters={{ text: "", colors: [], type: "", sets: [], browseFormat: "all" }}
+        onSearchFiltersChange={vi.fn()}
+        onResetSearch={vi.fn()}
+      />,
+    );
+
+    const nameInput = await screen.findByRole("textbox", { name: "Deck name" });
+    await waitFor(() => expect(nameInput).toHaveValue("Old Deck"));
+    await user.clear(nameInput);
+    await user.type(nameInput, "Renamed Deck");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(localStorage.getItem(STORAGE_KEY_PREFIX + "Renamed Deck")).not.toBeNull(),
+    );
+    // Organization follows the deck to its new name; the old entry is gone.
+    const meta = getDeckMeta("Renamed Deck");
+    expect(meta?.folderId).toBe(folder.id);
+    expect(meta?.starred).toBe(true);
+    expect(getDeckMeta("Old Deck")).toBeNull();
+  });
+
   it("warns about unsaved changes when leaving after an edit", async () => {
     const user = userEvent.setup();
     localStorage.setItem(
@@ -404,6 +453,46 @@ describe("DeckBuilder", () => {
       title: "Deck cloned",
       description: 'A copy was saved as "My Deck copy".',
     });
+  });
+
+  it("clones into the source's folder but starts the copy unstarred", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      STORAGE_KEY_PREFIX + "My Deck",
+      JSON.stringify({
+        main: [{ name: "Lightning Bolt", count: 4 }],
+        sideboard: [],
+        format: "Standard",
+      }),
+    );
+    const folder = createFolder("Commander")!;
+    setDeckFolder("My Deck", folder.id);
+    toggleDeckStar("My Deck");
+
+    render(
+      <DeckBuilder
+        format="Standard"
+        onFormatChange={vi.fn()}
+        initialDeckName="My Deck"
+        searchFilters={{ text: "", colors: [], type: "", sets: [], browseFormat: "all" }}
+        onSearchFiltersChange={vi.fn()}
+        onResetSearch={vi.fn()}
+      />,
+    );
+
+    const nameInput = await screen.findByRole("textbox", { name: "Deck name" });
+    await waitFor(() => expect(nameInput).toHaveValue("My Deck"));
+    await user.click(screen.getByRole("button", { name: "Clone" }));
+
+    await waitFor(() =>
+      expect(localStorage.getItem(STORAGE_KEY_PREFIX + "My Deck copy")).not.toBeNull(),
+    );
+    // The clone inherits the folder, but the star is a deliberate per-deck pin.
+    const meta = getDeckMeta("My Deck copy");
+    expect(meta?.folderId).toBe(folder.id);
+    expect(meta?.starred).toBeUndefined();
+    // Source deck keeps its own star.
+    expect(getDeckMeta("My Deck")?.starred).toBe(true);
   });
 
   it("does not reactively auto-resolve a commander mid-edit", async () => {

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -10,9 +10,11 @@ import { evaluateDeckCompatibility, type DeckCompatibilityResult } from "../../s
 import {
   ACTIVE_DECK_KEY,
   STORAGE_KEY_PREFIX,
+  getDeckMeta,
   loadSavedDeck,
   loadSavedDeckBracket,
-  removeDeckMeta,
+  migrateDeckMeta,
+  setDeckFolder,
   stampDeckMeta,
 } from "../../constants/storage";
 import { BASIC_LAND_NAMES } from "../../constants/game";
@@ -443,7 +445,13 @@ export function useDeckBuilder({
       && localStorage.getItem(STORAGE_KEY_PREFIX + savedDeckName) !== null
     ) {
       localStorage.removeItem(STORAGE_KEY_PREFIX + savedDeckName);
-      removeDeckMeta(savedDeckName);
+      // Carry folder/star membership + timestamps to the new name; the
+      // trailing stampDeckMeta(nextName) then no-ops since the entry exists.
+      // If nextName already names another deck, the setItem below overwrites
+      // its data (pre-existing Save behavior) and this migration likewise
+      // replaces its metadata — both correctly reflect the surviving deck's
+      // identity now living under nextName.
+      migrateDeckMeta(savedDeckName, nextName);
       if (localStorage.getItem(ACTIVE_DECK_KEY) === savedDeckName) {
         localStorage.setItem(ACTIVE_DECK_KEY, nextName);
       }
@@ -484,6 +492,12 @@ export function useDeckBuilder({
     if (bracket !== null) payload.bracket = bracket;
     localStorage.setItem(STORAGE_KEY_PREFIX + cloneName, JSON.stringify(payload));
     stampDeckMeta(cloneName);
+    // A clone lands beside its source: inherit the folder, but start unstarred
+    // (the star is a deliberate per-deck pin, not a copyable property).
+    const sourceFolderId = savedDeckName
+      ? getDeckMeta(savedDeckName)?.folderId ?? null
+      : null;
+    if (sourceFolderId) setDeckFolder(cloneName, sourceFolderId);
     setDeckName(cloneName);
     setSavedDeckName(cloneName);
     setSavedDecks(listSavedDecks());
@@ -493,7 +507,7 @@ export function useDeckBuilder({
       title: t("toolbar.clonedToastTitle"),
       description: t("toolbar.clonedToastDescription", { name: cloneName }),
     });
-  }, [deckName, currentDeck, format, bracket, showNotification, t]);
+  }, [deckName, currentDeck, format, bracket, savedDeckName, showNotification, t]);
 
   useEffect(() => {
     if (!justSaved) return;

--- a/client/src/components/menu/DeckActionsMenu.tsx
+++ b/client/src/components/menu/DeckActionsMenu.tsx
@@ -1,0 +1,122 @@
+import { useTranslation } from "react-i18next";
+
+import type { DeckFolder } from "../../constants/storage";
+import { PopoverMenu, popoverMenuItemClass } from "./PopoverMenu";
+
+interface DeckActionsMenuProps {
+  starred: boolean;
+  folders: DeckFolder[];
+  /** Folder the deck currently lives in (checked, omitted as a move target). */
+  currentFolderId?: string;
+  onToggleStar: () => void;
+  /** Assign to a folder, or `null` for Unfiled. */
+  onAssignFolder: (folderId: string | null) => void;
+  /** Create a new folder and move this deck into it (parent prompts for a name). */
+  onNewFolder: () => void;
+}
+
+/**
+ * Per-tile overflow (kebab) menu for organizing a saved user deck: star/unstar
+ * and move-to-folder (including "New folder…"). Built on {@link PopoverMenu}.
+ */
+export function DeckActionsMenu({
+  starred,
+  folders,
+  currentFolderId,
+  onToggleStar,
+  onAssignFolder,
+  onNewFolder,
+}: DeckActionsMenuProps) {
+  const { t } = useTranslation("menu");
+
+  const runAndClose = (close: () => void, action: () => void) => (event: React.MouseEvent) => {
+    event.stopPropagation();
+    action();
+    close();
+  };
+
+  return (
+    <PopoverMenu ariaLabel={t("deckTile.actionsMenu")}>
+      {(close) => (
+        <>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={runAndClose(close, onToggleStar)}
+            className={popoverMenuItemClass}
+          >
+            <StarIcon filled={starred} />
+            {starred ? t("deckTile.unstar") : t("deckTile.star")}
+          </button>
+
+          <div className="my-1 border-t border-white/8" />
+          <div
+            role="presentation"
+            className="px-3 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-slate-500"
+          >
+            {t("deckTile.moveToFolder")}
+          </div>
+
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={currentFolderId == null}
+            onClick={runAndClose(close, () => onAssignFolder(null))}
+            className={popoverMenuItemClass}
+          >
+            <span className="min-w-0 flex-1 truncate">{t("deckTile.unfiled")}</span>
+            {currentFolderId == null && <CheckIcon />}
+          </button>
+          {folders.map((folder) => (
+            <button
+              key={folder.id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={currentFolderId === folder.id}
+              onClick={runAndClose(close, () => onAssignFolder(folder.id))}
+              className={popoverMenuItemClass}
+              title={folder.name}
+            >
+              <span className="min-w-0 flex-1 truncate">{folder.name}</span>
+              {currentFolderId === folder.id && <CheckIcon />}
+            </button>
+          ))}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={runAndClose(close, onNewFolder)}
+            className={popoverMenuItemClass}
+          >
+            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-3.5 w-3.5 text-slate-400">
+              <path d="M8.75 4.75a.75.75 0 0 0-1.5 0V7.25H4.75a.75.75 0 0 0 0 1.5H7.25v2.5a.75.75 0 0 0 1.5 0V8.75h2.5a.75.75 0 0 0 0-1.5H8.75V4.75Z" />
+            </svg>
+            {t("deckTile.newFolder")}
+          </button>
+        </>
+      )}
+    </PopoverMenu>
+  );
+}
+
+function StarIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth={filled ? 0 : 1.3}
+      aria-hidden="true"
+      className={`h-3.5 w-3.5 ${filled ? "text-amber-300" : "text-slate-400"}`}
+    >
+      <path d="M8 1.5l1.9 3.85 4.25.62-3.07 3 .72 4.23L8 11.2l-3.8 2 .72-4.23-3.07-3 4.25-.62L8 1.5Z" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-emerald-300">
+      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-6.5 6.5a.75.75 0 0 1-1.06 0l-3-3a.75.75 0 1 1 1.06-1.06L6.75 10.19l5.97-5.97a.75.75 0 0 1 1.06 0Z" />
+    </svg>
+  );
+}

--- a/client/src/components/menu/DeckSection.tsx
+++ b/client/src/components/menu/DeckSection.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+
+interface DeckSectionProps {
+  title: string;
+  count: number;
+  /** Leading glyph (e.g. star for the Starred section, lock for system folders). */
+  icon?: ReactNode;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  /** Right-aligned header control (folder kebab, "Manage feeds", "Browse all"). */
+  headerAction?: ReactNode;
+  /** Shown in place of the body when the section is expanded but has no decks. */
+  emptyHint?: string;
+  children: ReactNode;
+}
+
+/**
+ * One collapsible deck-library section. Shared chrome for user folders, the
+ * virtual Starred/Unfiled buckets, and the immutable system folders (Starter,
+ * Precons) — so the whole library speaks one visual language and every section
+ * participates in Collapse-All / Expand-All.
+ */
+export function DeckSection({
+  title,
+  count,
+  icon,
+  collapsed,
+  onToggleCollapsed,
+  headerAction,
+  emptyHint,
+  children,
+}: DeckSectionProps) {
+  return (
+    <section>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-expanded={!collapsed}
+          className="group/section flex min-w-0 items-center gap-2 text-xs font-semibold uppercase tracking-wider text-slate-400 transition-colors hover:text-slate-200"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+            className={`h-3.5 w-3.5 shrink-0 text-slate-500 transition-transform duration-150 ${
+              collapsed ? "-rotate-90" : ""
+            }`}
+          >
+            <path d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" />
+          </svg>
+          {icon}
+          <span className="min-w-0 truncate">{title}</span>
+          <span className="text-slate-600">{count}</span>
+        </button>
+        {headerAction}
+      </div>
+      {!collapsed &&
+        (count === 0 && emptyHint ? (
+          <p className="rounded-lg border border-dashed border-white/10 px-3 py-4 text-center text-xs text-slate-500">
+            {emptyHint}
+          </p>
+        ) : (
+          children
+        ))}
+    </section>
+  );
+}

--- a/client/src/components/menu/FolderActionsMenu.tsx
+++ b/client/src/components/menu/FolderActionsMenu.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from "react-i18next";
+
+import { PopoverMenu, popoverMenuItemClass } from "./PopoverMenu";
+
+interface FolderActionsMenuProps {
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+/** Per-folder header kebab: rename or delete a user folder (its decks move to
+ * Unfiled on delete — handled by the caller). Built on {@link PopoverMenu}. */
+export function FolderActionsMenu({ onRename, onDelete }: FolderActionsMenuProps) {
+  const { t } = useTranslation("menu");
+
+  const runAndClose = (close: () => void, action: () => void) => (event: React.MouseEvent) => {
+    event.stopPropagation();
+    action();
+    close();
+  };
+
+  return (
+    <PopoverMenu ariaLabel={t("folder.actionsMenu")} menuWidthPx={176}>
+      {(close) => (
+        <>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={runAndClose(close, onRename)}
+            className={popoverMenuItemClass}
+          >
+            {t("folder.rename")}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={runAndClose(close, onDelete)}
+            className={`${popoverMenuItemClass} text-red-300 hover:bg-red-500/15`}
+          >
+            {t("folder.delete")}
+          </button>
+        </>
+      )}
+    </PopoverMenu>
+  );
+}

--- a/client/src/components/menu/MyDecks.tsx
+++ b/client/src/components/menu/MyDecks.tsx
@@ -4,8 +4,13 @@ import { useTranslation } from "react-i18next";
 
 import type { GameFormat, MatchType } from "../../adapter/types";
 import type { FeedDeck } from "../../types/feed";
-import { ACTIVE_DECK_KEY, listSavedDeckNames, getDeckMeta, deleteDeck } from "../../constants/storage";
+import { ACTIVE_DECK_KEY, listSavedDeckNames, getDeckMeta, deleteDeck, type DeckFolder } from "../../constants/storage";
 import { PROFILE_REPLACED_EVENT } from "../../stores/cloudSyncStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { useDeckFolders } from "../../hooks/useDeckFolders";
+import { DeckActionsMenu } from "./DeckActionsMenu";
+import { FolderActionsMenu } from "./FolderActionsMenu";
+import { DeckSection } from "./DeckSection";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import {
   getDeckFeedOrigin,
@@ -48,6 +53,12 @@ import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import { getSharedAdapter } from "../../adapter/wasm-adapter";
 const PRECON_PREFIX = "[Pre-built] ";
 const PRECON_PAGE_SIZE = 12;
+/** Sentinel section ids for the virtual/system folders in the collapse set. */
+const STARRED_SECTION_ID = "__starred__";
+const UNFILED_SECTION_ID = "__unfiled__";
+const STARTER_SECTION_ID = "__starter__";
+const PRECON_SECTION_ID = "__precon__";
+const DECK_GRID_CLASS = "grid w-full gap-4 grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]";
 const DECK_SCAN_BATCH_SIZE = 1;
 const COVERAGE_SCAN_BATCH_SIZE = 6;
 
@@ -178,9 +189,11 @@ interface DeckTileProps {
   /** Catalog candidate — when provided and the deck is Commander format, renders
    *  a BracketEstimateChip in the tile's footer. */
   catalogCandidate?: DeckCatalogCandidate;
+  /** Organize control (star + move-to-folder kebab) rendered next to Edit. */
+  actionsMenu?: ReactNode;
 }
 
-const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onClick, onEdit, onDelete, onAdopt, hideFeedBadge, feedDeckOverride, preconDeckOverride, catalogCandidate }: DeckTileProps) {
+const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onClick, onEdit, onDelete, onAdopt, hideFeedBadge, feedDeckOverride, preconDeckOverride, catalogCandidate, actionsMenu }: DeckTileProps) {
   const { t } = useTranslation("menu");
   const [coverageHovered, setCoverageHovered] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -314,6 +327,7 @@ const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onC
               </svg>
             </button>
           )}
+          {actionsMenu}
         </div>
         <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
           <span className="font-display text-xs text-slate-400 tabular-nums">{t("deckTile.cardCount", { count })}</span>
@@ -395,6 +409,20 @@ interface SavedDeckTileProps {
   preconCandidate?: DeckCatalogCandidate;
   /** Non-precon catalog candidate — provides deck + format data for bracket chip. */
   catalogCandidate?: DeckCatalogCandidate;
+  /**
+   * Organize props — passed flat (not wrapped in an object) so each one keeps a
+   * stable identity across re-renders and `SavedDeckTile`'s memo holds during
+   * coverage-scan storms. The star + move-to-folder kebab renders only when the
+   * organize callbacks are present (manage mode, user decks); `folders` and the
+   * callbacks are stable refs from the parent, `starred`/`currentFolderId` are
+   * primitives read from the deck's metadata.
+   */
+  folders?: DeckFolder[];
+  starred?: boolean;
+  currentFolderId?: string;
+  onToggleStar?: (deckName: string) => void;
+  onAssignFolder?: (deckName: string, folderId: string | null) => void;
+  onNewFolder?: (deckName: string) => void;
 }
 
 const SavedDeckTile = memo(function SavedDeckTile({
@@ -406,6 +434,12 @@ const SavedDeckTile = memo(function SavedDeckTile({
   onDeleteDeck,
   preconCandidate,
   catalogCandidate,
+  folders,
+  starred,
+  currentFolderId,
+  onToggleStar,
+  onAssignFolder,
+  onNewFolder,
 }: SavedDeckTileProps) {
   const handleClick = useCallback(() => onTileClick(deckName), [deckName, onTileClick]);
   const handleEdit = useMemo(
@@ -418,6 +452,20 @@ const SavedDeckTile = memo(function SavedDeckTile({
     [preconCandidate],
   );
 
+  // The four narrow together, so TS proves the callbacks defined inside — no
+  // non-null assertions needed. Present only in manage mode for user decks.
+  const actionsMenu =
+    folders && onToggleStar && onAssignFolder && onNewFolder ? (
+      <DeckActionsMenu
+        starred={!!starred}
+        folders={folders}
+        currentFolderId={currentFolderId}
+        onToggleStar={() => onToggleStar(deckName)}
+        onAssignFolder={(folderId) => onAssignFolder(deckName, folderId)}
+        onNewFolder={() => onNewFolder(deckName)}
+      />
+    ) : undefined;
+
   return (
     <DeckTile
       deckName={deckName}
@@ -428,6 +476,7 @@ const SavedDeckTile = memo(function SavedDeckTile({
       onClick={handleClick}
       onEdit={handleEdit}
       onDelete={handleDelete}
+      actionsMenu={actionsMenu}
     />
   );
 });
@@ -584,6 +633,50 @@ export function MyDecks({
     sortMenuItems.find((item) => item.value === activeSort)?.label ?? t("myDecks.sortName");
   const [sortAsc, setSortAsc] = useState(mode !== "select");
   const [searchQuery, setSearchQuery] = useState("");
+
+  // Folder/star organization (user decks only). The grouping authority +
+  // mutators come from useDeckFolders; collapse state lives in preferences so
+  // it persists and cloud-syncs.
+  const { folders, group, createFolder, renameFolder, deleteFolder, assignDeck, toggleStar } =
+    useDeckFolders();
+  const collapsedFolderIds = usePreferencesStore((s) => s.collapsedFolderIds);
+  const toggleFolderCollapsed = usePreferencesStore((s) => s.toggleFolderCollapsed);
+  const setCollapsedFolderIds = usePreferencesStore((s) => s.setCollapsedFolderIds);
+
+  const handleToggleStar = useCallback((name: string) => toggleStar(name), [toggleStar]);
+  const handleAssignFolder = useCallback(
+    (name: string, folderId: string | null) => assignDeck(name, folderId),
+    [assignDeck],
+  );
+  const handleNewFolderForDeck = useCallback(
+    (name: string) => {
+      const folderName = prompt(t("folder.newFolderPrompt"));
+      if (!folderName?.trim()) return;
+      const folder = createFolder(folderName);
+      if (folder) assignDeck(name, folder.id);
+    },
+    [createFolder, assignDeck, t],
+  );
+  const handleCreateFolder = useCallback(() => {
+    const folderName = prompt(t("folder.newFolderPrompt"));
+    if (folderName?.trim()) createFolder(folderName);
+  }, [createFolder, t]);
+  const handleRenameFolder = useCallback(
+    (id: string, currentName: string) => {
+      const next = prompt(t("folder.renamePrompt"), currentName);
+      if (next != null) renameFolder(id, next);
+    },
+    [renameFolder, t],
+  );
+  const handleDeleteFolder = useCallback(
+    (id: string, name: string) => {
+      if (!confirm(t("folder.deleteConfirm", { name }))) return;
+      deleteFolder(id);
+      // Drop the now-dead id from the persisted collapse set so it can't leak.
+      setCollapsedFolderIds(collapsedFolderIds.filter((existing) => existing !== id));
+    },
+    [deleteFolder, t, setCollapsedFolderIds, collapsedFolderIds],
+  );
 
   useEffect(() => {
     setActiveFilter(contextualFilter ?? "all");
@@ -1066,6 +1159,98 @@ export function MyDecks({
     setDeckNames(listSavedDeckNames());
   };
 
+  // Group the user's own decks into Starred / folders / Unfiled. Bundled and
+  // precon decks are separate immutable system folders, handled below.
+  const groupedUserDecks = useMemo(() => group(userDecks), [group, userDecks]);
+  const hasUserOrganization =
+    folders.length > 0 || groupedUserDecks.starred.length > 0;
+  const searching = searchQuery.trim().length > 0;
+
+  const renderedSectionIds = useMemo(() => {
+    const ids: string[] = [];
+    if (hasUserOrganization) {
+      if (groupedUserDecks.starred.length > 0) ids.push(STARRED_SECTION_ID);
+      for (const { folder } of groupedUserDecks.folders) ids.push(folder.id);
+      ids.push(UNFILED_SECTION_ID);
+    }
+    if (bundledDecks.length > 0) ids.push(STARTER_SECTION_ID);
+    if (preconDeckNames.length > 0) ids.push(PRECON_SECTION_ID);
+    return ids;
+  }, [hasUserOrganization, groupedUserDecks, bundledDecks.length, preconDeckNames.length]);
+
+  // A section is collapsed only when explicitly collapsed AND not overridden by
+  // an active search (force-expand) or, in select mode, by holding the active
+  // deck (so the current selection is never hidden).
+  const isSectionCollapsed = useCallback(
+    (id: string, sectionDeckNames: string[]): boolean => {
+      if (searching) return false;
+      if (
+        mode === "select" &&
+        activeDeckName != null &&
+        sectionDeckNames.includes(activeDeckName)
+      ) {
+        return false;
+      }
+      return collapsedFolderIds.includes(id);
+    },
+    [searching, mode, activeDeckName, collapsedFolderIds],
+  );
+
+  // While a search is active every section is force-expanded (see
+  // isSectionCollapsed), so toggling collapse would only mutate the persisted
+  // set with no visible effect — and surprise the user once the search clears.
+  // Make the chevron an honest no-op during search.
+  const handleToggleSection = useCallback(
+    (id: string) => {
+      if (searching) return;
+      toggleFolderCollapsed(id);
+    },
+    [searching, toggleFolderCollapsed],
+  );
+
+  const renderUserDeckTile = useCallback(
+    (deckName: string) => {
+      // Manage mode supplies the organize props (stable callbacks + folders ref,
+      // primitive star/folder reads) so the tile's memo holds during scans;
+      // select mode passes none, hiding the kebab.
+      const manage = mode === "manage";
+      const meta = manage ? getDeckMeta(deckName) : null;
+      return (
+        <SavedDeckTile
+          key={deckName}
+          deckName={deckName}
+          isActive={deckName === activeDeckName}
+          compatibility={compatibilities[deckName]}
+          onTileClick={handleTileClick}
+          onEditDeck={onEditDeck}
+          onDeleteDeck={handleDeleteDeck}
+          preconCandidate={legalPreconByName.get(deckName)}
+          catalogCandidate={deckCandidatesByName.get(deckName)}
+          folders={manage ? folders : undefined}
+          starred={meta?.starred}
+          currentFolderId={meta?.folderId}
+          onToggleStar={manage ? handleToggleStar : undefined}
+          onAssignFolder={manage ? handleAssignFolder : undefined}
+          onNewFolder={manage ? handleNewFolderForDeck : undefined}
+        />
+      );
+    },
+    [
+      mode,
+      activeDeckName,
+      compatibilities,
+      handleTileClick,
+      onEditDeck,
+      handleDeleteDeck,
+      legalPreconByName,
+      deckCandidatesByName,
+      folders,
+      handleToggleStar,
+      handleAssignFolder,
+      handleNewFolderForDeck,
+    ],
+  );
+
   const Wrapper = bare ? "div" : MenuPanel;
   const wrapperClass = bare
     ? "flex w-full min-w-0 flex-col items-center gap-4"
@@ -1306,15 +1491,38 @@ export function MyDecks({
         </div>
       ) : (
         <div className="flex w-full flex-col gap-6">
-          {/* User decks section */}
-          <div>
-            <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
-              {t("myDecks.sectionMyDecks")}
-              {userDecks.length > 0 && (
-                <span className="ml-2 text-slate-600">{userDecks.length}</span>
-              )}
-            </h3>
-            <div className="grid w-full gap-4 grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]">
+          {/* Quick actions: import/precon entry points + folder controls. */}
+          <div className="flex flex-col gap-3">
+            {mode === "manage" && (
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleCreateFolder}
+                  className={menuButtonClass({ tone: "neutral", size: "sm" })}
+                >
+                  {t("folder.newFolder")}
+                </button>
+                {renderedSectionIds.length > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setCollapsedFolderIds(renderedSectionIds)}
+                      className="rounded px-2 py-1 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white"
+                    >
+                      {t("myDecks.collapseAll")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setCollapsedFolderIds([])}
+                      className="rounded px-2 py-1 text-xs text-slate-400 ring-1 ring-white/10 transition-colors hover:bg-white/5 hover:text-white"
+                    >
+                      {t("myDecks.expandAll")}
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+            <div className={DECK_GRID_CLASS}>
               <AddDeckTile
                 label={t("myDecks.importDeckTile")}
                 onClick={() => setShowImport(true)}
@@ -1329,39 +1537,80 @@ export function MyDecks({
                   <path d="M3 3.5A1.5 1.5 0 0 1 4.5 2h7A1.5 1.5 0 0 1 13 3.5v13a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 16.5v-13Zm11.25.5a.75.75 0 0 1 .75.75v11.5a.75.75 0 0 1-1.5 0V4.75a.75.75 0 0 1 .75-.75Zm2.5 1.5a.75.75 0 0 1 .75.75v8.5a.75.75 0 0 1-1.5 0v-8.5a.75.75 0 0 1 .75-.75Z" />
                 }
               />
-
-              {userDecks.map((deckName) => (
-                <SavedDeckTile
-                  key={deckName}
-                  deckName={deckName}
-                  isActive={deckName === activeDeckName}
-                  compatibility={compatibilities[deckName]}
-                  onTileClick={handleTileClick}
-                  onEditDeck={onEditDeck}
-                  onDeleteDeck={handleDeleteDeck}
-                  preconCandidate={legalPreconByName.get(deckName)}
-                  catalogCandidate={deckCandidatesByName.get(deckName)}
-                />
-              ))}
             </div>
           </div>
 
-          {/* Bundled decks section */}
+          {/* User decks: a flat grid until the user creates a folder or stars a
+              deck, then collapsible Starred / folder / Unfiled sections. */}
+          {!hasUserOrganization ? (
+            userDecks.length > 0 && (
+              <div className={DECK_GRID_CLASS}>{userDecks.map(renderUserDeckTile)}</div>
+            )
+          ) : (
+            <>
+              {groupedUserDecks.starred.length > 0 && (
+                <DeckSection
+                  title={t("myDecks.sectionStarred")}
+                  count={groupedUserDecks.starred.length}
+                  icon={<SectionStarIcon />}
+                  collapsed={isSectionCollapsed(STARRED_SECTION_ID, groupedUserDecks.starred)}
+                  onToggleCollapsed={() => handleToggleSection(STARRED_SECTION_ID)}
+                >
+                  <div className={DECK_GRID_CLASS}>
+                    {groupedUserDecks.starred.map(renderUserDeckTile)}
+                  </div>
+                </DeckSection>
+              )}
+              {groupedUserDecks.folders.map(({ folder, decks }) => (
+                <DeckSection
+                  key={folder.id}
+                  title={folder.name}
+                  count={decks.length}
+                  collapsed={isSectionCollapsed(folder.id, decks)}
+                  onToggleCollapsed={() => handleToggleSection(folder.id)}
+                  emptyHint={t("folder.emptyHint")}
+                  headerAction={
+                    <FolderActionsMenu
+                      onRename={() => handleRenameFolder(folder.id, folder.name)}
+                      onDelete={() => handleDeleteFolder(folder.id, folder.name)}
+                    />
+                  }
+                >
+                  <div className={DECK_GRID_CLASS}>{decks.map(renderUserDeckTile)}</div>
+                </DeckSection>
+              ))}
+              <DeckSection
+                title={t("myDecks.sectionUnfiled")}
+                count={groupedUserDecks.unfiled.length}
+                collapsed={isSectionCollapsed(UNFILED_SECTION_ID, groupedUserDecks.unfiled)}
+                onToggleCollapsed={() => handleToggleSection(UNFILED_SECTION_ID)}
+                emptyHint={t("folder.unfiledEmptyHint")}
+              >
+                <div className={DECK_GRID_CLASS}>
+                  {groupedUserDecks.unfiled.map(renderUserDeckTile)}
+                </div>
+              </DeckSection>
+            </>
+          )}
+
+          {/* Starter decks — an immutable system folder. */}
           {bundledDecks.length > 0 && (
-            <div>
-              <div className="mb-3 flex items-center justify-between">
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  {t("myDecks.sectionStarterDecks")}
-                  <span className="ml-2 text-slate-600">{bundledDecks.length}</span>
-                </h3>
+            <DeckSection
+              title={t("myDecks.sectionStarterDecks")}
+              count={bundledDecks.length}
+              icon={<SectionLockIcon />}
+              collapsed={isSectionCollapsed(STARTER_SECTION_ID, bundledDecks)}
+              onToggleCollapsed={() => handleToggleSection(STARTER_SECTION_ID)}
+              headerAction={
                 <button
                   onClick={() => setShowFeedManager(true)}
                   className="text-[11px] text-slate-500 transition-colors hover:text-slate-300"
                 >
                   {t("myDecks.manageFeeds")}
                 </button>
-              </div>
-              <div className="grid w-full gap-4 grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]">
+              }
+            >
+              <div className={DECK_GRID_CLASS}>
                 {bundledDecks.map((deckName) => (
                   <SavedDeckTile
                     key={deckName}
@@ -1376,39 +1625,39 @@ export function MyDecks({
                   />
                 ))}
               </div>
-            </div>
+            </DeckSection>
           )}
 
+          {/* Legal precons — an immutable system folder. */}
           {preconDeckNames.length > 0 && (
-            <div className="rounded-[18px] border border-white/8 bg-black/10 p-3">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-                  {t("myDecks.sectionLegalPrecons")}
-                  <span className="ml-2 text-slate-600">{preconDeckNames.length}</span>
-                </h3>
+            <DeckSection
+              title={t("myDecks.sectionLegalPrecons")}
+              count={preconDeckNames.length}
+              icon={<SectionLockIcon />}
+              collapsed={isSectionCollapsed(PRECON_SECTION_ID, displayedPreconDeckNames)}
+              onToggleCollapsed={() => handleToggleSection(PRECON_SECTION_ID)}
+              headerAction={
                 <button
                   onClick={() => setShowPrecon(true)}
                   className="text-[11px] text-slate-500 transition-colors hover:text-slate-300"
                 >
                   {t("myDecks.browseAll")}
                 </button>
-              </div>
-              <div className="grid w-full gap-4 grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]">
-                {displayedPreconDeckNames.map((deckName) => {
-                  const candidate = legalPreconByName.get(deckName);
-                  return (
-                    <SavedDeckTile
-                      key={deckName}
-                      deckName={deckName}
-                      isActive={deckName === activeDeckName}
-                      compatibility={compatibilities[deckName]}
-                      onTileClick={handleTileClick}
-                      onEditDeck={onEditDeck}
-                      onDeleteDeck={handleDeleteDeck}
-                      preconCandidate={candidate}
-                    />
-                  );
-                })}
+              }
+            >
+              <div className={DECK_GRID_CLASS}>
+                {displayedPreconDeckNames.map((deckName) => (
+                  <SavedDeckTile
+                    key={deckName}
+                    deckName={deckName}
+                    isActive={deckName === activeDeckName}
+                    compatibility={compatibilities[deckName]}
+                    onTileClick={handleTileClick}
+                    onEditDeck={onEditDeck}
+                    onDeleteDeck={handleDeleteDeck}
+                    preconCandidate={legalPreconByName.get(deckName)}
+                  />
+                ))}
               </div>
               {displayedPreconDeckNames.length < preconDeckNames.length && (
                 <div className="mt-4 flex justify-center">
@@ -1421,7 +1670,7 @@ export function MyDecks({
                   </button>
                 </div>
               )}
-            </div>
+            </DeckSection>
           )}
         </div>
       )}
@@ -1576,5 +1825,21 @@ function AddDeckTile({ label, icon, onClick }: AddDeckTileProps) {
         {label}
       </span>
     </button>
+  );
+}
+
+function SectionStarIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-amber-300">
+      <path d="M8 1.5l1.9 3.85 4.25.62-3.07 3 .72 4.23L8 11.2l-3.8 2 .72-4.23-3.07-3 4.25-.62L8 1.5Z" />
+    </svg>
+  );
+}
+
+function SectionLockIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-slate-500">
+      <path fillRule="evenodd" d="M4.5 7V5.5a3.5 3.5 0 1 1 7 0V7h.25A1.25 1.25 0 0 1 13 8.25v4.5A1.25 1.25 0 0 1 11.75 14h-7.5A1.25 1.25 0 0 1 3 12.75v-4.5A1.25 1.25 0 0 1 4.25 7H4.5Zm1.5-1.5a2 2 0 1 1 4 0V7H6V5.5Z" clipRule="evenodd" />
+    </svg>
   );
 }

--- a/client/src/components/menu/PopoverMenu.tsx
+++ b/client/src/components/menu/PopoverMenu.tsx
@@ -1,0 +1,156 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+
+const MENU_GAP_PX = 4;
+const MENU_VIEWPORT_PADDING_PX = 8;
+const OPEN_UP_THRESHOLD_PX = 200;
+
+interface PopoverMenuStyle {
+  top: number | "auto";
+  bottom: number | "auto";
+  left: number;
+  maxHeight: number;
+}
+
+interface PopoverMenuProps {
+  ariaLabel: string;
+  /** Menu panel width in px — the menu is wider than the kebab trigger. */
+  menuWidthPx?: number;
+  /** Extra classes on the kebab trigger button. */
+  triggerClassName?: string;
+  /** Render the menu items; call `close` after an action runs. */
+  children: (close: () => void) => ReactNode;
+}
+
+/**
+ * Kebab (⋯) trigger + portaled `role="menu"` popover with outside-click /
+ * Escape dismissal and viewport-aware placement (flips above when it would
+ * clip below). Shared by the per-deck and per-folder action menus so there is
+ * one popover authority — `MenuSelect` is a single-select `listbox` whose menu
+ * tracks its trigger width, which doesn't fit an icon-triggered action menu.
+ */
+export function PopoverMenu({
+  ariaLabel,
+  menuWidthPx = 224,
+  triggerClassName,
+  children,
+}: PopoverMenuProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<PopoverMenuStyle>({
+    top: 0,
+    bottom: "auto",
+    left: 0,
+    maxHeight: 320,
+  });
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const position = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const left = Math.max(
+      MENU_VIEWPORT_PADDING_PX,
+      Math.min(
+        rect.right - menuWidthPx,
+        window.innerWidth - menuWidthPx - MENU_VIEWPORT_PADDING_PX,
+      ),
+    );
+    const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP_PX - MENU_VIEWPORT_PADDING_PX;
+    const spaceAbove = rect.top - MENU_GAP_PX - MENU_VIEWPORT_PADDING_PX;
+    const openUp = spaceBelow < OPEN_UP_THRESHOLD_PX && spaceAbove > spaceBelow;
+    setStyle({
+      top: openUp ? "auto" : rect.bottom + MENU_GAP_PX,
+      bottom: openUp ? window.innerHeight - rect.top + MENU_GAP_PX : "auto",
+      left,
+      maxHeight: Math.max(120, openUp ? spaceAbove : spaceBelow),
+    });
+  }, [menuWidthPx]);
+
+  useLayoutEffect(() => {
+    if (open) position();
+  }, [open, position]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      close();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+        triggerRef.current?.focus();
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("resize", position);
+    window.addEventListener("scroll", position, true);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("resize", position);
+      window.removeEventListener("scroll", position, true);
+    };
+  }, [open, close, position]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        className={
+          triggerClassName ??
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-black/35 text-gray-400 transition-colors hover:bg-white/15 hover:text-white"
+        }
+      >
+        <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="h-4 w-4">
+          <path d="M8 4a1.25 1.25 0 1 0 0-2.5A1.25 1.25 0 0 0 8 4Zm0 5.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5ZM9.25 13.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z" />
+        </svg>
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            aria-label={ariaLabel}
+            onClick={(event) => event.stopPropagation()}
+            style={{
+              top: style.top,
+              bottom: style.bottom,
+              left: style.left,
+              width: menuWidthPx,
+              maxHeight: style.maxHeight,
+            }}
+            className="fixed z-[120] flex flex-col overflow-y-auto overscroll-contain rounded-xl border border-white/10 bg-[#0a0f1b]/98 py-1 shadow-xl backdrop-blur-md thin-scrollbar"
+          >
+            {children(close)}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+/** Shared menu-item button styling for {@link PopoverMenu} children. */
+export const popoverMenuItemClass =
+  "flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-200 transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none";

--- a/client/src/components/ui/MenuSelect.tsx
+++ b/client/src/components/ui/MenuSelect.tsx
@@ -74,6 +74,17 @@ export interface MenuSelectProps {
   /** Highlights the matching option in the open menu. */
   selectedValue?: string;
   /**
+   * When true, render a search box at the top of the open menu that filters
+   * items/groups by label substring. Focus lands on the input when the menu
+   * opens (instead of the first option). Off by default — existing call sites
+   * keep their plain listbox behavior.
+   */
+  filterable?: boolean;
+  /** Placeholder for the filter input (only used when `filterable`). */
+  filterPlaceholder?: string;
+  /** Message shown when a `filterable` search matches no options. */
+  noMatchesLabel?: string;
+  /**
    * `auto` (default): bottom sheet below 820px, anchored dropdown at wider
    * widths. `dropdown`: always anchor below/above the trigger like a native
    * select — use inside scrollable panels (e.g. deck-builder filters).
@@ -192,6 +203,9 @@ export function MenuSelect({
   disabled = false,
   ariaLabel,
   selectedValue,
+  filterable = false,
+  filterPlaceholder,
+  noMatchesLabel,
   menuLayout = "auto",
   fitContainer = false,
   wrapperClassName = "",
@@ -208,11 +222,39 @@ export function MenuSelect({
   const mobileSheet = useMobileSheetLayout();
   const useBottomSheet = menuLayout === "auto" && mobileSheet;
   const [open, setOpen] = useState(false);
+  const [filterText, setFilterText] = useState("");
   const [minWidthPx, setMinWidthPx] = useState<number | undefined>(undefined);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
+  const filterInputRef = useRef<HTMLInputElement>(null);
   const allItems = useMemo(() => flattenMenuItems(items, groups), [items, groups]);
+
+  // When filterable, narrow items/groups by label substring; empty groups drop.
+  const filterQuery = filterable ? filterText.trim().toLowerCase() : "";
+  const visibleItems = useMemo(
+    () =>
+      filterQuery
+        ? (items ?? []).filter((item) => item.label.toLowerCase().includes(filterQuery))
+        : items,
+    [items, filterQuery],
+  );
+  const visibleGroups = useMemo(
+    () =>
+      filterQuery
+        ? (groups ?? [])
+            .map((group) => ({
+              ...group,
+              items: group.items.filter((item) =>
+                item.label.toLowerCase().includes(filterQuery),
+              ),
+            }))
+            .filter((group) => group.items.length > 0)
+        : groups,
+    [groups, filterQuery],
+  );
+  const hasVisibleOptions =
+    (visibleItems?.length ?? 0) > 0 || (visibleGroups?.length ?? 0) > 0;
   const [menuStyle, setMenuStyle] = useState<AnchoredMenuStyle>({
     top: 0,
     bottom: "auto",
@@ -253,6 +295,7 @@ export function MenuSelect({
 
   const closeMenu = useCallback(() => {
     setOpen(false);
+    setFilterText("");
     onOptionHoverRef.current?.(null);
   }, []);
 
@@ -272,6 +315,12 @@ export function MenuSelect({
   useLayoutEffect(() => {
     if (!open) return;
     updatePosition();
+    // When filterable, focus the search box so the user can type-to-narrow
+    // immediately; ArrowDown then drops into the option list.
+    if (filterable) {
+      filterInputRef.current?.focus();
+      return;
+    }
     // APG listbox pattern: move focus into the menu so the keyboard path
     // (Arrow keys + Enter) works like the native select this replaces.
     const menu = menuRef.current;
@@ -281,7 +330,7 @@ export function MenuSelect({
         : null;
     (selectedOption ?? menu?.querySelector<HTMLButtonElement>('[role="option"]'))?.focus();
     selectedOption?.scrollIntoView({ block: "nearest" });
-  }, [open, selectedValue, updatePosition, useBottomSheet]);
+  }, [open, selectedValue, updatePosition, useBottomSheet, filterable]);
 
   useEffect(() => {
     if (!open) return;
@@ -438,8 +487,21 @@ export function MenuSelect({
                     }
               }
             >
-              {items?.map((item) => renderOption(item))}
-              {groups?.map((group) => (
+              {filterable && (
+                <div className="sticky top-0 z-10 border-b border-white/10 bg-[#0a0f1b] px-2 pb-1.5 pt-1.5">
+                  <input
+                    ref={filterInputRef}
+                    type="text"
+                    value={filterText}
+                    onChange={(event) => setFilterText(event.target.value)}
+                    placeholder={filterPlaceholder ?? ""}
+                    aria-label={filterPlaceholder ?? ariaLabel ?? label}
+                    className="w-full rounded-md bg-black/40 px-2 py-1.5 text-sm text-slate-200 outline-none ring-1 ring-white/10 placeholder:text-slate-500 focus:ring-white/25"
+                  />
+                </div>
+              )}
+              {visibleItems?.map((item) => renderOption(item))}
+              {visibleGroups?.map((group) => (
                 <div key={group.label}>
                   <div
                     role="presentation"
@@ -450,6 +512,11 @@ export function MenuSelect({
                   {group.items.map((item) => renderOption(item))}
                 </div>
               ))}
+              {filterable && !hasVisibleOptions && noMatchesLabel && (
+                <div className="px-3 py-3 text-center text-xs text-slate-500">
+                  {noMatchesLabel}
+                </div>
+              )}
             </div>
           </>,
           document.body,

--- a/client/src/components/ui/__tests__/MenuSelect.test.tsx
+++ b/client/src/components/ui/__tests__/MenuSelect.test.tsx
@@ -132,6 +132,55 @@ describe("MenuSelect", () => {
     spy.mockRestore();
   });
 
+  it("filters options as the user types and focuses the search box on open", () => {
+    render(
+      <MenuSelect
+        label="Load deck..."
+        items={items}
+        onSelect={vi.fn()}
+        filterable
+        filterPlaceholder="Search decks…"
+        noMatchesLabel="No decks match"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Load deck..." }));
+
+    const search = screen.getByPlaceholderText("Search decks…");
+    expect(search).toHaveFocus();
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+
+    fireEvent.change(search, { target: { value: "azor" } });
+    const filtered = screen.getAllByRole("option");
+    expect(filtered.map((o) => o.textContent)).toEqual(["Azorius Control"]);
+
+    fireEvent.change(search, { target: { value: "zzz" } });
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+    expect(screen.getByText("No decks match")).toBeInTheDocument();
+  });
+
+  it("filters grouped options and drops groups with no matches", () => {
+    render(
+      <MenuSelect
+        label="Switch deck"
+        groups={[
+          { label: "Starred", items: [{ value: "Atraxa", label: "Atraxa" }] },
+          { label: "Aggro", items: [{ value: "Mono Red", label: "Mono Red" }] },
+        ]}
+        onSelect={vi.fn()}
+        filterable
+        filterPlaceholder="Search decks…"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Switch deck" }));
+    fireEvent.change(screen.getByPlaceholderText("Search decks…"), {
+      target: { value: "atra" },
+    });
+
+    expect(screen.getByText("Starred")).toBeInTheDocument();
+    expect(screen.queryByText("Aggro")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual(["Atraxa"]);
+  });
+
   it("does not apply content-based minWidth when fitContainer is set", () => {
     const longLabel = "Option ".repeat(12).trimEnd();
     const items = [{ value: "option-a", label: longLabel }];

--- a/client/src/constants/__tests__/storage.test.ts
+++ b/client/src/constants/__tests__/storage.test.ts
@@ -1,9 +1,19 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  createFolder,
+  deleteFolder,
+  getDeckMeta,
+  listFolders,
   loadSavedDeck,
   loadSavedDeckBracket,
+  migrateDeckMeta,
+  renameFolder,
   saveSavedDeckBracket,
+  setDeckFolder,
+  stampDeckMeta,
+  toggleDeckStar,
+  touchDeckPlayed,
   STORAGE_KEY_PREFIX,
 } from "../storage";
 import { expandParsedDeck } from "../../services/deckParser";
@@ -84,5 +94,135 @@ describe("saved-deck bracket sidecar", () => {
   it("saveSavedDeckBracket is a no-op when the deck does not exist", () => {
     saveSavedDeckBracket("Missing", 3);
     expect(localStorage.getItem(STORAGE_KEY_PREFIX + "Missing")).toBeNull();
+  });
+});
+
+describe("folder registry", () => {
+  it("createFolder appends with an incrementing order and returns the folder", () => {
+    const a = createFolder("Control");
+    const b = createFolder("Aggro");
+    expect(a).not.toBeNull();
+    expect(a?.name).toBe("Control");
+    expect(a?.order).toBe(0);
+    expect(b?.order).toBe(1);
+    expect(a?.id).not.toBe(b?.id);
+    expect(listFolders().map((f) => f.name)).toEqual(["Control", "Aggro"]);
+  });
+
+  it("createFolder trims, caps length, and rejects blank names", () => {
+    expect(createFolder("   ")).toBeNull();
+    const folder = createFolder(`  ${"x".repeat(60)}  `);
+    expect(folder?.name).toHaveLength(40);
+  });
+
+  it("listFolders sorts by order then name", () => {
+    createFolder("Zed"); // order 0
+    createFolder("Alpha"); // order 1
+    // Same order value sorts by name as a tiebreak.
+    localStorage.setItem(
+      "phase-deck-folders",
+      JSON.stringify([
+        { id: "1", name: "Zed", order: 5 },
+        { id: "2", name: "Alpha", order: 5 },
+      ]),
+    );
+    expect(listFolders().map((f) => f.name)).toEqual(["Alpha", "Zed"]);
+  });
+
+  it("renameFolder updates the name and ignores unknown ids / blanks", () => {
+    const folder = createFolder("Old")!;
+    renameFolder(folder.id, "New");
+    expect(listFolders()[0].name).toBe("New");
+    renameFolder(folder.id, "  ");
+    expect(listFolders()[0].name).toBe("New");
+    renameFolder("nonexistent", "Ghost");
+    expect(listFolders()).toHaveLength(1);
+  });
+
+  it("deleteFolder removes the folder and reassigns its decks to Unfiled", () => {
+    const folder = createFolder("Brews")!;
+    stampDeckMeta("Deck A");
+    setDeckFolder("Deck A", folder.id);
+    expect(getDeckMeta("Deck A")?.folderId).toBe(folder.id);
+
+    deleteFolder(folder.id);
+
+    expect(listFolders()).toHaveLength(0);
+    // Deck survives; only its folder membership is cleared.
+    expect(getDeckMeta("Deck A")?.folderId).toBeUndefined();
+  });
+});
+
+describe("deck membership + stars", () => {
+  it("setDeckFolder assigns and clears membership", () => {
+    const folder = createFolder("Commander")!;
+    stampDeckMeta("Atraxa");
+    setDeckFolder("Atraxa", folder.id);
+    expect(getDeckMeta("Atraxa")?.folderId).toBe(folder.id);
+    setDeckFolder("Atraxa", null);
+    expect(getDeckMeta("Atraxa")?.folderId).toBeUndefined();
+  });
+
+  it("setDeckFolder seeds metadata for a deck that was never stamped", () => {
+    const folder = createFolder("Imported")!;
+    setDeckFolder("Fresh Import", folder.id);
+    const meta = getDeckMeta("Fresh Import");
+    expect(meta?.folderId).toBe(folder.id);
+    expect(typeof meta?.addedAt).toBe("number");
+  });
+
+  it("toggleDeckStar flips and returns the resulting state", () => {
+    stampDeckMeta("Burn");
+    expect(toggleDeckStar("Burn")).toBe(true);
+    expect(getDeckMeta("Burn")?.starred).toBe(true);
+    expect(toggleDeckStar("Burn")).toBe(false);
+    expect(getDeckMeta("Burn")?.starred).toBeUndefined();
+  });
+});
+
+describe("metadata migration on rename", () => {
+  it("migrateDeckMeta carries folder, star, and timestamps to the new name", () => {
+    const folder = createFolder("Modern")!;
+    stampDeckMeta("Old Name", 1000);
+    setDeckFolder("Old Name", folder.id);
+    toggleDeckStar("Old Name");
+    touchDeckPlayed("Old Name");
+    const before = getDeckMeta("Old Name")!;
+
+    migrateDeckMeta("Old Name", "New Name");
+
+    expect(getDeckMeta("Old Name")).toBeNull();
+    const after = getDeckMeta("New Name")!;
+    expect(after.folderId).toBe(folder.id);
+    expect(after.starred).toBe(true);
+    expect(after.addedAt).toBe(1000);
+    expect(after.lastPlayedAt).toBe(before.lastPlayedAt);
+  });
+
+  it("migrateDeckMeta is a no-op when the source has no metadata", () => {
+    migrateDeckMeta("Never Stamped", "New Name");
+    expect(getDeckMeta("New Name")).toBeNull();
+  });
+
+  it("migrateDeckMeta is a no-op when source and target names match", () => {
+    stampDeckMeta("Same", 500);
+    migrateDeckMeta("Same", "Same");
+    expect(getDeckMeta("Same")?.addedAt).toBe(500);
+  });
+});
+
+describe("touchDeckPlayed preserves organization", () => {
+  it("keeps folderId and starred when stamping lastPlayedAt", () => {
+    const folder = createFolder("Pauper")!;
+    stampDeckMeta("Affinity");
+    setDeckFolder("Affinity", folder.id);
+    toggleDeckStar("Affinity");
+
+    touchDeckPlayed("Affinity");
+
+    const meta = getDeckMeta("Affinity")!;
+    expect(meta.folderId).toBe(folder.id);
+    expect(meta.starred).toBe(true);
+    expect(typeof meta.lastPlayedAt).toBe("number");
   });
 });

--- a/client/src/constants/storage.ts
+++ b/client/src/constants/storage.ts
@@ -17,8 +17,19 @@ export const GAME_CHECKPOINTS_PREFIX = "phase-game-checkpoints:";
 /** Key for the active game metadata (id, mode, difficulty) */
 export const ACTIVE_GAME_KEY = "phase-active-game";
 
-/** Key for deck metadata (timestamps, source tracking) */
+/** Key for deck metadata (timestamps, source tracking, folder/star) */
 export const DECK_METADATA_KEY = "phase-deck-metadata";
+
+/** Key for the user's deck-folder registry (an array of {@link DeckFolder}). */
+export const DECK_FOLDERS_KEY = "phase-deck-folders";
+
+/** Window event fired when folder/star/membership state changes, so views
+ * (library, builder switcher) can re-read without prop-drilling. Decks
+ * themselves are tracked separately (callers re-list saved-deck keys). */
+export const DECKS_CHANGED_EVENT = "phase-decks-changed";
+
+/** Max length for a folder name; longer input is trimmed on create/rename. */
+export const MAX_FOLDER_NAME_LENGTH = 40;
 
 /** Key for the list of subscribed feeds */
 export const FEED_SUBSCRIPTIONS_KEY = "phase-feed-subscriptions";
@@ -58,6 +69,7 @@ export function isUserOwnedStorageKey(key: string): boolean {
   return (
     key === PREFERENCES_KEY ||
     key === DECK_METADATA_KEY ||
+    key === DECK_FOLDERS_KEY ||
     key === ACTIVE_DECK_KEY ||
     key === FEED_SUBSCRIPTIONS_KEY ||
     key === FEED_DECK_ORIGINS_KEY ||
@@ -68,6 +80,33 @@ export function isUserOwnedStorageKey(key: string): boolean {
 export interface DeckMeta {
   addedAt: number;
   lastPlayedAt?: number;
+  /** Id of the folder this deck lives in. Absent ⇒ "Unfiled". */
+  folderId?: string;
+  /** Whether the deck is starred (pinned above folders in the library). */
+  starred?: boolean;
+}
+
+/** A user-created folder for organizing saved decks. Folders are flat
+ * (single-level); a deck belongs to at most one via {@link DeckMeta.folderId}. */
+export interface DeckFolder {
+  id: string;
+  name: string;
+  /** Manual position; folders render sorted by `order` then `name`. */
+  order: number;
+}
+
+/**
+ * Fire {@link DECKS_CHANGED_EVENT} so mounted views re-read folder state.
+ * Contract: every mutator that changes folder membership or star state
+ * (`setDeckFolder`, `toggleDeckStar`, `migrateDeckMeta`) MUST call this, and
+ * every registry write goes through `saveFolderStore` which calls it — this is
+ * what drives `useDeckFolders` to regroup. A new mutator that forgets it will
+ * leave the library/switcher showing stale groupings.
+ */
+function notifyDecksChanged(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(DECKS_CHANGED_EVENT));
+  }
 }
 
 function loadMetadataStore(): Record<string, DeckMeta> {
@@ -96,8 +135,55 @@ export function stampDeckMeta(deckName: string, addedAt?: number): void {
 export function touchDeckPlayed(deckName: string): void {
   const store = loadMetadataStore();
   const existing = store[deckName];
-  store[deckName] = { addedAt: existing?.addedAt ?? Date.now(), lastPlayedAt: Date.now() };
+  // Spread the existing entry so folder/star membership survives a play.
+  store[deckName] = {
+    ...existing,
+    addedAt: existing?.addedAt ?? Date.now(),
+    lastPlayedAt: Date.now(),
+  };
   saveMetadataStore(store);
+}
+
+/**
+ * Move a deck's metadata from one name to another, preserving folder/star
+ * membership and timestamps. Used by the in-place rename path (Save under a
+ * new name), which would otherwise drop the deck's organization. No-op when
+ * the source has no metadata — the caller's `stampDeckMeta` then seeds a
+ * fresh entry under the new name.
+ */
+export function migrateDeckMeta(oldName: string, newName: string): void {
+  if (oldName === newName) return;
+  const store = loadMetadataStore();
+  const src = store[oldName];
+  if (!src) return;
+  store[newName] = { ...src };
+  delete store[oldName];
+  saveMetadataStore(store);
+  notifyDecksChanged();
+}
+
+/** Assign a deck to a folder, or pass `null` to move it to Unfiled. */
+export function setDeckFolder(deckName: string, folderId: string | null): void {
+  const store = loadMetadataStore();
+  const meta = store[deckName] ?? { addedAt: Date.now() };
+  if (folderId === null) delete meta.folderId;
+  else meta.folderId = folderId;
+  store[deckName] = meta;
+  saveMetadataStore(store);
+  notifyDecksChanged();
+}
+
+/** Toggle a deck's starred flag. Returns the resulting starred state. */
+export function toggleDeckStar(deckName: string): boolean {
+  const store = loadMetadataStore();
+  const meta = store[deckName] ?? { addedAt: Date.now() };
+  const starred = !meta.starred;
+  if (starred) meta.starred = true;
+  else delete meta.starred;
+  store[deckName] = meta;
+  saveMetadataStore(store);
+  notifyDecksChanged();
+  return starred;
 }
 
 /** Get metadata for a single deck, or null if not tracked. */
@@ -131,6 +217,75 @@ export function listSavedDeckNames(): string[] {
     }
   }
   return names.sort();
+}
+
+// --- Folder registry helpers ---
+
+function loadFolderStore(): DeckFolder[] {
+  try {
+    const raw = localStorage.getItem(DECK_FOLDERS_KEY);
+    return raw ? (JSON.parse(raw) as DeckFolder[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveFolderStore(folders: DeckFolder[]): void {
+  localStorage.setItem(DECK_FOLDERS_KEY, JSON.stringify(folders));
+  notifyDecksChanged();
+}
+
+/** List folders sorted by manual `order`, then name as a stable tiebreak. */
+export function listFolders(): DeckFolder[] {
+  return loadFolderStore()
+    .slice()
+    .sort((a, b) => a.order - b.order || a.name.localeCompare(b.name));
+}
+
+/**
+ * Create a folder, appending it after the last by `order`. Returns the new
+ * folder, or `null` when the name is blank. Duplicate names are permitted —
+ * folders are identified by `id`, not name.
+ */
+export function createFolder(name: string): DeckFolder | null {
+  const trimmed = name.trim().slice(0, MAX_FOLDER_NAME_LENGTH);
+  if (!trimmed) return null;
+  const folders = loadFolderStore();
+  const order = folders.reduce((max, f) => Math.max(max, f.order), -1) + 1;
+  const folder: DeckFolder = { id: crypto.randomUUID(), name: trimmed, order };
+  folders.push(folder);
+  saveFolderStore(folders);
+  return folder;
+}
+
+/** Rename a folder in place. No-op when the id is unknown or name is blank. */
+export function renameFolder(id: string, name: string): void {
+  const trimmed = name.trim().slice(0, MAX_FOLDER_NAME_LENGTH);
+  if (!trimmed) return;
+  const folders = loadFolderStore();
+  const folder = folders.find((f) => f.id === id);
+  if (!folder) return;
+  folder.name = trimmed;
+  saveFolderStore(folders);
+}
+
+/**
+ * Delete a folder. Member decks are reassigned to Unfiled (never deleted).
+ * Metadata is updated first so a single notify carries a consistent state.
+ */
+export function deleteFolder(id: string): void {
+  const folders = loadFolderStore();
+  if (!folders.some((f) => f.id === id)) return;
+  const store = loadMetadataStore();
+  let changed = false;
+  for (const meta of Object.values(store)) {
+    if (meta.folderId === id) {
+      delete meta.folderId;
+      changed = true;
+    }
+  }
+  if (changed) saveMetadataStore(store);
+  saveFolderStore(folders.filter((f) => f.id !== id));
 }
 
 /**

--- a/client/src/hooks/__tests__/useDeckFolders.test.ts
+++ b/client/src/hooks/__tests__/useDeckFolders.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { groupSavedDecks, useDeckFolders } from "../useDeckFolders";
+import { DECK_FOLDERS_KEY, type DeckFolder, type DeckMeta } from "../../constants/storage";
+import { PROFILE_REPLACED_EVENT } from "../../stores/cloudSyncStore";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const folders: DeckFolder[] = [
+  { id: "control", name: "Control", order: 0 },
+  { id: "aggro", name: "Aggro", order: 1 },
+];
+
+/** Build a `metaOf` lookup from a plain name → meta record. */
+function metaLookup(
+  record: Record<string, Partial<DeckMeta>>,
+): (name: string) => DeckMeta | null {
+  return (name) => {
+    const meta = record[name];
+    return meta ? { addedAt: 0, ...meta } : null;
+  };
+}
+
+describe("groupSavedDecks", () => {
+  it("buckets decks into their folder, leaving the rest Unfiled", () => {
+    const result = groupSavedDecks(
+      ["Teferi", "Goblins", "Loose Deck"],
+      metaLookup({
+        Teferi: { folderId: "control" },
+        Goblins: { folderId: "aggro" },
+        // Loose Deck has no meta at all.
+      }),
+      folders,
+    );
+    expect(result.folders[0].decks).toEqual(["Teferi"]);
+    expect(result.folders[1].decks).toEqual(["Goblins"]);
+    expect(result.unfiled).toEqual(["Loose Deck"]);
+    expect(result.starred).toEqual([]);
+  });
+
+  it("lifts starred decks out of their folder and pins them on top", () => {
+    const result = groupSavedDecks(
+      ["Teferi", "Goblins"],
+      metaLookup({
+        Teferi: { folderId: "control", starred: true },
+        Goblins: { folderId: "aggro" },
+      }),
+      folders,
+    );
+    // Starred Teferi is pinned, NOT duplicated inside its folder.
+    expect(result.starred).toEqual(["Teferi"]);
+    expect(result.folders[0].decks).toEqual([]);
+    expect(result.folders[1].decks).toEqual(["Goblins"]);
+  });
+
+  it("preserves input order within each section", () => {
+    const result = groupSavedDecks(
+      ["C", "A", "B"],
+      metaLookup({
+        C: { folderId: "control" },
+        A: { folderId: "control" },
+        B: { folderId: "control" },
+      }),
+      folders,
+    );
+    // Caller-provided order is kept verbatim — grouping never re-sorts decks.
+    expect(result.folders[0].decks).toEqual(["C", "A", "B"]);
+  });
+
+  it("keeps empty folders so they remain visible move targets", () => {
+    const result = groupSavedDecks([], metaLookup({}), folders);
+    expect(result.folders.map((f) => f.folder.name)).toEqual(["Control", "Aggro"]);
+    expect(result.folders.every((f) => f.decks.length === 0)).toBe(true);
+  });
+
+  it("treats a dangling folderId (deleted folder) as Unfiled", () => {
+    const result = groupSavedDecks(
+      ["Orphan"],
+      metaLookup({ Orphan: { folderId: "deleted-folder" } }),
+      folders,
+    );
+    expect(result.unfiled).toEqual(["Orphan"]);
+  });
+
+  it("places a bundled/starter deck (no folder) in Unfiled and is star-eligible", () => {
+    // Bundled starter decks are real saved-deck keys with metadata, so they
+    // participate in folders/stars like any user deck.
+    const unstarred = groupSavedDecks(
+      ["Starter: Mono-Red"],
+      metaLookup({ "Starter: Mono-Red": {} }),
+      folders,
+    );
+    expect(unstarred.unfiled).toEqual(["Starter: Mono-Red"]);
+
+    const starred = groupSavedDecks(
+      ["Starter: Mono-Red"],
+      metaLookup({ "Starter: Mono-Red": { starred: true } }),
+      folders,
+    );
+    expect(starred.starred).toEqual(["Starter: Mono-Red"]);
+    expect(starred.unfiled).toEqual([]);
+  });
+});
+
+describe("useDeckFolders (reactive)", () => {
+  it("regroups after membership + star mutations made through the hook", () => {
+    const { result } = renderHook(() => useDeckFolders());
+
+    let folderId = "";
+    act(() => {
+      folderId = result.current.createFolder("Aggro")!.id;
+    });
+    act(() => {
+      result.current.assignDeck("Burn", folderId);
+    });
+
+    // A membership change (metadata only — folder registry unchanged) must
+    // still re-drive grouping; this is the load-bearing notify contract.
+    const grouped = result.current.group(["Burn"]);
+    expect(grouped.folders.find((f) => f.folder.id === folderId)?.decks).toEqual(["Burn"]);
+
+    act(() => {
+      result.current.toggleStar("Burn");
+    });
+    const afterStar = result.current.group(["Burn"]);
+    expect(afterStar.starred).toEqual(["Burn"]);
+    expect(afterStar.folders.find((f) => f.folder.id === folderId)?.decks).toEqual([]);
+  });
+
+  it("refreshes folder state on a cross-tab storage event", () => {
+    const { result } = renderHook(() => useDeckFolders());
+    expect(result.current.folders).toHaveLength(0);
+
+    // Simulate another tab writing the registry, then the native storage event.
+    act(() => {
+      localStorage.setItem(
+        DECK_FOLDERS_KEY,
+        JSON.stringify([{ id: "x", name: "External", order: 0 }]),
+      );
+      window.dispatchEvent(new Event("storage"));
+    });
+
+    expect(result.current.folders.map((f) => f.name)).toEqual(["External"]);
+  });
+
+  it("refreshes folder state when a cloud-sync snapshot replaces the profile", () => {
+    const { result } = renderHook(() => useDeckFolders());
+    expect(result.current.folders).toHaveLength(0);
+
+    // A same-tab cloud-sync restore overwrites the registry then broadcasts
+    // PROFILE_REPLACED_EVENT (not DECKS_CHANGED / storage); the hook must still
+    // re-read so grouping doesn't desync from the freshly-synced decks.
+    act(() => {
+      localStorage.setItem(
+        DECK_FOLDERS_KEY,
+        JSON.stringify([{ id: "synced", name: "From Phone", order: 0 }]),
+      );
+      window.dispatchEvent(new CustomEvent(PROFILE_REPLACED_EVENT));
+    });
+
+    expect(result.current.folders.map((f) => f.name)).toEqual(["From Phone"]);
+  });
+
+  it("removes the window listeners on unmount", () => {
+    const { result, unmount } = renderHook(() => useDeckFolders());
+    unmount();
+    // After unmount, an event must not throw or mutate the captured result.
+    act(() => {
+      window.dispatchEvent(new Event("phase-decks-changed"));
+    });
+    expect(result.current.folders).toHaveLength(0);
+  });
+});

--- a/client/src/hooks/useDeckFolders.ts
+++ b/client/src/hooks/useDeckFolders.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  DECKS_CHANGED_EVENT,
+  createFolder as createFolderStore,
+  deleteFolder as deleteFolderStore,
+  getDeckMeta,
+  listFolders,
+  renameFolder as renameFolderStore,
+  setDeckFolder,
+  toggleDeckStar,
+  type DeckFolder,
+  type DeckMeta,
+} from "../constants/storage";
+import { PROFILE_REPLACED_EVENT } from "../stores/cloudSyncStore";
+
+export interface FolderGroup {
+  folder: DeckFolder;
+  decks: string[];
+}
+
+export interface GroupedDecks {
+  /** Starred decks, lifted out of their folder and pinned above everything. */
+  starred: string[];
+  /** Every folder in display order — including empty ones, so they remain
+   * visible as move targets. */
+  folders: FolderGroup[];
+  /** Decks belonging to no folder. */
+  unfiled: string[];
+}
+
+/**
+ * Pure grouping authority shared by the deck library and the builder's deck
+ * switcher. `deckNames` is assumed to already be in the caller's desired sort
+ * order; that order is preserved within each section. A deck appears in
+ * exactly one place: Starred if starred, else its folder, else Unfiled. A
+ * deck whose `folderId` no longer matches any folder falls through to Unfiled,
+ * so a dangling reference is self-healing rather than hidden.
+ */
+export function groupSavedDecks(
+  deckNames: string[],
+  metaOf: (name: string) => DeckMeta | null,
+  folders: DeckFolder[],
+): GroupedDecks {
+  const folderIds = new Set(folders.map((f) => f.id));
+  const starred: string[] = [];
+  const unfiled: string[] = [];
+  const byFolder = new Map<string, string[]>();
+
+  for (const name of deckNames) {
+    const meta = metaOf(name);
+    if (meta?.starred) {
+      starred.push(name);
+      continue;
+    }
+    const folderId = meta?.folderId;
+    if (folderId && folderIds.has(folderId)) {
+      const bucket = byFolder.get(folderId);
+      if (bucket) bucket.push(name);
+      else byFolder.set(folderId, [name]);
+    } else {
+      unfiled.push(name);
+    }
+  }
+
+  return {
+    starred,
+    folders: folders.map((folder) => ({
+      folder,
+      decks: byFolder.get(folder.id) ?? [],
+    })),
+    unfiled,
+  };
+}
+
+export interface UseDeckFoldersResult {
+  folders: DeckFolder[];
+  /** Group a (pre-sorted) list of saved deck names into Starred/folders/Unfiled. */
+  group: (deckNames: string[]) => GroupedDecks;
+  createFolder: (name: string) => DeckFolder | null;
+  renameFolder: (id: string, name: string) => void;
+  deleteFolder: (id: string) => void;
+  assignDeck: (deckName: string, folderId: string | null) => void;
+  toggleStar: (deckName: string) => boolean;
+}
+
+/**
+ * Reactive view over the folder registry + deck metadata. Re-reads on
+ * {@link DECKS_CHANGED_EVENT} (our own writes), the native `storage` event
+ * (writes from another tab), and {@link PROFILE_REPLACED_EVENT} (a cloud-sync
+ * snapshot overwriting the folder registry in this same tab). Each refresh
+ * produces a fresh `folders` array, so `group()` re-memoizes and consumers
+ * recompute with current metadata.
+ */
+export function useDeckFolders(): UseDeckFoldersResult {
+  const [folders, setFolders] = useState<DeckFolder[]>(listFolders);
+
+  useEffect(() => {
+    const refresh = () => setFolders(listFolders());
+    window.addEventListener(DECKS_CHANGED_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    window.addEventListener(PROFILE_REPLACED_EVENT, refresh);
+    return () => {
+      window.removeEventListener(DECKS_CHANGED_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+      window.removeEventListener(PROFILE_REPLACED_EVENT, refresh);
+    };
+  }, []);
+
+  const group = useCallback(
+    (deckNames: string[]) => groupSavedDecks(deckNames, getDeckMeta, folders),
+    [folders],
+  );
+
+  return {
+    folders,
+    group,
+    createFolder: createFolderStore,
+    renameFolder: renameFolderStore,
+    deleteFolder: deleteFolderStore,
+    assignDeck: setDeckFolder,
+    toggleStar: toggleDeckStar,
+  };
+}

--- a/client/src/i18n/locales/de/deck-builder.json
+++ b/client/src/i18n/locales/de/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "Das Deck hat {{count}} Karten (Minimum 60)",
     "maxCopies": "{{name}}: {{count}} Kopien (max. 4)",
     "companionInMain": "{{name}} ist dein Gefährte, befindet sich aber auch im Hauptdeck — das verstößt gegen seine Deckbau-Bedingung. Entferne ihn aus dem Hauptdeck, um ihn als Gefährten zu nutzen."
+  },
+  "switcher": {
+    "starred": "Favoriten",
+    "unfiled": "Nicht zugeordnet",
+    "searchPlaceholder": "Decks suchen…",
+    "noMatches": "Keine Decks gefunden"
   }
 }

--- a/client/src/i18n/locales/de/menu.json
+++ b/client/src/i18n/locales/de/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Unbekannt {{count}}",
     "unknownCardsTitle": "Unbekannte Karten:\n{{cards}}",
     "unsupportedTitle": "Nicht unterstützt ({{unique}} eindeutige, {{copies}} Kopien):\n{{cards}}",
-    "setIconAlt": "{{code}} Set-Symbol"
+    "setIconAlt": "{{code}} Set-Symbol",
+    "actionsMenu": "Deck-Optionen",
+    "star": "Favorit",
+    "unstar": "Favorit entfernen",
+    "moveToFolder": "In Ordner verschieben",
+    "unfiled": "Nicht zugeordnet",
+    "newFolder": "Neuer Ordner…"
   },
   "myDecks": {
     "headingManage": "Meine Decks",
@@ -254,7 +260,11 @@
     "loadMore": "Mehr laden",
     "selectedDeck": "Ausgewähltes Deck",
     "chooseDeckToContinue": "Wähle ein Deck, um fortzufahren",
-    "filterAll": "Alle"
+    "filterAll": "Alle",
+    "sectionStarred": "Favoriten",
+    "sectionUnfiled": "Nicht zugeordnet",
+    "collapseAll": "Alle einklappen",
+    "expandAll": "Alle ausklappen"
   },
   "subscriptions": {
     "emptyTitle": "Keine Feed-Abonnements",
@@ -281,5 +291,16 @@
     "alpha": "Alpha",
     "profile": "Profil",
     "settings": "Einstellungen"
+  },
+  "folder": {
+    "actionsMenu": "Ordneroptionen",
+    "rename": "Umbenennen",
+    "delete": "Löschen",
+    "newFolder": "Neuer Ordner",
+    "newFolderPrompt": "Ordnername:",
+    "renamePrompt": "Ordner umbenennen:",
+    "deleteConfirm": "Ordner „{{name}}“ löschen? Decks werden zu „Nicht zugeordnet“ verschoben.",
+    "emptyHint": "Dieser Ordner ist leer.",
+    "unfiledEmptyHint": "Keine nicht zugeordneten Decks."
   }
 }

--- a/client/src/i18n/locales/en/deck-builder.json
+++ b/client/src/i18n/locales/en/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "Deck has {{count}} cards (minimum 60)",
     "maxCopies": "{{name}}: {{count}} copies (max 4)",
     "companionInMain": "{{name}} is your companion but is also in the main deck — this violates its deckbuilding condition. Remove it from the main deck to use it as a companion."
+  },
+  "switcher": {
+    "starred": "Starred",
+    "unfiled": "Unfiled",
+    "searchPlaceholder": "Search decks…",
+    "noMatches": "No decks match"
   }
 }

--- a/client/src/i18n/locales/en/menu.json
+++ b/client/src/i18n/locales/en/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Unknown {{count}}",
     "unknownCardsTitle": "Unknown cards:\n{{cards}}",
     "unsupportedTitle": "Unsupported ({{unique}} unique, {{copies}} copies):\n{{cards}}",
-    "setIconAlt": "{{code}} set icon"
+    "setIconAlt": "{{code}} set icon",
+    "actionsMenu": "Deck options",
+    "star": "Star",
+    "unstar": "Unstar",
+    "moveToFolder": "Move to folder",
+    "unfiled": "Unfiled",
+    "newFolder": "New folder…"
   },
   "myDecks": {
     "headingManage": "My Decks",
@@ -254,7 +260,11 @@
     "loadMore": "Load More",
     "selectedDeck": "Selected deck",
     "chooseDeckToContinue": "Choose a deck to continue",
-    "filterAll": "All"
+    "filterAll": "All",
+    "sectionStarred": "Starred",
+    "sectionUnfiled": "Unfiled",
+    "collapseAll": "Collapse all",
+    "expandAll": "Expand all"
   },
   "subscriptions": {
     "emptyTitle": "No feed subscriptions",
@@ -281,5 +291,16 @@
     "alpha": "Alpha",
     "profile": "Profile",
     "settings": "Settings"
+  },
+  "folder": {
+    "actionsMenu": "Folder options",
+    "rename": "Rename",
+    "delete": "Delete",
+    "newFolder": "New folder",
+    "newFolderPrompt": "Folder name:",
+    "renamePrompt": "Rename folder:",
+    "deleteConfirm": "Delete folder \"{{name}}\"? Its decks move to Unfiled.",
+    "emptyHint": "This folder is empty.",
+    "unfiledEmptyHint": "No unfiled decks."
   }
 }

--- a/client/src/i18n/locales/es/deck-builder.json
+++ b/client/src/i18n/locales/es/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "El mazo tiene {{count}} cartas (mínimo 60)",
     "maxCopies": "{{name}}: {{count}} copias (máx. 4)",
     "companionInMain": "{{name}} es tu compañero pero también está en el mazo principal — esto infringe su condición de construcción de mazo. Quítalo del mazo principal para usarlo como compañero."
+  },
+  "switcher": {
+    "starred": "Destacados",
+    "unfiled": "Sin clasificar",
+    "searchPlaceholder": "Buscar mazos…",
+    "noMatches": "No hay mazos"
   }
 }

--- a/client/src/i18n/locales/es/menu.json
+++ b/client/src/i18n/locales/es/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Desconocidas {{count}}",
     "unknownCardsTitle": "Cartas desconocidas:\n{{cards}}",
     "unsupportedTitle": "No compatibles ({{unique}} únicas, {{copies}} copias):\n{{cards}}",
-    "setIconAlt": "Icono de la colección {{code}}"
+    "setIconAlt": "Icono de la colección {{code}}",
+    "actionsMenu": "Opciones del mazo",
+    "star": "Destacar",
+    "unstar": "Quitar destacado",
+    "moveToFolder": "Mover a carpeta",
+    "unfiled": "Sin clasificar",
+    "newFolder": "Nueva carpeta…"
   },
   "myDecks": {
     "headingManage": "Mis mazos",
@@ -254,7 +260,11 @@
     "loadMore": "Cargar más",
     "selectedDeck": "Mazo seleccionado",
     "chooseDeckToContinue": "Elige un mazo para continuar",
-    "filterAll": "Todos"
+    "filterAll": "Todos",
+    "sectionStarred": "Destacados",
+    "sectionUnfiled": "Sin clasificar",
+    "collapseAll": "Contraer todo",
+    "expandAll": "Expandir todo"
   },
   "subscriptions": {
     "emptyTitle": "Sin suscripciones a feeds",
@@ -281,5 +291,16 @@
     "alpha": "Alfa",
     "profile": "Perfil",
     "settings": "Ajustes"
+  },
+  "folder": {
+    "actionsMenu": "Opciones de carpeta",
+    "rename": "Renombrar",
+    "delete": "Eliminar",
+    "newFolder": "Nueva carpeta",
+    "newFolderPrompt": "Nombre de la carpeta:",
+    "renamePrompt": "Renombrar carpeta:",
+    "deleteConfirm": "¿Eliminar la carpeta «{{name}}»? Los mazos pasarán a Sin clasificar.",
+    "emptyHint": "Esta carpeta está vacía.",
+    "unfiledEmptyHint": "No hay mazos sin clasificar."
   }
 }

--- a/client/src/i18n/locales/fr/deck-builder.json
+++ b/client/src/i18n/locales/fr/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "Le deck contient {{count}} cartes (minimum 60)",
     "maxCopies": "{{name}} : {{count}} copies (max 4)",
     "companionInMain": "{{name}} est votre compagnon mais figure aussi dans le deck principal — cela enfreint sa condition de construction. Retirez-le du deck principal pour l'utiliser comme compagnon."
+  },
+  "switcher": {
+    "starred": "Favoris",
+    "unfiled": "Non classé",
+    "searchPlaceholder": "Rechercher des decks…",
+    "noMatches": "Aucun deck trouvé"
   }
 }

--- a/client/src/i18n/locales/fr/menu.json
+++ b/client/src/i18n/locales/fr/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Inconnues {{count}}",
     "unknownCardsTitle": "Cartes inconnues :\n{{cards}}",
     "unsupportedTitle": "Non prises en charge ({{unique}} uniques, {{copies}} copies) :\n{{cards}}",
-    "setIconAlt": "Icône d'extension {{code}}"
+    "setIconAlt": "Icône d'extension {{code}}",
+    "actionsMenu": "Options du deck",
+    "star": "Mettre en favori",
+    "unstar": "Retirer des favoris",
+    "moveToFolder": "Déplacer vers un dossier",
+    "unfiled": "Non classé",
+    "newFolder": "Nouveau dossier…"
   },
   "myDecks": {
     "headingManage": "Mes decks",
@@ -254,7 +260,11 @@
     "loadMore": "Charger plus",
     "selectedDeck": "Deck sélectionné",
     "chooseDeckToContinue": "Choisissez un deck pour continuer",
-    "filterAll": "Tous"
+    "filterAll": "Tous",
+    "sectionStarred": "Favoris",
+    "sectionUnfiled": "Non classé",
+    "collapseAll": "Tout réduire",
+    "expandAll": "Tout développer"
   },
   "subscriptions": {
     "emptyTitle": "Aucun abonnement à un flux",
@@ -281,5 +291,16 @@
     "alpha": "Alpha",
     "profile": "Profil",
     "settings": "Réglages"
+  },
+  "folder": {
+    "actionsMenu": "Options du dossier",
+    "rename": "Renommer",
+    "delete": "Supprimer",
+    "newFolder": "Nouveau dossier",
+    "newFolderPrompt": "Nom du dossier :",
+    "renamePrompt": "Renommer le dossier :",
+    "deleteConfirm": "Supprimer le dossier « {{name}} » ? Les decks passeront dans Non classé.",
+    "emptyHint": "Ce dossier est vide.",
+    "unfiledEmptyHint": "Aucun deck non classé."
   }
 }

--- a/client/src/i18n/locales/it/deck-builder.json
+++ b/client/src/i18n/locales/it/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "Il mazzo ha {{count}} carte (minimo 60)",
     "maxCopies": "{{name}}: {{count}} copie (max 4)",
     "companionInMain": "{{name}} è il tuo compagno ma è anche nel mazzo principale — questo viola la sua condizione di costruzione del mazzo. Rimuovilo dal mazzo principale per usarlo come compagno."
+  },
+  "switcher": {
+    "starred": "Preferiti",
+    "unfiled": "Senza cartella",
+    "searchPlaceholder": "Cerca mazzi…",
+    "noMatches": "Nessun mazzo trovato"
   }
 }

--- a/client/src/i18n/locales/it/menu.json
+++ b/client/src/i18n/locales/it/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Sconosciute {{count}}",
     "unknownCardsTitle": "Carte sconosciute:\n{{cards}}",
     "unsupportedTitle": "Non supportate ({{unique}} uniche, {{copies}} copie):\n{{cards}}",
-    "setIconAlt": "Icona set {{code}}"
+    "setIconAlt": "Icona set {{code}}",
+    "actionsMenu": "Opzioni mazzo",
+    "star": "Aggiungi ai preferiti",
+    "unstar": "Rimuovi dai preferiti",
+    "moveToFolder": "Sposta nella cartella",
+    "unfiled": "Senza cartella",
+    "newFolder": "Nuova cartella…"
   },
   "myDecks": {
     "headingManage": "I miei mazzi",
@@ -254,7 +260,11 @@
     "loadMore": "Carica altri",
     "selectedDeck": "Mazzo selezionato",
     "chooseDeckToContinue": "Scegli un mazzo per continuare",
-    "filterAll": "Tutti"
+    "filterAll": "Tutti",
+    "sectionStarred": "Preferiti",
+    "sectionUnfiled": "Senza cartella",
+    "collapseAll": "Comprimi tutto",
+    "expandAll": "Espandi tutto"
   },
   "subscriptions": {
     "emptyTitle": "Nessuna iscrizione ai feed",
@@ -281,5 +291,16 @@
     "alpha": "Alpha",
     "profile": "Profilo",
     "settings": "Impostazioni"
+  },
+  "folder": {
+    "actionsMenu": "Opzioni cartella",
+    "rename": "Rinomina",
+    "delete": "Elimina",
+    "newFolder": "Nuova cartella",
+    "newFolderPrompt": "Nome della cartella:",
+    "renamePrompt": "Rinomina cartella:",
+    "deleteConfirm": "Eliminare la cartella «{{name}}»? I mazzi verranno spostati in Senza cartella.",
+    "emptyHint": "Questa cartella è vuota.",
+    "unfiledEmptyHint": "Nessun mazzo senza cartella."
   }
 }

--- a/client/src/i18n/locales/pl/deck-builder.json
+++ b/client/src/i18n/locales/pl/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "Talia ma {{count}} kart (minimum 60)",
     "maxCopies": "{{name}}: {{count}} kopii (maks. 4)",
     "companionInMain": "{{name}} jest twoim towarzyszem, ale znajduje się też w talii głównej — to narusza jego warunek budowy talii. Usuń go z talii głównej, aby użyć go jako towarzysza."
+  },
+  "switcher": {
+    "starred": "Ulubione",
+    "unfiled": "Bez folderu",
+    "searchPlaceholder": "Szukaj talii…",
+    "noMatches": "Brak talii"
   }
 }

--- a/client/src/i18n/locales/pl/menu.json
+++ b/client/src/i18n/locales/pl/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Nieznane {{count}}",
     "unknownCardsTitle": "Nieznane karty:\n{{cards}}",
     "unsupportedTitle": "Nieobsługiwane ({{unique}} unikalnych, {{copies}} kopii):\n{{cards}}",
-    "setIconAlt": "Ikona dodatku {{code}}"
+    "setIconAlt": "Ikona dodatku {{code}}",
+    "actionsMenu": "Opcje talii",
+    "star": "Oznacz gwiazdką",
+    "unstar": "Usuń gwiazdkę",
+    "moveToFolder": "Przenieś do folderu",
+    "unfiled": "Bez folderu",
+    "newFolder": "Nowy folder…"
   },
   "myDecks": {
     "headingManage": "Moje talie",
@@ -254,7 +260,11 @@
     "loadMore": "Wczytaj więcej",
     "selectedDeck": "Wybrana talia",
     "chooseDeckToContinue": "Wybierz talię, aby kontynuować",
-    "filterAll": "Wszystkie"
+    "filterAll": "Wszystkie",
+    "sectionStarred": "Ulubione",
+    "sectionUnfiled": "Bez folderu",
+    "collapseAll": "Zwiń wszystko",
+    "expandAll": "Rozwiń wszystko"
   },
   "subscriptions": {
     "emptyTitle": "Brak subskrypcji kanałów",
@@ -281,5 +291,16 @@
     "alpha": "Alfa",
     "profile": "Profil",
     "settings": "Ustawienia"
+  },
+  "folder": {
+    "actionsMenu": "Opcje folderu",
+    "rename": "Zmień nazwę",
+    "delete": "Usuń",
+    "newFolder": "Nowy folder",
+    "newFolderPrompt": "Nazwa folderu:",
+    "renamePrompt": "Zmień nazwę folderu:",
+    "deleteConfirm": "Usunąć folder „{{name}}”? Talie zostaną przeniesione do „Bez folderu”.",
+    "emptyHint": "Ten folder jest pusty.",
+    "unfiledEmptyHint": "Brak talii bez folderu."
   }
 }

--- a/client/src/i18n/locales/pt/deck-builder.json
+++ b/client/src/i18n/locales/pt/deck-builder.json
@@ -271,5 +271,11 @@
     "minimumCount": "O deck tem {{count}} cartas (mínimo de 60)",
     "maxCopies": "{{name}}: {{count}} cópias (máx. 4)",
     "companionInMain": "{{name}} é seu companheiro, mas também está no deck principal — isso viola sua condição de construção. Remova-o do deck principal para usá-lo como companheiro."
+  },
+  "switcher": {
+    "starred": "Destacados",
+    "unfiled": "Sem pasta",
+    "searchPlaceholder": "Buscar baralhos…",
+    "noMatches": "Nenhum baralho"
   }
 }

--- a/client/src/i18n/locales/pt/menu.json
+++ b/client/src/i18n/locales/pt/menu.json
@@ -199,7 +199,13 @@
     "unknown": "Desconhecida {{count}}",
     "unknownCardsTitle": "Cartas desconhecidas:\n{{cards}}",
     "unsupportedTitle": "Não suportadas ({{unique}} únicas, {{copies}} cópias):\n{{cards}}",
-    "setIconAlt": "Ícone da coleção {{code}}"
+    "setIconAlt": "Ícone da coleção {{code}}",
+    "actionsMenu": "Opções do baralho",
+    "star": "Destacar",
+    "unstar": "Remover destaque",
+    "moveToFolder": "Mover para pasta",
+    "unfiled": "Sem pasta",
+    "newFolder": "Nova pasta…"
   },
   "myDecks": {
     "headingManage": "Meus Decks",
@@ -254,7 +260,11 @@
     "loadMore": "Carregar Mais",
     "selectedDeck": "Deck selecionado",
     "chooseDeckToContinue": "Escolha um deck para continuar",
-    "filterAll": "Todos"
+    "filterAll": "Todos",
+    "sectionStarred": "Destacados",
+    "sectionUnfiled": "Sem pasta",
+    "collapseAll": "Recolher tudo",
+    "expandAll": "Expandir tudo"
   },
   "subscriptions": {
     "emptyTitle": "Nenhuma inscrição em feed",
@@ -281,5 +291,16 @@
     "alpha": "Alpha",
     "profile": "Perfil",
     "settings": "Definições"
+  },
+  "folder": {
+    "actionsMenu": "Opções da pasta",
+    "rename": "Renomear",
+    "delete": "Excluir",
+    "newFolder": "Nova pasta",
+    "newFolderPrompt": "Nome da pasta:",
+    "renamePrompt": "Renomear pasta:",
+    "deleteConfirm": "Excluir a pasta \"{{name}}\"? Os baralhos irão para Sem pasta.",
+    "emptyHint": "Esta pasta está vazia.",
+    "unfiledEmptyHint": "Nenhum baralho sem pasta."
   }
 }

--- a/client/src/services/__tests__/backup.test.ts
+++ b/client/src/services/__tests__/backup.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { applyBackup, buildBackup, importBackupFromFile, type PhaseBackupV1 } from "../backup";
+import { DECK_FOLDERS_KEY, STORAGE_KEY_PREFIX } from "../../constants/storage";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const FOLDERS_JSON = JSON.stringify([{ id: "f1", name: "Control", order: 0 }]);
+
+describe("backup — deck folders", () => {
+  it("round-trips the folder registry through build + apply", () => {
+    localStorage.setItem(DECK_FOLDERS_KEY, FOLDERS_JSON);
+    localStorage.setItem(
+      STORAGE_KEY_PREFIX + "Deck A",
+      JSON.stringify({ main: [], sideboard: [] }),
+    );
+
+    const backup = buildBackup();
+    expect(backup.deckFolders).toBe(FOLDERS_JSON);
+
+    localStorage.clear();
+    applyBackup(backup, "overwrite");
+    expect(localStorage.getItem(DECK_FOLDERS_KEY)).toBe(FOLDERS_JSON);
+  });
+
+  it("overwrite-importing a pre-folders backup clears the local folder registry", () => {
+    // An old backup object predates the feature: no `deckFolders` field.
+    const oldBackup: PhaseBackupV1 = {
+      version: 1,
+      exportedAt: new Date(0).toISOString(),
+      preferences: null,
+      decks: {},
+      deckMetadata: null,
+      activeDeck: null,
+      feedSubscriptions: null,
+      feedDeckOrigins: null,
+    };
+    localStorage.setItem(DECK_FOLDERS_KEY, JSON.stringify([{ id: "stale", name: "Stale", order: 0 }]));
+
+    applyBackup(oldBackup, "overwrite");
+
+    // Cleared by the overwrite sweep; the absent field writes nothing back.
+    expect(localStorage.getItem(DECK_FOLDERS_KEY)).toBeNull();
+  });
+
+  it("validates a pre-folders backup file that omits deckFolders entirely", async () => {
+    const json = JSON.stringify({
+      version: 1,
+      exportedAt: new Date(0).toISOString(),
+      preferences: null,
+      decks: { "Deck A": JSON.stringify({ main: [], sideboard: [] }) },
+      deckMetadata: null,
+      activeDeck: null,
+      feedSubscriptions: null,
+      feedDeckOrigins: null,
+    });
+    const file = new File([json], "phase-backup.json", { type: "application/json" });
+
+    const result = await importBackupFromFile(file, "merge");
+    expect(result.decksImported).toBe(1);
+  });
+});

--- a/client/src/services/backup.ts
+++ b/client/src/services/backup.ts
@@ -14,6 +14,7 @@
  */
 import {
   ACTIVE_DECK_KEY,
+  DECK_FOLDERS_KEY,
   DECK_METADATA_KEY,
   FEED_DECK_ORIGINS_KEY,
   FEED_SUBSCRIPTIONS_KEY,
@@ -32,6 +33,12 @@ export interface PhaseBackupV1 {
   decks: Record<string, string>;
   /** Raw JSON of the deck metadata store, or null. */
   deckMetadata: string | null;
+  /**
+   * Raw JSON of the deck-folder registry, or null. Optional on read so
+   * backups exported before folders existed still validate (treated as
+   * "no folders"); always present on write.
+   */
+  deckFolders?: string | null;
   /** Currently-active deck name, or null. */
   activeDeck: string | null;
   /** Raw JSON of the feed subscriptions array, or null. */
@@ -59,6 +66,7 @@ export function buildBackup(): PhaseBackupV1 {
     preferences: localStorage.getItem(PREFERENCES_KEY),
     decks,
     deckMetadata: localStorage.getItem(DECK_METADATA_KEY),
+    deckFolders: localStorage.getItem(DECK_FOLDERS_KEY),
     activeDeck: localStorage.getItem(ACTIVE_DECK_KEY),
     feedSubscriptions: localStorage.getItem(FEED_SUBSCRIPTIONS_KEY),
     feedDeckOrigins: localStorage.getItem(FEED_DECK_ORIGINS_KEY),
@@ -95,9 +103,13 @@ function isBackupV1(value: unknown): value is PhaseBackupV1 {
   }
   const stringOrNull = (field: unknown): boolean =>
     field === null || typeof field === "string";
+  // `deckFolders` is optional on read: pre-folders backups omit it entirely.
+  const optionalStringOrNull = (field: unknown): boolean =>
+    field === undefined || stringOrNull(field);
   return (
     stringOrNull(v.preferences) &&
     stringOrNull(v.deckMetadata) &&
+    optionalStringOrNull(v.deckFolders) &&
     stringOrNull(v.activeDeck) &&
     stringOrNull(v.feedSubscriptions) &&
     stringOrNull(v.feedDeckOrigins)
@@ -191,6 +203,7 @@ export function applyBackup(
     true,
   );
   writeValidated(DECK_METADATA_KEY, backup.deckMetadata, true);
+  writeValidated(DECK_FOLDERS_KEY, backup.deckFolders ?? null, true);
   writeValidated(ACTIVE_DECK_KEY, backup.activeDeck, false);
   writeValidated(FEED_SUBSCRIPTIONS_KEY, backup.feedSubscriptions, true);
   writeValidated(FEED_DECK_ORIGINS_KEY, backup.feedDeckOrigins, true);

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -272,6 +272,7 @@ function buildDefaultPreferences(): PreferencesState {
     audioThemeId: "planeswalker",
     customThemeUrls: [],
     battlefieldCardDisplay: "art_crop",
+    collapsedFolderIds: [],
     commandZoneDisplay: "auto",
     tapRotation: "mtga",
     spellPaymentMode: "auto",
@@ -327,6 +328,9 @@ interface PreferencesState {
   audioThemeId: string;
   customThemeUrls: Array<{ id: string; url: string }>;
   battlefieldCardDisplay: BattlefieldCardDisplay;
+  /** Ids of deck-library folders the user has collapsed (id present = collapsed).
+   * Also holds the sentinel ids for the virtual Starred/Unfiled sections. */
+  collapsedFolderIds: string[];
   /** Command-zone layout mode (inline dock / compact pile / auto-by-viewport). */
   commandZoneDisplay: CommandZoneDisplay;
   tapRotation: TapRotation;
@@ -398,6 +402,8 @@ interface PreferencesActions {
   addCustomThemeUrl: (id: string, url: string) => void;
   removeCustomThemeUrl: (id: string) => void;
   setBattlefieldCardDisplay: (display: BattlefieldCardDisplay) => void;
+  toggleFolderCollapsed: (id: string) => void;
+  setCollapsedFolderIds: (ids: string[]) => void;
   setCommandZoneDisplay: (display: CommandZoneDisplay) => void;
   setTapRotation: (rotation: TapRotation) => void;
   setSpellPaymentMode: (mode: SpellPaymentMode) => void;
@@ -538,6 +544,13 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
           ...(state.audioThemeId === id ? { audioThemeId: "planeswalker" } : {}),
         })),
       setBattlefieldCardDisplay: (display) => set({ battlefieldCardDisplay: display }),
+      toggleFolderCollapsed: (id) =>
+        set((state) => ({
+          collapsedFolderIds: state.collapsedFolderIds.includes(id)
+            ? state.collapsedFolderIds.filter((existing) => existing !== id)
+            : [...state.collapsedFolderIds, id],
+        })),
+      setCollapsedFolderIds: (ids) => set({ collapsedFolderIds: ids }),
       setCommandZoneDisplay: (display) => set({ commandZoneDisplay: display }),
       setTapRotation: (rotation) => set({ tapRotation: rotation }),
       setSpellPaymentMode: (mode) => set({ spellPaymentMode: mode }),
@@ -698,7 +711,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 16,
+      version: 17,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -727,6 +740,8 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          via the shallow merge. The default bands reproduce today's
       //          gridTemplateRows exactly, so this is a zero-regression seed —
       //          no explicit migration block needed.
+      // v16 → v17: Add collapsedFolderIds; legacy stores default to [] (nothing
+      //          collapsed — the prior behavior) via the shallow merge.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;


### PR DESCRIPTION
Add a single-level folder system with per-deck/per-folder stars for the
saved-deck library and the deck-builder switcher.

Persistence (constants/storage.ts):
- `phase-deck-folders` registry + `folderId`/`starred` on DeckMeta
- folder CRUD, membership + star mutators, rename/clone metadata
  migration, all routed through a single `DECKS_CHANGED_EVENT` notify
- registered in `isUserOwnedStorageKey`; round-tripped in PhaseBackupV1
  (optional-on-read for pre-folders backups)

Grouping authority (hooks/useDeckFolders.ts):
- pure `groupSavedDecks` (Starred lifted out, dangling folderId →
  Unfiled, input order preserved) shared by library + switcher
- reactive hook refreshing on DECKS_CHANGED, native `storage`, and
  cloud-sync `PROFILE_REPLACED_EVENT`

Library (components/menu): unified collapsible DeckSection chrome with
Starter/Precons as immutable system folders; per-tile star + move-to-folder
kebab and per-folder rename/delete via a shared portaled PopoverMenu;
Collapse-/Expand-All; collapse state persisted in preferences (v17).

Builder: folder-aware, filterable Load switcher reusing the same grouping.

i18n: new menu + deck-builder keys translated across all 7 locales.
