### PR TITLE
fix(endure): Warden of the Grove dynamic endure X targets entering creature

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2907,8 +2907,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         Effect::CollectEvidence { amount } => {
             d.push(("amount".into(), amount.to_string()));
         }
-        Effect::Endure { amount } => {
-            d.push(("amount".into(), amount.to_string()));
+        Effect::Endure { amount, .. } => {
+            d.push(("amount".into(), fmt_quantity(amount)));
         }
         Effect::BlightEffect { count, player } => {
             d.push(("count".into(), count.to_string()));

--- a/crates/engine/src/game/effects/endure.rs
+++ b/crates/engine/src/game/effects/endure.rs
@@ -109,6 +109,8 @@ pub fn resolve(
     Ok(())
 }
 
+// CR 608.2k + CR 701.63a: Resolve the enduring permanent from the parsed subject;
+// `SelfRef` is always the ability source, never the current trigger event.
 fn enduring_object_id(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -120,17 +122,10 @@ fn enduring_object_id(
         .and_then(extract_source_from_event);
 
     match subject {
-        TargetFilter::SelfRef => {
-            // Issue #1120: "it endures" on another creature entering — the parser
-            // may leave SelfRef, but the enduring permanent is the trigger object.
-            if let Some(event_src) = event_source {
-                if event_src != ability.source_id {
-                    return event_src;
-                }
-            }
-            ability.source_id
+        TargetFilter::SelfRef => ability.source_id,
+        TargetFilter::CostPaidObject | TargetFilter::TriggeringSource => {
+            event_source.unwrap_or(ability.source_id)
         }
-        TargetFilter::CostPaidObject => event_source.unwrap_or(ability.source_id),
         TargetFilter::SpecificObject { id } => *id,
         _ => ability.source_id,
     }
@@ -328,7 +323,7 @@ mod tests {
                         counter_type: None,
                     },
                 },
-                subject: TargetFilter::CostPaidObject,
+                subject: TargetFilter::TriggeringSource,
             },
             vec![],
             warden,
@@ -349,6 +344,104 @@ mod tests {
         assert_eq!(
             enduring, bear,
             "it endures must target the entering creature"
+        );
+    }
+
+    #[test]
+    fn endure_production_path_counter_branch_targets_entering_creature() {
+        use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef};
+        use crate::types::events::GameEvent;
+        use crate::types::game_state::ZoneChangeRecord;
+
+        let mut state = GameState::new_two_player(42);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        let warden = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Warden".to_string(),
+            Zone::Battlefield,
+        );
+        let bear = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [warden, bear] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        state
+            .objects
+            .get_mut(&warden)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 2);
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: bear,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                bear,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        });
+
+        let ability = ResolvedAbility::new(
+            Effect::Endure {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: None,
+                    },
+                },
+                subject: TargetFilter::TriggeringSource,
+            },
+            vec![],
+            warden,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        effects::resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        let counter_index = match &state.waiting_for {
+            WaitingFor::ChooseOneOfBranch {
+                source_id,
+                player,
+                branches,
+                ..
+            } => {
+                assert_eq!(*source_id, bear);
+                assert_eq!(*player, PlayerId(0));
+                branches
+                    .iter()
+                    .position(|b| matches!(*b.effect, Effect::PutCounter { .. }))
+                    .expect("counter branch present")
+            }
+            other => panic!("expected ChooseOneOfBranch, got {other:?}"),
+        };
+
+        apply_as_current(&mut state, GameAction::ChooseBranch { index: counter_index }).unwrap();
+
+        assert_eq!(
+            state.objects[&bear]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            2,
+            "counter branch must land on the entering creature"
         );
     }
 

--- a/crates/engine/src/game/effects/endure.rs
+++ b/crates/engine/src/game/effects/endure.rs
@@ -1,4 +1,6 @@
 use crate::game::effects::choose_one_of;
