### PR TITLE
feat(engine): impulse-cast exiled card until EOT with any-type mana (Black Widow)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8392,18 +8392,39 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
 }
 
 fn try_parse_play_the_exiled_card_grant(tp: TextPair) -> Option<ParsedEffectClause> {
-    let (duration, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
-        let (input, _) = opt(alt((tag("you may "), tag("may ")))).parse(input)?;
-        let (input, _) = alt((tag("play "), tag("cast "))).parse(input)?;
-        let (input, _) = tag("the exiled card").parse(input)?;
-        let (input, duration) = alt((
-            value(Duration::UntilEndOfTurn, tag(" this turn")),
-            value(Duration::UntilEndOfTurn, tag(" until end of turn")),
-            value(Duration::UntilEndOfTurn, tag(" until the end of turn")),
-        ))
-        .parse(input)?;
-        Ok((input, duration))
-    })?;
+    let ((duration, mana_spend_permission), rest_orig) =
+        nom_on_lower(tp.original, tp.lower, |input| {
+            let (input, _) = opt(alt((tag("you may "), tag("may ")))).parse(input)?;
+            let (input, _) = alt((tag("play "), tag("cast "))).parse(input)?;
+            // "the exiled nonland card" generalizes the bare "the exiled card"
+            // referent — the optional "nonland " qualifier (Black Widow, Super
+            // Spy) selects the same tracked exile set, so the grant is identical.
+            let (input, _) = tag("the exiled ").parse(input)?;
+            let (input, _) = opt(tag("nonland ")).parse(input)?;
+            let (input, _) = tag("card").parse(input)?;
+            // CR 514.2 + CR 611.2a: inline "until end of turn" sets the grant
+            // duration directly (it is not patched by `with_clause_duration` for
+            // this mid-clause position); the permission ends at cleanup.
+            let (input, duration) = alt((
+                value(Duration::UntilEndOfTurn, tag(" this turn")),
+                value(Duration::UntilEndOfTurn, tag(" until end of turn")),
+                value(Duration::UntilEndOfTurn, tag(" until the end of turn")),
+            ))
+            .parse(input)?;
+            // CR 609.4b + CR 601.2: optional trailing "and mana of any type can
+            // be spent to cast that spell" scopes the any-type/any-color mana
+            // permission to the granted cast (Black Widow, Super Spy).
+            let (input, mana_spend_permission) = opt(value(
+                ManaSpendPermission::AnyTypeOrColor,
+                (
+                    tag(" and mana of any "),
+                    alt((tag("type"), tag("color"))),
+                    tag(" can be spent to cast that spell"),
+                ),
+            ))
+            .parse(input)?;
+            Ok((input, (duration, mana_spend_permission)))
+        })?;
     if !rest_orig.trim().is_empty() {
         return None;
     }
@@ -8415,7 +8436,7 @@ fn try_parse_play_the_exiled_card_grant(tp: TextPair) -> Option<ParsedEffectClau
             frequency: CastFrequency::Unlimited,
             source_id: None,
             exiled_by_ability_controller: None,
-            mana_spend_permission: None,
+            mana_spend_permission,
             card_filter: None,
             single_use_group: None,
             single_use: false,
