### PR TITLE
ci(deploy): unlock MSH/MSC/TMSH on release (remove GATED_SETS)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,20 +34,6 @@ jobs:
     timeout-minutes: 30
     outputs:
       card_data_filename: ${{ steps.card-data-hash.outputs.filename }}
-    env:
-      # Release-gate: Marvel Super Heroes (MSH/MSC/TMSH) are implemented in the
-      # engine but must NOT be playable on the preview/staging site until release
-      # (2026-06-26). GATED_SETS gates these sets two ways at data-generation
-      # time: (1) cards available ONLY through gated sets stay in card-data.json
-      # (so they remain browsable/previewable) but are marked Banned in every
-      # format, excluding them from every format-scoped deck-builder pool; and
-      # (2) the sets are hidden from set-list.json (set pickers / draft UI) and
-      # draft-pools.json (draftable sets), so they cannot be drafted. Reprint-
-      # aware — a card also printed in a non-gated set keeps its real legalities.
-      # Local dev is unaffected (GATED_SETS is unset there).
-      # TO UNLOCK ON RELEASE: delete this `GATED_SETS` line (or set it empty) and
-      # re-run the deploy — real MTGJSON legalities and the sets are restored.
-      GATED_SETS: MSH,MSC,TMSH
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Marvel Super Heroes (MSH/MSC/TMSH) went live on Arena/MTGO on 2026-06-23, so the preview/staging release-gate is no longer needed.

Removes the `GATED_SETS: MSH,MSC,TMSH` env block from the `card-data` deploy job. On the next deploy this lets the data pipeline:
- regenerate `card-data.json` from fresh MTGJSON, which now carries real legalities for these sets (previously `future`-only, which normalized to empty and excluded the cards from every format pool), and
- stop hiding the sets from `set-list.json` and `draft-pools.json`.

The gating mechanism itself stays fully documented in `engine::database::set_gating` for any future preview set.