### PR TITLE
fix(client): make attached permanents clickable as targets/activation sources

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -222,6 +222,7 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
     incomingAttackerCounts,
     manaTappableObjectIds,
     selectableManaCostCreatureIds,
+    selectableSacrificeObjectIds,
     undoableTapObjectIds,
     validAttackerIds,
     validTargetObjectIds,
@@ -346,9 +347,28 @@ export const PermanentCard = memo(function PermanentCard({ objectId, attachments
 
   const ptDisplay = computePTDisplay(obj);
   const isSelected = selectedObjectId === objectId;
+  // CR 301.5 / CR 303.4: An attached Equipment/Aura is an independent permanent
+  // that can be a valid target, an activation source (re-equip), or a board
+  // choice in its own right. Collapsed behind its host it is unreachable —
+  // clicks land on the host instead, so a "put a counter on target nonland
+  // permanent you control" trigger lands on the creature rather than the chosen
+  // Equipment, and an attached Equipment can't be re-activated to move it. Open
+  // a host's attachments whenever any of them is actionable in the current
+  // waiting state so each is independently clickable without requiring a hover.
+  const attachmentsActionable =
+    obj.attachments.length > 0
+    && obj.attachments.some(
+      (id) =>
+        validTargetObjectIds.has(id)
+        || activatableObjectIds.has(id)
+        || manaTappableObjectIds.has(id)
+        || boardChoiceObjectIds.has(id)
+        || selectableSacrificeObjectIds.has(id)
+        || selectableManaCostCreatureIds.has(id),
+    );
   const attachmentsLifted =
     obj.attachments.length > 0
-    && (attachmentsLiftedByAncestor || isInHoveredAttachmentTree || isSelected || isInspected);
+    && (attachmentsLiftedByAncestor || isInHoveredAttachmentTree || isSelected || isInspected || attachmentsActionable);
   const attachmentsExpanded = obj.attachments.length <= 1 || attachmentsLifted;
   const visibleAttachmentIds = attachmentsExpanded ? obj.attachments : obj.attachments.slice(0, 1);
   const hiddenAttachmentCount = obj.attachments.length - visibleAttachmentIds.length;

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -122,11 +122,12 @@ function renderPermanent(
   validTargetObjectIds = new Set<number>(),
   selectableSacrificeObjectIds = new Set<number>(),
   boardChoiceObjectIds = new Set<number>(),
+  activatableObjectIds = new Set<number>(),
 ) {
   return render(
     <BoardInteractionContext.Provider
       value={{
-        activatableObjectIds: new Set(),
+        activatableObjectIds,
         boardChoiceObjectIds,
         committedAttackerIds: new Set(),
         incomingAttackerCounts: new Map(),
@@ -251,6 +252,73 @@ describe("PermanentCard attachments", () => {
     });
     fireEvent.mouseEnter(container.querySelector('[data-object-id="1"]') as HTMLElement);
 
+    expect(container.querySelector('[data-object-id="4"]')).not.toBeNull();
+  });
+
+  it("auto-expands collapsed attachments when one is a valid target", () => {
+    // Regression: Moira Brown's "put a quest counter on target nonland
+    // permanent you control" offers the host's attached Equipment/Auras as
+    // targets. Collapsed behind the host they are unclickable, so the counter
+    // lands on the host creature instead of the chosen attachment. A host with
+    // an actionable attachment must open WITHOUT requiring a hover.
+    const secondEquipment = makeObject({
+      id: 4,
+      card_id: 400,
+      attached_to: { type: "Object", data: 1 },
+      name: "Second Equipment",
+      power: null,
+      toughness: null,
+      base_power: null,
+      base_toughness: null,
+      card_types: { supertypes: [], core_types: ["Artifact"], subtypes: ["Equipment"] },
+      color: [],
+      base_color: [],
+    });
+    const gameState = makeState();
+    gameState.objects[1].attachments = [2, 4];
+    gameState.objects[4] = secondEquipment;
+    gameState.battlefield = [1, 2, 3, 4];
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    // Attachment 4 is a valid target — both attachments must render even though
+    // the host is neither hovered nor inspected.
+    const { container } = renderPermanent(new Set([4]));
+
+    expect(container.querySelector('[data-object-id="2"]')).not.toBeNull();
+    expect(container.querySelector('[data-object-id="4"]')).not.toBeNull();
+  });
+
+  it("auto-expands collapsed attachments when one is activatable (re-equip)", () => {
+    // Regression: an attached Equipment whose Equip ability is activatable must
+    // be reachable so it can be moved to another creature. Collapsed behind the
+    // host it cannot be clicked, so equip appears stuck once attached.
+    const secondEquipment = makeObject({
+      id: 4,
+      card_id: 400,
+      attached_to: { type: "Object", data: 1 },
+      name: "Second Equipment",
+      power: null,
+      toughness: null,
+      base_power: null,
+      base_toughness: null,
+      card_types: { supertypes: [], core_types: ["Artifact"], subtypes: ["Equipment"] },
+      color: [],
+      base_color: [],
+    });
+    const gameState = makeState();
+    gameState.objects[1].attachments = [2, 4];
+    gameState.objects[4] = secondEquipment;
+    gameState.battlefield = [1, 2, 3, 4];
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    const { container } = renderPermanent(
+      new Set(),
+      new Set(),
+      new Set(),
+      new Set([4]),
+    );
+
+    expect(container.querySelector('[data-object-id="2"]')).not.toBeNull();
     expect(container.querySelector('[data-object-id="4"]')).not.toBeNull();
   });
 


### PR DESCRIPTION
Attached Equipment/Auras render as cards tucked behind their host and
collapse to a single peeking card when a host has more than one. During
target selection or activation those attachments are valid game objects
(CR 301.5 / CR 303.4) but are occluded behind the host, so clicks fall
through to the host: a "put a counter on target nonland permanent you
control" trigger lands on the host creature instead of the chosen
Equipment, and an attached Equipment can't be re-activated to move it.

Auto-expand and lift a host's attachments whenever any of them is
actionable in the current waiting state (valid target, activation
source, mana-tap source, board choice, or sacrifice choice), so each is
independently clickable without requiring a hover. Keyed on the
attachment's id, so hosts don't fan out during unrelated targeting.
