### PR TITLE
test(engine): regression tests for Shalai and Hallar + Forgotten Anci…

### DIFF
--- a/crates/engine/tests/integration/issue_680_shalai_and_hallar_forgotten_ancient.rs
+++ b/crates/engine/tests/integration/issue_680_shalai_and_hallar_forgotten_ancient.rs
@@ -1,0 +1,89 @@
+//! Issue #680 — Shalai and Hallar + Forgotten Ancient on the opponent's turn.
+//!
+//! Scenario: P0 controls Shalai and Hallar and Forgotten Ancient. On P1's
+//! turn P1 casts a spell; Forgotten Ancient's optional trigger puts a +1/+1
+//! counter on itself; Shalai and Hallar's CounterAdded trigger must deal that
+//! much damage to a target opponent (CR 122.1 + CR 603.2).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::Effect;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const SHALAI_AND_HALLAR: &str = "Flying, vigilance\n\
+Whenever one or more +1/+1 counters are put on a creature you control, \
+Shalai and Hallar deals that much damage to target opponent.";
+
+const FORGOTTEN_ANCIENT: &str = "Whenever a player casts a spell, you may put a \
++1/+1 counter on this creature.\n\
+At the beginning of your upkeep, you may move any number of +1/+1 counters from \
+this creature onto other creatures.";
+
+fn p1p1(state: &engine::types::game_state::GameState, id: ObjectId) -> u32 {
+    state
+        .objects
+        .get(&id)
+        .unwrap()
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn zero_cost_spell(scenario: &mut GameScenario, player: PlayerId) -> ObjectId {
+    scenario
+        .add_spell_to_hand(player, "Zero Cantrip", true)
+        .with_ability(Effect::NoOp)
+        .id()
+}
+
+#[test]
+fn issue_680_forgotten_ancient_counter_on_opponent_turn_triggers_shalai_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_creature_from_oracle(P0, "Shalai and Hallar", 3, 3, SHALAI_AND_HALLAR);
+    let ancient = scenario
+        .add_creature_from_oracle(P0, "Forgotten Ancient", 0, 0, FORGOTTEN_ANCIENT)
+        .id();
+    let spell = zero_cost_spell(&mut scenario, P1);
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    let p1_life_before = runner.state().players[P1.0 as usize].life;
+
+    let outcome = runner
+        .cast(spell)
+        .accept_optional()
+        .target_player(P1)
+        .resolve();
+
+    assert_eq!(
+        p1p1(outcome.state(), ancient),
+        1,
+        "Forgotten Ancient must receive exactly one +1/+1 counter"
+    );
+    assert_eq!(
+        outcome.life_delta(P1),
+        -1,
+        "Shalai and Hallar must deal 1 damage to the chosen opponent on P1's turn"
+    );
+    assert_eq!(
+        outcome.state().players[P1.0 as usize].life,
+        p1_life_before - 1,
+    );
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::Priority { player: p } if *p == P1
+        ),
+        "resolution must finish on P1's priority with an empty stack, got {:?}",
+        outcome.final_waiting_for()
+    );
+}

--- a/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
+++ b/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
@@ -79,9 +79,7 @@ fn issue_680_upkeep_move_counters_triggers_shalai_damage_per_creature() {
             }
             WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
             WaitingFor::Priority { .. } => {
-                runner
-                    .act(GameAction::PassPriority)
-                    .expect("pass priority");
+                runner.act(GameAction::PassPriority).expect("pass priority");
             }
             other => panic!("unexpected {other:?}"),
         }

