### PR TITLE
feat(engine): implement Two-Headed Giant shared team play (CR 810)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -3460,18 +3460,24 @@ fn casting_variant_candidates(
         candidates.push(CastingVariant::Prowl);
     }
 
-    // CR 702.117a: Surge — a hand alternative cost legal when the caster has cast
-    // another spell this turn (in non–Two-Headed-Giant games there are no
-    // teammates). The surge spell isn't recorded in `spells_cast_this_turn_by_player`
-    // yet at offer time, so any prior entry for the caster satisfies "another spell".
+    // CR 702.117a: Surge — a hand alternative cost legal when the caster OR
+    // one of their teammates (CR 810.5 doesn't share hand/casting resources,
+    // but Surge's own text explicitly extends to teammates) has cast another
+    // spell this turn. The surge spell isn't recorded in
+    // `spells_cast_this_turn_by_player` yet at offer time, so any prior entry
+    // for the caster or a teammate satisfies "another spell".
     if obj.zone == Zone::Hand
         && effective_spell_keywords(state, player, object_id)
             .iter()
             .any(|k| matches!(k, Keyword::Surge(_)))
-        && state
-            .spells_cast_this_turn_by_player
-            .get(&player)
-            .is_some_and(|spells| !spells.is_empty())
+        && std::iter::once(player)
+            .chain(super::players::teammates(state, player))
+            .any(|p| {
+                state
+                    .spells_cast_this_turn_by_player
+                    .get(&p)
+                    .is_some_and(|spells| !spells.is_empty())
+            })
     {
         candidates.push(CastingVariant::Surge);
     }
@@ -14919,8 +14925,8 @@ mod tests {
         );
     }
 
-    /// CR 702.117a: surge keys on the caster's own spells — an opponent casting a
-    /// spell this turn must not enable your surge (no teammates outside 2HG).
+    /// CR 702.117a: surge keys on the caster's own (or a teammate's) spells —
+    /// an opponent casting a spell this turn must not enable your surge.
     #[test]
     fn surge_unavailable_when_only_opponent_cast_a_spell() {
         let mut state = setup_game_at_main_phase();
@@ -14930,6 +14936,26 @@ mod tests {
         assert!(
             !candidates.contains(&CastingVariant::Surge),
             "an opponent's spell must not enable your surge; got {candidates:?}",
+        );
+    }
+
+    /// CR 702.117a + CR 810: "You may pay [cost] ... if you or one of your
+    /// teammates has cast another spell this turn." Under a team-based
+    /// format, a teammate's spell (not just the caster's own) must enable
+    /// Surge.
+    #[test]
+    fn surge_available_when_teammate_cast_a_spell() {
+        let mut state = setup_game_at_main_phase();
+        state.format_config.team_based = true;
+        let object_id = add_surge_card_in_hand(&mut state);
+        // PlayerId(1) is PlayerId(0)'s teammate under the team-based override
+        // (`players::teammates`'s positional pairing: seats 0+1).
+        record_one_spell_cast_this_turn(&mut state, PlayerId(1));
+
+        let candidates = casting_variant_candidates(&state, PlayerId(0), object_id);
+        assert!(
+            candidates.contains(&CastingVariant::Surge),
+            "a teammate's spell must enable your surge; got {candidates:?}",
         );
     }
 

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -400,9 +400,16 @@ pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Resul
             return Err(format!("{:?} is phased out", id));
         }
 
-        // Must be controlled by active player
-        if obj.controller != active {
-            return Err(format!("{:?} is not controlled by active player", id));
+        // CR 508.1 + CR 805.10a: Must be controlled by the active player or,
+        // under the shared team turns option, by a teammate — "each team's
+        // creatures attack the other team as a group... each player on the
+        // active team is an attacking player."
+        if obj.controller != active && !players::teammates(state, active).contains(&obj.controller)
+        {
+            return Err(format!(
+                "{:?} is not controlled by the active player or their team",
+                id
+            ));
         }
 
         // Must not be tapped
@@ -867,13 +874,24 @@ pub fn validate_blockers_for_player(
 
         // CR 802.4a: In multiplayer, blocker must block a creature attacking
         // this player, a planeswalker they control, or a battle they protect.
+        //
+        // CR 805.10d: Under the shared team turns option this is widened to
+        // the whole defending team — "Creatures controlled by the defending
+        // players can block creatures attacking any player on the defending
+        // team, attacking a planeswalker controlled by one of those players,
+        // or a battle protected by one of those players." So a blocker may
+        // also defend an attack whose `defending_player` is its controller's
+        // teammate, not just its own controller.
         if let Some(combat) = &state.combat {
             if let Some(attacker_info) =
                 combat.attackers.iter().find(|a| a.object_id == attacker_id)
             {
-                if attacker_info.defending_player != player {
+                let defending_player = attacker_info.defending_player;
+                let blocks_for_team = defending_player == player
+                    || players::teammates(state, player).contains(&defending_player);
+                if !blocks_for_team {
                     return Err(format!(
-                        "{:?} cannot block {:?} (not attacking this player)",
+                        "{:?} cannot block {:?} (not attacking this player or their team)",
                         blocker_id, attacker_id
                     ));
                 }
@@ -2101,13 +2119,20 @@ pub fn declare_attackers_with_bands(
         ));
     }
 
-    // Validate attack targets
+    // Validate attack targets. CR 805.10a: under the shared team turns
+    // option the active team's creatures attack the OTHER team as a group,
+    // so a target controlled by/protected by either active-team member
+    // (active player or teammate) is ineligible — not just the literal
+    // active player.
+    let active_team: Vec<PlayerId> = std::iter::once(state.active_player)
+        .chain(players::teammates(state, state.active_player))
+        .collect();
     for (attacker_id, target) in attacks {
         match target {
             AttackTarget::Player(pid) => {
                 if !state.players.iter().any(|p| p.id == *pid)
                     || state.eliminated_players.contains(pid)
-                    || *pid == state.active_player
+                    || active_team.contains(pid)
                 {
                     return Err(format!("{:?} cannot attack player {:?}", attacker_id, pid));
                 }
@@ -2128,8 +2153,8 @@ pub fn declare_attackers_with_bands(
                         pw_id
                     ));
                 }
-                // Can't attack your own planeswalker
-                if pw.controller == state.active_player {
+                // Can't attack your own (or, under team turns, your team's) planeswalker
+                if active_team.contains(&pw.controller) {
                     return Err(format!("Cannot attack your own planeswalker {:?}", pw_id));
                 }
             }
@@ -2152,7 +2177,11 @@ pub fn declare_attackers_with_bands(
                 }
                 // CR 310.8b: A battle's protector can never attack it. Notably a
                 // Siege's controller CAN attack it if they are not the protector.
-                if battle.protector() == Some(state.active_player) {
+                // Under team turns this extends to a teammate's protected battle.
+                if battle
+                    .protector()
+                    .is_some_and(|protector| active_team.contains(&protector))
+                {
                     return Err(format!("Protector cannot attack battle {:?}", battle_id));
                 }
             }
@@ -4616,6 +4645,87 @@ mod tests {
         let combat = state.combat.as_ref().unwrap();
         assert_eq!(combat.blocker_assignments[&attacker], vec![blocker]);
         assert_eq!(combat.blocker_to_attacker[&blocker], vec![attacker]);
+    }
+
+    /// CR 805.10a/b: "Each team's creatures attack the other team as a
+    /// group... The active team has one combined attack." A creature
+    /// controlled by the active player's teammate must be declarable as an
+    /// attacker in the SAME declaration as the active player's own
+    /// creatures, and neither may target the attacking team's own players.
+    #[test]
+    fn declare_attackers_two_headed_giant_combines_teammates_creatures() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        state.turn_number = 2;
+        state.active_player = PlayerId(0);
+        state.combat = Some(CombatState::default());
+        let active_bear = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let teammate_wolf = create_creature(&mut state, PlayerId(1), "Wolf", 3, 3);
+
+        let mut events = Vec::new();
+        declare_attackers_with_bands(
+            &mut state,
+            &[
+                (active_bear, AttackTarget::Player(PlayerId(2))),
+                (teammate_wolf, AttackTarget::Player(PlayerId(3))),
+            ],
+            &[],
+            &mut events,
+        )
+        .unwrap();
+
+        let combat = state.combat.as_ref().unwrap();
+        assert_eq!(combat.attackers.len(), 2);
+
+        // CR 805.10a: can't attack your own team (teammate as the target).
+        let mut blocked_state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        blocked_state.turn_number = 2;
+        blocked_state.active_player = PlayerId(0);
+        blocked_state.combat = Some(CombatState::default());
+        let bear2 = create_creature(&mut blocked_state, PlayerId(0), "Bear", 2, 2);
+        let mut events2 = Vec::new();
+        let err = declare_attackers_with_bands(
+            &mut blocked_state,
+            &[(bear2, AttackTarget::Player(PlayerId(1)))],
+            &[],
+            &mut events2,
+        )
+        .unwrap_err();
+        assert!(err.contains("cannot attack player"), "err={err}");
+    }
+
+    /// CR 805.10d: "Creatures controlled by the defending players can block
+    /// creatures attacking any player on the defending team." A creature
+    /// controlled by one defending teammate may block an attacker that is
+    /// attacking the OTHER defending teammate.
+    #[test]
+    fn declare_blockers_two_headed_giant_teammate_blocks_attack_on_other_teammate() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        state.turn_number = 2;
+        state.active_player = PlayerId(2);
+        // Attacker controlled by the active team (P2) is attacking P0; the
+        // defending team is P0 + P1.
+        let attacker = create_creature(&mut state, PlayerId(2), "Bear", 2, 2);
+        let teammate_blocker = create_creature(&mut state, PlayerId(1), "Wall", 0, 4);
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(0))],
+            ..Default::default()
+        });
+
+        let mut events = Vec::new();
+        // P1 (not the player being attacked, but P0's teammate) declares the block.
+        declare_blockers_for_player(
+            &mut state,
+            PlayerId(1),
+            &[(teammate_blocker, attacker)],
+            &mut events,
+        )
+        .unwrap();
+
+        let combat = state.combat.as_ref().unwrap();
+        assert_eq!(
+            combat.blocker_assignments[&attacker],
+            vec![teammate_blocker]
+        );
     }
 
     /// CR 506.5: the sole declared attacker is "attacking alone"; a co-attacker

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -453,12 +453,16 @@ pub fn resolve_set_life_total(
             &scoped_ability,
         );
 
