### PR TITLE
fix(client): reset ChooseFromZoneModal selection between sequential per-player choices

### DIFF
--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -151,7 +151,17 @@ export function CardChoiceModal() {
       );
     case "ChooseFromZoneChoice":
       if (!canActForWaitingState) return null;
-      return <ChooseFromZoneModal data={waitingFor.data} />;
+      // A "for each player, choose ..." iteration (Breach the Multiverse) emits
+      // this WaitingFor once per player's zone in sequence. Keying on the prompt
+      // identity (player + source + card set) remounts the modal between steps so
+      // its internal `selectedSet` resets — otherwise a stale prior pick survives
+      // and the next confirm dispatches a card not in the new candidate set.
+      return (
+        <ChooseFromZoneModal
+          key={`${waitingFor.data.player}:${waitingFor.data.source_id}:${waitingFor.data.cards.join(",")}`}
+          data={waitingFor.data}
+        />
+      );
     case "EffectZoneChoice":
       if (!canActForWaitingState) return null;
       if (getBoardChoiceView(waitingFor, objects)) return null;


### PR DESCRIPTION
A "for each player, choose a card in that player's graveyard" effect (Breach
the Multiverse) emits ChooseFromZoneChoice once per player in sequence. Without a
changing key, React reuses the same modal instance, so its internal selectedSet
carries the prior player's pick into the next prompt. With count=1 the stale
selection blocks selecting a new card and can't be deselected, so Confirm
dispatches a card outside the new candidate set and the engine rejects it
("Selected card not in available set") — a softlock.

Key the modal on prompt identity (player + source + card set) so it remounts and
resets selection between steps, matching the existing OutsideGameModal /
DiscardModal pattern in this file.
