### PR TITLE
Fix/issue 3987 jace split graveyard face choice

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1604,18 +1604,48 @@ fn exile_alt_cost_permission_grants_to_player(
     }
 }
 
+/// CR 601.2a + CR 118.9: Whether an `ExileWithAltCost` permission carries the
+/// casting card's own printed mana cost (Jace −3 class) rather than a fixed
+/// alternate cost or a free-cast zero.
+fn exile_alt_cost_permission_uses_casting_cards_mana_cost(
+    permission_cost: &ManaCost,
+    obj: &crate::game::game_object::GameObject,
+) -> bool {
+    match permission_cost {
+        ManaCost::SelfManaCost => true,
+        cost if cost.is_without_paying_mana() => false,
+        cost => {
+            if *cost == obj.mana_cost {
+                return true;
+            }
+            obj.back_face
+                .as_ref()
+                .is_some_and(|bf| *cost == bf.mana_cost)
+        }
+    }
+}
+
 /// CR 709.3 + CR 712.11b + CR 601.2a: `CastFromZone` and similar grants stamp
 /// `ExileWithAltCost { cost: obj.mana_cost }` when the card is permitted to be
 /// cast for its normal mana cost. Split cards and spell//spell MDFCs choose a
-/// face at cast time, so the payable cost is the active face's mana cost — not
-/// the front-face snapshot stored on the permission (#3987).
+/// face at cast time, so after face choice the payable cost is the active
+/// face's mana cost — not the front-face snapshot stored on the permission
+/// (#3987). Free-cast and fixed alternate costs must keep the stored permission
+/// cost (CR 118.9a).
 fn resolve_exile_with_alt_cost_permission_mana_cost(
     permission_cost: &ManaCost,
     obj: &crate::game::game_object::GameObject,
 ) -> ManaCost {
+    if permission_cost.is_without_paying_mana() {
+        return permission_cost.clone();
+    }
     match permission_cost {
         ManaCost::SelfManaCost => obj.mana_cost.clone(),
-        _ if obj.modal_back_face || cast_spell_face_choice_available(obj) => obj.mana_cost.clone(),
+        _ if obj.modal_back_face
+            && exile_alt_cost_permission_uses_casting_cards_mana_cost(permission_cost, obj) =>
+        {
+            obj.mana_cost.clone()
+        }
         other => other.clone(),
     }
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1593,6 +1593,33 @@ fn exile_alt_cost_permission_grants_to_player(
     }
 }
 
