### PR TITLE
fix(match-setup): restore bottom spacing at end of format picker scroll

### DIFF
--- a/client/src/components/menu/FormatPicker.tsx
+++ b/client/src/components/menu/FormatPicker.tsx
@@ -69,7 +69,7 @@ interface FormatPickerProps {
 
 export function FormatPicker({ onFormatSelect }: FormatPickerProps) {
   return (
-    <div className="flex w-full max-w-3xl flex-col gap-6 pb-8 sm:gap-8 sm:pb-10">
+    <div className="flex w-full max-w-3xl flex-col gap-6 sm:gap-8">
       {FORMAT_GROUPS.map((group) => {
         const tone = GROUP_TONES[group.tone];
         return (

--- a/client/src/components/menu/FormatPicker.tsx
+++ b/client/src/components/menu/FormatPicker.tsx
@@ -69,7 +69,7 @@ interface FormatPickerProps {
 
 export function FormatPicker({ onFormatSelect }: FormatPickerProps) {
   return (
-    <div className="flex w-full max-w-3xl flex-col gap-6 sm:gap-8">
+    <div className="flex w-full max-w-3xl flex-col gap-6 pb-8 sm:gap-8 sm:pb-10">
       {FORMAT_GROUPS.map((group) => {
         const tone = GROUP_TONES[group.tone];
         return (

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -548,7 +548,7 @@ export function GameSetupPage() {
         subtitle={t("gameSetup.formatPicker.subtitle")}
         onClose={() => setFormatPickerOpen(false)}
         maxWidthClassName="max-w-3xl"
-        bodyClassName="overflow-y-auto px-4 py-4 lg:px-6 lg:py-6"
+        bodyClassName="overflow-y-auto px-4 pt-4 lg:px-6 lg:pt-6"
       >
         <FormatPicker
           onFormatSelect={(format) => {

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -550,12 +550,14 @@ export function GameSetupPage() {
         maxWidthClassName="max-w-3xl"
         bodyClassName="overflow-y-auto px-4 pt-4 lg:px-6 lg:pt-6"
       >
-        <FormatPicker
-          onFormatSelect={(format) => {
-            applyFormat(format);
-            setFormatPickerOpen(false);
-          }}
-        />
+        <div className="pb-8 sm:pb-10">
+          <FormatPicker
+            onFormatSelect={(format) => {
+              applyFormat(format);
+              setFormatPickerOpen(false);
+            }}
+          />
+        </div>
       </ModalPanelShell>
     </div>
   );

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -550,7 +550,7 @@ export function GameSetupPage() {
         maxWidthClassName="max-w-3xl"
         bodyClassName="overflow-y-auto px-4 pt-4 lg:px-6 lg:pt-6"
       >
-        <div className="pb-8 sm:pb-10">
+        <div className="pb-4 lg:pb-6">
           <FormatPicker
             onFormatSelect={(format) => {
               applyFormat(format);


### PR DESCRIPTION
### Summary

* Add bottom padding to `FormatPicker` so the final format group (**Multiplayer**) no longer sits flush against the bottom edge of the dialog when scrolled to the end
* Adjust format picker modal body padding in `GameSetupPage` to use top and horizontal padding only, since bottom spacing is now handled by the scrollable content itself

## Related Issues

Fixes #4214

## Test Plan

* [ ] Open **Match Setup**
* [ ] Open the **Choose a format** dialog
* [ ] Scroll to the bottom of the format list
* [ ] Verify visible spacing appears below the Multiplayer cards
* [ ] Verify *Free-for-All*, *Momir's Madness*, and other final cards no longer touch the dialog edge
* [ ] Repeat on a mobile or narrow viewport and verify spacing remains natural
* [ ] Confirm top and horizontal padding are unchanged
* [ ] Verify other `ModalPanelShell` dialogs are unaffected

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/e177cfed-68b3-4e73-bf3d-74224fe179d7" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/6112f80a-77a5-41da-844c-56dd48fb517c" />
