### PR TITLE
fix: Sliver Gravemother encore activating at X=0 or for free (#3997)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -143,21 +143,34 @@ fn activation_ability_definition(
     source_id: ObjectId,
     ability_index: usize,
 ) -> Option<AbilityDefinition> {
-    let obj = state.objects.get(&source_id)?;
-    if let Some(ability) = obj.abilities.get(ability_index) {
-        return Some(ability.clone());
+    let Some(obj) = state.objects.get(&source_id) else {
+        return None;
+    };
+    let mut ability = if let Some(ability) = obj.abilities.get(ability_index) {
+        ability.clone()
+    } else {
+        let offset = ability_index.checked_sub(obj.abilities.len())?;
+        // Must match the append order in `activated_ability_definitions`: printed
+        // abilities first, then runtime-granted cycling, then runtime-granted
+        // graveyard activated (Encore/Scavenge).
+        runtime_granted_cycling_abilities(state, source_id)
+            .into_iter()
+            .chain(runtime_granted_graveyard_activated_abilities(
+                state, source_id,
+            ))
+            .nth(offset)?
+    };
+    if let Some(ref cost) = ability.cost {
+        ability.cost = Some(super::keywords::resolve_self_mana_in_ability_cost(
+            state, source_id, cost,
+        ));
     }
-
-    let offset = ability_index.checked_sub(obj.abilities.len())?;
-    // Must match the append order in `activated_ability_definitions`: printed
-    // abilities first, then runtime-granted cycling, then runtime-granted
-    // graveyard activated (Encore/Scavenge).
-    runtime_granted_cycling_abilities(state, source_id)
-        .into_iter()
-        .chain(runtime_granted_graveyard_activated_abilities(
-            state, source_id,
-        ))
-        .nth(offset)
+    if matches!(ability.effect.as_ref(), Effect::Encore) {
+        if let Some(ref mut cost) = ability.cost {
+            super::keywords::concretize_encore_mana_value_in_ability_cost(state, source_id, cost);
+        }
+    }
+    Some(ability)
 }
 
 pub(crate) fn variable_speed_payment_range(cost: &AbilityCost, max_speed: u8) -> Option<(u8, u8)> {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -143,9 +143,7 @@ fn activation_ability_definition(
     source_id: ObjectId,
     ability_index: usize,
 ) -> Option<AbilityDefinition> {
-    let Some(obj) = state.objects.get(&source_id) else {
-        return None;
-    };
+    let obj = state.objects.get(&source_id)?;
     let mut ability = if let Some(ability) = obj.abilities.get(ability_index) {
         ability.clone()
     } else {

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -1744,7 +1744,6 @@ mod tests {
     }
 
     use crate::game::combat::{AttackerInfo, CombatState};
-    use crate::game::zones::create_object;
     use crate::types::events::GameEvent;
     use crate::types::game_state::GameState;
 
@@ -1957,7 +1956,6 @@ mod tests {
     #[test]
     fn ninjutsu_enter_as_copy_defers_combat_placement_until_copy_resolves() {
         use crate::game::engine::apply_as_current;
-        use crate::game::zones::create_object;
         use crate::types::ability::{
             AbilityDefinition, AbilityKind, ContinuousModification, Effect, ReplacementDefinition,
             ReplacementMode, TargetFilter, TargetRef, TypeFilter, TypedFilter,

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -956,10 +956,12 @@ mod tests {
     use std::sync::Arc;
 
     use crate::ai_support::legal_actions;
+    use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction,
+        AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction, TargetFilter,
     };
     use crate::types::actions::GameAction;
+    use crate::types::counter::CounterType;
     use crate::types::game_state::WaitingFor;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
@@ -986,10 +988,6 @@ mod tests {
 
     #[test]
     fn resolve_self_mana_in_ability_cost_descends_per_counter_base() {
-        use crate::game::zones::create_object;
-        use crate::types::ability::TargetFilter;
-        use crate::types::counter::CounterType;
-
         let mut state = GameState::new_two_player(1);
         let source = create_object(
             &mut state,
@@ -1034,10 +1032,6 @@ mod tests {
 
     #[test]
     fn concretize_encore_mana_value_descends_per_counter_base() {
-        use crate::game::zones::create_object;
-        use crate::types::ability::TargetFilter;
-        use crate::types::counter::CounterType;
-
         let mut state = GameState::new_two_player(1);
         let source = create_object(
             &mut state,

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -239,6 +239,65 @@ fn resolve_keyword_mana_cost(state: &GameState, object_id: ObjectId, cost: &Mana
     }
 }
 
+/// CR 602.1a + CR 702.141a: Resolve `SelfManaCost` / `SelfManaValue` placeholders
+/// anywhere in an activated ability's cost tree before legality or payment.
+/// The mana payment path treats those placeholders as free, so every activation
+/// fetch must concretize them against the source object (Sliver Gravemother class).
+pub(crate) fn resolve_self_mana_in_ability_cost(
+    state: &GameState,
+    source_id: ObjectId,
+    cost: &crate::types::ability::AbilityCost,
+) -> crate::types::ability::AbilityCost {
+    use crate::types::ability::AbilityCost;
+    match cost {
+        AbilityCost::Mana { cost: mana } => AbilityCost::Mana {
+            cost: resolve_keyword_mana_cost(state, source_id, mana),
+        },
+        AbilityCost::Composite { costs } => AbilityCost::Composite {
+            costs: costs
+                .iter()
+                .map(|sub| resolve_self_mana_in_ability_cost(state, source_id, sub))
+                .collect(),
+        },
+        AbilityCost::OneOf { costs } => AbilityCost::OneOf {
+            costs: costs
+                .iter()
+                .map(|sub| resolve_self_mana_in_ability_cost(state, source_id, sub))
+                .collect(),
+        },
+        other => other.clone(),
+    }
+}
+
+/// CR 702.141a + CR 202.3: Encore grants that bind X to the card's mana value
+/// (Sliver Gravemother) must not enter `ChooseXValue` with X choosable at 0.
+/// When the synthesized cost still carries a symbolic `{X}` shard, concretize it
+/// to the source object's mana value before activation proceeds.
+pub(crate) fn concretize_encore_mana_value_in_ability_cost(
+    state: &GameState,
+    source_id: ObjectId,
+    cost: &mut crate::types::ability::AbilityCost,
+) {
+    use crate::game::casting_costs::cost_has_x;
+    use crate::types::ability::AbilityCost;
+    match cost {
+        AbilityCost::Mana { cost: mana } if cost_has_x(mana) => {
+            let mana_value = state
+                .objects
+                .get(&source_id)
+                .map(|obj| obj.mana_cost.mana_value())
+                .unwrap_or(0);
+            mana.concretize_x(mana_value);
+        }
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+            for sub in costs {
+                concretize_encore_mana_value_in_ability_cost(state, source_id, sub);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// CR 702.97a / CR 702.128a / CR 702.129a / CR 702.141a + CR 602.1a: Resolve a
 /// `ManaCost::SelfManaCost` or `ManaCost::SelfManaValue` payload carried by a
 /// granted graveyard activated keyword to the recipient card's concrete mana

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use crate::game::casting_costs::cost_has_x;
 use crate::game::combat::AttackTarget;
 use crate::game::game_object::GameObject;
 use crate::game::zone_pipeline::{self, ZoneMoveRequest};
@@ -246,9 +247,8 @@ fn resolve_keyword_mana_cost(state: &GameState, object_id: ObjectId, cost: &Mana
 pub(crate) fn resolve_self_mana_in_ability_cost(
     state: &GameState,
     source_id: ObjectId,
-    cost: &crate::types::ability::AbilityCost,
-) -> crate::types::ability::AbilityCost {
-    use crate::types::ability::AbilityCost;
+    cost: &AbilityCost,
+) -> AbilityCost {
     match cost {
         AbilityCost::Mana { cost: mana } => AbilityCost::Mana {
             cost: resolve_keyword_mana_cost(state, source_id, mana),
@@ -265,6 +265,15 @@ pub(crate) fn resolve_self_mana_in_ability_cost(
                 .map(|sub| resolve_self_mana_in_ability_cost(state, source_id, sub))
                 .collect(),
         },
+        AbilityCost::PerCounter {
+            counter,
+            target,
+            base,
+        } => AbilityCost::PerCounter {
+            counter: counter.clone(),
+            target: target.clone(),
+            base: Box::new(resolve_self_mana_in_ability_cost(state, source_id, base)),
+        },
         other => other.clone(),
     }
 }
@@ -276,10 +285,8 @@ pub(crate) fn resolve_self_mana_in_ability_cost(
 pub(crate) fn concretize_encore_mana_value_in_ability_cost(
     state: &GameState,
     source_id: ObjectId,
-    cost: &mut crate::types::ability::AbilityCost,
+    cost: &mut AbilityCost,
 ) {
-    use crate::game::casting_costs::cost_has_x;
-    use crate::types::ability::AbilityCost;
     match cost {
         AbilityCost::Mana { cost: mana } if cost_has_x(mana) => {
             let mana_value = state
@@ -293,6 +300,9 @@ pub(crate) fn concretize_encore_mana_value_in_ability_cost(
             for sub in costs {
                 concretize_encore_mana_value_in_ability_cost(state, source_id, sub);
             }
+        }
+        AbilityCost::PerCounter { base, .. } => {
+            concretize_encore_mana_value_in_ability_cost(state, source_id, base);
         }
         _ => {}
     }
@@ -972,6 +982,106 @@ mod tests {
         obj.keywords.push(Keyword::Flying);
         assert!(has_keyword(&obj, &Keyword::Flying));
         assert!(!has_keyword(&obj, &Keyword::Haste));
+    }
+
+    #[test]
+    fn resolve_self_mana_in_ability_cost_descends_per_counter_base() {
+        use crate::game::zones::create_object;
+        use crate::types::ability::TargetFilter;
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(1);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.mana_cost = ManaCost::Cost {
+                generic: 0,
+                shards: vec![
+                    ManaCostShard::White,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Black,
+                    ManaCostShard::Red,
+                    ManaCostShard::Green,
+                ],
+            };
+        }
+
+        let cost = AbilityCost::PerCounter {
+            counter: CounterType::Generic("charge".to_string()),
+            target: TargetFilter::SelfRef,
+            base: Box::new(AbilityCost::Mana {
+                cost: ManaCost::SelfManaValue,
+            }),
+        };
+
+        let resolved = resolve_self_mana_in_ability_cost(&state, source, &cost);
+        let AbilityCost::PerCounter { base, .. } = resolved else {
+            panic!("expected PerCounter wrapper preserved");
+        };
+        assert_eq!(
+            *base,
+            AbilityCost::Mana {
+                cost: ManaCost::generic(5),
+            }
+        );
+    }
+
+    #[test]
+    fn concretize_encore_mana_value_descends_per_counter_base() {
+        use crate::game::zones::create_object;
+        use crate::types::ability::TargetFilter;
+        use crate::types::counter::CounterType;
+
+        let mut state = GameState::new_two_player(1);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.mana_cost = ManaCost::Cost {
+                generic: 0,
+                shards: vec![
+                    ManaCostShard::White,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Black,
+                    ManaCostShard::Red,
+                    ManaCostShard::Green,
+                ],
+            };
+        }
+
+        let mut cost = AbilityCost::PerCounter {
+            counter: CounterType::Generic("charge".to_string()),
+            target: TargetFilter::SelfRef,
+            base: Box::new(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    generic: 0,
+                    shards: vec![ManaCostShard::X],
+                },
+            }),
+        };
+
+        concretize_encore_mana_value_in_ability_cost(&state, source, &mut cost);
+
+        let AbilityCost::PerCounter { base, .. } = cost else {
+            panic!("expected PerCounter wrapper preserved");
+        };
+        assert_eq!(
+            *base,
+            AbilityCost::Mana {
+                cost: ManaCost::generic(5),
+            }
+        );
     }
 
     /// CR 702.164b: a creature's total toxic value is the sum of N over ALL its

--- a/crates/engine/tests/integration/issue_3997_sliver_gravemother_encore_legion.rs
+++ b/crates/engine/tests/integration/issue_3997_sliver_gravemother_encore_legion.rs
@@ -1,0 +1,145 @@
+//! Regression for GitHub issue #3997 — Sliver Gravemother grants encore equal to
+//! each Sliver's mana value; activating Sliver Legion's encore must cost {5}
+//! generic mana, must not offer ChooseX at 0, and must be unpayable without
+//! sufficient mana.
+//!
+//! https://github.com/phase-rs/phase/issues/3997
+
+use engine::game::casting::{
+    activated_ability_definitions, can_activate_ability_now, handle_activate_ability,
+};
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{AbilityCost, Effect};
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const GRAVEMOTHER_ORACLE: &str = "The \"legend rule\" doesn't apply to Slivers you control.\n\
+Each Sliver creature card in your graveyard has encore {X}, where X is its mana value.\n\
+Encore {5} ({5}, Exile this card from your graveyard: For each opponent, create a token copy that attacks that opponent this turn if able. They gain haste. Sacrifice them at the beginning of the next end step. Activate only as a sorcery.)";
+
+fn legion_mana_cost() -> ManaCost {
+    ManaCost::Cost {
+        generic: 0,
+        shards: vec![
+            ManaCostShard::White,
+            ManaCostShard::Blue,
+            ManaCostShard::Black,
+            ManaCostShard::Red,
+            ManaCostShard::Green,
+        ],
+    }
+}
+
+fn colorless_mana(count: usize) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn encore_ability_index(state: &engine::types::game_state::GameState, source: ObjectId) -> usize {
+    activated_ability_definitions(state, source)
+        .into_iter()
+        .find(|(_, ability)| matches!(&*ability.effect, Effect::Encore))
+        .map(|(index, _)| index)
+        .expect("granted encore ability")
+}
+
+#[test]
+fn sliver_legion_encore_costs_mana_value_not_choose_x() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Sliver Gravemother", 6, 6, GRAVEMOTHER_ORACLE);
+
+    let legion_id = scenario
+        .add_creature_to_graveyard(P0, "Sliver Legion", 7, 7)
+        .with_mana_cost(legion_mana_cost())
+        .with_subtypes(vec!["Sliver"])
+        .id();
+
+    scenario.with_mana_pool(P0, colorless_mana(5));
+
+    let runner = scenario.build();
+    let encore_idx = encore_ability_index(runner.state(), legion_id);
+
+    let abilities = activated_ability_definitions(runner.state(), legion_id);
+    let (_, encore) = abilities
+        .iter()
+        .find(|(_, ability)| matches!(&*ability.effect, Effect::Encore))
+        .expect("granted encore");
+    let Some(AbilityCost::Composite { costs }) = &encore.cost else {
+        panic!("encore cost must be composite, got {:?}", encore.cost);
+    };
+    assert!(
+        costs
+            .iter()
+            .any(|c| { matches!(c, AbilityCost::Mana { cost } if *cost == ManaCost::generic(5)) }),
+        "encore mana sub-cost must equal Legion's mana value (5), got {costs:?}"
+    );
+
+    assert!(
+        can_activate_ability_now(runner.state(), P0, legion_id, encore_idx),
+        "encore must be legal with five mana available"
+    );
+
+    let mut state = runner.state().clone();
+    let waiting = handle_activate_ability(
+        &mut state,
+        P0,
+        legion_id,
+        encore_idx,
+        &mut Vec::<GameEvent>::new(),
+    )
+    .expect("activate encore");
+
+    assert!(
+        !matches!(waiting, WaitingFor::ChooseXValue { .. }),
+        "encore bound to mana value must not enter ChooseXValue, got {waiting:?}"
+    );
+}
+
+#[test]
+fn sliver_legion_encore_unpayable_without_mana_value_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Sliver Gravemother", 6, 6, GRAVEMOTHER_ORACLE);
+
+    let legion_id = scenario
+        .add_creature_to_graveyard(P0, "Sliver Legion", 7, 7)
+        .with_mana_cost(legion_mana_cost())
+        .with_subtypes(vec!["Sliver"])
+        .id();
+
+    let runner = scenario.build();
+    let encore_idx = encore_ability_index(runner.state(), legion_id);
+
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, legion_id, encore_idx),
+        "encore must be illegal without mana to pay Legion's mana value"
+    );
+}
+
+#[test]
+fn sliver_legion_encore_illegal_with_partial_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Sliver Gravemother", 6, 6, GRAVEMOTHER_ORACLE);
+
+    let legion_id = scenario
+        .add_creature_to_graveyard(P0, "Sliver Legion", 7, 7)
+        .with_mana_cost(legion_mana_cost())
+        .with_subtypes(vec!["Sliver"])
+        .id();
+
+    scenario.with_mana_pool(P0, colorless_mana(4));
+
+    let runner = scenario.build();
+    let encore_idx = encore_ability_index(runner.state(), legion_id);
+
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, legion_id, encore_idx),
+        "encore must be illegal when the player cannot pay the full mana value"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -345,6 +345,7 @@ mod issue_3991_carnage_interpreter;
 mod issue_3992_lotleth_regenerate_combat;
 mod issue_3994_malevolent_rumble;
 mod issue_3996_return_the_favor;
+mod issue_3997_sliver_gravemother_encore_legion;
 mod issue_3998_marang_river_prowler;
 mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;


### PR DESCRIPTION
## Summary

- Fixes [issue #3997](https://github.com/phase-rs/phase/issues/3997): while controlling Sliver Gravemother, the AI could Encore Sliver Legion (MV=5) with X=0 or otherwise pay less than the required mana.
- Concretizes `SelfManaCost` / `SelfManaValue` placeholders and bound `{X}` encore costs at **activation fetch time**, before legality checks, ChooseX, and payment.
- Adds integration regression tests for Sliver Legion encore costing `{5}`, skipping `ChooseXValue`, and rejecting activation when mana is insufficient.

## Problem

Sliver Gravemother grants each Sliver creature card in your graveyard encore `{X}`, where X is its mana value (CR 702.141a + CR 202.3). Two gaps let activation proceed for free or at X=0:

1. **Unresolved self-referential placeholders** — the mana payment path treats `ManaCost::SelfManaCost` / `SelfManaValue` as free (`can_pay_for_spell` / `pay_cost_with_demand_and_choices`).
2. **Literal `{X}` entering ChooseX** — if the synthesized cost still carries a symbolic `{X}` shard, activation detours to `ChooseXValue` with min=0. Encore's effect does not reference X, so the AI's `XValuePolicy` leaves X=0 as the default.

Prior work in #3655 / #4062 fixed parsing and runtime synthesis, but activation still fetched costs that could reach payment/ChooseX unresolved.

## Fix

**`activation_ability_definition`** (single fetch authority for legality + activation) now:

1. **`resolve_self_mana_in_ability_cost`** — recursively resolves `SelfManaCost` / `SelfManaValue` anywhere in the activated ability cost tree against the source object.
2. **`concretize_encore_mana_value_in_ability_cost`** — for `Effect::Encore`, if the cost still has `{X}`, concretizes it to the source card's mana value so Encore never enters `ChooseXValue` with a choosable zero.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/game/keywords.rs` | Add `resolve_self_mana_in_ability_cost` and `concretize_encore_mana_value_in_ability_cost` |
| `crates/engine/src/game/casting.rs` | Wire both resolvers in `activation_ability_definition` |
| `crates/engine/tests/integration/issue_3997_sliver_gravemother_encore_legion.rs` | Regression: MV=5 encore costs `{5}`, no ChooseX, illegal without full mana |
| `crates/engine/tests/integration/main.rs` | Register new test module |

## Test plan

- [x] `cargo test -p engine issue_3997_sliver_gravemother_encore_legion`
- [x] `cargo test -p engine issue_3655_sliver_gravemother_encore` (existing #3655 coverage)
- [ ] Manual: Sliver Gravemother on battlefield, Sliver Legion in graveyard — Encore should cost `{5}` and be unpayable without five mana; AI should not offer X=0
