### PR TITLE
fix(ai): clamp SacrificeValue + scaled policy deltas into the critical band

### DIFF
--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -401,25 +401,40 @@ impl PolicyRegistry {
             let scaled = match verdict {
                 PolicyVerdict::Reject { reason } => PolicyVerdict::Reject { reason },
                 PolicyVerdict::Score { delta, reason } => {
-                    let scaled_delta = delta * activation as f64;
+                    // The critical band is a contract on each policy's *raw*
+                    // delta — the `PolicyVerdict::score`/`critical` constructors
+                    // clamp magnitudes to `CRITICAL_MAX`. A raw delta past the
+                    // ceiling means a policy bypassed them and emitted an
+                    // out-of-band value; assert that here (the meaningful
+                    // invariant). The prior code asserted on the *scaled* value,
+                    // which is wrong: `activation` can exceed 1.0 (turn-phase /
+                    // archetype multipliers), so an in-band raw delta can scale
+                    // past the ceiling legitimately — yet the assert panicked on
+                    // it in builds with debug-assertions enabled (issue #4282).
                     debug_assert!(
-                        scaled_delta.abs() <= CRITICAL_MAX,
-                        "policy {:?} scaled delta {} exceeds critical band ceiling {}",
+                        delta.abs() <= CRITICAL_MAX,
+                        "policy {:?} raw delta {} exceeds critical band ceiling {}",
                         policy_id,
-                        scaled_delta,
+                        delta,
                         CRITICAL_MAX
                     );
-                    if scaled_delta.abs() > CRITICAL_MAX {
+                    // A single policy must never exceed the critical-band ceiling
+                    // of influence over the aggregate, so clamp the scaled value
+                    // into the band rather than letting an activation multiplier
+                    // push it past the ceiling and dominate the sum.
+                    let scaled_delta = delta * activation as f64;
+                    let clamped = scaled_delta.clamp(-CRITICAL_MAX, CRITICAL_MAX);
+                    if scaled_delta != clamped {
                         tracing::warn!(
                             target: "phase_ai::decision_trace",
                             ?policy_id,
                             scaled_delta,
                             activation,
-                            "policy scaled delta exceeds critical band ceiling"
+                            "policy scaled delta clamped to critical band ceiling"
                         );
                     }
                     PolicyVerdict::Score {
-                        delta: scaled_delta,
+                        delta: clamped,
                         reason,
                     }
                 }

--- a/crates/phase-ai/src/policies/sacrifice_value.rs
+++ b/crates/phase-ai/src/policies/sacrifice_value.rs
@@ -60,10 +60,13 @@ impl TacticalPolicy for SacrificeValuePolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        PolicyVerdict::Score {
-            delta: self.score(ctx),
-            reason: PolicyReason::new("sacrifice_value_score"),
-        }
+        // `score` sums every sacrificed permanent's value into one delta, which
+        // is unbounded (a costly multi-permanent sacrifice can far exceed the
+        // critical band). Route it through the shared `PolicyVerdict::score`
+        // constructor so the raw delta is clamped into the critical band like
+        // every other policy, instead of emitting an out-of-band value the
+        // registry would otherwise have to defend against (issue #4282).
+        PolicyVerdict::score(self.score(ctx), PolicyReason::new("sacrifice_value_score"))
     }
 }
 
@@ -185,6 +188,93 @@ mod tests {
             token_score > creature_score,
             "Should prefer sacrificing token ({token_score}) over creature ({creature_score})"
         );
+    }
+
+    /// Regression for #4282: a high-cost sacrifice (the summed value of many
+    /// permanents) produces a raw `score` well past the critical band, but
+    /// `verdict` must clamp it into the band so the registry never receives an
+    /// out-of-band delta — previously this surfaced as a recovered engine panic
+    /// ("policy SacrificeValue scaled delta … exceeds critical band ceiling 15").
+    #[test]
+    fn high_cost_sacrifice_verdict_stays_within_critical_band() {
+        use crate::policies::registry::CRITICAL_MAX;
+
+        let mut state = GameState::new_two_player(42);
+
+        // Eight beefy creatures whose combined sacrifice value far exceeds the
+        // critical band ceiling, so the raw score is unambiguously out of band.
+        let mut choices = Vec::new();
+        for i in 0..8 {
+            let id = create_object(
+                &mut state,
+                CardId(1 + i),
+                PlayerId(0),
+                format!("Behemoth {i}"),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(8);
+            obj.toughness = Some(8);
+            choices.push(id);
+        }
+
+        let config = AiConfig::default();
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::PayCost {
+                player: PlayerId(0),
+                kind: PayCostKind::Sacrifice,
+                choices: choices.clone(),
+                count: choices.len(),
+                min_count: choices.len(),
+                resume: CostResume::Spell {
+                    spell: dummy_pending(),
+                },
+            },
+            candidates: Vec::new(),
+        };
+        let candidate = CandidateAction {
+            action: GameAction::SelectCards {
+                cards: choices.clone(),
+            },
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Selection,
+            },
+        };
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+
+        // The raw score is genuinely out of band (otherwise the regression would
+        // not exercise the clamp at all).
+        let raw = SacrificeValuePolicy.score(&ctx);
+        assert!(
+            raw < -CRITICAL_MAX,
+            "scenario must drive the raw score past the critical band (got {raw})"
+        );
+
+        // The verdict clamps it into the band: a single policy never emits a
+        // delta whose magnitude exceeds the critical-band ceiling.
+        match SacrificeValuePolicy.verdict(&ctx) {
+            PolicyVerdict::Score { delta, .. } => {
+                assert!(
+                    delta.abs() <= CRITICAL_MAX,
+                    "verdict delta {delta} must be clamped into the critical band (±{CRITICAL_MAX})"
+                );
+                assert!(
+                    delta < 0.0,
+                    "sacrificing value remains a negative incentive"
+                );
+            }
+            other => panic!("expected a Score verdict, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/tests/score_contract_lint.rs
+++ b/crates/phase-ai/src/policies/tests/score_contract_lint.rs
@@ -30,7 +30,7 @@ const LEGACY_SCORE_LITERAL_COUNTS: &[(&str, usize)] = &[
     ("plus_one_counters.rs", 10),
     ("reactive_self_protection.rs", 0),
     ("recursion_awareness.rs", 1),
-    ("sacrifice_value.rs", 1),
+    ("sacrifice_value.rs", 0),
     ("spellskite_priority.rs", 1),
     ("stack_awareness.rs", 1),
     ("x_value.rs", 1),


### PR DESCRIPTION
Fixes #4282

## Summary
`SacrificeValuePolicy::verdict` returned its raw `score` — the summed value of every sacrificed permanent — directly as the verdict delta via a `PolicyVerdict::Score { .. }` struct literal, bypassing the band-clamping constructors (`PolicyVerdict::score`/`critical`) that every other policy uses to keep deltas inside the critical band. A costly multi-permanent sacrifice therefore produced an out-of-band delta (the report shows `-21.360…`), and the registry's per-candidate scaling `debug_assert!`-panicked on it (`policy SacrificeValue scaled delta … exceeds critical band ceiling 15`) in builds with debug-assertions enabled.

## Fix
- **`SacrificeValuePolicy::verdict`** now routes its raw score through the shared `PolicyVerdict::score` constructor, clamping the policy's own delta into the critical band like every peer policy.
- **Registry scaling invariant corrected.** The old `debug_assert!` checked the *scaled* delta (`delta * activation`), which is the wrong invariant: `activation` can legitimately exceed `1.0` (turn-phase / archetype multipliers from `turn_phase_mult`), so an in-band raw delta can scale past the ceiling without any policy misbehaving. The assertion now checks the **raw** delta (the actual per-policy contract), and the **scaled** delta is **clamped** into the band — a single policy never exceeds the critical-band ceiling of influence — instead of being passed through unclamped (release) or panicked on (debug-assertions). A `tracing::warn!` still records any clamp for decision-trace telemetry.

## Tests
- New regression `high_cost_sacrifice_verdict_stays_within_critical_band` drives a high-cost sacrifice past the band (asserting the raw score is genuinely out of band first, so the clamp is actually exercised) and asserts the verdict delta stays within `±CRITICAL_MAX` while remaining a negative incentive.
- Ratchets the `score_contract_lint` legacy `PolicyVerdict::Score` literal count for `sacrifice_value.rs` from 1 → 0 (one fewer band-bypassing site).
- `cargo fmt --all`, `cargo clippy -p phase-ai --all-targets -- -D warnings`, and `cargo test -p phase-ai` (1095 lib tests + integration) all green.