+/// CR 709.3 + CR 712.11b + CR 601.2a: `CastFromZone` and similar grants stamp
+/// `ExileWithAltCost { cost: obj.mana_cost }` when the card is permitted to be
+/// cast for its normal mana cost. Split cards and spell//spell MDFCs choose a
+/// face at cast time, so the payable cost is the active face's mana cost — not
+/// the front-face snapshot stored on the permission (#3987).
+fn resolve_exile_with_alt_cost_permission_mana_cost(
+    permission_cost: &ManaCost,
+    obj: &crate::game::game_object::GameObject,
+) -> ManaCost {
+    match permission_cost {
+        ManaCost::SelfManaCost => obj.mana_cost.clone(),
+        _ if obj.modal_back_face || cast_spell_face_choice_available(obj) => obj.mana_cost.clone(),
+        other => other.clone(),
+    }
+}
+
+fn simulate_chosen_split_spell_back_face(obj: &mut crate::game::game_object::GameObject) {
+    swap_to_alternative_spell_face(obj);
+    // Mirror `ChooseModalFace { back_face: true }` so affordability preview and
+    // alt-cost resolution use the chosen face without re-prompting or swapping
+    // back to the front half (#3987).
+    obj.modal_back_face = true;
+    if let Some(ref mut bf) = obj.back_face {
+        bf.layout_kind = None;
+    }
+}
+
 pub(super) fn exile_alt_cost_permission_supports_cast(
     state: &GameState,
     obj: &crate::game::game_object::GameObject,
@@ -3766,7 +3793,7 @@ fn prepare_spell_cast_with_variant_override_inner(
                 crate::types::ability::CastingPermission::ExileWithAltCost { cost, .. }
                     if exile_alt_cost_permission_supports_cast(state, obj, player, p, None) =>
                 {
-                    Some(cost.clone())
+                    Some(resolve_exile_with_alt_cost_permission_mana_cost(cost, obj))
                 }
                 crate::types::ability::CastingPermission::Foretold { cost, .. } => {
                     Some(cost.clone())
@@ -6030,6 +6057,21 @@ fn cast_face_choice_offered_from_zone(
         || (state.format_config.command_zone && obj.zone == Zone::Command && obj.is_commander)
 }
 
+/// CR 709.3 + CR 712.11b: Spell//spell split cards and spell//spell MDFCs need a
+/// cast-time face choice from any zone that permits casting the card, not only
+/// hand or command (#3987 — Life // Death from graveyard via Jace, Telepath
+/// Unbound).
+fn cast_spell_face_choice_offered_from_zone(
+    state: &GameState,
+    obj: &crate::game::game_object::GameObject,
+) -> bool {
+    if !cast_spell_face_choice_available(obj) {
+        return false;
+    }
+    cast_face_choice_offered_from_zone(state, obj)
+        || matches!(obj.zone, Zone::Graveyard | Zone::Exile)
+}
+
 fn casting_variant_for_alternative_spell(layout: LayoutKind) -> CastingVariant {
     match layout {
         LayoutKind::Adventure => CastingVariant::Adventure,
@@ -8023,7 +8065,7 @@ pub fn handle_cast_spell_with_payment_mode(
     // re-enters this function; the swap clears the back face's Modal
     // `layout_kind`, so the re-entry casts the chosen face without re-prompting.
     if let Some(obj) = state.objects.get(&object_id) {
-        if cast_face_choice_offered_from_zone(state, obj) && cast_spell_face_choice_available(obj) {
+        if cast_spell_face_choice_offered_from_zone(state, obj) {
             return Ok(WaitingFor::ModalFaceChoice {
                 player,
                 object_id,
@@ -10008,6 +10050,19 @@ pub fn can_cast_object_now(state: &GameState, player: PlayerId, object_id: Objec
                     return can_cast_prepared_now(&sim, player, &prepared);
                 }
             }
+            // CR 709.3 + CR 712.11b: Spell//spell split cards and spell//spell
+            // MDFCs may be castable via the other face even when prepare fails
+            // on the current face — e.g. a graveyard permission cast of Life //
+            // Death when only Death is affordable (#3987).
+            if cast_spell_face_choice_available(obj)
+                && cast_spell_face_choice_offered_from_zone(state, obj)
+            {
+                let mut sim = state.clone();
+                if let Some(sim_obj) = sim.objects.get_mut(&object_id) {
+                    simulate_chosen_split_spell_back_face(sim_obj);
+                }
+                return can_cast_object_now(&sim, player, object_id);
+            }
         }
         let choices = casting_variant_choice_set(state, player, object_id);
         return !choices.options.is_empty();
@@ -10347,13 +10402,13 @@ fn can_cast_prepared_now(
     // (Esika, God of the Tree needs {1}{G}{G}) while the back face is castable
     // (The Prismatic Bridge needs {W}{U}{B}{R}{G}); the card is still legally
     // castable and will prompt ModalFaceChoice (CR 712.11b). Mirror the Adventure
-    // recursion: swap to the back face and re-test. `swap_to_alternative_spell_face`
-    // clears the back face's `layout_kind`, so the recursive call does not
+    // recursion: swap to the back face and re-test. `simulate_chosen_split_spell_back_face`
+    // clears the stashed face's `layout_kind`, so the recursive call does not
     // re-enter this branch (no infinite recursion).
     if cast_spell_face_choice_available(obj) {
         let mut sim = state.clone();
         if let Some(sim_obj) = sim.objects.get_mut(&prepared.object_id) {
-            swap_to_alternative_spell_face(sim_obj);
+            simulate_chosen_split_spell_back_face(sim_obj);
         }
         return can_cast_object_now(&sim, player, prepared.object_id);
     }

--- a/crates/engine/tests/integration/issue_3987_jace_life_death_split_graveyard_cast.rs
+++ b/crates/engine/tests/integration/issue_3987_jace_life_death_split_graveyard_cast.rs
@@ -7,7 +7,7 @@
 use engine::game::scenario::{GameScenario, P0};
 use engine::game::scenario_db::GameScenarioDbExt;
 use engine::types::ability::{CastingPermission, Duration};
-use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
@@ -68,6 +68,58 @@ fn graveyard_split_card_cast_offers_face_choice_for_affordable_half() {
         .map(|e| &commit.state().objects[&e.source_id]);
     let Some(spell) = stack_spell else {
         panic!("Death half should reach the stack after graveyard face choice");
+    };
+    assert_eq!(spell.name, "Death");
+}
+
+#[test]
+fn exiled_split_card_free_cast_permission_stays_free_after_face_choice() {
+    let Some(db) = shared_card_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let life = scenario.add_real_card(P0, "Life", Zone::Exile, db);
+    let creature_in_gy = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    {
+        let obj = runner.state_mut().objects.get_mut(&life).unwrap();
+        obj.casting_permissions
+            .push(CastingPermission::ExileWithAltCost {
+                cost: ManaCost::zero(),
+                cast_transformed: false,
+                constraint: None,
+                granted_to: Some(P0),
+                resolution_cleanup: None,
+                duration: None,
+                exile_instead_of_graveyard_on_resolve: false,
+                enters_with_counter: None,
+            });
+    }
+
+    assert!(
+        engine::game::casting::can_cast_object_now(runner.state(), P0, life),
+        "free-cast split card must stay castable with no mana in pool"
+    );
+
+    let commit = runner
+        .cast(life)
+        .modal_back_face(true)
+        .target_object(creature_in_gy)
+        .commit();
+
+    let stack_spell = commit
+        .state()
+        .stack
+        .last()
+        .map(|e| &commit.state().objects[&e.source_id]);
+    let Some(spell) = stack_spell else {
+        panic!("Death half should reach the stack via a free exile permission");
     };
     assert_eq!(spell.name, "Death");
 }

--- a/crates/engine/tests/integration/issue_3987_jace_life_death_split_graveyard_cast.rs
+++ b/crates/engine/tests/integration/issue_3987_jace_life_death_split_graveyard_cast.rs
@@ -1,0 +1,73 @@
+//! Regression for GitHub issue #3987 — Jace, Telepath Unbound's −3 targets a
+//! split card in the graveyard; casting it must offer ModalFaceChoice so the
+//! controller can cast the affordable half (Life // Death → Death).
+//!
+//! https://github.com/phase-rs/phase/issues/3987
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::{CastingPermission, Duration};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db;
+
+#[test]
+fn graveyard_split_card_cast_offers_face_choice_for_affordable_half() {
+    let Some(db) = shared_card_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let life = scenario.add_real_card(P0, "Life", Zone::Graveyard, db);
+    let creature_in_gy = scenario.add_real_card(P0, "Grizzly Bears", Zone::Graveyard, db);
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, life, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, life, false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    {
+        let obj = runner.state_mut().objects.get_mut(&life).unwrap();
+        obj.casting_permissions
+            .push(CastingPermission::ExileWithAltCost {
+                cost: obj.mana_cost.clone(),
+                cast_transformed: false,
+                constraint: None,
+                granted_to: Some(P0),
+                resolution_cleanup: None,
+                duration: Some(Duration::UntilEndOfTurn),
+                exile_instead_of_graveyard_on_resolve: true,
+                enters_with_counter: None,
+            });
+    }
+
+    assert!(
+        engine::game::casting::can_cast_object_now(runner.state(), P0, life),
+        "Death half must be castable from graveyard when only {{1}}{{B}} is affordable"
+    );
+
+    let commit = runner
+        .cast(life)
+        .modal_back_face(true)
+        .target_object(creature_in_gy)
+        .commit();
+
+    let stack_spell = commit
+        .state()
+        .stack
+        .last()
+        .map(|e| &commit.state().objects[&e.source_id]);
+    let Some(spell) = stack_spell else {
+        panic!("Death half should reach the stack after graveyard face choice");
+    };
+    assert_eq!(spell.name, "Death");
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -340,6 +340,7 @@ mod issue_3876_gadrak_treasure_count;
 mod issue_3878_go_shintai_combat_damage;
 mod issue_3881_feed_swarm_darksteel_mutation;
 mod issue_3883_kari_zev_ragavan;
+mod issue_3987_jace_life_death_split_graveyard_cast;
 mod issue_3988_vaultborn_tyrant;
 mod issue_3989_bloodchiefs_thirst;
 mod issue_3991_carnage_interpreter;


### PR DESCRIPTION
# Fix split-card graveyard casts skipping face choice (#3987)

## Summary

- Fixes [issue #3987](https://github.com/phase-rs/phase/issues/3987): Jace, Telepath Unbound's −3 targeting Life // Death in the graveyard failed to offer a split face choice, so the engine tried to cast the unaffordable front half (Life) instead of Death.
- Extends split/MDFC `ModalFaceChoice` to **graveyard and exile** cast paths (not only hand/command).
- Resolves graveyard `ExileWithAltCost` permissions against the **active face's** mana cost and mirrors `ChooseModalFace` in affordability preview so legal actions agree with the cast pipeline.
- Adds an integration regression test simulating Jace's grant on Life // Death in the graveyard.

## Problem

Split cards and spell//spell MDFCs require a cast-time face choice (CR 709.3 / CR 712.11b). Two engine gaps blocked the Jace −3 flow:

1. **Face-choice gate was hand/command-only** — `handle_cast_spell_with_payment_mode` offered `ModalFaceChoice` only when `cast_face_choice_offered_from_zone` matched hand or commander, so graveyard/exile permission casts (Jace's `CastFromZone` grant) skipped face choice entirely.
2. **Permission cost pinned to front face** — `CastFromZone` stamps `ExileWithAltCost { cost: obj.mana_cost }` at grant time. For Life // Death that is Life's `{3}{W}{W}`; after choosing Death, payment and `can_cast_object_now` still evaluated the front-face snapshot. Affordability preview also ping-ponged between halves because it did not mirror `ChooseModalFace` (`modal_back_face` + clearing `layout_kind`).

## Fix

**`casting.rs`**

1. **`cast_spell_face_choice_offered_from_zone`** — offer split/MDFC face choice from graveyard and exile when casting is permitted from those zones.
2. **`resolve_exile_with_alt_cost_permission_mana_cost`** — use the active face's mana cost for split/MDFC cards (and `SelfManaCost`) when resolving `ExileWithAltCost` during `prepare_spell_cast`.
3. **`simulate_chosen_split_spell_back_face`** — shared helper for affordability preview: swap to back face, set `modal_back_face`, clear stashed `layout_kind` (same as real `ChooseModalFace`).
4. **`can_cast_object_now` / `can_cast_prepared_now`** — use the helper when evaluating the alternate split half from non-hand zones or when the front face is unaffordable.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/game/casting.rs` | Graveyard/exile split face choice, permission cost resolution, affordability preview |
| `crates/engine/tests/integration/issue_3987_jace_life_death_split_graveyard_cast.rs` | Regression: Life // Death in GY with Jace-style grant, only `{1}{B}` available, casts Death |
| `crates/engine/tests/integration/main.rs` | Register new test module |

## Test plan

- [x] `cargo test -p engine graveyard_split_card_cast_offers_face_choice`
- [x] `cargo test -p engine life_death` (existing #3287 split-card coverage)
- [ ] Manual: Jace, Telepath Unbound −3 targeting Life // Death in graveyard with only `{1}{B}` — should prompt face choice and allow casting Death