### PR TITLE
feat(client): collapse stack-pacing wait by recent resolution rate, not just depth

### DIFF
--- a/client/src/components/stack/StackDisplay.tsx
+++ b/client/src/components/stack/StackDisplay.tsx
@@ -3,10 +3,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import { StackEntry } from "./StackEntry.tsx";
-import {
-  pressureMultiplier,
-  stackPressureFromLength,
-} from "../../utils/stackPressure.ts";
+import { pressureMultiplier } from "../../utils/stackPressure.ts";
+import { effectiveStackPressure } from "../../utils/stackThroughput.ts";
 import { StackTargetArcs } from "./StackTargetArcs.tsx";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
@@ -316,11 +314,12 @@ export function StackDisplay() {
             >
               <AnimatePresence mode="popLayout">
                 {(() => {
-                  // Mass-trigger pacing: engine-authored StackPressure thresholds
-                  // (10/30/100) collapse per-entry animation under stack pressure.
-                  // See crates/engine/src/game/stack.rs + utils/stackPressure.ts.
+                  // Mass-trigger pacing: collapse per-entry animation under stack
+                  // pressure — depth (engine thresholds 10/30/100) OR recent
+                  // resolution churn (rate axis, for low-depth-high-throughput
+                  // loops depth can't see). See utils/stackThroughput.ts.
                   const pacing = pressureMultiplier(
-                    stackPressureFromLength(displayStack.length),
+                    effectiveStackPressure(displayStack.length),
                   );
                   return groupedStack.map(({ entry, count }, index) => (
                     <StackEntry

--- a/client/src/game/controllers/aiController.ts
+++ b/client/src/game/controllers/aiController.ts
@@ -2,7 +2,8 @@ import { AI_BASE_DELAY_MS, AI_DELAY_VARIANCE_MS, PLAYER_ID } from "../../constan
 import { useGameStore } from "../../stores/gameStore";
 import type { GameAction, WaitingFor } from "../../adapter/types";
 import { AdapterError, AdapterErrorCode } from "../../adapter/types";
-import { STACK_PRESSURE_ELEVATED } from "../../utils/stackPressure";
+import { pressureMultiplier, STACK_PRESSURE_ELEVATED } from "../../utils/stackPressure";
+import { effectiveStackPressure } from "../../utils/stackThroughput";
 import { debugLog } from "../debugLog";
 import { dispatchAction } from "../dispatch";
 import { attemptStateRehydrate, isEnginePanic, notifyEngineLost, routePanic } from "../engineRecovery";
@@ -277,7 +278,13 @@ export function createAIController(config: AIControllerConfig): AIController {
       waitingForType === "MulliganDecision" ||
       waitingForType === "MulliganBottomCards" ||
       waitingForType === "OpeningHandBottomCards";
-    const delay = isMulligan ? 0 : AI_BASE_DELAY_MS + Math.random() * AI_DELAY_VARIANCE_MS;
+    // Collapse the humanization delay under stack pressure. The depth-based skip
+    // gate (checkAndSchedule) only fires at Elevated depth, which a 0↔1 trigger
+    // loop never reaches — so without this the AI pays a full 500–900ms beat on
+    // every oscillation cycle. Rate-driven pressure shrinks it (Rapid → ~75ms).
+    const stackLen = gameState?.stack?.length ?? 0;
+    const baseDelay = isMulligan ? 0 : AI_BASE_DELAY_MS + Math.random() * AI_DELAY_VARIANCE_MS;
+    const delay = Math.round(baseDelay * pressureMultiplier(effectiveStackPressure(stackLen)));
     timeoutId = setTimeout(async () => {
       timeoutId = null;
       if (!active) {

--- a/client/src/game/controllers/gameLoopController.ts
+++ b/client/src/game/controllers/gameLoopController.ts
@@ -2,7 +2,8 @@ import { getPlayerId } from "../../hooks/usePlayerId";
 import { useGameStore } from "../../stores/gameStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { useUiStore } from "../../stores/uiStore";
-import { STACK_PRESSURE_ELEVATED } from "../../utils/stackPressure";
+import { pressureMultiplier, STACK_PRESSURE_ELEVATED } from "../../utils/stackPressure";
+import { effectiveStackPressure } from "../../utils/stackThroughput";
 import { shouldAutoPass } from "../autoPass";
 import { dispatchAction, dispatchResolveAll } from "../dispatch";
 import { createAIController, type AISeatBinding } from "./aiController";
@@ -81,11 +82,20 @@ export function createGameLoopController(config: GameLoopConfig): GameLoopContro
     if (autoPassTimeout != null) {
       clearTimeout(autoPassTimeout);
     }
+    // Scale the auto-pass beat by stack pressure. A low-depth-high-churn loop
+    // (Exquisite Blood + Sanguine Bond) keeps depth < Elevated forever, so the
+    // batch path never engages and the human seat pays a full 200ms beat per
+    // cycle — the dominant artificial wait in that case. Rate-driven pressure
+    // collapses the beat (Rapid → ~30ms) once the loop is churning.
+    const stackLen = useGameStore.getState().gameState?.stack?.length ?? 0;
+    const beat = Math.round(
+      AUTO_PASS_BEAT_MS * pressureMultiplier(effectiveStackPressure(stackLen)),
+    );
     autoPassTimeout = setTimeout(() => {
       autoPassTimeout = null;
       if (!active) return;
       dispatchAction({ type: "PassPriority" });
-    }, AUTO_PASS_BEAT_MS);
+    }, beat);
   }
 
   function start(): void {

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -14,7 +14,8 @@ import { isMultiplayerMode, useGameStore, legalResultState, saveGame, saveCheckp
 import { getOpponentDisplayName } from "../stores/multiplayerStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
-import { stackPressureFromLength, STACK_PRESSURE_ELEVATED } from "../utils/stackPressure";
+import { pressureMultiplier, stackPressureFromLength, STACK_PRESSURE_ELEVATED } from "../utils/stackPressure";
+import { effectiveStackPressure, recordStackResolutions } from "../utils/stackThroughput";
 import { applySpellPaymentPreference } from "./castPaymentMode";
 
 /**
@@ -209,6 +210,20 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   const { gameId } = useGameStore.getState();
   if (gameId) saveGame(gameId, newState);
 
+  // 3c. Feed the throughput tracker: count stack entries that left the stack
+  //     this action (resolved, countered, or otherwise removed), id-diffed so a
+  //     resolution that spawns replacement triggers still counts even when net
+  //     stack length is unchanged. Drives rate-based pacing for the
+  //     low-depth-high-churn loops the depth signal can't see (Exquisite Blood +
+  //     Sanguine Bond and friends). Single-dispatch resolves one item per pass;
+  //     the batch path feeds its own gross count below.
+  const nextStackIds = new Set(newState.stack.map((e) => e.id));
+  const resolvedCount = gameState.stack.reduce(
+    (n, e) => (nextStackIds.has(e.id) ? n : n + 1),
+    0,
+  );
+  if (resolvedCount > 0) recordStackResolutions(resolvedCount);
+
   // 4. Checkpoint: save pre-action state on turn boundaries for debug restore
   const turnEvent = events.find((e) => e.type === "TurnStarted");
   if (turnEvent) {
@@ -244,8 +259,13 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   const pacingMultipliers = usePreferencesStore.getState().pacingMultipliers;
   const steps = normalizeEvents(events, { pacingMultipliers });
 
-  // 7. Play animations (unless instant — multiplier === 0)
-  const multiplier = usePreferencesStore.getState().animationSpeedMultiplier;
+  // 7. Play animations (unless instant — multiplier === 0). Fold in stack
+  //    pressure so per-resolution timing collapses under depth OR recent churn —
+  //    without this the single-dispatch path animated every oscillation cycle at
+  //    full speed (it previously read only the user speed preference).
+  const multiplier =
+    usePreferencesStore.getState().animationSpeedMultiplier *
+    pressureMultiplier(effectiveStackPressure(newState.stack.length));
 
   if (steps.length > 0 && multiplier > 0) {
     useAnimationStore.getState().setAnimationNewState(newState);
@@ -653,6 +673,12 @@ export async function dispatchResolveAll(
 
       if (latchedTotal === 0) latchedTotal = batchResult.total;
       resolvedSoFar += batchResult.itemsResolved;
+      // Keep the throughput tracker warm so a storm draining below Instant keeps
+      // its animated tail fast instead of snapping back to full pacing.
+      // `itemsResolved` is a net-shrink count (can lag the true gross when a
+      // resolution spawns triggers) — an acceptable under-count here since the
+      // batch path is already depth-gated, where the depth axis dominates pacing.
+      if (batchResult.itemsResolved > 0) recordStackResolutions(batchResult.itemsResolved);
       // Surface progress only for a genuine storm (trivial multi-item resolves
       // drain too fast to render). Clamp to the latched total: `itemsResolved`
       // is a net-shrink count that can lag the true gross when a resolution

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -18,6 +18,7 @@ import { MAX_UNDO_HISTORY, UNDOABLE_ACTIONS } from "../constants/game";
 import { applySpellPaymentPreference } from "../game/castPaymentMode";
 import { getPlayerId } from "../hooks/usePlayerId";
 import { loadCheckpoints, saveGame } from "../services/gamePersistence";
+import { resetStackThroughput } from "../utils/stackThroughput";
 
 /** Map a LegalActionsResult to the store fields it owns — single source of truth. */
 export function legalResultState(result: LegalActionsResult): Pick<GameStoreState, "legalActions" | "autoPassRecommended" | "spellCosts" | "legalActionsByObject" | "stuckDiagnostic"> {
@@ -193,6 +194,10 @@ export const useGameStore = create<GameStore>()(
     ...initialState,
 
     initGame: async (gameId, adapter, deckData, formatConfig, playerCount, matchConfig, firstPlayer) => {
+      // Clear the display-only stack-pacing tracker so a fast-churning end to a
+      // prior game can't bleed stale resolution rate into this game's opening
+      // pacing (rematch started within the throughput window).
+      resetStackThroughput();
       await adapter.initialize();
       const initResult = await adapter.initializeGame(deckData, formatConfig, playerCount, matchConfig, firstPlayer);
       const state = await adapter.getState();
@@ -235,6 +240,9 @@ export const useGameStore = create<GameStore>()(
     },
 
     resumeGame: async (gameId, adapter, savedState) => {
+      // Reset stack-pacing throughput — resuming may load a different game than
+      // the one just played; stale churn must not carry across.
+      resetStackThroughput();
       await adapter.initialize();
       await adapter.restoreState(savedState);
       const state = await adapter.getState();
@@ -256,6 +264,8 @@ export const useGameStore = create<GameStore>()(
     },
 
     resumeP2PHost: async (gameId, adapter) => {
+      // Reset stack-pacing throughput on entry to this game context.
+      resetStackThroughput();
       // `adapter.initialize()` on a resumed P2PHostAdapter already
       // called `wasm.resumeMultiplayerHostState(savedState)` — the
       // engine is populated and in multiplayer mode. All we need here

--- a/client/src/utils/__tests__/stackThroughput.test.ts
+++ b/client/src/utils/__tests__/stackThroughput.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  effectiveStackPressure,
+  RATE_PRESSURE_ELEVATED,
+  RATE_PRESSURE_RAPID,
+  recordStackResolutions,
+  resetStackThroughput,
+  stackPressureFromRate,
+  THROUGHPUT_WINDOW_MS,
+} from "../stackThroughput";
+
+// The tracker is a module-level singleton; reset between cases so windows don't
+// bleed across tests. Timestamps are injected (never `performance.now()`) to
+// keep the sliding-window math deterministic.
+afterEach(() => resetStackThroughput());
+
+describe("stackPressureFromRate", () => {
+  it("is Normal with no recent resolutions", () => {
+    expect(stackPressureFromRate(1000)).toBe("Normal");
+  });
+
+  it("escalates to Elevated then Rapid as in-window resolutions accumulate", () => {
+    recordStackResolutions(RATE_PRESSURE_ELEVATED, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Elevated");
+
+    recordStackResolutions(RATE_PRESSURE_RAPID - RATE_PRESSURE_ELEVATED, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Rapid");
+  });
+
+  it("never reports Instant from rate alone — that stays a depth-only verdict", () => {
+    recordStackResolutions(RATE_PRESSURE_RAPID * 10, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Rapid");
+  });
+
+  it("decays back to Normal once resolutions age out of the window", () => {
+    recordStackResolutions(RATE_PRESSURE_RAPID, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Rapid");
+
+    // Just inside the window: still hot.
+    expect(stackPressureFromRate(1000 + THROUGHPUT_WINDOW_MS - 1)).toBe("Rapid");
+    // Just past the window: every timestamp has aged out.
+    expect(stackPressureFromRate(1000 + THROUGHPUT_WINDOW_MS + 1)).toBe("Normal");
+  });
+
+  it("ignores non-positive counts as a no-op", () => {
+    recordStackResolutions(0, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Normal");
+  });
+
+  it("resetStackThroughput clears accumulated churn immediately", () => {
+    // Guards the new-game-boundary fix: a fast-churning prior game must not bleed
+    // rate into the next game's opening pacing, even within the window.
+    recordStackResolutions(RATE_PRESSURE_RAPID, 1000);
+    expect(stackPressureFromRate(1000)).toBe("Rapid");
+    resetStackThroughput();
+    expect(stackPressureFromRate(1000)).toBe("Normal");
+  });
+});
+
+describe("effectiveStackPressure", () => {
+  it("takes the hotter of depth and rate", () => {
+    // Depth quiet, rate hot → rate wins (the oscillating-loop case).
+    recordStackResolutions(RATE_PRESSURE_RAPID, 1000);
+    expect(effectiveStackPressure(1, 1000)).toBe("Rapid");
+  });
+
+  it("lets depth win when it outranks the rate axis (a true storm)", () => {
+    // No churn recorded, but the stack is 100+ deep → depth says Instant, which
+    // the rate axis (capped at Rapid) can never reach.
+    expect(effectiveStackPressure(100, 1000)).toBe("Instant");
+  });
+
+  it("relaxes to Normal only when both axes are quiet", () => {
+    expect(effectiveStackPressure(0, 1000)).toBe("Normal");
+  });
+});

--- a/client/src/utils/stackThroughput.ts
+++ b/client/src/utils/stackThroughput.ts
@@ -26,16 +26,25 @@ export const THROUGHPUT_WINDOW_MS = 1500;
 export const RATE_PRESSURE_ELEVATED = 8;
 export const RATE_PRESSURE_RAPID = 24;
 
-// Monotonic non-decreasing ring of resolution timestamps (performance.now()).
-// Bounded by RATE_PRESSURE_RAPID-ish counts within the window in practice; a
-// pathological burst is pruned to the window on every record/read.
-const resolutionTimes: number[] = [];
+// Recent resolutions stored as {timestamp, count} batches — one entry per
+// record() call (one action / one batch chunk), NOT one per resolution. A storm
+// chunk that resolves thousands of items is a single push instead of thousands,
+// keeping the array O(record-calls-in-window) rather than O(resolutions). The
+// rate only needs to clear RATE_PRESSURE_RAPID, so storing exact per-item
+// timestamps buys nothing. Timestamps are monotonic non-decreasing, so stale
+// entries are always a prunable prefix.
+interface ResolutionBatch {
+  timestamp: number;
+  count: number;
+}
+
+const resolutionBatches: ResolutionBatch[] = [];
 
 function prune(now: number): void {
   const cutoff = now - THROUGHPUT_WINDOW_MS;
   let drop = 0;
-  while (drop < resolutionTimes.length && resolutionTimes[drop] < cutoff) drop++;
-  if (drop > 0) resolutionTimes.splice(0, drop);
+  while (drop < resolutionBatches.length && resolutionBatches[drop].timestamp < cutoff) drop++;
+  if (drop > 0) resolutionBatches.splice(0, drop);
 }
 
 /** Record `count` stack items that just left the stack (resolved/countered). */
@@ -43,13 +52,14 @@ export function recordStackResolutions(
   count: number,
   now: number = performance.now(),
 ): void {
-  for (let i = 0; i < count; i++) resolutionTimes.push(now);
+  if (count <= 0) return;
+  resolutionBatches.push({ timestamp: now, count });
   prune(now);
 }
 
 /** Clear throughput history — for new-game boundaries and tests. */
 export function resetStackThroughput(): void {
-  resolutionTimes.length = 0;
+  resolutionBatches.length = 0;
 }
 
 /**
@@ -60,10 +70,12 @@ export function resetStackThroughput(): void {
  */
 export function stackPressureFromRate(now: number = performance.now()): StackPressure {
   prune(now);
-  const n = resolutionTimes.length;
-  if (n >= RATE_PRESSURE_RAPID) return "Rapid";
-  if (n >= RATE_PRESSURE_ELEVATED) return "Elevated";
-  return "Normal";
+  let total = 0;
+  for (const batch of resolutionBatches) {
+    total += batch.count;
+    if (total >= RATE_PRESSURE_RAPID) return "Rapid";
+  }
+  return total >= RATE_PRESSURE_ELEVATED ? "Elevated" : "Normal";
 }
 
 const PRESSURE_RANK: Record<StackPressure, number> = {

--- a/client/src/utils/stackThroughput.ts
+++ b/client/src/utils/stackThroughput.ts
@@ -1,0 +1,89 @@
+/**
+ * Display-only stack *throughput* pacing — the rate companion to the
+ * depth-based `StackPressure` mirror in `stackPressure.ts`.
+ *
+ * The engine's `StackPressure` reads instantaneous stack *depth*. That signal is
+ * blind to low-depth-high-churn loops (e.g. Exquisite Blood + Sanguine Bond,
+ * which oscillates the stack between 0 and 1): depth never crosses the Elevated
+ * threshold, so every cycle pays full artificial wait even though dozens of
+ * items are flowing through. This module adds the missing *rate* axis — a
+ * sliding window of recent stack resolutions — and combines it with depth via
+ * `effectiveStackPressure`, so pacing escalates when EITHER the stack is deep OR
+ * it is churning fast.
+ *
+ * This is wall-clock-derived and therefore strictly frontend-only: the engine is
+ * a pure, clock-free reducer and cannot (and must not) express "resolutions per
+ * second". Pacing is a presentation choice, the same category as
+ * `animationSpeedMultiplier`.
+ */
+import { type StackPressure, stackPressureFromLength } from "./stackPressure";
+
+// Snappy defaults — tune alongside the engine-mirrored STACK_PRESSURE_* depth
+// thresholds. A 0↔1 loop reaches Rapid (0.15× pacing) within ~1s of sustained
+// churn, then restores full pacing ~THROUGHPUT_WINDOW_MS after the churn stops
+// (the window self-empties — no explicit reset needed for the common case).
+export const THROUGHPUT_WINDOW_MS = 1500;
+export const RATE_PRESSURE_ELEVATED = 8;
+export const RATE_PRESSURE_RAPID = 24;
+
+// Monotonic non-decreasing ring of resolution timestamps (performance.now()).
+// Bounded by RATE_PRESSURE_RAPID-ish counts within the window in practice; a
+// pathological burst is pruned to the window on every record/read.
+const resolutionTimes: number[] = [];
+
+function prune(now: number): void {
+  const cutoff = now - THROUGHPUT_WINDOW_MS;
+  let drop = 0;
+  while (drop < resolutionTimes.length && resolutionTimes[drop] < cutoff) drop++;
+  if (drop > 0) resolutionTimes.splice(0, drop);
+}
+
+/** Record `count` stack items that just left the stack (resolved/countered). */
+export function recordStackResolutions(
+  count: number,
+  now: number = performance.now(),
+): void {
+  for (let i = 0; i < count; i++) resolutionTimes.push(now);
+  prune(now);
+}
+
+/** Clear throughput history — for new-game boundaries and tests. */
+export function resetStackThroughput(): void {
+  resolutionTimes.length = 0;
+}
+
+/**
+ * Pressure implied purely by recent resolution *rate*. Capped at `Rapid`:
+ * `Instant` (skip animation entirely) stays a depth-only verdict — a true
+ * hundreds-deep storm — because mere fast oscillation still wants a visible
+ * flipbook of life/counter changes, not a blank skip.
+ */
+export function stackPressureFromRate(now: number = performance.now()): StackPressure {
+  prune(now);
+  const n = resolutionTimes.length;
+  if (n >= RATE_PRESSURE_RAPID) return "Rapid";
+  if (n >= RATE_PRESSURE_ELEVATED) return "Elevated";
+  return "Normal";
+}
+
+const PRESSURE_RANK: Record<StackPressure, number> = {
+  Normal: 0,
+  Elevated: 1,
+  Rapid: 2,
+  Instant: 3,
+};
+
+/**
+ * The pacing pressure every display / auto-pass consumer should read: the hotter
+ * of depth (`stackPressureFromLength`) and recent rate (`stackPressureFromRate`).
+ * `max` because either a deep stack or fast churn warrants speeding up; pacing
+ * relaxes only when both signals are quiet.
+ */
+export function effectiveStackPressure(
+  stackLen: number,
+  now: number = performance.now(),
+): StackPressure {
+  const byDepth = stackPressureFromLength(stackLen);
+  const byRate = stackPressureFromRate(now);
+  return PRESSURE_RANK[byRate] > PRESSURE_RANK[byDepth] ? byRate : byDepth;
+}


### PR DESCRIPTION
Stack-resolution pacing (artificial wait between resolutions) was driven
purely by instantaneous stack DEPTH via StackPressure (Normal/Elevated/
Rapid/Instant at depth 0/10/30/100). That signal is blind to low-depth-
high-churn loops: Exquisite Blood + Sanguine Bond oscillates the stack
0<->1, never crosses Elevated, and pays full artificial wait every cycle
(auto-pass beat, AI humanization delay, per-resolution animation) — tens
of seconds for a microsecond loop.

Add a frontend-only resolution-RATE axis (utils/stackThroughput.ts): a
sliding window of recent stack resolutions combined with depth via
effectiveStackPressure = max(depth, rate). Rate is wall-clock-derived so
it belongs in the display layer, not the clock-free engine reducer. Rate
caps at Rapid (Instant stays a depth-only verdict — a true deep storm).

- dispatch.ts: feed the tracker by id-diffing the stack each action
  (truthful when a resolution spawns triggers) + the batch path; make the
  single-action animation multiplier pressure-aware (it previously read
  only the user speed preference).
- gameLoopController.ts: scale the 200ms auto-pass beat by effective
  pressure (dominant human-mode oscillation cost).
- aiController.ts: scale the 500-900ms AI humanization delay (dominant
  AI-mode cost). Depth-only batch/skip gates intentionally unchanged —
  batching a depth-<=1 loop is pointless.
- gameStore.ts: reset the tracker on every fresh-game boundary so a
  fast-churning prior game can't bleed rate into the next game's opening.

Depth-based StackPressure mirror (engine-authoritative) untouched.
