### PR TITLE
feat: manual mana payment UX — tap sources, pip selection, live cost + draggable modals

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1878,6 +1878,16 @@ export interface DerivedViews {
    * `engine::game::derived_views::DerivedViews::player_status`.
    */
   player_status?: PlayerStatusView[];
+  /**
+   * CR 118.3a + CR 601.2g: during the viewing player's own manual mana payment
+   * for a spell, the portion of the locked cost still UNPAID by the pool units
+   * they have pinned (selected). The payment UI renders this as the cost shrinks
+   * while the player picks mana; an empty/`NoCost` value means their selection
+   * alone covers the whole cost. Omitted outside a non-convoke spell payment the
+   * viewer controls. Mirrors
+   * `engine::game::derived_views::DerivedViews::pending_payment_remaining`.
+   */
+  pending_payment_remaining?: ManaCost;
 }
 
 /** Mirrors `engine::types::game_state::NextSpellModifier` (serde tag="type"). */

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -421,6 +421,9 @@ export type ManaSpellGrant =
 export interface ManaUnit {
   color: ManaType;
   source_id: ObjectId;
+  // CR 118.3a: stable per-unit id used to pin which pool unit pays a cost.
+  // `0` is the unstamped sentinel (convoke markers / detached preview pools).
+  pip_id: number;
   snow: boolean;
   restrictions: ManaRestriction[];
   // `#[serde(default, skip_serializing_if = "Vec::is_empty")]` — absent when empty.
@@ -1017,6 +1020,9 @@ export interface PendingCast {
   activation_cost?: SerializedAbilityCost;
   activation_ability_index?: number;
   target_constraints?: Array<{ type: string }>;
+  // CR 118.3a: pip ids the caster pinned to direct payment. `#[serde(default,
+  // skip_serializing_if = "Vec::is_empty")]` — absent when no pin is recorded.
+  pinned_pool_units?: number[];
 }
 
 export interface TargetSelectionSlot {
@@ -1558,6 +1564,9 @@ export type GameAction =
   | { type: "ReorderHand"; data: { order: ObjectId[] } }
   | { type: "TapLandForMana"; data: { object_id: ObjectId } }
   | { type: "UntapLandForMana"; data: { object_id: ObjectId } }
+  // CR 118.3a: pin / unpin a specific pool unit during manual mana payment.
+  | { type: "SpendPoolMana"; data: { pip_id: number } }
+  | { type: "UnspendPoolMana"; data: { pip_id: number } }
   | { type: "TapForConvoke"; data: { object_id: ObjectId; mana_type: ManaType } }
   | { type: "SelectCards"; data: { cards: ObjectId[] } }
   | { type: "SelectCoinFlips"; data: { keep_indices: number[] } }

--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../viewmodel/gameStateView.ts";
 import { BoardInteractionContext } from "./BoardInteractionContext.tsx";
 import { CombatLine } from "./CombatLine.tsx";
+import { ManualManaToggle } from "./ManualManaToggle.tsx";
 import { PlayerArea } from "./PlayerArea.tsx";
 import { DraggableWidget } from "../flexlayout/DraggableWidget.tsx";
 
@@ -245,6 +246,17 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
     </button>
   ) : null;
 
+  // Land-column stack: the per-game "Manual mana" toggle above the undo button.
+  // `landColumnExtra` is an absolutely-positioned single-child overlay that
+  // stacks upward from `bottom-0` (see PlayerArea), where the undo button's
+  // `mt-auto` is inert — so use an explicit `gap-1` flex column for spacing.
+  const landColumnExtra = (
+    <div className="flex flex-col items-center gap-1">
+      <ManualManaToggle />
+      {undoButton}
+    </div>
+  );
+
   return (
     <BoardInteractionContext.Provider value={boardInteractionState}>
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
@@ -297,7 +309,7 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
           battlefieldView={playerBattlefieldView}
           playerId={myId}
           mode="full"
-          landColumnExtra={undoButton}
+          landColumnExtra={landColumnExtra}
           creatureOverride={sortedPlayerCreatures}
           hud={playerHud}
         />

--- a/client/src/components/board/ManualManaToggle.tsx
+++ b/client/src/components/board/ManualManaToggle.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "react-i18next";
+
+import { useUiStore } from "../../stores/uiStore.ts";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+
+/**
+ * Thin pill that forces Manual mana payment for the current game only. Toggles
+ * the ephemeral `manualManaOverride` in uiStore (reset on every game boundary by
+ * `clearPromptOverlayState`) — it never touches the persisted `spellPaymentMode`
+ * preference. Pure display + dispatch leaf; rendered in the local player's land
+ * column beside the undo button.
+ */
+export function ManualManaToggle() {
+  const { t } = useTranslation("game");
+  const manualManaOverride = useUiStore((s) => s.manualManaOverride);
+  const toggleManualMana = useUiStore((s) => s.toggleManualManaOverride);
+
+  return (
+    <button
+      type="button"
+      onClick={toggleManualMana}
+      aria-pressed={manualManaOverride}
+      className={`group relative inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+        manualManaOverride
+          ? "bg-cyan-500/20 text-cyan-200 ring-1 ring-cyan-400/40"
+          : "bg-gray-800/80 text-gray-400 hover:bg-gray-700/80 hover:text-gray-200"
+      }`}
+    >
+      {t("mana.manualMana")}
+      <GameplayTooltip>{t("mana.manualManaTooltip")}</GameplayTooltip>
+    </button>
+  );
+}

--- a/client/src/components/hud/ManaPoolSummary.tsx
+++ b/client/src/components/hud/ManaPoolSummary.tsx
@@ -1,12 +1,8 @@
 import { useTranslation } from "react-i18next";
 
-import type {
-  ManaRestriction,
-  ManaSpellGrant,
-  ManaType,
-  ManaUnit,
-} from "../../adapter/types.ts";
+import type { ManaType, ManaUnit } from "../../adapter/types.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { groupManaPoolUnits, manaGroupTooltip } from "../../viewmodel/manaPoolGroups.ts";
 
 const EMPTY_MANA: ManaUnit[] = [];
 
@@ -19,62 +15,6 @@ const MANA_COLORS: Record<ManaType, string> = {
   Colorless: "bg-slate-300 text-slate-800 ring-1 ring-white/20 shadow-[0_0_0_1px_rgba(255,255,255,0.06)]",
 };
 
-const MANA_ORDER: ManaType[] = ["White", "Blue", "Black", "Red", "Green", "Colorless"];
-
-// Discriminant key of a `ManaRestriction` — the bare string for unit variants,
-// or the single object key for data variants. Keyed exhaustively below so
-// TypeScript enforces completeness when a new restriction variant is added.
-type ManaRestrictionTag =
-  | "OnlyForSpellType"
-  | "OnlyForCreatureType"
-  | "OnlyForTypeSpellsOrAbilities"
-  | "OnlyForSpellWithKeywordKind"
-  | "OnlyForSpellWithKeywordKindFromZone"
-  | "OnlyForActivation"
-  | "OnlyForXCosts"
-  | "ConvokePayment";
-
-// i18n key (under the `manaPool` group) per restriction variant. Exhaustive
-// `Record` — adding a `ManaRestriction` variant without a tooltip key here is a
-// type error.
-const RESTRICTION_LABEL_KEYS: Record<ManaRestrictionTag, string> = {
-  OnlyForSpellType: "manaPool.onlyForSpellType",
-  OnlyForCreatureType: "manaPool.onlyForCreatureType",
-  OnlyForTypeSpellsOrAbilities: "manaPool.onlyForTypeSpellsOrAbilities",
-  OnlyForSpellWithKeywordKind: "manaPool.onlyForSpellWithKeywordKind",
-  OnlyForSpellWithKeywordKindFromZone: "manaPool.onlyForSpellWithKeywordKindFromZone",
-  OnlyForActivation: "manaPool.onlyForActivation",
-  OnlyForXCosts: "manaPool.onlyForXCosts",
-  ConvokePayment: "manaPool.convokePayment",
-};
-
-function restrictionTag(restriction: ManaRestriction): ManaRestrictionTag {
-  return (
-    typeof restriction === "string"
-      ? restriction
-      : (Object.keys(restriction)[0] as ManaRestrictionTag)
-  );
-}
-
-// Canonical, payload-inclusive string for a restriction — so "Legendary-only
-// green" and "Creature-only green" hash to distinct group keys.
-function canonRestriction(restriction: ManaRestriction): string {
-  return typeof restriction === "string"
-    ? restriction
-    : JSON.stringify(restriction);
-}
-
-function canonGrant(grant: ManaSpellGrant): string {
-  return typeof grant === "string" ? grant : JSON.stringify(grant);
-}
-
-interface ManaGroup {
-  color: ManaType;
-  restrictions: ManaRestriction[];
-  grants: ManaSpellGrant[];
-  count: number;
-}
-
 interface ManaPoolSummaryProps {
   playerId: number;
   size?: "default" | "sm";
@@ -86,59 +26,26 @@ export function ManaPoolSummary({ playerId, size = "default" }: ManaPoolSummaryP
     (s) => s.gameState?.players[playerId]?.mana_pool.mana ?? EMPTY_MANA,
   );
 
-  // Group by a deterministic composite key (color, restrictions, grants) so
-  // distinctly-restricted mana of the same color renders as separate pills.
-  const groups = new Map<string, ManaGroup>();
-  for (const unit of manaUnits) {
-    if (unit.restrictions.includes("ConvokePayment")) continue;
-    const restrictions = unit.restrictions;
-    const grants = unit.grants ?? [];
-    const key = JSON.stringify([
-      unit.color,
-      [...restrictions].map(canonRestriction).sort(),
-      [...grants].map(canonGrant).sort(),
-    ]);
-    const existing = groups.get(key);
-    if (existing) {
-      existing.count += 1;
-    } else {
-      groups.set(key, { color: unit.color, restrictions, grants, count: 1 });
-    }
-  }
-
-  // Stable display order: by color, plain (unrestricted) groups before
-  // restricted/granting ones of the same color.
-  const entries = [...groups.values()].sort((a, b) => {
-    const colorDelta =
-      MANA_ORDER.indexOf(a.color) - MANA_ORDER.indexOf(b.color);
-    if (colorDelta !== 0) return colorDelta;
-    const aSpecial = a.restrictions.length > 0 || a.grants.length > 0 ? 1 : 0;
-    const bSpecial = b.restrictions.length > 0 || b.grants.length > 0 ? 1 : 0;
-    return aSpecial - bSpecial;
-  });
+  // Group fungible units (color, restrictions, grants) so distinctly-restricted
+  // mana of the same color renders as separate pills (shared with the payment UI).
+  const entries = groupManaPoolUnits(manaUnits);
 
   if (entries.length === 0) return null;
 
   return (
     <div className={`flex items-center ${size === "sm" ? "gap-0.5" : "gap-1"}`}>
       {entries.map((group, index) => {
-        const special =
-          group.restrictions.length > 0 || group.grants.length > 0;
-        const tooltipParts = group.restrictions.map(
-          (r) => t(RESTRICTION_LABEL_KEYS[restrictionTag(r)]),
-        );
-        if (group.grants.length > 0) tooltipParts.push(t("manaPool.grantsProperty"));
-        const title = special ? tooltipParts.join("; ") : undefined;
+        const title = manaGroupTooltip((k) => t(k), group);
         return (
           <span
             key={index}
             title={title}
             className={`relative inline-flex items-center justify-center rounded-full font-bold tabular-nums ${size === "sm" ? "h-5 min-w-5 px-1 text-[10px]" : "h-6 min-w-6 px-1.5 text-[11px]"} ${MANA_COLORS[group.color]} ${
-              special ? "ring-2 ring-dashed ring-white/70" : ""
+              group.special ? "ring-2 ring-dashed ring-white/70" : ""
             }`}
           >
-            {group.count}
-            {special && (
+            {group.pipIds.length}
+            {group.special && (
               <span
                 aria-hidden
                 className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-white/90 ring-1 ring-slate-900/40"

--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -20,6 +20,12 @@ import { PeekTab } from "../modal/DialogShell.tsx";
 import { useOptionalDialogPeek } from "../modal/dialogPeekContext.ts";
 import { ManaBadge } from "./ManaBadge.tsx";
 import { ManaSymbol } from "./ManaSymbol.tsx";
+import {
+  canonGrant,
+  canonRestriction,
+  manaGroupTooltip,
+} from "../../viewmodel/manaPoolGroups.ts";
+import type { ManaRestriction, ManaSpellGrant } from "../../adapter/types.ts";
 
 const MANA_ORDER: ManaType[] = ["White", "Blue", "Black", "Red", "Green", "Colorless"];
 
@@ -146,18 +152,56 @@ export function ManaPaymentUI() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [costShards, isPhyrexianPayment]);
 
-  // Summarize mana pool by color
-  const manaPoolSummary = useMemo(() => {
-    if (!player) return [];
-    const counts: Record<ManaType, number> = {
-      White: 0, Blue: 0, Black: 0, Red: 0, Green: 0, Colorless: 0,
-    };
+  // CR 118.3a: spendable pool units grouped by (color, restrictions, grants,
+  // source). Each group renders as one `N×{symbol}` chip labelled with its
+  // source permanent, so a large pool stays compact and rules-relevant mana
+  // (Delighted Halfling / Cavern of Souls — distinct grants AND a named source)
+  // is its own directable chip. Convoke markers are excluded (not spendable).
+  // The frontend resolves the source NAME for display only; it computes no
+  // eligibility — the engine accepts or rejects each pin.
+  const paymentGroups = useMemo<PaymentGroup[]>(() => {
+    if (!player || !gameState) return [];
+    const groups = new Map<string, PaymentGroup>();
     for (const unit of player.mana_pool.mana) {
       if (unit.restrictions.includes("ConvokePayment")) continue;
-      counts[unit.color]++;
+      const grants = unit.grants ?? [];
+      const sourceName = gameState.objects[unit.source_id]?.name ?? null;
+      const key = JSON.stringify([
+        unit.color,
+        [...unit.restrictions].map(canonRestriction).sort(),
+        [...grants].map(canonGrant).sort(),
+        sourceName,
+      ]);
+      const existing = groups.get(key);
+      if (existing) {
+        existing.pipIds.push(unit.pip_id);
+      } else {
+        groups.set(key, {
+          key,
+          color: unit.color,
+          restrictions: unit.restrictions,
+          grants,
+          special: unit.restrictions.length > 0 || grants.length > 0,
+          sourceName,
+          pipIds: [unit.pip_id],
+        });
+      }
     }
-    return MANA_ORDER.filter((c) => counts[c] > 0).map((c) => ({ color: c, amount: counts[c] }));
-  }, [player]);
+    return [...groups.values()].sort((a, b) => {
+      const colorDelta = MANA_ORDER.indexOf(a.color) - MANA_ORDER.indexOf(b.color);
+      if (colorDelta !== 0) return colorDelta;
+      return (a.special ? 1 : 0) - (b.special ? 1 : 0);
+    });
+  }, [player, gameState]);
+
+  // CR 118.3a + CR 601.2g: engine-computed cost still unpaid by the units the
+  // player has selected so far (`null` when not exposed — e.g. ambiguous/
+  // activation/Phyrexian). The frontend never computes this — it renders the
+  // engine's residual so the cost visibly shrinks as mana is picked.
+  const remainingShards = useMemo(() => {
+    const remaining = gameState?.derived?.pending_payment_remaining;
+    return remaining ? manaCostToShards(remaining) : null;
+  }, [gameState]);
 
   // CR 118.3a: the engine records player-directed pins on `pending_cast`.
   // The frontend is a pure mirror — it renders the engine's pin set and the
@@ -168,24 +212,24 @@ export function ManaPaymentUI() {
     [gameState],
   );
 
-  // One entry per individual (non-convoke) pool unit, keyed by its stable
-  // `pip_id`. Convoke markers are excluded for the same reason as the summary.
-  const pinnableUnits = useMemo(() => {
-    if (!player) return [];
-    return player.mana_pool.mana.filter(
-      (unit) => !unit.restrictions.includes("ConvokePayment"),
-    );
-  }, [player]);
-
-  const togglePin = useCallback(
-    (pipId: number) => {
-      if (pinnedPipIds.has(pipId)) {
-        dispatch({ type: "UnspendPoolMana", data: { pip_id: pipId } });
-      } else {
+  const pinUnit = useCallback(
+    (pipId: number) => dispatch({ type: "SpendPoolMana", data: { pip_id: pipId } }),
+    [dispatch],
+  );
+  const unpinUnit = useCallback(
+    (pipId: number) => dispatch({ type: "UnspendPoolMana", data: { pip_id: pipId } }),
+    [dispatch],
+  );
+  // Shift / fill: pin several units of one group at once. Over-pinning is safe —
+  // the engine spends pinned units first only up to the cost (CR 118.3a), so any
+  // extra pinned mana simply stays in the pool at finalize.
+  const pinPips = useCallback(
+    (pipIds: number[]) => {
+      for (const pipId of pipIds) {
         dispatch({ type: "SpendPoolMana", data: { pip_id: pipId } });
       }
     },
-    [dispatch, pinnedPipIds],
+    [dispatch],
   );
 
   // CR 702.51a / CR 702.126a: each creature/artifact tapped for convoke/improvise
@@ -312,11 +356,29 @@ export function ManaPaymentUI() {
 
           {costShards && (
             <>
-              {/* Cost display row */}
+              {/* Cost display row — for a plain (non-ambiguous) cost we show the
+                  cost STILL TO PAY after the player's current selection
+                  (engine-computed `pending_payment_remaining`), so it visibly
+                  shrinks as mana is picked and reads "covered" once the
+                  selection pays the whole cost. Ambiguous (hybrid/Phyrexian)
+                  costs keep the full-cost display because their per-shard
+                  toggles index the full shard list. */}
               <div className="mb-3 flex items-center justify-center gap-1.5">
-                {costShards.map((shard, idx) => (
-                  <ManaSymbol key={idx} shard={shard} size="lg" />
-                ))}
+                {!isAmbiguous && remainingShards != null ? (
+                  remainingShards.length > 0 ? (
+                    remainingShards.map((shard, idx) => (
+                      <ManaSymbol key={idx} shard={shard} size="lg" />
+                    ))
+                  ) : (
+                    <span className="text-sm font-semibold text-emerald-400">
+                      {t("mana.covered")}
+                    </span>
+                  )
+                ) : (
+                  costShards.map((shard, idx) => (
+                    <ManaSymbol key={idx} shard={shard} size="lg" />
+                  ))
+                )}
               </div>
 
               {convokeMode && (
@@ -465,46 +527,78 @@ export function ManaPaymentUI() {
             </p>
           )}
 
-          {/* Current mana pool — non-interactive color-grouped overview. */}
-          <div className="mb-3 flex items-center justify-center gap-2">
-            <span className="text-xs text-gray-500">{t("mana.poolLabel")}</span>
-            {manaPoolSummary.length > 0 ? (
-              manaPoolSummary.map(({ color, amount }) => (
-                <ManaBadge key={color} color={color} amount={amount} />
-              ))
-            ) : (
-              <span className="text-xs text-gray-600">{t("mana.poolEmpty")}</span>
+          {/* CR 118.3a: two-pile mana selection. Each fungible group renders as
+              one `N×{symbol}` chip (count + source permanent) so a large pool
+              stays compact. Tapping an AVAILABLE chip moves one unit to SPENDING
+              (shift-click moves all of that group); the engine spends pinned
+              units first, so a selection covering the cost pays with exactly
+              those units — and applies any rider they carry (Cavern of Souls /
+              Delighted Halfling "can't be countered"). Tapping a SPENDING chip
+              returns one. Phyrexian payment shows the pool read-only (no piles). */}
+          <div className="mb-3 space-y-2">
+            {paymentGroups.length === 0 && (
+              <div className="flex items-center justify-center gap-2">
+                <span className="text-xs text-gray-500">{t("mana.poolLabel")}</span>
+                <span className="text-xs text-gray-600">{t("mana.poolEmpty")}</span>
+              </div>
+            )}
+
+            {paymentGroups.length > 0 && !isManaPayment && (
+              <div className="flex flex-wrap items-center justify-center gap-1.5">
+                {paymentGroups.map((group) => (
+                  <ManaChip key={group.key} group={group} count={group.pipIds.length} />
+                ))}
+              </div>
+            )}
+
+            {paymentGroups.length > 0 && isManaPayment && (
+              <>
+                <div>
+                  <p className="mb-1 text-center text-[11px] text-gray-500">
+                    {t("mana.spendHint")}
+                    <span className="ml-1 text-gray-600">{t("mana.fillHint")}</span>
+                  </p>
+                  <div className="flex flex-wrap items-center justify-center gap-1.5">
+                    {paymentGroups.map((group) => {
+                      const ids = group.pipIds.filter((id) => !pinnedPipIds.has(id));
+                      if (ids.length === 0) return null;
+                      return (
+                        <ManaChip
+                          key={group.key}
+                          group={group}
+                          count={ids.length}
+                          onActivate={(fill) => (fill ? pinPips(ids) : pinUnit(ids[0]))}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {pinnedPipIds.size > 0 && (
+                  <div className="rounded-lg bg-cyan-500/5 px-2 py-1.5 ring-1 ring-cyan-400/20">
+                    <p className="mb-1 text-center text-[11px] text-cyan-300/80">
+                      {t("mana.spending")}
+                    </p>
+                    <div className="flex flex-wrap items-center justify-center gap-1.5">
+                      {paymentGroups.map((group) => {
+                        const ids = group.pipIds.filter((id) => pinnedPipIds.has(id));
+                        if (ids.length === 0) return null;
+                        return (
+                          <ManaChip
+                            key={group.key}
+                            group={group}
+                            count={ids.length}
+                            selected
+                            onActivate={() => unpinUnit(ids[ids.length - 1])}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
-
-          {/* CR 118.3a: interactive per-unit pin row. Clicking a pip pins it so
-              the engine prefers it when paying the cost; clicking a pinned pip
-              unpins it. The unit is never removed by pinning — the engine owns
-              the pin set and eligibility, so an ineligible pin is simply not
-              recorded (no client-side filtering). Shown only for manual mana
-              payment with a pending cast. */}
-          {isManaPayment && pinnableUnits.length > 0 && (
-            <div className="mb-3 flex flex-wrap items-center justify-center gap-1.5">
-              {pinnableUnits.map((unit, idx) => {
-                const pinned = pinnedPipIds.has(unit.pip_id);
-                return (
-                  <button
-                    key={unit.pip_id || `unstamped-${idx}`}
-                    onClick={() => togglePin(unit.pip_id)}
-                    aria-pressed={pinned}
-                    title={
-                      pinned ? t("mana.unpinUnit") : t("mana.pinUnit")
-                    }
-                    className={`rounded-full transition ${
-                      pinned ? "ring-2 ring-cyan-400" : "ring-1 ring-transparent hover:ring-gray-500"
-                    }`}
-                  >
-                    <ManaBadge color={unit.color} amount={1} />
-                  </button>
-                );
-              })}
-            </div>
-          )}
 
           {/* Confirm / Cancel buttons */}
           <div className="flex justify-center gap-3">
@@ -516,7 +610,7 @@ export function ManaPaymentUI() {
             </button>
             <button
               onClick={handleCancel}
-              className="rounded-lg bg-gray-700 px-4 py-1.5 text-sm font-semibold text-gray-200 transition hover:bg-gray-600"
+              className={gameButtonClass({ tone: "slate", size: "md" })}
             >
               {t("common:actions.cancel")}
             </button>
@@ -524,5 +618,98 @@ export function ManaPaymentUI() {
         </div>
       </motion.div>
     </AnimatePresence>
+  );
+}
+
+// Color → shard symbol code for `ManaSymbol` (White→"W", …, Colorless→"C").
+const COLOR_SHARD: Record<ManaType, string> = {
+  White: "W",
+  Blue: "U",
+  Black: "B",
+  Red: "R",
+  Green: "G",
+  Colorless: "C",
+};
+
+/**
+ * A run of fungible pool units the payment panel renders as one chip — same
+ * color, spend restrictions, spell grants, AND source permanent. `pipIds` holds
+ * the concrete unit ids (the pin targets); `sourceName` is resolved for display
+ * only. Grouping by source keeps a large pool compact while still giving
+ * rules-relevant mana (Delighted Halfling, Cavern of Souls) its own labeled chip.
+ */
+interface PaymentGroup {
+  key: string;
+  color: ManaType;
+  restrictions: ManaRestriction[];
+  grants: ManaSpellGrant[];
+  special: boolean;
+  sourceName: string | null;
+  pipIds: number[];
+}
+
+interface ManaChipProps {
+  group: PaymentGroup;
+  /** How many units of the group this chip represents (available or spending). */
+  count: number;
+  selected?: boolean;
+  /** Present → interactive. `fill` is true on shift-click (act on all, not one). */
+  onActivate?: (fill: boolean) => void;
+}
+
+/**
+ * CR 118.3a: one fungible group as `N×{symbol}` + source label. Clicking pins or
+ * returns a unit of the group; shift-click acts on all of it. The amber dot +
+ * tooltip surface any spend restriction / spell grant (e.g. "legendary-only;
+ * uncounterable") so the player can direct rider-bearing mana on purpose.
+ */
+function ManaChip({ group, count, selected = false, onActivate }: ManaChipProps) {
+  const { t } = useTranslation("game");
+  const tooltip = manaGroupTooltip((k) => t(k), group) ?? group.sourceName ?? undefined;
+
+  const ring = selected
+    ? "bg-cyan-400/15 ring-1 ring-cyan-400/60"
+    : "bg-white/5 ring-1 ring-white/10";
+
+  const inner = (
+    <>
+      <span className="text-[11px] font-bold tabular-nums text-gray-200">{count}×</span>
+      <span className="relative inline-flex">
+        <ManaSymbol shard={COLOR_SHARD[group.color]} size="md" />
+        {group.special && (
+          <span
+            aria-hidden
+            className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-amber-300 ring-1 ring-slate-900/60"
+          />
+        )}
+      </span>
+      {group.sourceName && (
+        <span className="max-w-[120px] truncate text-[10px] text-gray-400">
+          {group.sourceName}
+        </span>
+      )}
+    </>
+  );
+
+  const base = `inline-flex items-center gap-1 rounded-full px-2 py-1 ${ring}`;
+
+  if (!onActivate) {
+    return (
+      <span title={tooltip} className={base}>
+        {inner}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => onActivate(e.shiftKey)}
+      aria-pressed={selected}
+      title={tooltip}
+      className={`${base} transition hover:ring-gray-400`}
+    >
+      {inner}
+    </button>
   );
 }

--- a/client/src/components/mana/ManaPaymentUI.tsx
+++ b/client/src/components/mana/ManaPaymentUI.tsx
@@ -159,6 +159,35 @@ export function ManaPaymentUI() {
     return MANA_ORDER.filter((c) => counts[c] > 0).map((c) => ({ color: c, amount: counts[c] }));
   }, [player]);
 
+  // CR 118.3a: the engine records player-directed pins on `pending_cast`.
+  // The frontend is a pure mirror — it renders the engine's pin set and the
+  // individual pool units, and dispatches Spend/UnspendPoolMana on click. It
+  // computes no eligibility (the engine accepts or rejects each pin).
+  const pinnedPipIds = useMemo(
+    () => new Set(gameState?.pending_cast?.pinned_pool_units ?? []),
+    [gameState],
+  );
+
+  // One entry per individual (non-convoke) pool unit, keyed by its stable
+  // `pip_id`. Convoke markers are excluded for the same reason as the summary.
+  const pinnableUnits = useMemo(() => {
+    if (!player) return [];
+    return player.mana_pool.mana.filter(
+      (unit) => !unit.restrictions.includes("ConvokePayment"),
+    );
+  }, [player]);
+
+  const togglePin = useCallback(
+    (pipId: number) => {
+      if (pinnedPipIds.has(pipId)) {
+        dispatch({ type: "UnspendPoolMana", data: { pip_id: pipId } });
+      } else {
+        dispatch({ type: "SpendPoolMana", data: { pip_id: pipId } });
+      }
+    },
+    [dispatch, pinnedPipIds],
+  );
+
   // CR 702.51a / CR 702.126a: each creature/artifact tapped for convoke/improvise
   // adds a `ConvokePayment`-restricted marker to the pool (engine
   // `ManaUnit::convoke_payment`). These are deliberately excluded from
@@ -436,7 +465,7 @@ export function ManaPaymentUI() {
             </p>
           )}
 
-          {/* Current mana pool */}
+          {/* Current mana pool — non-interactive color-grouped overview. */}
           <div className="mb-3 flex items-center justify-center gap-2">
             <span className="text-xs text-gray-500">{t("mana.poolLabel")}</span>
             {manaPoolSummary.length > 0 ? (
@@ -447,6 +476,35 @@ export function ManaPaymentUI() {
               <span className="text-xs text-gray-600">{t("mana.poolEmpty")}</span>
             )}
           </div>
+
+          {/* CR 118.3a: interactive per-unit pin row. Clicking a pip pins it so
+              the engine prefers it when paying the cost; clicking a pinned pip
+              unpins it. The unit is never removed by pinning — the engine owns
+              the pin set and eligibility, so an ineligible pin is simply not
+              recorded (no client-side filtering). Shown only for manual mana
+              payment with a pending cast. */}
+          {isManaPayment && pinnableUnits.length > 0 && (
+            <div className="mb-3 flex flex-wrap items-center justify-center gap-1.5">
+              {pinnableUnits.map((unit, idx) => {
+                const pinned = pinnedPipIds.has(unit.pip_id);
+                return (
+                  <button
+                    key={unit.pip_id || `unstamped-${idx}`}
+                    onClick={() => togglePin(unit.pip_id)}
+                    aria-pressed={pinned}
+                    title={
+                      pinned ? t("mana.unpinUnit") : t("mana.pinUnit")
+                    }
+                    className={`rounded-full transition ${
+                      pinned ? "ring-2 ring-cyan-400" : "ring-1 ring-transparent hover:ring-gray-500"
+                    }`}
+                  >
+                    <ManaBadge color={unit.color} amount={1} />
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
           {/* Confirm / Cancel buttons */}
           <div className="flex justify-center gap-3">

--- a/client/src/components/modal/DialogHost.tsx
+++ b/client/src/components/modal/DialogHost.tsx
@@ -77,17 +77,18 @@ function isClickThroughDialog(
 ): boolean {
   if (!waitingFor) return false;
   if (isClickThroughWaitingFor(waitingFor, objects)) return true;
-  // CR 702.51a (Convoke) / CR 701.67a (Waterbend) / CR 702.126a (Improvise):
-  // these tap-payment modes let the caster tap creatures/artifacts on the
-  // battlefield to pay generic/colored mana while the `ManaPaymentUI` panel
-  // is open. The host still anchors the panel at `fixed inset-0 z-40` (so it
-  // can't be trapped beneath the board), but click-through marks it
-  // `pointer-events: none` so those board taps reach the cards — the panel's
-  // own controls re-enable events. Plain/hybrid/Phyrexian payment needs no
-  // board interaction (the panel's Pay button passes priority), so it keeps
-  // pointer events — `convoke_mode` is the engine's signal that board taps are
-  // live.
-  return waitingFor.type === "ManaPayment" && waitingFor.data.convoke_mode != null;
+  // Any `ManaPayment` panel is click-through. The host still anchors the panel
+  // at `fixed inset-0 z-40` (so it can't be trapped beneath the board), but
+  // click-through marks it `pointer-events: none` so board taps reach the
+  // battlefield — the panel's own controls re-enable events.
+  //
+  // Manual payment of plain/hybrid mana DOES need board interaction: the player
+  // taps their own lands and clicks mana-pool pips behind the panel to pay. (In
+  // auto mode an unambiguous cast finalizes before any panel is shown, so a
+  // `ManaPayment` WaitingFor only ever reaches the UI when board taps are live.)
+  // Convoke/improvise (CR 702.51a / CR 702.126a), which additionally tap
+  // creatures/artifacts, are a subset of this same click-through behavior.
+  return waitingFor.type === "ManaPayment";
 }
 
 export function DialogHost({ children }: { children: ReactNode }) {
@@ -142,15 +143,15 @@ export function DialogHost({ children }: { children: ReactNode }) {
   // Click-through is achieved with `pointer-events: none` (below), NOT by
   // un-anchoring, so board taps still reach the battlefield.
   const anchored = dialogVisible;
-  // The convoke/improvise payment panel is bottom-anchored and can overlap the
-  // very creatures the player must tap to pay. Unlike the translucent full-screen
-  // target overlays, it benefits from the peek/slide affordance so the player can
-  // collapse it off an overlapped creature — so it stays peekable even while
-  // click-through. Other click-through overlays (target picking) are translucent
-  // and full-screen, so they stay put and pass taps straight through.
-  const isConvokePayment =
-    waitingFor?.type === "ManaPayment" && waitingFor.data.convoke_mode != null;
-  const peekable = anchored && (!clickThrough || isConvokePayment);
+  // Any mana-payment panel is bottom-anchored and can overlap the very lands /
+  // creatures the player must tap to pay (manual mana, convoke, improvise). Unlike
+  // the translucent full-screen target overlays, it benefits from the peek/slide
+  // affordance so the player can collapse it off an overlapped permanent — so it
+  // stays peekable even while click-through. Other click-through overlays (target
+  // picking) are translucent and full-screen, so they stay put and pass taps
+  // straight through.
+  const isManaPayment = waitingFor?.type === "ManaPayment";
+  const peekable = anchored && (!clickThrough || isManaPayment);
   const showPeekTab = peeked && peekable;
 
   const ctxValue = useMemo<DialogPeekContext>(

--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -1,5 +1,5 @@
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { useEffect, type ReactNode } from "react";
+import { AnimatePresence, motion, useDragControls, useReducedMotion } from "framer-motion";
+import { useEffect, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ObjectId } from "../../adapter/types.ts";
@@ -47,6 +47,15 @@ export function DialogShell({
   const cardHoverProps =
     previewObjectId != null ? inspectHoverProps(previewObjectId) : undefined;
 
+  // Drag-to-reposition: the dialog can sit over board content the player needs
+  // to see (targets, the mana they're paying with). `dragListener={false}` +
+  // `dragControls` mean a drag only begins from the header handle, so clicks on
+  // body controls never start a drag. Constrained to the overlay so the card
+  // can't be flung off-screen. Position resets on each open (fresh mount).
+  const dragControls = useDragControls();
+  const constraintsRef = useRef<HTMLDivElement>(null);
+  const startHeaderDrag = (event: ReactPointerEvent) => dragControls.start(event);
+
   // Esc-to-close: standard modal contract. Only attach when the dialog is
   // dismissable (consumers like ChoiceOverlay that omit `onClose` have a
   // different dismissal model and shouldn't intercept Escape).
@@ -76,6 +85,7 @@ export function DialogShell({
   return (
     <AnimatePresence>
       <motion.div
+        ref={constraintsRef}
         className="fixed inset-0 z-50 flex items-center justify-center px-2 py-2 lg:px-4 lg:py-6"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -94,6 +104,12 @@ export function DialogShell({
           animate={{ scale: 1, opacity: 1, y: 0 }}
           exit={{ scale: 0.95, opacity: 0, y: 10 }}
           transition={{ duration: 0.2, ease: "easeOut" }}
+          drag
+          dragListener={false}
+          dragControls={dragControls}
+          dragMomentum={false}
+          dragElastic={0.05}
+          dragConstraints={constraintsRef}
         >
           <div {...cardHoverProps} className={cardClass}>
             <DialogHeader
@@ -101,6 +117,7 @@ export function DialogShell({
               eyebrowClassName={eyebrowClassName}
               title={title}
               subtitle={subtitle}
+              onHandlePointerDown={startHeaderDrag}
             />
             {onClose ? <CloseButton onClose={onClose} /> : null}
             {children}
@@ -122,6 +139,9 @@ interface DialogHeaderProps {
   eyebrowClassName?: string;
   title: ReactNode;
   subtitle?: ReactNode;
+  /** When provided, the header acts as the dialog's drag handle: pointer-down
+   * starts a drag via the shell's `dragControls`. Absent → static header. */
+  onHandlePointerDown?: (event: ReactPointerEvent) => void;
 }
 
 export function DialogHeader({
@@ -129,14 +149,24 @@ export function DialogHeader({
   eyebrowClassName,
   title,
   subtitle,
+  onHandlePointerDown,
 }: DialogHeaderProps) {
   const eyebrowClass = [
     "text-[0.68rem] uppercase tracking-[0.22em]",
     eyebrowClassName ?? "text-slate-500",
   ].join(" ");
 
+  // `touch-none` keeps a touch-drag on the handle from scrolling the page;
+  // `cursor-grab` signals the affordance. Only applied when draggable.
+  const handleClass = onHandlePointerDown
+    ? "cursor-grab touch-none select-none active:cursor-grabbing"
+    : "";
+
   return (
-    <div className="relative border-b border-white/10 px-3 py-3 lg:px-5 lg:py-5">
+    <div
+      onPointerDown={onHandlePointerDown}
+      className={`relative border-b border-white/10 px-3 py-3 lg:px-5 lg:py-5 ${handleClass}`}
+    >
       <div className={eyebrowClass}>{eyebrow}</div>
       <h2 className="mt-1 text-base font-semibold text-white lg:text-xl">
         {title}

--- a/client/src/components/modal/__tests__/DialogHost.test.tsx
+++ b/client/src/components/modal/__tests__/DialogHost.test.tsx
@@ -138,9 +138,12 @@ describe("DialogHost", () => {
     expect(wrapper?.style.pointerEvents).not.toBe("none");
   });
 
-  it("keeps the viewport wrapper for plain mana payment without convoke", () => {
-    // Plain payment is committed via the panel's Pay button (no board taps), so
-    // the host wraps normally — only `convoke_mode` payments go click-through.
+  it("anchors plain (manual) mana payment but leaves it click-through so board taps reach lands", () => {
+    // Manual payment of plain mana requires the player to tap their own lands and
+    // click mana-pool pips on the board BEHIND the panel. The host stays anchored
+    // at `fixed inset-0 z-40` (so the panel can't be trapped beneath the board) but
+    // goes click-through via `pointer-events: none` so those board taps land — even
+    // without `convoke_mode`. (Reverting Part A flips pointerEvents back to "" here.)
     setWaitingFor({
       type: "ManaPayment",
       data: { player: 0 },
@@ -152,6 +155,52 @@ describe("DialogHost", () => {
     );
     const wrapper = container.firstElementChild as HTMLElement | null;
     expect(wrapper?.className ?? "").toMatch(/fixed/);
+    expect(wrapper?.className ?? "").toMatch(/z-40/);
+    expect(wrapper?.style.pointerEvents).toBe("none");
+  });
+
+  it("keeps plain mana payment peekable so it can be slid off overlapped lands", () => {
+    // Any ManaPayment panel (manual plain, convoke, improvise) is bottom-anchored
+    // and can overlap the lands the player must tap — so it stays peekable even
+    // while click-through. Before Part A, a non-convoke ManaPayment was click-through
+    // but NOT peekable, so the peek tab never appeared here.
+    setWaitingFor({
+      type: "ManaPayment",
+      data: { player: 0 },
+    } as never);
+    render(
+      <DialogHost>
+        <DialogShell title="t">
+          <div />
+        </DialogShell>
+      </DialogHost>,
+    );
+    fireEvent.click(screen.getByLabelText("Move dialog out of the way"));
+    expect(screen.getByLabelText("Restore dialog")).toBeInTheDocument();
+  });
+
+  it("suppresses plain mana payment click-through while a UI dialog is open", () => {
+    // A UI dialog opened mid-payment (e.g. a mana-ability picker) renders inside the
+    // host; leaving the host click-through would make its buttons dead. So even for
+    // plain ManaPayment, an open `pendingAbilityChoice` restores host pointer events.
+    setWaitingFor({
+      type: "ManaPayment",
+      data: { player: 0 },
+    } as never);
+    useUiStore.setState({
+      pendingAbilityChoice: {
+        objectId: 7,
+        actions: [{ type: "TapForConvoke", data: { object_id: 7, mana_type: "Green" } }],
+      },
+    });
+    const { container } = render(
+      <DialogHost>
+        <div data-testid="child" />
+      </DialogHost>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper?.className ?? "").toMatch(/fixed/);
+    expect(wrapper?.style.pointerEvents).not.toBe("none");
   });
 
   it("anchors battlefield sacrifice choices but leaves them click-through", () => {

--- a/client/src/game/__tests__/castPaymentMode.test.ts
+++ b/client/src/game/__tests__/castPaymentMode.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { GameAction } from "../../adapter/types";
+import { applySpellPaymentPreference } from "../castPaymentMode";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { useUiStore } from "../../stores/uiStore";
+
+const castAction: GameAction = {
+  type: "CastSpell",
+  data: { object_id: 1 },
+} as GameAction;
+
+describe("applySpellPaymentPreference", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({ spellPaymentMode: "auto" });
+    useUiStore.setState({ manualManaOverride: false });
+  });
+
+  it("leaves the action unchanged when both the preference and override are off", () => {
+    const result = applySpellPaymentPreference(castAction);
+    expect(result).toBe(castAction);
+  });
+
+  it("stamps Manual when the persisted preference is manual", () => {
+    usePreferencesStore.setState({ spellPaymentMode: "manual" });
+    const result = applySpellPaymentPreference(castAction);
+    expect(result).not.toBe(castAction);
+    expect((result as Extract<GameAction, { type: "CastSpell" }>).data.payment_mode).toEqual({
+      type: "Manual",
+    });
+  });
+
+  it("stamps Manual when only the per-game override is on", () => {
+    useUiStore.setState({ manualManaOverride: true });
+    const result = applySpellPaymentPreference(castAction);
+    expect(result).not.toBe(castAction);
+    expect((result as Extract<GameAction, { type: "CastSpell" }>).data.payment_mode).toEqual({
+      type: "Manual",
+    });
+  });
+});

--- a/client/src/game/__tests__/sessionCleanup.test.ts
+++ b/client/src/game/__tests__/sessionCleanup.test.ts
@@ -11,6 +11,7 @@ describe("clearPromptOverlayState", () => {
     useUiStore.setState({
       pendingAbilityChoice: null,
       enchantmentsDialogPlayer: null,
+      manualManaOverride: false,
     });
   });
 
@@ -52,5 +53,13 @@ describe("clearPromptOverlayState", () => {
     expect(state.gameState).not.toBeNull();
     expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
     expect(useUiStore.getState().enchantmentsDialogPlayer).toBeNull();
+  });
+
+  it("resets the per-game manualManaOverride toggle so it can't leak across games", () => {
+    useUiStore.setState({ manualManaOverride: true });
+
+    clearPromptOverlayState();
+
+    expect(useUiStore.getState().manualManaOverride).toBe(false);
   });
 });

--- a/client/src/game/castPaymentMode.ts
+++ b/client/src/game/castPaymentMode.ts
@@ -1,10 +1,16 @@
 import type { CastPaymentMode, GameAction } from "../adapter/types";
 import { usePreferencesStore } from "../stores/preferencesStore";
+import { useUiStore } from "../stores/uiStore";
 
 const MANUAL_CAST_PAYMENT_MODE: CastPaymentMode = { type: "Manual" };
 
 export function applySpellPaymentPreference(action: GameAction): GameAction {
-  if (usePreferencesStore.getState().spellPaymentMode !== "manual") return action;
+  // Two intended sources of truth: the durable `spellPaymentMode` preference and
+  // the ephemeral per-game `manualManaOverride` toggle. Manual wins if EITHER is on.
+  const manual =
+    usePreferencesStore.getState().spellPaymentMode === "manual" ||
+    useUiStore.getState().manualManaOverride;
+  if (!manual) return action;
 
   switch (action.type) {
     case "CastSpell":

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -19,4 +19,6 @@ export function clearPromptOverlayState(): void {
   });
   useUiStore.getState().setPendingAbilityChoice(null);
   useUiStore.getState().setEnchantmentsDialogPlayer(null);
+  // The per-game "Manual mana" toggle must never leak into the next game.
+  useUiStore.getState().setManualManaOverride(false);
 }

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "Die Bezahlung steht noch aus. Tappe bleibende Karten oder brich diese Aktion ab.",
     "poolLabel": "Vorrat:",
     "poolEmpty": "Leer",
+    "pinUnit": "Dieses Mana zum Bezahlen vormerken",
+    "unpinUnit": "Mana-Vormerkung aufheben",
     "pay": "Bezahlen",
     "chooseAmountTitle": "Wähle die zu zahlende Menge",
     "chooseAmountAria": "Wähle die zu zahlende Menge",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "Energie",
     "resourceMana": "Mana",
     "resourceCounters": "Marken",
-    "resourceSpeed": "Tempo"
+    "resourceSpeed": "Tempo",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Volle Hand ansehen ({{count}} Karte)",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "Nur zum Aktivieren von Fähigkeiten ausgeben",
     "onlyForXCosts": "Nur für Kosten ausgeben, die {X} enthalten",
     "convokePayment": "Beschwörbeitrag-Bezahlung",
-    "grantsProperty": "Verleiht dem Zauberspruch eine Eigenschaft"
+    "grantsProperty": "Verleiht dem Zauberspruch eine Eigenschaft",
+    "grantCantBeCountered": "Für diesen Zauberspruch ausgeben, damit er nicht neutralisiert werden kann"
   },
   "zone": {
     "commandZone": "Kommandozone",
@@ -427,7 +428,11 @@
     "resourceCounters": "Marken",
     "resourceSpeed": "Tempo",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Klicke auf dein Mana, um es für diese Kosten einzusetzen",
+    "covered": "✓ Gedeckt",
+    "spending": "Wird ausgegeben",
+    "fillHint": "(Umschalt+Klick fügt alle einer Quelle hinzu)"
   },
   "hand": {
     "viewFullHand_one": "Volle Hand ansehen ({{count}} Karte)",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -445,6 +445,8 @@
     "paymentPending": "Payment is still pending. Tap permanents or cancel this action.",
     "poolLabel": "Pool:",
     "poolEmpty": "Empty",
+    "pinUnit": "Pin this mana to pay first",
+    "unpinUnit": "Unpin this mana",
     "pay": "Pay",
     "chooseAmountTitle": "Choose amount to pay",
     "chooseAmountAria": "Choose amount to pay",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -452,7 +452,9 @@
     "resourceEnergy": "energy",
     "resourceMana": "mana",
     "resourceCounters": "counters",
-    "resourceSpeed": "speed"
+    "resourceSpeed": "speed",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "View full hand ({{count}} card)",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -388,7 +388,8 @@
     "onlyForActivation": "Spend only to activate abilities",
     "onlyForXCosts": "Spend only on costs that include {X}",
     "convokePayment": "Convoke payment",
-    "grantsProperty": "Grants a property to the spell"
+    "grantsProperty": "Grants a property to the spell",
+    "grantCantBeCountered": "Spend on this spell to make it uncounterable"
   },
   "zone": {
     "commandZone": "Command Zone",
@@ -456,7 +457,11 @@
     "resourceCounters": "counters",
     "resourceSpeed": "speed",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Click your mana to spend it on this cost",
+    "covered": "✓ Covered",
+    "spending": "Spending",
+    "fillHint": "(shift-click to add all of one source)"
   },
   "hand": {
     "viewFullHand_one": "View full hand ({{count}} card)",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "Gastar solo para activar habilidades",
     "onlyForXCosts": "Gastar solo en costes que incluyan {X}",
     "convokePayment": "Pago de convocar",
-    "grantsProperty": "Otorga una propiedad al hechizo"
+    "grantsProperty": "Otorga una propiedad al hechizo",
+    "grantCantBeCountered": "Gástalo en este hechizo para que no se pueda contrarrestar"
   },
   "zone": {
     "commandZone": "Zona de mando",
@@ -427,7 +428,11 @@
     "resourceCounters": "contadores",
     "resourceSpeed": "velocidad",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Haz clic en tu maná para gastarlo en este coste",
+    "covered": "✓ Cubierto",
+    "spending": "Gastando",
+    "fillHint": "(mayús+clic para añadir todos de una fuente)"
   },
   "hand": {
     "viewFullHand_one": "Ver la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "energía",
     "resourceMana": "maná",
     "resourceCounters": "contadores",
-    "resourceSpeed": "velocidad"
+    "resourceSpeed": "velocidad",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Ver la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "El pago sigue pendiente. Gira permanentes o cancela esta acción.",
     "poolLabel": "Reserva:",
     "poolEmpty": "Vacía",
+    "pinUnit": "Fijar este maná para pagar primero",
+    "unpinUnit": "Quitar fijación de este maná",
     "pay": "Pagar",
     "chooseAmountTitle": "Elige la cantidad a pagar",
     "chooseAmountAria": "Elige la cantidad a pagar",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "À dépenser uniquement pour activer des capacités",
     "onlyForXCosts": "À dépenser uniquement pour des coûts incluant {X}",
     "convokePayment": "Paiement de la convocation",
-    "grantsProperty": "Accorde une propriété au sort"
+    "grantsProperty": "Accorde une propriété au sort",
+    "grantCantBeCountered": "À dépenser pour ce sort afin qu'il ne puisse pas être contrecarré"
   },
   "zone": {
     "commandZone": "Zone de commandement",
@@ -427,7 +428,11 @@
     "resourceCounters": "marqueurs",
     "resourceSpeed": "vitesse",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Cliquez sur votre mana pour le dépenser pour ce coût",
+    "covered": "✓ Couvert",
+    "spending": "Dépense",
+    "fillHint": "(maj+clic pour ajouter toute une source)"
   },
   "hand": {
     "viewFullHand_one": "Voir la main complète ({{count}} carte)",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "Le paiement est toujours en attente. Engagez des permanents ou annulez cette action.",
     "poolLabel": "Réserve :",
     "poolEmpty": "Vide",
+    "pinUnit": "Épingler ce mana pour payer en premier",
+    "unpinUnit": "Désépingler ce mana",
     "pay": "Payer",
     "chooseAmountTitle": "Choisissez la quantité à payer",
     "chooseAmountAria": "Choisir la quantité à payer",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "énergie",
     "resourceMana": "mana",
     "resourceCounters": "marqueurs",
-    "resourceSpeed": "vitesse"
+    "resourceSpeed": "vitesse",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Voir la main complète ({{count}} carte)",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "Spendi solo per attivare abilità",
     "onlyForXCosts": "Spendi solo su costi che includono {X}",
     "convokePayment": "Pagamento di Convocare",
-    "grantsProperty": "Concede una proprietà alla magia"
+    "grantsProperty": "Concede una proprietà alla magia",
+    "grantCantBeCountered": "Spendi per questa magia per renderla impossibile da neutralizzare"
   },
   "zone": {
     "commandZone": "Zona di comando",
@@ -427,7 +428,11 @@
     "resourceCounters": "segnalini",
     "resourceSpeed": "velocità",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Clicca sul tuo mana per spenderlo per questo costo",
+    "covered": "✓ Coperto",
+    "spending": "In spesa",
+    "fillHint": "(maiusc+clic per aggiungere tutti di una fonte)"
   },
   "hand": {
     "viewFullHand_one": "Vedi la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "energia",
     "resourceMana": "mana",
     "resourceCounters": "segnalini",
-    "resourceSpeed": "velocità"
+    "resourceSpeed": "velocità",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Vedi la mano completa ({{count}} carta)",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "Il pagamento è ancora in sospeso. TAPpa i permanenti o annulla questa azione.",
     "poolLabel": "Riserva:",
     "poolEmpty": "Vuota",
+    "pinUnit": "Fissa questo mana per pagare per primo",
+    "unpinUnit": "Rimuovi fissaggio di questo mana",
     "pay": "Paga",
     "chooseAmountTitle": "Scegli quanto pagare",
     "chooseAmountAria": "Scegli quanto pagare",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "Wydaj tylko na aktywowanie zdolności",
     "onlyForXCosts": "Wydaj tylko na koszty zawierające {X}",
     "convokePayment": "Płatność Convoke",
-    "grantsProperty": "Nadaje czarowi właściwość"
+    "grantsProperty": "Nadaje czarowi właściwość",
+    "grantCantBeCountered": "Wydaj na ten czar, aby nie można było go skontrować"
   },
   "zone": {
     "commandZone": "Strefa dowodzenia",
@@ -427,7 +428,11 @@
     "resourceCounters": "znaczników",
     "resourceSpeed": "prędkości",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Kliknij swoją manę, aby wydać ją na ten koszt",
+    "covered": "✓ Pokryte",
+    "spending": "Wydawane",
+    "fillHint": "(shift+klik dodaje wszystkie z jednego źródła)"
   },
   "hand": {
     "viewFullHand_one": "Zobacz całą rękę ({{count}} karta)",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "energii",
     "resourceMana": "many",
     "resourceCounters": "znaczników",
-    "resourceSpeed": "prędkości"
+    "resourceSpeed": "prędkości",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Zobacz całą rękę ({{count}} karta)",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "Płatność wciąż oczekuje. Obróć trwałe lub anuluj tę akcję.",
     "poolLabel": "Pula:",
     "poolEmpty": "Pusta",
+    "pinUnit": "Przypnij tę manę, aby zapłacić najpierw",
+    "unpinUnit": "Odepnij tę manę",
     "pay": "Zapłać",
     "chooseAmountTitle": "Wybierz kwotę do zapłaty",
     "chooseAmountAria": "Wybierz kwotę do zapłaty",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -416,6 +416,8 @@
     "paymentPending": "O pagamento ainda está pendente. Vire permanentes ou cancele esta ação.",
     "poolLabel": "Reserva:",
     "poolEmpty": "Vazia",
+    "pinUnit": "Fixar este mana para pagar primeiro",
+    "unpinUnit": "Desafixar este mana",
     "pay": "Pagar",
     "chooseAmountTitle": "Escolha a quantia a pagar",
     "chooseAmountAria": "Escolher a quantia a pagar",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -423,7 +423,9 @@
     "resourceEnergy": "energia",
     "resourceMana": "mana",
     "resourceCounters": "marcadores",
-    "resourceSpeed": "velocidade"
+    "resourceSpeed": "velocidade",
+    "manualMana": "Manual",
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
   },
   "hand": {
     "viewFullHand_one": "Ver mão completa ({{count}} carta)",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -359,7 +359,8 @@
     "onlyForActivation": "Gaste apenas para ativar habilidades",
     "onlyForXCosts": "Gaste apenas em custos que incluam {X}",
     "convokePayment": "Pagamento de convocação",
-    "grantsProperty": "Concede uma propriedade à mágica"
+    "grantsProperty": "Concede uma propriedade à mágica",
+    "grantCantBeCountered": "Gaste nesta mágica para que ela não possa ser anulada"
   },
   "zone": {
     "commandZone": "Zona de comando",
@@ -427,7 +428,11 @@
     "resourceCounters": "marcadores",
     "resourceSpeed": "velocidade",
     "manualMana": "Manual",
-    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay."
+    "manualManaTooltip": "Manual mana — this game only. Tap your own lands and mana to pay.",
+    "spendHint": "Clique no seu mana para gastá-lo neste custo",
+    "covered": "✓ Coberto",
+    "spending": "Gastando",
+    "fillHint": "(shift+clique para adicionar todos de uma fonte)"
   },
   "hand": {
     "viewFullHand_one": "Ver mão completa ({{count}} carta)",

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -168,6 +168,12 @@ interface UiStoreState {
    *  transient "the user is currently rearranging the board" toggle that gates
    *  the edit overlay, widget dragging, and resize grabbers. */
   flexEditMode: boolean;
+  /** Per-game override that forces Manual mana payment for the current game
+   *  only, without touching the persisted `spellPaymentMode` preference.
+   *  Ephemeral (never persisted) and reset on every game-session boundary
+   *  (see `clearPromptOverlayState`) so it can't leak across games. Manual
+   *  payment wins if EITHER this override or the durable preference is on. */
+  manualManaOverride: boolean;
 }
 
 interface UiStoreActions {
@@ -230,6 +236,8 @@ interface UiStoreActions {
   toggleLogPanel: () => void;
   setFlexEditMode: (active: boolean) => void;
   toggleFlexEditMode: () => void;
+  setManualManaOverride: (on: boolean) => void;
+  toggleManualManaOverride: () => void;
 }
 
 export type UiStore = UiStoreState & UiStoreActions;
@@ -270,6 +278,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   debugHighlightedPlayerId: null,
   logPanelOpen: false,
   flexEditMode: false,
+  manualManaOverride: false,
 
   selectObject: (id) => set({ selectedObjectId: id }),
   hoverObject: (id) => set({ hoveredObjectId: id }),
@@ -524,4 +533,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   toggleLogPanel: () => set((state) => ({ logPanelOpen: !state.logPanelOpen })),
   setFlexEditMode: (active) => set({ flexEditMode: active }),
   toggleFlexEditMode: () => set((state) => ({ flexEditMode: !state.flexEditMode })),
+  setManualManaOverride: (on) => set({ manualManaOverride: on }),
+  toggleManualManaOverride: () =>
+    set((s) => ({ manualManaOverride: !s.manualManaOverride })),
 }));

--- a/client/src/viewmodel/manaPoolGroups.ts
+++ b/client/src/viewmodel/manaPoolGroups.ts
@@ -1,0 +1,129 @@
+import type {
+  ManaRestriction,
+  ManaSpellGrant,
+  ManaType,
+  ManaUnit,
+} from "../adapter/types.ts";
+
+// Discriminant key of a `ManaRestriction` — the bare string for unit variants,
+// or the single object key for data variants. Exhaustive so adding a new
+// restriction variant forces an update to the label map below.
+export type ManaRestrictionTag =
+  | "OnlyForSpellType"
+  | "OnlyForCreatureType"
+  | "OnlyForTypeSpellsOrAbilities"
+  | "OnlyForSpellWithKeywordKind"
+  | "OnlyForSpellWithKeywordKindFromZone"
+  | "OnlyForActivation"
+  | "OnlyForXCosts"
+  | "ConvokePayment";
+
+// i18n key (under the `manaPool` group) per restriction variant. Exhaustive
+// `Record` — adding a `ManaRestriction` variant without a tooltip key here is a
+// type error.
+export const RESTRICTION_LABEL_KEYS: Record<ManaRestrictionTag, string> = {
+  OnlyForSpellType: "manaPool.onlyForSpellType",
+  OnlyForCreatureType: "manaPool.onlyForCreatureType",
+  OnlyForTypeSpellsOrAbilities: "manaPool.onlyForTypeSpellsOrAbilities",
+  OnlyForSpellWithKeywordKind: "manaPool.onlyForSpellWithKeywordKind",
+  OnlyForSpellWithKeywordKindFromZone: "manaPool.onlyForSpellWithKeywordKindFromZone",
+  OnlyForActivation: "manaPool.onlyForActivation",
+  OnlyForXCosts: "manaPool.onlyForXCosts",
+  ConvokePayment: "manaPool.convokePayment",
+};
+
+export function restrictionTag(restriction: ManaRestriction): ManaRestrictionTag {
+  return typeof restriction === "string"
+    ? restriction
+    : (Object.keys(restriction)[0] as ManaRestrictionTag);
+}
+
+// Canonical, payload-inclusive string for a restriction — so "Legendary-only
+// green" and "Creature-only green" hash to distinct group keys.
+export function canonRestriction(restriction: ManaRestriction): string {
+  return typeof restriction === "string"
+    ? restriction
+    : JSON.stringify(restriction);
+}
+
+export function canonGrant(grant: ManaSpellGrant): string {
+  return typeof grant === "string" ? grant : JSON.stringify(grant);
+}
+
+const MANA_ORDER: ManaType[] = ["White", "Blue", "Black", "Red", "Green", "Colorless"];
+
+/**
+ * A run of fungible pool units — same color, spend restrictions, and spell
+ * grants. Per CR 118.3a the engine treats identical units interchangeably, so
+ * the UI groups them and tracks the concrete `pip_id`s (in pool order) so a
+ * specific unit can be pinned for payment.
+ */
+export interface ManaPoolGroup {
+  color: ManaType;
+  restrictions: ManaRestriction[];
+  grants: ManaSpellGrant[];
+  /** Carries spend restrictions or spell grants — rendered distinctly. */
+  special: boolean;
+  /** Concrete pip ids in this group, in pool order — the pin targets. */
+  pipIds: number[];
+}
+
+/**
+ * Group a player's pool units by (color, restrictions, grants), excluding the
+ * internal `ConvokePayment` markers (not spendable mana). Stable display order:
+ * by color, with plain (unrestricted) groups before restricted/granting ones of
+ * the same color.
+ */
+export function groupManaPoolUnits(units: ManaUnit[]): ManaPoolGroup[] {
+  const groups = new Map<string, ManaPoolGroup>();
+  for (const unit of units) {
+    if (unit.restrictions.includes("ConvokePayment")) continue;
+    const grants = unit.grants ?? [];
+    const key = JSON.stringify([
+      unit.color,
+      [...unit.restrictions].map(canonRestriction).sort(),
+      [...grants].map(canonGrant).sort(),
+    ]);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.pipIds.push(unit.pip_id);
+    } else {
+      groups.set(key, {
+        color: unit.color,
+        restrictions: unit.restrictions,
+        grants,
+        special: unit.restrictions.length > 0 || grants.length > 0,
+        pipIds: [unit.pip_id],
+      });
+    }
+  }
+  return [...groups.values()].sort((a, b) => {
+    const colorDelta = MANA_ORDER.indexOf(a.color) - MANA_ORDER.indexOf(b.color);
+    if (colorDelta !== 0) return colorDelta;
+    return (a.special ? 1 : 0) - (b.special ? 1 : 0);
+  });
+}
+
+/**
+ * Human-readable tooltip for a group's restrictions and grants, or `undefined`
+ * for plain mana. `CantBeCountered` is surfaced specifically (Cavern of Souls)
+ * so the player knows which mana makes the spell uncounterable; other grants
+ * fall back to a generic label.
+ */
+export function manaGroupTooltip(
+  translate: (key: string) => string,
+  group: Pick<ManaPoolGroup, "restrictions" | "grants" | "special">,
+): string | undefined {
+  if (!group.special) return undefined;
+  const parts = group.restrictions.map((r) =>
+    translate(RESTRICTION_LABEL_KEYS[restrictionTag(r)]),
+  );
+  for (const grant of group.grants) {
+    parts.push(
+      grant === "CantBeCountered"
+        ? translate("manaPool.grantCantBeCountered")
+        : translate("manaPool.grantsProperty"),
+    );
+  }
+  return parts.join("; ");
+}

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -5364,6 +5364,57 @@ mod tests {
     }
 
     #[test]
+    fn ai_does_not_pin_pool_mana_during_mana_payment() {
+        // CR 118.3a: pinning a pool unit is a human-only manual-payment affordance.
+        // The AI candidate generator must never emit SpendPoolMana/UnspendPoolMana
+        // (they are excluded by the `!is_mana_ability` flat-list filter / by
+        // `mana_payment_actions` not generating them).
+        let mut state = GameState::new_two_player(42);
+        state.waiting_for = WaitingFor::ManaPayment {
+            player: PlayerId(0),
+            convoke_mode: None,
+        };
+        let spell = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Some Spell".to_string(),
+            Zone::Stack,
+        );
+        state.pending_cast = Some(Box::new(crate::types::game_state::PendingCast::new(
+            spell,
+            CardId(500),
+            crate::types::ability::ResolvedAbility::new(
+                Effect::Unimplemented {
+                    name: "test".to_string(),
+                    description: None,
+                },
+                Vec::new(),
+                spell,
+                PlayerId(0),
+            ),
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 1,
+            },
+        )));
+        // Floated mana that a pin could target — must still not surface a pin action.
+        state.add_mana_to_pool(
+            PlayerId(0),
+            crate::types::mana::ManaUnit::new(ManaType::Red, ObjectId(0), false, Vec::new()),
+        );
+
+        let actions = candidate_actions(&state);
+        assert!(
+            !actions.iter().any(|c| matches!(
+                c.action,
+                GameAction::SpendPoolMana { .. } | GameAction::UnspendPoolMana { .. }
+            )),
+            "AI candidate generation must never offer pool-mana pinning"
+        );
+    }
+
+    #[test]
     fn convoke_offers_only_cost_relevant_colored_taps() {
         // CR 702.51a: a Convoke tap reduces the cost by {1} (Colorless marker) or by one
         // mana of the creature's color (a colored marker that pays ONLY a matching colored
@@ -5939,6 +5990,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Blue,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -6080,6 +6132,7 @@ mod tests {
         state.players[player].mana_pool.add(ManaUnit {
             color,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -1392,6 +1392,7 @@ mod tests {
         state.players[1].mana_pool.add(ManaUnit {
             color: ManaType::Black,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -2717,6 +2718,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -2726,6 +2728,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11345,6 +11345,8 @@ fn pay_non_cast_mana_cost(
         permissions.any_color,
         None,
         permissions.life_colors,
+        // CR 118.3a: non-cast mana costs (effects/special actions) are not pinnable.
+        &[],
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
     if !spent_units.is_empty() && mana_payment::has_unspent_mana_continuous_effects(state) {
@@ -11460,6 +11462,12 @@ fn auto_tap_and_pay_cost_excluding(
         }
         None => hand_demand,
     };
+    // CR 118.3a: read the caster's player-directed pin hints for THIS spell.
+    // `finalize_mana_payment` moves them onto the transient `active_payment_pins`
+    // (it `take()`s `pending_cast` before the spend, so they can't be read from
+    // there). The funnel early-outs to legacy ordering when this slice is empty,
+    // so non-manual casts and activated-ability / sub-cost payments are unaffected.
+    let pins: Vec<crate::types::mana::ManaPipId> = state.active_payment_pins.clone();
     let player_data = state
         .players
         .iter_mut()
@@ -11473,6 +11481,7 @@ fn auto_tap_and_pay_cost_excluding(
         permissions.any_color,
         phyrexian_choices,
         permissions.life_colors,
+        &pins,
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
     if !spent_units.is_empty() && mana_payment::has_unspent_mana_continuous_effects(state) {
@@ -14026,6 +14035,7 @@ mod tests {
             player_data.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -14066,6 +14076,7 @@ mod tests {
         player_data.mana_pool.add(ManaUnit {
             color,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions,
@@ -15457,6 +15468,7 @@ mod tests {
         let unit = ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -15541,6 +15553,7 @@ mod tests {
         let unit = ManaUnit {
             color: ManaType::Blue,
             source_id: orb,
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -15662,6 +15675,7 @@ mod tests {
         let unit = ManaUnit {
             color: ManaType::Green,
             source_id: path,
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -15749,6 +15763,7 @@ mod tests {
             .add(ManaUnit {
                 color: ManaType::Blue,
                 source_id: orb,
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -19548,6 +19563,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Black,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: Some(crate::types::mana::ManaSupertype::Snow),
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -47947,6 +47963,614 @@ mod tests {
                 .iter()
                 .any(|k| matches!(k, Keyword::Convoke)),
             "second historic spell (a historic spell already recorded) must NOT receive Convoke"
+        );
+    }
+
+    // --- CR 118.3a: pin a pool pip to direct mana payment ---------------------
+
+    use crate::types::mana::ManaPipId;
+
+    /// Seed one mana unit and return its freshly-minted pip id. Routes through
+    /// `add_mana_to_pool` so every seeded unit is stamped distinctly (a direct
+    /// `pool.add` would leave the sentinel `ManaPipId(0)` and pins would collide).
+    fn seed_unit(state: &mut GameState, player: PlayerId, unit: ManaUnit) -> ManaPipId {
+        state.add_mana_to_pool(player, unit);
+        state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .unwrap()
+            .mana_pool
+            .mana
+            .last()
+            .unwrap()
+            .pip_id
+    }
+
+    fn plain_unit(color: ManaType, source: ObjectId) -> ManaUnit {
+        ManaUnit::new(color, source, false, Vec::new())
+    }
+
+    /// Begin a real manual cast of a `{3}{R}` creature (Hill Giant) and pause at
+    /// `WaitingFor::ManaPayment` with `pending_cast` populated.
+    fn begin_manual_cast(state: &mut GameState, caster: PlayerId, obj: ObjectId) {
+        let result = handle_cast_spell_with_payment_mode(
+            state,
+            caster,
+            obj,
+            CardId(22),
+            crate::types::game_state::CastPaymentMode::Manual,
+            &mut Vec::new(),
+        )
+        .expect("manual cast should begin");
+        state.waiting_for = result;
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ManaPayment { .. }),
+            "manual {{3}}{{R}} cast must pause at ManaPayment, got {:?}",
+            state.waiting_for
+        );
+    }
+
+    /// TEST 1 (the #1 case): generic-cost pin honored. With four same-color
+    /// floated units and a `{3}` generic shard, the legacy spend leaves the
+    /// FIRST-seeded colorless surviving (proven by `empty_pins_baseline_unchanged`).
+    /// Here we PIN that exact unit (`legacy_survivor`); the pin funnel must spend
+    /// it FIRST, so it is consumed and a DIFFERENT colorless survives. Reverting
+    /// the generic-path pin scan makes `legacy_survivor` survive again, flipping
+    /// the `!pool.contains(&legacy_survivor)` assertion.
+    #[test]
+    fn generic_cost_pin_honored() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        // {3}{R}: one red for the {R} shard, four colorless for {3} (one survives).
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(0)),
+        );
+        // The first colorless seeded is the unit legacy ordering leaves surviving.
+        let legacy_survivor = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(1)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(2)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(3)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(4)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+
+        // Pin the unit legacy would have preserved, for the generic spend.
+        apply_as_current(
+            &mut state,
+            GameAction::SpendPoolMana {
+                pip_id: legacy_survivor,
+            },
+        )
+        .expect("pinning an eligible unit is legal");
+
+        // Finalize.
+        apply_as_current(&mut state, GameAction::PassPriority).expect("finalize the cast");
+
+        let pool: Vec<ManaPipId> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id)
+            .collect();
+        // Exactly one colorless survives, and it is NOT the pinned unit — the pin
+        // forced the engine to spend the unit legacy would otherwise have kept.
+        assert_eq!(
+            pool.len(),
+            1,
+            "{{3}}{{R}} over 1R+4C leaves one survivor; {pool:?}"
+        );
+        assert!(
+            !pool.contains(&legacy_survivor),
+            "the pinned generic-paying unit must be spent (legacy would have kept it); pool {pool:?}"
+        );
+    }
+
+    /// TEST 2: colored-shard pin + grant preservation. Pin a grant-carrying unit
+    /// onto the {R} shard; assert the resolving spell received the grant — proving
+    /// staged pinned units flow through the normal grant-application accounting.
+    #[test]
+    fn colored_shard_pin_preserves_grant() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        // Red unit carrying a CantBeCountered grant + three colorless for {3}.
+        let mut red_grant = plain_unit(ManaType::Red, ObjectId(5));
+        red_grant.grants.push(ManaSpellGrant::CantBeCountered);
+        let red_pip = seed_unit(&mut state, PlayerId(0), red_grant);
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(6)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(7)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(8)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: red_pip })
+            .expect("pinning the red grant unit onto {R} is legal");
+        apply_as_current(&mut state, GameAction::PassPriority).expect("finalize");
+
+        // CR 106.6: the grant must have been applied to the spell object as a
+        // CantBeCountered static (`apply_mana_spell_grants`).
+        let obj_data = state.objects.get(&obj).expect("spell object exists");
+        assert!(
+            obj_data
+                .static_definitions
+                .iter_all()
+                .any(|sd| sd.mode == StaticMode::CantBeCountered),
+            "pinned grant-carrying red unit must apply CantBeCountered to the spell"
+        );
+    }
+
+    /// TEST 3: omitted-axis. Two units identical except one is {Z}-eligible
+    /// (`source_could_produce_two_or_more_colors`). Pin the non-{Z} one for a
+    /// generic shard; the {Z}-eligible one is preserved for a later use.
+    #[test]
+    fn pin_preserves_z_eligible_unit() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(9)),
+        );
+        // Non-{Z} colorless (pinned) and a {Z}-eligible colorless (preserved).
+        let non_z = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(10)),
+        );
+        let mut z_unit = plain_unit(ManaType::Colorless, ObjectId(11));
+        z_unit.source_could_produce_two_or_more_colors = true;
+        let z_pip = seed_unit(&mut state, PlayerId(0), z_unit);
+        // Two more colorless so {3} is payable leaving one survivor.
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(12)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(13)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: non_z })
+            .expect("pinning the non-Z unit is legal");
+        apply_as_current(&mut state, GameAction::PassPriority).expect("finalize");
+
+        let pool: Vec<ManaPipId> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id)
+            .collect();
+        assert!(
+            !pool.contains(&non_z),
+            "pinned non-Z unit must be consumed; pool {pool:?}"
+        );
+        assert!(
+            pool.contains(&z_pip),
+            "the {{Z}}-eligible unit must be preserved when the non-Z one is pinned; pool {pool:?}"
+        );
+    }
+
+    /// TEST 4 (M2): ineligible pin rejected. Pin a unit that can pay no shard of
+    /// the locked cost; engine returns ActionNotAllowed; pins unchanged.
+    #[test]
+    fn ineligible_pin_rejected() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        // {3}{R}: the {R} is colored, {3} is generic (any color pays). To make a
+        // unit pay NOTHING, give the cost a pure single-color shard with no
+        // generic. Override Hill Giant's cost to {W} only.
+        state.objects.get_mut(&obj).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::White],
+            generic: 0,
+        };
+        // A white unit (eligible) and a red unit (ineligible: wrong color, no generic).
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::White, ObjectId(14)),
+        );
+        let red = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(15)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        let res = apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: red });
+        assert!(
+            res.is_err(),
+            "pinning a red unit for a {{W}}-only cost must be rejected"
+        );
+        let pins = &state.pending_cast.as_ref().unwrap().pinned_pool_units;
+        assert!(
+            pins.is_empty(),
+            "a rejected pin must not be recorded; pins = {pins:?}"
+        );
+    }
+
+    /// TEST 5 (M1): stale pin pruned. Pin a unit, then drain it via
+    /// UntapLandForMana during ManaPayment; the dangling pin is pruned and
+    /// finalize succeeds without panic.
+    #[test]
+    fn stale_pin_pruned_on_untap() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        // A Mountain that will be tapped for {R}; record it as manually tapped so
+        // UntapLandForMana can drain its produced mana.
+        let mountain = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(0),
+            "Mountain".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let m = state.objects.get_mut(&mountain).unwrap();
+            m.card_types.core_types.push(CoreType::Land);
+            m.card_types.subtypes.push("Mountain".to_string());
+            m.tapped = true;
+        }
+        // The {R} produced by the mountain, stamped and tracked for untap.
+        let red_pip = seed_unit(&mut state, PlayerId(0), plain_unit(ManaType::Red, mountain));
+        // Colorless for {3}.
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(16)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(17)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(18)),
+        );
+        state
+            .lands_tapped_for_mana
+            .entry(PlayerId(0))
+            .or_default()
+            .push(mountain);
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: red_pip })
+            .expect("pinning the red unit is legal");
+        // Drain the pinned unit by untapping the mountain.
+        apply_as_current(
+            &mut state,
+            GameAction::UntapLandForMana {
+                object_id: mountain,
+            },
+        )
+        .expect("untap drains the produced red mana");
+
+        let pins = &state.pending_cast.as_ref().unwrap().pinned_pool_units;
+        assert!(
+            !pins.contains(&red_pip),
+            "the drained unit's pin must be pruned; pins = {pins:?}"
+        );
+    }
+
+    /// TEST 6: cancel clears pins. Pin units, CancelCast, assert pending_cast is
+    /// gone (so pins drop with it) and the pool is intact.
+    #[test]
+    fn cancel_clears_pins() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(19)),
+        );
+        let c = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(20)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(21)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(22)),
+        );
+        let pool_before = state.players[0].mana_pool.mana.len();
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: c })
+            .expect("pinning is legal");
+        apply_as_current(&mut state, GameAction::CancelCast).expect("manual cast is cancellable");
+
+        assert!(
+            state.pending_cast.is_none(),
+            "CancelCast must tear down pending_cast (and its pins)"
+        );
+        assert_eq!(
+            state.players[0].mana_pool.mana.len(),
+            pool_before,
+            "cancelling must leave the pool intact (pin is a hint, not a removal)"
+        );
+    }
+
+    /// TEST 7: MP-accepts — SpendPoolMana is classified as a mana ability so it
+    /// rides session skip_legality.
+    #[test]
+    fn spend_pool_mana_is_mana_ability() {
+        assert!(
+            GameAction::SpendPoolMana {
+                pip_id: ManaPipId(1)
+            }
+            .is_mana_ability(),
+            "SpendPoolMana must be a mana ability (MP skip_legality)"
+        );
+        assert!(
+            GameAction::UnspendPoolMana {
+                pip_id: ManaPipId(1)
+            }
+            .is_mana_ability(),
+            "UnspendPoolMana must be a mana ability (MP skip_legality)"
+        );
+    }
+
+    /// TEST 9 (C1): save/load counter round-trips. Produce N units, serialize +
+    /// deserialize, produce one more, assert its pip_id differs from all prior —
+    /// the counter is not reset by a reload.
+    #[test]
+    fn pip_id_counter_survives_save_load() {
+        let mut state = setup_game_at_main_phase();
+        let mut prior: Vec<ManaPipId> = Vec::new();
+        for i in 0..4 {
+            prior.push(seed_unit(
+                &mut state,
+                PlayerId(0),
+                plain_unit(ManaType::Red, ObjectId(i)),
+            ));
+        }
+        let json = serde_json::to_string(&state).expect("serialize");
+        let mut reloaded: GameState = serde_json::from_str(&json).expect("deserialize");
+        let after = seed_unit(
+            &mut reloaded,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(99)),
+        );
+        assert!(
+            !prior.contains(&after),
+            "a unit minted after reload must not collide with pre-save ids ({after:?} in {prior:?})"
+        );
+    }
+
+    /// TEST 10: non-pinned baseline. With no pins, the spend is byte-identical to
+    /// the pre-feature ordering (colorless-first / first-available). Asserts the
+    /// funnel early-out leaves the legacy result.
+    #[test]
+    fn empty_pins_baseline_unchanged() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(23)),
+        );
+        let first_cl = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(24)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(25)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(26)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(27)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        // No pin recorded.
+        apply_as_current(&mut state, GameAction::PassPriority).expect("finalize");
+
+        // With NO pin recorded the spend must be byte-identical to the
+        // pre-feature ordering: the pin-scan early-outs and `swap_remove`-based
+        // selection leaves the same single survivor it always did (the first
+        // colorless seeded, `first_cl`). If the empty-pins funnel reordered the
+        // spend, this survivor identity would change.
+        assert!(state.pending_cast.is_none(), "cast must finalize");
+        let survivors: Vec<ManaPipId> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id)
+            .collect();
+        assert_eq!(
+            survivors,
+            vec![first_cl],
+            "empty-pins spend must match legacy ordering exactly (one colorless survivor)"
+        );
+    }
+
+    /// TEST 11: Phyrexian not corrupted. Manual-cast a Phyrexian-cost spell, pin
+    /// an unrelated unit; pinning removes nothing, so the pool the engine pauses
+    /// against is unchanged and the cast still pauses for the Phyrexian choice.
+    #[test]
+    fn phyrexian_shards_uncorrupted_by_pin() {
+        let mut state = setup_game_at_main_phase();
+        let obj = create_creature_spell_in_hand(&mut state, PlayerId(0));
+        // {R/P}{2}: a Phyrexian red shard plus generic. Mana is present to pay it,
+        // so the engine pauses at PhyrexianPayment (mana-or-life choice).
+        state.objects.get_mut(&obj).unwrap().mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianRed],
+            generic: 1,
+        };
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Red, ObjectId(28)),
+        );
+        let extra = seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(29)),
+        );
+        seed_unit(
+            &mut state,
+            PlayerId(0),
+            plain_unit(ManaType::Colorless, ObjectId(30)),
+        );
+
+        begin_manual_cast(&mut state, PlayerId(0), obj);
+        let pool_len_before = state.players[0].mana_pool.mana.len();
+        // Pin an unrelated colorless unit (eligible for the {1} generic).
+        apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: extra })
+            .expect("pin is legal");
+        assert_eq!(
+            state.players[0].mana_pool.mana.len(),
+            pool_len_before,
+            "pinning must not remove any unit — compute_phyrexian_shards must see the true pool"
+        );
+    }
+
+    /// TEST 12 (CR 602 / CR 106.6): pinning for an ACTIVATED ability uses the
+    /// activation payment context, not the spell context. A unit restricted
+    /// `OnlyForActivation` (allows_spell == false, allows_activation == true) can
+    /// legally pay an activation, so it must be pinnable when `pending_cast` is an
+    /// activated ability. `handle_spend_pool_mana` branches on
+    /// `activation_ability_index`: with the fix it builds a
+    /// `PaymentContext::Activation` and the pin is accepted; reverting the branch
+    /// (always `PaymentContext::Spell`) makes `mana_unit_eligible_for_cost` consult
+    /// `allows_spell` → false → the pin is REJECTED, flipping the `.is_ok()`
+    /// assertion below. The spell-context sibling proves the discriminator: the
+    /// same restricted unit is correctly REJECTED for a spell `pending_cast`.
+    #[test]
+    fn activation_pin_uses_activation_context() {
+        // Shared fixture: a battlefield source with one activated ability and a
+        // single floated unit restricted to activations only.
+        fn setup(activation: bool) -> (GameState, ManaPipId) {
+            let mut state = setup_game_at_main_phase();
+            let source = create_object(
+                &mut state,
+                CardId(700),
+                PlayerId(0),
+                "Activated Source".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&source).unwrap();
+                obj.card_types.core_types.push(CoreType::Artifact);
+                Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Unimplemented {
+                        name: "Activated".to_string(),
+                        description: None,
+                    },
+                ));
+            }
+            // The ability's mana cost is {R}: a colored shard the activation-only
+            // unit can pay.
+            let cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 0,
+            };
+            let resolved = ResolvedAbility::new(
+                Effect::Unimplemented {
+                    name: "Activated".to_string(),
+                    description: None,
+                },
+                Vec::new(),
+                source,
+                PlayerId(0),
+            );
+            let mut pending = PendingCast::new(source, CardId(700), resolved, cost);
+            // The discriminator: activation vs spell pending_cast.
+            pending.activation_ability_index = if activation { Some(0) } else { None };
+            state.pending_cast = Some(Box::new(pending));
+            state.waiting_for = WaitingFor::ManaPayment {
+                player: PlayerId(0),
+                convoke_mode: None,
+            };
+
+            // A red unit usable only for activations (CR 106.6).
+            let restricted = ManaUnit::new(
+                ManaType::Red,
+                source,
+                false,
+                vec![ManaRestriction::OnlyForActivation],
+            );
+            let pip = seed_unit(&mut state, PlayerId(0), restricted);
+            (state, pip)
+        }
+
+        // Activation pending_cast: the activation-only unit IS pinnable.
+        let (mut state, pip) = setup(true);
+        let res = apply_as_current(&mut state, GameAction::SpendPoolMana { pip_id: pip });
+        assert!(
+            res.is_ok(),
+            "an OnlyForActivation unit must be pinnable for an activated ability \
+             (PaymentContext::Activation); got {res:?}"
+        );
+        assert!(
+            state
+                .pending_cast
+                .as_ref()
+                .unwrap()
+                .pinned_pool_units
+                .contains(&pip),
+            "the accepted pin must be recorded on the activation's pending_cast"
+        );
+
+        // Spell pending_cast (sibling discriminator): the SAME unit is NOT pinnable,
+        // because `allows_spell` rejects OnlyForActivation mana.
+        let (mut spell_state, spell_pip) = setup(false);
+        let spell_res = apply_as_current(
+            &mut spell_state,
+            GameAction::SpendPoolMana { pip_id: spell_pip },
+        );
+        assert!(
+            spell_res.is_err(),
+            "an OnlyForActivation unit must NOT be pinnable for a spell cast \
+             (PaymentContext::Spell); got {spell_res:?}"
         );
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -7252,6 +7252,10 @@ pub fn enter_payment_step(
     convoke_mode: Option<ConvokeMode>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    // CR 118.3a: normalize pool pip ids before any payment so each unit is
+    // individually pinnable in manual mode — self-heals the `ManaPipId(0)`
+    // sentinel left by debug tooling / pre-stamping saves / any bypassing path.
+    state.restamp_pool_pip_ids(player);
     if let Some(pending) = state.pending_cast.as_ref() {
         let activation_counter_x_max = pending.activation_cost.as_ref().and_then(|cost| {
             activation_counter_cost_x_max(state, player, pending.object_id, &pending.ability, cost)

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -7522,140 +7522,155 @@ pub fn finalize_mana_payment(
         .take()
         .ok_or_else(|| EngineError::InvalidAction("No pending cast to finalize".to_string()))?;
 
-    // CR 702.132a: commit point reached — apply any committed Assist contribution
-    // (tap the helper's sources) now that the cast can no longer be cancelled.
-    apply_committed_assist(state, &pending, events)?;
+    // CR 118.3a: `pending_cast` is now gone, but the caster's pin hints must
+    // still reach the spend. Carry them on the transient `active_payment_pins`
+    // for the duration of this finalize; the spend reads them. The spend body
+    // runs in an inner closure so the transient is cleared on EVERY exit —
+    // including the `Err` path — keeping the invariant "active_payment_pins is
+    // empty outside an in-progress finalize spend". (Without this, an `Err` from
+    // the spend propagates before any caller clear runs, leaking stale pins onto
+    // a later spend.)
+    state.active_payment_pins = pending.pinned_pool_units.clone();
+    let finalize_result = (|| -> Result<WaitingFor, EngineError> {
+        // CR 702.132a: commit point reached — apply any committed Assist contribution
+        // (tap the helper's sources) now that the cast can no longer be cancelled.
+        apply_committed_assist(state, &pending, events)?;
 
-    if let Some(ability_index) = pending.activation_ability_index {
-        let excluded_sources = pending
-            .activation_cost
-            .as_ref()
-            .map(|cost| {
-                super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
-            })
-            .unwrap_or_default();
-        super::casting::pay_ability_mana_cost_excluding(
-            state,
-            player,
-            pending.object_id,
-            &pending.cost,
-            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
-            events,
-            &excluded_sources,
-            // Interactive activation resume: top-level, no outer cost on the stack.
-            None,
-        )?;
-        return push_activated_ability_to_stack(
-            state,
-            player,
-            pending.object_id,
-            ability_index,
-            pending.ability,
-            pending.activation_cost.as_ref(),
-            pending.x_residual_activation,
-            events,
-        );
-    }
-
-    if let Some(unit) = pending.distribute {
-        // CR 601.2d: X-spell distribution — pay mana first to determine X, then
-        // trigger DistributeAmong with total = X.
-        let pool_before = state
-            .players
-            .iter()
-            .find(|pl| pl.id == player)
-            .map(|pl| pl.mana_pool.total())
-            .unwrap_or(0);
-
-        super::casting::pay_mana_cost(state, player, pending.object_id, &pending.cost, events)?;
-
-        let pool_after = state
-            .players
-            .iter()
-            .find(|pl| pl.id == player)
-            .map(|pl| pl.mana_pool.total())
-            .unwrap_or(0);
-        // CR 107.1b + CR 601.2f: Prefer the explicit `chosen_x` set during
-        // `WaitingFor::ChooseXValue`. Fallback to inference (total paid minus
-        // non-X colored/generic costs) preserves behavior for any legacy paths
-        // that bypass ChooseX. ManaCost::mana_value() excludes X (CR 202.3e).
-        let non_x_cost = pending.cost.mana_value();
-        let total_paid = pool_before.saturating_sub(pool_after) as u32;
-        let x_value = pending
-            .ability
-            .chosen_x
-            .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
-
-        let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
-        // Store pending cast for post-distribution resumption. Use `ManaCost::NoCost`
-        // since mana was already paid above — `finalize_cast` must not re-deduct.
-        let mut pending_resumed = PendingCast::new(
-            pending.object_id,
-            pending.card_id,
-            pending.ability,
-            crate::types::mana::ManaCost::NoCost,
-        );
-        pending_resumed.casting_variant = pending.casting_variant;
-        pending_resumed.origin_zone = pending.origin_zone;
-        pending_resumed.convoked_creatures = pending.convoked_creatures.clone();
-
-        // CR 601.2d: "divided evenly, rounded down" — EvenSplitDamage bypasses
-        // interactive distribution. Remainder is intentionally lost per Oracle text.
-        if unit == DistributionUnit::EvenSplitDamage && !targets.is_empty() {
-            let num = targets.len() as u32;
-            let per_target = x_value / num;
-            let distribution: Vec<_> = targets.iter().map(|t| (t.clone(), per_target)).collect();
-            pending_resumed.ability.distribution = Some(distribution);
-            state.pending_cast = Some(Box::new(pending_resumed));
-
-            let pending = state.pending_cast.take().unwrap();
-            stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
-            let waiting_for = finalize_cast(
+        if let Some(ability_index) = pending.activation_ability_index {
+            let excluded_sources = pending
+                .activation_cost
+                .as_ref()
+                .map(|cost| {
+                    super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
+                })
+                .unwrap_or_default();
+            super::casting::pay_ability_mana_cost_excluding(
                 state,
                 player,
                 pending.object_id,
-                pending.card_id,
-                pending.ability,
                 &pending.cost,
-                pending.casting_variant,
-                pending.cast_timing_permission,
-                pending.origin_zone,
+                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
                 events,
+                &excluded_sources,
+                // Interactive activation resume: top-level, no outer cost on the stack.
+                None,
             )?;
-            return Ok(drain_deferred_triggers_after_stack_object_announcement(
+            return push_activated_ability_to_stack(
                 state,
+                player,
+                pending.object_id,
+                ability_index,
+                pending.ability,
+                pending.activation_cost.as_ref(),
+                pending.x_residual_activation,
                 events,
-                waiting_for,
-            ));
+            );
         }
 
-        state.pending_cast = Some(Box::new(pending_resumed));
-        return Ok(WaitingFor::DistributeAmong {
-            player,
-            total: x_value,
-            targets,
-            unit,
-        });
-    }
+        if let Some(unit) = pending.distribute {
+            // CR 601.2d: X-spell distribution — pay mana first to determine X, then
+            // trigger DistributeAmong with total = X.
+            let pool_before = state
+                .players
+                .iter()
+                .find(|pl| pl.id == player)
+                .map(|pl| pl.mana_pool.total())
+                .unwrap_or(0);
 
-    stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
-    let waiting_for = finalize_cast(
-        state,
-        player,
-        pending.object_id,
-        pending.card_id,
-        pending.ability,
-        &pending.cost,
-        pending.casting_variant,
-        pending.cast_timing_permission,
-        pending.origin_zone,
-        events,
-    )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+            super::casting::pay_mana_cost(state, player, pending.object_id, &pending.cost, events)?;
+
+            let pool_after = state
+                .players
+                .iter()
+                .find(|pl| pl.id == player)
+                .map(|pl| pl.mana_pool.total())
+                .unwrap_or(0);
+            // CR 107.1b + CR 601.2f: Prefer the explicit `chosen_x` set during
+            // `WaitingFor::ChooseXValue`. Fallback to inference (total paid minus
+            // non-X colored/generic costs) preserves behavior for any legacy paths
+            // that bypass ChooseX. ManaCost::mana_value() excludes X (CR 202.3e).
+            let non_x_cost = pending.cost.mana_value();
+            let total_paid = pool_before.saturating_sub(pool_after) as u32;
+            let x_value = pending
+                .ability
+                .chosen_x
+                .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
+
+            let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
+            // Store pending cast for post-distribution resumption. Use `ManaCost::NoCost`
+            // since mana was already paid above — `finalize_cast` must not re-deduct.
+            let mut pending_resumed = PendingCast::new(
+                pending.object_id,
+                pending.card_id,
+                pending.ability,
+                crate::types::mana::ManaCost::NoCost,
+            );
+            pending_resumed.casting_variant = pending.casting_variant;
+            pending_resumed.origin_zone = pending.origin_zone;
+            pending_resumed.convoked_creatures = pending.convoked_creatures.clone();
+
+            // CR 601.2d: "divided evenly, rounded down" — EvenSplitDamage bypasses
+            // interactive distribution. Remainder is intentionally lost per Oracle text.
+            if unit == DistributionUnit::EvenSplitDamage && !targets.is_empty() {
+                let num = targets.len() as u32;
+                let per_target = x_value / num;
+                let distribution: Vec<_> =
+                    targets.iter().map(|t| (t.clone(), per_target)).collect();
+                pending_resumed.ability.distribution = Some(distribution);
+                state.pending_cast = Some(Box::new(pending_resumed));
+
+                let pending = state.pending_cast.take().unwrap();
+                stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
+                let waiting_for = finalize_cast(
+                    state,
+                    player,
+                    pending.object_id,
+                    pending.card_id,
+                    pending.ability,
+                    &pending.cost,
+                    pending.casting_variant,
+                    pending.cast_timing_permission,
+                    pending.origin_zone,
+                    events,
+                )?;
+                return Ok(drain_deferred_triggers_after_stack_object_announcement(
+                    state,
+                    events,
+                    waiting_for,
+                ));
+            }
+
+            state.pending_cast = Some(Box::new(pending_resumed));
+            return Ok(WaitingFor::DistributeAmong {
+                player,
+                total: x_value,
+                targets,
+                unit,
+            });
+        }
+
+        stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
+        let waiting_for = finalize_cast(
+            state,
+            player,
+            pending.object_id,
+            pending.card_id,
+            pending.ability,
+            &pending.cost,
+            pending.casting_variant,
+            pending.cast_timing_permission,
+            pending.origin_zone,
+            events,
+        )?;
+        Ok(drain_deferred_triggers_after_stack_object_announcement(
+            state,
+            events,
+            waiting_for,
+        ))
+    })();
+    // CR 118.3a: the transient is self-contained — cleared on Ok and Err alike.
+    state.active_payment_pins.clear();
+    finalize_result
 }
 
 fn stamp_convoked_creatures(
@@ -7689,143 +7704,156 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
         .take()
         .ok_or_else(|| EngineError::InvalidAction("No pending cast to finalize".to_string()))?;
 
-    // CR 702.132a: commit point reached — apply any committed Assist contribution
-    // (tap the helper's sources) now that the cast can no longer be cancelled.
-    apply_committed_assist(state, &pending, events)?;
+    // CR 118.3a: `pending_cast` is now gone, but the caster's pin hints must
+    // still reach the spend. Carry them on the transient `active_payment_pins`
+    // for the duration of this finalize; the spend reads them. The spend body
+    // runs in an inner closure so the transient is cleared on EVERY exit —
+    // including the `Err` path — keeping the invariant "active_payment_pins is
+    // empty outside an in-progress finalize spend".
+    state.active_payment_pins = pending.pinned_pool_units.clone();
+    let finalize_result = (|| -> Result<WaitingFor, EngineError> {
+        // CR 702.132a: commit point reached — apply any committed Assist contribution
+        // (tap the helper's sources) now that the cast can no longer be cancelled.
+        apply_committed_assist(state, &pending, events)?;
 
-    if let Some(ability_index) = pending.activation_ability_index {
-        let excluded_sources = pending
-            .activation_cost
-            .as_ref()
-            .map(|cost| {
-                super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
-            })
-            .unwrap_or_default();
-        super::casting::pay_ability_mana_cost_with_choices_excluding(
-            state,
-            player,
-            pending.object_id,
-            &pending.cost,
-            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
-            Some(phyrexian_choices),
-            events,
-            &excluded_sources,
-            // Interactive Phyrexian-choice resume: top-level activation, no outer cost.
-            None,
-        )?;
-        return push_activated_ability_to_stack(
-            state,
-            player,
-            pending.object_id,
-            ability_index,
-            pending.ability,
-            pending.activation_cost.as_ref(),
-            pending.x_residual_activation,
-            events,
-        );
-    }
-
-    if let Some(unit) = pending.distribute {
-        // CR 601.2d: X + distribution + Phyrexian is extremely rare (no known current cards).
-        // Fall through to the auto-decision distribution path for safety — the Phyrexian
-        // choices were already consumed via pay_mana_cost_with_choices above (the X-spell
-        // distribution path is orthogonal).
-        let pool_before = state
-            .players
-            .iter()
-            .find(|pl| pl.id == player)
-            .map(|pl| pl.mana_pool.total())
-            .unwrap_or(0);
-
-        super::casting::pay_mana_cost_with_choices(
-            state,
-            player,
-            pending.object_id,
-            &pending.cost,
-            Some(phyrexian_choices),
-            events,
-        )?;
-
-        let pool_after = state
-            .players
-            .iter()
-            .find(|pl| pl.id == player)
-            .map(|pl| pl.mana_pool.total())
-            .unwrap_or(0);
-        let non_x_cost = pending.cost.mana_value();
-        let total_paid = pool_before.saturating_sub(pool_after) as u32;
-        let x_value = pending
-            .ability
-            .chosen_x
-            .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
-
-        let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
-        let mut pending_resumed = PendingCast::new(
-            pending.object_id,
-            pending.card_id,
-            pending.ability,
-            crate::types::mana::ManaCost::NoCost,
-        );
-        pending_resumed.casting_variant = pending.casting_variant;
-        pending_resumed.origin_zone = pending.origin_zone;
-        pending_resumed.convoked_creatures = pending.convoked_creatures.clone();
-
-        if unit == DistributionUnit::EvenSplitDamage && !targets.is_empty() {
-            let num = targets.len() as u32;
-            let per_target = x_value / num;
-            let distribution: Vec<_> = targets.iter().map(|t| (t.clone(), per_target)).collect();
-            pending_resumed.ability.distribution = Some(distribution);
-            state.pending_cast = Some(Box::new(pending_resumed));
-
-            let pending = state.pending_cast.take().unwrap();
-            stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
-            let waiting_for = finalize_cast(
+        if let Some(ability_index) = pending.activation_ability_index {
+            let excluded_sources = pending
+                .activation_cost
+                .as_ref()
+                .map(|cost| {
+                    super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
+                })
+                .unwrap_or_default();
+            super::casting::pay_ability_mana_cost_with_choices_excluding(
                 state,
                 player,
                 pending.object_id,
-                pending.card_id,
-                pending.ability,
                 &pending.cost,
-                pending.casting_variant,
-                pending.cast_timing_permission,
-                pending.origin_zone,
+                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+                Some(phyrexian_choices),
                 events,
+                &excluded_sources,
+                // Interactive Phyrexian-choice resume: top-level activation, no outer cost.
+                None,
             )?;
-            return Ok(drain_deferred_triggers_after_stack_object_announcement(
+            return push_activated_ability_to_stack(
                 state,
+                player,
+                pending.object_id,
+                ability_index,
+                pending.ability,
+                pending.activation_cost.as_ref(),
+                pending.x_residual_activation,
                 events,
-                waiting_for,
-            ));
+            );
         }
 
-        state.pending_cast = Some(Box::new(pending_resumed));
-        return Ok(WaitingFor::DistributeAmong {
-            player,
-            total: x_value,
-            targets,
-            unit,
-        });
-    }
+        if let Some(unit) = pending.distribute {
+            // CR 601.2d: X + distribution + Phyrexian is extremely rare (no known current cards).
+            // Fall through to the auto-decision distribution path for safety — the Phyrexian
+            // choices were already consumed via pay_mana_cost_with_choices above (the X-spell
+            // distribution path is orthogonal).
+            let pool_before = state
+                .players
+                .iter()
+                .find(|pl| pl.id == player)
+                .map(|pl| pl.mana_pool.total())
+                .unwrap_or(0);
 
-    stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
-    let waiting_for = finalize_cast_with_phyrexian_choices(
-        state,
-        player,
-        pending.object_id,
-        pending.card_id,
-        pending.ability,
-        &pending.cost,
-        pending.casting_variant,
-        pending.cast_timing_permission,
-        pending.origin_zone,
-        Some(phyrexian_choices),
-        events,
-    )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+            super::casting::pay_mana_cost_with_choices(
+                state,
+                player,
+                pending.object_id,
+                &pending.cost,
+                Some(phyrexian_choices),
+                events,
+            )?;
+
+            let pool_after = state
+                .players
+                .iter()
+                .find(|pl| pl.id == player)
+                .map(|pl| pl.mana_pool.total())
+                .unwrap_or(0);
+            let non_x_cost = pending.cost.mana_value();
+            let total_paid = pool_before.saturating_sub(pool_after) as u32;
+            let x_value = pending
+                .ability
+                .chosen_x
+                .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
+
+            let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
+            let mut pending_resumed = PendingCast::new(
+                pending.object_id,
+                pending.card_id,
+                pending.ability,
+                crate::types::mana::ManaCost::NoCost,
+            );
+            pending_resumed.casting_variant = pending.casting_variant;
+            pending_resumed.origin_zone = pending.origin_zone;
+            pending_resumed.convoked_creatures = pending.convoked_creatures.clone();
+
+            if unit == DistributionUnit::EvenSplitDamage && !targets.is_empty() {
+                let num = targets.len() as u32;
+                let per_target = x_value / num;
+                let distribution: Vec<_> =
+                    targets.iter().map(|t| (t.clone(), per_target)).collect();
+                pending_resumed.ability.distribution = Some(distribution);
+                state.pending_cast = Some(Box::new(pending_resumed));
+
+                let pending = state.pending_cast.take().unwrap();
+                stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
+                let waiting_for = finalize_cast(
+                    state,
+                    player,
+                    pending.object_id,
+                    pending.card_id,
+                    pending.ability,
+                    &pending.cost,
+                    pending.casting_variant,
+                    pending.cast_timing_permission,
+                    pending.origin_zone,
+                    events,
+                )?;
+                return Ok(drain_deferred_triggers_after_stack_object_announcement(
+                    state,
+                    events,
+                    waiting_for,
+                ));
+            }
+
+            state.pending_cast = Some(Box::new(pending_resumed));
+            return Ok(WaitingFor::DistributeAmong {
+                player,
+                total: x_value,
+                targets,
+                unit,
+            });
+        }
+
+        stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
+        let waiting_for = finalize_cast_with_phyrexian_choices(
+            state,
+            player,
+            pending.object_id,
+            pending.card_id,
+            pending.ability,
+            &pending.cost,
+            pending.casting_variant,
+            pending.cast_timing_permission,
+            pending.origin_zone,
+            Some(phyrexian_choices),
+            events,
+        )?;
+        Ok(drain_deferred_triggers_after_stack_object_announcement(
+            state,
+            events,
+            waiting_for,
+        ))
+    })();
+    // CR 118.3a: the transient is self-contained — cleared on Ok and Err alike.
+    state.active_payment_pins.clear();
+    finalize_result
 }
 
 /// CR 107.4f + CR 601.2f: Determine whether this cast needs to pause for per-shard
@@ -8396,6 +8424,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -10207,6 +10236,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color,
                 source_id: floated_source,
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -10274,6 +10304,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Blue,
             source_id: ObjectId(99),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -12134,6 +12165,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(99),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -12528,6 +12560,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -12654,6 +12687,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -12749,6 +12783,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -12833,6 +12868,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -12950,6 +12986,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -13679,6 +13716,7 @@ it for each time it was kicked.\n{T}: Add {C} for each charge counter on this ar
             p0.mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -13700,6 +13738,7 @@ it for each time it was kicked.\n{T}: Add {C} for each charge counter on this ar
             p0.mana_pool.add(ManaUnit {
                 color: ManaType::White,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -13877,6 +13916,7 @@ library in a random order.";
             p0.mana_pool.add(ManaUnit {
                 color: ManaType::Blue,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -1085,6 +1085,7 @@ mod tests {
             player_data.mana_pool.add(ManaUnit {
                 color: ManaType::Red,
                 source_id: crate::types::identifiers::ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -1161,6 +1162,7 @@ mod tests {
             player_data.mana_pool.add(ManaUnit {
                 color: ManaType::Red,
                 source_id: crate::types::identifiers::ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -1251,6 +1253,7 @@ mod tests {
         player_data.mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: crate::types::identifiers::ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -1353,6 +1356,7 @@ mod tests {
         player_data.mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: crate::types::identifiers::ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -187,6 +187,16 @@ pub struct DerivedViews {
     /// Empty (and omitted) in the dominant case where no player is afflicted.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub player_status: Vec<PlayerStatusView>,
+
+    /// CR 118.3a + CR 601.2g: during the viewer's own manual mana payment for a
+    /// spell, the portion of the locked cost still UNPAID by the pool units they
+    /// have pinned (selected) so far — the cost reduced against a pool of ONLY
+    /// those pinned units. Lets the payment UI show the cost shrinking as the
+    /// player picks mana, and "covered" (`NoCost`) when their selection alone
+    /// pays the whole cost. `None` outside a non-convoke spell `ManaPayment` the
+    /// viewer controls. Viewer-scoped — one caster's private in-progress choice.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_payment_remaining: Option<ManaCost>,
 }
 
 /// Serialize-only wrapper: the WASM getter passes `&GameState` by reference
@@ -231,6 +241,70 @@ pub struct ClientGameState {
 /// unconditionally for every Commander-format game regardless of who is
 /// viewing. Partner commanders under the same controller each get their
 /// own `CommanderDamageView` entry, not a summed total.
+/// CR 118.3a + CR 601.2g: the cost still unpaid by `viewer`'s pinned pool units
+/// during their own manual mana payment for a spell. Reduces the locked spell
+/// cost against a pool containing ONLY the pinned units (so the residual is
+/// exactly what the player has chosen to spend), under the same spend-restriction
+/// context (`PaymentContext::Spell`) the finalize spend uses. Returns `None`
+/// unless the viewer is mid (non-convoke) spell `ManaPayment` with a pending
+/// cast — activated-ability mana payment keeps its full-cost display, and
+/// convoke/improvise/delve pay via board taps tracked by their own staged UI.
+///
+/// KNOWN LIMITATION: reduces with `any_color = false` and no life-for-color
+/// permissions, so under an any-color spend permission (Chromatic Orrery) or a
+/// K'rrik-style life-as-colored-mana grant the displayed residual can over-state
+/// the cost (a colorless unit pinned toward `{R}` reads as not covering it).
+/// This is deliberately consistent with the pin-eligibility gate
+/// (`mana_unit_eligible_for_cost`), which is also `any_color`-blind and would
+/// reject such a pin — both layers agree on the stricter behavior, and the
+/// common cases (generic + plain colored costs) are exact. Threading the real
+/// permission bundle through both sites is the follow-up to lift this.
+fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<ManaCost> {
+    use crate::types::game_state::WaitingFor;
+    use crate::types::mana::{ManaPool, PaymentContext};
+
+    let WaitingFor::ManaPayment {
+        player,
+        convoke_mode,
+    } = &state.waiting_for
+    else {
+        return None;
+    };
+    if *player != viewer || convoke_mode.is_some() {
+        return None;
+    }
+
+    let pending = state.pending_cast.as_ref()?;
+    // The mana portion the spend funnel reduces is `pending.cost` for both spells
+    // and activations; live-shrink is scoped to spell casts, where that cost is
+    // exactly what the payment panel displays (no activated-ability cost mismatch).
+    if pending.activation_ability_index.is_some() {
+        return None;
+    }
+    let cost = pending.cost.clone();
+
+    // Scratch pool of ONLY the pinned units = the player's current selection.
+    let player_obj = state.players.iter().find(|p| p.id == viewer)?;
+    let mut selected = ManaPool::default();
+    for unit in &player_obj.mana_pool.mana {
+        if pending.pinned_pool_units.contains(&unit.pip_id) {
+            selected.add(unit.clone());
+        }
+    }
+
+    // CR 106.6: reduce under the SAME spend-restriction context the finalize
+    // spend uses, so restricted mana the spell can't accept stays in the residual.
+    let spell_meta = crate::game::casting::build_spell_meta(state, viewer, pending.object_id);
+    let ctx = spell_meta.as_ref().map(PaymentContext::Spell);
+    Some(crate::game::mana_payment::reduce_cost_by_pool(
+        &selected,
+        &cost,
+        ctx.as_ref(),
+        false,
+        None,
+    ))
+}
+
 pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews {
     let mut views = DerivedViews::default();
 
@@ -287,6 +361,12 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
                 }
             }
         }
+    }
+
+    // CR 118.3a + CR 601.2g: viewer-scoped remaining cost after the caster's
+    // pinned (selected) pool mana — drives the payment UI's live-shrinking cost.
+    if let Some(viewer) = viewer {
+        views.pending_payment_remaining = pending_payment_remaining(state, viewer);
     }
 
     // CR 104.2b / 119.7 / 119.8 / 118.3 / 101.2 / 702.50b: aggregate
@@ -972,6 +1052,93 @@ mod tests {
         assert!(
             empty.stack_display_groups.is_empty(),
             "empty-stack short-circuit must leave the group vec empty"
+        );
+    }
+
+    /// SHAPE test (constructs `pending_cast`/pool directly, not via the cast
+    /// pipeline): `pending_payment_remaining` is the locked cost reduced by ONLY
+    /// the units the caster has pinned, so the payment UI's cost visibly shrinks
+    /// as mana is selected and reads covered (`NoCost`) once the selection alone
+    /// pays the whole cost. Also pins the viewer-scoping: an opponent never sees
+    /// the caster's in-progress private selection.
+    #[test]
+    fn pending_payment_remaining_reflects_pinned_selection() {
+        use crate::types::ability::{Effect, ResolvedAbility};
+        use crate::types::game_state::{PendingCast, WaitingFor};
+        use crate::types::mana::{ManaCost, ManaType, ManaUnit};
+
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+        let spell = create_object(&mut state, CardId(1), p0, "Test Spell".into(), Zone::Stack);
+
+        // Three colorless pool units, each stamped with a distinct pip id.
+        for _ in 0..3 {
+            state.add_mana_to_pool(
+                p0,
+                ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            );
+        }
+        let pip_ids: Vec<_> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id)
+            .collect();
+
+        let ability = ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "test".into(),
+                description: None,
+            },
+            vec![],
+            spell,
+            p0,
+        );
+        state.pending_cast = Some(Box::new(PendingCast::new(
+            spell,
+            CardId(1),
+            ability,
+            ManaCost::generic(2),
+        )));
+        state.waiting_for = WaitingFor::ManaPayment {
+            player: p0,
+            convoke_mode: None,
+        };
+
+        // No selection → the whole {2} still has to be paid.
+        assert_eq!(
+            derive_views(&state, Some(p0)).pending_payment_remaining,
+            Some(ManaCost::generic(2)),
+        );
+
+        // Pin one unit → {1} remains.
+        state
+            .pending_cast
+            .as_mut()
+            .unwrap()
+            .pinned_pool_units
+            .push(pip_ids[0]);
+        assert_eq!(
+            derive_views(&state, Some(p0)).pending_payment_remaining,
+            Some(ManaCost::generic(1)),
+        );
+
+        // Pin a second → the selection alone covers the cost (NoCost).
+        state
+            .pending_cast
+            .as_mut()
+            .unwrap()
+            .pinned_pool_units
+            .push(pip_ids[1]);
+        assert_eq!(
+            derive_views(&state, Some(p0)).pending_payment_remaining,
+            Some(ManaCost::NoCost),
+        );
+
+        // Viewer scoping: the opponent never sees the caster's private selection.
+        assert_eq!(
+            derive_views(&state, Some(PlayerId(1))).pending_payment_remaining,
+            None,
         );
     }
 

--- a/crates/engine/src/game/effects/double.rs
+++ b/crates/engine/src/game/effects/double.rs
@@ -213,23 +213,26 @@ fn resolve_double_mana(
     };
 
     // CR 701.10f: Add equal amount of each mana type
-    let player = state
-        .players
-        .iter_mut()
-        .find(|p| p.id == player_id)
-        .ok_or(EffectError::PlayerNotFound)?;
+    if !state.players.iter().any(|p| p.id == player_id) {
+        return Err(EffectError::PlayerNotFound);
+    }
 
     for (mana_type, count) in mana_to_add {
         for _ in 0..count {
-            player.mana_pool.add(ManaUnit {
-                color: mana_type,
-                source_id: ability.source_id,
-                supertype: None,
-                source_could_produce_two_or_more_colors: false,
-                restrictions: vec![],
-                grants: vec![],
-                expiry: None,
-            });
+            // CR 118.3a: stamp a pip id on pool entry so the unit can be pinned.
+            state.add_mana_to_pool(
+                player_id,
+                ManaUnit {
+                    color: mana_type,
+                    source_id: ability.source_id,
+                    pip_id: crate::types::mana::ManaPipId(0),
+                    supertype: None,
+                    source_could_produce_two_or_more_colors: false,
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                },
+            );
 
             events.push(GameEvent::ManaAdded {
                 player_id,
@@ -697,16 +700,21 @@ mod tests {
     fn double_mana_pool() {
         let mut state = GameState::default();
         // Add 3 red mana to player 0's pool
+        let p0 = state.players[0].id;
         for _ in 0..3 {
-            state.players[0].mana_pool.add(ManaUnit {
-                color: ManaType::Red,
-                source_id: ObjectId(50),
-                supertype: None,
-                source_could_produce_two_or_more_colors: false,
-                restrictions: vec![],
-                grants: vec![],
-                expiry: None,
-            });
+            state.add_mana_to_pool(
+                p0,
+                ManaUnit {
+                    color: ManaType::Red,
+                    source_id: ObjectId(50),
+                    pip_id: crate::types::mana::ManaPipId(0),
+                    supertype: None,
+                    source_could_produce_two_or_more_colors: false,
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                },
+            );
         }
 
         let mut events = Vec::new();

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -365,6 +365,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -479,6 +480,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForActivation],
@@ -654,6 +656,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -691,6 +694,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForActivation],
@@ -719,6 +723,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -748,6 +753,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -1379,6 +1385,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1497,6 +1504,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1659,6 +1667,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1766,6 +1775,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1874,6 +1884,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1965,6 +1976,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -1976,6 +1988,7 @@ mod tests {
             state.players[1].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],
@@ -2199,6 +2212,7 @@ mod tests {
             state.players[player.0 as usize].mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![],

--- a/crates/engine/src/game/effects/regenerate.rs
+++ b/crates/engine/src/game/effects/regenerate.rs
@@ -355,6 +355,7 @@ mod tests {
             p.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -592,6 +593,7 @@ mod tests {
             .add(ManaUnit {
                 color: ManaType::Black,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -5210,6 +5210,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::White,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3072,6 +3072,8 @@ fn apply_action(
         // CR 601.2h: Player has confirmed payment — delegate to the shared finalizer
         // that both this branch and the auto-pay path in `enter_payment_step` share.
         (WaitingFor::ManaPayment { player, .. }, GameAction::PassPriority) => {
+            // CR 118.3a: `finalize_mana_payment` clears `active_payment_pins`
+            // itself on every Ok/Err path, so no caller clear is needed.
             casting_costs::finalize_mana_payment(state, *player, &mut events)?
         }
         // CR 107.4f + CR 601.2f + CR 601.2h: Caster submitted per-shard Phyrexian
@@ -3184,6 +3186,8 @@ fn apply_action(
                     }
                 }
             }
+            // CR 118.3a: `finalize_mana_payment_with_phyrexian_choices` clears
+            // `active_payment_pins` itself on every Ok/Err path; no caller clear.
             casting_costs::finalize_mana_payment_with_phyrexian_choices(
                 state,
                 player,
@@ -3308,6 +3312,37 @@ fn apply_action(
                 convoke_mode: *convoke_mode,
             }
         }
+        // CR 118.3a: Pin a specific pool unit so the finalize spend prefers it.
+        // Immediate-stage: records the hint on `pending_cast`, no stack push.
+        (
+            WaitingFor::ManaPayment {
+                player,
+                convoke_mode,
+            },
+            GameAction::SpendPoolMana { pip_id },
+        ) => {
+            let (player, convoke_mode) = (*player, *convoke_mode);
+            handle_spend_pool_mana(state, player, pip_id)?;
+            WaitingFor::ManaPayment {
+                player,
+                convoke_mode,
+            }
+        }
+        // CR 118.3a: Remove a previously-recorded pin (always legal).
+        (
+            WaitingFor::ManaPayment {
+                player,
+                convoke_mode,
+            },
+            GameAction::UnspendPoolMana { pip_id },
+        ) => {
+            let (player, convoke_mode) = (*player, *convoke_mode);
+            handle_unspend_pool_mana(state, pip_id);
+            WaitingFor::ManaPayment {
+                player,
+                convoke_mode,
+            }
+        }
         // CR 702.51a / Waterbend: Tap a creature or artifact to pay mana.
         // CR 702.51a + CR 302.6: Convoke taps creatures to pay mana; summoning sickness
         // (CR 302.6) is not checked because convoke does not use the tap activated-ability mechanism.
@@ -3398,9 +3433,10 @@ fn apply_action(
                 }
                 ConvokeMode::Delve => unreachable!("delve uses its own ManaPayment arm"),
             };
-            if let Some(p) = state.players.iter_mut().find(|p| p.id == *player) {
-                p.mana_pool.add(unit);
-            }
+            // CR 118.3a: stamp a pip id on pool entry. Convoke/improvise markers
+            // are consumed by the shared algorithm and never pinned (the frontend
+            // filters ConvokePayment units); Waterbend produces real pinnable mana.
+            state.add_mana_to_pool(*player, unit);
             if mode == ConvokeMode::Waterbend {
                 events.push(GameEvent::ManaAdded {
                     player_id: *player,
@@ -3460,12 +3496,15 @@ fn apply_action(
             if let Some(spell_id) = state.pending_cast.as_ref().map(|p| p.object_id) {
                 crate::game::exile_links::push_tracked_by_source(state, object_id, spell_id);
             }
-            if let Some(p) = state.players.iter_mut().find(|p| p.id == player) {
-                p.mana_pool.add(crate::types::mana::ManaUnit::convoke_payment(
+            // CR 118.3a: route through the stamping authority (delve marker is a
+            // generic-only convoke marker, never pinned).
+            state.add_mana_to_pool(
+                player,
+                crate::types::mana::ManaUnit::convoke_payment(
                     crate::types::mana::ManaType::Colorless,
                     object_id,
-                ));
-            }
+                ),
+            );
             WaitingFor::ManaPayment {
                 player,
                 convoke_mode: Some(ConvokeMode::Delve),
@@ -5961,6 +6000,23 @@ pub(super) fn handle_untap_land_for_mana(
         player_data.mana_pool.remove_from_source(*aura_id);
     }
 
+    // CR 118.3a: an UntapLandForMana during ManaPayment can drain a pinned unit
+    // out of the pool. Prune any dangling pins so the finalize spend never tries
+    // to honor a pip that no longer exists. Done AFTER the `player_data` borrow
+    // above ends so the immutable pool read and the `pending_cast` mutation don't
+    // overlap a live `&mut`.
+    if state.pending_cast.is_some() {
+        let surviving: std::collections::HashSet<crate::types::mana::ManaPipId> = state
+            .players
+            .iter()
+            .find(|p| p.id == player)
+            .map(|p| p.mana_pool.mana.iter().map(|u| u.pip_id).collect())
+            .unwrap_or_default();
+        if let Some(pc) = state.pending_cast.as_mut() {
+            pc.pinned_pool_units.retain(|id| surviving.contains(id));
+        }
+    }
+
     // Untap the land
     let obj = state
         .objects
@@ -5978,6 +6034,145 @@ pub(super) fn handle_untap_land_for_mana(
     }
 
     Ok(())
+}
+
+/// CR 118.3a: Record a player-directed pin on a specific pool unit so the
+/// finalize spend prefers it. The unit stays in the pool — this is a priority
+/// hint, not a removal. A pin is accepted only when the unit is eligible to pay
+/// at least one shard (or a generic pip) of the full locked cost; otherwise the
+/// pin could never be honored, so it is rejected (`ActionNotAllowed`).
+pub(super) fn handle_spend_pool_mana(
+    state: &mut GameState,
+    player: PlayerId,
+    pip_id: crate::types::mana::ManaPipId,
+) -> Result<(), EngineError> {
+    // The unit must currently exist in the player's pool.
+    let unit = state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .and_then(|p| p.mana_pool.mana.iter().find(|u| u.pip_id == pip_id))
+        .cloned()
+        .ok_or_else(|| {
+            EngineError::ActionNotAllowed("No such mana unit in pool to pin".to_string())
+        })?;
+
+    let pending = state.pending_cast.as_ref().ok_or_else(|| {
+        EngineError::ActionNotAllowed("No pending cast to pin mana for".to_string())
+    })?;
+    let object_id = pending.object_id;
+    let cost = pending.cost.clone();
+    let activation_ability_index = pending.activation_ability_index;
+
+    // CR 118.3a: eligibility against the full LOCKED cost. Nothing is paid at pin
+    // time, so there is no "currently-unpaid" subset — the unit qualifies if it
+    // could pay any shard (or generic pip) of the whole cost under the SAME
+    // spend-restriction context the finalize spend will use. A `pending_cast`
+    // can be an activated ability, not just a spell (CR 602): mirror
+    // `finalize_mana_payment` and build a `PaymentContext::Activation` so an
+    // activation-restricted unit (`OnlyForActivation`, `allows_spell == false`)
+    // is correctly eligible to pin when it can legally pay the activation.
+    // Owned holders so the context's borrowed slices outlive the eligibility check.
+    let spell_meta;
+    let source_types;
+    let source_subtypes;
+    let ability_tag;
+    let ctx = if let Some(ability_index) = activation_ability_index {
+        let (types, subtypes) = super::casting::activation_source_types(state, object_id);
+        source_types = types;
+        source_subtypes = subtypes;
+        ability_tag = super::casting::activation_ability_tag(state, object_id, ability_index);
+        Some(crate::types::mana::PaymentContext::Activation {
+            source_types: &source_types,
+            source_subtypes: &source_subtypes,
+            ability_tag,
+        })
+    } else {
+        spell_meta = super::casting::build_spell_meta(state, player, object_id);
+        spell_meta
+            .as_ref()
+            .map(crate::types::mana::PaymentContext::Spell)
+    };
+
+    if !mana_unit_eligible_for_cost(&unit, &cost, ctx.as_ref()) {
+        return Err(EngineError::ActionNotAllowed(
+            "Mana unit cannot pay any part of this cost".to_string(),
+        ));
+    }
+
+    if let Some(pc) = state.pending_cast.as_mut() {
+        if !pc.pinned_pool_units.contains(&pip_id) {
+            pc.pinned_pool_units.push(pip_id);
+        }
+    }
+    Ok(())
+}
+
+/// CR 118.3a: Remove a previously-recorded pin. Always legal — a no-op if the
+/// pin is absent or there is no pending cast.
+pub(super) fn handle_unspend_pool_mana(
+    state: &mut GameState,
+    pip_id: crate::types::mana::ManaPipId,
+) {
+    if let Some(pc) = state.pending_cast.as_mut() {
+        pc.pinned_pool_units.retain(|id| *id != pip_id);
+    }
+}
+
+/// CR 118.3a: True when `unit` could legally pay at least one shard or generic
+/// pip of `cost` under the spell's spend-restriction context. Combines
+/// restriction gating (`ManaRestriction::allows`) with shard color/attribute
+/// matching (`shard_to_mana_type`) — the same predicates the spend funnel uses.
+fn mana_unit_eligible_for_cost(
+    unit: &crate::types::mana::ManaUnit,
+    cost: &crate::types::mana::ManaCost,
+    ctx: Option<&crate::types::mana::PaymentContext<'_>>,
+) -> bool {
+    use crate::types::mana::{ManaCost, ManaType};
+    use mana_payment::ShardRequirement;
+
+    // CR 106.6: a unit whose restrictions reject this context can pay nothing here.
+    if let Some(ctx) = ctx {
+        if !unit.restrictions.iter().all(|r| r.allows(ctx)) {
+            return false;
+        }
+    }
+    // Convoke/improvise/delve markers are creature-tap stand-ins, never pinned.
+    if unit.is_convoke_payment() {
+        return false;
+    }
+
+    let (shards, generic) = match cost {
+        ManaCost::Cost { shards, generic } => (shards, *generic),
+        // No-cost / self-referential costs have no payable pip.
+        _ => return false,
+    };
+
+    // CR 107.4b: any unit can pay a generic pip ({N} or {X}).
+    if generic > 0 {
+        return true;
+    }
+
+    shards.iter().any(|&shard| {
+        // CR 107.4: a unit pays a shard if its color (or attribute, for {S}/{Z})
+        // is among those the shard accepts.
+        let accepts = |c: ManaType| unit.color == c;
+        match mana_payment::shard_to_mana_type(shard) {
+            ShardRequirement::Single(mt) => accepts(mt),
+            ShardRequirement::Hybrid(a, b) => accepts(a) || accepts(b),
+            ShardRequirement::Phyrexian(c) => accepts(c),
+            ShardRequirement::HybridPhyrexian(a, b) => accepts(a) || accepts(b),
+            // {2/C} and {C/color}: payable with the color, or (for {2/C}) generic.
+            ShardRequirement::TwoGenericHybrid(c) => accepts(c),
+            ShardRequirement::ColorlessHybrid(c) => accepts(ManaType::Colorless) || accepts(c),
+            ShardRequirement::Snow => unit.is_snow(),
+            ShardRequirement::TwoOrMoreColorSource => unit.source_could_produce_two_or_more_colors,
+            // {X} contributes nothing off the stack (CR 107.3); generic-payable
+            // when X > 0 is already covered by the `generic` check above.
+            ShardRequirement::X => false,
+            ShardRequirement::TwoGenericHybridPhyrexian(c) => accepts(c),
+        }
+    })
 }
 
 fn handle_equip_activation(
@@ -10662,6 +10857,7 @@ mod tests {
             player.mana_pool.add(ManaUnit {
                 color: ManaType::Blue,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -10736,6 +10932,7 @@ mod tests {
             player.mana_pool.add(ManaUnit {
                 color: ManaType::Blue,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -10834,6 +11031,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Blue,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -11664,6 +11862,7 @@ mod tests {
         player.mana_pool.add(ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -11722,6 +11921,7 @@ mod tests {
             player_data.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -12243,6 +12443,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -12629,6 +12830,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -13681,6 +13883,7 @@ mod tests {
         player.mana_pool.add(ManaUnit {
             color: ManaType::Blue,
             source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -16871,6 +17074,7 @@ mod phase_trigger_regression_tests {
                 .add(ManaUnit {
                     color: ManaType::Colorless,
                     source_id: ObjectId(0),
+                    pip_id: crate::types::mana::ManaPipId(0),
                     supertype: None,
                     source_could_produce_two_or_more_colors: false,
                     restrictions: Vec::new(),
@@ -24111,6 +24315,7 @@ mod mdfc_land_tests {
             p.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -9909,6 +9909,56 @@ mod tests {
         ));
     }
 
+    /// CR 118.3a regression: each land tapped for mana must yield a pool unit
+    /// with a DISTINCT, nonzero `pip_id`. A shared/zero id makes every same-color
+    /// pip in the manual-payment UI select and deselect together (the reported
+    /// "tap one → all select, tap again → all deselect" bug), because pinning a
+    /// `pip_id` then matches every unit carrying that same id.
+    #[test]
+    fn tapped_lands_produce_distinct_pip_ids() {
+        let mut state = setup_game_at_main_phase();
+
+        let mut land_ids = Vec::new();
+        for _ in 0..3 {
+            let land_id = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Forest".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&land_id).unwrap();
+                obj.card_types.core_types.push(CoreType::Land);
+                obj.card_types.subtypes.push("Forest".to_string());
+                obj.entered_battlefield_turn = Some(1);
+            }
+            land_ids.push(land_id);
+        }
+
+        for land_id in land_ids {
+            apply_as_current(
+                &mut state,
+                GameAction::TapLandForMana { object_id: land_id },
+            )
+            .unwrap();
+        }
+
+        let ids: Vec<u64> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id.0)
+            .collect();
+        assert_eq!(ids.len(), 3, "three taps must float three pool units");
+        assert!(
+            ids.iter().all(|&id| id != 0),
+            "every pooled unit must be stamped (nonzero pip_id), got {ids:?}"
+        );
+        let unique: std::collections::HashSet<u64> = ids.iter().copied().collect();
+        assert_eq!(unique.len(), 3, "pip ids must be distinct, got {ids:?}");
+    }
+
     /// Build a Wild Growth–style aura attached to `land_id` for tests in this
     /// module. Single-color "{G}" `TapsForMana` trigger via
     /// `valid_card: AttachedTo`. Returns the aura's `ObjectId`.

--- a/crates/engine/src/game/engine_combat.rs
+++ b/crates/engine/src/game/engine_combat.rs
@@ -1395,6 +1395,7 @@ mod tests {
             .add(ManaUnit {
                 color: ManaType::White,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -1471,6 +1472,7 @@ mod tests {
                 .add(ManaUnit {
                     color: ManaType::Colorless,
                     source_id: ObjectId(0),
+                    pip_id: crate::types::mana::ManaPipId(0),
                     supertype: None,
                     source_could_produce_two_or_more_colors: false,
                     restrictions: Vec::new(),

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -387,15 +387,16 @@ pub fn apply_debug_action(
 
         DebugAction::AddMana { player_id, mana } => {
             validate_player(state, player_id)?;
-            if let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) {
-                for mana_type in mana {
-                    player.mana_pool.add(crate::types::mana::ManaUnit::new(
-                        mana_type,
-                        ObjectId(0),
-                        false,
-                        vec![],
-                    ));
-                }
+            for mana_type in mana {
+                // CR 118.3a: route through the stamping authority so each
+                // debug-added unit gets a distinct `pip_id`, exactly like
+                // produced mana. A bare `mana_pool.add` leaves the unstamped
+                // sentinel (`ManaPipId(0)`) on every unit, which makes all of
+                // them pin/unpin together in the manual-payment UI.
+                state.add_mana_to_pool(
+                    player_id,
+                    crate::types::mana::ManaUnit::new(mana_type, ObjectId(0), false, vec![]),
+                );
             }
         }
 
@@ -757,6 +758,50 @@ mod tests {
         let mut state = GameState::new(FormatConfig::standard().with_sandbox(), 2, 42);
         state.debug_mode = true;
         state
+    }
+
+    /// CR 118.3a regression: debug-added mana must route through the stamping
+    /// authority so each unit gets a DISTINCT, nonzero `pip_id`. A bare
+    /// `mana_pool.add` leaves every unit at the unstamped sentinel (0), which
+    /// makes all same-color pips in the manual-payment UI pin/unpin together.
+    #[test]
+    fn debug_add_mana_stamps_distinct_pip_ids() {
+        let mut state = sandbox_state();
+        let mut events = Vec::new();
+        apply_debug_action(
+            &mut state,
+            PlayerId(0),
+            DebugAction::AddMana {
+                player_id: PlayerId(0),
+                mana: vec![
+                    crate::types::mana::ManaType::Green,
+                    crate::types::mana::ManaType::Green,
+                    crate::types::mana::ManaType::Green,
+                ],
+            },
+            &mut events,
+        )
+        .unwrap();
+
+        let ids: Vec<u64> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id.0)
+            .collect();
+        assert_eq!(ids.len(), 3, "three AddMana entries → three pool units");
+        assert!(
+            ids.iter().all(|&id| id != 0),
+            "debug-added units must be stamped (nonzero pip_id), got {ids:?}"
+        );
+        assert_eq!(
+            ids.iter()
+                .copied()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            3,
+            "debug-added pip ids must be distinct, got {ids:?}"
+        );
     }
 
     fn zero_zero_creature() -> TokenCharacteristics {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -429,28 +429,29 @@ pub(super) fn handle_replacement_choice(
                     tapped_for_mana,
                     ..
                 } => {
-                    if let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) {
-                        for _ in 0..count {
-                            let unit = crate::types::mana::ManaUnit {
-                                color: mana_type,
-                                source_id,
-                                supertype: None,
-                                source_could_produce_two_or_more_colors: false,
-                                restrictions: Vec::new(),
-                                grants: Vec::new(),
-                                expiry: None,
-                            };
-                            player.mana_pool.add(unit);
-                            events.push(GameEvent::ManaAdded {
-                                player_id,
-                                mana_type,
-                                source_id,
-                                tap_state: ManaTapState::from_tap(tapped_for_mana),
-                            });
-                        }
-                        if count > 0 {
-                            state.layers_dirty.mark_full();
-                        }
+                    for _ in 0..count {
+                        let unit = crate::types::mana::ManaUnit {
+                            color: mana_type,
+                            source_id,
+                            pip_id: crate::types::mana::ManaPipId(0),
+                            supertype: None,
+                            source_could_produce_two_or_more_colors: false,
+                            restrictions: Vec::new(),
+                            grants: Vec::new(),
+                            expiry: None,
+                        };
+                        // CR 118.3a: stamp a stable pip id on pool entry so the unit
+                        // can be pinned to direct payment.
+                        state.add_mana_to_pool(player_id, unit);
+                        events.push(GameEvent::ManaAdded {
+                            player_id,
+                            mana_type,
+                            source_id,
+                            tap_state: ManaTapState::from_tap(tapped_for_mana),
+                        });
+                    }
+                    if count > 0 {
+                        state.layers_dirty.mark_full();
                     }
                 }
                 // CR 614.1b + CR 614.10: BeginTurn / BeginPhase replacements are

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -1836,6 +1836,7 @@ mod tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2587,6 +2587,8 @@ fn debit_cost_with_plan(
         false,
         None,
         crate::types::mana::LifePaymentColors::EMPTY,
+        // CR 118.3a: mana-ability activation sub-costs are not pinnable.
+        &[],
     )
     .map(|_| ())
 }
@@ -2681,6 +2683,8 @@ fn pay_mana_sub_cost(
             None,
             // CR 107.4f: same K'rrik-not-applicable rationale as above.
             crate::types::mana::LifePaymentColors::EMPTY,
+            // CR 118.3a: mana-ability activation sub-costs are not pinnable.
+            &[],
         )
         .map_err(|_| {
             EngineError::ActionNotAllowed("Mana pool cannot cover mana ability cost".to_string())
@@ -3207,6 +3211,7 @@ mod tests {
             state.players[player.0 as usize].mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -7,8 +7,8 @@ use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{GameState, ShardChoice};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{
-    ManaCost, ManaCostShard, ManaExpiry, ManaPool, ManaRestriction, ManaSpellGrant, ManaType,
-    ManaUnit, PaymentContext,
+    ManaCost, ManaCostShard, ManaExpiry, ManaPipId, ManaPool, ManaRestriction, ManaSpellGrant,
+    ManaType, ManaUnit, PaymentContext,
 };
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
@@ -78,22 +78,33 @@ pub fn refill_infinite_mana(state: &mut GameState) {
     }
     let flagged: Vec<PlayerId> = state.debug_infinite_mana.iter().copied().collect();
     for &player_id in &flagged {
-        let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) else {
+        let Some(player) = state.players.iter().find(|p| p.id == player_id) else {
             continue;
         };
-        for color in INFINITE_MANA_TYPES {
-            // Count only the units this top-up owns (unrestricted, non-expiring)
-            // so card-produced restricted/expiring mana never suppresses a refill.
-            let have = player
-                .mana_pool
-                .mana
-                .iter()
-                .filter(|u| u.color == color && u.restrictions.is_empty() && u.expiry.is_none())
-                .count();
-            for _ in have..INFINITE_MANA_PER_TYPE {
-                player
+        // Read every per-color `have` count up front (immutable borrow), then
+        // release the borrow before routing additions through
+        // `state.add_mana_to_pool` (which needs `&mut state`).
+        let to_add: Vec<(ManaType, usize)> = INFINITE_MANA_TYPES
+            .into_iter()
+            .map(|color| {
+                // Count only the units this top-up owns (unrestricted, non-expiring)
+                // so card-produced restricted/expiring mana never suppresses a refill.
+                let have = player
                     .mana_pool
-                    .add(ManaUnit::new(color, ObjectId(0), false, Vec::new()));
+                    .mana
+                    .iter()
+                    .filter(|u| u.color == color && u.restrictions.is_empty() && u.expiry.is_none())
+                    .count();
+                (color, INFINITE_MANA_PER_TYPE.saturating_sub(have))
+            })
+            .collect();
+        for (color, count) in to_add {
+            for _ in 0..count {
+                // CR 118.3a: stamp pip ids so debug-refilled mana is pinnable too.
+                state.add_mana_to_pool(
+                    player_id,
+                    ManaUnit::new(color, ObjectId(0), false, Vec::new()),
+                );
             }
         }
     }
@@ -316,6 +327,7 @@ pub(crate) fn produce_mana_with_attributes_from_source_quality(
         let unit = ManaUnit {
             color: final_mana_type,
             source_id,
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors,
             restrictions: restrictions.to_vec(),
@@ -323,12 +335,8 @@ pub(crate) fn produce_mana_with_attributes_from_source_quality(
             expiry,
         };
 
-        let player = state
-            .players
-            .iter_mut()
-            .find(|p| p.id == player_id)
-            .expect("player exists");
-        player.mana_pool.add(unit);
+        // CR 118.3a: stamp a stable pip id on pool entry so the unit can be pinned.
+        state.add_mana_to_pool(player_id, unit);
 
         events.push(GameEvent::ManaAdded {
             player_id,
@@ -508,24 +516,25 @@ pub fn can_pay_for_spell(
                     ShardRequirement::Single(mt) => {
                         // CR 609.4b: When any_color is true, any mana can pay colored costs.
                         if any_color && mt != ManaType::Colorless {
-                            if spend_any_for_required_colors(&mut sim, &[mt], spell, None).is_none()
+                            if spend_any_for_required_colors(&mut sim, &[mt], spell, None, &[])
+                                .is_none()
                             {
                                 return false;
                             }
-                        } else if spend_eligible(&mut sim, mt, spell).is_none() {
+                        } else if spend_eligible(&mut sim, mt, spell, &[]).is_none() {
                             return false;
                         }
                     }
                     // CR 107.4e: Hybrid mana — can be paid with either color.
                     ShardRequirement::Hybrid(a, b) => {
                         if any_color {
-                            if spend_any_for_required_colors(&mut sim, &[a, b], spell, None)
+                            if spend_any_for_required_colors(&mut sim, &[a, b], spell, None, &[])
                                 .is_none()
                             {
                                 return false;
                             }
-                        } else if spend_eligible(&mut sim, a, spell).is_none()
-                            && spend_eligible(&mut sim, b, spell).is_none()
+                        } else if spend_eligible(&mut sim, a, spell, &[]).is_none()
+                            && spend_eligible(&mut sim, b, spell, &[]).is_none()
                         {
                             return false;
                         }
@@ -538,28 +547,28 @@ pub fn can_pay_for_spell(
                     ShardRequirement::TwoGenericHybrid(color) => {
                         // CR 609.4b: When any_color, any mana satisfies the colored half.
                         if any_color {
-                            if spend_any_for_required_colors(&mut sim, &[color], spell, None)
+                            if spend_any_for_required_colors(&mut sim, &[color], spell, None, &[])
                                 .is_none()
                             {
                                 return false;
                             }
-                        } else if spend_eligible(&mut sim, color, spell).is_none() {
-                            if spend_generic_eligible(&mut sim, spell, None).is_none() {
+                        } else if spend_eligible(&mut sim, color, spell, &[]).is_none() {
+                            if spend_generic_eligible(&mut sim, spell, None, &[]).is_none() {
                                 return false;
                             }
-                            if spend_generic_eligible(&mut sim, spell, None).is_none() {
+                            if spend_generic_eligible(&mut sim, spell, None, &[]).is_none() {
                                 return false;
                             }
                         }
                     }
                     // CR 107.4h: Snow mana {S} — paid with mana from a snow source.
                     ShardRequirement::Snow => {
-                        if !spend_snow(&mut sim) {
+                        if !spend_snow(&mut sim, &[]) {
                             return false;
                         }
                     }
                     ShardRequirement::TwoOrMoreColorSource => {
-                        if spend_two_or_more_color_source_eligible(&mut sim, spell).is_none() {
+                        if spend_two_or_more_color_source_eligible(&mut sim, spell, &[]).is_none() {
                             return false;
                         }
                     }
@@ -573,13 +582,15 @@ pub fn can_pay_for_spell(
                                 &[ManaType::Colorless, color],
                                 spell,
                                 None,
+                                &[],
                             )
                             .is_none()
                             {
                                 return false;
                             }
-                        } else if spend_eligible(&mut sim, ManaType::Colorless, spell).is_none()
-                            && spend_eligible(&mut sim, color, spell).is_none()
+                        } else if spend_eligible(&mut sim, ManaType::Colorless, spell, &[])
+                            .is_none()
+                            && spend_eligible(&mut sim, color, spell, &[]).is_none()
                         {
                             return false;
                         }
@@ -613,19 +624,19 @@ pub fn can_pay_for_spell(
                     match deferred {
                         PhyrexianDeferred::Single(color) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*color], spell, None)
+                                spend_any_for_required_colors(&mut sim, &[*color], spell, None, &[])
                                     .is_some()
                             } else {
-                                spend_eligible(&mut sim, *color, spell).is_some()
+                                spend_eligible(&mut sim, *color, spell, &[]).is_some()
                             }
                         }
                         PhyrexianDeferred::Hybrid(a, b) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*a, *b], spell, None)
+                                spend_any_for_required_colors(&mut sim, &[*a, *b], spell, None, &[])
                                     .is_some()
                             } else {
-                                spend_eligible(&mut sim, *a, spell).is_some()
-                                    || spend_eligible(&mut sim, *b, spell).is_some()
+                                spend_eligible(&mut sim, *a, spell, &[]).is_some()
+                                    || spend_eligible(&mut sim, *b, spell, &[]).is_some()
                             }
                         }
                         // CR 107.4f + CR 107.4e: {2/C} promoted by K'rrik —
@@ -634,14 +645,15 @@ pub fn can_pay_for_spell(
                         // still consumed via the budget arm below.
                         PhyrexianDeferred::TwoGeneric(color) => {
                             if any_color {
-                                spend_any_for_required_colors(&mut sim, &[*color], spell, None)
+                                spend_any_for_required_colors(&mut sim, &[*color], spell, None, &[])
                                     .is_some()
-                            } else if spend_eligible(&mut sim, *color, spell).is_some() {
+                            } else if spend_eligible(&mut sim, *color, spell, &[]).is_some() {
                                 true
                             } else {
                                 let mut backup = sim.clone();
-                                if spend_generic_eligible(&mut backup, spell, None).is_some()
-                                    && spend_generic_eligible(&mut backup, spell, None).is_some()
+                                if spend_generic_eligible(&mut backup, spell, None, &[]).is_some()
+                                    && spend_generic_eligible(&mut backup, spell, None, &[])
+                                        .is_some()
                                 {
                                     sim = backup;
                                     true
@@ -668,7 +680,7 @@ pub fn can_pay_for_spell(
 
             // Pay generic
             for _ in 0..*generic {
-                if spend_generic_eligible(&mut sim, spell, None).is_none() {
+                if spend_generic_eligible(&mut sim, spell, None, &[]).is_none() {
                     return false;
                 }
             }
@@ -731,18 +743,19 @@ pub(crate) fn reduce_cost_by_pool(
             // ordering handles it downstream).
             ShardRequirement::Single(color) | ShardRequirement::Phyrexian(color) => {
                 if any_color && color != ManaType::Colorless {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None, &[])
+                        .is_some()
                 } else {
-                    spend_eligible(&mut scratch, color, spell).is_some()
+                    spend_eligible(&mut scratch, color, spell, &[]).is_some()
                 }
             }
             // CR 107.4e/f: Hybrid pays either half.
             ShardRequirement::Hybrid(a, b) | ShardRequirement::HybridPhyrexian(a, b) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[a, b], spell, None).is_some()
+                    spend_any_for_required_colors(&mut scratch, &[a, b], spell, None, &[]).is_some()
                 } else {
-                    spend_eligible(&mut scratch, a, spell).is_some()
-                        || spend_eligible(&mut scratch, b, spell).is_some()
+                    spend_eligible(&mut scratch, a, spell, &[]).is_some()
+                        || spend_eligible(&mut scratch, b, spell, &[]).is_some()
                 }
             }
             // CR 107.4e: {C/color} — prefer colorless, else the colored half.
@@ -753,11 +766,12 @@ pub(crate) fn reduce_cost_by_pool(
                         &[ManaType::Colorless, color],
                         spell,
                         None,
+                        &[],
                     )
                     .is_some()
                 } else {
-                    spend_eligible(&mut scratch, ManaType::Colorless, spell).is_some()
-                        || spend_eligible(&mut scratch, color, spell).is_some()
+                    spend_eligible(&mut scratch, ManaType::Colorless, spell, &[]).is_some()
+                        || spend_eligible(&mut scratch, color, spell, &[]).is_some()
                 }
             }
             // CR 107.4e: {2/color} — 1 colored is cheaper than 2 generic; try colored first.
@@ -765,13 +779,14 @@ pub(crate) fn reduce_cost_by_pool(
             // afford both halves, rather than half-draining it.
             ShardRequirement::TwoGenericHybrid(color) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
-                } else if spend_eligible(&mut scratch, color, spell).is_some() {
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None, &[])
+                        .is_some()
+                } else if spend_eligible(&mut scratch, color, spell, &[]).is_some() {
                     true
                 } else {
                     let mut backup = scratch.clone();
-                    if spend_generic_non_demanded(&mut backup, spell, demand).is_some()
-                        && spend_generic_non_demanded(&mut backup, spell, demand).is_some()
+                    if spend_generic_non_demanded(&mut backup, spell, demand, &[]).is_some()
+                        && spend_generic_non_demanded(&mut backup, spell, demand, &[]).is_some()
                     {
                         scratch = backup;
                         true
@@ -781,9 +796,9 @@ pub(crate) fn reduce_cost_by_pool(
                 }
             }
             // CR 107.4h: Snow mana only from snow sources.
-            ShardRequirement::Snow => spend_snow_unit(&mut scratch).is_some(),
+            ShardRequirement::Snow => spend_snow_unit(&mut scratch, &[]).is_some(),
             ShardRequirement::TwoOrMoreColorSource => {
-                spend_two_or_more_color_source_eligible(&mut scratch, spell).is_some()
+                spend_two_or_more_color_source_eligible(&mut scratch, spell, &[]).is_some()
             }
             // CR 107.1b: `ManaCost::concretize_x` strips `X` shards into generic
             // before auto-tap runs, so this arm is defensive. Keep the shard in
@@ -796,13 +811,14 @@ pub(crate) fn reduce_cost_by_pool(
             // direct dispatch path. Pay-mana semantics mirror `TwoGenericHybrid`.
             ShardRequirement::TwoGenericHybridPhyrexian(color) => {
                 if any_color {
-                    spend_any_for_required_colors(&mut scratch, &[color], spell, None).is_some()
-                } else if spend_eligible(&mut scratch, color, spell).is_some() {
+                    spend_any_for_required_colors(&mut scratch, &[color], spell, None, &[])
+                        .is_some()
+                } else if spend_eligible(&mut scratch, color, spell, &[]).is_some() {
                     true
                 } else {
                     let mut backup = scratch.clone();
-                    if spend_generic_non_demanded(&mut backup, spell, demand).is_some()
-                        && spend_generic_non_demanded(&mut backup, spell, demand).is_some()
+                    if spend_generic_non_demanded(&mut backup, spell, demand, &[]).is_some()
+                        && spend_generic_non_demanded(&mut backup, spell, demand, &[]).is_some()
                     {
                         scratch = backup;
                         true
@@ -824,7 +840,7 @@ pub(crate) fn reduce_cost_by_pool(
     // the pip stays in `residual_generic` and auto-tap will tap another source
     // for it. Without `demand` the prior least-available ordering is preserved.
     for _ in 0..generic {
-        if spend_generic_non_demanded(&mut scratch, spell, demand).is_some() {
+        if spend_generic_non_demanded(&mut scratch, spell, demand, &[]).is_some() {
             residual_generic = residual_generic.saturating_sub(1);
         } else {
             break;
@@ -864,6 +880,7 @@ pub fn pay_cost_with_demand(
         any_color,
         None,
         crate::types::mana::LifePaymentColors::EMPTY,
+        &[],
     )
 }
 
@@ -875,6 +892,7 @@ pub fn pay_cost_with_demand(
 /// `LifePayment`, `PayMana` spends one mana of the shard's color (hybrid-Phyrexian picks
 /// via `auto_pay_hybrid`). A `None` choice vector preserves the existing auto-decision
 /// behavior: prefer mana when available, fall back to 2 life.
+#[allow(clippy::too_many_arguments)]
 pub fn pay_cost_with_demand_and_choices(
     pool: &mut ManaPool,
     cost: &ManaCost,
@@ -883,6 +901,10 @@ pub fn pay_cost_with_demand_and_choices(
     any_color: bool,
     phyrexian_choices: Option<&[ShardChoice]>,
     life_colors: crate::types::mana::LifePaymentColors,
+    // CR 118.3a: player-directed pin hints. At the real finalize spend this is
+    // `pending_cast.pinned_pool_units`; every dry-run/test caller passes `&[]`,
+    // which makes the spend byte-identical to the pre-feature ordering.
+    pins: &[ManaPipId],
 ) -> Result<(Vec<ManaUnit>, Vec<LifePayment>), PaymentError> {
     match cost {
         ManaCost::NoCost | ManaCost::SelfManaCost | ManaCost::SelfManaValue => {
@@ -904,11 +926,12 @@ pub fn pay_cost_with_demand_and_choices(
                     ShardRequirement::Single(mt) => {
                         // CR 609.4b: When any_color, any mana can pay colored costs.
                         if any_color && mt != ManaType::Colorless {
-                            let unit = spend_any_for_required_colors(pool, &[mt], spell, None)
-                                .ok_or(PaymentError::InsufficientMana)?;
+                            let unit =
+                                spend_any_for_required_colors(pool, &[mt], spell, None, pins)
+                                    .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         } else {
-                            let unit = spend_eligible(pool, mt, spell)
+                            let unit = spend_eligible(pool, mt, spell, pins)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         }
@@ -916,8 +939,9 @@ pub fn pay_cost_with_demand_and_choices(
                     // CR 107.4e: Hybrid mana — pay with either half.
                     ShardRequirement::Hybrid(a, b) => {
                         if any_color {
-                            let unit = spend_any_for_required_colors(pool, &[a, b], spell, None)
-                                .ok_or(PaymentError::InsufficientMana)?;
+                            let unit =
+                                spend_any_for_required_colors(pool, &[a, b], spell, None, pins)
+                                    .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         } else {
                             let remaining_pair_shards =
@@ -930,7 +954,7 @@ pub fn pay_cost_with_demand_and_choices(
                                 remaining_pair_shards,
                                 &mut preferred_hybrid_colors,
                             );
-                            let unit = spend_eligible(pool, color, spell)
+                            let unit = spend_eligible(pool, color, spell, pins)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         }
@@ -948,9 +972,9 @@ pub fn pay_cost_with_demand_and_choices(
                             }
                             Some(ShardChoice::PayMana) => {
                                 let unit = if any_color {
-                                    spend_any_for_required_colors(pool, &[color], spell, None)
+                                    spend_any_for_required_colors(pool, &[color], spell, None, pins)
                                 } else {
-                                    spend_eligible(pool, color, spell)
+                                    spend_eligible(pool, color, spell, pins)
                                 }
                                 .ok_or(PaymentError::InsufficientMana)?;
                                 spent.push(unit);
@@ -961,9 +985,15 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_ok = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[color], spell, None)
+                                        spend_any_for_required_colors(
+                                            pool,
+                                            &[color],
+                                            spell,
+                                            None,
+                                            pins,
+                                        )
                                     } else {
-                                        spend_eligible(pool, color, spell)
+                                        spend_eligible(pool, color, spell, pins)
                                     }
                                 } else {
                                     None
@@ -979,14 +1009,15 @@ pub fn pay_cost_with_demand_and_choices(
                     // CR 107.4e: Monocolored hybrid {2/C} — pay 1 colored or 2 generic.
                     ShardRequirement::TwoGenericHybrid(color) => {
                         if any_color {
-                            let unit = spend_any_for_required_colors(pool, &[color], spell, None)
-                                .ok_or(PaymentError::InsufficientMana)?;
+                            let unit =
+                                spend_any_for_required_colors(pool, &[color], spell, None, pins)
+                                    .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
-                        } else if let Some(unit) = spend_eligible(pool, color, spell) {
+                        } else if let Some(unit) = spend_eligible(pool, color, spell, pins) {
                             spent.push(unit);
                         } else {
                             for _ in 0..2 {
-                                let unit = spend_generic_eligible(pool, spell, None)
+                                let unit = spend_generic_eligible(pool, spell, None, pins)
                                     .ok_or(PaymentError::InsufficientMana)?;
                                 spent.push(unit);
                             }
@@ -994,11 +1025,12 @@ pub fn pay_cost_with_demand_and_choices(
                     }
                     // CR 107.4h: Snow mana {S} — paid with mana from a snow source.
                     ShardRequirement::Snow => {
-                        let unit = spend_snow_unit(pool).ok_or(PaymentError::InsufficientMana)?;
+                        let unit =
+                            spend_snow_unit(pool, pins).ok_or(PaymentError::InsufficientMana)?;
                         spent.push(unit);
                     }
                     ShardRequirement::TwoOrMoreColorSource => {
-                        let unit = spend_two_or_more_color_source_eligible(pool, spell)
+                        let unit = spend_two_or_more_color_source_eligible(pool, spell, pins)
                             .ok_or(PaymentError::InsufficientMana)?;
                         spent.push(unit);
                     }
@@ -1012,14 +1044,16 @@ pub fn pay_cost_with_demand_and_choices(
                                 &[ManaType::Colorless, color],
                                 spell,
                                 None,
+                                pins,
                             )
                             .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
-                        } else if let Some(unit) = spend_eligible(pool, ManaType::Colorless, spell)
+                        } else if let Some(unit) =
+                            spend_eligible(pool, ManaType::Colorless, spell, pins)
                         {
                             spent.push(unit);
                         } else {
-                            let unit = spend_eligible(pool, color, spell)
+                            let unit = spend_eligible(pool, color, spell, pins)
                                 .ok_or(PaymentError::InsufficientMana)?;
                             spent.push(unit);
                         }
@@ -1037,7 +1071,7 @@ pub fn pay_cost_with_demand_and_choices(
                             }
                             Some(ShardChoice::PayMana) => {
                                 let unit = if any_color {
-                                    spend_any_for_required_colors(pool, &[a, b], spell, None)
+                                    spend_any_for_required_colors(pool, &[a, b], spell, None, pins)
                                 } else {
                                     let remaining_pair_shards =
                                         count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1049,7 +1083,7 @@ pub fn pay_cost_with_demand_and_choices(
                                         remaining_pair_shards,
                                         &mut preferred_hybrid_colors,
                                     );
-                                    spend_eligible(pool, color, spell)
+                                    spend_eligible(pool, color, spell, pins)
                                 }
                                 .ok_or(PaymentError::InsufficientMana)?;
                                 spent.push(unit);
@@ -1060,7 +1094,13 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_ok = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[a, b], spell, None)
+                                        spend_any_for_required_colors(
+                                            pool,
+                                            &[a, b],
+                                            spell,
+                                            None,
+                                            pins,
+                                        )
                                     } else {
                                         let remaining_pair_shards =
                                             count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1072,7 +1112,7 @@ pub fn pay_cost_with_demand_and_choices(
                                             remaining_pair_shards,
                                             &mut preferred_hybrid_colors,
                                         );
-                                        spend_eligible(pool, color, spell)
+                                        spend_eligible(pool, color, spell, pins)
                                     }
                                 } else {
                                     None
@@ -1102,15 +1142,21 @@ pub fn pay_cost_with_demand_and_choices(
                             Some(ShardChoice::PayMana) => {
                                 // Mirror auto-pay preference: 1 colored, then 2 generic.
                                 if any_color {
-                                    let unit =
-                                        spend_any_for_required_colors(pool, &[color], spell, None)
-                                            .ok_or(PaymentError::InsufficientMana)?;
+                                    let unit = spend_any_for_required_colors(
+                                        pool,
+                                        &[color],
+                                        spell,
+                                        None,
+                                        pins,
+                                    )
+                                    .ok_or(PaymentError::InsufficientMana)?;
                                     spent.push(unit);
-                                } else if let Some(unit) = spend_eligible(pool, color, spell) {
+                                } else if let Some(unit) = spend_eligible(pool, color, spell, pins)
+                                {
                                     spent.push(unit);
                                 } else {
                                     for _ in 0..2 {
-                                        let unit = spend_generic_eligible(pool, spell, None)
+                                        let unit = spend_generic_eligible(pool, spell, None, pins)
                                             .ok_or(PaymentError::InsufficientMana)?;
                                         spent.push(unit);
                                     }
@@ -1122,13 +1168,20 @@ pub fn pay_cost_with_demand_and_choices(
                                 let can_spare = pool.total() > *generic as usize;
                                 let mana_paid = if can_spare {
                                     if any_color {
-                                        spend_any_for_required_colors(pool, &[color], spell, None)
-                                            .map(|u| {
-                                                spent.push(u);
-                                                true
-                                            })
-                                            .unwrap_or(false)
-                                    } else if let Some(u) = spend_eligible(pool, color, spell) {
+                                        spend_any_for_required_colors(
+                                            pool,
+                                            &[color],
+                                            spell,
+                                            None,
+                                            pins,
+                                        )
+                                        .map(|u| {
+                                            spent.push(u);
+                                            true
+                                        })
+                                        .unwrap_or(false)
+                                    } else if let Some(u) = spend_eligible(pool, color, spell, pins)
+                                    {
                                         spent.push(u);
                                         true
                                     } else {
@@ -1136,9 +1189,12 @@ pub fn pay_cost_with_demand_and_choices(
                                         let mut backup = pool.clone();
                                         let mut tmp_spent: Vec<ManaUnit> = Vec::new();
                                         let ok = (0..2).all(|_| {
-                                            if let Some(u) =
-                                                spend_generic_eligible(&mut backup, spell, None)
-                                            {
+                                            if let Some(u) = spend_generic_eligible(
+                                                &mut backup,
+                                                spell,
+                                                None,
+                                                pins,
+                                            ) {
                                                 tmp_spent.push(u);
                                                 true
                                             } else {
@@ -1177,7 +1233,7 @@ pub fn pay_cost_with_demand_and_choices(
             // deprioritizes a hand-demanded color when filling generic. This only
             // reorders WHICH eligible unit pays a generic pip; it never refuses one.
             for _ in 0..*generic {
-                let unit = spend_generic_eligible(pool, spell, hand_demand)
+                let unit = spend_generic_eligible(pool, spell, hand_demand, pins)
                     .ok_or(PaymentError::InsufficientMana)?;
                 spent.push(unit);
             }
@@ -1232,14 +1288,14 @@ pub fn compute_phyrexian_shards(
         match effective_shard_requirement(shard_to_mana_type(shards[idx]), life_colors) {
             ShardRequirement::Single(mt) => {
                 if any_color && mt != ManaType::Colorless {
-                    let _ = spend_any_for_required_colors(&mut sim, &[mt], spell, None);
+                    let _ = spend_any_for_required_colors(&mut sim, &[mt], spell, None, &[]);
                 } else {
-                    let _ = spend_eligible(&mut sim, mt, spell);
+                    let _ = spend_eligible(&mut sim, mt, spell, &[]);
                 }
             }
             ShardRequirement::Hybrid(a, b) => {
                 if any_color {
-                    let _ = spend_any_for_required_colors(&mut sim, &[a, b], spell, None);
+                    let _ = spend_any_for_required_colors(&mut sim, &[a, b], spell, None, &[]);
                 } else {
                     let remaining_pair_shards = count_remaining_hybrid_shards(shards, idx, a, b);
                     let color = select_hybrid_payment_color(
@@ -1250,7 +1306,7 @@ pub fn compute_phyrexian_shards(
                         remaining_pair_shards,
                         &mut preferred_hybrid_colors,
                     );
-                    let _ = spend_eligible(&mut sim, color, spell);
+                    let _ = spend_eligible(&mut sim, color, spell, &[]);
                 }
             }
             ShardRequirement::Phyrexian(color) => {
@@ -1278,9 +1334,9 @@ pub fn compute_phyrexian_shards(
                 // if mana is unavailable or would starve generic, consume life budget.
                 if effective_mana {
                     let _ = if any_color {
-                        spend_any_for_required_colors(&mut sim, &[color], spell, None)
+                        spend_any_for_required_colors(&mut sim, &[color], spell, None, &[])
                     } else {
-                        spend_eligible(&mut sim, color, spell)
+                        spend_eligible(&mut sim, color, spell, &[])
                     };
                 } else {
                     life_budget = life_budget.saturating_sub(1);
@@ -1288,18 +1344,18 @@ pub fn compute_phyrexian_shards(
             }
             ShardRequirement::TwoGenericHybrid(color) => {
                 if any_color {
-                    let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None);
-                } else if spend_eligible(&mut sim, color, spell).is_none() {
+                    let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None, &[]);
+                } else if spend_eligible(&mut sim, color, spell, &[]).is_none() {
                     for _ in 0..2 {
-                        let _ = spend_generic_eligible(&mut sim, spell, None);
+                        let _ = spend_generic_eligible(&mut sim, spell, None, &[]);
                     }
                 }
             }
             ShardRequirement::Snow => {
-                let _ = spend_snow_unit(&mut sim);
+                let _ = spend_snow_unit(&mut sim, &[]);
             }
             ShardRequirement::TwoOrMoreColorSource => {
-                let _ = spend_two_or_more_color_source_eligible(&mut sim, spell);
+                let _ = spend_two_or_more_color_source_eligible(&mut sim, spell, &[]);
             }
             ShardRequirement::X => {}
             ShardRequirement::ColorlessHybrid(color) => {
@@ -1309,9 +1365,10 @@ pub fn compute_phyrexian_shards(
                         &[ManaType::Colorless, color],
                         spell,
                         None,
+                        &[],
                     );
-                } else if spend_eligible(&mut sim, ManaType::Colorless, spell).is_none() {
-                    let _ = spend_eligible(&mut sim, color, spell);
+                } else if spend_eligible(&mut sim, ManaType::Colorless, spell, &[]).is_none() {
+                    let _ = spend_eligible(&mut sim, color, spell, &[]);
                 }
             }
             ShardRequirement::HybridPhyrexian(a, b) => {
@@ -1341,7 +1398,7 @@ pub fn compute_phyrexian_shards(
                 });
                 if effective_mana {
                     let _ = if any_color {
-                        spend_any_for_required_colors(&mut sim, &[a, b], spell, None)
+                        spend_any_for_required_colors(&mut sim, &[a, b], spell, None, &[])
                     } else {
                         let remaining_pair_shards =
                             count_remaining_hybrid_shards(shards, idx, a, b);
@@ -1353,7 +1410,7 @@ pub fn compute_phyrexian_shards(
                             remaining_pair_shards,
                             &mut preferred_hybrid_colors,
                         );
-                        spend_eligible(&mut sim, color, spell)
+                        spend_eligible(&mut sim, color, spell, &[])
                     };
                 } else {
                     life_budget = life_budget.saturating_sub(1);
@@ -1375,8 +1432,8 @@ pub fn compute_phyrexian_shards(
                         true
                     } else {
                         let mut probe = sim.clone();
-                        spend_generic_eligible(&mut probe, spell, None).is_some()
-                            && spend_generic_eligible(&mut probe, spell, None).is_some()
+                        spend_generic_eligible(&mut probe, spell, None, &[]).is_some()
+                            && spend_generic_eligible(&mut probe, spell, None, &[]).is_some()
                     }
                 };
                 // CR 107.4f + CR 118.3: Only offer mana when spending it
@@ -1399,11 +1456,11 @@ pub fn compute_phyrexian_shards(
                     // Mirror `pay_cost_with_demand_and_choices`'s preference:
                     // prefer 1 colored, then atomic 2-generic fallback.
                     if any_color {
-                        let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None);
-                    } else if spend_eligible(&mut sim, color, spell).is_none() {
+                        let _ = spend_any_for_required_colors(&mut sim, &[color], spell, None, &[]);
+                    } else if spend_eligible(&mut sim, color, spell, &[]).is_none() {
                         let mut backup = sim.clone();
-                        if spend_generic_eligible(&mut backup, spell, None).is_some()
-                            && spend_generic_eligible(&mut backup, spell, None).is_some()
+                        if spend_generic_eligible(&mut backup, spell, None, &[]).is_some()
+                            && spend_generic_eligible(&mut backup, spell, None, &[]).is_some()
                         {
                             sim = backup;
                         }
@@ -1437,7 +1494,7 @@ fn sim_any_for_required_colors_available(
     required_colors: &[ManaType],
 ) -> bool {
     let mut clone = pool.clone();
-    spend_any_for_required_colors(&mut clone, required_colors, spell, None).is_some()
+    spend_any_for_required_colors(&mut clone, required_colors, spell, None, &[]).is_some()
 }
 
 fn sim_color_available(
@@ -1446,7 +1503,7 @@ fn sim_color_available(
     color: ManaType,
 ) -> bool {
     let mut clone = pool.clone();
-    spend_eligible(&mut clone, color, spell).is_some()
+    spend_eligible(&mut clone, color, spell, &[]).is_some()
 }
 
 /// CR 107.4a: Phyrexian shards always reference one of the five colors; `Colorless`
@@ -1610,9 +1667,10 @@ fn spend_eligible(
     pool: &mut ManaPool,
     color: ManaType,
     spell: Option<&PaymentContext<'_>>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
     match spell {
-        Some(ctx) => spend_color_prefer_non_z(pool, color, |unit| {
+        Some(ctx) => spend_color_prefer_non_z(pool, color, pins, |unit| {
             if color == ManaType::Colorless && unit.is_convoke_payment() {
                 return false;
             }
@@ -1620,26 +1678,62 @@ fn spend_eligible(
                 .iter()
                 .all(|restriction| restriction.allows(ctx))
         }),
-        None => spend_color_prefer_non_z(pool, color, |unit| {
+        None => spend_color_prefer_non_z(pool, color, pins, |unit| {
             !(color == ManaType::Colorless && unit.is_convoke_payment())
         }),
     }
 }
 
+/// CR 118.3a: among pool positions satisfying `allows`, prefer a pinned (player-
+/// directed) unit before the existing fallback ordering. When `pins` is empty
+/// this is byte-identical to calling `fallback` directly — the feature is inert
+/// for every non-manual cast.
+fn pick_position(
+    pool: &ManaPool,
+    pins: &[ManaPipId],
+    allows: impl Fn(&ManaUnit) -> bool,
+    fallback: impl FnOnce(&ManaPool) -> Option<usize>,
+) -> Option<usize> {
+    if !pins.is_empty() {
+        if let Some(pos) = pool
+            .mana
+            .iter()
+            .position(|u| allows(u) && pins.contains(&u.pip_id))
+        {
+            return Some(pos);
+        }
+    }
+    fallback(pool)
+}
+
 fn spend_color_prefer_non_z(
     pool: &mut ManaPool,
     color: ManaType,
+    pins: &[ManaPipId],
     allows: impl Fn(&ManaUnit) -> bool,
 ) -> Option<ManaUnit> {
-    if let Some(pos) = pool.mana.iter().position(|unit| {
-        unit.color == color && !unit.source_could_produce_two_or_more_colors && allows(unit)
-    }) {
-        return Some(pool.mana.swap_remove(pos));
-    }
-    pool.mana
-        .iter()
-        .position(|unit| unit.color == color && allows(unit))
-        .map(|pos| pool.mana.swap_remove(pos))
+    // CR 118.3a: a player-pinned eligible unit of this color is spent first;
+    // otherwise the legacy non-`Z`-then-any ordering is preserved exactly.
+    let pos = pick_position(
+        pool,
+        pins,
+        |unit| unit.color == color && allows(unit),
+        |pool| {
+            pool.mana
+                .iter()
+                .position(|unit| {
+                    unit.color == color
+                        && !unit.source_could_produce_two_or_more_colors
+                        && allows(unit)
+                })
+                .or_else(|| {
+                    pool.mana
+                        .iter()
+                        .position(|unit| unit.color == color && allows(unit))
+                })
+        },
+    );
+    pos.map(|pos| pool.mana.swap_remove(pos))
 }
 
 // --- Internal helpers ---
@@ -1839,10 +1933,27 @@ fn spend_any_eligible(
     pool: &mut ManaPool,
     spell: Option<&PaymentContext<'_>>,
     demand: Option<&ColorDemand>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
+    // CR 118.3a: GENERIC-cost pin placement. A generic pip is payable with mana
+    // of ANY color, so the pin scan must span every color before color-selection
+    // chooses one — installing the scan only inside the per-color terminal
+    // (`spend_color_prefer_non_z`) would silently ignore a pin on a color the
+    // demand/least-available logic didn't pick. The scan accepts any unit that
+    // could legally pay a generic pip (non-convoke; restrictions allow under
+    // `spell`). Empty `pins` => skipped => byte-identical legacy ordering below.
+    if !pins.is_empty() {
+        if let Some(pos) = pool.mana.iter().position(|unit| {
+            pins.contains(&unit.pip_id)
+                && !unit.is_convoke_payment()
+                && spell.is_none_or(|ctx| unit.restrictions.iter().all(|r| r.allows(ctx)))
+        }) {
+            return Some(pool.mana.swap_remove(pos));
+        }
+    }
     match spell {
         Some(ctx) => {
-            if let Some(unit) = spend_eligible(pool, ManaType::Colorless, Some(ctx)) {
+            if let Some(unit) = spend_eligible(pool, ManaType::Colorless, Some(ctx), pins) {
                 return Some(unit);
             }
 
@@ -1889,7 +2000,7 @@ fn spend_any_eligible(
                 }
             }
             best.and_then(|(color, _, _)| {
-                spend_color_prefer_non_z(pool, color, |unit| {
+                spend_color_prefer_non_z(pool, color, pins, |unit| {
                     !unit.is_convoke_payment()
                         && unit
                             .restrictions
@@ -1898,7 +2009,7 @@ fn spend_any_eligible(
                 })
             })
         }
-        None => spend_any_unit(pool),
+        None => spend_any_unit(pool, pins),
     }
 }
 
@@ -1907,14 +2018,29 @@ fn spend_any_for_required_colors(
     required_colors: &[ManaType],
     spell: Option<&PaymentContext<'_>>,
     demand: Option<&ColorDemand>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
+    // CR 118.3a: this path pays a colored/hybrid requirement that any of
+    // `required_colors` can satisfy. Scan a pinned unit across the eligible colors
+    // first so a pin on (say) the white half of a W/U hybrid is honored before the
+    // positional per-color fallback. Empty `pins` => unchanged ordering.
+    if !pins.is_empty() {
+        if let Some(pos) = pool.mana.iter().position(|unit| {
+            pins.contains(&unit.pip_id)
+                && required_colors.contains(&unit.color)
+                && !unit.is_convoke_payment()
+                && spell.is_none_or(|ctx| unit.restrictions.iter().all(|r| r.allows(ctx)))
+        }) {
+            return Some(pool.mana.swap_remove(pos));
+        }
+    }
     for color in required_colors {
-        if let Some(unit) = spend_eligible(pool, *color, spell) {
+        if let Some(unit) = spend_eligible(pool, *color, spell, pins) {
             return Some(unit);
         }
     }
 
-    spend_any_eligible(pool, spell, demand)
+    spend_any_eligible(pool, spell, demand, pins)
 }
 
 /// Planner-layer generic spend that respects an outer cost's colored `demand`.
@@ -1939,9 +2065,10 @@ fn spend_generic_non_demanded(
     pool: &mut ManaPool,
     spell: Option<&PaymentContext<'_>>,
     demand: Option<&ColorDemand>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
     let Some(demand) = demand else {
-        return spend_generic_eligible(pool, spell, None);
+        return spend_generic_eligible(pool, spell, None, pins);
     };
 
     // Convoke payment units are creature-tap stand-ins, not floated colored mana;
@@ -2001,7 +2128,23 @@ fn spend_generic_eligible(
     pool: &mut ManaPool,
     spell: Option<&PaymentContext<'_>>,
     demand: Option<&ColorDemand>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
+    // CR 118.3a: a player-pinned real unit takes precedence over the convoke-first
+    // ordering — the player explicitly directed which floated mana pays this
+    // generic pip. Convoke markers are unstamped (`ManaPipId(0)`), so they can
+    // never match a pin; the convoke-first fallback below is unchanged when no pin
+    // applies. Empty `pins` => skip => legacy convoke-first then color-select.
+    if !pins.is_empty() {
+        if let Some(pos) = pool.mana.iter().position(|unit| {
+            pins.contains(&unit.pip_id)
+                && !unit.is_convoke_payment()
+                && spell.is_none_or(|ctx| unit.restrictions.iter().all(|r| r.allows(ctx)))
+        }) {
+            return Some(pool.mana.swap_remove(pos));
+        }
+    }
+
     if let Some(ctx) = spell {
         if let Some(pos) = pool.mana.iter().position(|unit| {
             unit.is_convoke_payment()
@@ -2020,16 +2163,28 @@ fn spend_generic_eligible(
     // paid from a non-demanded color when one is eligible, still spending a
     // demanded color when it is the only payable mana (CR 601.2h: a payable cost
     // can't be left unpaid — never false-unpayable).
-    spend_any_eligible(pool, spell, demand)
+    spend_any_eligible(pool, spell, demand, pins)
 }
 
-fn spend_any_unit(pool: &mut ManaPool) -> Option<ManaUnit> {
+fn spend_any_unit(pool: &mut ManaPool, pins: &[ManaPipId]) -> Option<ManaUnit> {
     if pool.mana.is_empty() {
         return None;
     }
 
+    // CR 118.3a: honor a pin (any non-convoke unit) before the colorless-first /
+    // least-available ordering. Empty `pins` => unchanged.
+    if !pins.is_empty() {
+        if let Some(pos) = pool
+            .mana
+            .iter()
+            .position(|unit| pins.contains(&unit.pip_id) && !unit.is_convoke_payment())
+        {
+            return Some(pool.mana.swap_remove(pos));
+        }
+    }
+
     // Prefer colorless first, then least-available color
-    if let Some(unit) = spend_eligible(pool, ManaType::Colorless, None) {
+    if let Some(unit) = spend_eligible(pool, ManaType::Colorless, None, pins) {
         return Some(unit);
     }
 
@@ -2059,41 +2214,54 @@ fn spend_any_unit(pool: &mut ManaPool) -> Option<ManaUnit> {
     }
 
     best.and_then(|(color, _)| {
-        spend_color_prefer_non_z(pool, color, |unit| !unit.is_convoke_payment())
+        spend_color_prefer_non_z(pool, color, pins, |unit| !unit.is_convoke_payment())
     })
 }
 
-fn spend_snow(pool: &mut ManaPool) -> bool {
-    spend_snow_unit(pool).is_some()
+fn spend_snow(pool: &mut ManaPool, pins: &[ManaPipId]) -> bool {
+    spend_snow_unit(pool, pins).is_some()
 }
 
 /// CR 107.4h: Snow mana {S} — paid with one mana of any type from a snow source.
-fn spend_snow_unit(pool: &mut ManaPool) -> Option<ManaUnit> {
-    if let Some(pos) = pool.mana.iter().position(|m| m.is_snow()) {
-        Some(pool.mana.swap_remove(pos))
-    } else {
-        None
-    }
+fn spend_snow_unit(pool: &mut ManaPool, pins: &[ManaPipId]) -> Option<ManaUnit> {
+    // CR 118.3a: prefer a pinned snow unit before the first available one.
+    let pos = pick_position(
+        pool,
+        pins,
+        |unit| unit.is_snow(),
+        |pool| pool.mana.iter().position(|m| m.is_snow()),
+    );
+    pos.map(|pos| pool.mana.swap_remove(pos))
 }
 
 fn spend_two_or_more_color_source_eligible(
     pool: &mut ManaPool,
     spell: Option<&PaymentContext<'_>>,
+    pins: &[ManaPipId],
 ) -> Option<ManaUnit> {
-    let position = match spell {
-        Some(ctx) => pool.mana.iter().position(|unit| {
+    // CR 118.3a: prefer a pinned {Z}-eligible unit before the first match.
+    let pos = pick_position(
+        pool,
+        pins,
+        |unit| {
             unit.source_could_produce_two_or_more_colors
-                && unit
-                    .restrictions
-                    .iter()
-                    .all(|restriction| restriction.allows(ctx))
-        }),
-        None => pool
-            .mana
-            .iter()
-            .position(|unit| unit.source_could_produce_two_or_more_colors),
-    }?;
-    Some(pool.mana.swap_remove(position))
+                && spell.is_none_or(|ctx| unit.restrictions.iter().all(|r| r.allows(ctx)))
+        },
+        |pool| match spell {
+            Some(ctx) => pool.mana.iter().position(|unit| {
+                unit.source_could_produce_two_or_more_colors
+                    && unit
+                        .restrictions
+                        .iter()
+                        .all(|restriction| restriction.allows(ctx))
+            }),
+            None => pool
+                .mana
+                .iter()
+                .position(|unit| unit.source_could_produce_two_or_more_colors),
+        },
+    );
+    pos.map(|pos| pool.mana.swap_remove(pos))
 }
 
 #[cfg(test)]
@@ -2183,6 +2351,7 @@ mod tests {
         ManaUnit {
             color,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -3005,6 +3174,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Green,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForCreatureType("Elf".to_string())],
@@ -3072,6 +3242,7 @@ mod tests {
             pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(1),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![ManaRestriction::OnlyForTypeSpellsOrAbilities {
@@ -3141,6 +3312,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForTypeSpellsOrAbilities {
@@ -3232,6 +3404,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Blue,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: runtime,
@@ -3338,6 +3511,7 @@ mod tests {
             vec![ManaUnit {
                 color: ManaType::Blue,
                 source_id: ObjectId(9999),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: vec![ManaRestriction::OnlyForTypeSpellsOrAbilities {
@@ -3368,6 +3542,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForSpellWithKeywordKind(
@@ -3433,6 +3608,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::OnlyForSpellWithKeywordKindFromZone(
@@ -3500,6 +3676,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Green,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],
@@ -3532,6 +3709,7 @@ mod tests {
         pool.add(ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![],

--- a/crates/engine/src/game/merge_tests.rs
+++ b/crates/engine/src/game/merge_tests.rs
@@ -1201,6 +1201,7 @@ mod cast_pipeline {
             pd.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -2247,6 +2247,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Black,
             source_id: crate::types::identifiers::ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -287,9 +287,15 @@ impl GameScenario {
     }
 
     /// Replace a player's mana pool for deterministic payment tests.
+    ///
+    /// CR 118.3a: routes each unit through `add_mana_to_pool` so every seeded
+    /// unit receives a distinct `ManaPipId` (a direct `mana_pool.mana = mana`
+    /// would leave all units at the `ManaPipId(0)` sentinel, so pins would
+    /// collide). All callers seed a fresh pool exactly once per player, so
+    /// appending is equivalent to replacing.
     pub fn with_mana_pool(&mut self, player: PlayerId, mana: Vec<ManaUnit>) -> &mut Self {
-        if let Some(p) = self.state.players.iter_mut().find(|p| p.id == player) {
-            p.mana_pool.mana = mana;
+        for unit in mana {
+            self.state.add_mana_to_pool(player, unit);
         }
         self
     }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -19972,6 +19972,7 @@ pub mod tests {
                 p0.mana_pool.add(ManaUnit {
                     color: ManaType::Colorless,
                     source_id: ObjectId(0),
+                    pip_id: crate::types::mana::ManaPipId(0),
                     supertype: None,
                     source_could_produce_two_or_more_colors: false,
                     restrictions: Vec::new(),
@@ -19981,6 +19982,7 @@ pub mod tests {
                 p0.mana_pool.add(ManaUnit {
                     color: ManaType::Black,
                     source_id: ObjectId(0),
+                    pip_id: crate::types::mana::ManaPipId(0),
                     supertype: None,
                     source_could_produce_two_or_more_colors: false,
                     restrictions: Vec::new(),
@@ -20129,6 +20131,7 @@ pub mod tests {
             p0.mana_pool.add(ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -20309,6 +20312,7 @@ pub mod tests {
             p0.mana_pool.add(ManaUnit {
                 color: ManaType::Red,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),
@@ -22854,6 +22858,7 @@ mod dedup_regression_tests {
             state.players[0].mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -2433,6 +2433,7 @@ mod tests {
         state.players[0].mana_pool.add(ManaUnit {
             color: ManaType::Green,
             source_id: ObjectId(1),
+            pip_id: crate::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -937,6 +937,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: crate::types::game_state::AssistState::NotOffered,

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -8,7 +8,7 @@ use super::game_state::{
 };
 use super::identifiers::{CardId, ObjectId};
 use super::keywords::Keyword;
-use super::mana::ManaType;
+use super::mana::{ManaPipId, ManaType};
 use super::match_config::DeckCardCount;
 use super::phase::Phase;
 use super::player::{PlayerCounterKind, PlayerId};
@@ -204,6 +204,17 @@ pub enum GameAction {
     /// Only valid for lands in `lands_tapped_for_mana` whose mana hasn't been spent.
     UntapLandForMana {
         object_id: ObjectId,
+    },
+    /// CR 118.3a: Pin a specific pool `ManaUnit` (by id) so the finalize spend
+    /// prefers it. The unit stays in the pool — this records a priority hint on
+    /// `PendingCast.pinned_pool_units`, it does not remove mana.
+    SpendPoolMana {
+        pip_id: ManaPipId,
+    },
+    /// CR 118.3a: Remove a previously-recorded pin. Always legal (no-op if the
+    /// pin is absent).
+    UnspendPoolMana {
+        pip_id: ManaPipId,
     },
     SelectCards {
         cards: Vec<ObjectId>,
@@ -1204,7 +1215,13 @@ impl GameAction {
     pub fn is_mana_ability(&self) -> bool {
         matches!(
             self,
-            GameAction::TapLandForMana { .. } | GameAction::UntapLandForMana { .. }
+            GameAction::TapLandForMana { .. }
+                | GameAction::UntapLandForMana { .. }
+                // CR 118.3a: pinning/unpinning a pool unit is a mana-payment-window
+                // action; classifying it here grants MP skip_legality acceptance and
+                // AI-exclusion via the single !is_mana_ability authority.
+                | GameAction::SpendPoolMana { .. }
+                | GameAction::UnspendPoolMana { .. }
         )
     }
 
@@ -1238,6 +1255,8 @@ impl GameAction {
             GameAction::ActivateAbility { source_id, .. } => Some(*source_id),
             GameAction::TapLandForMana { object_id } => Some(*object_id),
             GameAction::UntapLandForMana { object_id } => Some(*object_id),
+            // CR 118.3a: act on a pool pip, not a battlefield object.
+            GameAction::SpendPoolMana { .. } | GameAction::UnspendPoolMana { .. } => None,
             GameAction::Equip { equipment_id, .. } => Some(*equipment_id),
             GameAction::CrewVehicle { vehicle_id, .. } => Some(*vehicle_id),
             GameAction::ActivateStation { spacecraft_id, .. } => Some(*spacecraft_id),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -7115,6 +7115,32 @@ impl GameState {
         }
     }
 
+    /// CR 118.3a: defensively guarantee every unit in `player`'s mana pool carries
+    /// a unique, nonzero `pip_id`, re-stamping the `ManaPipId(0)` sentinel and any
+    /// duplicate. Production mana is stamped on entry via [`Self::add_mana_to_pool`],
+    /// but mana from debug tooling, restored pre-stamping saves, or any path that
+    /// reached `ManaPool::add` directly can carry the sentinel — which would make
+    /// every such unit pin/unpin together in manual payment. Run at payment entry
+    /// so each unit is individually pinnable regardless of how it was produced.
+    /// Safe for loop detection: `pip_id` is excluded from `ManaUnit` equality and
+    /// `next_pip_id` is zeroed by `normalize_for_loop`.
+    pub(crate) fn restamp_pool_pip_ids(&mut self, player: PlayerId) {
+        let Some(idx) = self.players.iter().position(|p| p.id == player) else {
+            return;
+        };
+        let len = self.players[idx].mana_pool.mana.len();
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for i in 0..len {
+            let pid = self.players[idx].mana_pool.mana[i].pip_id.0;
+            if pid != 0 && seen.insert(pid) {
+                continue; // already unique and stamped — leave it
+            }
+            let fresh = self.next_pip_id();
+            seen.insert(fresh.0);
+            self.players[idx].mana_pool.mana[i].pip_id = fresh;
+        }
+    }
+
     /// CR 702.26b: Returns battlefield object ids filtered to only phased-in
     /// permanents. Use this instead of `state.battlefield.iter()` anywhere a
     /// rule would otherwise treat a phased-out permanent as existing
@@ -8072,6 +8098,54 @@ mod tests {
         assert!(
             loop_states_equal(&a.normalize_for_loop(), &b.normalize_for_loop()),
             "states differing only in pool-unit pip_ids must confirm as a repeat"
+        );
+    }
+
+    /// CR 118.3a: the self-heal that fixes the reported "tap one mana → all
+    /// select" bug. Mana that bypassed `add_mana_to_pool` (debug tooling, restored
+    /// pre-stamping saves) carries the sentinel `pip_id 0`; `restamp_pool_pip_ids`
+    /// must give every unit a unique, nonzero id so each is individually pinnable.
+    #[test]
+    fn restamp_pool_pip_ids_heals_sentinel_and_duplicate_ids() {
+        let mut state = GameState::new_two_player(7);
+        let player = state.players[0].id;
+        // Bypass the stamping authority: three units all at the unstamped sentinel.
+        for _ in 0..3 {
+            state.players[0].mana_pool.add(ManaUnit::new(
+                ManaType::Green,
+                ObjectId(0),
+                false,
+                vec![],
+            ));
+        }
+        assert!(
+            state.players[0]
+                .mana_pool
+                .mana
+                .iter()
+                .all(|u| u.pip_id.0 == 0),
+            "precondition: all three units are unstamped (pip_id 0)"
+        );
+
+        state.restamp_pool_pip_ids(player);
+
+        let ids: Vec<u64> = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .map(|u| u.pip_id.0)
+            .collect();
+        assert!(
+            ids.iter().all(|&id| id != 0),
+            "every unit must be stamped (no sentinel remains), got {ids:?}"
+        );
+        assert_eq!(
+            ids.iter()
+                .copied()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            ids.len(),
+            "all pip ids must be unique after restamp, got {ids:?}"
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -23,7 +23,7 @@ use super::events::{GameEvent, PlayerActionKind};
 use super::format::FormatConfig;
 use super::identifiers::{CardId, ObjectId, TrackedSetId};
 use super::keywords::{Keyword, KeywordKind};
-use super::mana::{ManaColor, ManaCost, ManaType, StepEndManaAction};
+use super::mana::{ManaColor, ManaCost, ManaPipId, ManaType, ManaUnit, StepEndManaAction};
 use super::match_config::{MatchConfig, MatchPhase, MatchScore};
 use super::phase::Phase;
 use super::player::{Player, PlayerCounterKind, PlayerId};
@@ -1751,6 +1751,12 @@ pub struct PendingCast {
     /// quantities can resolve later.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub convoked_creatures: Vec<ObjectId>,
+    /// CR 118.3a: Player-directed pin hints recorded during
+    /// `WaitingFor::ManaPayment`. Each id names a pool `ManaUnit` the caster
+    /// prefers to spend first; pins are priority hints, not removals — the unit
+    /// stays in the pool and is consumed by the normal finalize spend.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pinned_pool_units: Vec<ManaPipId>,
     /// CR 601.2i + CR 722.3c: Optional source permanent to re-mark as
     /// prepared if this cast is cancelled and rolled back. Used by the
     /// prepared-copy special action to restore pre-cast state.
@@ -1823,6 +1829,7 @@ impl PendingCast {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
@@ -5483,6 +5490,18 @@ pub struct GameState {
     // showed SipHash hashing + HAMT lookup was ~35% of resolution CPU.
     pub objects: im::HashMap<ObjectId, GameObject, rustc_hash::FxBuildHasher>,
     pub next_object_id: u64,
+    /// CR 118.3a: monotonic counter minting `ManaPipId`s for pool units so they
+    /// can be pinned. Serialized plainly (mirrors `next_object_id`) so reloaded
+    /// games don't re-mint colliding ids.
+    #[serde(default)]
+    pub next_pip_id: u64,
+    /// CR 118.3a: transient carrier for the caster's pin hints during a single
+    /// finalize spend. `finalize_mana_payment` takes `pending_cast` (removing the
+    /// pins) BEFORE the spend runs, so the pins are moved here for the duration of
+    /// the spend and cleared immediately after. Never serialized and never part of
+    /// state equality — it is empty outside the synchronous finalize window.
+    #[serde(skip)]
+    pub active_payment_pins: Vec<ManaPipId>,
 
     // Shared zones
     pub battlefield: im::Vector<ObjectId>,
@@ -7076,6 +7095,26 @@ const _: fn() = || {
 };
 
 impl GameState {
+    /// CR 118.3a: Mint the next stable `ManaPipId` for a pool unit. Monotonic,
+    /// never returns the `ManaPipId(0)` unstamped sentinel (counter starts at 1).
+    fn next_pip_id(&mut self) -> ManaPipId {
+        let id = self.next_pip_id;
+        self.next_pip_id += 1;
+        ManaPipId(id)
+    }
+
+    /// CR 118.3a: Stamp a stable pip id on `unit` and add it to `player`'s mana
+    /// pool. This is the single authority for mana entering a *real* pool: every
+    /// production/refill/convoke/delve injection routes here so that each pooled
+    /// unit has a unique id the player can pin to direct payment. Detached
+    /// preview pools (with no `GameState`) keep calling `ManaPool::add` directly.
+    pub fn add_mana_to_pool(&mut self, player: PlayerId, mut unit: ManaUnit) {
+        unit.pip_id = self.next_pip_id();
+        if let Some(p) = self.players.iter_mut().find(|p| p.id == player) {
+            p.mana_pool.add(unit);
+        }
+    }
+
     /// CR 702.26b: Returns battlefield object ids filtered to only phased-in
     /// permanents. Use this instead of `state.battlefield.iter()` anywhere a
     /// rule would otherwise treat a phased-out permanent as existing
@@ -7234,6 +7273,10 @@ impl GameState {
             turn_decision_controller: None,
             objects: im::HashMap::default(),
             next_object_id: 1,
+            // CR 118.3a: start at 1 so minted pip ids never collide with the
+            // `ManaPipId(0)` unstamped sentinel.
+            next_pip_id: 1,
+            active_payment_pins: Vec::new(),
             battlefield: im::Vector::new(),
             stack: im::Vector::new(),
             stack_paid_facts: HashMap::new(),
@@ -7636,6 +7679,9 @@ impl GameState {
         clone.state_revision = 0;
         clone.next_timestamp = 0;
         clone.next_object_id = 0;
+        // CR 104.4b: pip-id counter is a volatile monotonic field; zero it (like
+        // next_object_id) so two otherwise-identical loop states compare equal.
+        clone.next_pip_id = 0;
         clone.layers_dirty = LayersDirty::full();
         clone.public_state_dirty = PublicStateDirty::all_dirty();
         clone
@@ -7706,6 +7752,7 @@ impl PartialEq for GameState {
             && self.turn_decision_controller == other.turn_decision_controller
             && self.objects.len() == other.objects.len()
             && self.next_object_id == other.next_object_id
+            && self.next_pip_id == other.next_pip_id
             && self.battlefield == other.battlefield
             && self.stack == other.stack
             && self.stack_paid_facts == other.stack_paid_facts
@@ -7992,6 +8039,42 @@ mod tests {
         );
     }
 
+    /// CR 104.4b: pool-unit `pip_id` is a runtime/UI identity tag stamped with a
+    /// unique monotonic value each time mana enters a pool. It must NOT affect
+    /// game-state equality, otherwise a mandatory loop that floats mana every
+    /// iteration would compare its iterations unequal (each pooled unit has a
+    /// fresh pip_id) and the CR 104.4b draw would never fire — burning the
+    /// auto-pass iteration cap before downgrading to a wrong CR 732.2 halt.
+    /// Revert-failing: if `pip_id` is restored to `ManaUnit`'s derived
+    /// `PartialEq`, the two pools differ and this assertion fails.
+    #[test]
+    fn loop_states_equal_ignores_pool_pip_ids() {
+        let mut a = GameState::new_two_player(7);
+        let player = a.players[0].id;
+        // One floated unit, stamped with a distinct pip_id on pool entry.
+        a.add_mana_to_pool(
+            player,
+            ManaUnit::new(ManaType::Red, ObjectId(900), false, vec![]),
+        );
+        // `b` is identical EXCEPT its pool unit carries a different pip_id — the
+        // shape a mandatory mana-floating loop produces (each iteration mints a
+        // fresh monotonic id on the same logical unit). Pool length and every
+        // other field are identical.
+        let mut b = a.clone();
+        let pip_a = b.players[0].mana_pool.mana[0].pip_id;
+        b.players[0].mana_pool.mana[0].pip_id = ManaPipId(pip_a.0 + 1);
+        let pip_b = b.players[0].mana_pool.mana[0].pip_id;
+        assert_ne!(
+            pip_a, pip_b,
+            "the two pool units must differ only in pip_id"
+        );
+
+        assert!(
+            loop_states_equal(&a.normalize_for_loop(), &b.normalize_for_loop()),
+            "states differing only in pool-unit pip_ids must confirm as a repeat"
+        );
+    }
+
     #[test]
     fn default_creates_two_player_game() {
         let state = GameState::default();
@@ -8202,6 +8285,7 @@ mod tests {
                 declared_kickers_to_pay: Vec::new(),
                 declined_kickers: Vec::new(),
                 convoked_creatures: Vec::new(),
+                pinned_pool_units: Vec::new(),
                 cancel_restore_prepared_source: None,
                 payment_mode: CastPaymentMode::Auto,
                 assist_state: AssistState::NotOffered,
@@ -8540,6 +8624,7 @@ mod tests {
             declared_kickers_to_pay: Vec::new(),
             declined_kickers: Vec::new(),
             convoked_creatures: Vec::new(),
+            pinned_pool_units: Vec::new(),
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -891,10 +891,24 @@ pub mod snow_compat {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Stable per-unit identity for an individual mana pip in a player's pool.
+///
+/// Minted by `GameState::next_pip_id` when mana enters a real pool so that a
+/// player can direct (pin) which specific unit pays a pending cost. The sentinel
+/// `ManaPipId(0)` marks an unstamped unit (convoke markers, detached preview
+/// pools) and never matches a real pin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ManaPipId(pub u64);
+
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 pub struct ManaUnit {
     pub color: ManaType,
     pub source_id: ObjectId,
+    /// CR 118.3a: stable identity used to direct which pool unit pays a cost.
+    /// `ManaPipId(0)` = unstamped sentinel (set by constructors; stamped on pool
+    /// entry by `GameState::add_mana_to_pool`).
+    #[serde(default = "unstamped_pip_id")]
+    pub pip_id: ManaPipId,
     #[serde(default, with = "snow_compat", rename = "snow")]
     pub supertype: Option<ManaSupertype>,
     /// True when this unit was produced by a source that could produce two or
@@ -911,6 +925,27 @@ pub struct ManaUnit {
     pub expiry: Option<ManaExpiry>,
 }
 
+// CR 104.4b: `pip_id` is a runtime/UI identity tag (the pin key used to direct
+// which pool unit pays a cost), NOT a game-state-semantic property. It must not
+// participate in `ManaUnit` value-equality, otherwise two pool units that differ
+// only by their monotonic pip_id would compare unequal and break game-state
+// equality — defeating CR 104.4b mandatory-loop detection (a loop that floats
+// mana each iteration would never compare equal) and AI-search state dedup.
+// `Eq` is derived (it only requires `PartialEq` to exist); ignoring one field
+// keeps the relation reflexive/symmetric/transitive.
+impl PartialEq for ManaUnit {
+    fn eq(&self, other: &Self) -> bool {
+        self.color == other.color
+            && self.source_id == other.source_id
+            && self.supertype == other.supertype
+            && self.source_could_produce_two_or_more_colors
+                == other.source_could_produce_two_or_more_colors
+            && self.restrictions == other.restrictions
+            && self.grants == other.grants
+            && self.expiry == other.expiry
+    }
+}
+
 impl ManaUnit {
     /// Construct a standard mana unit with no expiry.
     pub fn new(
@@ -922,6 +957,7 @@ impl ManaUnit {
         Self {
             color,
             source_id,
+            pip_id: ManaPipId(0),
             supertype: snow.then_some(ManaSupertype::Snow),
             source_could_produce_two_or_more_colors: false,
             restrictions,
@@ -941,6 +977,7 @@ impl ManaUnit {
         Self {
             color,
             source_id,
+            pip_id: ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: vec![ManaRestriction::ConvokePayment],
@@ -1369,6 +1406,12 @@ fn is_zero_u32(n: &u32) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+/// Serde default for `ManaUnit::pip_id`: legacy saves and freshly built units
+/// carry the unstamped sentinel until pool entry stamps a real id.
+fn unstamped_pip_id() -> ManaPipId {
+    ManaPipId(0)
 }
 
 impl ColoredManaCount {

--- a/crates/engine/tests/become_color_set_std_batch.rs
+++ b/crates/engine/tests/become_color_set_std_batch.rs
@@ -566,6 +566,7 @@ fn colorless_mana(n: usize) -> Vec<ManaUnit> {
         .map(|_| ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/integration/issue_1544_zinnia_offspring.rs
+++ b/crates/engine/tests/integration/issue_1544_zinnia_offspring.rs
@@ -24,6 +24,7 @@ fn fund_mana(runner: &mut engine::game::scenario::GameRunner, count: usize) {
         p0.mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
+++ b/crates/engine/tests/integration/issue_2914_shiko_flurry_target_gate.rs
@@ -17,6 +17,7 @@ fn red_mana(n: usize) -> Vec<ManaUnit> {
         .map(|_| ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/integration/issue_3299_syr_konrad_duplicate_damage.rs
+++ b/crates/engine/tests/integration/issue_3299_syr_konrad_duplicate_damage.rs
@@ -115,6 +115,7 @@ fn syr_konrad_deals_one_damage_per_milled_creature() {
         p0.mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: dummy,
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),
@@ -124,6 +125,7 @@ fn syr_konrad_deals_one_damage_per_milled_creature() {
         p0.mana_pool.add(ManaUnit {
             color: ManaType::Black,
             source_id: dummy,
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/integration/issue_924_offspring.rs
+++ b/crates/engine/tests/integration/issue_924_offspring.rs
@@ -26,6 +26,7 @@ fn fund_mana(runner: &mut GameRunner, count: usize) {
         p0.mana_pool.add(ManaUnit {
             color: ManaType::Colorless,
             source_id: engine::types::identifiers::ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/shiko_reflexive_copy_draw_1370.rs
+++ b/crates/engine/tests/shiko_reflexive_copy_draw_1370.rs
@@ -27,6 +27,7 @@ fn red_mana(n: usize) -> Vec<ManaUnit> {
         .map(|_| ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/engine/tests/taigam_master_opportunist_exiles_cast_spell_749.rs
+++ b/crates/engine/tests/taigam_master_opportunist_exiles_cast_spell_749.rs
@@ -32,6 +32,7 @@ fn red_mana(n: usize) -> Vec<ManaUnit> {
         .map(|_| ManaUnit {
             color: ManaType::Red,
             source_id: ObjectId(0),
+            pip_id: engine::types::mana::ManaPipId(0),
             supertype: None,
             source_could_produce_two_or_more_colors: false,
             restrictions: Vec::new(),

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -440,6 +440,7 @@ mod tests {
             .map(|_| ManaUnit {
                 color: ManaType::Colorless,
                 source_id: ObjectId(0),
+                pip_id: engine::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -2228,6 +2228,7 @@ mod tests {
             p.mana_pool.add(ManaUnit {
                 color,
                 source_id: ObjectId(0),
+                pip_id: engine::types::mana::ManaPipId(0),
                 supertype: None,
                 source_could_produce_two_or_more_colors: false,
                 restrictions: Vec::new(),

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -371,6 +371,8 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::MulliganDecision { .. }
         | GameAction::TapLandForMana { .. }
         | GameAction::UntapLandForMana { .. }
+        | GameAction::SpendPoolMana { .. }
+        | GameAction::UnspendPoolMana { .. }
         | GameAction::ChooseTarget { .. }
         | GameAction::ChooseReplacement { .. }
         | GameAction::CancelCast


### PR DESCRIPTION
Ships the manual mana payment overhaul as one feature stack:

- **fix(client):** allow tapping lands/sources while the payment panel is open (DialogHost click-through).
- **feat(client):** per-game manual-mana session toggle next to the lands row.
- **feat(engine,client):** direct payment by pinning specific pool units (`SpendPoolMana`/`UnspendPoolMana`, stable `ManaPipId`, grants like Cavern of Souls / Delighted Halfling applied on the pinned unit).
- **feat(engine,client):** UX rework — engine-computed live remaining cost (`DerivedViews::pending_payment_remaining`), source-grouped `N×{symbol}` two-pile selection, and a pip-id self-heal (`restamp_pool_pip_ids` at payment entry) that fixes the sentinel-0 collision from debug/pre-stamping mana.
- **feat(client):** draggable dialog modals (title-bar handle).

Tests: new engine regressions for distinct pip stamping (land tap, debug AddMana, restamp self-heal) and `pending_payment_remaining`; all engine + frontend gates green locally.