### PR TITLE
fix(ai): clamp SacrificeValue/BlightValue policies to critical band ceiling (#4282)

### DIFF
--- a/crates/phase-ai/src/policies/blight_value.rs
+++ b/crates/phase-ai/src/policies/blight_value.rs
@@ -6,7 +6,6 @@ use engine::types::player::PlayerId;
 use crate::config::PolicyPenalties;
 use crate::features::DeckFeatures;
 
-use super::activation::turn_only;
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 use super::strategy_helpers::sacrifice_cost;
@@ -66,18 +65,27 @@ impl TacticalPolicy for BlightValuePolicy {
 
     fn activation(
         &self,
-        features: &DeckFeatures,
-        state: &GameState,
+        _features: &DeckFeatures,
+        _state: &GameState,
         _player: PlayerId,
     ) -> Option<f32> {
-        turn_only(features, state)
+        // The cost of placing a -1/-1 counter is intrinsic to the creature being
+        // blighted — a 12/1 dies just as dead on turn 2 as on turn 9 — so it must
+        // not scale with game phase. Mirrors SacrificeValuePolicy /
+        // PaymentSelectionPolicy. A turn-phase multiplier (>1.0) over the
+        // unbounded blight score could push a high-power, low-toughness creature
+        // past the registry's CRITICAL_MAX ceiling (see issue #4282).
+        // activation-constant: phase-independent blight resource valuation.
+        Some(1.0)
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        PolicyVerdict::Score {
-            delta: self.score(ctx),
-            reason: PolicyReason::new("blight_value_score"),
-        }
+        // Route through the band contract helper rather than hand-building a raw
+        // `Score`: `self.score()` is an unbounded sum of per-creature blight
+        // costs, and `PolicyVerdict::score` clamps its magnitude into the
+        // declared bands (|delta| <= CRITICAL_MAX). With activation pinned to
+        // 1.0 above, the scaled delta can never exceed the critical ceiling.
+        PolicyVerdict::score(self.score(ctx), PolicyReason::new("blight_value_score"))
     }
 }
 
@@ -195,6 +203,83 @@ mod tests {
             "Should prefer blighting the 3/5 ({big_score}) over the 3/1 ({small_score}) — \
              the 3/1 dies to its -1/-1 counter"
         );
+    }
+
+    /// Regression for #4282 (sibling of SacrificeValuePolicy): blighting a
+    /// high-power, low-toughness creature must not produce a scaled delta beyond
+    /// the critical band ceiling. A toughness-1 creature dies to its -1/-1
+    /// counter, so `blight_cost` returns its full (unbounded) sacrifice value;
+    /// before the fix, `verdict` returned that raw score and `activation` scaled
+    /// it by `turn_phase_mult` (up to 1.3), tripping the registry's
+    /// `debug_assert!(scaled_delta.abs() <= CRITICAL_MAX)`.
+    #[test]
+    fn large_blight_stays_within_critical_band() {
+        use super::super::registry::CRITICAL_MAX;
+
+        let mut state = GameState::new_two_player(42);
+
+        // 12/1 => dies to the -1/-1 counter, so blight_cost = evaluate_creature
+        // = 12*1.5 + 1 = 19.0, comfortably over the critical ceiling of 15.
+        let glass_cannon = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Glass Cannon".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&glass_cannon).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(12);
+        obj.toughness = Some(1);
+
+        let config = AiConfig::default();
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::BlightChoice {
+                player: PlayerId(0),
+                counters: 1,
+                creatures: vec![glass_cannon],
+                pending_cast: dummy_pending(),
+            },
+            candidates: Vec::new(),
+        };
+        let candidate = CandidateAction {
+            action: GameAction::SelectCards {
+                cards: vec![glass_cannon],
+            },
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Selection,
+            },
+        };
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+
+        // The raw score must exceed the ceiling, proving the clamp is exercised.
+        assert!(
+            BlightValuePolicy.score(&ctx).abs() > CRITICAL_MAX,
+            "test premise: raw blight score should exceed the critical ceiling"
+        );
+
+        let PolicyVerdict::Score { delta, .. } = BlightValuePolicy.verdict(&ctx) else {
+            panic!("blight value policy must return a Score verdict");
+        };
+        assert!(
+            delta.abs() <= CRITICAL_MAX,
+            "verdict delta {delta} must be clamped to the critical band ceiling {CRITICAL_MAX}"
+        );
+
+        let activation = BlightValuePolicy
+            .activation(&DeckFeatures::default(), &state, PlayerId(0))
+            .expect("blight value policy always activates");
+        assert_eq!(activation, 1.0, "blight valuation must not scale by phase");
+        assert!((delta * f64::from(activation)).abs() <= CRITICAL_MAX);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/sacrifice_value.rs
+++ b/crates/phase-ai/src/policies/sacrifice_value.rs
@@ -4,7 +4,6 @@ use engine::types::player::PlayerId;
 
 use crate::features::DeckFeatures;
 
