### PR TITLE
fix(engine): route remaining individual-life reads through team total (CR 810.9a)

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4515,12 +4515,9 @@ fn max_pay_life_x(state: &GameState, player: PlayerId) -> u32 {
     if !super::life_costs::can_pay_life_cast_or_activation_cost(state, player, 1) {
         return 0;
     }
-    state
-        .players
-        .iter()
-        .find(|p| p.id == player)
-        .map(|p| u32::try_from(p.life.max(0)).unwrap_or(0))
-        .unwrap_or(0)
+    // CR 119.4a: in a team format the max X payable via life is bounded by the
+    // team's shared total (off-team this is the player's own life).
+    u32::try_from(super::players::team_life_total(state, player).max(0)).unwrap_or(0)
 }
 
 pub(super) fn effective_casualty_additional_cost(
@@ -15838,5 +15835,39 @@ its replicate cost was paid.)\nDraw a card.";
             true,
             &mut events,
         );
+    }
+
+    /// CR 119.4a + CR 810.9a: in 2HG the max X payable via a "pay X life"
+    /// additional cost is bounded by the TEAM total. Team A at 3 + 9 = 12 → max
+    /// X is 12, not the controller's individual 3. Reverting Site 8 to `p.life`
+    /// reads 3. A `CantLoseLife` lock short-circuits to 0.
+    #[test]
+    fn max_pay_life_x_team_bounded_in_2hg() {
+        let mut state =
+            GameState::new(crate::types::format::FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 3;
+        state.players[1].life = 9; // team total 12
+
+        assert_eq!(max_pay_life_x(&state, PlayerId(0)), 12);
+
+        // CR 119.8: a CantLoseLife lock on the payer forces 0.
+        let lock = create_object(
+            &mut state,
+            CardId(7777),
+            PlayerId(0),
+            "Life Lock".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&lock)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CantLoseLife).affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                )),
+            );
+        assert_eq!(max_pay_life_x(&state, PlayerId(0)), 0);
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -465,8 +465,6 @@ pub(crate) fn candidate_player_scalar(p: &Player, attr: &QuantityRef) -> Option<
     match attr {
         // CR 402.1: cards in the candidate's hand.
         QuantityRef::HandSize { .. } => Some(usize_to_i32_saturating(p.hand.len())),
-        // CR 119.1: the candidate's current life total.
-        QuantityRef::LifeTotal { .. } => Some(p.life),
         // CR 119.3: life lost this turn is tracked per candidate player.
         QuantityRef::LifeLostThisTurn { .. } => Some(u32_to_i32_saturating(p.life_lost_this_turn)),
         // CR 404.1: cards in the candidate's graveyard.
@@ -496,6 +494,13 @@ pub(crate) fn candidate_player_scalar_with_state(
         return Some(value);
     }
     match attr {
+        // CR 119.1 + CR 810.9a: the candidate's life total reads the team's
+        // shared total in a team format (off-team it is the candidate's own
+        // life). Stateful because `team_life_total` folds over teammates'
+        // `Player::life` via the live game state.
+        QuantityRef::LifeTotal { .. } => {
+            Some(crate::game::players::team_life_total(state, candidate.id))
+        }
         QuantityRef::BattlefieldEntriesThisTurn { filter, .. } => {
             Some(crate::game::arithmetic::usize_to_i32_saturating(
                 state
@@ -18179,10 +18184,24 @@ mod tests {
             ),
             Some(3)
         );
-        // CR 119.1: life total reads p.life.
+        // CR 810.9a: life total now needs game state (team fold), so the
+        // STATELESS reader returns None and falls the predicate closed.
         assert_eq!(
             candidate_player_scalar(
                 p,
+                &QuantityRef::LifeTotal {
+                    player: PlayerScope::ScopedPlayer
+                }
+            ),
+            None
+        );
+        // CR 119.1 + CR 810.9a: the STATEFUL reader returns the team total —
+        // off-team (Commander) this is the candidate's own life (17).
+        assert_eq!(
+            candidate_player_scalar_with_state(
+                &state,
+                p,
+                PlayerId(0),
                 &QuantityRef::LifeTotal {
                     player: PlayerScope::ScopedPlayer
                 }

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -124,17 +124,17 @@ pub fn resolve(
         // `life_costs::pay_life_as_cost` and stamps `last_effect_count` so the
         // downstream "draw/look at that many" step reads the chosen amount.
         AbilityCost::PayLife { amount } if is_pay_any_amount(amount) => {
-            let life = state
-                .players
-                .iter()
-                .find(|p| p.id == payer)
-                .map(|p| p.life)
-                .unwrap_or(0);
-            let max = if life > 0 && crate::game::life_costs::can_pay_life_cost(state, payer, 1) {
-                u32::try_from(life).unwrap_or(0)
-            } else {
-                0
-            };
+            // CR 119.4a + CR 810.9a: max payable for "pay any amount of life" is
+            // the TEAM total; guard on team_life (a member may be individually
+            // <= 0 while the team is positive, CR 810.9 — life loss lands on
+            // each Player::life individually).
+            let team_life = crate::game::players::team_life_total(state, payer);
+            let max =
+                if team_life > 0 && crate::game::life_costs::can_pay_life_cost(state, payer, 1) {
+                    u32::try_from(team_life).unwrap_or(0)
+                } else {
+                    0
+                };
             state.waiting_for = WaitingFor::PayAmountChoice {
                 player: payer,
                 resource: PayableResource::Life,
@@ -404,6 +404,73 @@ mod tests {
         let result = resolve(&mut state, &ability, &mut events);
         assert!(result.is_ok());
         assert!(state.cost_payment_failed_flag);
+    }
+
+    /// CR 119.4a + CR 810.9a: "pay any amount of life" surfaces a
+    /// `PayAmountChoice` whose `max` is the payer's TEAM total in 2HG. Payer P0
+    /// individually at -2, teammate P1 at 9 → team total 7, so `max == 7` even
+    /// though the payer's individual life is negative (a member may be below 0
+    /// while the team is positive, CR 810.9). Reverting Site 9 to the
+    /// individual `p.life` read (-2, not > 0) would set `max == 0`.
+    #[test]
+    fn pay_any_amount_life_max_is_team_total_in_2hg() {
+        let mut state =
+            GameState::new(crate::types::format::FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = -2;
+        state.players[1].life = 9; // team total 7
+
+        let ability = make_ability(Effect::PayCost {
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        });
+        let mut events = Vec::new();
+        let result = resolve(&mut state, &ability, &mut events);
+        assert!(result.is_ok());
+        match &state.waiting_for {
+            WaitingFor::PayAmountChoice {
+                player,
+                resource,
+                max,
+                ..
+            } => {
+                assert_eq!(*player, PlayerId(0));
+                assert!(matches!(resource, PayableResource::Life));
+                assert_eq!(*max, 7, "max payable is the team total (7), not 0");
+            }
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
+    }
+
+    /// Off-team degeneracy sibling for Site 9: in a 1v1 the max is the payer's
+    /// own life (5).
+    #[test]
+    fn pay_any_amount_life_max_off_team_is_individual() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 5;
+        let ability = make_ability(Effect::PayCost {
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        });
+        let mut events = Vec::new();
+        assert!(resolve(&mut state, &ability, &mut events).is_ok());
+        match &state.waiting_for {
+            WaitingFor::PayAmountChoice { max, .. } => assert_eq!(*max, 5),
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -263,8 +263,10 @@ fn players_for_filter(
                 .filter(|player| !player.is_eliminated)
                 .filter(|player| {
                     crate::game::players::matches_relation(state, player.id, controller, *relation)
-                        && crate::game::effects::candidate_player_scalar(player, attr)
-                            .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
+                        && crate::game::effects::candidate_player_scalar_with_state(
+                            state, player, controller, attr,
+                        )
+                        .is_some_and(|lhs| comparator.evaluate(lhs, threshold))
                 })
                 .map(|player| player.id)
                 .collect()
@@ -332,4 +334,65 @@ pub fn resolve_change_speed(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{
+        Comparator, PlayerRelation, PlayerScope, QuantityExpr, QuantityRef, TargetRef,
+    };
+    use crate::types::format::FormatConfig;
+    use crate::types::identifiers::ObjectId;
+
+    /// CR 119.1 + CR 810.9a: `players_for_filter` with a `PlayerAttribute`
+    /// life-total predicate reads each candidate's TEAM total through the
+    /// migrated `candidate_player_scalar_with_state` call (Site 6). Controller
+    /// P0 (team A); opposing team B {2,3} has members at 5 and 6 (team 11).
+    /// A `LifeTotal >= 10` opponent predicate counts BOTH team-B members
+    /// because each reads the team total (11 >= 10), even though neither
+    /// individual reaches 10. Reverting Site 6 (stateless `Some(p.life)`)
+    /// reads 5 and 6 individually and the filter selects NOBODY.
+    #[test]
+    fn player_attribute_life_total_reads_team_total_in_2hg() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[2].life = 5;
+        state.players[3].life = 6; // team B total = 11
+
+        let filter = PlayerFilter::PlayerAttribute {
+            relation: PlayerRelation::Opponent,
+            attr: Box::new(QuantityRef::LifeTotal {
+                player: PlayerScope::ScopedPlayer,
+            }),
+            comparator: Comparator::GE,
+            value: Box::new(QuantityExpr::Fixed { value: 10 }),
+        };
+        let ability = ResolvedAbility::new(
+            Effect::StartYourEngines {
+                player_scope: PlayerFilter::Controller,
+            },
+            Vec::<TargetRef>::new(),
+            ObjectId(0),
+            PlayerId(0),
+        );
+
+        let mut selected = players_for_filter(&state, &filter, &ability);
+        selected.sort_by_key(|p| p.0);
+        assert_eq!(
+            selected,
+            vec![PlayerId(2), PlayerId(3)],
+            "both team-B members count: each reads the team total (11 >= 10)"
+        );
+
+        // Sibling: raise the threshold above the team total → neither counts.
+        let filter_high = PlayerFilter::PlayerAttribute {
+            relation: PlayerRelation::Opponent,
+            attr: Box::new(QuantityRef::LifeTotal {
+                player: PlayerScope::ScopedPlayer,
+            }),
+            comparator: Comparator::GE,
+            value: Box::new(QuantityExpr::Fixed { value: 12 }),
+        };
+        assert!(players_for_filter(&state, &filter_high, &ability).is_empty());
+    }
 }

--- a/crates/engine/src/game/life_costs.rs
+++ b/crates/engine/src/game/life_costs.rs
@@ -69,12 +69,8 @@ pub fn max_phyrexian_life_payments(state: &GameState, player: PlayerId) -> u32 {
     if player_has_cant_lose_life(state, player) || player_cant_pay_life_as_cost(state, player) {
         return 0;
     }
-    state
-        .players
-        .iter()
-        .find(|p| p.id == player)
-        .map(|p| u32::try_from((p.life / 2).max(0)).unwrap_or(0))
-        .unwrap_or(0)
+    // CR 119.4a: in a team format the payable budget is bounded by the team total.
+    u32::try_from((crate::game::players::team_life_total(state, player) / 2).max(0)).unwrap_or(0)
 }
 
 /// CR 118.3 + CR 119.4b + CR 119.8: Pure predicate — can this player pay `amount` life?
@@ -91,12 +87,9 @@ pub fn can_pay_life_cost(state: &GameState, player: PlayerId, amount: u32) -> bo
     if player_has_cant_lose_life(state, player) {
         return false;
     }
-    // CR 118.3: life total must be at least the amount to be paid.
-    state
-        .players
-        .iter()
-        .find(|p| p.id == player)
-        .is_some_and(|p| p.life >= amount as i32)
+    // CR 119.4a: in a team format affordability is bounded by the team's
+    // shared life total (off-team this is the player's own life).
+    crate::game::players::team_life_total(state, player) >= amount as i32
 }
 
 /// CR 118.3b + CR 119.4 + CR 119.8: Pay `amount` life from `player` as a cost.
@@ -129,12 +122,11 @@ pub fn pay_life_as_cost(
         return PayLifeCostResult::Prohibited;
     }
 
-    // CR 118.3: Resource check — must have enough life.
-    let has_life = state
-        .players
-        .iter()
-        .find(|p| p.id == player)
-        .is_some_and(|p| p.life >= amount as i32);
+    // CR 119.4a: Resource check — affordability is bounded by the team's
+    // shared total. The DEDUCTION below lands on the individual `Player::life`
+    // (CR 810.9: life loss happens to each player individually) and may go
+    // negative — only the affordability gate reads the team total.
+    let has_life = crate::game::players::team_life_total(state, player) >= amount as i32;
     if !has_life {
         return PayLifeCostResult::InsufficientLife;
     }
@@ -188,6 +180,7 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{ControllerRef, StaticDefinition, TargetFilter, TypedFilter};
+    use crate::types::format::FormatConfig;
     use crate::types::identifiers::CardId;
     use crate::types::statics::{CostPaymentProhibition, ProhibitionScope, StaticMode};
     use crate::types::zones::Zone;
@@ -347,5 +340,74 @@ mod tests {
 
         assert_eq!(result, PayLifeCostResult::Paid { amount: 3 });
         assert_eq!(state.players[1].life, 17);
+    }
+
+    /// CR 119.4a + CR 810.9a: in 2HG, `can_pay_life_cost` affordability is
+    /// bounded by the TEAM total. Member at 3, teammate at 9 (team 12) → a
+    /// 10-life cost is payable even though the individual has only 3. Reverting
+    /// Site 3 to `p.life >= amount` flips this to unpayable. The order is
+    /// preserved: 0 is payable and a lock blocks any positive amount.
+    #[test]
+    fn can_pay_life_cost_team_bounded_in_2hg() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 3;
+        state.players[1].life = 9; // team total 12
+
+        assert!(
+            can_pay_life_cost(&state, PlayerId(0), 10),
+            "team total 12 affords a 10-life cost"
+        );
+        assert!(!can_pay_life_cost(&state, PlayerId(0), 13));
+        // CR 119.4b: 0 always payable.
+        assert!(can_pay_life_cost(&state, PlayerId(0), 0));
+        // CR 119.8: lock blocks any positive amount.
+        add_cant_lose_life_permanent(&mut state, PlayerId(0));
+        assert!(!can_pay_life_cost(&state, PlayerId(0), 1));
+    }
+
+    /// Off-team degeneracy sibling for Site 3: in a 1v1, affordability is the
+    /// player's own life (no team fold).
+    #[test]
+    fn can_pay_life_cost_off_team_individual() {
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 4;
+        assert!(can_pay_life_cost(&state, PlayerId(0), 4));
+        assert!(!can_pay_life_cost(&state, PlayerId(0), 5));
+    }
+
+    /// CR 119.4a + CR 810.9: `max_phyrexian_life_payments` is bounded by the
+    /// team total (12 / 2 = 6), not the individual (3 / 2 = 1). The lock still
+    /// short-circuits to 0.
+    #[test]
+    fn max_phyrexian_payments_team_bounded_in_2hg() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 3;
+        state.players[1].life = 9; // team 12
+        assert_eq!(max_phyrexian_life_payments(&state, PlayerId(0)), 6);
+        add_cant_lose_life_permanent(&mut state, PlayerId(0));
+        assert_eq!(max_phyrexian_life_payments(&state, PlayerId(0)), 0);
+    }
+
+    /// CR 119.4a + CR 810.9: pay-life affordability is team-bounded, and the
+    /// DEDUCTION lands on the individual `Player::life` — a member may go
+    /// negative while the team stays positive. Pay 6 from a {2, 6} team: payer
+    /// goes to -4 (team 4), no SBA runs here (this is the cost helper only).
+    #[test]
+    fn pay_life_team_bounded_deduction_lands_individual_in_2hg() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 2;
+        state.players[1].life = 6; // team 8
+        let mut events = Vec::new();
+
+        let result = pay_life_as_cost(&mut state, PlayerId(0), 6, &mut events);
+
+        assert_eq!(result, PayLifeCostResult::Paid { amount: 6 });
+        // Deduction is individual (CR 810.9): payer 2 - 6 = -4.
+        assert_eq!(state.players[0].life, -4);
+        // Team total now 2 (-4 + 6).
+        assert_eq!(
+            crate::game::players::team_life_total(&state, PlayerId(0)),
+            2
+        );
     }
 }

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -1,4 +1,4 @@
-use crate::types::ability::{ControllerRef, PlayerRelation, SeatDirection};
+use crate::types::ability::{AggregateFunction, ControllerRef, PlayerRelation, SeatDirection};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
 use crate::types::game_state::LinkedExileSnapshot;
@@ -303,8 +303,41 @@ pub fn teammates(state: &GameState, player: PlayerId) -> Vec<PlayerId> {
     }
 }
 
-fn team_index(player: PlayerId) -> u8 {
+pub(crate) fn team_index(player: PlayerId) -> u8 {
     player.0 / 2
+}
+
+/// CR 810.9a + CR 810.9d: Fold a player population into one i32 by aggregating
+/// each DISTINCT team's shared `team_life_total` exactly once (dedup by team).
+/// Min/Max = extremum over team totals; Sum = Σ team totals (no double-count).
+/// Empty population → 0. Off-team every player is its own singleton team, so
+/// this matches a per-individual fold: the dedup key falls back to `pid.0`,
+/// which is distinct per player even when two players share a `team_index`
+/// (e.g. a 1v1 where players 0 and 1 are both `team_index == 0`).
+/// CR 810.9d is the confirming example: a per-team extremum (Repay in Kind)
+/// reads each team's total once, not each member.
+pub(crate) fn aggregate_over_teams<I>(
+    state: &GameState,
+    players: I,
+    aggregate: AggregateFunction,
+) -> i32
+where
+    I: IntoIterator<Item = PlayerId>,
+{
+    let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    let team_totals = players.into_iter().filter_map(|pid| {
+        let key = if state.format_config.team_based {
+            team_index(pid) as u32
+        } else {
+            pid.0 as u32
+        };
+        seen.insert(key).then(|| team_life_total(state, pid))
+    });
+    match aggregate {
+        AggregateFunction::Max => team_totals.max().unwrap_or(0),
+        AggregateFunction::Min => team_totals.min().unwrap_or(0),
+        AggregateFunction::Sum => team_totals.sum(),
+    }
 }
 
 /// CR 810.4 + CR 810.9a: A player's team's shared life total. In non-team
@@ -715,5 +748,69 @@ mod tests {
         assert_eq!(team_poison_total(&state, PlayerId(1)), 15);
         // Opposing team is unaffected.
         assert_eq!(team_poison_total(&state, PlayerId(2)), 0);
+    }
+
+    // --- aggregate_over_teams ---
+
+    /// CR 810.9a + CR 810.9d: aggregating life over a population folds each
+    /// DISTINCT team's shared total exactly once. Over the two opponents of
+    /// team A (players 2 and 3 with 9 and 5 = team total 14), Sum/Max/Min all
+    /// read 14 ONCE — not 28 (double-counted) and not 9 (individual). This is
+    /// the byte-distinguishing regression for Malignus-style off-team reads.
+    #[test]
+    fn aggregate_over_teams_dedups_a_shared_team() {
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[2].life = 9;
+        state.players[3].life = 5;
+        let opp_team = vec![PlayerId(2), PlayerId(3)];
+        assert_eq!(
+            aggregate_over_teams(&state, opp_team.clone(), AggregateFunction::Sum),
+            14,
+            "Sum must count the shared team total once, not 28"
+        );
+        assert_eq!(
+            aggregate_over_teams(&state, opp_team.clone(), AggregateFunction::Max),
+            14
+        );
+        assert_eq!(
+            aggregate_over_teams(&state, opp_team, AggregateFunction::Min),
+            14
+        );
+    }
+
+    /// The dedup key falls back to `pid.0` off-team so two players that share a
+    /// `team_index` in a NON-team format are NOT collapsed. In Commander,
+    /// players 0 and 1 both have `team_index == 0` (0/2 and 1/2); a bare
+    /// `team_index` key would drop one and break Sum. With the `pid.0` guard,
+    /// Sum over [11, 7] is 18 (both counted as singleton teams).
+    #[test]
+    fn aggregate_over_teams_non_team_format_keeps_players_distinct() {
+        let mut state = GameState::new(FormatConfig::commander(), 4, 0);
+        state.players[0].life = 11;
+        state.players[1].life = 7;
+        assert_eq!(
+            aggregate_over_teams(
+                &state,
+                vec![PlayerId(0), PlayerId(1)],
+                AggregateFunction::Sum
+            ),
+            18,
+            "non-team players sharing a team_index must stay distinct via the pid.0 guard"
+        );
+    }
+
+    /// Empty population → 0 for every aggregate.
+    #[test]
+    fn aggregate_over_teams_empty_population_is_zero() {
+        let state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        let empty: Vec<PlayerId> = Vec::new();
+        assert_eq!(
+            aggregate_over_teams(&state, empty.clone(), AggregateFunction::Max),
+            0
+        );
+        assert_eq!(
+            aggregate_over_teams(&state, empty, AggregateFunction::Sum),
+            0
+        );
     }
 }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1471,9 +1471,15 @@ fn resolve_ref(
                 usize_to_i32_saturating(p.hand.len())
             })
         }
-        // CR 119: life total for the scoped player(s).
+        // CR 119 + CR 810.9a: a single player's life total reads the team's
+        // shared total in a team format; aggregate scopes fold over team
+        // totals (deduped). Off-team this is byte-identical (singleton teams,
+        // team_life_total == p.life). CR 810.9d confirms the per-team extremum.
         QuantityRef::LifeTotal { player: scope } => {
-            resolve_per_player_scalar(state, scope, controller, ctx, targets, ability, |p| p.life)
+            match resolve_single_player_scope(state, scope, controller, ctx, targets, ability) {
+                Some(pid) => crate::game::players::team_life_total(state, pid),
+                None => resolve_per_team_life(state, scope, controller, ctx, targets, ability),
+            }
         }
         // CR 106.4: floating mana of `color` (or any color) in the controller's
         // mana pool. Controller-scoped — `player` is the controller. Omnath,
@@ -1504,9 +1510,11 @@ fn resolve_ref(
                 usize_to_i32_saturating(p.graveyard.len())
             })
         }
-        QuantityRef::LifeAboveStarting => {
-            player.map_or(0, |p| p.life - state.format_config.starting_life)
-        }
+        // CR 810.9a + CR 810.4: team total minus the (already team-correct, 30)
+        // starting life. Single controller bind — no double-count.
+        QuantityRef::LifeAboveStarting => player.map_or(0, |p| {
+            crate::game::players::team_life_total(state, p.id) - state.format_config.starting_life
+        }),
         // CR 103.4: The format's starting life total.
         QuantityRef::StartingLifeTotal => state.format_config.starting_life,
         // CR 118.4 + CR 119.3: Life lost this turn, scoped via PlayerScope (Π-3).
@@ -4184,6 +4192,52 @@ fn defending_player_from_event(
         .or(Some(*defending_player))
 }
 
+/// CR 810.9a + CR 810.9d: Resolve an aggregate (multi-player) `LifeTotal`
+/// scope by folding over each DISTINCT team's shared life total. Mirrors the
+/// population semantics of the aggregate arms in `resolve_per_player_scalar`
+/// (Opponent / AllPlayers); single-player scopes never reach here (they are
+/// handled by the `Some(pid)` branch of the LifeTotal arm). A non-aggregate
+/// scope that failed to resolve a single player returns 0, preserving the
+/// pre-fix `map_or(0)` fallback.
+fn resolve_per_team_life(
+    state: &GameState,
+    scope: &PlayerScope,
+    controller: PlayerId,
+    ctx: QuantityContext,
+    targets: &[TargetRef],
+    ability: Option<&ResolvedAbility>,
+) -> i32 {
+    match scope {
+        // CR 102.2: aggregate over all opponents' teams.
+        PlayerScope::Opponent { aggregate } => crate::game::players::aggregate_over_teams(
+            state,
+            state
+                .players
+                .iter()
+                .filter(|p| p.id != controller)
+                .map(|p| p.id),
+            *aggregate,
+        ),
+        // CR 102.1: aggregate over all players' teams, optionally excluding
+        // the `exclude` anchor ("each OTHER player").
+        PlayerScope::AllPlayers { aggregate, exclude } => {
+            let excluded_id = exclude.as_deref().and_then(|ex| {
+                resolve_single_player_scope(state, ex, controller, ctx, targets, ability)
+            });
+            crate::game::players::aggregate_over_teams(
+                state,
+                state
+                    .players
+                    .iter()
+                    .filter(|p| Some(p.id) != excluded_id)
+                    .map(|p| p.id),
+                *aggregate,
+            )
+        }
+        _ => 0,
+    }
+}
+
 /// CR 107.3e: Reduce a player iterator to a single i32 by aggregate function.
 /// Returns 0 for an empty iterator (mirrors the prior `OpponentLifeTotal`
 /// `.unwrap_or(0)` semantics — there is always at least one opponent in a
@@ -5346,6 +5400,115 @@ mod tests {
         assert_eq!(
             resolve_quantity(&state, &all_expr, PlayerId(0), ObjectId(0)),
             8
+        );
+    }
+
+    /// CR 119 + CR 810.9a + CR 810.9d: in a 2HG game, `LifeTotal { Opponent }`
+    /// (Malignus "highest life total among your opponents") folds over each
+    /// DISTINCT team's shared total exactly once, rather than over individual
+    /// `Player::life` values. The `Opponent` population is `p.id != controller`
+    /// (mirroring the pre-fix aggregate arm — see NOTE below on teammate
+    /// inclusion), so it spans the controller's teammate AND the opposing team;
+    /// the team dedup collapses each to its shared total.
+    ///
+    /// Setup: controller P0 on team A {0,1} at 2 + 3 = 5; opposing team B {2,3}
+    /// at 9 + 5 = 14. The deduped team totals are {A=5, B=14}. Max = 14
+    /// post-fix (pre-fix individual Max{P1=3, P2=9, P3=5} = 9); Min = 5 post-fix
+    /// (pre-fix individual Min{P1=3, P2=9, P3=5} = 3). Both assertions flip if
+    /// Site 1 is reverted to a per-individual fold.
+    ///
+    /// NOTE: `PlayerScope::Opponent` here still includes the controller's
+    /// 2HG teammate (population `p.id != controller`), a PRE-EXISTING population
+    /// quirk this change deliberately preserves (the plan mirrors the existing
+    /// aggregate semantics; CR 102.2 teammate-exclusion is out of scope). With
+    /// team A (5) below team B (14), Max coincides with the opposing-team total,
+    /// which is the Malignus-intended read.
+    #[test]
+    fn life_total_opponent_max_reads_team_total_in_2hg() {
+        use crate::types::format::FormatConfig;
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 2;
+        state.players[1].life = 3; // team A total 5
+        state.players[2].life = 9;
+        state.players[3].life = 5; // team B total 14
+
+        let max_expr = QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Max,
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &max_expr, PlayerId(0), ObjectId(0)),
+            14,
+            "deduped team fold Max{{A=5, B=14}} = 14, not the individual max (9)"
+        );
+
+        // Sibling: Min over the deduped team totals {A=5, B=14} = 5, not the
+        // individual minimum (3).
+        let min_expr = QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Min,
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &min_expr, PlayerId(0), ObjectId(0)),
+            5,
+            "deduped team fold Min{{A=5, B=14}} = 5, not the individual min (3)"
+        );
+
+        // Negative: an unresolved single-player Target scope (no player target)
+        // returns 0, preserving the pre-fix map_or(0) fallback.
+        let target_expr = QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::Target,
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &target_expr, PlayerId(0), ObjectId(0)),
+            0
+        );
+    }
+
+    /// Off-team degeneracy sibling for Site 1: in a 1v1 (non-team) game the
+    /// single opponent's life reads through unchanged (no team fold).
+    #[test]
+    fn life_total_opponent_max_off_team_is_individual_life() {
+        let mut state = GameState::new_two_player(0);
+        state.players[1].life = 7;
+        let max_expr = QuantityExpr::Ref {
+            qty: QuantityRef::LifeTotal {
+                player: PlayerScope::Opponent {
+                    aggregate: AggregateFunction::Max,
+                },
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &max_expr, PlayerId(0), ObjectId(0)),
+            7
+        );
+    }
+
+    /// CR 810.9a + CR 810.4: `LifeAboveStarting` reads the controller's TEAM
+    /// total minus the (team-correct) starting life (30 in 2HG). Team at 55 →
+    /// 25 above starting. Reverting Site 7 to `p.life` reads only the
+    /// controller's individual share.
+    #[test]
+    fn life_above_starting_reads_team_total_in_2hg() {
+        use crate::types::format::FormatConfig;
+        let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 30;
+        state.players[1].life = 25;
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::LifeAboveStarting,
+        };
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(0)),
+            25,
+            "team total (55) minus starting life (30) = 25"
         );
     }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -3681,9 +3681,14 @@ fn evaluate_replacement_condition(
             });
             !controls_any
         }
