### PR TITLE
fix(engine): prevent Insidious Roots double-trigger on graveyard leave (fixes #3866)

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -417,6 +417,95 @@ fn partition_lki_trigger_definitions(
     (printed, granted_keywords)
 }
 
+fn batched_zone_change_batch(events: &[GameEvent]) -> bool {
+    !events.is_empty()
+        && events
+            .iter()
+            .all(|event| matches!(event, GameEvent::ZoneChanged { .. }))
+}
+
+fn batched_zone_change_replay_guard_applies(
+    trig_def: &TriggerDefinition,
+    trigger_events: &[GameEvent],
+) -> bool {
+    trig_def.batched
+        && matches!(
+            trig_def.mode,
+            TriggerMode::ChangesZone | TriggerMode::ChangesZoneAll | TriggerMode::Evolve
+        )
+        && batched_zone_change_batch(trigger_events)
+}
+
+fn batched_zone_change_already_collected(
+    state: &GameState,
+    source_id: ObjectId,
+    trig_idx: usize,
+    trigger_events: &[GameEvent],
+) -> bool {
+    let keys: Vec<(ObjectId, Option<Zone>, Zone)> = trigger_events
+        .iter()
+        .filter_map(|event| {
+            if let GameEvent::ZoneChanged {
+                object_id,
+                from,
+                to,
+                ..
+            } = event
+            {
+                Some((*object_id, *from, *to))
+            } else {
+                None
+            }
+        })
+        .collect();
+    !keys.is_empty()
+        && keys.iter().all(|(moved_object, from, to)| {
+            state.batched_zone_change_trigger_fired.contains(&(
+                source_id,
+                trig_idx,
+                *moved_object,
+                *from,
+                *to,
+            ))
+        })
+}
+
+fn record_batched_zone_change_collected(
+    state: &mut GameState,
+    source_id: ObjectId,
+    trig_idx: usize,
+    trigger_events: &[GameEvent],
+) {
+    for event in trigger_events {
+        if let GameEvent::ZoneChanged {
+            object_id,
+            from,
+            to,
+            ..
+        } = event
+        {
+            state
+                .batched_zone_change_trigger_fired
+                .insert((source_id, trig_idx, *object_id, *from, *to));
+        }
+    }
+}
+
+fn record_matched_batched_zone_change_replay(
+    state: &mut GameState,
+    source_id: ObjectId,
+    matched: &MatchedTrigger,
+) {
+    if matched.batched && batched_zone_change_batch(&matched.trigger_events) {
+        record_batched_zone_change_collected(
+            state,
+            source_id,
+            matched.trig_idx,
+            &matched.trigger_events,
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn collect_matching_triggers(
     state: &GameState,
@@ -690,6 +779,16 @@ fn collect_matching_triggers_inner(
                 vec![vec![event.clone()]]
             };
             for trigger_events in trigger_event_batches {
+                if batched_zone_change_replay_guard_applies(trig_def, &trigger_events)
+                    && batched_zone_change_already_collected(
+                        state,
+                        obj_id,
+                        trig_idx,
+                        &trigger_events,
+                    )
+                {
+                    continue;
+                }
                 let trigger_event = trigger_events
                     .first()
                     .cloned()
@@ -1301,6 +1400,7 @@ fn collect_pending_triggers(
                     matched.trig_idx,
                     event,
                 );
+                record_matched_batched_zone_change_replay(state, obj_id, &matched);
                 if matched.batched {
                     batched_this_pass.insert((obj_id, matched.trig_idx));
                 }
@@ -1701,6 +1801,7 @@ fn collect_pending_triggers(
                         matched.trig_idx,
                         event,
                     );
+                    record_matched_batched_zone_change_replay(state, *moved_id, &matched);
                     if matched.batched {
                         batched_this_pass.insert((*moved_id, matched.trig_idx));
                     }
@@ -1750,6 +1851,7 @@ fn collect_pending_triggers(
                         matched.trig_idx,
                         event,
                     );
+                    record_matched_batched_zone_change_replay(state, *exploiter, &matched);
                     if matched.batched {
                         batched_this_pass.insert((*exploiter, matched.trig_idx));
                     }
@@ -1819,6 +1921,7 @@ fn collect_pending_triggers(
                         matched.trig_idx,
                         event,
                     );
+                    record_matched_batched_zone_change_replay(state, observer_id, &matched);
                     if matched.batched {
                         batched_this_pass.insert((observer_id, matched.trig_idx));
                     }
@@ -1935,6 +2038,7 @@ fn collect_pending_triggers(
                         matched.trig_idx,
                         event,
                     );
+                    record_matched_batched_zone_change_replay(state, obj_id, &matched);
                     if matched.batched {
                         batched_this_pass.insert((obj_id, matched.trig_idx));
                     }

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -624,6 +624,7 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.players_who_sacrificed_artifact_this_turn.clear();
     state.sacrificed_permanents_this_turn.clear();
     state.zone_changes_this_turn.clear();
+    state.batched_zone_change_trigger_fired.clear();
     state.battlefield_entries_this_turn.clear();
     // CR 701.26 + CR 603.4: reset per-object tap counts so "first time it became
     // tapped this turn" intervening-ifs start fresh each turn.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6205,6 +6205,12 @@ pub struct GameState {
     /// CR 400.7: Zone-change snapshots this turn, enabling data-driven condition queries.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub zone_changes_this_turn: Vec<ZoneChangeRecord>,
+    /// CR 603.2c: Batched zone-change triggers already collected for
+    /// `(source_id, trig_idx, moved_object, from, to)`. Prevents a second
+    /// `process_triggers` pass over the same `ZoneChanged` events from
+    /// stacking duplicate batched triggers (issue #3866).
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub batched_zone_change_trigger_fired: HashSet<(ObjectId, usize, ObjectId, Option<Zone>, Zone)>,
     /// CR 403.3: Battlefield entry snapshots this turn, enabling data-driven ETB queries.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub battlefield_entries_this_turn: Vec<BattlefieldEntryRecord>,
@@ -7295,6 +7301,7 @@ impl GameState {
             players_who_sacrificed_artifact_this_turn: HashSet::new(),
             sacrificed_permanents_this_turn: Vec::new(),
             zone_changes_this_turn: Vec::new(),
+            batched_zone_change_trigger_fired: HashSet::new(),
             battlefield_entries_this_turn: Vec::new(),
             damage_dealt_this_turn: im::Vector::new(),
             assassin_or_commander_dealt_combat_damage_this_turn: HashSet::new(),
@@ -7756,6 +7763,7 @@ impl PartialEq for GameState {
                 == other.players_who_sacrificed_artifact_this_turn
             && self.sacrificed_permanents_this_turn == other.sacrificed_permanents_this_turn
             && self.zone_changes_this_turn == other.zone_changes_this_turn
+            && self.batched_zone_change_trigger_fired == other.batched_zone_change_trigger_fired
             && self.battlefield_entries_this_turn == other.battlefield_entries_this_turn
             && self.damage_dealt_this_turn == other.damage_dealt_this_turn
             && self.assassin_or_commander_dealt_combat_damage_this_turn

--- a/crates/engine/tests/integration/issue_3866_insidious_roots_double_trigger.rs
+++ b/crates/engine/tests/integration/issue_3866_insidious_roots_double_trigger.rs
@@ -1,0 +1,252 @@
+//! Issue #3866 — Insidious Roots must trigger once when creature cards leave
+//! your graveyard, not twice.
+//!
+//! https://github.com/phase-rs/phase/issues/3866
+
+use engine::database::card_db::CardDatabase;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::game::zones::move_to_zone;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const REANIMATE_ORACLE: &str =
+    "Return target creature card from your graveyard to the battlefield.";
+
+fn card_db() -> &'static CardDatabase {
+    static DB: std::sync::OnceLock<CardDatabase> = std::sync::OnceLock::new();
+    DB.get_or_init(|| {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/card-data.json");
+        CardDatabase::from_export(&path).expect("card-data.json must load")
+    })
+}
+
+fn plant_token_count(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| {
+            o.zone == Zone::Battlefield
+                && o.is_token
+                && o.card_types.subtypes.iter().any(|s| s == "Plant")
+        })
+        .count()
+}
+
+fn insidious_roots_stack_triggers(
+    runner: &engine::game::scenario::GameRunner,
+    roots: ObjectId,
+) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|e| e.source_id == roots)
+        .count()
+}
+
+fn drain_stack(runner: &mut engine::game::scenario::GameRunner) {
+    for _ in 0..200 {
+        if matches!(runner.state().waiting_for, WaitingFor::OrderTriggers { .. }) {
+            engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            continue;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn issue_3866_insidious_roots_trigger_definitions_not_duplicated() {
+    let db = card_db();
+    let face = db
+        .get_face_by_name("Insidious Roots")
+        .expect("Insidious Roots must be in card-data");
+    assert_eq!(
+        face.triggers.len(),
+        1,
+        "Insidious Roots must have exactly one printed trigger definition"
+    );
+    assert!(
+        face.triggers[0].batched,
+        "graveyard-leave trigger must be batched (CR 603.2c)"
+    );
+}
+
+#[test]
+fn issue_3866_insidious_roots_fires_once_when_creature_leaves_graveyard() {
+    let db = card_db();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let roots = scenario.add_real_card(P0, "Insidious Roots", Zone::Battlefield, db);
+    let gy_creature = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+
+    let mut runner = scenario.build();
+    let trigger_count = runner
+        .state()
+        .objects
+        .get(&roots)
+        .map(|o| o.trigger_definitions.len())
+        .unwrap_or(0);
+    assert_eq!(
+        trigger_count, 1,
+        "runtime object must carry a single trigger definition"
+    );
+
+    let plants_before = plant_token_count(&runner);
+
+    let mut events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        gy_creature,
+        Zone::Battlefield,
+        &mut events,
+    );
+    engine::game::triggers::process_triggers(runner.state_mut(), &events);
+    engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+
+    assert_eq!(
+        insidious_roots_stack_triggers(&runner, roots),
+        1,
+        "exactly one Insidious Roots trigger must be on the stack"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&gy_creature].zone,
+        Zone::Battlefield,
+        "creature should be on the battlefield"
+    );
+    assert_eq!(
+        plant_token_count(&runner) - plants_before,
+        1,
+        "Insidious Roots must create exactly one Plant token"
+    );
+}
+
+#[test]
+fn issue_3866_insidious_roots_fires_once_when_two_creatures_leave_graveyard() {
+    let db = card_db();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let roots = scenario.add_real_card(P0, "Insidious Roots", Zone::Battlefield, db);
+    let gy_a = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    let gy_b = scenario.add_real_card(P0, "Elvish Mystic", Zone::Graveyard, db);
+
+    let mut runner = scenario.build();
+    let plants_before = plant_token_count(&runner);
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), gy_a, Zone::Battlefield, &mut events);
+    move_to_zone(runner.state_mut(), gy_b, Zone::Battlefield, &mut events);
+    engine::game::triggers::process_triggers(runner.state_mut(), &events);
+    engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+
+    assert_eq!(
+        insidious_roots_stack_triggers(&runner, roots),
+        1,
+        "batched graveyard-leave trigger must register once for simultaneous leaves (CR 603.2c)"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        plant_token_count(&runner) - plants_before,
+        1,
+        "one batched trigger must create one Plant token even when two creatures leave"
+    );
+}
+
+#[test]
+fn issue_3866_double_process_triggers_on_same_events_is_regression_guard() {
+    let db = card_db();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let roots = scenario.add_real_card(P0, "Insidious Roots", Zone::Battlefield, db);
+    let gy_creature = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+
+    let mut runner = scenario.build();
+
+    let mut events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        gy_creature,
+        Zone::Battlefield,
+        &mut events,
+    );
+
+    engine::game::triggers::process_triggers(runner.state_mut(), &events);
+    engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+    let after_first = insidious_roots_stack_triggers(&runner, roots);
+
+    engine::game::triggers::process_triggers(runner.state_mut(), &events);
+    engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+    let after_second = insidious_roots_stack_triggers(&runner, roots);
+
+    assert_eq!(
+        after_first, 1,
+        "first trigger scan must enqueue exactly one Insidious Roots trigger"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "re-scanning the same graveyard-leave events must not enqueue a duplicate trigger"
+    );
+}
+
+#[test]
+fn issue_3866_insidious_roots_fires_once_via_reanimate_spell() {
+    let db = card_db();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let roots = scenario.add_real_card(P0, "Insidious Roots", Zone::Battlefield, db);
+    let gy_creature = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    let reanimate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", true, REANIMATE_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    let plants_before = plant_token_count(&runner);
+
+    runner.cast(reanimate).target_object(gy_creature).resolve();
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&gy_creature].zone,
+        Zone::Battlefield,
+        "reanimated creature should be on the battlefield"
+    );
+    assert_eq!(
+        plant_token_count(&runner) - plants_before,
+        1,
+        "Insidious Roots must create exactly one Plant token when a creature leaves the graveyard via Reanimate"
+    );
+    assert!(
+        insidious_roots_stack_triggers(&runner, roots) <= 1,
+        "at most one Insidious Roots trigger should remain on stack after resolution"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -324,6 +324,7 @@ mod issue_3665_smugglers_share;
 mod issue_3681_inferno_titan_divided_damage;
 mod issue_3817_sheoldred_apocalypse;
 mod issue_3864_swords_two_targets;
+mod issue_3866_insidious_roots_double_trigger;
 mod issue_3869_pentad_prism_mana;
 mod issue_3871_summoners_pact;
 mod issue_3872_tithe_taker_turn_scoped_tax;


### PR DESCRIPTION
## Summary
- Insidious Roots (`ChangesZoneAll`, batched, origin Graveyard) was stacking twice when the same `ZoneChanged` events were scanned more than once in a single action (e.g. inline `collect_triggers_into_deferred` plus `run_post_action_pipeline`).
- Add a per-turn ledger keyed by `(source, trigger index, moved object, from, to)` so batched zone-change triggers are collected at most once per physical zone change.
- Integration tests cover single/batched graveyard leaves, double `process_triggers` replay, and a full Reanimate cast path.

## Test plan
- [x] `cargo test -p engine --test integration issue_3866` (5 tests)

Fixes #3866

Made with [Cursor](https://cursor.com)