### PR TITLE
feat(settings): replace reset preferences confirm with styled ConfirmDialog

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -499,17 +499,10 @@ export function PreferencesModal({
                       onMove={moveArtChainEntry}
                     />
                     {artOverrideCount > 0 && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          if (window.confirm(t("visual.clearArtOverridesConfirm", { count: artOverrideCount }))) {
-                            clearAllArtOverrides();
-                          }
-                        }}
-                        className="mt-2 rounded-[14px] border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-200 transition hover:bg-white/10"
-                      >
-                        {t("visual.clearArtOverrides", { count: artOverrideCount })}
-                      </button>
+                      <ClearArtOverridesButton
+                        count={artOverrideCount}
+                        onClear={clearAllArtOverrides}
+                      />
                     )}
                   </SettingGroup>
 
@@ -694,6 +687,43 @@ export function PreferencesModal({
             </div>
           </div>
     </ModalPanelShell>
+  );
+}
+
+function ClearArtOverridesButton({
+  count,
+  onClear,
+}: {
+  count: number;
+  onClear: () => void;
+}) {
+  const { t } = useTranslation("settings");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const onConfirm = useCallback(() => {
+    onClear();
+    setConfirmOpen(false);
+  }, [onClear]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setConfirmOpen(true)}
+        className="mt-2 rounded-[14px] border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-200 transition hover:bg-white/10"
+      >
+        {t("visual.clearArtOverrides", { count })}
+      </button>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t("visual.clearArtOverrides", { count })}
+        message={t("visual.clearArtOverridesConfirm", { count })}
+        confirmLabel={t("visual.clearArtOverridesAction")}
+        onConfirm={onConfirm}
+        onCancel={() => setConfirmOpen(false)}
+        tone="danger"
+      />
+    </>
   );
 }
 
@@ -921,6 +951,7 @@ function DataSection() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingImportFile, setPendingImportFile] = useState<File | null>(null);
 
   const onExport = useCallback(() => {
     setError(null);
@@ -958,6 +989,19 @@ function DataSection() {
     [t],
   );
 
+  const dismissImportDialog = useCallback(() => {
+    setPendingImportFile(null);
+  }, []);
+
+  const confirmImport = useCallback(
+    (mode: ImportMode) => {
+      if (!pendingImportFile) return;
+      void onImport(pendingImportFile, mode);
+      setPendingImportFile(null);
+    },
+    [onImport, pendingImportFile],
+  );
+
   return (
     <SettingsSection title={t("data.title")}>
       <p className="text-xs text-slate-400">
@@ -988,11 +1032,20 @@ function DataSection() {
           const file = e.target.files?.[0];
           e.target.value = "";
           if (!file) return;
-          const mode: ImportMode = window.confirm(t("data.importConfirm"))
-            ? "overwrite"
-            : "merge";
-          void onImport(file, mode);
+          setPendingImportFile(file);
         }}
+      />
+      <ConfirmDialog
+        open={pendingImportFile != null}
+        title={t("data.importModeTitle")}
+        message={t("data.importModeMessage")}
+        confirmLabel={t("data.importOverwrite")}
+        secondaryConfirmLabel={t("data.importMerge")}
+        onConfirm={() => confirmImport("overwrite")}
+        onSecondaryConfirm={() => confirmImport("merge")}
+        onCancel={dismissImportDialog}
+        tone="danger"
+        secondaryTone="primary"
       />
       {status && <p className="text-xs text-emerald-400">{status}</p>}
       {error && <p className="text-xs text-rose-400">{error}</p>}

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -38,6 +38,7 @@ import type { SupportedLng } from "../../i18n/resources.ts";
 import { LanguageFlag } from "../ui/LanguageFlag.tsx";
 import { BATTLEFIELDS } from "../board/battlefields.ts";
 import { PLAIN_BACKGROUNDS } from "../board/plainBackgrounds.ts";
+import { ConfirmDialog } from "../ui/ConfirmDialog.tsx";
 import { ModalPanelShell } from "../ui/ModalPanelShell";
 import { MenuSelect } from "../ui/MenuSelect";
 import { downloadBackup, importBackupFromFile, type ImportMode } from "../../services/backup.ts";
@@ -706,20 +707,32 @@ function ResetAllFooter({
   resetAllPreferences: () => void;
 }) {
   const { t } = useTranslation("settings");
-  const onClick = useCallback(() => {
-    if (window.confirm(t("resetAll.confirm"))) {
-      resetAllPreferences();
-    }
-  }, [resetAllPreferences, t]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const onConfirm = useCallback(() => {
+    resetAllPreferences();
+    setConfirmOpen(false);
+  }, [resetAllPreferences]);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-rose-300"
-    >
-      {t("resetAll.button")}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setConfirmOpen(true)}
+        className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500 transition-colors hover:text-rose-300"
+      >
+        {t("resetAll.button")}
+      </button>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t("resetAll.button")}
+        message={t("resetAll.confirm")}
+        confirmLabel={t("resetAll.confirmAction")}
+        onConfirm={onConfirm}
+        onCancel={() => setConfirmOpen(false)}
+        tone="danger"
+      />
+    </>
   );
 }
 