@@ -52778,6 +52799,123 @@ mod tests {
         assert_eq!(
             grantee,
             crate::types::ability::PermissionGrantee::AbilityController
+        );
+    }
+
+    /// CR 514.2 + CR 609.4b + CR 611.2a: "cast the exiled nonland card until end
+    /// of turn and mana of any type can be spent to cast that spell" (Black
+    /// Widow, Super Spy) extends `try_parse_play_the_exiled_card_grant` with the
+    /// optional `nonland` referent qualifier and the optional trailing any-type
+    /// mana conjunct, yielding a typed `PlayFromExile` grant with both the EOT
+    /// duration and the any-type/any-color mana permission.
+    #[test]
+    fn play_exiled_nonland_card_until_eot_with_any_type_mana_grant() {
+        let e = parse_effect(
+            "cast the exiled nonland card until end of turn and mana of any type \
+             can be spent to cast that spell",
+        );
+        let Effect::GrantCastingPermission {
+            permission,
+            target,
+            grantee,
+        } = e
+        else {
+            panic!("expected GrantCastingPermission, got {e:?}");
+        };
+        let CastingPermission::PlayFromExile {
+            duration,
+            mana_spend_permission,
+            ..
+        } = permission
+        else {
+            panic!("expected PlayFromExile permission");
+        };
+        assert_eq!(duration, Duration::UntilEndOfTurn);
+        assert_eq!(
+            mana_spend_permission,
+            Some(ManaSpendPermission::AnyTypeOrColor)
+        );
+        assert_eq!(
+            target,
+            TargetFilter::TrackedSet {
+                id: TrackedSetId(0)
+            }
+        );
+        assert_eq!(
+            grantee,
+            crate::types::ability::PermissionGrantee::AbilityController
+        );
+    }
+
+    /// The any-type mana conjunct is optional: the bare "cast the exiled nonland
+    /// card until end of turn" form must still yield `mana_spend_permission:
+    /// None` (the `opt(value(..))` returns `None` when the conjunct is absent).
+    #[test]
+    fn play_exiled_nonland_card_until_eot_no_mana_conjunct() {
+        let e = parse_effect("cast the exiled nonland card until end of turn");
+        let Effect::GrantCastingPermission { permission, .. } = e else {
+            panic!("expected GrantCastingPermission, got {e:?}");
+        };
+        let CastingPermission::PlayFromExile {
+            duration,
+            mana_spend_permission,
+            ..
+        } = permission
+        else {
+            panic!("expected PlayFromExile permission");
+        };
+        assert_eq!(duration, Duration::UntilEndOfTurn);
+        assert_eq!(mana_spend_permission, None);
+    }
+
+    /// Regression: the pre-existing bare "the exiled card" referent (Expressive
+    /// Iteration class) must be unaffected by the `nonland` and mana-conjunct
+    /// extensions — still `PlayFromExile { UntilEndOfTurn, None }`.
+    #[test]
+    fn play_exiled_card_this_turn_regression_unchanged() {
+        let e = parse_effect("you may play the exiled card this turn");
+        let Effect::GrantCastingPermission { permission, .. } = e else {
+            panic!("expected GrantCastingPermission, got {e:?}");
+        };
+        let CastingPermission::PlayFromExile {
+            duration,
+            mana_spend_permission,
+            ..
+        } = permission
+        else {
+            panic!("expected PlayFromExile permission");
+        };
+        assert_eq!(duration, Duration::UntilEndOfTurn);
+        assert_eq!(mana_spend_permission, None);
+    }
+
+    /// Discriminating: the "for as long as it remains exiled, and mana of any
+    /// type..." form (Blightwing Bandit class) must keep dispatching to
+    /// `try_parse_exile_play_grant_with_any_mana` (duration `Permanent`), NOT be
+    /// captured by the extended `try_parse_play_the_exiled_card_grant`. The
+    /// extended combinator's `tag("the exiled ")` referent never matches the
+    /// "that card"/"it" anaphor here, so no shadowing occurs.
+    #[test]
+    fn for_as_long_as_remains_exiled_any_mana_not_shadowed() {
+        let e = parse_effect(
+            "you may cast that card for as long as it remains exiled, \
+             and mana of any type can be spent to cast that spell",
+        );
+        let Effect::GrantCastingPermission { permission, .. } = e else {
+            panic!("expected GrantCastingPermission, got {e:?}");
+        };
+        let CastingPermission::PlayFromExile {
+            duration,
+            mana_spend_permission,
+            ..
+        } = permission
+        else {
+            panic!("expected PlayFromExile permission");
+        };
+        assert_ne!(duration, Duration::UntilEndOfTurn);
+        assert_eq!(
+            mana_spend_permission,
+            Some(ManaSpendPermission::AnyTypeOrColor)
         );
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4950,4 +4950,93 @@ mod tests {
             "the seventh-counter reflexive rider must lower to Effect::ControlNextTurn"
         );
     }