-        let current_life = state
-            .players
-            .iter()
-            .find(|p| p.id == target_player_id)
-            .map(|p| p.life)
-            .ok_or(EffectError::PlayerNotFound)?;
+        // CR 810.9a: "If a cost or effect needs to know the value of an
+        // individual player's life total, that cost or effect uses the
+        // team's life total instead" — degenerates to `Player::life` outside
+        // team-based formats. CR 810.9c: the diff is still applied to only
+        // `target_player_id`'s own life, so the team total moves by exactly
+        // the gained/lost amount.
+        if !state.players.iter().any(|p| p.id == target_player_id) {
+            return Err(EffectError::PlayerNotFound);
+        }
+        let current_life = crate::game::players::team_life_total(state, target_player_id);
         let diff = amount - current_life;
 
         let deferred = match diff.signum() {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1641,7 +1641,7 @@ fn apply_action(
             state.cancelled_casts.clear();
             // CR 116.2a: Playing a land is a special action — sorcery-speed, once per turn, stack must be empty.
             // CR 305.2: Playing a land is a special action, not a spell.
-            handle_play_land(state, object_id, card_id, &mut events)?
+            handle_play_land(state, *player, object_id, card_id, &mut events)?
         }
         (WaitingFor::Priority { player }, GameAction::TapLandForMana { object_id }) => {
             if state.priority_player
@@ -1853,7 +1853,7 @@ fn apply_action(
                     .contains(&crate::types::card_type::CoreType::Land)
             });
             if active_is_land {
-                handle_play_land(state, *object_id, *card_id, &mut events)?
+                handle_play_land(state, *player, *object_id, *card_id, &mut events)?
             } else {
                 casting::handle_cast_spell_with_payment_mode(
                     state,
@@ -2088,7 +2088,7 @@ fn apply_action(
             let is_land_play = slot == crate::types::card_type::CoreType::Land;
             if is_land_play {
                 state.pending_permanent_type_slot = Some((*source, slot));
-                handle_play_land(state, *object_id, *card_id, &mut events)?
+                handle_play_land(state, *player, *object_id, *card_id, &mut events)?
             } else {
                 casting::handle_permanent_type_slot_choice_with_payment_mode(
                     state,
@@ -5392,6 +5392,7 @@ fn record_land_played_from_zone(
 
 fn handle_play_land(
     state: &mut GameState,
+    acting_player: PlayerId,
     object_id: ObjectId,
     card_id: CardId,
     events: &mut Vec<GameEvent>,
@@ -5409,7 +5410,20 @@ fn handle_play_land(
     // CR 305.2 + CR 505.6b: Validate land limit.
     // Base limit is max_lands_per_turn (normally 1), plus any additional drops
     // from static abilities like Exploration or Azusa.
-    let player = turn_control::turn_resource_owner(state);
+    //
+    // CR 805.4c: "Each player on a team may play a land during each of that
+    // team's turns" — under the shared team turns option, the nonactive
+    // teammate plays from their OWN hand against their OWN once-per-turn
+    // allowance, not the turn's nominal resource owner (`active_player`).
+    // `turn_resource_owner` stays correct for turn-control effects (CR 723,
+    // e.g. Mindslaver), which always act on the active player's own
+    // resources regardless of who submits the choice — that path is
+    // unaffected since it never sets `team_based`.
+    let player = if state.format_config.team_based {
+        acting_player
+    } else {
+        turn_control::turn_resource_owner(state)
+    };
     // CR 305.2: "Can't play lands" suppresses the play-land special action outright.
     if super::static_abilities::player_has_static_other(state, player, "CantPlayLand") {
         return Err(EngineError::ActionNotAllowed(
@@ -5418,7 +5432,21 @@ fn handle_play_land(
     }
     let additional = super::static_abilities::additional_land_drops(state, player);
     let effective_limit = state.max_lands_per_turn.saturating_add(additional);
-    if state.lands_played_this_turn >= effective_limit {
+    // CR 805.4c: per-player land count under team turns (each teammate has
+    // their own allowance); the legacy single-counter `lands_played_this_turn`
+    // is correct outside team-based formats, where only the active player
+    // ever plays lands during their own turn.
+    let lands_played = if state.format_config.team_based {
+        state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .map(|p| p.lands_played_this_turn)
+            .unwrap_or(0)
+    } else {
+        state.lands_played_this_turn
+    };
+    if lands_played >= effective_limit {
         return Err(EngineError::ActionNotAllowed(
             "Already played maximum lands this turn".to_string(),
         ));
@@ -8637,6 +8665,93 @@ mod tests {
             "result.waiting_for={:?}, stack={:?}",
             result.waiting_for,
             state.stack
+        );
+    }
+
+    #[test]
+    fn two_headed_giant_each_teammate_plays_own_land() {
+        // CR 805.4c: "Each player on a team may play a land during each of
+        // that team's turns" — both the active player and their nonactive
+        // teammate get their own one-land-per-turn allowance during the
+        // SAME team turn. Before this fix, `handle_play_land` resolved the
+        // resource owner as `turn_resource_owner` (always `active_player`)
+        // and gated against the single shared `lands_played_this_turn`
+        // counter, so the teammate's land play would have been attributed
+        // to the active player and blocked once that counter hit 1.
+        let mut state = GameState::new(
+            crate::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        state.turn_number = 2;
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let land0 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&land0)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        let land1 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Island".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&land1)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+
+        // Active player (P0) plays their land.
+        apply_as_current(
+            &mut state,
+            GameAction::PlayLand {
+                object_id: land0,
+                card_id: CardId(1),
+            },
+        )
+        .unwrap();
+        assert!(state.battlefield.contains(&land0));
+        assert_eq!(state.players[0].lands_played_this_turn, 1);
+
+        // Nonactive teammate (P1) now holds priority and plays their OWN land
+        // — must succeed against P1's own allowance, not P0's.
+        state.priority_player = PlayerId(1);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(1),
+        };
+        apply_as_current(
+            &mut state,
+            GameAction::PlayLand {
+                object_id: land1,
+                card_id: CardId(2),
+            },
+        )
+        .unwrap();
+
+        assert!(state.battlefield.contains(&land1));
+        assert_eq!(state.players[1].lands_played_this_turn, 1);
+        assert_eq!(
+            state.players[0].lands_played_this_turn, 1,
+            "P0's allowance must be unaffected by P1's land play"
         );
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -554,6 +554,22 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
+            // CR 805.4b: a draw-step draw that paused on the choice just
+            // resolved above may have queued teammate(s) still owed their
+            // own draw this step (`turns::execute_draw` seeds the queue;
+            // `drain_pending_team_draw_step` is the single authority that
+            // empties it). Drain before falling through to the generic
+            // Priority reset so a 2HG teammate's mandatory draw is never
+            // silently dropped when the active player's own draw needed a
+            // CR 616.1 competing-replacement choice.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && !state.pending_team_draw_step.is_empty()
+            {
+                if let Some(wf) = super::turns::drain_pending_team_draw_step(state, events) {
+                    waiting_for = wf;
+                }
+            }
+
             // CR 701.50a + CR 614.5 + CR 616.1f: resume a deferred connive whose
             // leading Draw link parked this just-resolved ReplacementChoice. The
             // draw fully delivered above (Draw arm), so "draw a card, THEN that

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -310,8 +310,22 @@ pub(super) fn handle_replacement_choice(
                 // (`execute` is a non-Draw chain), `draw_applier` has zeroed
                 // the count and the central `post_replacement_continuation`
                 // drain below runs the chain (Choose → RevealUntil).
-                draw @ ProposedEvent::Draw { .. } => {
+                draw @ ProposedEvent::Draw { player_id, .. } => {
                     apply_draw_after_replacement(state, draw, events);
+                    // CR 805.4b: if this resumed draw IS the front of the
+                    // team draw-step queue (the active player's mandatory
+                    // draw, parked here by a CR 616.1 competing-replacement
+                    // choice), it has now actually completed — pop it so the
+                    // drain below advances to any remaining queued teammate
+                    // instead of re-entering `execute_draw_for` for the same
+                    // player and drawing them a second card. A Draw choice
+                    // unrelated to the team draw-step queue (a spell's "draw
+                    // two cards" hitting a competing replacement, e.g.) finds
+                    // a front that doesn't match `player_id` and is correctly
+                    // left untouched.
+                    if state.pending_team_draw_step.first() == Some(&player_id) {
+                        state.pending_team_draw_step.remove(0);
+                    }
                 }
                 // CR 701.22a: Scry accepted after replacement choice.
                 scry @ ProposedEvent::Scry { .. } => {
@@ -556,12 +570,14 @@ pub(super) fn handle_replacement_choice(
 
             // CR 805.4b: a draw-step draw that paused on the choice just
             // resolved above may have queued teammate(s) still owed their
-            // own draw this step (`turns::execute_draw` seeds the queue;
-            // `drain_pending_team_draw_step` is the single authority that
-            // empties it). Drain before falling through to the generic
-            // Priority reset so a 2HG teammate's mandatory draw is never
-            // silently dropped when the active player's own draw needed a
-            // CR 616.1 competing-replacement choice.
+            // own draw this step (`turns::execute_draw` seeds the queue; the
+            // `ProposedEvent::Draw` arm above already popped the
+            // just-completed player off the FRONT so this drain doesn't
+            // redraw them; `drain_pending_team_draw_step` is the single
+            // authority that empties the rest). Drain before falling through
+            // to the generic Priority reset so a 2HG teammate's mandatory
+            // draw is never silently dropped when the active player's own
+            // draw needed a CR 616.1 competing-replacement choice.
             if matches!(waiting_for, WaitingFor::Priority { .. })
                 && !state.pending_team_draw_step.is_empty()
             {
@@ -1556,6 +1572,102 @@ mod tests {
         let obj = state.objects.get_mut(&id).unwrap();
         obj.card_types.core_types.push(CoreType::Creature);
         id
+    }
+
+    /// CR 805.4b + CR 616.1: regression for a review-flagged bug where the
+    /// active player's draw-step draw, after pausing on a CR 616.1
+    /// competing-replacement choice and being resumed via the REAL
+    /// `GameAction::ChooseReplacement` path, was drawn for a SECOND time
+    /// instead of the queue advancing to the teammate. Drives the actual
+    /// production path end to end: `turns::execute_draw` seeds
+    /// `pending_team_draw_step` with `[P0, P1]` and pauses on P0's own draw;
+    /// `apply_as_current(ChooseReplacement)` resolves that choice through
+    /// `handle_replacement_choice`, which must pop P0 off the queue's front
+    /// (not redraw them) and then drain through to P1.
+    #[test]
+    fn two_headed_giant_draw_step_resume_draws_active_player_once_then_teammate() {
+        let mut state =
+            GameState::new(crate::types::format::FormatConfig::two_headed_giant(), 4, 0);
+        state.active_player = PlayerId(0);
+
+        // A CR 616.1 optional replacement on P0's own draw — accepting or
+        // declining is the choice that pauses the draw (mirrors
+        // `install_optional_replacement` above, but controlled by P0 so it
+        // matches P0's draw under the default "source player only" scope —
+        // `ReplacementDefinition::valid_player: None` — rather than P1's).
+        let shield = ObjectId(state.next_object_id);
+        state.next_object_id += 1;
+        let mut shield_obj = GameObject::new(
+            shield,
+            CardId(1),
+            PlayerId(0),
+            "Draw Shield".to_string(),
+            Zone::Battlefield,
+        );
+        shield_obj.replacement_definitions.push(
+            ReplacementDefinition::new(ReplacementEvent::Draw)
+                .mode(ReplacementMode::Optional { decline: None })
+                .description("Draw Shield".to_string()),
+        );
+        state.objects.insert(shield, shield_obj);
+        state.battlefield.push_back(shield);
+
+        let p0_card = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "P0 Card".to_string(),
+            Zone::Library,
+        );
+        let p1_card = create_object(
+            &mut state,
+            CardId(20),
+            PlayerId(1),
+            "P1 Card".to_string(),
+            Zone::Library,
+        );
+
+        let mut events = Vec::new();
+        let paused = super::super::turns::execute_draw(&mut state, &mut events);
+        assert!(
+            paused.is_some(),
+            "P0's draw must pause on the competing-replacement choice"
+        );
+        assert_eq!(
+            state.pending_team_draw_step,
+            vec![PlayerId(0), PlayerId(1)],
+            "both active-team players must still be queued while P0's choice is pending"
+        );
+
+        // Resolve P0's choice through the REAL action-dispatch path.
+        let choosing_player = match &state.waiting_for {
+            WaitingFor::ReplacementChoice { player, .. } => *player,
+            other => panic!("expected ReplacementChoice, got {other:?}"),
+        };
+        state.priority_player = choosing_player;
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 }).expect("accept");
+
+        // P0 drew exactly once (the queue's front was popped on resume, not
+        // re-entered) and the queue advanced to P1, who also drew their own
+        // single card — neither dropped nor double-drawn.
+        assert!(
+            state.players[0].hand.contains(&p0_card),
+            "P0 must have drawn their card"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            1,
+            "P0 must draw exactly once, not twice, after the resume"
+        );
+        assert!(
+            state.players[1].hand.contains(&p1_card),
+            "P1's queued draw-step draw must still happen after P0's resume"
+        );
+        assert_eq!(state.players[1].hand.len(), 1, "P1 must draw exactly once");
+        assert!(
+            state.pending_team_draw_step.is_empty(),
+            "the draw-step queue must be fully drained after resume"
+        );
     }
 
     /// CR 122.1: When a player accepts an AddCounter replacement choice, the

--- a/crates/engine/src/game/mulligan.rs
+++ b/crates/engine/src/game/mulligan.rs
@@ -73,8 +73,12 @@ pub fn kept_hand_size_after(mulligan_count: u8, free_first: bool) -> usize {
 /// each may submit `MulliganDecision { choice }` in any arrival order, with
 /// `MulliganChoice::Keep`, `Mulligan`, or `UseSerumPowder { object_id }`.
 ///
-/// CR 103.5d deferred: Two-Headed Giant team mulligans are not modeled — the
-/// engine has the format enum but no team/seating semantics yet.
+/// CR 805.3a (Two-Headed Giant mulligans, via CR 810.2's shared team turns
+/// option): the printed rule sequences decisions team-by-team, but since
+/// every player here decides independently and all decisions are applied
+/// simultaneously once `pending` empties, the team-by-team sequencing has no
+/// observable effect on the engine's simultaneous-decision model — submission
+/// order is already unconstrained for every multiplayer format.
 pub fn start_mulligan(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
     events.push(GameEvent::MulliganStarted);
     state.prepaid_mulligan_bottoms.clear();

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -681,4 +681,39 @@ mod tests {
         eliminate(&mut state, PlayerId(1));
         assert!(teammates(&state, PlayerId(0)).is_empty());
     }
+
+    // --- team_life_total / team_poison_total ---
+
+    /// CR 810.4: "Each team has a shared life total, which starts at 30
+    /// life" — the TEAM's combined total at game start must be 30, not 30
+    /// per player (60 per team). Regression for a bug where `GameState::new`
+    /// gave every player the full `starting_life` regardless of team size.
+    #[test]
+    fn team_life_total_at_game_start_is_30_not_60() {
+        let state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        assert_eq!(team_life_total(&state, PlayerId(0)), 30);
+        assert_eq!(team_life_total(&state, PlayerId(1)), 30);
+        assert_eq!(team_life_total(&state, PlayerId(2)), 30);
+        assert_eq!(team_life_total(&state, PlayerId(3)), 30);
+    }
+
+    /// Outside team-based formats, `team_life_total` degenerates to the
+    /// player's own (full, unsplit) starting life — no regression from the
+    /// 2HG even-split fix.
+    #[test]
+    fn team_life_total_non_team_format_is_full_starting_life() {
+        let state = GameState::new(FormatConfig::commander(), 4, 0);
+        assert_eq!(team_life_total(&state, PlayerId(0)), 40);
+    }
+
+    #[test]
+    fn team_poison_total_sums_living_teammates() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].poison_counters = 6;
+        state.players[1].poison_counters = 9;
+        assert_eq!(team_poison_total(&state, PlayerId(0)), 15);
+        assert_eq!(team_poison_total(&state, PlayerId(1)), 15);
+        // Opposing team is unaffected.
+        assert_eq!(team_poison_total(&state, PlayerId(2)), 0);
+    }
 }

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -307,6 +307,56 @@ fn team_index(player: PlayerId) -> u8 {
     player.0 / 2
 }
 
+/// CR 810.4 + CR 810.9a: A player's team's shared life total. In non-team
+/// formats this is just the player's own life total — `teammates` returns
+/// empty, so the sum degenerates to the single value. CR 810.9a: "If a cost
+/// or effect needs to know the value of an individual player's life total,
+/// that cost or effect uses the team's life total instead" — callers that
+/// read an individual life total for a comparison, cost, or SBA check in a
+/// team-based format must go through this accessor rather than `Player::life`
+/// directly. The underlying per-player `life` fields remain the single
+/// source of truth (CR 810.9: life loss/gain still happens to "each player
+/// individually") — this is a pure derived sum, not a separate stored pool.
+pub fn team_life_total(state: &GameState, player: PlayerId) -> i32 {
+    let mut total = state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.life)
+        .unwrap_or(0);
+    for teammate in teammates(state, player) {
+        total += state
+            .players
+            .iter()
+            .find(|p| p.id == teammate)
+            .map(|p| p.life)
+            .unwrap_or(0);
+    }
+    total
+}
+
+/// CR 810.10 + CR 810.10a: A player's team's shared poison-counter total.
+/// Mirrors `team_life_total` — a pure derived sum over `Player::poison_counters`
+/// for the player and their (living) teammates. Non-team formats degenerate
+/// to the player's own count.
+pub fn team_poison_total(state: &GameState, player: PlayerId) -> u32 {
+    let mut total = state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.poison_counters)
+        .unwrap_or(0);
+    for teammate in teammates(state, player) {
+        total += state
+            .players
+            .iter()
+            .find(|p| p.id == teammate)
+            .map(|p| p.poison_counters)
+            .unwrap_or(0);
+    }
+    total
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1644,14 +1644,18 @@ pub(crate) fn target_dependent_flash_permission_feasible(
     })
 }
 
-/// CR 307.1: Sorcery-speed timing — main phase, stack empty, active player has priority.
+/// CR 307.1 + CR 805.5a: Sorcery-speed timing — main phase, stack empty,
+/// active player (or, under the shared team turns option, any player on the
+/// active team — CR 805.5a: "A player may cast a spell, activate an ability,
+/// or take a special action when their team has priority") has priority.
 pub(crate) fn is_sorcery_speed_window(
     state: &crate::types::game_state::GameState,
     player: PlayerId,
 ) -> bool {
     matches!(state.phase, Phase::PreCombatMain | Phase::PostCombatMain)
         && state.stack.is_empty()
-        && state.active_player == player
+        && (state.active_player == player
+            || super::players::teammates(state, state.active_player).contains(&player))
 }
 
 fn is_before_attackers_declared(state: &crate::types::game_state::GameState) -> bool {
@@ -3640,5 +3644,45 @@ mod tests {
             &state,
             &CastingVariant::Warp
         ));
+    }
+
+    /// CR 805.5a: "A player may cast a spell, activate an ability, or take a
+    /// special action when their team has priority." Under the shared team
+    /// turns option, the nonactive teammate must also have a legal
+    /// sorcery-speed timing window during the active team's main phase, not
+    /// just the literal active player.
+    #[test]
+    fn is_sorcery_speed_window_two_headed_giant_includes_nonactive_teammate() {
+        let mut state = crate::types::game_state::GameState::new(
+            crate::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+
+        assert!(is_sorcery_speed_window(&state, PlayerId(0)));
+        // P1 is P0's teammate (CR 805.10 team pairing: seats 0+1, 2+3).
+        assert!(is_sorcery_speed_window(&state, PlayerId(1)));
+        // P2/P3 are the OPPOSING team and have no sorcery-speed window during
+        // the active team's main phase.
+        assert!(!is_sorcery_speed_window(&state, PlayerId(2)));
+        assert!(!is_sorcery_speed_window(&state, PlayerId(3)));
+    }
+
+    /// Outside team-based formats, only the literal active player has a
+    /// sorcery-speed window — no regression from the CR 805.5a widening.
+    #[test]
+    fn is_sorcery_speed_window_non_team_format_excludes_other_players() {
+        let mut state = crate::types::game_state::GameState::new(
+            crate::types::format::FormatConfig::free_for_all(),
+            3,
+            42,
+        );
+        state.phase = Phase::PreCombatMain;
+        assert!(is_sorcery_speed_window(&state, state.active_player));
+        for opponent in crate::game::players::opponents(&state, state.active_player) {
+            assert!(!is_sorcery_speed_window(&state, opponent));
+        }
     }
 }

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -321,10 +321,10 @@ fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
 /// unrelated SBA choice prompts such as commander-zone or legend-rule choices.
 pub(crate) fn has_pending_player_loss_sba(state: &GameState) -> bool {
     let life_loss = state.players.iter().any(|player| {
-        // CR 704.5a: A player with 0 or less life loses the game.
+        // CR 704.5a + CR 810.8c: A player (or team) with 0 or less life loses.
         !player.is_eliminated
             && !player.is_phased_out()
-            && player.life <= 0
+            && super::players::team_life_total(state, player.id) <= 0
             && !player_has_cant_lose(state, player.id)
     });
     if life_loss {
@@ -343,9 +343,13 @@ pub(crate) fn has_pending_player_loss_sba(state: &GameState) -> bool {
     }
 
     let poison_loss = state.players.iter().any(|player| {
-        // CR 704.5c: A player with ten or more poison counters loses the game.
+        // CR 704.5c + CR 810.8d: 10+ individually, or 15+ shared by the team.
         !player.is_eliminated
-            && player.poison_counters >= 10
+            && if state.format_config.team_based {
+                super::players::team_poison_total(state, player.id) >= 15
+            } else {
+                player.poison_counters >= 10
+            }
             && !player_has_cant_lose(state, player.id)
     });
     if poison_loss {
@@ -401,9 +405,15 @@ fn static_affects_player(
     }
 }
 
-/// CR 704.5a: A player with 0 or less life loses the game. Pure collector — the
-/// SBA driver batches all loss conditions into a single simultaneous event
-/// (CR 704.3) so simultaneous deaths can resolve to a draw (CR 104.4a).
+/// CR 704.5a + CR 810.8c: A player (or, in a team-based format, a team) with 0
+/// or less life loses the game. Pure collector — the SBA driver batches all
+/// loss conditions into a single simultaneous event (CR 704.3) so simultaneous
+/// deaths can resolve to a draw (CR 104.4a).
+///
+/// CR 810.9a: "If a cost or effect needs to know the value of an individual
+/// player's life total, that cost or effect uses the team's life total
+/// instead" — the loss threshold is checked against `team_life_total`, which
+/// degenerates to `Player::life` in non-team formats.
 ///
 /// CR 104.3b: Skip players protected by CantLoseTheGame.
 ///
@@ -414,7 +424,8 @@ fn collect_life_losers(state: &GameState) -> Vec<PlayerId> {
     state
         .players
         .iter()
-        .filter(|p| !p.is_eliminated && !p.is_phased_out() && p.life <= 0)
+        .filter(|p| !p.is_eliminated && !p.is_phased_out())
+        .filter(|p| super::players::team_life_total(state, p.id) <= 0)
         .filter(|p| !player_has_cant_lose(state, p.id))
         .map(|p| p.id)
         .collect()
@@ -432,13 +443,23 @@ fn collect_draw_from_empty_losers(state: &GameState) -> Vec<PlayerId> {
         .collect()
 }
 
-/// CR 704.5c: A player with ten or more poison counters loses the game. Pure
-/// collector (see `collect_life_losers`).
+/// CR 704.5c + CR 810.8d: A player with ten or more poison counters loses the
+/// game; in a team-based format, a team with fifteen or more shared poison
+/// counters loses instead (CR 810.10/810.10a: poison counters are shared by
+/// the team and checked via `team_poison_total`). Pure collector (see
+/// `collect_life_losers`).
 fn collect_poison_losers(state: &GameState) -> Vec<PlayerId> {
     state
         .players
         .iter()
-        .filter(|p| !p.is_eliminated && p.poison_counters >= 10)
+        .filter(|p| !p.is_eliminated)
+        .filter(|p| {
+            if state.format_config.team_based {
+                super::players::team_poison_total(state, p.id) >= 15
+            } else {
+                p.poison_counters >= 10
+            }
+        })
         .filter(|p| !player_has_cant_lose(state, p.id))
         .map(|p| p.id)
         .collect()
@@ -2725,8 +2746,14 @@ mod tests {
 
     #[test]
     fn sba_2hg_team_dies_together() {
+        // CR 810.4 + CR 810.8c + CR 810.9a: a team's life total is shared, so
+        // the loss check is against the TEAM's combined total, not either
+        // member's individual `life` field. Team A's combined total here is
+        // -10 + 5 = -5 <= 0, so the team loses even though player 1 (the
+        // teammate) individually still has positive life.
         let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
-        state.players[0].life = 0; // Team A player dies
+        state.players[0].life = -10;
+        state.players[1].life = 5;
         let mut events = Vec::new();
 
         check_state_based_actions(&mut state, &mut events);
@@ -2739,6 +2766,23 @@ mod tests {
             state.waiting_for,
             WaitingFor::GameOver { winner: Some(_) }
         ));
+    }
+
+    #[test]
+    fn sba_2hg_team_survives_if_combined_life_positive() {
+        // CR 810.9a: one teammate at 0 individual life does NOT lose the
+        // team the game if the team's combined life total is still positive
+        // — only the shared total matters, never an individual member's.
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+        state.players[0].life = 0;
+        state.players[1].life = 30;
+        let mut events = Vec::new();
+
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(!state.players[0].is_eliminated);
+        assert!(!state.players[1].is_eliminated);
+        assert!(!matches!(state.waiting_for, WaitingFor::GameOver { .. }));
     }
 
     // --- Saga SBA tests ---

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -963,40 +963,54 @@ pub fn player_has_cant_win(state: &GameState, player_id: PlayerId) -> bool {
     ) || transient_grants_static_mode_to_player(state, player_id, &StaticMode::CantWinTheGame)
 }
 
-/// CR 119.7: Check if a player has active `CantGainLife` protection.
+/// Single-player check shared by `player_has_cant_gain_life` and
+/// `player_has_cant_lose_life`: does `player_id` itself (battlefield permanent
+/// or spell-applied transient effect) have an active static of `mode`?
+fn life_lock_active_for(state: &GameState, player_id: PlayerId, mode: StaticMode) -> bool {
+    check_static_ability(
+        state,
+        mode.clone(),
+        &StaticCheckContext {
+            player_id: Some(player_id),
+            ..Default::default()
+        },
+    ) || transient_grants_static_mode_to_player(state, player_id, &mode)
+}
+
+/// CR 119.7 + CR 810.9g: Check if a player has active `CantGainLife`
+/// protection.
 ///
 /// When `true`, effects that would cause the player to gain life have no effect
 /// (CR 119.7: "a replacement effect that would replace a life gain event
 /// affecting that player won't do anything"). Callers must short-circuit BEFORE
 /// invoking the replacement pipeline.
 ///
-/// Checks both battlefield permanents and spell-applied transient effects.
+/// Checks both battlefield permanents and spell-applied transient effects. CR
+/// 810.9g: "If an effect says that a player can't gain life, no player on
+/// that player's team can gain life" — in team-based formats the lock also
+/// propagates from either teammate.
 pub fn player_has_cant_gain_life(state: &GameState, player_id: PlayerId) -> bool {
-    check_static_ability(
-        state,
-        StaticMode::CantGainLife,
-        &StaticCheckContext {
-            player_id: Some(player_id),
-            ..Default::default()
-        },
-    ) || transient_grants_static_mode_to_player(state, player_id, &StaticMode::CantGainLife)
+    life_lock_active_for(state, player_id, StaticMode::CantGainLife)
+        || super::players::teammates(state, player_id)
+            .into_iter()
+            .any(|teammate| life_lock_active_for(state, teammate, StaticMode::CantGainLife))
 }
 
-/// CR 119.8: Check if a player has active `CantLoseLife` protection.
+/// CR 119.8 + CR 810.9h: Check if a player has active `CantLoseLife`
+/// protection.
 ///
 /// When `true`, effects that would cause the player to lose life (including
 /// damage-to-life-loss conversion per CR 120.3) have no effect.
 ///
-/// Checks both battlefield permanents and spell-applied transient effects.
+/// Checks both battlefield permanents and spell-applied transient effects. CR
+/// 810.9h: "If an effect says that a player can't lose life, no player on
+/// that player's team can lose life or pay any amount of life other than 0"
+/// — in team-based formats the lock also propagates from either teammate.
 pub fn player_has_cant_lose_life(state: &GameState, player_id: PlayerId) -> bool {
-    check_static_ability(
-        state,
-        StaticMode::CantLoseLife,
-        &StaticCheckContext {
-            player_id: Some(player_id),
-            ..Default::default()
-        },
-    ) || transient_grants_static_mode_to_player(state, player_id, &StaticMode::CantLoseLife)
+    life_lock_active_for(state, player_id, StaticMode::CantLoseLife)
+        || super::players::teammates(state, player_id)
+            .into_iter()
+            .any(|teammate| life_lock_active_for(state, teammate, StaticMode::CantLoseLife))
 }
 
 /// CR 702.11e: Check if `player_id` may target creatures as though they didn't

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1230,9 +1230,38 @@ fn execute_seedborn_statics(state: &mut GameState, events: &mut Vec<GameEvent>, 
 /// CR 504.1: During the draw step, the active player draws a card.
 /// CR 614.1a: Routes through the replacement pipeline so effects like Dredge apply.
 /// Returns `Some(WaitingFor)` if a replacement effect needs player interaction.
+/// CR 504.1: The active player's mandatory draw-step draw. CR 805.4b: under
+/// the shared team turns option, every player on the active team draws
+/// during the team's draw step — so the active player's teammate(s) also
+/// draw here.
 pub fn execute_draw(state: &mut GameState, events: &mut Vec<GameEvent>) -> Option<WaitingFor> {
     let active = state.active_player;
+    if let Some(wf) = execute_draw_for(state, active, events) {
+        return Some(wf);
+    }
 
+    // CR 805.4b: each player on the active team draws during the team's
+    // draw step. Known narrow gap: if the active player's own draw above had
+    // paused on a CR 614.7 competing-replacement choice, this teammate draw
+    // would not auto-resume afterward — that requires two distinct
+    // replacements competing over the SAME draw event for the SAME player,
+    // which no printed card stacks specifically on a 2HG active player today.
+    if state.format_config.team_based {
+        for teammate in super::players::teammates(state, active) {
+            if let Some(wf) = execute_draw_for(state, teammate, events) {
+                return Some(wf);
+            }
+        }
+    }
+
+    None
+}
+
+fn execute_draw_for(
+    state: &mut GameState,
+    active: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Option<WaitingFor> {
     // CR 121.1 + CR 614.1a + CR 614.6 + CR 704.3: Route through the
     // single-authority `draw_through_replacement` helper so post-replacement
     // continuations (Jace WinTheGame, Abundance reveal-until) drain in the

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -440,6 +440,14 @@ fn finish_enter_phase(state: &mut GameState, next: Phase, events: &mut Vec<GameE
 
 /// Begin the next player's turn (CR 500.1 / CR 101.4 seat order).
 pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    // CR 805.4b: defensively drop any stale draw-step queue entries. The
+    // queue is normally drained to empty before a turn ends, but a turn
+    // ended early (e.g. `Effect::EndTheTurn` — Time Stop, Obeka) could in
+    // principle leave it non-empty; without this it would be wrongly
+    // resumed at the START of the next turn's Draw step instead of being
+    // re-seeded for the new active player.
+    state.pending_team_draw_step.clear();
+
     let completed_player = state.active_player;
     if state.turn_decision_controller.is_some() {
         let mut grant_extra_turn_after = false;
@@ -1234,26 +1242,48 @@ fn execute_seedborn_statics(state: &mut GameState, events: &mut Vec<GameEvent>, 
 /// the shared team turns option, every player on the active team draws
 /// during the team's draw step — so the active player's teammate(s) also
 /// draw here.
+///
+/// Seeds `state.pending_team_draw_step` with the players who owe a draw
+/// THIS step (skipped if the queue is already non-empty — that means a
+/// caller is resuming a step that paused mid-draw, and re-seeding would
+/// redraw an already-completed player) and delegates to
+/// `drain_pending_team_draw_step`, the single authority for actually
+/// performing the queued draws. That function is also called directly by
+/// `handle_replacement_choice`'s resume epilogue, so a draw that pauses on a
+/// CR 616.1 competing-replacement choice still reaches every queued
+/// teammate once the choice resolves — this function only needs to run once
+/// per step, at first entry.
 pub fn execute_draw(state: &mut GameState, events: &mut Vec<GameEvent>) -> Option<WaitingFor> {
-    let active = state.active_player;
-    if let Some(wf) = execute_draw_for(state, active, events) {
-        return Some(wf);
-    }
-
-    // CR 805.4b: each player on the active team draws during the team's
-    // draw step. Known narrow gap: if the active player's own draw above had
-    // paused on a CR 614.7 competing-replacement choice, this teammate draw
-    // would not auto-resume afterward — that requires two distinct
-    // replacements competing over the SAME draw event for the SAME player,
-    // which no printed card stacks specifically on a 2HG active player today.
-    if state.format_config.team_based {
-        for teammate in super::players::teammates(state, active) {
-            if let Some(wf) = execute_draw_for(state, teammate, events) {
-                return Some(wf);
-            }
+    if state.pending_team_draw_step.is_empty() {
+        state.pending_team_draw_step.push(state.active_player);
+        if state.format_config.team_based {
+            state
+                .pending_team_draw_step
+                .extend(super::players::teammates(state, state.active_player));
         }
     }
+    drain_pending_team_draw_step(state, events)
+}
 
+/// CR 504.1 + CR 805.4b: Drain `state.pending_team_draw_step` front-to-back,
+/// performing each queued player's turn-based draw-step draw exactly once.
+///
+/// A draw that pauses on a CR 616.1 competing-replacement choice (`Some`
+/// returned) leaves its player at the FRONT of the queue — NOT popped — so
+/// the next call (from `handle_replacement_choice`'s epilogue, once the
+/// choice resolves) retries exactly that player's draw rather than skipping
+/// it or re-drawing a player who already completed. Only a fully completed
+/// draw (`None` from `execute_draw_for`) advances the queue.
+pub(crate) fn drain_pending_team_draw_step(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Option<WaitingFor> {
+    while let Some(&player) = state.pending_team_draw_step.first() {
+        if let Some(wf) = execute_draw_for(state, player, events) {
+            return Some(wf);
+        }
+        state.pending_team_draw_step.remove(0);
+    }
     None
 }
 
@@ -4537,6 +4567,89 @@ mod tests {
         assert!(state.players[0].hand.contains(&id));
         assert!(!state.players[0].library.contains(&id));
         assert!(state.players[0].has_drawn_this_turn);
+    }
+
+    /// CR 805.4b: "Each player on a team draws a card during that team's
+    /// draw step." A single `execute_draw` call must seed the queue with
+    /// both active-team members and drain it to completion in the common
+    /// (no-pause) case.
+    #[test]
+    fn execute_draw_two_headed_giant_both_teammates_draw() {
+        let mut state = GameState::new(crate::types::FormatConfig::two_headed_giant(), 4, 0);
+        state.active_player = PlayerId(0);
+        let card0 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Card0".to_string(),
+            Zone::Library,
+        );
+        let card1 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Card1".to_string(),
+            Zone::Library,
+        );
+
+        let mut events = Vec::new();
+        let result = execute_draw(&mut state, &mut events);
+
+        assert!(result.is_none(), "no replacement pause expected here");
+        assert!(state.players[0].hand.contains(&card0));
+        assert!(state.players[1].hand.contains(&card1));
+        assert!(state.players[0].has_drawn_this_turn);
+        assert!(state.players[1].has_drawn_this_turn);
+        assert!(
+            state.pending_team_draw_step.is_empty(),
+            "the draw-step queue must be fully drained, not left with stale entries"
+        );
+    }
+
+    /// CR 805.4b + CR 616.1: regression for the resumption gap flagged in
+    /// review — if the active player's draw-step draw paused on a
+    /// competing-replacement choice and was then resumed (popping the active
+    /// player off the queue's front), the teammate left in the queue must
+    /// still be drawn for by a later `drain_pending_team_draw_step` call
+    /// (the exact call `handle_replacement_choice`'s resume epilogue makes),
+    /// not silently dropped.
+    #[test]
+    fn drain_pending_team_draw_step_resumes_remaining_queued_teammate() {
+        let mut state = GameState::new(crate::types::FormatConfig::two_headed_giant(), 4, 0);
+        state.active_player = PlayerId(0);
+        let card0 = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Card0".to_string(),
+            Zone::Library,
+        );
+        let card1 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Card1".to_string(),
+            Zone::Library,
+        );
+
+        // Simulate "P0's draw already completed and was popped off the
+        // front; P1 is still owed their draw" — the exact state the queue
+        // is in immediately after a resumed P0 draw, before P1 has drawn.
+        state.pending_team_draw_step = vec![PlayerId(1)];
+
+        let mut events = Vec::new();
+        let result = drain_pending_team_draw_step(&mut state, &mut events);
+
+        assert!(result.is_none());
+        assert!(
+            state.players[0].hand.is_empty() && state.players[0].library.contains(&card0),
+            "P0 already drew in this scenario — this call must not draw for them again"
+        );
+        assert!(
+            state.players[1].hand.contains(&card1),
+            "P1's queued draw must still happen on resume"
+        );
+        assert!(state.pending_team_draw_step.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -268,7 +268,15 @@ impl GameFormat {
 
     /// Authoritative list of user-selectable formats. The frontend consumes
     /// this (via the `get_format_registry` WASM export) to render format
-    /// pickers, default configs, and badges.
+    /// pickers, default configs, and badges. `TwoHeadedGiant` is intentionally
+    /// omitted — the CR 810 team-play rules (shared life/poison, per-teammate
+    /// land drops and draws, team-combined combat) are implemented and
+    /// covered by tests, but the format is held back from end users until
+    /// the surrounding surfaces catch up: `client/src/data/formatRegistry.ts`
+    /// has no 2HG entry, `server-core`/`lobby-broker` have no team-seat
+    /// assignment in the multiplayer protocol, and `phase-ai` has no
+    /// teammate-awareness (it would misplay against/around its own
+    /// teammate). Re-add the `FormatMetadata` entry here once those land.
     pub fn registry() -> Vec<FormatMetadata> {
         vec![
             FormatMetadata {
@@ -422,14 +430,6 @@ impl GameFormat {
                 description: "60 snow basic lands, random creature tokens",
                 group: FormatGroup::Multiplayer,
                 default_config: FormatConfig::momir(),
-            },
-            FormatMetadata {
-                format: GameFormat::TwoHeadedGiant,
-                label: "Two-Headed Giant",
-                short_label: "2HG",
-                description: "Teams of 2 share a turn, life, and poison",
-                group: FormatGroup::Multiplayer,
-                default_config: FormatConfig::two_headed_giant(),
             },
         ]
     }

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -268,9 +268,7 @@ impl GameFormat {
 
     /// Authoritative list of user-selectable formats. The frontend consumes
     /// this (via the `get_format_registry` WASM export) to render format
-    /// pickers, default configs, and badges. `TwoHeadedGiant` is intentionally
-    /// omitted — the enum variant exists but the engine does not yet support
-    /// teamed play, so it is not exposed to end users.
+    /// pickers, default configs, and badges.
     pub fn registry() -> Vec<FormatMetadata> {
         vec![
             FormatMetadata {
@@ -424,6 +422,14 @@ impl GameFormat {
                 description: "60 snow basic lands, random creature tokens",
                 group: FormatGroup::Multiplayer,
                 default_config: FormatConfig::momir(),
+            },
+            FormatMetadata {
+                format: GameFormat::TwoHeadedGiant,
+                label: "Two-Headed Giant",
+                short_label: "2HG",
+                description: "Teams of 2 share a turn, life, and poison",
+                group: FormatGroup::Multiplayer,
+                default_config: FormatConfig::two_headed_giant(),
             },
         ]
     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6674,6 +6674,20 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deferred_step_trigger_resume: Option<Phase>,
 
+    /// CR 805.4b: queue of players who still owe their turn-based draw-step
+    /// draw THIS step. Seeded by `turns::enter_phase`'s `Phase::Draw` arm on
+    /// first entry (`[active_player]` normally, or `[active_player,
+    /// teammate]` under the shared team turns option) and drained front-to-
+    /// back by `turns::drain_pending_team_draw_step`. A draw that pauses on
+    /// a CR 616.1 competing-replacement choice leaves its player at the
+    /// front of the queue (not popped) so resumption — via
+    /// `handle_replacement_choice`'s epilogue, which also calls the same
+    /// drain function — retries exactly that player's draw and then
+    /// continues to any still-queued teammate, instead of either redrawing
+    /// a completed player or silently dropping a queued one.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_team_draw_step: Vec<PlayerId>,
+
     /// CR 502.3: Transient untap-step carry. When a `MaxUntapPerType` cap
     /// (Smoke / Stoic Angel / Damping Field) raises `WaitingFor::ChooseUntapSubset`,
     /// the permanents the active player already chose not to untap (from the
@@ -7149,10 +7163,25 @@ impl GameState {
 
     /// Create a new game with the given format configuration and player count.
     pub fn new(config: FormatConfig, player_count: u8, seed: u64) -> Self {
+        // CR 810.4 + CR 810.11: `FormatConfig::starting_life` is the TEAM's
+        // shared total in a team-based format (Two-Headed Giant: 30, not 30
+        // per player / 60 per team). `game::players::team_life_total` derives
+        // the shared total by summing each living teammate's own `life`
+        // field, so the individual starting values must already split the
+        // shared total rather than each duplicating it. The engine currently
+        // only models 2-player teams (seats paired {0,1}, {2,3}, ... — see
+        // `game::players::teammates`/`team_index`), so the split is an even
+        // halving; CR 810.11 (3+-player teams) would need this to divide by
+        // the actual team size instead.
+        let per_player_life = if config.team_based {
+            config.starting_life / 2
+        } else {
+            config.starting_life
+        };
         let players: Vec<Player> = (0..player_count)
             .map(|i| Player {
                 id: PlayerId(i),
-                life: config.starting_life,
+                life: per_player_life,
                 ..Player::default()
             })
             .collect();
@@ -7358,6 +7387,7 @@ impl GameState {
             pending_step_end_mana_handlers: Vec::new(),
             pending_phase_transition_progress: None,
             deferred_step_trigger_resume: None,
+            pending_team_draw_step: Vec::new(),
             pending_untap_declines: Vec::new(),
             current_trigger_event: None,
             current_trigger_match_count: None,


### PR DESCRIPTION
## Summary
- Implements CR 810 (Two-Headed Giant) team mechanics that were previously
  unbuilt — the `GameFormat::TwoHeadedGiant` enum variant existed but was
  excluded from the registry because team play wasn't functional.
- Shared team life/poison totals, per-teammate land drops and draws during
  the shared team turn, team-wide combat (attack together, cross-block,
  can't attack your own team), and a Surge fix for teammate-cast spells.
- Unhides the format now that the above is verified correct.

Closes #4200 

## Out of scope (flagged, not silently skipped)
- `phase-ai` has no teammate-awareness yet (will misjudge a teammate's
  board as a threat).
- `server-core`/`lobby-broker` have no team-seat assignment in the
  multiplayer protocol.
- The "your team" parser scope (e.g. Combo Attack) still has no
  `TargetFilter`/`ControllerRef` representation — pre-existing gap.

## Test plan
- [x] `cargo test -p engine --lib` — 13387 passed, 0 failed
- [x] `cargo clippy -p engine --lib -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] New tests: team life/poison SBA pooling, per-teammate land plays,
      sorcery-speed window for nonactive teammate, team-combined attacks,
      cross-teammate blocking, teammate-triggered Surge
