### PR TITLE
fix: add integration regression test for issue #3993

### DIFF
--- a/crates/engine/tests/integration/issue_3993_delve_cancel_payment.rs
+++ b/crates/engine/tests/integration/issue_3993_delve_cancel_payment.rs
@@ -1,0 +1,118 @@
+//! Regression for issue #3993: Cancelling during delve mana payment must return
+//! delved graveyard cards from exile instead of leaving them stranded.
+//!
+//! CR 601.2i: If the player is unable or unwilling to complete a cast, the
+//! process is reversed and any choices made (including delve exiles) are undone.
+//!
+//! https://github.com/phase-rs/phase/issues/3993
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, ConvokeMode, WaitingFor};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DELVE_DRAW_ORACLE: &str =
+    "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n\
+Draw a card.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, ty: ManaType, count: usize) {
+    let pool = &mut runner.state_mut().players[P0.0 as usize].mana_pool;
+    for _ in 0..count {
+        pool.add(ManaUnit::new(
+            ty,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+}
+
+#[test]
+fn issue_3993_cancel_during_delve_payment_returns_graveyard_cards() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Delve Draw", false, DELVE_DRAW_ORACLE)
+        .id();
+    let delve_a = scenario
+        .add_spell_to_graveyard(P0, "Old Bolt", true)
+        .id();
+    let delve_b = scenario
+        .add_spell_to_graveyard(P0, "Old Shock", true)
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(&mut runner, ManaType::Colorless, 3);
+    add_mana(&mut runner, ManaType::Red, 1);
+
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("begin casting delve spell");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment {
+            convoke_mode: Some(ConvokeMode::Delve),
+            ..
+        }
+    ));
+
+    for gy_id in [delve_a, delve_b] {
+        runner
+            .act(GameAction::TapForConvoke {
+                object_id: gy_id,
+                mana_type: ManaType::Colorless,
+            })
+            .expect("delve graveyard card");
+        assert_eq!(
+            runner.state().objects[&gy_id].zone,
+            Zone::Exile,
+            "delved card should be exiled before cancel"
+        );
+    }
+
+    runner
+        .act(GameAction::CancelCast)
+        .expect("cancel during delve payment");
+
+    for gy_id in [delve_a, delve_b] {
+        assert_eq!(
+            runner.state().objects[&gy_id].zone,
+            Zone::Graveyard,
+            "cancelled delve payment must return the card to the graveyard"
+        );
+    }
+    assert_eq!(
+        runner.state().objects[&spell].zone,
+        Zone::Hand,
+        "cancelled spell must return to hand"
+    );
+    assert!(
+        runner.state().stack.is_empty(),
+        "cancelled spell must be removed from the stack"
+    );
+    assert!(
+        !runner
+            .state()
+            .cards_exiled_with_source_this_turn
+            .get(&spell)
+            .is_some_and(|ids| ids.contains(&delve_a) || ids.contains(&delve_b)),
+        "delve exile-with-source tracking must be cleared on cancel"
+    );
+    assert!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .mana
+            .iter()
+            .all(|unit| !unit.is_convoke_payment()),
+        "delve mana markers must be removed from the pool on cancel"
+    );
+}

--- a/crates/engine/tests/integration/issue_3993_delve_cancel_payment.rs
+++ b/crates/engine/tests/integration/issue_3993_delve_cancel_payment.rs
@@ -9,6 +9,7 @@
 use engine::game::scenario::{GameScenario, P0};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, ConvokeMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -17,16 +18,20 @@ const DELVE_DRAW_ORACLE: &str =
     "Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)\n\
 Draw a card.";
 
-fn add_mana(runner: &mut engine::game::scenario::GameRunner, ty: ManaType, count: usize) {
-    let pool = &mut runner.state_mut().players[P0.0 as usize].mana_pool;
-    for _ in 0..count {
-        pool.add(ManaUnit::new(
-            ty,
-            engine::types::identifiers::ObjectId(0),
+fn mana_pool(generic: usize, red: usize) -> Vec<ManaUnit> {
+    let mut pool = Vec::new();
+    for _ in 0..generic {
+        pool.push(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
             false,
             vec![],
         ));
     }
+    for _ in 0..red {
+        pool.push(ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]));
+    }
+    pool
 }
 
 #[test]
@@ -36,16 +41,11 @@ fn issue_3993_cancel_during_delve_payment_returns_graveyard_cards() {
     let spell = scenario
         .add_spell_to_hand_from_oracle(P0, "Delve Draw", false, DELVE_DRAW_ORACLE)
         .id();
-    let delve_a = scenario
-        .add_spell_to_graveyard(P0, "Old Bolt", true)
-        .id();
-    let delve_b = scenario
-        .add_spell_to_graveyard(P0, "Old Shock", true)
-        .id();
+    let delve_a = scenario.add_spell_to_graveyard(P0, "Old Bolt", true).id();
+    let delve_b = scenario.add_spell_to_graveyard(P0, "Old Shock", true).id();
+    scenario.with_mana_pool(P0, mana_pool(3, 1));
 
     let mut runner = scenario.build();
-    add_mana(&mut runner, ManaType::Colorless, 3);
-    add_mana(&mut runner, ManaType::Red, 1);
 
     let card_id = runner.state().objects[&spell].card_id;
     runner

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -342,6 +342,7 @@ mod issue_3988_vaultborn_tyrant;
 mod issue_3989_bloodchiefs_thirst;
 mod issue_3991_carnage_interpreter;
 mod issue_3992_lotleth_regenerate_combat;
+mod issue_3993_delve_cancel_payment;
 mod issue_3994_malevolent_rumble;
 mod issue_3996_return_the_favor;
 mod issue_3998_marang_river_prowler;


### PR DESCRIPTION
## Summary

- Adds an end-to-end integration regression test for [issue #3993](https://github.com/phase-rs/phase/issues/3993): cancelling during Delve mana payment must return delved graveyard cards from exile.
- The engine fix landed on `main` in #4129 (`handle_cancel_cast` rollback for delve exiles). This PR adds `GameScenario`-level coverage so the reported user flow stays locked in alongside the existing unit tests in `casting.rs`.

## Problem

While paying a Delve cost, clicking **Cancel** left already-delved graveyard cards stranded in exile instead of returning them to the graveyard.

## Fix context

Engine behavior (already on `main` via #4129):

- On `CancelCast` during `WaitingFor::ManaPayment`, `handle_cancel_cast` finds delve payments via convoke-style mana pool markers.
- Moves those cards from exile back to the graveyard (CR 601.2i).
- Clears `exile_links` and `cards_exiled_with_source_this_turn` tracking.
- Removes delve mana markers from the pool and pops the placeholder stack entry.

This PR does **not** change engine logic — it adds integration coverage for the full cast pipeline.

## Changes

| File | Change |
|------|--------|
| `crates/engine/tests/integration/issue_3993_delve_cancel_payment.rs` | New regression test: cast delve spell → delve two GY cards → `CancelCast` → assert cards return to graveyard, spell returns to hand, stack clears, tracking and pool markers reset |
| `crates/engine/tests/integration/main.rs` | Register new test module |

## Test plan

- [x] `cargo test -p engine issue_3993_cancel_during_delve_payment`
- [x] `cargo test -p engine delve_cancel_cast` (existing unit tests in `casting.rs`)
- [ ] Manual: cast a Delve spell (e.g. Murktide Regent), delve one or more graveyard cards, click **Cancel** in the mana payment 