### PR TITLE
ci(release): raise Build WASM+Frontend timeout 30m->60m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,11 @@ jobs:
     name: Build WASM + Frontend
     needs: [resolve-release-ref, tauri-preflight]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Card-data generation grows with the card/deck corpus: this job hit 28m for
+    # v0.4.0 and crossed the prior 30m ceiling for v0.5.0 (killed mid-frontend
+    # build, stranding the release). Raised to 60m for headroom — the ceiling
+    # only bills the failure case, so a normal ~30m run still ends at ~30m.
+    timeout-minutes: 60
     env:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
     steps:


### PR DESCRIPTION
The build-wasm job (card-data gen + draft pools + WASM + frontend build)
crept past its 30m timeout as the card/deck corpus grew: v0.4.0 finished at
28m, v0.5.0 crossed 30m and was killed mid-frontend-build, stranding the
release (tag pushed, GitHub Release + prod deploy never ran). Raise to 60m
for headroom; the ceiling only bills the failure case.