+use crate::game::quantity::resolve_quantity_with_targets;
+use crate::game::targeting::extract_source_from_event;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, Effect, EffectError, EffectKind, PtValue, QuantityExpr,
     ResolvedAbility, TargetFilter,
@@ -6,6 +8,7 @@ use crate::types::ability::{
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaColor;
 
 /// CR 701.63a: Endure N.
@@ -23,10 +26,12 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let amount = match &ability.effect {
-        Effect::Endure { amount } => *amount,
+    let (amount_expr, subject) = match &ability.effect {
+        Effect::Endure { amount, subject } => (amount, subject),
         _ => return Ok(()),
     };
+
+    let amount = resolve_quantity_with_targets(state, amount_expr, ability).max(0) as u32;
 
     // CR 701.63b: Endure 0 — nothing happens, no prompt is presented.
     if amount == 0 {
@@ -36,6 +41,8 @@ pub fn resolve(
         });
         return Ok(());
     }
+
+    let enduring_id = enduring_object_id(state, ability, subject);
 
     // CR 701.63a + CR 111.1/111.4: Branch A creates one N/N white Spirit
     // creature token. The N is the token's power/toughness, not the count —
@@ -62,8 +69,7 @@ pub fn resolve(
     token_branch.description = Some(format!("Create a {amount}/{amount} white Spirit token."));
 
     // CR 701.63a + CR 122.1: Branch B puts N +1/+1 counters on the enduring
-    // permanent. `SelfRef` resolves to the ability source (the permanent that
-    // is enduring).
+    // permanent.
     let mut counter_branch = AbilityDefinition::new(
         AbilityKind::Spell,
         Effect::PutCounter {
@@ -76,25 +82,58 @@ pub fn resolve(
     );
     counter_branch.description = Some(format!("Put {amount} +1/+1 counters on it."));
 
+    let enduring_controller = state
+        .objects
+        .get(&enduring_id)
+        .map(|o| o.controller)
+        .unwrap_or(ability.controller);
+
     // CR 701.63a: "that permanent's controller" makes the choice — a single
     // chooser. Delegate to the modal machine, which sets
     // `WaitingFor::ChooseOneOfBranch` and owns AI/multiplayer/frontend wiring.
     choose_one_of::prompt_next(
         state,
-        ability.controller,
-        ability.source_id,
+        enduring_controller,
+        enduring_id,
         vec![token_branch, counter_branch],
         ability.targets.clone(),
         ability.context.clone(),
-        vec![ability.controller],
+        vec![enduring_controller],
     );
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Endure,
-        source_id: ability.source_id,
+        source_id: enduring_id,
     });
 
     Ok(())
+}
+
+fn enduring_object_id(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    subject: &TargetFilter,
+) -> ObjectId {
+    let event_source = state
+        .current_trigger_event
+        .as_ref()
+        .and_then(extract_source_from_event);
+
+    match subject {
+        TargetFilter::SelfRef => {
+            // Issue #1120: "it endures" on another creature entering — the parser
+            // may leave SelfRef, but the enduring permanent is the trigger object.
+            if let Some(event_src) = event_source {
+                if event_src != ability.source_id {
+                    return event_src;
+                }
+            }
+            ability.source_id
+        }
+        TargetFilter::CostPaidObject => event_source.unwrap_or(ability.source_id),
+        TargetFilter::SpecificObject { id } => *id,
+        _ => ability.source_id,
+    }
 }
 
 #[cfg(test)]
@@ -133,8 +172,17 @@ mod tests {
             .card_types
             .core_types
             .push(CoreType::Creature);
-        let ability =
-            ResolvedAbility::new(Effect::Endure { amount }, vec![], source_id, PlayerId(0));
+        let ability = ResolvedAbility::new(
+            Effect::Endure {
+                amount: QuantityExpr::Fixed {
+                    value: amount as i32,
+                },
+                subject: TargetFilter::SelfRef,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
         (state, source_id, ability)
     }
 
@@ -234,7 +282,78 @@ mod tests {
     }
 
     #[test]
-    fn endure_zero_does_nothing() {
+    fn endure_dynamic_amount_uses_source_counters_for_entering_creature() {
+        use crate::game::quantity::resolve_quantity_with_targets;
+        use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef};
+        use crate::types::events::GameEvent;
+        use crate::types::game_state::ZoneChangeRecord;
+
+        let mut state = GameState::new_two_player(42);
+        let warden = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Warden".to_string(),
+            Zone::Battlefield,
+        );
+        let bear = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&warden)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 2);
+        state.current_trigger_event = Some(GameEvent::ZoneChanged {
+            object_id: bear,
+            from: Some(Zone::Hand),
+            to: Zone::Battlefield,
+            record: Box::new(ZoneChangeRecord::test_minimal(
+                bear,
+                Some(Zone::Hand),
+                Zone::Battlefield,
+            )),
+        });
+
+        let ability = ResolvedAbility::new(
+            Effect::Endure {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: None,
+                    },
+                },
+                subject: TargetFilter::CostPaidObject,
+            },
+            vec![],
+            warden,
+            PlayerId(0),
+        );
+
+        let amount = resolve_quantity_with_targets(
+            &state,
+            match &ability.effect {
+                Effect::Endure { amount, .. } => amount,
+                _ => unreachable!(),
+            },
+            &ability,
+        );
+        assert_eq!(amount, 2, "X should equal Warden's counters");
+
+        let enduring = enduring_object_id(&state, &ability, &TargetFilter::CostPaidObject);
+        assert_eq!(
+            enduring, bear,
+            "it endures must target the entering creature"
+        );
+    }
+
+    #[test]
+    fn endure_zero_skips_branch_choice() {
         let (mut state, source_id, ability) = setup(0);
         let mut events = Vec::new();
 

--- a/crates/engine/src/game/effects/endure.rs
+++ b/crates/engine/src/game/effects/endure.rs
@@ -432,7 +432,13 @@ mod tests {
             other => panic!("expected ChooseOneOfBranch, got {other:?}"),
         };
 
-        apply_as_current(&mut state, GameAction::ChooseBranch { index: counter_index }).unwrap();
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseBranch {
+                index: counter_index,
+            },
+        )
+        .unwrap();
 
         assert_eq!(
             state.objects[&bear]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7781,7 +7781,7 @@ pub(super) fn parse_imperative_family_ast(
             // CR 608.2k: subject-shifted "it endures" in a trigger names the
             // event object (the entering creature), not the ability source.
             let subject = if ctx.subject.is_some() {
-                TargetFilter::CostPaidObject
+                resolve_it_pronoun(ctx)
             } else {
                 TargetFilter::SelfRef
             };

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7758,20 +7758,34 @@ pub(super) fn parse_imperative_family_ast(
         }
         // Endure N keyword action
         "endure" | "endures" => {
+            use crate::parser::oracle_effect::lower::{
+                parse_where_x_quantity_expression, strip_trailing_where_x,
+            };
+            use crate::parser::oracle_effect::TextPair;
+
+            let (text_pair, where_x) = strip_trailing_where_x(TextPair::new(text, lower));
             let rest = alt((tag::<_, _, OracleError<'_>>("endure "), tag("endures ")))
-                .parse(lower)
+                .parse(text_pair.lower)
                 .map(|(r, _)| r)
                 .unwrap_or("");
-            // CR 701.63b: "endure X" degrades to 0 (nothing happens). parse_number_or_x
-            // maps a bare "x" to 0; the unwrap fallback only applies when no count token
-            // is present at all.
-            let count = nom_primitives::parse_number_or_x
-                .parse(rest.trim())
-                .map(|(_, n)| n)
-                .unwrap_or(1);
-            Some(ImperativeFamilyAst::GainKeyword(Effect::Endure {
-                amount: count,
-            }))
+            let amount = if let Some(expr) = where_x {
+                parse_where_x_quantity_expression(&expr)
+                    .unwrap_or(QuantityExpr::Fixed { value: 0 })
+            } else {
+                let count = nom_primitives::parse_number_or_x
+                    .parse(rest.trim())
+                    .map(|(_, n)| n as i32)
+                    .unwrap_or(1);
+                QuantityExpr::Fixed { value: count }
+            };
+            // CR 608.2k: subject-shifted "it endures" in a trigger names the
+            // event object (the entering creature), not the ability source.
+            let subject = if ctx.subject.is_some() {
+                TargetFilter::CostPaidObject
+            } else {
+                TargetFilter::SelfRef
+            };
+            Some(ImperativeFamilyAst::GainKeyword(Effect::Endure { amount, subject }))
         }
         // CR 701.53a: "incubate N"
         "incubate" => try_parse_incubate(lower).map(ImperativeFamilyAst::GainKeyword),

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -11,7 +11,9 @@ use super::counter::{
     parse_counter_anaphor, try_parse_double_effect, try_parse_move_counters_from,
     try_parse_multiply_pt_effect, try_parse_put_counter, try_parse_remove_counter,
 };
-use super::lower::parse_for_each_multiplier_prefix;
+use super::lower::{
+    parse_for_each_multiplier_prefix, parse_where_x_quantity_expression, strip_trailing_where_x,
+};
 use super::mana::{try_parse_activate_only_condition, try_parse_add_mana_effect};
 use super::token::try_parse_token;
 use super::{
@@ -7758,11 +7760,6 @@ pub(super) fn parse_imperative_family_ast(
         }
         // Endure N keyword action
         "endure" | "endures" => {
-            use crate::parser::oracle_effect::lower::{
-                parse_where_x_quantity_expression, strip_trailing_where_x,
-            };
-            use crate::parser::oracle_effect::TextPair;
-
             let (text_pair, where_x) = strip_trailing_where_x(TextPair::new(text, lower));
             let rest = alt((tag::<_, _, OracleError<'_>>("endure "), tag("endures ")))
                 .parse(text_pair.lower)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -29586,7 +29586,13 @@ mod tests {
             .sub_ability
             .expect("endure conjunct must survive as a sub_ability");
         assert!(
-            matches!(*sub.effect, Effect::Endure { amount: 1 }),
+            matches!(
+                *sub.effect,
+                Effect::Endure {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    ..
+                }
+            ),
             "expected chained Endure{{1}}, got {:?}",
             sub.effect
         );
@@ -29602,7 +29608,13 @@ mod tests {
     fn effect_it_endures_strips_subject_to_endure() {
         let e = parse_effect("it endures 1");
         assert!(
-            matches!(e, Effect::Endure { amount: 1 }),
+            matches!(
+                e,
+                Effect::Endure {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    ..
+                }
+            ),
             "expected Endure{{amount:1}}, got {e:?}"
         );
     }
@@ -29611,7 +29623,13 @@ mod tests {
     fn effect_this_creature_endures_strips_subject_to_endure() {
         let e = parse_effect("this creature endures 2");
         assert!(
-            matches!(e, Effect::Endure { amount: 2 }),
+            matches!(
+                e,
+                Effect::Endure {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    ..
+                }
+            ),
             "expected Endure{{amount:2}}, got {e:?}"
         );
     }
@@ -29622,24 +29640,51 @@ mod tests {
         // ("Fortress Kin-Guard endures N" → "~ endures N" upstream).
         let e = parse_effect("~ endures 3");
         assert!(
-            matches!(e, Effect::Endure { amount: 3 }),
+            matches!(
+                e,
+                Effect::Endure {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                    ..
+                }
+            ),
             "expected Endure{{amount:3}}, got {e:?}"
         );
     }
 
     #[test]
-    fn effect_endure_dynamic_x_degrades_gracefully() {
-        // CR 701.63b: "it endures X, where X is ..." cannot fit the `amount: u32`
-        // field. It must degrade to a benign value (endure 0 = nothing happens),
-        // never panic. Documented follow-up: dynamic endure amount.
+    fn effect_endure_dynamic_x_degrades_gracefully_without_binding() {
+        // CR 701.63b: bare "it endures X" without a defining clause still
+        // degrades to endure 0 (nothing happens).
         let e = parse_effect("it endures X");
         assert!(
             matches!(
                 e,
-                Effect::Endure { amount: 0 } | Effect::Unimplemented { .. }
+                Effect::Endure {
+                    amount: QuantityExpr::Fixed { value: 0 },
+                    ..
+                } | Effect::Unimplemented { .. }
             ),
-            "dynamic endure X must degrade to Endure{{0}} or Unimplemented, got {e:?}"
+            "bare dynamic endure X must degrade to Endure{{0}} or Unimplemented, got {e:?}"
         );
+    }
+
+    #[test]
+    fn effect_endure_dynamic_x_binds_counters_on_this_creature() {
+        use crate::types::ability::{ObjectScope, QuantityRef};
+        let e = parse_effect("it endures X, where X is the number of counters on this creature");
+        match e {
+            Effect::Endure { amount, .. } => match amount {
+                QuantityExpr::Ref { qty } => match qty {
+                    QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: None,
+                    } => {}
+                    other => panic!("unexpected qty {other:?}"),
+                },
+                other => panic!("unexpected amount {other:?}"),
+            },
+            other => panic!("expected Endure, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10162,7 +10162,8 @@ pub enum Effect {
     ///
     /// `subject` is the permanent that endures. Defaults to the ability source
     /// ("~ endures N"). Triggered "it endures X" on another creature entering
-    /// uses `CostPaidObject` (issue #1120 — Warden of the Grove).
+    /// uses `TargetFilter::TriggeringSource` (resolved from the trigger event
+    /// source at runtime; issue #1120 — Warden of the Grove).
     Endure {
         amount: QuantityExpr,
         #[serde(default = "default_target_filter_self_ref")]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10123,8 +10123,14 @@ pub enum Effect {
     /// CR 701.63a: Endure N — the enduring permanent's controller chooses: create an
     /// N/N white Spirit creature token, or put N +1/+1 counters on that permanent.
     /// CR 701.63b: Endure 0 does nothing.
+    ///
+    /// `subject` is the permanent that endures. Defaults to the ability source
+    /// ("~ endures N"). Triggered "it endures X" on another creature entering
+    /// uses `CostPaidObject` (issue #1120 — Warden of the Grove).
     Endure {
-        amount: u32,
+        amount: QuantityExpr,
+        #[serde(default = "default_target_filter_self_ref")]
+        subject: TargetFilter,
     },
     /// CR 701.68a: Blight N as an effect — the blighting player puts N -1/-1
     /// counters on a creature *they* control. Non-targeted: the player choosing

--- a/crates/engine/tests/integration/issue_1120_warden_of_the_grove.rs
+++ b/crates/engine/tests/integration/issue_1120_warden_of_the_grove.rs
@@ -20,10 +20,7 @@ fn floating_mana(n: usize, ty: ManaType) -> Vec<ManaUnit> {
         .collect()
 }
 
-fn plus_one_counters(
-    runner: &engine::game::scenario::GameRunner,
-    id: ObjectId,
-) -> u32 {
+fn plus_one_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {
     runner
         .state()
         .objects
@@ -41,7 +38,9 @@ fn warden_endure_counter_branch_puts_warden_counters_on_entering_creature() {
     let warden = scenario
         .add_creature_from_oracle(P0, "Warden of the Grove", 2, 2, WARDEN_ORACLE)
         .id();
-    let bear = scenario.add_creature_to_hand(P0, "Grizzly Bears", 2, 2).id();
+    let bear = scenario
+        .add_creature_to_hand(P0, "Grizzly Bears", 2, 2)
+        .id();
     scenario.with_mana_pool(
         P0,
         floating_mana(1, ManaType::Colorless)

--- a/crates/engine/tests/integration/issue_1120_warden_of_the_grove.rs
+++ b/crates/engine/tests/integration/issue_1120_warden_of_the_grove.rs
@@ -1,0 +1,126 @@
+//! Regression for issue #1120: Warden of the Grove's "it endures X" must put
+//! counters on the entering creature (or offer a Spirit token) using X from
+//! Warden's counters, through the production endure choose-one path.
+//!
+//! https://github.com/phase-rs/phase/issues/1120
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const WARDEN_ORACLE: &str = "At the beginning of your end step, put a +1/+1 counter on this creature.\nWhenever another nontoken creature you control enters, it endures X, where X is the number of counters on this creature. (Put X +1/+1 counters on the creature that entered or create an X/X white Spirit creature token.)";
+
+fn floating_mana(n: usize, ty: ManaType) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ty, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn plus_one_counters(
+    runner: &engine::game::scenario::GameRunner,
+    id: ObjectId,
+) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1))
+        .copied()
+        .unwrap_or(0)
+}
+
+#[test]
+fn warden_endure_counter_branch_puts_warden_counters_on_entering_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let warden = scenario
+        .add_creature_from_oracle(P0, "Warden of the Grove", 2, 2, WARDEN_ORACLE)
+        .id();
+    let bear = scenario.add_creature_to_hand(P0, "Grizzly Bears", 2, 2).id();
+    scenario.with_mana_pool(
+        P0,
+        floating_mana(1, ManaType::Colorless)
+            .into_iter()
+            .chain(floating_mana(1, ManaType::Green))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&warden)
+        .expect("warden on battlefield")
+        .counters
+        .insert(CounterType::Plus1Plus1, 2);
+
+    let card_id = runner.state().objects[&bear].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: bear,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("begin casting Grizzly Bears");
+
+    let mut chose_counter_branch = false;
+    for _ in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseOneOfBranch {
+                source_id,
+                branches,
+                ..
+            } => {
+                assert_eq!(
+                    source_id, bear,
+                    "endure prompt source must be the entering creature"
+                );
+                let counter_index = branches
+                    .iter()
+                    .position(|b| {
+                        matches!(
+                            &*b.effect,
+                            engine::types::ability::Effect::PutCounter { .. }
+                        )
+                    })
+                    .expect("counter branch present");
+                runner
+                    .act(GameAction::ChooseBranch {
+                        index: counter_index,
+                    })
+                    .expect("choosing counter branch must succeed");
+                chose_counter_branch = true;
+            }
+            WaitingFor::Priority { .. } => {
+                if chose_counter_branch && runner.state().stack.is_empty() {
+                    break;
+                }
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            other => panic!("unexpected waiting state: {other:?}"),
+        }
+    }
+
+    assert!(
+        chose_counter_branch,
+        "Warden ETB must surface endure choose-one prompt"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, bear),
+        2,
+        "entering creature must receive X counters from Warden"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, warden),
+        2,
+        "Warden's counters must be unchanged"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -133,6 +133,7 @@ mod issue_1021_recurring_nightmare;
 mod issue_1022_savai_triome_cycling;
 mod issue_1023_oversold_cemetery;
 mod issue_1025_rishkars_expertise;
+mod issue_1120_warden_of_the_grove;
 mod issue_1124_ohran_frostfang_attacking_deathtouch;
 mod issue_1156_coin_of_mastery;
 mod issue_1191_tzaangor_shaman;


### PR DESCRIPTION
## Summary

- Parse endure clauses with `, where X is ...` so Warden of the Grove binds X to counters on the source creature instead of enduring 0.
- Resolve the enduring permanent from the zone-change trigger event when the parser marks `CostPaidObject` / "it endures", so counters land on the entering creature.
- Route endure branch choice through that creature's controller via `prompt_next`.

Fixes #1120

## Test plan

- [x] `cargo test -p engine --lib game::effects::endure::tests`
- [x] `cargo test -p engine effect_endure_dynamic`
- [x] `cargo clippy -p engine -- -D warnings`

Made with [Cursor](https://cursor.com)