--- a/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
+++ b/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
@@ -1,0 +1,95 @@
+//! Issue #680 — Shalai and Hallar + Forgotten Ancient upkeep move counters.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const SHALAI_AND_HALLAR: &str = "Flying, vigilance\n\
+Whenever one or more +1/+1 counters are put on a creature you control, \
+Shalai and Hallar deals that much damage to target opponent.";
+
+const FORGOTTEN_ANCIENT: &str = "Whenever a player casts a spell, you may put a \
++1/+1 counter on this creature.\n\
+At the beginning of your upkeep, you may move any number of +1/+1 counters from \
+this creature onto other creatures.";
+
+fn p1p1(state: &engine::types::game_state::GameState, id: ObjectId) -> u32 {
+    state
+        .objects
+        .get(&id)
+        .unwrap()
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+#[test]
+fn issue_680_upkeep_move_counters_triggers_shalai_damage_per_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Upkeep);
+    scenario.add_creature_from_oracle(P0, "Shalai and Hallar", 3, 3, SHALAI_AND_HALLAR);
+    let ancient = scenario
+        .add_creature_from_oracle(P0, "Forgotten Ancient", 0, 0, FORGOTTEN_ANCIENT)
+        .with_plus_counters(2)
+        .id();
+    let bear = scenario.add_creature(P0, "Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+
+    let p1_life_before = runner.state().players[P1.0 as usize].life;
+
+    runner.auto_advance_to_main_phase();
+
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 50, "stuck at {:?}", runner.state().waiting_for);
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept upkeep move");
+            }
+            WaitingFor::MoveCountersDistribution { .. } => {
+                runner
+                    .act(GameAction::ChooseCounterMoveDistribution {
+                        selections: vec![engine::types::game_state::CounterMoveChoice {
+                            destination_id: bear,
+                            counter_type: CounterType::Plus1Plus1,
+                            count: 2,
+                        }],
+                    })
+                    .expect("move both counters to bear");
+            }
+            WaitingFor::TriggerTargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Player(P1)),
+                    })
+                    .expect("pick opponent for Shalai damage");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).ok();
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    assert_eq!(p1p1(runner.state(), ancient), 0);
+    assert_eq!(p1p1(runner.state(), bear), 2);
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        p1_life_before - 2,
+        "moving 2 counters onto Bear must trigger Shalai for 2 damage total"
+    );
+}

--- a/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
+++ b/crates/engine/tests/integration/issue_680_shalai_upkeep_move.rs
@@ -79,7 +79,9 @@ fn issue_680_upkeep_move_counters_triggers_shalai_damage_per_creature() {
             }
             WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
             WaitingFor::Priority { .. } => {
-                runner.act(GameAction::PassPriority).ok();
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority");
             }
             other => panic!("unexpected {other:?}"),
         }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -366,6 +366,8 @@ mod issue_580_solitude_evoke_prompt;
 mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_629_fractured_sanity_cycling;
+mod issue_680_shalai_and_hallar_forgotten_ancient;
+mod issue_680_shalai_upkeep_move;
 mod issue_688_mind_into_matter;
 mod issue_689_resonating_lute_hand_size;
 mod issue_691_sheoldred_saga_lore;


### PR DESCRIPTION
## Summary

Fixes [issue #680](https://github.com/phase-rs/phase/issues/680): regression tests for **Shalai and Hallar** + **Forgotten Ancient** counter → damage chains.

Discord report: on an opponent's turn, P1 casts a spell; P0 accepts Forgotten Ancient's optional +1/+1 counter; Shalai and Hallar should deal that much damage to a target opponent. Engine investigation found the cast/trigger pipeline already resolves this correctly (CR 122.1 + CR 603.2); this PR locks the behavior in with integration tests so it cannot silently regress.

## Changes

- **`issue_680_forgotten_ancient_counter_on_opponent_turn_triggers_shalai_damage`:** P1 casts on P1's turn → P0 accepts Forgotten Ancient's optional counter → Shalai and Hallar deals 1 damage to the chosen opponent (`EventContextAmount` from the `CounterAdded` event).
- **`issue_680_upkeep_move_counters_triggers_shalai_damage_per_creature`:** P0 upkeep → move two +1/+1 counters from Forgotten Ancient onto another creature → Shalai and Hallar triggers for 2 total damage.
- **`main.rs`:** register both integration modules.

## Test plan

- [x] `cargo test -p engine --test integration issue_680`
- [x] `cargo fmt --all` + clippy green

## Notes

- In two-player games Shalai and Hallar's "target opponent" slot auto-selects the sole opponent (no `TriggerTargetSelection` prompt), matching the reported "ping an opponent" flow.
- If a live-game softlock persists after this lands, suspect the frontend `#459`-class dispatch/priority path rather than engine trigger resolution — these tests exercise the real cast pipeline end-to-end.