-use super::activation::turn_only;
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
 use super::strategy_helpers::sacrifice_cost;
@@ -52,18 +51,28 @@ impl TacticalPolicy for SacrificeValuePolicy {
 
     fn activation(
         &self,
-        features: &DeckFeatures,
-        state: &GameState,
+        _features: &DeckFeatures,
+        _state: &GameState,
         _player: PlayerId,
     ) -> Option<f32> {
-        turn_only(features, state)
+        // Sacrifice resource valuation is intrinsic to the permanent being given
+        // up — a 6/6 costs the same to sacrifice on turn 2 as on turn 9 — so it
+        // must not scale with game phase. Mirrors the sibling
+        // PaymentSelectionPolicy, which handles the same SelectCards / PayCost
+        // decision with a constant 1.0 activation. A turn-phase multiplier (>1.0)
+        // here could push a legitimate critical-band score past the registry's
+        // CRITICAL_MAX ceiling (see issue #4282).
+        // activation-constant: phase-independent sacrifice resource valuation.
+        Some(1.0)
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        PolicyVerdict::Score {
-            delta: self.score(ctx),
-            reason: PolicyReason::new("sacrifice_value_score"),
-        }
+        // Route through the band contract helper rather than hand-building a
+        // raw `Score`: `self.score()` is an unbounded sum of per-card sacrifice
+        // costs, and `PolicyVerdict::score` clamps its magnitude into the
+        // declared bands (|delta| <= CRITICAL_MAX). With activation pinned to
+        // 1.0 above, the scaled delta can never exceed the critical ceiling.
+        PolicyVerdict::score(self.score(ctx), PolicyReason::new("sacrifice_value_score"))
     }
 }
 
@@ -185,6 +194,90 @@ mod tests {
             token_score > creature_score,
             "Should prefer sacrificing token ({token_score}) over creature ({creature_score})"
         );