--- a/client/src/components/ui/ConfirmDialog.tsx
+++ b/client/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
@@ -11,6 +12,10 @@ interface ConfirmDialogProps {
   onCancel: () => void;
   /** Visual emphasis for the confirm action. */
   tone?: "danger" | "primary";
+  /** Optional second confirm action (e.g. import merge vs overwrite). */
+  secondaryConfirmLabel?: string;
+  onSecondaryConfirm?: () => void;
+  secondaryTone?: "danger" | "primary";
 }
 
 const CONFIRM_TONE_CLASS = {
@@ -32,8 +37,24 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
   tone = "danger",
+  secondaryConfirmLabel,
+  onSecondaryConfirm,
+  secondaryTone = "primary",
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onCancel]);
 
   return createPortal(
     <AnimatePresence>
@@ -77,14 +98,24 @@ export function ConfirmDialog({
             >
               {message}
             </p>
-            <div className="mt-6 flex justify-end gap-3">
+            <div className="mt-6 flex flex-wrap justify-end gap-3">
               <button
                 type="button"
+                autoFocus
                 onClick={onCancel}
                 className="rounded-[14px] border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-100 transition hover:bg-white/10"
               >
                 {t("actions.cancel")}
               </button>
+              {secondaryConfirmLabel && onSecondaryConfirm ? (
+                <button
+                  type="button"
+                  onClick={onSecondaryConfirm}
+                  className={`rounded-[14px] border px-4 py-2 text-sm font-medium transition ${CONFIRM_TONE_CLASS[secondaryTone]}`}
+                >
+                  {secondaryConfirmLabel}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={onConfirm}

--- a/client/src/components/ui/ConfirmDialog.tsx
+++ b/client/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,102 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** Visual emphasis for the confirm action. */
+  tone?: "danger" | "primary";
+}
+
+const CONFIRM_TONE_CLASS = {
+  danger:
+    "border-rose-400/40 bg-rose-500/20 text-rose-100 hover:bg-rose-500/30 hover:text-white",
+  primary:
+    "border-sky-400/60 bg-sky-500/14 text-sky-100 hover:bg-sky-500/25 hover:text-white",
+} as const;
+
+/**
+ * Lightweight confirmation dialog styled to match settings/workspace modals.
+ * Portals above `ModalPanelShell` (z-50) so it can stack on nested flows.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  tone = "danger",
+}: ConfirmDialogProps) {
+  const { t } = useTranslation();
+
+  return createPortal(
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          key="confirm-dialog"
+          className="fixed inset-0 z-[70] flex items-center justify-center px-4 py-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/68 backdrop-blur-[2px]"
+            onClick={onCancel}
+            aria-label={t("actions.closeNamed", { name: title })}
+          />
+
+          <motion.div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="confirm-dialog-title"
+            aria-describedby="confirm-dialog-message"
+            className="relative z-10 w-full max-w-md overflow-hidden rounded-[20px] border border-white/10 bg-[#0b1020]/96 p-6 shadow-[0_28px_80px_rgba(0,0,0,0.42)] backdrop-blur-md"
+            initial={{ scale: 0.97, opacity: 0, y: 10 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.97, opacity: 0, y: 10 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2
+              id="confirm-dialog-title"
+              className="text-lg font-semibold text-white"
+            >
+              {title}
+            </h2>
+            <p
+              id="confirm-dialog-message"
+              className="mt-2 text-sm leading-relaxed text-slate-400"
+            >
+              {message}
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="rounded-[14px] border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-100 transition hover:bg-white/10"
+              >
+                {t("actions.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                className={`rounded-[14px] border px-4 py-2 text-sm font-medium transition ${CONFIRM_TONE_CLASS[tone]}`}
+              >
+                {confirmLabel}
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Alle Artwork-Überschreibungen aufheben ({{count}})",
     "clearArtOverridesConfirm_one": "Alle {{count}} Artwork-Überschreibung aufheben?",
     "clearArtOverridesConfirm_other": "Alle {{count}} Artwork-Überschreibungen aufheben?",
+    "clearArtOverridesAction": "Löschen",
     "vfxQualityOptions": {
       "full": "Voll",
       "reduced": "Reduziert",
@@ -160,6 +161,10 @@
     "description": "Der Export bündelt deine Einstellungen, importierten Decks und Feed-Abonnements in einer einzigen JSON-Datei. Der Import stellt sie auf einem anderen Gerät wieder her. IndexedDB-Caches (Feed-Cache, Audio-Cache, gespeicherte Spiele) sind nicht enthalten — diese werden automatisch neu aufgebaut.",
     "exportBackup": "Sicherung exportieren…",
     "importBackup": "Sicherung importieren…",
+    "importModeTitle": "Sicherung importieren",
+    "importModeMessage": "Alles durch die Sicherung ersetzen (destruktiv) oder zusammenführen — vorhandene Decks behalten und neue aus der Sicherung hinzufügen.",
+    "importOverwrite": "Alles ersetzen",
+    "importMerge": "Zusammenführen",
     "importConfirm": "Vorhandene Einstellungen und Decks überschreiben?\n\nOK: alles durch die Sicherung ersetzen (destruktiv).\nAbbrechen: zusammenführen — vorhandene Decks behalten, neue aus der Sicherung hinzufügen.",
     "backupDownloaded": "Sicherung heruntergeladen.",
     "imported_one": "{{count}} Deck importiert.",

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Alle Einstellungen auf die Standardwerte zurücksetzen? Dies löscht jede Einstellung in diesem Dialog.",
-    "button": "Alle Einstellungen zurücksetzen"
+    "button": "Alle Einstellungen zurücksetzen",
+    "confirmAction": "Zurücksetzen"
   },
   "pacing": {
     "title": "Tempo",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Reset all preferences to defaults? This clears every setting in this dialog.",
-    "button": "Reset all preferences"
+    "button": "Reset all preferences",
+    "confirmAction": "Reset"
   },
   "pacing": {
     "title": "Pacing",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Clear All Art Overrides ({{count}})",
     "clearArtOverridesConfirm_one": "Clear all {{count}} art override?",
     "clearArtOverridesConfirm_other": "Clear all {{count}} art overrides?",
+    "clearArtOverridesAction": "Clear",
     "vfxQualityOptions": {
       "full": "Full",
       "reduced": "Reduced",
@@ -160,6 +161,10 @@
     "description": "Export bundles your preferences, imported decks, and feed subscriptions into a single JSON file. Import restores them on another machine. IndexedDB caches (feed cache, audio cache, saved games) are not included — those rebuild automatically.",
     "exportBackup": "Export backup…",
     "importBackup": "Import backup…",
+    "importModeTitle": "Import backup",
+    "importModeMessage": "Replace everything with the backup (destructive), or merge — keep existing decks and add new ones from the backup.",
+    "importOverwrite": "Replace all",
+    "importMerge": "Merge",
     "importConfirm": "Overwrite existing preferences and decks?\n\nOK: replace everything with the backup (destructive).\nCancel: merge — keep existing decks, add new ones from the backup.",
     "backupDownloaded": "Backup downloaded.",
     "imported_one": "Imported {{count}} deck.",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Borrar todas las anulaciones de ilustración ({{count}})",
     "clearArtOverridesConfirm_one": "¿Borrar la anulación de ilustración? ({{count}})",
     "clearArtOverridesConfirm_other": "¿Borrar las {{count}} anulaciones de ilustración?",
+    "clearArtOverridesAction": "Borrar",
     "vfxQualityOptions": {
       "full": "Completa",
       "reduced": "Reducida",
@@ -160,6 +161,10 @@
     "description": "Exportar agrupa tus preferencias, mazos importados y suscripciones a feeds en un único archivo JSON. Importar los restaura en otra máquina. Las cachés de IndexedDB (caché de feeds, caché de audio, partidas guardadas) no se incluyen — esas se reconstruyen automáticamente.",
     "exportBackup": "Exportar copia de seguridad…",
     "importBackup": "Importar copia de seguridad…",
+    "importModeTitle": "Importar copia de seguridad",
+    "importModeMessage": "Reemplazar todo con la copia de seguridad (destructivo), o fusionar — conservar los mazos existentes y añadir los nuevos de la copia.",
+    "importOverwrite": "Reemplazar todo",
+    "importMerge": "Fusionar",
     "importConfirm": "¿Sobrescribir las preferencias y mazos existentes?\n\nAceptar: reemplazar todo con la copia de seguridad (destructivo).\nCancelar: fusionar — conservar los mazos existentes y añadir los nuevos de la copia de seguridad.",
     "backupDownloaded": "Copia de seguridad descargada.",
     "imported_one": "Se importó {{count}} mazo.",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "¿Restablecer todas las preferencias a sus valores predeterminados? Esto borra todos los ajustes de este diálogo.",
-    "button": "Restablecer todas las preferencias"
+    "button": "Restablecer todas las preferencias",
+    "confirmAction": "Restablecer"
   },
   "pacing": {
     "title": "Ritmo",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Réinitialiser toutes les préférences aux valeurs par défaut ? Cela efface tous les paramètres de cette boîte de dialogue.",
-    "button": "Réinitialiser toutes les préférences"
+    "button": "Réinitialiser toutes les préférences",
+    "confirmAction": "Réinitialiser"
   },
   "pacing": {
     "title": "Rythme",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Effacer tous les remplacements d'illustration ({{count}})",
     "clearArtOverridesConfirm_one": "Effacer les {{count}} remplacement d'illustration ?",
     "clearArtOverridesConfirm_other": "Effacer les {{count}} remplacements d'illustration ?",
+    "clearArtOverridesAction": "Effacer",
     "vfxQualityOptions": {
       "full": "Complète",
       "reduced": "Réduite",
@@ -160,6 +161,10 @@
     "description": "L'export regroupe vos préférences, decks importés et abonnements à des flux dans un seul fichier JSON. L'import les restaure sur une autre machine. Les caches IndexedDB (cache de flux, cache audio, parties enregistrées) ne sont pas inclus — ils se reconstruisent automatiquement.",
     "exportBackup": "Exporter une sauvegarde…",
     "importBackup": "Importer une sauvegarde…",
+    "importModeTitle": "Importer une sauvegarde",
+    "importModeMessage": "Tout remplacer par la sauvegarde (destructif), ou fusionner — conserver les decks existants et ajouter ceux de la sauvegarde.",
+    "importOverwrite": "Tout remplacer",
+    "importMerge": "Fusionner",
     "importConfirm": "Écraser les préférences et decks existants ?\n\nOK : tout remplacer par la sauvegarde (destructif).\nAnnuler : fusionner — conserver les decks existants, ajouter les nouveaux de la sauvegarde.",
     "backupDownloaded": "Sauvegarde téléchargée.",
     "imported_one": "{{count}} deck importé.",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Cancella tutte le sostituzioni di illustrazione ({{count}})",
     "clearArtOverridesConfirm_one": "Cancellare tutte le {{count}} sostituzione di illustrazione?",
     "clearArtOverridesConfirm_other": "Cancellare tutte le {{count}} sostituzioni di illustrazione?",
+    "clearArtOverridesAction": "Cancella",
     "vfxQualityOptions": {
       "full": "Completa",
       "reduced": "Ridotta",
@@ -160,6 +161,10 @@
     "description": "L'esportazione raccoglie le tue preferenze, i mazzi importati e le iscrizioni ai feed in un unico file JSON. L'importazione li ripristina su un'altra macchina. Le cache di IndexedDB (cache dei feed, cache audio, partite salvate) non sono incluse — quelle si ricostruiscono automaticamente.",
     "exportBackup": "Esporta backup…",
     "importBackup": "Importa backup…",
+    "importModeTitle": "Importa backup",
+    "importModeMessage": "Sostituire tutto con il backup (distruttivo) o unire — mantenere i mazzi esistenti e aggiungere quelli nuovi dal backup.",
+    "importOverwrite": "Sostituisci tutto",
+    "importMerge": "Unisci",
     "importConfirm": "Sovrascrivere le preferenze e i mazzi esistenti?\n\nOK: sostituisci tutto con il backup (distruttivo).\nAnnulla: unisci — mantieni i mazzi esistenti, aggiungi quelli nuovi dal backup.",
     "backupDownloaded": "Backup scaricato.",
     "imported_one": "Importato {{count}} mazzo.",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Reimpostare tutte le preferenze ai valori predefiniti? Questo cancella ogni impostazione in questa finestra.",
-    "button": "Reimposta tutte le preferenze"
+    "button": "Reimposta tutte le preferenze",
+    "confirmAction": "Reimposta"
   },
   "pacing": {
     "title": "Ritmo",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Zresetować wszystkie preferencje do wartości domyślnych? Spowoduje to wyczyszczenie każdego ustawienia w tym oknie.",
-    "button": "Zresetuj wszystkie preferencje"
+    "button": "Zresetuj wszystkie preferencje",
+    "confirmAction": "Zresetuj"
   },
   "pacing": {
     "title": "Tempo",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Wyczyść wszystkie nadpisania grafiki ({{count}})",
     "clearArtOverridesConfirm_one": "Wyczyścić {{count}} nadpisanie grafiki?",
     "clearArtOverridesConfirm_other": "Wyczyścić wszystkie nadpisania grafiki ({{count}})?",
+    "clearArtOverridesAction": "Wyczyść",
     "vfxQualityOptions": {
       "full": "Pełna",
       "reduced": "Zredukowana",
@@ -160,6 +161,10 @@
     "description": "Eksport pakuje twoje preferencje, zaimportowane talie i subskrypcje kanałów do jednego pliku JSON. Import przywraca je na innym komputerze. Pamięci podręczne IndexedDB (pamięć kanałów, pamięć dźwięku, zapisane gry) nie są dołączane — odbudowują się automatycznie.",
     "exportBackup": "Eksportuj kopię zapasową…",
     "importBackup": "Importuj kopię zapasową…",
+    "importModeTitle": "Importuj kopię zapasową",
+    "importModeMessage": "Zastąp wszystko kopią zapasową (destrukcyjnie) lub scal — zachowaj istniejące talie i dodaj nowe z kopii.",
+    "importOverwrite": "Zastąp wszystko",
+    "importMerge": "Scal",
     "importConfirm": "Nadpisać istniejące preferencje i talie?\n\nOK: zastąp wszystko kopią zapasową (destrukcyjne).\nAnuluj: scal — zachowaj istniejące talie, dodaj nowe z kopii zapasowej.",
     "backupDownloaded": "Kopia zapasowa pobrana.",
     "imported_one": "Zaimportowano {{count}} talię.",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -171,7 +171,8 @@
   },
   "resetAll": {
     "confirm": "Redefinir todas as preferências para os padrões? Isso limpa todas as configurações deste diálogo.",
-    "button": "Redefinir todas as preferências"
+    "button": "Redefinir todas as preferências",
+    "confirmAction": "Redefinir"
   },
   "pacing": {
     "title": "Ritmo",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -74,6 +74,7 @@
     "clearArtOverrides_other": "Limpar Todas as Substituições de Arte ({{count}})",
     "clearArtOverridesConfirm_one": "Limpar todas as {{count}} substituição de arte?",
     "clearArtOverridesConfirm_other": "Limpar todas as {{count}} substituições de arte?",
+    "clearArtOverridesAction": "Limpar",
     "vfxQualityOptions": {
       "full": "Completa",
       "reduced": "Reduzida",
@@ -160,6 +161,10 @@
     "description": "A exportação agrupa suas preferências, decks importados e inscrições em feeds em um único arquivo JSON. A importação os restaura em outra máquina. Os caches do IndexedDB (cache de feeds, cache de áudio, jogos salvos) não são incluídos — eles se reconstroem automaticamente.",
     "exportBackup": "Exportar backup…",
     "importBackup": "Importar backup…",
+    "importModeTitle": "Importar backup",
+    "importModeMessage": "Substituir tudo pelo backup (destrutivo) ou mesclar — manter os decks existentes e adicionar os novos do backup.",
+    "importOverwrite": "Substituir tudo",
+    "importMerge": "Mesclar",
     "importConfirm": "Sobrescrever preferências e decks existentes?\n\nOK: substituir tudo pelo backup (destrutivo).\nCancelar: mesclar — manter os decks existentes e adicionar os novos do backup.",
     "backupDownloaded": "Backup baixado.",
     "imported_one": "Importado {{count}} deck.",


### PR DESCRIPTION
## Summary

Replaces the browser-native `window.confirm()` used by **Reset all preferences** in Settings with a custom in-app `ConfirmDialog` that matches the application's existing modal styling and UX patterns.

### Changes

* Add reusable `ConfirmDialog` component (`client/src/components/ui/ConfirmDialog.tsx`)
* Replace `window.confirm()` in the Settings reset flow with a dialog-driven confirmation flow
* Portal the dialog above the Settings modal (`z-[70]`) to ensure correct stacking and backdrop behavior
* Match existing workspace modal styling:

  * Dark themed panel
  * Blurred backdrop
  * Gray Cancel button
  * Rose destructive Reset button
* Add `resetAll.confirmAction` translation key across all Settings locale files
* Preserve existing reset behavior and preference defaults

## Related Issues

Fixes #4209

## Motivation

The native browser confirmation dialog displayed browser-specific chrome and styling that did not match the application's dark theme. Since the confirmation appears while the Settings modal is already open, the native dialog felt visually disconnected from the rest of the UI.

## Solution

Introduce a reusable `ConfirmDialog` component and use it for the Settings reset flow. The dialog follows existing modal patterns, supports localization, and renders correctly above the Settings panel on both desktop and mobile layouts.

## Test Plan

* [ ] Open **Settings** → click **Reset all preferences**
* [ ] Verify a custom confirmation dialog appears
* [ ] Verify no native browser confirmation dialog is shown
* [ ] Click **Cancel** and verify preferences remain unchanged
* [ ] Click **Reset** and verify all preferences return to defaults
* [ ] Verify the dialog closes after reset
* [ ] Verify the dialog renders above the Settings modal on desktop layouts
* [ ] Verify the dialog renders correctly on mobile layouts
* [ ] Run `pnpm run type-check` and verify it passes

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2746d8a1-8cae-43f6-b56a-0fb1a9d35a78" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/52c772b2-2728-49f3-b658-03332ab06565" />
