### PR TITLE
fix(engine): guard against zero-candidate ReplacementChoice softlock (#4277)

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -368,6 +368,25 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
         })
         .unwrap_or((0, vec![]));
 
+    // Issue #4277 softlock guard: a zero-candidate `ReplacementChoice` is
+    // unactionable. `candidate_actions_exact` enumerates `(0..candidate_count)`,
+    // so count 0 yields an empty legal-action set, and the frontend
+    // `ReplacementModal` returns null on `candidate_count == 0` — the game wedges
+    // and `stuck_decision_diagnostic` reports "Waiting for: ReplacementChoice".
+    // Every legitimate park flows from `pipeline_loop`, which only returns
+    // `NeedsChoice` for an Optional candidate (count 2) or 2+ materially-ordered
+    // candidates; reaching count 0 here means an upstream caller re-parked after
+    // `continue_replacement` already `.take()`-consumed the record (or an
+    // `EmptyManaPool` handler list emptied) — i.e. there is nothing left to
+    // choose. Return to a clean priority state so the drain machinery resumes any
+    // paused iteration (e.g. a mass simultaneous battlefield entry) instead of
+    // softlocking.
+    if candidate_count == 0 {
+        return WaitingFor::Priority {
+            player: state.active_player,
+        };
+    }
+
     WaitingFor::ReplacementChoice {
         player,
         candidate_count,
@@ -10153,6 +10172,73 @@ mod tests {
         );
         assert!(state.battlefield.contains(&hyena_umbra));
         assert!(state.battlefield.contains(&bear_umbra));
+    }
+
+    #[test]
+    fn zero_candidate_replacement_choice_returns_priority_not_softlock() {
+        // Issue #4277: a `ReplacementChoice` parked with `candidate_count == 0`
+        // is unactionable — `candidate_actions_exact` enumerates
+        // `(0..candidate_count)` (empty) and the frontend `ReplacementModal`
+        // renders nothing on count 0, wedging the game ("Waiting for:
+        // ReplacementChoice, Stuck players: 0"). The builder must never emit
+        // such a choice: when there is no pending replacement record to choose
+        // among (e.g. an upstream resume/drain re-parked after the record was
+        // already consumed), it must hand control back to priority so the drain
+        // machinery resumes instead of softlocking.
+        let state = GameState::new_two_player(42);
+        assert!(
+            state.pending_replacement.is_none(),
+            "precondition: no pending replacement"
+        );
+
+        let waiting_for = replacement_choice_waiting_for(PlayerId(0), &state);
+
+        assert!(
+            matches!(waiting_for, WaitingFor::Priority { .. }),
+            "a no-candidate replacement choice must resolve to Priority, not an \
+             actionless ReplacementChoice; got {waiting_for:?}"
+        );
+
+        // Defense-in-depth: whatever it is, it must not be a wedged
+        // ReplacementChoice. This is the exact softlock the diagnostic reported.
+        assert!(
+            !matches!(
+                waiting_for,
+                WaitingFor::ReplacementChoice {
+                    candidate_count: 0,
+                    ..
+                }
+            ),
+            "must never park on a zero-candidate ReplacementChoice"
+        );
+    }
+
+    #[test]
+    fn empty_candidates_replacement_record_returns_priority_not_softlock() {
+        // Issue #4277, sibling count-0 producer: the softlock arises not only when
+        // `pending_replacement` is None, but also when a `Some(record)` carries an
+        // empty `candidates` list. `replacement_choice_waiting_for` takes the
+        // `_ =>` arm and computes `count = candidates.len() == 0` (replacement.rs
+        // ~298), which must still route to Priority rather than an actionless
+        // ReplacementChoice — covering the non-None branch of the guard.
+        let mut state = GameState::new_two_player(42);
+        state.pending_replacement = Some(PendingReplacement {
+            proposed: ProposedEvent::zone_change(ObjectId(20), Zone::Hand, Zone::Battlefield, None),
+            candidates: vec![],
+            depth: 0,
+            is_optional: false,
+            library_placement: None,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+
+        let waiting_for = replacement_choice_waiting_for(PlayerId(0), &state);
+
+        assert!(
+            matches!(waiting_for, WaitingFor::Priority { .. }),
+            "an empty-candidates replacement record must resolve to Priority, not an \
+             actionless ReplacementChoice; got {waiting_for:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A ReplacementChoice parked with candidate_count == 0 produces an empty
legal-action set (candidate_actions_exact enumerates 0..candidate_count)
and renders no UI (ReplacementModal returns null on count 0), wedging the
game — surfaced by stuck_decision_diagnostic as "Waiting for:
ReplacementChoice, Stuck players: 0". This arises on a resume/drain
re-park after continue_replacement already take()-consumed the pending
record (e.g. a mass simultaneous battlefield entry whose nested token/copy
replacement resumed). replacement_choice_waiting_for now returns Priority
when there are no candidates so the drain machinery resumes paused
iteration instead of softlocking.

Adds building-block tests covering both count-0 producers (None record and
empty-candidates Some record).
