### PR TITLE
fix(my-decks): replace native folder prompts with TextPromptDialog

### DIFF
--- a/client/src/components/menu/MyDecks.tsx
+++ b/client/src/components/menu/MyDecks.tsx
@@ -4,7 +4,14 @@ import { useTranslation } from "react-i18next";
 
 import type { GameFormat, MatchType } from "../../adapter/types";
 import type { FeedDeck } from "../../types/feed";
-import { ACTIVE_DECK_KEY, listSavedDeckNames, getDeckMeta, deleteDeck, type DeckFolder } from "../../constants/storage";
+import {
+  ACTIVE_DECK_KEY,
+  listSavedDeckNames,
+  getDeckMeta,
+  deleteDeck,
+  MAX_FOLDER_NAME_LENGTH,
+  type DeckFolder,
+} from "../../constants/storage";
 import { PROFILE_REPLACED_EVENT } from "../../stores/cloudSyncStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { useDeckFolders } from "../../hooks/useDeckFolders";
@@ -50,6 +57,7 @@ import {
 import { BASIC_LAND_NAMES } from "../../constants/game";
 import { BracketEstimateChip } from "../deck-builder/BracketEstimateChip";
 import { MenuSelect } from "../ui/MenuSelect";
+import { TextPromptDialog } from "../ui/TextPromptDialog";
 import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import { getSharedAdapter } from "../../adapter/wasm-adapter";
 const PRECON_PREFIX = "[Pre-built] ";
@@ -62,6 +70,11 @@ const PRECON_SECTION_ID = "__precon__";
 const DECK_GRID_CLASS = "grid w-full gap-4 grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]";
 const DECK_SCAN_BATCH_SIZE = 1;
 const COVERAGE_SCAN_BATCH_SIZE = 6;
+
+type FolderPromptRequest =
+  | { kind: "create" }
+  | { kind: "create-and-assign"; deckName: string }
+  | { kind: "rename"; folderId: string; currentName: string };
 
 /** Tags that represent a format/archetype — shown with active (green) styling. */
 const FORMAT_TAGS = new Set([
@@ -634,6 +647,7 @@ export function MyDecks({
     sortMenuItems.find((item) => item.value === activeSort)?.label ?? t("myDecks.sortName");
   const [sortAsc, setSortAsc] = useState(mode !== "select");
   const [searchQuery, setSearchQuery] = useState("");
+  const [folderPrompt, setFolderPrompt] = useState<FolderPromptRequest | null>(null);
 
   // Folder/star organization (user decks only). The grouping authority +
   // mutators come from useDeckFolders; collapse state lives in preferences so
@@ -651,24 +665,41 @@ export function MyDecks({
   );
   const handleNewFolderForDeck = useCallback(
     (name: string) => {
-      const folderName = prompt(t("folder.newFolderPrompt"));
-      if (!folderName?.trim()) return;
-      const folder = createFolder(folderName);
-      if (folder) assignDeck(name, folder.id);
+      setFolderPrompt({ kind: "create-and-assign", deckName: name });
     },
-    [createFolder, assignDeck, t],
+    [],
   );
   const handleCreateFolder = useCallback(() => {
-    const folderName = prompt(t("folder.newFolderPrompt"));
-    if (folderName?.trim()) createFolder(folderName);
-  }, [createFolder, t]);
-  const handleRenameFolder = useCallback(
-    (id: string, currentName: string) => {
-      const next = prompt(t("folder.renamePrompt"), currentName);
-      if (next != null) renameFolder(id, next);
+    setFolderPrompt({ kind: "create" });
+  }, []);
+  const handleRenameFolder = useCallback((id: string, currentName: string) => {
+    setFolderPrompt({ kind: "rename", folderId: id, currentName });
+  }, []);
+  const handleFolderPromptConfirm = useCallback(
+    (folderName: string) => {
+      if (!folderPrompt) return;
+      switch (folderPrompt.kind) {
+        case "create": {
+          createFolder(folderName);
+          break;
+        }
+        case "create-and-assign": {
+          const folder = createFolder(folderName);
+          if (folder) assignDeck(folderPrompt.deckName, folder.id);
+          break;
+        }
+        case "rename": {
+          renameFolder(folderPrompt.folderId, folderName);
+          break;
+        }
+      }
+      setFolderPrompt(null);
     },
-    [renameFolder, t],
+    [folderPrompt, createFolder, assignDeck, renameFolder],
   );
+  const handleFolderPromptCancel = useCallback(() => {
+    setFolderPrompt(null);
+  }, []);
   const [folderPendingDelete, setFolderPendingDelete] = useState<{ id: string; name: string } | null>(
     null,
   );
@@ -687,6 +718,9 @@ export function MyDecks({
     setCollapsedFolderIds(collapsedFolderIds.filter((existing) => existing !== id));
     setFolderPendingDelete(null);
   }, [folderPendingDelete, deleteFolder, setCollapsedFolderIds, collapsedFolderIds]);
+  const cancelDeleteFolder = useCallback(() => {
+    setFolderPendingDelete(null);
+  }, []);
 
   useEffect(() => {
     setActiveFilter(contextualFilter ?? "all");
@@ -1737,8 +1771,32 @@ export function MyDecks({
         message={t("folder.deleteConfirm", { name: folderPendingDelete?.name ?? "" })}
         confirmLabel={t("folder.delete")}
         onConfirm={confirmDeleteFolder}
-        onCancel={() => setFolderPendingDelete(null)}
+        onCancel={cancelDeleteFolder}
         tone="danger"
+      />
+      <TextPromptDialog
+        open={folderPrompt != null}
+        title={
+          folderPrompt?.kind === "rename"
+            ? t("folder.rename")
+            : t("folder.newFolder")
+        }
+        label={
+          folderPrompt?.kind === "rename"
+            ? t("folder.renamePrompt")
+            : t("folder.newFolderPrompt")
+        }
+        initialValue={
+          folderPrompt?.kind === "rename" ? folderPrompt.currentName : ""
+        }
+        confirmLabel={
+          folderPrompt?.kind === "rename"
+            ? t("common:actions.save")
+            : t("folder.createButton")
+        }
+        maxLength={MAX_FOLDER_NAME_LENGTH}
+        onConfirm={handleFolderPromptConfirm}
+        onCancel={handleFolderPromptCancel}
       />
     </Wrapper>
   );

--- a/client/src/components/ui/TextPromptDialog.tsx
+++ b/client/src/components/ui/TextPromptDialog.tsx
@@ -1,0 +1,145 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import { menuButtonClass } from "../menu/buttonStyles";
+
+interface TextPromptDialogProps {
+  open: boolean;
+  title: string;
+  label: string;
+  initialValue?: string;
+  placeholder?: string;
+  confirmLabel: string;
+  maxLength?: number;
+  onConfirm: (value: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Site-styled replacement for `window.prompt()` — single-line text entry with
+ * Cancel / confirm actions. Used by deck-library folder flows and any other
+ * menu surfaces that need a short name without pulling in a full modal shell.
+ */
+export function TextPromptDialog({
+  open,
+  title,
+  label,
+  initialValue = "",
+  placeholder,
+  confirmLabel,
+  maxLength,
+  onConfirm,
+  onCancel,
+}: TextPromptDialogProps) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const labelId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (!open) return;
+    setValue(initialValue);
+    const frame = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [open, initialValue]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  const trimmed = value.trim();
+  const canConfirm = trimmed.length > 0;
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canConfirm) return;
+    onConfirm(trimmed);
+  };
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/68 backdrop-blur-[2px]"
+            onClick={onCancel}
+            aria-label={t("actions.closeNamed", { name: title })}
+          />
+
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            className="relative z-10 w-full max-w-md rounded-[22px] border border-white/10 bg-[#0b1020]/96 p-6 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md"
+            initial={{ scale: 0.97, opacity: 0, y: 10 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.97, opacity: 0, y: 10 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h2 id={titleId} className="text-base font-semibold text-white lg:text-lg">
+              {title}
+            </h2>
+
+            <form onSubmit={handleSubmit} className="mt-4">
+              <label id={labelId} htmlFor={`${labelId}-input`} className="text-sm text-slate-300">
+                {label}
+              </label>
+              <input
+                id={`${labelId}-input`}
+                ref={inputRef}
+                type="text"
+                value={value}
+                maxLength={maxLength}
+                placeholder={placeholder}
+                onChange={(event) => setValue(event.target.value)}
+                className="mt-2 w-full rounded-xl border border-white/20 bg-white/8 px-3 py-2.5 text-sm text-white placeholder-white/30 outline-none backdrop-blur-sm transition-colors focus:border-cyan-300/60 focus:ring-1 focus:ring-cyan-300/30"
+                aria-labelledby={labelId}
+              />
+
+              <div className="mt-5 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className={menuButtonClass({ tone: "neutral", size: "sm" })}
+                >
+                  {t("actions.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  disabled={!canConfirm}
+                  className={menuButtonClass({
+                    tone: "cyan",
+                    size: "sm",
+                    disabled: !canConfirm,
+                  })}
+                >
+                  {confirmLabel}
+                </button>
+              </div>
+            </form>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/client/src/components/ui/__tests__/TextPromptDialog.test.tsx
+++ b/client/src/components/ui/__tests__/TextPromptDialog.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { TextPromptDialog } from "../TextPromptDialog";
+
+describe("TextPromptDialog", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("submits trimmed input on confirm", async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <TextPromptDialog
+        open
+        title="New folder"
+        label="Folder name:"
+        confirmLabel="Create"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Folder name:"), "  Archetypes  ");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onConfirm).toHaveBeenCalledWith("Archetypes");
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels without submitting", async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <TextPromptDialog
+        open
+        title="New folder"
+        label="Folder name:"
+        confirmLabel="Create"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Folder name:"), "Draft");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("keeps confirm disabled until non-blank input", async () => {
+    render(
+      <TextPromptDialog
+        open
+        title="New folder"
+        label="Folder name:"
+        confirmLabel="Create"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+    await userEvent.type(screen.getByLabelText("Folder name:"), "   ");
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+  });
+});

--- a/client/src/i18n/locales/de/menu.json
+++ b/client/src/i18n/locales/de/menu.json
@@ -299,6 +299,7 @@
     "delete": "Löschen",
     "newFolder": "Neuer Ordner",
     "newFolderPrompt": "Ordnername:",
+    "createButton": "Erstellen",
     "renamePrompt": "Ordner umbenennen:",
     "deleteConfirm": "Ordner „{{name}}“ löschen? Decks werden zu „Nicht zugeordnet“ verschoben.",
     "emptyHint": "Dieser Ordner ist leer.",

--- a/client/src/i18n/locales/en/menu.json
+++ b/client/src/i18n/locales/en/menu.json
@@ -299,6 +299,7 @@
     "delete": "Delete",
     "newFolder": "New folder",
     "newFolderPrompt": "Folder name:",
+    "createButton": "Create",
     "renamePrompt": "Rename folder:",
     "deleteConfirm": "Delete folder \"{{name}}\"? Its decks move to Unfiled.",
     "emptyHint": "This folder is empty.",

--- a/client/src/i18n/locales/es/menu.json
+++ b/client/src/i18n/locales/es/menu.json
@@ -299,6 +299,7 @@
     "delete": "Eliminar",
     "newFolder": "Nueva carpeta",
     "newFolderPrompt": "Nombre de la carpeta:",
+    "createButton": "Crear",
     "renamePrompt": "Renombrar carpeta:",
     "deleteConfirm": "¿Eliminar la carpeta «{{name}}»? Los mazos pasarán a Sin clasificar.",
     "emptyHint": "Esta carpeta está vacía.",

--- a/client/src/i18n/locales/fr/menu.json
+++ b/client/src/i18n/locales/fr/menu.json
@@ -299,6 +299,7 @@
     "delete": "Supprimer",
     "newFolder": "Nouveau dossier",
     "newFolderPrompt": "Nom du dossier :",
+    "createButton": "Créer",
     "renamePrompt": "Renommer le dossier :",
     "deleteConfirm": "Supprimer le dossier « {{name}} » ? Les decks passeront dans Non classé.",
     "emptyHint": "Ce dossier est vide.",

--- a/client/src/i18n/locales/it/menu.json
+++ b/client/src/i18n/locales/it/menu.json
@@ -299,6 +299,7 @@
     "delete": "Elimina",
     "newFolder": "Nuova cartella",
     "newFolderPrompt": "Nome della cartella:",
+    "createButton": "Crea",
     "renamePrompt": "Rinomina cartella:",
     "deleteConfirm": "Eliminare la cartella «{{name}}»? I mazzi verranno spostati in Senza cartella.",
     "emptyHint": "Questa cartella è vuota.",

--- a/client/src/i18n/locales/pl/menu.json
+++ b/client/src/i18n/locales/pl/menu.json
@@ -299,6 +299,7 @@
     "delete": "Usuń",
     "newFolder": "Nowy folder",
     "newFolderPrompt": "Nazwa folderu:",
+    "createButton": "Utwórz",
     "renamePrompt": "Zmień nazwę folderu:",
     "deleteConfirm": "Usunąć folder „{{name}}”? Talie zostaną przeniesione do „Bez folderu”.",
     "emptyHint": "Ten folder jest pusty.",

--- a/client/src/i18n/locales/pt/menu.json
+++ b/client/src/i18n/locales/pt/menu.json
@@ -299,6 +299,7 @@
     "delete": "Excluir",
     "newFolder": "Nova pasta",
     "newFolderPrompt": "Nome da pasta:",
+    "createButton": "Criar",
     "renamePrompt": "Renomear pasta:",
     "deleteConfirm": "Excluir a pasta \"{{name}}\"? Os baralhos irão para Sem pasta.",
     "emptyHint": "Esta pasta está vazia.",


### PR DESCRIPTION
## Summary

Replaces browser-native `window.prompt()` dialogs used in My Decks folder management with a reusable `TextPromptDialog` component that matches the application's existing modal styling and UX.

### Changes

- Add reusable `TextPromptDialog` (`client/src/components/ui/TextPromptDialog.tsx`)
  - Dark themed modal styling
  - Auto-focused text input
  - Enter to confirm
  - Escape to cancel
  - Configurable title, description, and action labels

- Replace native folder prompts in `MyDecks.tsx` for:
  - New folder (toolbar)
  - New folder… (deck actions menu)
  - Rename folder (folder options)

- Validation improvements:
  - Enforce `MAX_FOLDER_NAME_LENGTH`
  - Trim input before submission
  - Disable confirm action for empty or whitespace-only names

- Localization:
  - Add `folder.createButton` translation key across locales

- Testing:
  - Add unit tests for `TextPromptDialog`

## Related Issues

Fixes #4204

## Problem

Folder creation and rename flows relied on the browser's native `window.prompt()`, which does not match the application's dark theme, modal styling, or interaction patterns. This created an inconsistent user experience compared to the rest of the UI.

## Solution

Introduce a reusable `TextPromptDialog` component and migrate all folder create/rename flows to use it. The new dialog follows existing modal patterns, provides better validation, supports keyboard interactions, and keeps folder management behavior unchanged.

## Test Plan

- [ ] Click **New folder** → styled dialog opens (no native browser prompt)
- [ ] Enter a valid name → folder is created successfully
- [ ] Click **Cancel** or press **Escape** → dialog closes without creating a folder
- [ ] Open deck actions menu → **New folder…** → dialog opens and selected deck is moved into the new folder after confirmation
- [ ] Open folder options → **Rename** → dialog is pre-filled with the current folder name and updates correctly after saving
- [ ] Confirm action remains disabled for empty or whitespace-only names
- [ ] `MAX_FOLDER_NAME_LENGTH` is enforced
- [ ] Run:
  ```bash
  pnpm exec vitest run src/components/ui/__tests__/TextPromptDialog.test.tsx
  
## Screenshots
  
### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/9ca070e0-a6bf-472c-a53d-b935526373b6" />
  
### After
 
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/0add6226-5be8-44f6-8e41-e26504a03b6d" />