-        // CR 614.1d: Bond lands — "unless a player has N or less life"
+        // CR 614.1d + CR 810.9a: Bond lands — "unless a player has N or less
+        // life". Each player's life reads the team total in a team format, so
+        // the OR over players is "any team total <= N".
         ReplacementCondition::UnlessPlayerLifeAtMost { amount } => {
-            let any_player_low = state.players.iter().any(|p| p.life <= *amount as i32);
+            let any_player_low = state
+                .players
+                .iter()
+                .any(|p| crate::game::players::team_life_total(state, p.id) <= *amount as i32);
             !any_player_low
         }
         // CR 614.1d: Battlebond lands — "unless you have two or more opponents"
@@ -8893,6 +8898,62 @@ mod tests {
             ),
             "two other lands satisfy `minimum: 2` with Another excluding source"
         );
+    }
+
+    /// CR 614.1d + CR 810.9a: Bond-land "unless a player has N or less life"
+    /// reads each player's TEAM total in 2HG. Both teams at 20 (10+10) → no
+    /// team is at or below 15, so the condition is true (not suppressed) even
+    /// though every individual is at 10. Reverting Site 5 to `p.life` would see
+    /// individuals at 10 (<= 15) and wrongly suppress (return false).
+    #[test]
+    fn unless_player_life_at_most_reads_team_total_in_2hg() {
+        let mut state =
+            GameState::new(crate::types::format::FormatConfig::two_headed_giant(), 4, 0);
+        for p in &mut state.players {
+            p.life = 10; // each team total = 20
+        }
+        let cond = ReplacementCondition::UnlessPlayerLifeAtMost { amount: 15 };
+        assert!(
+            evaluate_replacement_condition(
+                &cond,
+                PlayerId(0),
+                ObjectId(0),
+                &state,
+                None,
+                &dummy_begin_turn_event(),
+            ),
+            "no team total (20) is <= 15, so the replacement is not suppressed"
+        );
+
+        // A single low individual on an otherwise-healthy team must NOT trip the
+        // condition: player 0 at 8 + teammate at 20 → team 28 > 15.
+        state.players[0].life = 8;
+        state.players[1].life = 20;
+        state.players[2].life = 20;
+        state.players[3].life = 20;
+        assert!(
+            evaluate_replacement_condition(
+                &cond,
+                PlayerId(0),
+                ObjectId(0),
+                &state,
+                None,
+                &dummy_begin_turn_event(),
+            ),
+            "an individual at 8 must not trip the condition when its team is at 28"
+        );
+
+        // When a TEAM total drops to <= 15, the condition is satisfied (false).
+        state.players[0].life = 5;
+        state.players[1].life = 5; // team 10 <= 15
+        assert!(!evaluate_replacement_condition(
+            &cond,
+            PlayerId(0),
+            ObjectId(0),
+            &state,
+            None,
+            &dummy_begin_turn_event(),
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5576,9 +5576,12 @@ pub(crate) fn check_trigger_condition(
         TriggerCondition::TwoOrMoreSpellsCastLastTurn => {
             state.spells_cast_last_turn.unwrap_or(0) >= 2
         }
-        // CR 603.4: "if you have N or more life" — compare controller's life total.
+        // CR 603.4 + CR 810.9a: "if you have N or more life" reads the
+        // controller's TEAM total in a team format (own life off-team). Note:
+        // `minimum == 0` would flip a missing-player false→true vs. the prior
+        // `player_field` wrapper, but no real card has a 0 minimum.
         TriggerCondition::LifeTotalGE { minimum } => {
-            player_field(state, controller, |p| p.life >= *minimum)
+            super::players::team_life_total(state, controller) >= *minimum
         }
         // CR 603.4 + CR 102.1: "if it's <player>'s turn" — true when the named
         // player is currently the active player. Negation ("if it isn't <player>'s
@@ -12185,6 +12188,56 @@ pub mod tests {
             &condition,
             PlayerId(0),
             Some(source),
+            None,
+        ));
+    }
+
+    /// CR 603.4 + CR 810.9a: "if you have N or more life" reads the
+    /// controller's TEAM total in a 2HG game. Team A = 30 + 25 = 55 satisfies a
+    /// minimum of 50, even though neither individual reaches 50. Reverting Site
+    /// 2 to the individual `p.life` read (30) flips the assertion to false.
+    #[test]
+    fn life_total_ge_reads_team_total_in_2hg() {
+        let mut state =
+            GameState::new(crate::types::format::FormatConfig::two_headed_giant(), 4, 0);
+        state.players[0].life = 30;
+        state.players[1].life = 25;
+        let condition = TriggerCondition::LifeTotalGE { minimum: 50 };
+        assert!(
+            check_trigger_condition(&state, &condition, PlayerId(0), Some(ObjectId(10)), None),
+            "team total (55) >= 50 even though no individual reaches 50"
+        );
+        // Sibling: a minimum above the team total fails.
+        let high = TriggerCondition::LifeTotalGE { minimum: 56 };
+        assert!(!check_trigger_condition(
+            &state,
+            &high,
+            PlayerId(0),
+            Some(ObjectId(10)),
+            None,
+        ));
+    }
+
+    /// Off-team degeneracy sibling for Site 2: in a 1v1 the controller's own
+    /// life governs the threshold (no team fold).
+    #[test]
+    fn life_total_ge_off_team_is_individual_life() {
+        let mut state = setup();
+        state.players[0].life = 12;
+        let condition = TriggerCondition::LifeTotalGE { minimum: 12 };
+        assert!(check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(ObjectId(10)),
+            None,
+        ));
+        let condition = TriggerCondition::LifeTotalGE { minimum: 13 };
+        assert!(!check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(ObjectId(10)),
             None,
         ));
     }


