### PR TITLE
ci: shard Rust tests across 2 nextest partitions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+# CI test profile (activated with `cargo nextest run --profile ci`).
+#
+# nextest already defaults test-threads to the number of logical CPUs, so this
+# profile does NOT raise per-runner parallelism — the CI speedup comes from
+# sharding the test run across multiple runners (see the rust-test matrix in
+# .github/workflows/ci.yml). This profile adds two CI-appropriate behaviors:
+#   - fail-fast = false: a shard reports every failure, not just the first one.
+#   - slow-timeout: warn on any test running past 60s and hard-kill it after
+#     4 periods (240s) as a runaway/hang guard. The slowest legitimate test is
+#     ~12s, so this never trips on healthy tests.
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,13 @@ jobs:
           ./scripts/check-test-card-data-load.sh "$BASE"
 
   rust-test:
-    name: Rust tests
+    name: Rust tests (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v4
 
@@ -108,7 +112,7 @@ jobs:
         # caught before it lands on the branch that feeds staging/preview.
         env:
           PROPTEST_CASES: ${{ github.event_name == 'pull_request' && '32' || '256' }}
-        run: cargo nextest run --workspace --exclude phase-tauri --exclude mtgish-import --features engine/proptest --status-level fail --final-status-level fail
+        run: cargo nextest run --profile ci --partition count:${{ matrix.shard }}/2 --workspace --exclude phase-tauri --exclude mtgish-import --features engine/proptest --status-level fail --final-status-level fail
 
   card-data-gate:
     name: Card data (generate, validate, coverage)


### PR DESCRIPTION
The Rust tests job ran the whole ~1800s single-thread suite on one
ubuntu-latest runner (default test-threads = num-cpus), making it the
slowest CI job at 12-14 min. Split it into a 2-way nextest partition
matrix (count:i/2) so the test phase parallelizes across two runners;
exhaustive + disjoint partitioning means no test is dropped or double-run.

Keeps the rust-test job ID intact so rust-check's needs: rust-test gate
still requires all shards green. Adds a .config/nextest.toml [profile.ci]
with fail-fast=false (report every failure per shard) and a 240s
slow-timeout as a runaway/hang guard.