+
+    /// CR 514.2 + CR 609.4b + CR 611.2a: Black Widow's "if you don't" branch
+    /// grants a typed `PlayFromExile` impulse cast scoped to end of turn with
+    /// any-type/any-color mana spend permission. Before the
+    /// `try_parse_play_the_exiled_card_grant` extension this branch degraded to
+    /// `GenericEffect { SpendManaAsAnyColor, duration: null }` (dropping the
+    /// cast permission and the EOT window → `Swallow:Duration_UntilEndOfTurn`).
+    /// Discrimination: reverting either leaf addition flips the gated node back
+    /// to `GenericEffect` (proven via revert-probe), so the asserts below fail.
+    #[test]
+    fn black_widow_if_you_dont_grants_typed_play_from_exile_until_eot() {
+        use crate::types::ability::{AbilityCondition, CastingPermission, ManaSpendPermission};
+        use crate::types::statics::StaticMode;
+        use crate::types::Duration;
+
+        let parsed = parse_named(
+            "Menace\n\
+             Whenever Black Widow deals combat damage to a player, that player exiles \
+             cards from the top of their library until they exile a nonland card. You may \
+             put a +1/+1 counter on Black Widow. If you don't, you may cast the exiled \
+             nonland card until end of turn and mana of any type can be spent to cast that spell.",
+            "Black Widow, Super Spy",
+            &["Legendary", "Creature"],
+        );
+
+        // Walk the trigger sub_ability chain to the `Not(OptionalEffectPerformed)`
+        // gated node (the "if you don't" branch).
+        fn find_if_you_dont(def: &AbilityDefinition) -> Option<&AbilityDefinition> {
+            if def
+                .condition
+                .as_ref()
+                .is_some_and(AbilityCondition::is_not_optional_effect_performed)
+            {
+                return Some(def);
+            }
+            def.sub_ability.as_deref().and_then(find_if_you_dont)
+        }
+
+        let gated = parsed
+            .triggers
+            .iter()
+            .filter_map(|t| t.execute.as_deref())
+            .find_map(find_if_you_dont)
+            .expect("Black Widow trigger must carry a Not(OptionalEffectPerformed) gated node");
+
+        match &*gated.effect {
+            Effect::GrantCastingPermission { permission, .. } => match permission {
+                CastingPermission::PlayFromExile {
+                    duration,
+                    mana_spend_permission,
+                    ..
+                } => {
+                    assert_eq!(*duration, Duration::UntilEndOfTurn);
+                    assert_eq!(
+                        *mana_spend_permission,
+                        Some(ManaSpendPermission::AnyTypeOrColor)
+                    );
+                }
+                other => panic!("expected PlayFromExile permission, got {other:?}"),
+            },
+            other => panic!("expected GrantCastingPermission, got {other:?}"),
+        }
+
+        // The pre-fix degradation lowered to a GenericEffect carrying a
+        // `SpendManaAsAnyColor` static mode; assert no node in the chain does so,
+        // proving the cast permission was not dropped to that fallback.
+        fn chain_has_spend_mana_generic(def: &AbilityDefinition) -> bool {
+            let here = matches!(
+                &*def.effect,
+                Effect::GenericEffect { static_abilities, .. }
+                    if static_abilities.iter().any(|s| matches!(s.mode, StaticMode::SpendManaAsAnyColor { .. }))
+            );
+            here || def
+                .sub_ability
+                .as_deref()
+                .is_some_and(chain_has_spend_mana_generic)
+        }
+        assert!(
+            !parsed
+                .triggers
+                .iter()
+                .filter_map(|t| t.execute.as_deref())
+                .any(chain_has_spend_mana_generic),
+            "the cast permission must not degrade to GenericEffect{{SpendManaAsAnyColor}}"
+        );
+
+        // No swallowed-clause diagnostic for the dropped EOT duration.
+        assert!(!has_swallowed_detector(&parsed, "Duration_UntilEndOfTurn"));
+    }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Building block: impulse-cast the exiled card until end of turn with any-type mana