### PR DESCRIPTION
PR #4199 added the `team_life_total` derived-sum helper and wired it through
the SBA life-loss check and the SetLifeTotal effect, but left several
individual-life READ/comparison sites reading `Player::life` directly. Per
CR 810.9a ("If a cost or effect needs to know the value of an individual
player's life total, that cost or effect uses the team's life total
instead"), each of these must read the team's shared total. All degenerate
to the player's own life in non-team formats (teammates() returns empty).

Converted read sites (all crates/engine/src/game/):
- quantity.rs: QuantityRef::LifeTotal (single-player scopes -> team total;
  aggregate scopes -> new resolve_per_team_life) and LifeAboveStarting.
- triggers.rs: TriggerCondition::LifeTotalGE reads the controller's team total.
- life_costs.rs: can_pay_life_cost / max_phyrexian_life_payments /
  pay_life_as_cost affordability are team-bounded (CR 119.4a); the deduction
  still lands on the individual player's life (may go negative).
- replacement.rs: UnlessPlayerLifeAtMost (Bond lands) reads each team total.
- effects/mod.rs + effects/speed_effects.rs: candidate_player_scalar LifeTotal
  moved from the stateless to the state-aware accessor (team total).
- casting_costs.rs: max_pay_life_x is team-bounded.
- effects/pay.rs: pay-any-amount-of-life max offered is the team total.

New building block in players.rs: aggregate_over_teams folds a player
population into one i32 by aggregating each DISTINCT team's shared total
exactly once (dedup by team), preventing the double-count an all-players Sum
scope would otherwise produce across two teammates. The dedup key is guarded
`team_based ? team_index : pid.0` so 1v1 players (both team_index 0) are not
collapsed. team_index promoted to pub(crate).

Adds discriminating 2HG runtime regression tests for every converted site,
each with distinct non-default life across both teams so the assertion fails
on the pre-fix `Player::life` behavior and passes after.
