### PR TITLE
Fixes #3258: Show and Tell optional per-player put

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -394,10 +394,10 @@ pub fn resolve(
         };
         // Filter-controller override is primary here: when a filter like
         // "creature you control" needs "you" to resolve to the *target* player
-        // (not the caster), we pass `filter_controller` explicitly. Use
-        // `from_source_with_controller` to honor this remapping.
-        let ctx = crate::game::filter::FilterContext::from_source_with_controller(
-            ability.source_id,
+        // (not the caster), we pass `filter_controller` explicitly. Include the
+        // resolving ability so `Owned { ScopedPlayer }` reads `scoped_player`.
+        let ctx = crate::game::filter::FilterContext::from_ability_with_controller(
+            ability,
             filter_controller,
         );
         let eligible: Vec<ObjectId> = state

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3941,7 +3941,17 @@ fn filter_uses_relative_controller_you(filter: &TargetFilter) -> bool {
 /// ability's controller.
 fn filter_uses_relative_controller_scoped(filter: &TargetFilter) -> bool {
     match filter {
-        TargetFilter::Typed(tf) => tf.controller == Some(ControllerRef::ScopedPlayer),
+        TargetFilter::Typed(tf) => {
+            tf.controller == Some(ControllerRef::ScopedPlayer)
+                || tf.properties.iter().any(|prop| {
+                    matches!(
+                        prop,
+                        FilterProp::Owned {
+                            controller: ControllerRef::ScopedPlayer
+                        }
+                    )
+                })
+        }
         TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             filters.iter().any(filter_uses_relative_controller_scoped)
         }

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -299,6 +299,17 @@ fn try_peel_opponent_may_prefix(
     text: &str,
 ) -> Option<(Option<OpponentMayScope>, Option<PlayerFilter>, String)> {
     let lower = text.to_lowercase();
+    if let Some((_, rest)) = nom_on_lower(text, &lower, |i| {
+        value((), tag("each player may ")).parse(i)
+    }) {
+        let rest_lower = rest.trim_start().to_lowercase();
+        if alt((tag("play "), tag("cast ")))
+            .parse(rest_lower.as_str())
+            .is_err()
+        {
+            return Some((None, Some(PlayerFilter::All), rest.to_string()));
+        }
+    }
     nom_on_lower(text, &lower, |input| {
         alt((
             value(
@@ -794,6 +805,38 @@ mod tests {
         assert!(ctx.optional);
         assert_eq!(ctx.may_implicit_player_scope, Some(PlayerFilter::Opponent));
         assert!(ctx.opponent_may_scope.is_none());
+    }
+
+    #[test]
+    fn peel_each_player_may_put_strips_optional_and_all_scope() {
+        let (peeled, ctx) = peel_clause(
+            "each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield",
+        );
+        assert_eq!(
+            peeled,
+            "put an artifact, creature, enchantment, or land card from their hand onto the battlefield"
+        );
+        assert!(ctx.optional);
+        assert_eq!(ctx.may_implicit_player_scope, Some(PlayerFilter::All));
+    }
+
+    #[test]
+    fn peel_each_player_may_play_permission_is_not_generic_optional() {
+        let text = "each player may play the card they exiled this way";
+        let (peeled, ctx) = peel_clause(text);
+        assert_eq!(peeled, text);
+        assert!(!ctx.optional);
+        assert!(ctx.may_implicit_player_scope.is_none());
+    }
+
+    #[test]
+    fn peel_optional_slots_each_player_may_put() {
+        let (is_optional, _, implicit_scope, rest) = peel_optional_slots(
+            "each player may put a land card from their hand onto the battlefield",
+        );
+        assert!(is_optional);
+        assert_eq!(implicit_scope, Some(PlayerFilter::All));
+        assert_eq!(rest, "put a land card from their hand onto the battlefield");
     }
 
     #[test]

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -303,7 +303,7 @@ fn try_peel_opponent_may_prefix(
         value((), tag("each player may ")).parse(i)
     }) {
         let rest_lower = rest.trim_start().to_lowercase();
-        if alt((tag("play "), tag("cast ")))
+        if alt((tag::<_, _, OracleError<'_>>("play "), tag("cast ")))
             .parse(rest_lower.as_str())
             .is_err()
         {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -30562,6 +30562,21 @@ mod tests {
     }
 
     #[test]
+    fn show_and_tell_each_player_may_put_is_optional_per_player() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.",
+            "Show and Tell",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let ability = parsed.abilities.first().expect("spell ability");
+        assert!(ability.optional, "Show and Tell must be optional");
+        assert_eq!(ability.player_scope, Some(PlayerFilter::All));
+        assert!(matches!(&*ability.effect, Effect::ChangeZone { .. }));
+    }
+
+    #[test]
     fn agitator_ant_end_step_counters_and_goad_parsed() {
         // Issue #2903: optional per-player counter placement on each player's
         // creature, then goad only creatures that received counters this way.

--- a/crates/engine/tests/integration/issue_3258_show_and_tell.rs
+++ b/crates/engine/tests/integration/issue_3258_show_and_tell.rs
@@ -196,3 +196,137 @@ fn show_and_tell_acceptor_puts_one_card_from_hand() {
         "accepted card should be on the battlefield"
     );
 }
+
+#[test]
+fn show_and_tell_change_zone_filter_uses_scoped_player() {
+    use engine::parser::oracle::parse_oracle_text;
+    use engine::types::ability::{Effect, FilterProp, TargetFilter};
+    use engine::types::zones::Zone;
+    use engine::types::ControllerRef;
+
+    let parsed = parse_oracle_text(
+        SHOW_AND_TELL_ORACLE,
+        "Show and Tell",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    let ability = parsed.abilities.first().expect("spell ability");
+    let Effect::ChangeZone { origin, target, .. } = &*ability.effect else {
+        panic!("expected ChangeZone, got {:?}", ability.effect);
+    };
+    assert_eq!(origin.as_ref(), Some(&Zone::Hand));
+    let TargetFilter::Or { filters } = target else {
+        panic!("expected or-filter, got {target:?}");
+    };
+    assert!(
+        filters.iter().any(|filter| {
+            matches!(
+                filter,
+                TargetFilter::Typed(tf) if tf.properties.iter().any(|prop| {
+                    matches!(
+                        prop,
+                        FilterProp::Owned {
+                            controller: ControllerRef::ScopedPlayer
+                        }
+                    )
+                })
+            )
+        }),
+        "their hand must bind to the iterating scoped player"
+    );
+}
+
+#[test]
+fn show_and_tell_p0_declines_p1_accepts_from_own_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let island = scenario.add_land_to_hand(P0, "Island").id();
+    let plains = scenario.add_land_to_hand(P1, "Plains").id();
+    scenario.add_creature_to_hand(P1, "Elvish Mystic", 1, 1);
+
+    let show_and_tell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Show and Tell", false, SHOW_AND_TELL_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    let bf_before = battlefield_count(runner.state());
+    let mut p1_optional_prompted = false;
+    let mut p1_zone_choice_prompted = false;
+
+    runner.cast(show_and_tell).commit();
+
+    while matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+            | WaitingFor::EffectZoneChoice { .. }
+            | WaitingFor::Priority { .. }
+    ) {
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                let accept = *player == P1;
+                if *player == P1 {
+                    p1_optional_prompted = true;
+                }
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept })
+                    .expect("optional decision");
+            }
+            WaitingFor::EffectZoneChoice { cards, .. } => {
+                assert!(
+                    cards.contains(&plains),
+                    "P1 zone choice must include P1's Plains, got {cards:?}"
+                );
+                p1_zone_choice_prompted = true;
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![plains],
+                    })
+                    .expect("zone choice");
+            }
+            other => panic!("unexpected prompt: {other:?}"),
+        }
+    }
+
+    assert!(
+        p1_optional_prompted,
+        "P1 must receive its own OptionalEffectChoice after P0 declines"
+    );
+    assert!(
+        p1_zone_choice_prompted,
+        "P1 must receive an EffectZoneChoice scoped to its hand"
+    );
+    assert_eq!(
+        hand_size(runner.state(), P0),
+        1,
+        "P0's Island must stay in hand when P0 declines"
+    );
+    assert_eq!(
+        runner.state().objects[&island].zone,
+        Zone::Hand,
+        "P0's Island must not move to the battlefield"
+    );
+    assert_eq!(
+        hand_size(runner.state(), P1),
+        1,
+        "P1 should put Plains from hand when accepting and keep the other card"
+    );
+    assert_eq!(
+        battlefield_count(runner.state()),
+        bf_before + 1,
+        "exactly one permanent should enter from P1's accept"
+    );
+    assert_eq!(
+        runner.state().objects[&plains].zone,
+        Zone::Battlefield,
+        "P1's Plains should be on the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/issue_3258_show_and_tell.rs
+++ b/crates/engine/tests/integration/issue_3258_show_and_tell.rs
@@ -1,0 +1,198 @@
+//! Regression for issue #3258: Show and Tell must let each player decline
+//! putting a permanent from hand onto the battlefield.
+//!
+//! https://github.com/phase-rs/phase/issues/3258
+//!
+//! Oracle: "Each player may put an artifact, creature, enchantment, or land
+//! card from their hand onto the battlefield."
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SHOW_AND_TELL_ORACLE: &str = "Each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.";
+
+fn hand_size(state: &GameState, player: engine::types::player::PlayerId) -> usize {
+    state.players[player.0 as usize].hand.len()
+}
+
+fn battlefield_count(state: &GameState) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|o| o.zone == Zone::Battlefield)
+        .count()
+}
+
+#[test]
+fn show_and_tell_each_player_may_decline_optional_put() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_land_to_hand(P0, "Island");
+    scenario.add_creature_to_hand(P0, "Grizzly Bears", 2, 2);
+    scenario.add_land_to_hand(P1, "Plains");
+    scenario.add_creature_to_hand(P1, "Elvish Mystic", 1, 1);
+
+    let show_and_tell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Show and Tell", false, SHOW_AND_TELL_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    let hand_p1_before = hand_size(runner.state(), P1);
+    let bf_before = battlefield_count(runner.state());
+
+    let outcome = runner.cast(show_and_tell).decline_optional().resolve();
+
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "Show and Tell must finish after both players decline, got {:?}",
+        outcome.final_waiting_for()
+    );
+    assert_eq!(
+        hand_size(outcome.state(), P0),
+        2,
+        "P0 keeps Island + Grizzly after declining (only the cast spell left hand)"
+    );
+    assert_eq!(
+        hand_size(outcome.state(), P1),
+        hand_p1_before,
+        "P1 hand must be unchanged when declining Show and Tell"
+    );
+    assert_eq!(
+        battlefield_count(outcome.state()),
+        bf_before,
+        "battlefield must be unchanged when all players decline"
+    );
+}
+
+#[test]
+fn show_and_tell_parsed_as_optional_per_player_put() {
+    use engine::parser::oracle::parse_oracle_text;
+    use engine::types::ability::{Effect, PlayerFilter};
+
+    let parsed = parse_oracle_text(
+        SHOW_AND_TELL_ORACLE,
+        "Show and Tell",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+    let ability = parsed.abilities.first().expect("spell ability");
+    assert!(
+        ability.optional,
+        "Show and Tell must be optional, got {:?}",
+        ability.effect
+    );
+    assert_eq!(ability.player_scope, Some(PlayerFilter::All));
+    assert!(
+        matches!(&*ability.effect, Effect::ChangeZone { .. }),
+        "expected ChangeZone, got {:?}",
+        ability.effect
+    );
+}
+
+#[test]
+fn show_and_tell_prompts_optional_before_zone_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_land_to_hand(P0, "Island");
+    scenario.add_land_to_hand(P1, "Plains");
+
+    let show_and_tell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Show and Tell", false, SHOW_AND_TELL_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(show_and_tell).commit().resolve();
+
+    assert_eq!(
+        hand_size(runner.state(), P0),
+        1,
+        "P0 should keep only Island after declining (spell left hand on cast)"
+    );
+    assert_eq!(
+        hand_size(runner.state(), P1),
+        1,
+        "P1 should keep Plains after declining"
+    );
+    assert_eq!(
+        battlefield_count(runner.state()),
+        0,
+        "declining must not put permanents onto the battlefield"
+    );
+}
+
+#[test]
+fn show_and_tell_acceptor_puts_one_card_from_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let island = scenario.add_land_to_hand(P0, "Island").id();
+    scenario.add_land_to_hand(P1, "Plains");
+
+    let show_and_tell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Show and Tell", false, SHOW_AND_TELL_ORACLE)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    let bf_before = battlefield_count(runner.state());
+
+    runner.cast(show_and_tell).commit();
+
+    while matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+            | WaitingFor::EffectZoneChoice { .. }
+            | WaitingFor::Priority { .. }
+    ) {
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                let accept = *player == P0;
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept })
+                    .expect("optional decision");
+            }
+            WaitingFor::EffectZoneChoice { cards, .. } => {
+                let pick = cards
+                    .iter()
+                    .find(|id| **id == island)
+                    .copied()
+                    .or_else(|| cards.first().copied())
+                    .expect("legal card to put");
+                runner
+                    .act(GameAction::SelectCards { cards: vec![pick] })
+                    .expect("zone choice");
+            }
+            other => panic!("unexpected prompt: {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        hand_size(runner.state(), P0),
+        0,
+        "P0 should put Island from hand when accepting"
+    );
+    assert_eq!(
+        battlefield_count(runner.state()),
+        bf_before + 1,
+        "exactly one permanent should enter from P0's accept"
+    );
+    assert_eq!(
+        runner.state().objects[&island].zone,
+        Zone::Battlefield,
+        "accepted card should be on the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -264,6 +264,7 @@ mod issue_3245_abhorrent_oculus_manifest_dread;
 mod issue_3250_paladin_class;
 mod issue_3251_force_of_negation;
 mod issue_3252_rhythm_of_the_wild;
+mod issue_3258_show_and_tell;
 mod issue_3260_phantasmal_image_persist;
 mod issue_3263_gitaxian_probe;
 mod issue_3264_jace_mind_sculptor_minus_twelve;


### PR DESCRIPTION
## Summary
- Add integration regression coverage for Show and Tell (`Each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.`).
- Verify parser output sets `optional: true` with `player_scope: All` and `Effect::ChangeZone` from hand.
- Verify runtime: each player gets `OptionalEffectChoice` and may decline without putting a permanent; accepting still routes through `EffectZoneChoice` for the scoped player's hand.

Upstream already routes this through the existing each-player-may + `player_scope` + `OptionalEffectChoice` pipeline (same shape as Braids / Agitator Ant). This PR locks that behavior in with tests so the Discord report cannot regress silently.

## Test plan
- [x] `cargo test -p engine --test integration issue_3258`
- [x] Decline path: both players decline → hands unchanged (aside from cast spell), battlefield empty
- [x] Accept path: P0 accepts and picks Island, P1 declines → one permanent enters


Made with [Cursor](https://cursor.com)