### PR TITLE
fix(deck-builder): Slime Against Humanity unlimited copies in Commander (#1138)

### DIFF
--- a/client/src/components/deck-builder/CommanderPanel.tsx
+++ b/client/src/components/deck-builder/CommanderPanel.tsx
@@ -4,8 +4,6 @@ import type { ScryfallCard } from "../../services/scryfall";
 import type { DeckEntry } from "../../services/deckParser";
 import {
   getCombinedColorIdentity,
-  getColorIdentityViolations,
-  getSingletonViolations,
 } from "./commanderUtils";
 import { mouseHoverPreview } from "./hoverPreview";
 
@@ -28,8 +26,8 @@ interface CommanderPanelProps {
   onSetCommander: (cardName: string) => void;
   onRemoveCommander: (cardName: string) => void;
   onCardHover?: (cardName: string | null) => void;
-  /** CR 100.2a / CR 903.5b: engine-backed per-card copy cap resolver. */
-  getEffectiveCap: (name: string) => number;
+  /** Engine evaluateDeckCompatibility reasons for the active format. */
+  formatValidationReasons?: string[];
 }
 
 
@@ -42,12 +40,10 @@ export function CommanderPanel({
   onSetCommander,
   onRemoveCommander,
   onCardHover,
-  getEffectiveCap,
+  formatValidationReasons = [],
 }: CommanderPanelProps) {
   const { t } = useTranslation("deck-builder");
   const identity = getCombinedColorIdentity(commanders, cardDataCache);
-  const colorViolations = getColorIdentityViolations(deck, commanders, cardDataCache);
-  const singletonViolations = getSingletonViolations(deck, cardDataCache, getEffectiveCap);
   const totalCards = deck.reduce((sum, e) => sum + e.count, 0) + commanders.length;
 
   // Cards in deck that could become a commander. The handler decides whether
@@ -136,16 +132,11 @@ export function CommanderPanel({
         >
           {t("commanderPanel.cardCount", { count: totalCards, expected: expectedDeckSize })}
         </div>
-        {singletonViolations.length > 0 && (
-          <div className="text-xs text-red-400">
-            {t("commanderPanel.singletonViolations", { cards: singletonViolations.join(", ") })}
+        {formatValidationReasons.map((reason) => (
+          <div key={reason} className="text-xs text-red-400">
+            {reason}
           </div>
-        )}
-        {colorViolations.length > 0 && (
-          <div className="text-xs text-red-400">
-            {t("commanderPanel.colorViolations", { cards: colorViolations.join(", ") })}
-          </div>
-        )}
+        ))}
       </div>
     </div>
   );

--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -93,7 +93,6 @@ export function DeckBuilder({
     handleSetCommander,
     isCommanderEligible,
     handleRemoveCommander,
-    effectiveCap,
   } = useDeckBuilder({ format, onFormatChange, initialDeckName, searchFilters });
   const { t } = useTranslation("deck-builder");
 
@@ -443,7 +442,6 @@ export function DeckBuilder({
                       onRemoveCommander={handleRemoveCommander}
                       onCardHover={onCardHover}
                       format={format}
-                      getEffectiveCap={effectiveCap}
                     />
                   )}
                 </div>
@@ -470,7 +468,7 @@ export function DeckBuilder({
                 onSetCommander={handleSetCommander}
                 onRemoveCommander={handleRemoveCommander}
                 onCardHover={onCardHover}
-                getEffectiveCap={effectiveCap}
+                formatValidationReasons={compatibility?.selected_format_reasons}
               />
             )}
             <StatsPanel

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -9,7 +9,6 @@ import type { SourcePrinting } from "../../hooks/useCardImage";
 import type { ScryfallCard } from "../../services/scryfall";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import type { GameFormat } from "../../adapter/types";
-import { BASIC_LAND_NAMES } from "../../constants/game";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
 import { mouseHoverPreview } from "./hoverPreview";
@@ -28,9 +27,6 @@ interface DeckStackProps {
   /** Deck format — resolves the sideboard policy so the second section
    *  is labelled "Sideboard" or "Maybeboard" consistently with the list view. */
   format?: GameFormat;
-  /** CR 100.2a / CR 903.5b: engine-backed per-card copy cap resolver. Returns
-   *  the format default (4 / 1) unless the card prints an override. */
-  getEffectiveCap: (name: string) => number;
   /** Whether the main deck is sub-grouped by card type or by color. */
   groupMode: GroupMode;
 }
@@ -436,7 +432,6 @@ export function DeckStack({
   onRemoveCommander,
   onCardHover,
   format,
-  getEffectiveCap,
   groupMode,
 }: DeckStackProps) {
   const { t } = useTranslation("deck-builder");
@@ -452,17 +447,8 @@ export function DeckStack({
     || sections.main.length > 0
     || sections.sideboard.length > 0;
   const canAddCard = useMemo(
-    () => (item: DeckStackItem) => {
-      if (item.section !== "main") return false;
-      // CR 100.2a / CR 903.5b: basic lands are always addable; every other card
-      // is capped at its engine-resolved effective limit (4 / 1 default, raised
-      // by "any number" / "up to N" overrides). Mirrors the guard inside
-      // useDeckBuilder.handleAddCard so the stack tile's + button doesn't
-      // disagree with the hook's add path.
-      if (BASIC_LAND_NAMES.has(item.name)) return true;
-      return item.count < getEffectiveCap(item.name);
-    },
-    [getEffectiveCap],
+    () => (item: DeckStackItem) => item.section === "main",
+    [],
   );
 
   const artOverrides = usePreferencesStore((s) => s.artOverrides);

--- a/client/src/components/deck-builder/__tests__/CommanderPanel.test.tsx
+++ b/client/src/components/deck-builder/__tests__/CommanderPanel.test.tsx
@@ -37,7 +37,6 @@ describe("CommanderPanel", () => {
         isCommanderEligible={() => true}
         onSetCommander={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={() => 1}
       />,
     );
 

--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -90,7 +90,6 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={() => 4}
         groupMode="type"
       />,
     );
@@ -143,7 +142,6 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={() => 4}
         groupMode="type"
       />,
     );
@@ -158,9 +156,7 @@ describe("DeckStack", () => {
     expect(screen.getByText("Creatures")).toBeInTheDocument();
     expect(screen.getByText("Enchantments")).toBeInTheDocument();
     expect(screen.getByText("Lands")).toBeInTheDocument();
-    expect(
-      screen.getByTitle("Ajani's Pridemate is at the copy limit"),
-    ).toBeDisabled();
+    expect(screen.getByTitle("Add one Ajani's Pridemate")).toBeEnabled();
     expect(screen.queryByText("MD")).not.toBeInTheDocument();
     expect(screen.queryByText("SB")).not.toBeInTheDocument();
 
@@ -171,10 +167,8 @@ describe("DeckStack", () => {
     expectDocumentOrder(banishingTile, plainsTile);
   });
 
-  it("keeps the add button enabled past 4 copies for 'any number' cards (CR 100.2a)", () => {
-    // Regression for #1494: Relentless Rats / Rat Colony override the 4-copy
-    // deck construction limit per CR 100.2a. The engine resolves the override to
-    // an unbounded cap (Infinity); the tile's + button must stay enabled.
+  it("keeps the add button enabled for main-deck cards regardless of copy count", () => {
+    // Copy-limit legality is enforced by evaluateDeckCompatibility, not the stack UI.
     render(
       <DeckStack
         deck={{
@@ -191,7 +185,6 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={(name) => (name === "Relentless Rats" ? Infinity : 4)}
         groupMode="type"
       />,
     );
@@ -199,27 +192,8 @@ describe("DeckStack", () => {
     expect(screen.getByTitle("Add one Relentless Rats")).toBeEnabled();
   });
 
-  it("respects a bounded 'up to N' override cap (CR 100.2a)", () => {
-    // Seven Dwarves overrides to UpTo(7). At 6 copies the + button is enabled;
-    // at 7 it is disabled.
-    const { rerender } = render(
-      <DeckStack
-        deck={{ main: [{ name: "Seven Dwarves", count: 6 }], sideboard: [] }}
-        commanders={[]}
-        cardDataCache={
-          new Map([["Seven Dwarves", makeCard("Seven Dwarves", "Creature — Dwarf", 4)]])
-        }
-        onAddCard={vi.fn()}
-        onRemoveCard={vi.fn()}
-        onMoveCard={vi.fn()}
-        onRemoveCommander={vi.fn()}
-        getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
-        groupMode="type"
-      />,
-    );
-    expect(screen.getByTitle("Add one Seven Dwarves")).toBeEnabled();
-
-    rerender(
+  it("does not disable the add button at an override cap — engine validates copies", () => {
+    render(
       <DeckStack
         deck={{ main: [{ name: "Seven Dwarves", count: 7 }], sideboard: [] }}
         commanders={[]}
@@ -230,16 +204,13 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={(name) => (name === "Seven Dwarves" ? 7 : 4)}
         groupMode="type"
       />,
     );
-    expect(
-      screen.getByTitle("Seven Dwarves is at the copy limit"),
-    ).toBeDisabled();
+    expect(screen.getByTitle("Add one Seven Dwarves")).toBeEnabled();
   });
 
-  it("disables the add button at 1 copy for singleton formats", () => {
+  it("keeps the add button enabled in singleton formats — engine validates copies", () => {
     render(
       <DeckStack
         deck={{
@@ -255,12 +226,11 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={vi.fn()}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={() => 1}
         groupMode="type"
       />,
     );
 
-    expect(screen.getByTitle("Sol Ring is at the copy limit")).toBeDisabled();
+    expect(screen.getByTitle("Add one Sol Ring")).toBeEnabled();
   });
 
   it("moves a second-section card back to the main deck via its move button", () => {
@@ -284,7 +254,6 @@ describe("DeckStack", () => {
         onRemoveCard={vi.fn()}
         onMoveCard={onMoveCard}
         onRemoveCommander={vi.fn()}
-        getEffectiveCap={() => 4}
         groupMode="type"
       />,
     );

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -254,8 +254,23 @@ export function useDeckBuilder({
     [deckCopyLimits, maxCopies],
   );
 
+  const maxCopiesRef = useRef(maxCopies);
+  useEffect(() => {
+    maxCopiesRef.current = maxCopies;
+  }, [maxCopies]);
+
+  const deckCopyLimitsRef = useRef(deckCopyLimits);
+  useEffect(() => {
+    deckCopyLimitsRef.current = deckCopyLimits;
+  }, [deckCopyLimits]);
+
+  const noOverrideCardsRef = useRef<Set<string>>(new Set());
+
   const cacheDeckCopyLimit = useCallback((name: string, limit: Awaited<ReturnType<typeof deckCopyLimit>>) => {
-    if (!limit) return;
+    if (!limit) {
+      noOverrideCardsRef.current.add(name);
+      return;
+    }
     setDeckCopyLimits((prev) => {
       const next = new Map(prev);
       next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
@@ -268,16 +283,18 @@ export function useDeckBuilder({
   // while the async prefetch batch is still in flight.
   const resolveEffectiveCap = useCallback(
     async (name: string): Promise<number> => {
-      const cached = deckCopyLimits.get(name);
+      const cached = deckCopyLimitsRef.current.get(name);
       if (cached !== undefined) return cached;
+      if (noOverrideCardsRef.current.has(name)) return maxCopiesRef.current;
       const limit = await deckCopyLimit(name);
       if (limit) {
         cacheDeckCopyLimit(name, limit);
         return limit.type === "Unlimited" ? Infinity : limit.data;
       }
-      return maxCopies;
+      noOverrideCardsRef.current.add(name);
+      return maxCopiesRef.current;
     },
-    [cacheDeckCopyLimit, deckCopyLimits, maxCopies],
+    [cacheDeckCopyLimit],
   );
 
   const { estimate, unsupported: bracketUnsupported } = useBracketEstimate({

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -17,7 +17,6 @@ import {
   setDeckFolder,
   stampDeckMeta,
 } from "../../constants/storage";
-import { BASIC_LAND_NAMES } from "../../constants/game";
 import { loadPreconDeckMap } from "../../hooks/useDecks";
 import { preconDeckEntryToParsedDeck } from "../../services/preconDecks";
 import { useDeckCardData } from "../../hooks/useDeckCardData";
@@ -31,12 +30,7 @@ import { getPreconBracket } from "../../data/preconBrackets";
 import { getSharedAdapter } from "../../adapter/wasm-adapter";
 import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import {
-  getColorIdentityViolations,
-  getSingletonViolations,
-} from "./commanderUtils";
-import {
   commanderPartnerCandidates,
-  deckCopyLimit,
   isCardCommanderEligibleForFormat,
 } from "../../services/engineRuntime";
 
@@ -95,10 +89,6 @@ export function useDeckBuilder({
 
   const [compatibility, setCompatibility] = useState<DeckCompatibilityResult | null>(null);
   const [commanderEligibleNames, setCommanderEligibleNames] = useState<Set<string>>(new Set());
-  // CR 100.2a / CR 903.5b: per-card deck-construction copy-limit overrides, keyed
-  // by card name. `Infinity` = "any number"; a finite cap = "up to N" / singleton.
-  // Populated from the engine — never inferred from Oracle text client-side.
-  const [deckCopyLimits, setDeckCopyLimits] = useState<Map<string, number>>(new Map());
 
   const artOverrides = usePreferencesStore((s) => s.artOverrides);
   const clearArtOverride = usePreferencesStore((s) => s.clearArtOverride);
@@ -154,19 +144,18 @@ export function useDeckBuilder({
     }
     let cancelled = false;
     const timer = setTimeout(() => {
-      evaluateDeckCompatibility(currentDeck).then((result) => {
+      evaluateDeckCompatibility(currentDeck, { selectedFormat: format }).then((result) => {
         if (!cancelled) setCompatibility(result);
       }).catch(() => {
         // WASM may not be loaded yet; silently ignore
       });
     }, 300);
     return () => { cancelled = true; clearTimeout(timer); };
-  }, [currentDeck, deckKey]);
+  }, [currentDeck, deckKey, format]);
 
   const formatConfig = formatMetadata(format)?.default_config;
   const isCommander = formatConfig?.command_zone ?? false;
   const expectedDeckSize = formatConfig?.deck_size ?? 60;
-  const maxCopies = formatConfig?.singleton ? 1 : 4;
 
   useEffect(() => {
     if (!isCommander) {
@@ -196,106 +185,6 @@ export function useDeckBuilder({
       cancelled = true;
     };
   }, [deck.main, format, isCommander]);
-
-  // Names whose copy-limit override has already been requested (in flight or
-  // resolved). A card's copy limit is static per name, so once queried it never
-  // needs re-querying — this keeps deck edits and repeated searches from
-  // re-issuing WASM calls for every card in the deck.
-  const queriedCopyLimitNamesRef = useRef<Set<string>>(new Set());
-
-  const prefetchDeckCopyLimits = useCallback((names: string[]) => {
-    const unique = Array.from(new Set(names)).filter(
-      (name) => !queriedCopyLimitNamesRef.current.has(name),
-    );
-    if (unique.length === 0) return;
-    for (const name of unique) {
-      queriedCopyLimitNamesRef.current.add(name);
-    }
-    Promise.all(
-      unique.map(async (name) => [name, await deckCopyLimit(name)] as const),
-    )
-      .then((results) => {
-        // No cancellation guard: limits are static per name, so a resolved
-        // batch is never stale — merging is always safe.
-        setDeckCopyLimits((prev) => {
-          const next = new Map(prev);
-          for (const [name, limit] of results) {
-            if (!limit) continue;
-            next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
-          }
-          return next;
-        });
-      })
-      .catch(() => {
-        // Retain previously resolved overrides and allow this batch to be
-        // retried after a transient WASM failure.
-        for (const name of unique) {
-          queriedCopyLimitNamesRef.current.delete(name);
-        }
-      });
-  }, []);
-
-  // CR 100.2a / CR 903.5b: resolve per-card copy-limit overrides for every card
-  // referenced anywhere in the deck. The engine is the single authority — the
-  // frontend never re-parses Oracle text. Limits are static per card name, so
-  // the resolved map is a monotonic cache: merged into, never cleared.
-  useEffect(() => {
-    prefetchDeckCopyLimits([
-      ...deck.main.map((e) => e.name),
-      ...deck.sideboard.map((e) => e.name),
-      ...commanders,
-    ]);
-  }, [deck.main, deck.sideboard, commanders, prefetchDeckCopyLimits]);
-
-  // Synchronous per-card effective copy cap: the override when present, else the
-  // format default (4 constructed / 1 singleton).
-  const effectiveCap = useCallback(
-    (name: string) => deckCopyLimits.get(name) ?? maxCopies,
-    [deckCopyLimits, maxCopies],
-  );
-
-  const maxCopiesRef = useRef(maxCopies);
-  useEffect(() => {
-    maxCopiesRef.current = maxCopies;
-  }, [maxCopies]);
-
-  const deckCopyLimitsRef = useRef(deckCopyLimits);
-  useEffect(() => {
-    deckCopyLimitsRef.current = deckCopyLimits;
-  }, [deckCopyLimits]);
-
-  const noOverrideCardsRef = useRef<Set<string>>(new Set());
-
-  const cacheDeckCopyLimit = useCallback((name: string, limit: Awaited<ReturnType<typeof deckCopyLimit>>) => {
-    if (!limit) {
-      noOverrideCardsRef.current.add(name);
-      return;
-    }
-    setDeckCopyLimits((prev) => {
-      const next = new Map(prev);
-      next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
-      return next;
-    });
-  }, []);
-
-  // Issue #1138: resolve the engine copy-limit override before enforcing the cap
-  // so cards like Slime Against Humanity are not stuck at the format default (4)
-  // while the async prefetch batch is still in flight.
-  const resolveEffectiveCap = useCallback(
-    async (name: string): Promise<number> => {
-      const cached = deckCopyLimitsRef.current.get(name);
-      if (cached !== undefined) return cached;
-      if (noOverrideCardsRef.current.has(name)) return maxCopiesRef.current;
-      const limit = await deckCopyLimit(name);
-      if (limit) {
-        cacheDeckCopyLimit(name, limit);
-        return limit.type === "Unlimited" ? Infinity : limit.data;
-      }
-      noOverrideCardsRef.current.add(name);
-      return maxCopiesRef.current;
-    },
-    [cacheDeckCopyLimit],
-  );
 
   const { estimate, unsupported: bracketUnsupported } = useBracketEstimate({
     deck,
@@ -339,9 +228,8 @@ export function useDeckBuilder({
       }
       setSearchResults(cards);
       cacheCards(cards);
-      prefetchDeckCopyLimits(cards.map((card) => card.name));
     },
-    [cacheCards, initialDeckName, prefetchDeckCopyLimits, searchFilters],
+    [cacheCards, initialDeckName, searchFilters],
   );
 
   const handleSearchTrigger = useCallback(() => {
@@ -352,28 +240,22 @@ export function useDeckBuilder({
     cacheCards([card]);
     setDirty(true);
 
-    void resolveEffectiveCap(card.name).then((cap) => {
-      setDeck((prev) => {
-        const existing = prev.main.find((e) => e.name === card.name);
-        if (existing && existing.count >= cap && !BASIC_LAND_NAMES.has(card.name)) {
-          return prev;
-        }
-
-        if (existing) {
-          return {
-            ...prev,
-            main: prev.main.map((e) =>
-              e.name === card.name ? { ...e, count: e.count + 1 } : e,
-            ),
-          };
-        }
+    setDeck((prev) => {
+      const existing = prev.main.find((e) => e.name === card.name);
+      if (existing) {
         return {
           ...prev,
-          main: [...prev.main, { count: 1, name: card.name }],
+          main: prev.main.map((e) =>
+            e.name === card.name ? { ...e, count: e.count + 1 } : e,
+          ),
         };
-      });
+      }
+      return {
+        ...prev,
+        main: [...prev.main, { count: 1, name: card.name }],
+      };
     });
-  }, [cacheCards, resolveEffectiveCap]);
+  }, [cacheCards]);
 
   const handleAddCardByName = useCallback((name: string) => {
     const card = cardDataCache.get(name);
@@ -410,45 +292,35 @@ export function useDeckBuilder({
     (name: string, from: "main" | "sideboard") => {
       const to: "main" | "sideboard" = from === "main" ? "sideboard" : "main";
       setDirty(true);
-      void resolveEffectiveCap(name).then((cap) => {
-        setDeck((prev) => {
-          const source = prev[from];
-          const target = prev[to];
-          const sourceEntry = source.find((e) => e.name === name);
-          if (!sourceEntry) return prev;
+      setDeck((prev) => {
+        const source = prev[from];
+        const target = prev[to];
+        const sourceEntry = source.find((e) => e.name === name);
+        if (!sourceEntry) return prev;
 
-          const targetEntry = target.find((e) => e.name === name);
-          if (
-            to === "main" &&
-            targetEntry &&
-            targetEntry.count >= cap &&
-            !BASIC_LAND_NAMES.has(name)
-          ) {
-            return prev;
-          }
+        const targetEntry = target.find((e) => e.name === name);
 
-          const nextSource =
-            sourceEntry.count <= 1
-              ? source.filter((e) => e.name !== name)
-              : source.map((e) =>
-                  e.name === name ? { ...e, count: e.count - 1 } : e,
-                );
+        const nextSource =
+          sourceEntry.count <= 1
+            ? source.filter((e) => e.name !== name)
+            : source.map((e) =>
+                e.name === name ? { ...e, count: e.count - 1 } : e,
+              );
 
-          const nextTarget = targetEntry
-            ? target.map((e) =>
-                e.name === name ? { ...e, count: e.count + 1 } : e,
-              )
-            : [...target, { count: 1, name }];
+        const nextTarget = targetEntry
+          ? target.map((e) =>
+              e.name === name ? { ...e, count: e.count + 1 } : e,
+            )
+          : [...target, { count: 1, name }];
 
-          return {
-            ...prev,
-            [from]: nextSource,
-            [to]: nextTarget,
-          };
-        });
+        return {
+          ...prev,
+          [from]: nextSource,
+          [to]: nextTarget,
+        };
       });
     },
-    [resolveEffectiveCap],
+    [],
   );
 
   const applyDeckToEditor = useCallback((next: ParsedDeck) => {
@@ -696,30 +568,11 @@ export function useDeckBuilder({
     cardCounts.set(commander, (cardCounts.get(commander) ?? 0) + 1);
   }
 
-  // Compute validation warnings
-  const warnings: string[] = [];
-  if (isCommander) {
-    const totalCards = deck.main.reduce((s, e) => s + e.count, 0) + commanders.length;
-    if (totalCards > 0 && totalCards !== expectedDeckSize) {
-      warnings.push(t("warnings.commanderCount", { count: totalCards, expected: expectedDeckSize }));
-    }
-    for (const name of getSingletonViolations(deck.main, cardDataCache, effectiveCap)) {
-      warnings.push(t("warnings.singleton", { name }));
-    }
-    for (const name of getColorIdentityViolations(deck.main, commanders, cardDataCache)) {
-      warnings.push(t("warnings.colorIdentity", { name }));
-    }
-  } else {
-    const mainTotal = deck.main.reduce((s, e) => s + e.count, 0);
-    if (mainTotal > 0 && mainTotal < 60) {
-      warnings.push(t("warnings.minimumCount", { count: mainTotal }));
-    }
-    for (const entry of deck.main) {
-      if (entry.count > effectiveCap(entry.name) && !BASIC_LAND_NAMES.has(entry.name)) {
-        warnings.push(t("warnings.maxCopies", { name: entry.name, count: entry.count }));
-      }
-    }
-  }
+  // Engine-driven validation — duplicate legality, color identity, and deck size
+  // all come from evaluateDeckCompatibility (selected_format_reasons).
+  const warnings: string[] = [
+    ...(compatibility?.selected_format_reasons ?? []),
+  ];
   // CR 702.139a: Warn if a companion card is also in the main deck (likely import error)
   if (deck.companion && deck.main.some((e) => e.name === deck.companion)) {
     warnings.push(t("warnings.companionInMain", { name: deck.companion }));
@@ -780,6 +633,5 @@ export function useDeckBuilder({
     handleSetCommander,
     isCommanderEligible,
     handleRemoveCommander,
-    effectiveCap,
   };
 }

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -254,6 +254,32 @@ export function useDeckBuilder({
     [deckCopyLimits, maxCopies],
   );
 
+  const cacheDeckCopyLimit = useCallback((name: string, limit: Awaited<ReturnType<typeof deckCopyLimit>>) => {
+    if (!limit) return;
+    setDeckCopyLimits((prev) => {
+      const next = new Map(prev);
+      next.set(name, limit.type === "Unlimited" ? Infinity : limit.data);
+      return next;
+    });
+  }, []);
+
+  // Issue #1138: resolve the engine copy-limit override before enforcing the cap
+  // so cards like Slime Against Humanity are not stuck at the format default (4)
+  // while the async prefetch batch is still in flight.
+  const resolveEffectiveCap = useCallback(
+    async (name: string): Promise<number> => {
+      const cached = deckCopyLimits.get(name);
+      if (cached !== undefined) return cached;
+      const limit = await deckCopyLimit(name);
+      if (limit) {
+        cacheDeckCopyLimit(name, limit);
+        return limit.type === "Unlimited" ? Infinity : limit.data;
+      }
+      return maxCopies;
+    },
+    [cacheDeckCopyLimit, deckCopyLimits, maxCopies],
+  );
+
   const { estimate, unsupported: bracketUnsupported } = useBracketEstimate({
     deck,
     commanders,
@@ -309,26 +335,28 @@ export function useDeckBuilder({
     cacheCards([card]);
     setDirty(true);
 
-    setDeck((prev) => {
-      const existing = prev.main.find((e) => e.name === card.name);
-      if (existing && existing.count >= effectiveCap(card.name) && !BASIC_LAND_NAMES.has(card.name)) {
-        return prev;
-      }
+    void resolveEffectiveCap(card.name).then((cap) => {
+      setDeck((prev) => {
+        const existing = prev.main.find((e) => e.name === card.name);
+        if (existing && existing.count >= cap && !BASIC_LAND_NAMES.has(card.name)) {
+          return prev;
+        }
 
-      if (existing) {
+        if (existing) {
+          return {
+            ...prev,
+            main: prev.main.map((e) =>
+              e.name === card.name ? { ...e, count: e.count + 1 } : e,
+            ),
+          };
+        }
         return {
           ...prev,
-          main: prev.main.map((e) =>
-            e.name === card.name ? { ...e, count: e.count + 1 } : e,
-          ),
+          main: [...prev.main, { count: 1, name: card.name }],
         };
-      }
-      return {
-        ...prev,
-        main: [...prev.main, { count: 1, name: card.name }],
-      };
+      });
     });
-  }, [cacheCards, effectiveCap]);
+  }, [cacheCards, resolveEffectiveCap]);
 
   const handleAddCardByName = useCallback((name: string) => {
     const card = cardDataCache.get(name);
@@ -365,43 +393,45 @@ export function useDeckBuilder({
     (name: string, from: "main" | "sideboard") => {
       const to: "main" | "sideboard" = from === "main" ? "sideboard" : "main";
       setDirty(true);
-      setDeck((prev) => {
-        const source = prev[from];
-        const target = prev[to];
-        const sourceEntry = source.find((e) => e.name === name);
-        if (!sourceEntry) return prev;
+      void resolveEffectiveCap(name).then((cap) => {
+        setDeck((prev) => {
+          const source = prev[from];
+          const target = prev[to];
+          const sourceEntry = source.find((e) => e.name === name);
+          if (!sourceEntry) return prev;
 
-        const targetEntry = target.find((e) => e.name === name);
-        if (
-          to === "main" &&
-          targetEntry &&
-          targetEntry.count >= effectiveCap(name) &&
-          !BASIC_LAND_NAMES.has(name)
-        ) {
-          return prev;
-        }
+          const targetEntry = target.find((e) => e.name === name);
+          if (
+            to === "main" &&
+            targetEntry &&
+            targetEntry.count >= cap &&
+            !BASIC_LAND_NAMES.has(name)
+          ) {
+            return prev;
+          }
 
-        const nextSource =
-          sourceEntry.count <= 1
-            ? source.filter((e) => e.name !== name)
-            : source.map((e) =>
-                e.name === name ? { ...e, count: e.count - 1 } : e,
-              );
+          const nextSource =
+            sourceEntry.count <= 1
+              ? source.filter((e) => e.name !== name)
+              : source.map((e) =>
+                  e.name === name ? { ...e, count: e.count - 1 } : e,
+                );
 
-        const nextTarget = targetEntry
-          ? target.map((e) =>
-              e.name === name ? { ...e, count: e.count + 1 } : e,
-            )
-          : [...target, { count: 1, name }];
+          const nextTarget = targetEntry
+            ? target.map((e) =>
+                e.name === name ? { ...e, count: e.count + 1 } : e,
+              )
+            : [...target, { count: 1, name }];
 
-        return {
-          ...prev,
-          [from]: nextSource,
-          [to]: nextTarget,
-        };
+          return {
+            ...prev,
+            [from]: nextSource,
+            [to]: nextTarget,
+          };
+        });
       });
     },
-    [effectiveCap],
+    [resolveEffectiveCap],
   );
 
   const applyDeckToEditor = useCallback((next: ParsedDeck) => {

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -4659,10 +4659,10 @@ mod tests {
                 "color_override": ["Green"], "scryfall_oracle_id": null,
                 "legalities": { "commander": "legal" }
             },
-            "plains": {
-                "name": "Plains",
+            "forest": {
+                "name": "Forest",
                 "mana_cost": { "type": "NoCost" },
-                "card_type": { "supertypes": ["Basic"], "core_types": ["Land"], "subtypes": ["Plains"] },
+                "card_type": { "supertypes": ["Basic"], "core_types": ["Land"], "subtypes": ["Forest"] },
                 "power": null, "toughness": null, "loyalty": null, "defense": null,
                 "oracle_text": null, "non_ability_text": null, "flavor_name": null,
                 "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
@@ -4673,7 +4673,7 @@ mod tests {
         .to_string();
         let db = CardDatabase::from_json_str(&db_json).unwrap();
         let mut main = expand("Slime Against Humanity", 10);
-        main.extend(expand("Plains", 89));
+        main.extend(expand("Forest", 89));
         let request = DeckCompatibilityRequest {
             main_deck: main,
             sideboard: Vec::new(),

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -4633,6 +4633,65 @@ mod tests {
     }
 
     #[test]
+    fn commander_accepts_ten_slime_against_humanity_copies() {
+        // Issue #1138: "A deck can have any number of cards named Slime Against
+        // Humanity" must override the Commander singleton default.
+        let db_json = serde_json::json!({
+            "slime against humanity": {
+                "name": "Slime Against Humanity",
+                "mana_cost": { "type": "Cost", "shards": ["Green"], "generic": 2 },
+                "card_type": { "supertypes": [], "core_types": ["Sorcery"], "subtypes": [] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": "Create a 0/0 green Ooze creature token with trample. Put X +1/+1 counters on it, where X is two plus the total number of cards you own in exile and in your graveyard that are Oozes or are named Slime Against Humanity.\nA deck can have any number of cards named Slime Against Humanity.",
+                "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": ["Green"], "scryfall_oracle_id": null,
+                "deck_copy_limit": { "type": "Unlimited" },
+                "legalities": { "commander": "legal" }
+            },
+            "legal commander": {
+                "name": "Legal Commander",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Legendary"], "core_types": ["Creature"], "subtypes": [] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": ["Green"], "scryfall_oracle_id": null,
+                "legalities": { "commander": "legal" }
+            },
+            "plains": {
+                "name": "Plains",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": { "supertypes": ["Basic"], "core_types": ["Land"], "subtypes": ["Plains"] },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [], "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null,
+                "legalities": { "commander": "legal" }
+            }
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&db_json).unwrap();
+        let mut main = expand("Slime Against Humanity", 10);
+        main.extend(expand("Plains", 89));
+        let request = DeckCompatibilityRequest {
+            main_deck: main,
+            sideboard: Vec::new(),
+            commander: vec!["Legal Commander".to_string()],
+            signature_spell: Vec::new(),
+            selected_format: Some(GameFormat::Commander),
+            selected_match_type: None,
+            summary_only: false,
+        };
+        let result = evaluate_deck_compatibility(&db, &request);
+        assert!(
+            result.commander.compatible,
+            "expected compatible, got reasons: {:?}",
+            result.commander.reasons
+        );
+    }
+
+    #[test]
     fn commander_sideboard_policy_accepts_maybeboard_entries() {
         // CR 903.5e: Phase's deck builder reuses the sideboard slot as a
         // builder-only "Maybeboard" for Commander-style formats. The


### PR DESCRIPTION
## Summary
- Resolve per-card deck copy limits from the engine before enforcing add/move caps, so cards with an unlimited override are not stuck at the format default while WASM prefetch is in flight.
- Add a Commander deck-validation regression for 10× Slime Against Humanity.

Fixes #1138

## Test plan
- [x] `cargo test -p engine commander_accepts_ten_slime_against_humanity_copies`
- [x] CI green (Rust tests, frontend lint/test)