+    }
+
+    /// Regression for #4282: sacrificing a high-value creature must not produce
+    /// a scaled delta beyond the critical band ceiling. Before the fix, `verdict`
+    /// returned the raw unbounded `-evaluate_creature` score and `activation`
+    /// scaled it by `turn_phase_mult` (up to 1.3), so a single large creature
+    /// tripped the registry's `debug_assert!(scaled_delta.abs() <= CRITICAL_MAX)`.
+    #[test]
+    fn large_sacrifice_stays_within_critical_band() {
+        use super::super::registry::CRITICAL_MAX;
+
+        let mut state = GameState::new_two_player(42);
+
+        // 8/8 => evaluate_creature = 8*1.5 + 8 = 20.0, comfortably over the
+        // critical ceiling of 15, so the band clamp must actually engage.
+        let big = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Colossus".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&big).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(8);
+        obj.toughness = Some(8);
+
+        let config = AiConfig::default();
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::PayCost {
+                player: PlayerId(0),
+                kind: PayCostKind::Sacrifice,
+                choices: vec![big],
+                count: 1,
+                min_count: 1,
+                resume: CostResume::Spell {
+                    spell: dummy_pending(),
+                },
+            },
+            candidates: Vec::new(),
+        };
+        let candidate = CandidateAction {
+            action: GameAction::SelectCards { cards: vec![big] },
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Selection,
+            },
+        };
+        let ctx = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+
+        // The raw score must exceed the ceiling, proving the clamp is exercised.
+        assert!(
+            SacrificeValuePolicy.score(&ctx).abs() > CRITICAL_MAX,
+            "test premise: raw sacrifice score should exceed the critical ceiling"
+        );
+
+        // The banded verdict must clamp magnitude into the critical band.
+        let PolicyVerdict::Score { delta, .. } = SacrificeValuePolicy.verdict(&ctx) else {
+            panic!("sacrifice value policy must return a Score verdict");
+        };
+        assert!(
+            delta.abs() <= CRITICAL_MAX,
+            "verdict delta {delta} must be clamped to the critical band ceiling {CRITICAL_MAX}"
+        );
+
+        // Activation is the constant 1.0, so the scaled delta the registry
+        // asserts on equals the (already clamped) verdict delta — never above
+        // the ceiling regardless of turn number.
+        let activation = SacrificeValuePolicy
+            .activation(&DeckFeatures::default(), &state, PlayerId(0))
+            .expect("sacrifice value policy always activates");
+        assert_eq!(
+            activation, 1.0,
+            "sacrifice valuation must not scale by phase"
+        );
+        assert!((delta * f64::from(activation)).abs() <= CRITICAL_MAX);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/tests/score_contract_lint.rs
+++ b/crates/phase-ai/src/policies/tests/score_contract_lint.rs
@@ -9,7 +9,6 @@ use std::fs;
 use std::path::Path;
 
 const LEGACY_SCORE_LITERAL_COUNTS: &[(&str, usize)] = &[
-    ("blight_value.rs", 1),
     ("board_development.rs", 1),
     ("chalice_avoidance.rs", 1),
     ("combat_tax.rs", 3),
@@ -30,7 +29,6 @@ const LEGACY_SCORE_LITERAL_COUNTS: &[(&str, usize)] = &[
     ("plus_one_counters.rs", 10),
     ("reactive_self_protection.rs", 0),
     ("recursion_awareness.rs", 1),
-    ("sacrifice_value.rs", 1),
     ("spellskite_priority.rs", 1),
     ("stack_awareness.rs", 1),
     ("x_value.rs", 1),


### PR DESCRIPTION
Both policies hand-built a raw PolicyVerdict::Score from an unbounded
-sum(sacrifice_cost) score and scaled it by turn_only activation (up to
1.3x in early/late game). A single high-value permanent (e.g. a 6/6, or a
high-power toughness-1 creature for blight) drove delta * activation past
the registry's CRITICAL_MAX=15 ceiling, tripping the debug_assert at
registry.rs:405 — the recoverable engine panic users reported.

Mirror the sibling PaymentSelectionPolicy, which handles the same
SelectCards / PayCost decision: pin activation to a constant 1.0 (sacrifice
and blight resource valuation are intrinsic to the permanent given up and
do not scale with game phase) and route the verdict through the
PolicyVerdict::score() band helper, which clamps magnitude to CRITICAL_MAX.
Worst case is now 15 * 1.0 = 15 <= ceiling, so the invariant holds by
construction.

BlightValuePolicy carried the identical latent bug (same sacrifice_cost
score, same turn_only activation) and is fixed in lockstep. Adds a
discriminating regression test to each policy and drops both files from the
score_contract_lint legacy allowlist now that they use the band contract.

cargo ai-gate: 0 FAIL / 3 PASS / 0 win-loss flips vs baseline.