**Black Widow, Super Spy** — "Menace / Whenever Black Widow deals combat damage to a player, that player exiles cards from the top of their library until they exile a nonland card. You may put a +1/+1 counter on Black Widow. **If you don't, you may cast the exiled nonland card until end of turn and mana of any type can be spent to cast that spell.**" The impulse-cast branch degraded to `Effect::GenericEffect{SpendManaAsAnyColor, duration: null}` — the parser recognized the any-mana half but **dropped the cast permission and its until-end-of-turn duration** (`Swallow:Duration_UntilEndOfTurn`; `supported: false`, `gap_count: 1`).

**No new engine variant** (the `add-engine-variant` gate returned EXISTS_AS_PARAMETER). `CastingPermission::PlayFromExile` already carries `duration`, `granted_to`, and `mana_spend_permission`. The fix **extends the existing `try_parse_play_the_exiled_card_grant`** combinator (which already parses "play/cast the exiled card until end of turn" → `PlayFromExile{UntilEndOfTurn}`) with two leaf axes — rather than adding a sibling, per "parameterize, don't proliferate":

- optional `"nonland"` qualifier: `tag("the exiled ")` + `opt(tag("nonland "))` + `tag("card")`;
- optional trailing conjunct `"and mana of any type|color can be spent to cast that spell"` → `mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor)` (CR 609.4b — scoped to this exiled card, not a global player permission).

Black Widow's branch now lowers to:

```
GrantCastingPermission {
  permission: PlayFromExile { duration: UntilEndOfTurn,
                              mana_spend_permission: Some(AnyTypeOrColor),
                              card_filter: None },
  target: TrackedSet(0),
  grantee: AbilityController,
}
```

### Cross-player split

The damaged player exiles from their own library (and remains the card's **owner**), while the **caster** is Black Widow's controller: `granted_to` resolves to `ability.controller` via `grant_permission::resolve`, and `grantee` defaults to `AbilityController`. `card_filter` is `None` because `target: TrackedSet(0)` already scopes to exactly the just-exiled nonland card published by the preceding `ExileFromTopUntil`. The "if you don't" `Not(OptionalEffectPerformed)` gate is applied by the chain parser and is unchanged.

### Class generalization

The two leaf axes also fix the no-mana-tail "nonland card until end of turn" form and keep the existing bare "the exiled card this turn" form working — a small class win beyond Black Widow.

### CR references (grep-verified)

- **CR 609.4b** — "mana of any type can be spent" affects only how the cost is paid.
- **CR 611.2a** — durational continuous effect ("until end of turn").
- **CR 514.2** — "until end of turn" effects end at cleanup (permission prune).
- **CR 601.2** — casting.

### Tests (non-vacuous + discriminating; reviewer revert-probed)

- Full-card parse: the gated "if you don't" node is `GrantCastingPermission{PlayFromExile{UntilEndOfTurn, Some(AnyTypeOrColor)}}` (fail-before: `GenericEffect{SpendManaAsAnyColor}` — reverting either leaf restores the degraded shape).
- Discriminating: the untouched "for as long as it remains exiled, and mana of any type" path keeps `duration: Permanent` (not shadowed — the extended combinator's `tag("the exiled ")` rejects the "that card" referent, and dispatch order runs the for-as-long-as combinator first).
- Regression: bare "play the exiled card this turn" → `PlayFromExile{UntilEndOfTurn, None}`; no-conjunct "cast the exiled nonland card until end of turn" → `PlayFromExile{UntilEndOfTurn, None}`.

`mtgish/` untouched; no new variant/field; no dispatch reorder; clippy `-D warnings` clean; parser-combinator gate exit 0. The runtime `PlayFromExile` + `UntilEndOfTurn` prune + `mana_spend_permission` paths are pre-covered by existing supported impulse-exile cards — the only delta is the parser producing the typed grant. Coverage flips `supported: true`, `gap_count: 0` on the next card-data regeneration.
