### PR TITLE
Defer Birthing Ritual DigChoice until sacrificed creature sets MV bound.

### DIFF
--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -1,8 +1,10 @@
-use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::filter::{
+    matches_target_filter, target_filter_uses_unresolved_resolution_referent, FilterContext,
+};
 use crate::game::quantity::resolve_quantity_with_targets;
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter};
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{GameState, PendingDeferredDigChoice, WaitingFor};
 use crate::types::zones::Zone;
 
 /// CR 701.20e + CR 608.2c: Look at top N cards (shown only to the looking player),
@@ -129,6 +131,31 @@ pub fn resolve(
         });
     }
 
+    // CR 608.2c + CR 701.21a (Birthing Ritual, issue #4271): When the keep-
+    // selection filter references an object from a later instruction ("where X
+    // is 1 plus the sacrificed creature's mana value"), peek at the pile now but
+    // defer `DigChoice` until that referent is stamped onto the resolving ability.
+    if target_filter_uses_unresolved_resolution_referent(&filter, ability) {
+        state.private_look_ids = cards.clone();
+        state.private_look_player = Some(ability.controller);
+        state.pending_deferred_dig_choice = Some(PendingDeferredDigChoice {
+            ability: ability.clone(),
+            library_owner,
+            cards: cards.clone(),
+            keep_count: raw_keep_count,
+            up_to: is_up_to,
+            filter: filter.clone(),
+            kept_destination: kept_dest,
+            rest_destination: rest_dest,
+            enter_tapped,
+        });
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::from(&ability.effect),
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     // Pre-compute selectable cards by evaluating the filter against each card.
     // CR 107.3a + CR 601.2b: Use ability context so dynamic thresholds (e.g.
     // `CmcLE { Variable("X") }`) resolve against the caster's announced X.
@@ -192,6 +219,91 @@ pub fn resolve(
         source_id: ability.source_id,
     });
 
