### PR TITLE
June 2026 CR: connive-0 rule (701.50e) + annotation renumbering

### DIFF
--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -23,7 +23,7 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    // CR 701.50e + CR 107.3i: Dynamic connive counts (e.g. creatures that died
+    // CR 701.50d + CR 107.3i: Dynamic connive counts (e.g. creatures that died
     // this turn) resolve at ability resolution via the shared quantity pipeline.
     let count = match &ability.effect {
         Effect::Connive { count, .. } => {
@@ -84,7 +84,7 @@ pub(crate) fn propose_connive(
             resolve_connive_effect(state, conniver_id, count, events)
         }
         ReplacementResult::Prevented => {
-            // CR 701.50b + CR 701.50c: A replacement fully replaced the connive
+            // CR 701.50f + CR 701.50b: A replacement fully replaced the connive
             // action (Leader's applier already ran the modified action and its
             // own `EffectResolved`). Nothing more to do here.
             Ok(())
@@ -188,7 +188,7 @@ pub(crate) fn resolve_connive_effect(
         ReplacementResult::Execute(_) => {}
         ReplacementResult::Prevented => {
             // Draw was prevented — skip the discard step
-            // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's
+            // CR 701.50f + CR 701.50b: the EffectResolved carries the CONNIVER's
             // id (LKI if it left the battlefield) so "whenever a creature you
             // control connives" matches the conniving permanent, not the source.
             events.push(GameEvent::EffectResolved {
@@ -228,7 +228,7 @@ pub(crate) fn resolve_connive_effect(
         state.waiting_for = WaitingFor::ConniveDiscard {
             player: controller,
             conniver_id,
-            // CR 701.50c: metadata only (the discard handler ignores this field);
+            // CR 701.50b: metadata only (the discard handler ignores this field);
             // the conniving permanent is the natural source reference here.
             source_id: conniver_id,
             cards: hand_cards,
@@ -238,7 +238,7 @@ pub(crate) fn resolve_connive_effect(
         return Ok(());
     }
 
-    // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's id (LKI
+    // CR 701.50f + CR 701.50b: the EffectResolved carries the CONNIVER's id (LKI
     // if it left the battlefield) so "whenever a creature you control connives"
     // matches the conniving permanent, not the causing source.
     events.push(GameEvent::EffectResolved {
@@ -286,7 +286,7 @@ fn is_nonland_card(state: &GameState, object_id: ObjectId) -> bool {
 }
 
 /// Add +1/+1 counters to the conniving creature via the replacement pipeline.
-/// CR 701.50c: If the creature left the battlefield, skip the counter.
+/// CR 701.50b: If the creature left the battlefield, skip the counter.
 pub(crate) fn add_connive_counters(
     state: &mut GameState,
     conniver_id: ObjectId,
@@ -296,7 +296,7 @@ pub(crate) fn add_connive_counters(
     if count == 0 {
         return;
     }
-    // CR 701.50c: Skip if the conniver has left the battlefield
+    // CR 701.50b: Skip if the conniver has left the battlefield
     let on_battlefield = state
         .objects
         .get(&conniver_id)
@@ -831,7 +831,7 @@ mod tests {
         );
     }
 
-    /// CR 701.50a + CR 701.50e + CR 614.5 (Leader, Super-Genius): the replacement
+    /// CR 701.50a + CR 701.50d + CR 614.5 (Leader, Super-Genius): the replacement
     /// chain's "then that creature connives" is a PLAIN connive (draw 1, discard
     /// 1), independent of the count of the connive event that was replaced. When a
     /// creature connives with N=2 (e.g. a "connive 2" source), the replacement
@@ -876,7 +876,7 @@ mod tests {
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // CR 701.50a + CR 701.50e: plain connive draws 1 → discard 1 (count=1),
+        // CR 701.50a + CR 701.50d: plain connive draws 1 → discard 1 (count=1),
         // NOT 2. Pre-fix (inheriting N=2) this is count=2.
         assert!(
             matches!(
@@ -1616,7 +1616,7 @@ mod tests {
     /// there (Step 3) runs the deferred connive: its OWN draw (a fresh Draw 1
     /// event) is the lone surviving Prevent's only candidate, so it auto-applies
     /// and the connive's draw is prevented too. Per `resolve_connive_effect`'s
-    /// Prevented arm (CR 701.50b/c) the connive still emits its `EffectResolved`
+    /// Prevented arm (CR 701.50f/b) the connive still emits its `EffectResolved`
     /// and completes. A second Prevent (rather than a count-modifier survivor)
     /// keeps the connive's own draw deterministic — no leftover count-modifier
     /// can non-deterministically scale the connive's draw or re-park it.
@@ -1704,7 +1704,7 @@ mod tests {
         // CRUX (the flip): the leading draw was PREVENTED, but the deferred connive
         // STILL RAN. The dedicated slot is drained to None (NOT stranded) and the
         // connive completed (its own draw was prevented by the surviving Prevent,
-        // so per CR 701.50b/c it emits EffectResolved and finishes). Both
+        // so per CR 701.50f/b it emits EffectResolved and finishes). Both
         // assertions are FALSE pre-fix (Step 3 reverted: the slot stays Some and no
         // EffectResolved { Connive } is emitted).
         assert!(
@@ -1717,7 +1717,7 @@ mod tests {
             "the connive completed (its own draw prevented), returning to Priority, got {:?}",
             state.waiting_for
         );
-        // CR 614.5 + CR 701.50b/c: the connive completes EXACTLY once even though
+        // CR 614.5 + CR 701.50f/b: the connive completes EXACTLY once even though
         // both its leading (Leader-replacement) draw and its own draw were
         // prevented — the connive step itself is independent of the draws.
         assert_eq!(

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -107,7 +107,19 @@ pub(crate) fn resolve_connive_effect(
     count: u32,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    // CR 701.50a: The conniving permanent's controller draws and discards.
+    // CR 701.50e: If a permanent would connive 0, no connive event occurs and
+    // abilities that trigger whenever a permanent connives won't trigger. Return
+    // before any draw/discard/counter, before parking a ConniveDiscard, and
+    // without emitting EffectResolved{Connive} (the event match_connives keys on).
+    // Reachable via the dynamic count path (Spymaster's Vault X = creatures that
+    // died this turn) and via replacement count-modifiers reducing the count to 0
+    // (engine_replacement.rs Execute survivor). Printed "Connive N" (CR 701.50d)
+    // is always N>=1, so this never regresses the normal count>=1 flow.
+    if count == 0 {
+        return Ok(());
+    }
+
+    // CR 701.50a: The conviving permanent's controller draws and discards.
     let controller = state
         .objects
         .get(&conniver_id)
@@ -1721,6 +1733,97 @@ mod tests {
                 .count(),
             1,
             "the connive must complete exactly once even though the leading draw was prevented"
+        );
+    }
+
+    /// CR 701.50e: a connive whose resolved count is 0 is a complete no-op. Driven
+    /// through the top-level `resolve()` entry (the production path the combat
+    /// trigger / activated ability use): `resolve` resolves the `QuantityExpr` to
+    /// 0, `propose_connive` finds no connive replacement and returns the
+    /// `Execute(Connive { count: 0 })` survivor, which funnels into
+    /// `resolve_connive_effect(.., 0, ..)`. That must perform no
+    /// draw/discard/counter, park no `ConniveDiscard`, and emit no
+    /// `EffectResolved{Connive}` — so "whenever a permanent connives" abilities do
+    /// not trigger.
+    ///
+    /// Revert probe (the revert-failing assertion is `!ConniveDiscard`): without
+    /// the `count == 0` guard, the draw-of-0 is a no-op, but the discard step then
+    /// runs with `discard_count == 0`. The single hand card makes
+    /// `hand_cards.len() (1) <= discard_count (0)` false, so the else arm parks
+    /// `WaitingFor::ConniveDiscard { count: 0 }` and returns — the `!ConniveDiscard`
+    /// assertion flips. (With an empty hand the revert would instead reach the tail
+    /// and emit `EffectResolved{Connive}`; the one hand card pins the discard-park
+    /// arm, the discriminating no-op the guard prevents.)
+    #[test]
+    fn connive_count_zero_no_ops() {
+        let mut state = GameState::new_two_player(42);
+        let conniver = make_battlefield_creature(&mut state, PlayerId(0));
+
+        // A distinguishable card on library top and a card in hand. Neither must
+        // move if the connive is a complete no-op.
+        let top = add_card_to_library(&mut state, PlayerId(0), "Top", false);
+        let hand_card = add_card_to_hand(&mut state, PlayerId(0), "HandCard", false);
+
+        // Drive the entry point with a count that resolves to 0 (e.g. a dynamic
+        // "connive X" where X = 0). `resolve` -> `propose_connive(.., 0, ..)` ->
+        // `Execute(Connive { count: 0 })` survivor -> `resolve_connive_effect`.
+        let ability = ResolvedAbility::new(
+            Effect::Connive {
+                target: TargetFilter::Any,
+                count: QuantityExpr::Fixed { value: 0 },
+            },
+            vec![TargetRef::Object(conniver)],
+            conniver,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 701.50e: the connive is a complete no-op.
+        // No draw: the library-top card is untouched.
+        assert!(
+            state.players[0].library.contains(&top),
+            "connive 0 must not draw: library top must stay in library"
+        );
+        // No discard: the hand card is untouched and not in the graveyard.
+        assert!(
+            state.players[0].hand.contains(&hand_card),
+            "connive 0 must not discard: hand card must stay in hand"
+        );
+        assert!(
+            !state.players[0].graveyard.contains(&hand_card),
+            "connive 0 must not discard: hand card must not reach the graveyard"
+        );
+        // No counter.
+        assert_eq!(
+            state.objects[&conniver]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "connive 0 must place no +1/+1 counter"
+        );
+        // No ConniveDiscard pause.
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ConniveDiscard { .. }),
+            "connive 0 must not park a ConniveDiscard, got {:?}",
+            state.waiting_for
+        );
+        // No connive completion event — "whenever a permanent connives" never fires.
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(
+                    e,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::Connive,
+                        ..
+                    }
+                ))
+                .count(),
+            0,
+            "connive 0 must emit no EffectResolved{{Connive}} (no connive event occurs)"
         );
     }
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6335,7 +6335,7 @@ fn handle_crew_activation(
         ));
     }
 
-    // CR 702.122c: Exclude creatures with "can't crew Vehicles".
+    // CR 702.122d: Exclude creatures with "can't crew Vehicles".
     let eligible_creatures: Vec<ObjectId> = state
         .battlefield
         .iter()
@@ -6358,7 +6358,7 @@ fn handle_crew_activation(
         .collect();
 
     // Validate total power of all eligible creatures can meet the threshold.
-    // CR 702.122c: a creature's contribution may be modified ("as though its
+    // CR 702.122a: a creature's contribution may be modified ("as though its
     // power were N greater" / "using its toughness rather than its power").
     let total_power: i32 = eligible_creatures
         .iter()
@@ -6472,7 +6472,7 @@ fn handle_crew_announcement(
                 "Creature can't crew Vehicles".to_string(),
             ));
         }
-        // CR 702.122c: apply any crew power-contribution modifier.
+        // CR 702.122a: apply any crew power-contribution modifier.
         total_power += super::static_abilities::object_crew_power_contribution(
             state,
             cid,
@@ -6647,8 +6647,8 @@ fn handle_station_announcement(
 
     // CR 702.184a + CR 113.7a: Snapshot the creature's power BEFORE tapping —
     // the counter count is determined at cost-payment time and survives the
-    // creature leaving the battlefield before resolution. CR 702.184c +
-    // CR 702.122c: static abilities may modify the contributed value ("stations
+    // creature leaving the battlefield before resolution. CR 702.184c:
+    // static abilities may modify the contributed value ("stations
     // permanents as though its power were N greater"); the helper applies any
     // such modifier and otherwise reads `power`, the default per the rule.
     let snapshot_power = super::static_abilities::object_crew_power_contribution(
@@ -6748,7 +6748,7 @@ fn handle_saddle_activation(
         })
         .collect();
 
-    // CR 702.171a + CR 702.122c: a creature's saddle contribution may be modified.
+    // CR 702.171a: a creature's saddle contribution may be modified.
     let total_power: i32 = eligible_creatures
         .iter()
         .map(|&id| {
@@ -6824,7 +6824,7 @@ fn handle_saddle_announcement(
                 "Creature is no longer eligible for saddling".to_string(),
             ));
         }
-        // CR 702.122c: apply any saddle power-contribution modifier.
+        // CR 702.171a: apply any saddle power-contribution modifier.
         total_power += super::static_abilities::object_crew_power_contribution(
             state,
             cid,
@@ -22059,7 +22059,7 @@ mod crew_tests {
         assert!(result.is_err());
     }
 
-    /// CR 702.122c: a creature with "crews Vehicles as though its power were N
+    /// CR 702.122a: a creature with "crews Vehicles as though its power were N
     /// greater" (Reckoner Bankbuster) contributes its modified power, letting an
     /// otherwise-insufficient creature pay the crew cost alone.
     #[test]
@@ -22099,7 +22099,7 @@ mod crew_tests {
         );
     }
 
-    /// CR 702.122c: regression — the legal-action enumerator must measure crew
+    /// CR 702.122a: regression — the legal-action enumerator must measure crew
     /// contribution through `object_crew_power_contribution`, exactly like the
     /// activation gate and announcement validator. A Pilot-style creature whose
     /// raw power is below the crew cost but whose adjusted power meets it must
@@ -22143,7 +22143,7 @@ mod crew_tests {
         );
     }
 
-    /// CR 702.122c: "using its toughness rather than its power" (Giant Ox)
+    /// CR 702.122a: "using its toughness rather than its power" (Giant Ox)
     /// substitutes toughness for power, and the modifier applies only to the
     /// named keyword actions (crew-only here, not saddle).
     #[test]
@@ -22967,7 +22967,7 @@ mod keyword_action_stack_tests {
     //!     paid even if the ability is countered);
     //!   - a priority window opens between cost payment and resolution;
     //!   - triggers keyed off "becomes crewed/saddled/stationed/equipped"
-    //!     fire at resolution time, not at cost payment (CR 702.122d,
+    //!     fire at resolution time, not at cost payment (CR 702.122e,
     //!     CR 702.171b, CR 702.184a, CR 702.6a).
     //!
     //! Counterspells are simulated by popping the top stack entry directly
@@ -23476,7 +23476,7 @@ mod keyword_action_stack_tests {
 
     // --- Trigger timing -----------------------------------------------------
     //
-    // CR 702.122d / CR 702.171b / CR 702.184a: "Whenever [X] becomes crewed /
+    // CR 702.122e / CR 702.171b / CR 702.184a: "Whenever [X] becomes crewed /
     // saddled / stationed" resolves when the keyword ability resolves from the
     // stack — not when its cost is paid. The per-keyword matcher keys off the
     // resolution-time event (`VehicleCrewed` / `Saddled` / `Stationed`), so
@@ -23520,7 +23520,7 @@ mod keyword_action_stack_tests {
             .any(|e| match_vehicle_crewed(e, &trigger, vehicle_id, &state));
         assert!(
             !fires_at_announce,
-            "CR 702.122d: Crewed trigger must not fire at announcement"
+            "CR 702.122e: Crewed trigger must not fire at announcement"
         );
 
         apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
@@ -23531,7 +23531,7 @@ mod keyword_action_stack_tests {
             .any(|e| match_vehicle_crewed(e, &trigger, vehicle_id, &state));
         assert!(
             fires_at_resolve,
-            "CR 702.122d: Crewed trigger fires when the Crew ability resolves"
+            "CR 702.122e: Crewed trigger fires when the Crew ability resolves"
         );
     }
 

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2385,7 +2385,7 @@ pub(super) fn handle_resolution_choice(
             };
 
             effects::connive::add_connive_counters(state, conniver_id, nonland_count, events);
-            // CR 701.50b + CR 701.50c: the EffectResolved carries the CONNIVER's
+            // CR 701.50f + CR 701.50b: the EffectResolved carries the CONNIVER's
             // id (LKI if it left the battlefield) so "whenever a creature you
             // control connives" matches the conniving permanent, not the source.
             events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1831,7 +1831,7 @@ fn connive_applier(
     let mut current = Some(execute.as_ref());
     while let Some(def) = current {
         match &*def.effect {
-            // CR 701.50a + CR 701.50e: "then that creature connives" runs the
+            // CR 701.50a + CR 701.50d: "then that creature connives" runs the
             // chain's OWN connive at its parsed count (plain connive = Fixed(1);
             // connive N = Fixed(N) / dynamic), NOT the replaced event's count.
             // Resolve the def's QuantityExpr against the conniving permanent as

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -192,7 +192,7 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
         },
         handle_rule_mod,
     );
-    // CR 702.122c: CantCrew — creature can't be tapped to pay a crew cost.
+    // CR 702.122d: CantCrew — creature can't be tapped to pay a crew cost.
     registry.insert(StaticMode::CantCrew, handle_rule_mod);
     registry.insert(StaticMode::MayLookAtTopOfLibrary, handle_rule_mod);
     // CR 104.3b: CantLoseTheGame — player can't lose the game (Platinum Angel).
@@ -1341,7 +1341,7 @@ fn static_condition_matches_context(
     })
 }
 
-/// CR 702.122c: Returns true when the creature has an active "can't crew Vehicles" static.
+/// CR 702.122d: Returns true when the creature has an active "can't crew Vehicles" static.
 pub fn object_has_cant_crew(state: &GameState, object_id: ObjectId) -> bool {
     state.objects.get(&object_id).is_some_and(|obj| {
         super::functioning_abilities::active_static_definitions(state, obj)
@@ -1349,7 +1349,7 @@ pub fn object_has_cant_crew(state: &GameState, object_id: ObjectId) -> bool {
     })
 }
 
-/// CR 702.122c / 702.171a / 702.184a: The power a creature contributes toward a
+/// CR 702.122a / 702.171a / 702.184c: The power a creature contributes toward a
 /// crew / saddle / station cost, after applying any active `CrewContribution`
 /// static whose action list contains `action`. "Using its toughness rather than
 /// its power" substitutes the creature's toughness for its base power; "as

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -497,7 +497,7 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
     // evolve ability's resolution actually put one or more +1/+1 counters on it.
     r.insert(TriggerMode::Evolved, match_evolved);
 
-    // CR 702.122d: Crew trigger matchers
+    // CR 702.122e: Crew trigger matchers
     r.insert(TriggerMode::Crewed, match_vehicle_crewed);
     r.insert(TriggerMode::BecomesCrewed, match_vehicle_crewed);
 
@@ -2929,7 +2929,7 @@ pub(super) fn match_adapt(
     }
 }
 
-/// CR 701.50b: Connives — fires when a permanent connives.
+/// CR 701.50f: Connives — fires when a permanent connives.
 /// `valid_card` scopes the CONNIVER (the permanent that connived). With no
 /// filter, this is "this creature connives" — match the source by identity
 /// (Ultron's self-connive).
@@ -4086,10 +4086,10 @@ pub(super) fn match_unimplemented(
 }
 
 // ---------------------------------------------------------------------------
-// CR 702.122d: Crew trigger matchers
+// CR 702.122e: Crew trigger matchers
 // ---------------------------------------------------------------------------
 
-/// CR 702.122d: Matches when a Vehicle's crew ability resolves.
+/// CR 702.122e: Matches when a Vehicle's crew ability resolves.
 /// Both `Crewed` and `BecomesCrewed` are semantically identical — different Oracle text
 /// phrasings for the same trigger condition.
 pub(super) fn match_vehicle_crewed(

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2635,7 +2635,7 @@ pub(crate) fn parse_oracle_ir(
             }
         }
 
-        // Priority 3e2: Power-up — "Power-up — {cost}: {effect}" (CR 602.5b).
+        // Priority 3e2: Power-up — "Power-up — {cost}: {effect}" (CR 702.193a, CR 602.5b).
         // Power-up is a keyword-labeled activated ability (like Exhaust): it can
         // be activated only once per game, and its cost is reduced by the source's
         // mana value if it entered the battlefield this turn. The cost reduction is
@@ -2656,12 +2656,12 @@ pub(crate) fn parse_oracle_ir(
                 def.cost = Some(cost);
                 def.description = Some(line.to_string());
                 def.activation_restrictions.extend(constraints.restrictions);
-                // CR 602.5b: power-up may be activated only once per game.
+                // CR 702.193a: power-up may be activated only once.
                 def.activation_restrictions
                     .push(ActivationRestriction::OnlyOnce);
                 def.ability_tag = Some(AbilityTag::PowerUp);
-                // CR 602.2b + CR 601.2f + CR 302.6: the activation cost's generic
-                // mana is reduced by the source's mana value if it entered this turn.
+                // CR 702.193b + CR 602.2b + CR 601.2f + CR 302.6: the activation cost's
+                // generic mana is reduced by the source's mana value if it entered this turn.
                 def.cost_reduction = Some(CostReduction {
                     amount_per: 1,
                     count: QuantityExpr::Ref {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -6499,7 +6499,7 @@ fn strip_exile_top_face_down(after_lib: &str) -> (&str, bool) {
 /// dynamic count. When the suffix is missing or the inner phrase fails to
 /// parse to a known quantity, the original count (typically `Variable { "X" }`
 /// or `Fixed { value: N }`) is returned unchanged.
-/// CR 701.50e + CR 107.3i: Parse connive count from text after "connive"/"connives".
+/// CR 701.50d + CR 107.3i: Parse connive count from text after "connive"/"connives".
 /// Handles literal N, bare `X` (spell-cost path), and ", where X is <quantity>"
 /// bindings (Spymaster's Vault class).
 fn parse_connive_count_expr<'a>(rest_orig: &'a str, lower_rest: &str) -> (QuantityExpr, &'a str) {
@@ -7536,7 +7536,7 @@ pub(super) fn parse_imperative_family_ast(
         "explore" if lower == "explore" || lower == "explore again" => {
             Some(ImperativeFamilyAst::Explore)
         }
-        // CR 702.162a + CR 701.50e: "connive" / "connives" — extract optional
+        // CR 702.162a + CR 701.50d: "connive" / "connives" — extract optional
         // count ("connive 2", "connives X, where X is …") and target from remainder.
         "connive" | "connives" => {
             let after_verb_lower = &lower[first_word.len()..];

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36995,7 +36995,7 @@ mod tests {
         );
     }
 
-    /// CR 701.50e + CR 700.4 + CR 107.3i: Spymaster's Vault connive count must
+    /// CR 701.50d + CR 700.4 + CR 107.3i: Spymaster's Vault connive count must
     /// bind X to creatures that died this turn, not hardcode 1.
     #[test]
     fn connive_where_x_is_creatures_died_this_turn() {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3767,7 +3767,7 @@ pub(crate) fn static_mode_needs_grant_propagation(mode: &StaticMode) -> bool {
             | StaticMode::CantAttack
             | StaticMode::CantAttackOrBlock
             | StaticMode::CantCrew
-            // CR 702.122c: a granted crew/saddle/station power modifier (e.g. Stoic
+            // CR 702.122a / CR 702.171a / CR 702.184c: a granted crew/saddle/station power modifier (e.g. Stoic
             // Star-Captain's "Each creature you control crews … as though its power
             // were 2 greater") must propagate onto the affected creatures so the
             // crew/saddle power summation observes it via active_static_definitions.
@@ -3857,7 +3857,7 @@ fn parse_restriction_list_atom(input: &str) -> OracleResult<'_, Vec<StaticMode>>
             vec![StaticMode::Other("CantTransform".to_string())],
             tag("transform"),
         ),
-        // CR 702.122c: "crew [Vehicles]".
+        // CR 702.122d: "crew [Vehicles]".
         value(
             vec![StaticMode::CantCrew],
             (tag("crew"), opt(tag(" vehicles"))),

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1769,7 +1769,7 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // CR 702.122c / 702.171a / 702.184a: crew/saddle/station power-contribution
+    // CR 702.122a / 702.171a / 702.184c: crew/saddle/station power-contribution
     // modifier (Reckoner Bankbuster, Giant Ox, Stoic Star-Captain).
     if let Some(def) = parse_crew_contribution_static(&text) {
         return Some(def);

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -1989,7 +1989,7 @@ pub(crate) fn parse_subject_combat_rule_static(text: &str) -> Option<StaticDefin
     None
 }
 
-/// CR 702.122c / 702.171a / 702.184a: nom parser for the crew/saddle/station
+/// CR 702.122a / 702.171a / 702.184c: nom parser for the crew/saddle/station
 /// power-contribution modifier predicate. Composes the named action-list prefix
 /// (which records the affected keyword actions) with the modifier tail.
 fn parse_crew_contribution_predicate_nom(
@@ -2030,7 +2030,7 @@ fn parse_crew_contribution_predicate_nom(
     Ok((input, (kind, actions)))
 }
 
-/// CR 702.122c / 702.171a / 702.184a: "<subject> crews Vehicles [/ saddles
+/// CR 702.122a / 702.171a / 702.184c: "<subject> crews Vehicles [/ saddles
 /// Mounts / stations permanents] as though its power were N greater" or "…
 /// using its toughness rather than its power" — a continuous static that
 /// modifies the creature's contributed power when paying a crew/saddle/station

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18688,7 +18688,7 @@ fn eriette_charmed_apple_static_and_trigger_parse() {
     }
 }
 
-/// CR 702.122c / 702.171a / 702.184a: crew/saddle/station power-contribution
+/// CR 702.122a / 702.171a / 702.184c: crew/saddle/station power-contribution
 /// modifiers (Reckoner Bankbuster, the "Roads" cycle, Giant Ox, Stoic
 /// Star-Captain) parse into a `CrewContribution` static carrying the kind and
 /// the named action list.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8059,7 +8059,7 @@ fn try_parse_event(
         Exploits,
         /// CR 701.44b: A permanent "explores" after the explore process completes.
         Explores,
-        /// CR 701.50b: A permanent "connives" after the connive process completes.
+        /// CR 701.50f: A permanent "connives" after the connive process completes.
         Connives,
         /// CR 702.100b: A creature "evolves" when +1/+1 counters are put on it
         /// as a result of its evolve ability resolving.
@@ -8103,7 +8103,7 @@ fn try_parse_event(
             value(SimpleEvent::BecomesBlocked, tag("become blocked")),
             // CR 702.171b: Mount becomes saddled (saddled designation acquired).
             value(SimpleEvent::BecomesSaddled, tag("becomes saddled")),
-            // CR 702.122d: "Whenever [this Vehicle] becomes crewed" — trigger fires
+            // CR 702.122e: "Whenever [this Vehicle] becomes crewed" — trigger fires
             // when a crew ability of this Vehicle resolves. Needed for Mighty Servant
             // of Leuk-O, Mindlink Mech, etc.
             value(SimpleEvent::BecomesCrewed, tag("becomes crewed")),
@@ -8215,7 +8215,7 @@ fn try_parse_event(
             // CR 701.44b: "explores" / "explore" — explore trigger
             value(SimpleEvent::Explores, tag("explores")),
             value(SimpleEvent::Explores, tag("explore")),
-            // CR 701.50b: "connives" — connive trigger (fires after the connive
+            // CR 701.50f: "connives" — connive trigger (fires after the connive
             // process completes).
             value(SimpleEvent::Connives, tag("connives")),
             // CR 702.100b: "evolves" / "evolve" — evolve trigger
@@ -8381,7 +8381,7 @@ fn try_parse_event(
                 if !remaining.trim().is_empty() {
                     return None;
                 }
-                // CR 701.50b: "connives" fires after the connive process completes.
+                // CR 701.50f: "connives" fires after the connive process completes.
                 // `subject` ("a creature you control" / "~") scopes the conniver.
                 def.mode = TriggerMode::Connives;
                 def.valid_card = Some(subject.clone());
@@ -8412,7 +8412,7 @@ fn try_parse_event(
                 def.valid_card = Some(subject.clone());
             }
             SimpleEvent::BecomesCrewed => {
-                // CR 702.122d: "Whenever [this Vehicle] becomes crewed" — fires when
+                // CR 702.122e: "Whenever [this Vehicle] becomes crewed" — fires when
                 // a crew ability of this Vehicle resolves. Runtime matcher
                 // (match_vehicle_crewed) already handles TriggerMode::BecomesCrewed.
                 def.mode = TriggerMode::BecomesCrewed;

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -12898,7 +12898,8 @@ pub enum AbilityTag {
     Cycling,
     /// CR 702.165a: ability originated from a Backup keyword definition.
     Backup,
-    /// CR 602.5b + CR 602.1: This ability originated from a Power-up keyword definition.
+    /// CR 702.193a: This ability originated from a Power-up keyword definition (a
+    /// keyword-labeled activated ability, like Exhaust, per CR 602.5b + CR 602.1).
     PowerUp,
     /// CR 702.6a: This ability originated from an Equip keyword definition.
     Equip,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9043,7 +9043,7 @@ pub enum Effect {
     },
     /// CR 701.50a: Target creature connives (draw a card, then discard a card;
     /// if a nonland card is discarded, put a +1/+1 counter on it).
-    /// CR 701.50e: "Connive N" draws N, discards N, counters per nonland.
+    /// CR 701.50d: "Connive N" draws N, discards N, counters per nonland.
     /// `count` is a `QuantityExpr` so dynamic bindings (e.g. Spymaster's Vault's
     /// "connives X, where X is the number of creatures that died this turn") resolve
     /// at activation time via `resolve_quantity_with_targets`.

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -484,7 +484,7 @@ pub enum GameEvent {
         target: TargetRef,
         source_id: ObjectId,
     },
-    /// CR 702.122d: A Vehicle's crew ability resolved.
+    /// CR 702.122e: A Vehicle's crew ability resolved.
     /// Carries creature list for trigger conditions that reference "creatures that crewed it".
     VehicleCrewed {
         vehicle_id: ObjectId,

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -807,16 +807,16 @@ pub enum Keyword {
     Toxic(u32),
     /// CR 702.171a: Saddle N — tap creatures with total power N+ to saddle this Mount.
     Saddle(u32),
-    /// Teamwork N — "As an additional cost to cast this spell, you may tap any
-    /// number of creatures you control with total power N or more." The spell's
-    /// body then references whether this optional cost was paid ("if this spell
-    /// was cast using teamwork, ...").
+    /// CR 702.194a: Teamwork N — "As an additional cost to cast this spell, you
+    /// may tap any number of creatures you control with total power N or more."
+    /// The spell's body then references whether this optional cost was paid —
+    /// "if this spell was cast using teamwork, ..." (CR 702.194b).
     ///
-    /// Teamwork is not yet in the printed Comprehensive Rules (Marvel Super
-    /// Heroes set keyword). Its tap-any-number-with-total-power-N cost is
-    /// structurally identical to Crew (CR 702.122a) and Saddle (CR 702.171a); it
-    /// is an optional additional cast cost per CR 601.2b/f, and is a keyword
-    /// ability per CR 702.
+    /// Added to the printed Comprehensive Rules in the June 19, 2026 update
+    /// (Marvel Super Heroes set keyword). Its tap-any-number-with-total-power-N
+    /// cost is structurally identical to Crew (CR 702.122a) and Saddle
+    /// (CR 702.171a); paying it follows the additional-cost rules CR 601.2b and
+    /// CR 601.2f–h (CR 702.194a).
     ///
     /// Runtime: `database::synthesis::synthesize_teamwork` builds an
     /// `AdditionalCost::Optional { cost: TapCreatures { requirement:

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -642,8 +642,11 @@ pub enum AdditionalCostTaxAction {
     Cast,
 }
 
-/// CR 702.122c: How a creature's contributed power is modified when it crews a
-/// Vehicle, saddles a Mount, or stations a permanent. See [`StaticMode::CrewContribution`].
+/// CR 702.122a / CR 702.171a / CR 702.184c: How a creature's contributed power
+/// is modified when it crews a Vehicle, saddles a Mount, or stations a permanent.
+/// (Station's modifier is explicit in CR 702.184c; Crew/Saddle modify the
+/// "total power N" threshold of CR 702.122a / CR 702.171a.)
+/// See [`StaticMode::CrewContribution`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CrewContributionKind {
     /// "as though its power were N greater" — contribute `power + delta`.
@@ -1413,9 +1416,9 @@ pub enum StaticMode {
         action: CombatAloneAction,
         requirement: CombatAloneRequirement,
     },
-    /// CR 702.122c: This creature can't crew Vehicles.
+    /// CR 702.122d: This creature can't crew Vehicles.
     CantCrew,
-    /// CR 702.122c / CR 702.171a / CR 702.184a: This creature contributes to a
+    /// CR 702.122a / CR 702.171a / CR 702.184c: This creature contributes to a
     /// crew/saddle/station cost as though its power were modified (Reckoner
     /// Bankbuster: "as though its power were 2 greater") or using its toughness
     /// instead of its power (Giant Ox). `actions` records which keyword actions

--- a/crates/engine/src/types/triggers.rs
+++ b/crates/engine/src/types/triggers.rs
@@ -158,7 +158,7 @@ pub enum TriggerEventKey {
     DiscoverResolved,
     /// CR 701.46a: An adapt resolution.
     AdaptResolved,
-    /// CR 701.50b: A permanent connived (the connive process — draw, discard,
+    /// CR 701.50f: A permanent connived (the connive process — draw, discard,
     /// maybe +1/+1 — completed).
     ConniveResolved,
     /// CR 701.43d: A creature was exerted.
@@ -437,7 +437,7 @@ pub enum TriggerMode {
     // Adapt / amass / learn / venture
     /// CR 701.46: Triggers when a creature adapts.
     Adapt,
-    /// CR 701.50b: Triggers when a permanent connives (after the connive process
+    /// CR 701.50f: Triggers when a permanent connives (after the connive process
     /// completes).
     Connives,
     /// CR 702.143: Triggers when a card is foretold.

--- a/crates/engine/tests/connive_trigger_msh_wave1.rs
+++ b/crates/engine/tests/connive_trigger_msh_wave1.rs
@@ -6,9 +6,9 @@
 //! the local test fixture (MSH is release-gated), so the tests drive the real
 //! parser + trigger pipeline through representative Oracle text.
 //!
-//! CR 701.50b: a permanent "connives" after the connive process completes; the
+//! CR 701.50f: a permanent "connives" after the connive process completes; the
 //! `EffectResolved { kind: Connive }` event must carry the CONNIVER's id (CR
-//! 701.50c LKI), not the causing source — otherwise "whenever a creature you
+//! 701.50b LKI), not the causing source — otherwise "whenever a creature you
 //! control connives" is evaluated against the wrong object.
 
 use engine::game::ability_utils::build_resolved_from_def;
@@ -64,7 +64,7 @@ fn drain_priority(runner: &mut engine::game::scenario::GameRunner) {
     }
 }
 
-/// Glorious Purpose class + the CR 701.50c conviver-id fix (load-bearing).
+/// Glorious Purpose class + the CR 701.50b conviver-id fix (load-bearing).
 ///
 /// A creature you control connives, caused by an EXTERNAL source whose own
 /// characteristics do NOT satisfy the watcher's "a creature you control" filter

--- a/crates/engine/tests/connive_zero_no_op_701_50e.rs
+++ b/crates/engine/tests/connive_zero_no_op_701_50e.rs
@@ -1,0 +1,252 @@
+//! CR 701.50e — "If a permanent would connive 0, no connive event occurs.
+//! Abilities that trigger whenever a permanent connives won't trigger."
+//!
+//! A connive whose dynamic count resolves to 0 (Spymaster's Vault X = creatures
+//! that died this turn, with zero deaths recorded) must be a COMPLETE no-op: no
+//! draw, no discard, no +1/+1 counter, no `ConniveDiscard` pause, and crucially
+//! no `EffectResolved{Connive}` — so a "whenever a creature you control connives"
+//! watcher does NOT fire. The positive sibling proves count >= 1 is unregressed
+//! and the guard is count == 0-exact.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::GameScenario;
+use engine::game::triggers::process_triggers;
+use engine::game::zones::move_to_zone;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, ResolvedAbility, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Spymaster's Vault connive line — `connives X, where X is the number of
+/// creatures that died this turn` (a dynamic `ZoneChangeCountThisTurn`
+/// battlefield→graveyard count). With zero deaths recorded X resolves to 0.
+const VAULT_ORACLE: &str = "{B}, {T}: Target creature you control connives X, \
+where X is the number of creatures that died this turn.";
+
+/// Parse the Spymaster's Vault connive activated ability and return its
+/// definition for re-targeting at an arbitrary conviver from an arbitrary source.
+fn vault_connive_def() -> engine::types::ability::AbilityDefinition {
+    let parsed = parse_oracle_text(
+        VAULT_ORACLE,
+        "Spymaster's Vault",
+        &[],
+        &["Land".to_string()],
+        &[],
+    );
+    parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::Connive { .. }))
+        .expect("must parse a Connive activated ability")
+        .clone()
+}
+
+/// Drive priority until the stack empties (resolving any connive payoff trigger).
+/// Stops at the first non-priority wait so the turn does not advance.
+fn drain_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let mut guard = 0;
+    while !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(guard < 60, "stack did not drain");
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+}
+
+/// CR 701.50e (the revert-failing test): a connive whose dynamic count resolves
+/// to 0 is a COMPLETE no-op — no draw, no counter, no `ConniveDiscard` pause, and
+/// crucially no `EffectResolved{Connive}`, so a "whenever a creature you control
+/// connives" watcher does NOT fire.
+///
+/// The conviver's hand is EMPTY on purpose: without the guard a count-0 connive
+/// draws 0, finds an empty hand (so the discard step is skipped, NOT parked), and
+/// falls through to the tail that emits `EffectResolved{Connive}` — which fires
+/// the watcher for +2 life. With the guard, `resolve_connive_effect` returns
+/// before the tail, no event is emitted, and life is unchanged. (A nonempty hand
+/// would instead park a `ConniveDiscard` on revert and never reach the tail,
+/// making the life assertion non-discriminating — the inline
+/// `connive_count_zero_no_ops` test covers that nonempty-hand discard-park arm.)
+///
+/// REVERT-FAILING assertion: `life == life_before`. Without the `count == 0`
+/// guard in `resolve_connive_effect`, `EffectResolved{Connive}` is emitted, the
+/// watcher fires, and `life == life_before + 2`.
+#[test]
+fn connive_zero_fires_no_trigger_no_draw_no_counter() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    // A distinguishable card on library top — must NOT be drawn.
+    scenario.with_library_top(P0, &["Top Card"]);
+
+    // Watcher: "whenever a creature you control connives, you gain 2 life."
+    scenario.add_creature_from_oracle(
+        P0,
+        "Glorious Watcher",
+        2,
+        2,
+        "Whenever a creature you control connives, you gain 2 life.",
+    );
+    // The conviver — a plain creature you control.
+    let conniver = scenario.add_creature(P0, "Conniver", 2, 2).id();
+    // The Spymaster's Vault source carrying the dynamic-count connive ability.
+    let vault = scenario
+        .add_creature_from_oracle(P0, "Spymaster's Vault", 0, 0, VAULT_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    // Seed Priority so the "not ConniveDiscard" assertion below is meaningful.
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let life_before = runner.life(P0);
+    let top_card = runner.state().players[0].library[0];
+
+    // Empty hand (see the rationale in the doc comment) — required for the
+    // life/trigger assertion to be revert-failing.
+    assert!(
+        runner.state().players[0].hand.is_empty(),
+        "precondition: empty hand so a count-0 revert reaches the EffectResolved tail"
+    );
+    // ZERO creature deaths recorded → connive X resolves to 0.
+    assert_eq!(
+        runner.state().zone_changes_this_turn.len(),
+        0,
+        "precondition: no creature has died this turn, so connive X = 0"
+    );
+
+    // Resolve the connive on `conniver` from the Vault source, controlled by P0.
+    let def = vault_connive_def();
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Object(conniver)],
+        ..build_resolved_from_def(&def, vault, P0)
+    };
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("connive must resolve");
+
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    // CR 701.50e: no draw — the library-top card is still in the library.
+    assert!(
+        runner.state().players[0].library.contains(&top_card),
+        "connive 0 must not draw: library top must stay in library"
+    );
+    // CR 701.50e: no +1/+1 counter on the conviver.
+    assert_eq!(
+        runner.state().objects[&conniver]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "connive 0 must place no +1/+1 counter"
+    );
+    // CR 701.50e: no ConniveDiscard pause.
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ConniveDiscard { .. }
+        ),
+        "connive 0 must not park a ConniveDiscard, got {:?}",
+        runner.state().waiting_for
+    );
+    // CR 701.50e (REVERT-FAILING): no connive event occurs → the watcher never
+    // fires → life is unchanged. Pre-fix EffectResolved{Connive} fires the
+    // watcher and life += 2.
+    assert_eq!(
+        runner.life(P0),
+        life_before,
+        "connive 0 must not fire 'whenever a creature you control connives' — \
+         pre-fix the watcher fires and gains 2 life"
+    );
+}
+
+/// CR 701.50a + CR 701.50e (positive sibling): the same dynamic-count connive
+/// with TWO creature deaths recorded resolves X = 2 and connives NORMALLY — draws
+/// 2, discards 2, places 2 +1/+1 counters, and fires the watcher once. Proves the
+/// count >= 1 flow is unregressed and the guard is count == 0-exact.
+#[test]
+fn connive_count_two_connives_normally() {
+    let mut scenario = GameScenario::new_n_player(2, 9);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Two nonland cards on top so connive X=2 draws and auto-discards them
+    // (empty hand → draw 2 → discard all 2).
+    scenario.with_library_top(P0, &["Top A", "Top B"]);
+
+    scenario.add_creature_from_oracle(
+        P0,
+        "Glorious Watcher",
+        2,
+        2,
+        "Whenever a creature you control connives, you gain 2 life.",
+    );
+    let conniver = scenario.add_creature(P0, "Conniver", 2, 2).id();
+    let vault = scenario
+        .add_creature_from_oracle(P0, "Spymaster's Vault", 0, 0, VAULT_ORACLE)
+        .id();
+    // Two creatures that will die this turn → X = 2.
+    let dead_a = scenario.add_creature(P0, "Bear A", 2, 2).id();
+    let dead_b = scenario.add_creature(P0, "Bear B", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    // Populate two deaths through the production zone-change recorder.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), dead_a, Zone::Graveyard, &mut events);
+    move_to_zone(runner.state_mut(), dead_b, Zone::Graveyard, &mut events);
+    assert_eq!(
+        runner.state().zone_changes_this_turn.len(),
+        2,
+        "precondition: two deaths recorded so connive X = 2"
+    );
+    events.clear();
+
+    let life_before = runner.life(P0);
+
+    let def = vault_connive_def();
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Object(conniver)],
+        ..build_resolved_from_def(&def, vault, P0)
+    };
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("connive must resolve");
+
+    process_triggers(runner.state_mut(), &events);
+    drain_priority(&mut runner);
+
+    // CR 701.50a: drew 2, discarded both (auto), placed 2 +1/+1 counters.
+    assert_eq!(
+        runner.state().objects[&conniver]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        2,
+        "connive X=2 with two nonland discards must place two +1/+1 counters"
+    );
+    // The watcher fires exactly once for the single connive event → +2 life.
+    assert_eq!(
+        runner.life(P0),
+        life_before + 2,
+        "connive X=2 fires 'whenever a creature you control connives' once → +2 life"
+    );
+}

--- a/crates/engine/tests/integration/issue_2894_spymasters_vault_connive.rs
+++ b/crates/engine/tests/integration/issue_2894_spymasters_vault_connive.rs
@@ -4,7 +4,7 @@
 //! Oracle: `{B}, {T}: Target creature you control connives X, where X is the
 //! number of creatures that died this turn.`
 //!
-//! CR 701.50e + CR 700.4 + CR 107.3i: X is a dynamic zone-change count over
+//! CR 701.50d + CR 700.4 + CR 107.3i: X is a dynamic zone-change count over
 //! battlefield→graveyard transitions recorded in `zone_changes_this_turn`.
 
 use engine::game::ability_utils::build_resolved_from_def;
@@ -54,7 +54,7 @@ fn spymasters_vault_connive_parses_creatures_died_count() {
     );
 }
 
-/// CR 701.50a/e: With two creatures having died this turn (one nontoken, one
+/// CR 701.50a/d: With two creatures having died this turn (one nontoken, one
 /// token), connive draws and discards two cards, placing one +1/+1 counter per
 /// nonland discarded.
 #[test]


### PR DESCRIPTION
Integrates the **June 19 2026** Magic Comprehensive Rules update. `docs/MagicCompRules.txt` is gitignored (not redistributed), so it is not part of this diff — only the engine changes the update requires.

Three commits:

### 1. `feat(engine)` — CR 701.50e: connive 0 is a complete no-op (behavioral)
New CR 701.50e: *"If a permanent would connive 0, no connive event occurs. Abilities that trigger whenever a permanent connives won't trigger."* Dynamic connive counts (Spymaster's Vault — X = creatures that died this turn) can resolve to 0; previously the engine still emitted `EffectResolved{Connive}` (firing the connives trigger) and could park a degenerate `ConniveDiscard{count:0}`. A `count == 0` guard at the single chokepoint (`resolve_connive_effect`) now makes connive-0 perform no draw/discard/counter, park nothing, and emit no event. Covered by a discriminating runtime test (a connives watcher that must **not** fire at count 0, revert-failing on life) plus a count≥1 positive sibling.

### 2. `docs(engine)` — CR annotation renumbering (comment-only)
The June CR renumbered subrules; annotations citing the old letters now silently mis-cite (`rules_audit` only checks existence, not meaning).
- Connive (701.50): old 50b "connives after process" → **50f**; old 50c LKI → **50b**; old 50e "Connive N" → **50d**.
- Crew (702.122): old 122c "can't crew" → **122d**; old 122d "becomes crewed" → **122e**. Power-contribution annotations (never actually 122c) → 122a / 171a / **184c** (the explicit Station-modifier subrule).

### 3. `docs(engine)` — annotate Power-up with CR 702.193 (comment-only)
Power-up was implemented ahead of the printed rules; the June CR adds it as 702.193a/b. Teamwork was likewise updated to 702.194 in commit 2. (The Vibranium predefined token, 111.10w, is intentionally not annotated — it's data-driven via `known-tokens.toml` and resolved by the generic CR 111.4 path, with no Vibranium-specific engine code.)

Verification: `cargo fmt` clean; Tilt `clippy` + `test-engine` green (15,427 tests pass); `701.50c` is zero across the tree and every `701.50b–f` / `702.122a–e` / `702.193a–b` resolves in the CR text. The behavioral change passed an independent `/review-impl` (CLEAN) and the renumbering passed `/review-engine-plan`.