+    Ok(())
+}
+
+/// CR 608.2c + CR 701.21a: After the sacrificed creature referent exists, surface
+/// the deferred `DigChoice` with a recomputed selectable pile.
+pub fn try_begin_pending_deferred_dig_choice(
+    state: &mut GameState,
+    ability: Option<&ResolvedAbility>,
+    referent: Option<&crate::types::ability::CostPaidObjectSnapshot>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Some(mut pending) = state.pending_deferred_dig_choice.take() else {
+        return Ok(());
+    };
+
+    if let Some(snapshot) = referent.or_else(|| {
+        ability
+            .and_then(|a| a.effect_context_object.as_ref())
+            .or_else(|| ability.and_then(|a| a.cost_paid_object.as_ref()))
+    }) {
+        pending
+            .ability
+            .set_effect_context_object_recursive(snapshot.clone());
+    } else {
+        state.pending_deferred_dig_choice = Some(pending);
+        return Ok(());
+    }
+
+    let selectable_cards = if matches!(pending.filter, TargetFilter::Any) {
+        pending.cards.clone()
+    } else {
+        let ctx = FilterContext::from_ability(&pending.ability);
+        pending
+            .cards
+            .iter()
+            .filter(|&&card_id| matches_target_filter(state, card_id, &pending.filter, &ctx))
+            .copied()
+            .collect()
+    };
+
+    let keep_count = if pending.keep_count == u32::MAX as usize {
+        selectable_cards.len()
+    } else {
+        pending.keep_count.min(selectable_cards.len())
+    };
+
+    state.waiting_for = WaitingFor::DigChoice {
+        player: pending.ability.controller,
+        library_owner: pending.library_owner,
+        selectable_cards,
+        cards: pending.cards,
+        keep_count,
+        up_to: pending.up_to,
+        kept_destination: pending.kept_destination,
+        rest_destination: pending.rest_destination,
+        source_id: Some(pending.ability.source_id),
+        enter_tapped: pending.enter_tapped,
+    };
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Dig,
+        source_id: pending.ability.source_id,
+    });
+    Ok(())
+}
+
+/// CR 608.2c + CR 701.20a: When the deferred put-step's gate fails (optional
+/// sacrifice declined, or no creature sacrificed), route the entire looked-at
+/// pile to the rest destination without surfacing `DigChoice`.
+pub fn resolve_pending_deferred_dig_rest_only(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Some(pending) = state.pending_deferred_dig_choice.take() else {
+        return Ok(());
+    };
+
+    crate::game::engine_resolution_choices::route_rest_partition(
+        state,
+        &pending.cards,
+        pending.rest_destination.unwrap_or(Zone::Library),
+        events,
+    );
+    state.private_look_ids.clear();
+    state.private_look_player = None;
     Ok(())
 }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1757,6 +1757,11 @@ pub(super) fn resolve_optional_effect_decision(
             }
         }
         AutoMayChoice::Decline => {
+            if state.pending_deferred_dig_choice.is_some()
+                && matches!(ability.effect, Effect::Sacrifice { .. })
+            {
+                dig::resolve_pending_deferred_dig_rest_only(state, events)?;
+            }
             let decline_branch = ability.else_ability.as_ref().or_else(|| {
                 ability.sub_ability.as_ref().filter(|sub| {
                     // CR 608.2c: a conditioned decline branch (IfYouDo /
@@ -4575,6 +4580,7 @@ pub fn resolve_ability_chain(
         // decision (which re-enters at depth 1) preserves the peek it depends on.
         state.private_look_ids.clear();
         state.private_look_player = None;
+        state.pending_deferred_dig_choice = None;
         state.last_zone_changed_ids.clear();
         // CR 608.2c + CR 701.38: Per-resolution ballot ledger; populated by
         // `vote::resolve_tally` and read by `PlayerFilter::VotedFor`. Clear
@@ -5923,6 +5929,15 @@ fn resolve_chain_body(
         publish_tracked_set_with_causes(state, affected_with_causes);
     }
 
+    if matches!(ability.effect, Effect::Sacrifice { .. })
+        && state.pending_deferred_dig_choice.is_some()
+        && events[events_before..]
+            .iter()
+            .any(|event| matches!(event, GameEvent::PermanentSacrificed { .. }))
+    {
+        dig::try_begin_pending_deferred_dig_choice(state, Some(ability), None, events)?;
+    }
+
     // ExileFromTopUntil handles its own sub_ability chain internally for both
     // `UntilCondition` arms — `NextMatches` injects the hit card as the
     // sub-ability's target; `CumulativeThreshold` runs the sub-chain with the
@@ -6206,7 +6221,30 @@ fn resolve_chain_body(
             }
 
             let condition_met = evaluate_condition(condition, state, ability);
+            if condition_met {
+                if state.pending_deferred_dig_choice.is_some()
+                    && matches!(
+                        condition,
+                        AbilityCondition::EffectOutcome {
+                            signal: EffectOutcomeSignal::OptionalEffectPerformed,
+                        }
+                    )
+                {
+                    dig::try_begin_pending_deferred_dig_choice(state, Some(ability), None, events)?;
+                    return Ok(());
+                }
+            }
             if !condition_met {
+                if state.pending_deferred_dig_choice.is_some()
+                    && matches!(
+                        condition,
+                        AbilityCondition::EffectOutcome {
+                            signal: EffectOutcomeSignal::OptionalEffectPerformed,
+                        }
+                    )
+                {
+                    dig::resolve_pending_deferred_dig_rest_only(state, events)?;
+                }
                 // CR 608.2c: Execute else branch if present ("Otherwise, [effect]")
                 if let Some(ref else_branch) = sub.else_ability {
                     let mut else_resolved = else_branch.as_ref().clone();

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2700,6 +2700,12 @@ pub(super) fn handle_resolution_choice(
                 // Issue #423 audit: no cards chosen — this branch moves no
                 // objects and emits no battlefield-exit events, so no
                 // dies-trigger collection is needed.
+                if matches!(effect_kind, EffectKind::Sacrifice)
+                    && state.pending_deferred_dig_choice.is_some()
+                {
+                    effects::dig::resolve_pending_deferred_dig_rest_only(state, events)
+                        .map_err(|err| EngineError::InvalidAction(err.to_string()))?;
+                }
                 state.last_effect_count = Some(0);
                 events.push(GameEvent::EffectResolved {
                     kind: effect_kind,
@@ -3146,6 +3152,19 @@ pub(super) fn handle_resolution_choice(
                 if let Some(cont) = state.pending_continuation.as_mut() {
                     cont.chain.set_effect_context_object_recursive(snapshot);
                 }
+            }
+            if matches!(effect_kind, EffectKind::Sacrifice) && !chosen.is_empty() {
+                let referent = effects::parent_referent_context_from_events(
+                    state,
+                    &events[events_before_effect..],
+                );
+                effects::dig::try_begin_pending_deferred_dig_choice(
+                    state,
+                    None,
+                    referent.as_ref(),
+                    events,
+                )
+                .map_err(|err| EngineError::InvalidAction(err.to_string()))?;
             }
             if matches!(
                 effect_kind,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::game::combat;
 use crate::game::game_object::GameObject;
+use crate::game::quantity::quantity_expr_uses_resolution_only_object_scope;
 use crate::game::quantity::{
     counter_count_from_map, resolve_quantity, resolve_quantity_with_targets,
 };
@@ -493,6 +494,50 @@ pub fn normalize_contextual_filter(
                 .collect(),
         },
         _ => filter.clone(),
+    }
+}
+
+/// CR 608.2c + CR 608.2k: True when a filter threshold reads an object
+/// characteristic through a resolution-only scope (`CostPaidObject`, anaphoric
+/// demonstrative, etc.) and the resolving ability does not yet carry that
+/// referent. Birthing Ritual's Dig must peek at the looked-at pile now but defer
+/// `DigChoice` until a later sacrifice clause stamps `effect_context_object`.
+pub(crate) fn target_filter_uses_unresolved_resolution_referent(
+    filter: &TargetFilter,
+    ability: &ResolvedAbility,
+) -> bool {
+    if ability.cost_paid_object.is_some() || ability.effect_context_object.is_some() {
+        return false;
+    }
+    filter_uses_unresolved_resolution_referent(filter)
+}
+
+fn filter_uses_unresolved_resolution_referent(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(filter_prop_uses_unresolved_resolution_referent),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => filters
+            .iter()
+            .any(filter_uses_unresolved_resolution_referent),
+        TargetFilter::Not { filter } => filter_uses_unresolved_resolution_referent(filter),
+        _ => false,
+    }
+}
+
+fn filter_prop_uses_unresolved_resolution_referent(prop: &FilterProp) -> bool {
+    match prop {
+        FilterProp::Cmc { value, .. }
+        | FilterProp::PtComparison { value, .. }
+        | FilterProp::Counters { count: value, .. } => {
+            quantity_expr_uses_resolution_only_object_scope(value)
+        }
+        FilterProp::AnyOf { props } => props
+            .iter()
+            .any(filter_prop_uses_unresolved_resolution_referent),
+        FilterProp::Not { prop } => filter_prop_uses_unresolved_resolution_referent(prop),
+        _ => false,
     }
 }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -892,6 +892,22 @@ impl PendingContinuation {
     }
 }
 
+/// CR 608.2c + CR 701.21a: Stashed `DigChoice` state when a looked-at pile's
+/// filter references an object introduced by a later instruction in the same
+/// resolution (Birthing Ritual: mana value bound uses the sacrificed creature).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingDeferredDigChoice {
+    pub ability: ResolvedAbility,
+    pub library_owner: PlayerId,
+    pub cards: Vec<ObjectId>,
+    pub keep_count: usize,
+    pub up_to: bool,
+    pub filter: TargetFilter,
+    pub kept_destination: Option<Zone>,
+    pub rest_destination: Option<Zone>,
+    pub enter_tapped: bool,
+}
+
 /// CR 609.3 + CR 109.5: Resume state for a `repeat_for` iteration loop paused
 /// when the inner effect entered an interactive `WaitingFor` state.
 ///
@@ -6570,6 +6586,12 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub private_look_player: Option<PlayerId>,
 
+    /// CR 608.2c + CR 701.21a: A Dig whose keep-selection filter references an
+    /// object from a later clause in the same resolution (Birthing Ritual). The
+    /// look happens now; `DigChoice` is deferred until that referent exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_deferred_dig_choice: Option<PendingDeferredDigChoice>,
+
     /// ObjectIds of objects moved by the most recent zone-change effect.
     /// Used by AbilityCondition::ZoneChangedThisWay to gate sub_abilities on
     /// whether the parent effect moved an object matching a type filter.
@@ -7409,6 +7431,7 @@ impl GameState {
             last_revealed_ids: Vec::new(),
             private_look_ids: Vec::new(),
             private_look_player: None,
+            pending_deferred_dig_choice: None,
             last_zone_changed_ids: Vec::new(),
             last_vote_ballots: im::Vector::new(),
             player_actions_this_way: HashSet::new(),
@@ -7875,6 +7898,7 @@ impl PartialEq for GameState {
             && self.last_revealed_ids == other.last_revealed_ids
             && self.private_look_ids == other.private_look_ids
             && self.private_look_player == other.private_look_player
+            && self.pending_deferred_dig_choice == other.pending_deferred_dig_choice
             && self.last_zone_changed_ids == other.last_zone_changed_ids
             && self.last_vote_ballots == other.last_vote_ballots
             && self.player_actions_this_way == other.player_actions_this_way

--- a/crates/engine/tests/integration/issue_4271_birthing_ritual_mana_value.rs
+++ b/crates/engine/tests/integration/issue_4271_birthing_ritual_mana_value.rs
@@ -1,0 +1,148 @@
+//! Issue #4271 — Birthing Ritual must defer the looked-at pile's mana-value filter
+//! until after the player sacrifices a creature, so X resolves to (sacrificed MV + 1)
+//! rather than defaulting to 1.
+//!
+//! https://github.com/phase-rs/phase/issues/4271
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{StackEntryKind, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const BIRTHING_RITUAL_ORACLE: &str = "At the beginning of your end step, if you control a creature, look at the top seven cards of your library. Then you may sacrifice a creature. If you do, you may put a creature card with mana value X or less from among those cards onto the battlefield, where X is 1 plus the sacrificed creature's mana value. Put the rest on the bottom of your library in a random order.";
+
+fn reach_end_step_trigger_on_stack(
+    runner: &mut GameRunner,
+    ritual: engine::types::identifiers::ObjectId,
+) {
+    runner.advance_to_end_step();
+    for _ in 0..48 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare empty attackers");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::Priority { .. }
+                if runner.state().stack.iter().any(|entry| {
+                    matches!(
+                        &entry.kind,
+                        StackEntryKind::TriggeredAbility { source_id, .. } if *source_id == ritual
+                    )
+                }) =>
+            {
+                return;
+            }
+            WaitingFor::Priority { .. } => runner.pass_both_players(),
+            _ if runner.state().phase == Phase::End => return,
+            _ => runner.pass_both_players(),
+        }
+    }
+}
+
+fn seed_library_creature(
+    scenario: &mut GameScenario,
+    name: &str,
+) -> engine::types::identifiers::ObjectId {
+    scenario.add_card_to_library_top(P0, name)
+}
+
+fn mark_library_creature(
+    runner: &mut GameRunner,
+    id: engine::types::identifiers::ObjectId,
+    mana_value: u32,
+) {
+    let obj = runner
+        .state_mut()
+        .objects
+        .get_mut(&id)
+        .expect("library card");
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.mana_cost = ManaCost::generic(mana_value);
+}
+
+#[test]
+fn birthing_ritual_dig_choice_respects_sacrificed_creature_mana_value() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ritual = scenario
+        .add_creature(P0, "Birthing Ritual", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(BIRTHING_RITUAL_ORACLE)
+        .id();
+
+    let sacrifice_target = scenario
+        .add_creature(P0, "Grizzly Bears", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let _other_creature = scenario.add_creature(P0, "Elvish Mystic", 1, 1).id();
+
+    let mv3 = seed_library_creature(&mut scenario, "Three Drop");
+    let mv5 = seed_library_creature(&mut scenario, "Five Drop");
+    for i in 0..5 {
+        scenario.add_card_to_library_top(P0, &format!("Filler {i}"));
+    }
+
+    let mut runner = scenario.build();
+    mark_library_creature(&mut runner, mv3, 3);
+    mark_library_creature(&mut runner, mv5, 5);
+    reach_end_step_trigger_on_stack(&mut runner, ritual);
+
+    runner.pass_both_players();
+    runner.advance_until_stack_empty();
+
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+    ) {
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("accept optional sacrifice");
+    }
+
+    let WaitingFor::EffectZoneChoice { cards, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "expected EffectZoneChoice to sacrifice a creature, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&sacrifice_target),
+        "Grizzly Bears must be eligible to sacrifice"
+    );
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![sacrifice_target],
+        })
+        .expect("sacrifice Grizzly Bears");
+
+    let WaitingFor::DigChoice {
+        selectable_cards, ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "expected DigChoice after sacrifice (MV 2 + 1 = 3 bound), got {:?}",
+            runner.state().waiting_for
+        );
+    };
+
+    assert!(
+        selectable_cards.contains(&mv3),
+        "MV 3 creature must be selectable when sacrificing MV 2 (bound = 3); got {selectable_cards:?}"
+    );
+    assert!(
+        !selectable_cards.contains(&mv5),
+        "MV 5 creature must NOT be selectable when bound is 3; got {selectable_cards:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -354,6 +354,7 @@ mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
+mod issue_4271_birthing_ritual_mana_value;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary

Fixes [issue #4271](https://github.com/phase-rs/phase/issues/4271): Birthing Ritual's end-step ability now lets you put a creature whose mana value is at most **1 + the sacrificed creature's mana value** onto the battlefield from among the cards you looked at, instead of incorrectly capping the choice at mana value 1.

The parser already assembled the correct `Dig` filter (`Cmc <= Offset(ObjectManaValue { CostPaidObject }, +1)`). The bug was runtime ordering: `DigChoice` fired immediately after the look, before the optional sacrifice, so `CostPaidObject` had no referent and the bound resolved to `0 + 1 = 1`.

## Changes

- **Filter helper:** `target_filter_uses_unresolved_resolution_referent` detects when a dig filter's threshold reads a resolution-only object scope before that referent exists.
- **Deferred dig:** `Effect::Dig` with such a filter peeks privately (`private_look_ids`) and stashes `pending_deferred_dig_choice` instead of raising `DigChoice`.
- **Resume:** After a successful sacrifice (or when the "if you do" gate passes), `try_begin_pending_deferred_dig_choice` recomputes `selectable_cards` with the sacrificed creature's LKI. On decline / failed gate, `resolve_pending_deferred_dig_rest_only` puts the looked-at pile on the bottom.
- **Tests:** Integration regression `birthing_ritual_dig_choice_respects_sacrificed_creature_mana_value`; existing parser/runtime Birthing Ritual tests unchanged.

## Test plan

- [x] `cargo test -p engine birthing_ritual_dig_choice_respects_sacrificed_creature_mana_value`
- [x] `cargo test -p engine birthing_ritual_runtime_dig_filter_respects_sacrificed_creature_mana_value`
- [x] `cargo test -p engine birthing_ritual_assembles_dig_battlefield_sacrifice_chain`
- [x] `cargo fmt --all` + clippy green
