### PR TITLE
perf(combat): hoist O(battlefield²) static scan out of legality loops

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -663,6 +663,7 @@ pub fn collect_must_be_blocked_statics(state: &GameState) -> Vec<(ObjectId, Stat
         .collect()
 }
 
+/// CR 509.1b: Block restriction — these statics make a block declaration illegal.
 /// Re-resolve a precomputed `CantBeBlocked*` static against `attacker_id`,
 /// applying the SAME `affected` + `condition` filter stack as
 /// `block_restriction_statics_against` but without re-walking the battlefield.
@@ -702,6 +703,7 @@ fn block_restriction_statics_against_from_precomputed<'a>(
     })
 }
 
+/// CR 509.1b: Blocker-side restriction ("~ can't block").
 /// Precomputed counterpart of `blocker_restriction_statics_for`.
 fn blocker_restriction_statics_for_from_precomputed<'a>(
     state: &'a GameState,
@@ -735,6 +737,7 @@ fn blocker_restriction_statics_for_from_precomputed<'a>(
     })
 }
 
+/// CR 509.1b: Block-restriction exception ("~ can't block except …").
 /// Precomputed counterpart of `blocker_block_allowed_statics_for`.
 fn blocker_allowed_statics_for_from_precomputed<'a>(
     state: &'a GameState,
@@ -768,6 +771,7 @@ fn blocker_allowed_statics_for_from_precomputed<'a>(
     })
 }
 
+/// CR 509.1c: Block requirement ("~ must be blocked if able").
 /// Precomputed counterpart of `must_be_blocked_statics_for_attacker`.
 fn must_be_blocked_statics_for_attacker_from_precomputed<'a>(
     state: &'a GameState,
@@ -2967,6 +2971,8 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
     )
 }
 
+/// CR 509.1b: Pairwise block legality (restriction checks: can't-block,
+/// can't-be-blocked-by, landwalk, horsemanship).
 /// Precomputed-slice variant of [`can_block_pair`]: identical legality logic, but
 /// the three static scans read from caller-collected slices instead of re-walking
 /// the battlefield. Hoist [`collect_blocker_restriction_statics`],
@@ -3207,6 +3213,8 @@ pub fn min_blockers_required(state: &GameState, attacker_id: ObjectId) -> u32 {
     min_blockers_required_from_precomputed(state, attacker_id, &block_restriction)
 }
 
+/// CR 702.111b + CR 509.1b: Minimum blockers required (menace floor of 2 and any
+/// `MinBlockers` restriction floor).
 /// Precomputed-slice variant of [`min_blockers_required`]. Hoist
 /// [`collect_block_restriction_statics`] once before any attacker loop.
 pub fn min_blockers_required_from_precomputed(
@@ -3246,6 +3254,7 @@ pub fn max_blockers_allowed(state: &GameState, attacker_id: ObjectId) -> Option<
     max_blockers_allowed_from_precomputed(state, attacker_id, &block_restriction)
 }
 
+/// CR 509.1b: Maximum blockers allowed (`CantBeBlockedByMoreThan` restriction).
 /// Precomputed-slice variant of [`max_blockers_allowed`]. Hoist
 /// [`collect_block_restriction_statics`] once before any attacker loop.
 pub fn max_blockers_allowed_from_precomputed(

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -602,10 +602,13 @@ fn defending_player_for_target(state: &GameState, target: AttackTarget) -> Playe
 /// scan iterates the whole battlefield rather than only the attacker's own
 /// `static_definitions`. CR 702.26b functioning gates are applied before
 /// recipient-relative CR 604.1 / CR 613.1 condition gating.
-fn block_restriction_statics_against<'a>(
-    state: &'a GameState,
-    attacker_id: ObjectId,
-) -> impl Iterator<Item = (&'a GameObject, &'a StaticDefinition)> + 'a {
+/// CR 509.1b: Collect every functioning `CantBeBlocked*` static on the
+/// battlefield once per legality pass. The relevant set is tiny relative to the
+/// battlefield, so cloning the owned `StaticDefinition` is cheap and lets the
+/// per-candidate `_from_precomputed` filters run without re-walking the whole
+/// battlefield for every attacker. Mirrors the filter in
+/// `block_restriction_statics_against`.
+pub fn collect_block_restriction_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
     super::functioning_abilities::battlefield_functioning_statics(state)
         .filter(|(_, def)| {
             matches!(
@@ -616,41 +619,14 @@ fn block_restriction_statics_against<'a>(
                     | StaticMode::CantBeBlockedByMoreThan { .. }
             )
         })
-        .filter(move |(src, def)| match def.affected.as_ref() {
-            // CR 604.1: a static with no `affected` filter is implicitly about
-            // its own source (intrinsic SelfRef semantics — preserves the
-            // pre-fix behavior of `active_static_definitions(attacker)` for
-            // statics constructed without an explicit filter).
-            None => src.id == attacker_id,
-            Some(filter) => matches_target_filter(
-                state,
-                attacker_id,
-                filter,
-                &FilterContext::from_source(state, src.id),
-            ),
-        })
-        .filter(move |(src, def)| {
-            def.condition.as_ref().is_none_or(|condition| {
-                crate::game::layers::evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    src.controller,
-                    src.id,
-                    attacker_id,
-                )
-            })
-        })
+        .map(|(src, def)| (src.id, def.clone()))
+        .collect()
 }
 
-/// CR 509.1a: A blocker declaration is illegal if any functioning static says
-/// that creature can't block. The static may live on the blocker itself or on
-/// another battlefield/command-zone source whose `affected` filter matches the
-/// blocker, so this mirrors the attacker-side CantAttack check while preserving
-/// intrinsic `None` = SelfRef semantics.
-fn blocker_restriction_statics_for<'a>(
-    state: &'a GameState,
-    blocker_id: ObjectId,
-) -> impl Iterator<Item = (&'a GameObject, &'a StaticDefinition)> + 'a {
+/// CR 509.1b: Collect every functioning `CantBlock` / `CantAttackOrBlock` static
+/// once per legality pass. Mirrors the filter in
+/// `blocker_restriction_statics_for`.
+pub fn collect_blocker_restriction_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
     super::functioning_abilities::game_functioning_statics(state)
         .filter(|(_, def)| {
             matches!(
@@ -658,7 +634,83 @@ fn blocker_restriction_statics_for<'a>(
                 StaticMode::CantBlock | StaticMode::CantAttackOrBlock
             )
         })
-        .filter(move |(src, def)| match def.affected.as_ref() {
+        .map(|(src, def)| (src.id, def.clone()))
+        .collect()
+}
+
+/// CR 509.1b: Collect every functioning `BlockRestriction` ("can block only
+/// <filter>") static once per legality pass. Mirrors the filter in
+/// `blocker_block_allowed_statics_for`.
+pub fn collect_blocker_allowed_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    super::functioning_abilities::game_functioning_statics(state)
+        .filter(|(_, def)| matches!(def.mode, StaticMode::BlockRestriction { .. }))
+        .map(|(src, def)| (src.id, def.clone()))
+        .collect()
+}
+
+/// CR 509.1c: Collect every functioning `MustBeBlocked` / `MustBeBlockedByAll`
+/// static once per legality pass. Mirrors the filter in
+/// `must_be_blocked_statics_for_attacker`.
+pub fn collect_must_be_blocked_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    super::functioning_abilities::battlefield_functioning_statics(state)
+        .filter(|(_, def)| {
+            matches!(
+                def.mode,
+                StaticMode::MustBeBlocked | StaticMode::MustBeBlockedByAll
+            )
+        })
+        .map(|(src, def)| (src.id, def.clone()))
+        .collect()
+}
+
+/// Re-resolve a precomputed `CantBeBlocked*` static against `attacker_id`,
+/// applying the SAME `affected` + `condition` filter stack as
+/// `block_restriction_statics_against` but without re-walking the battlefield.
+/// Yields `(&StaticDefinition, ObjectId)` — the source id re-resolves the
+/// controller for `FilterContext`, so no `GameObject` field beyond `.id` is read.
+fn block_restriction_statics_against_from_precomputed<'a>(
+    state: &'a GameState,
+    attacker_id: ObjectId,
+    precomputed: &'a [(ObjectId, StaticDefinition)],
+) -> impl Iterator<Item = (&'a StaticDefinition, ObjectId)> + 'a {
+    precomputed.iter().filter_map(move |(src_id, def)| {
+        let src = state.objects.get(src_id)?;
+        // CR 604.1: a static with no `affected` filter is implicitly about its
+        // own source (intrinsic SelfRef semantics).
+        let affected_ok = match def.affected.as_ref() {
+            None => src.id == attacker_id,
+            Some(filter) => matches_target_filter(
+                state,
+                attacker_id,
+                filter,
+                &FilterContext::from_source(state, src.id),
+            ),
+        };
+        if !affected_ok {
+            return None;
+        }
+        let condition_ok = def.condition.as_ref().is_none_or(|condition| {
+            crate::game::layers::evaluate_condition_with_recipient(
+                state,
+                condition,
+                src.controller,
+                src.id,
+                attacker_id,
+            )
+        });
+        condition_ok.then_some((def, *src_id))
+    })
+}
+
+/// Precomputed counterpart of `blocker_restriction_statics_for`.
+fn blocker_restriction_statics_for_from_precomputed<'a>(
+    state: &'a GameState,
+    blocker_id: ObjectId,
+    precomputed: &'a [(ObjectId, StaticDefinition)],
+) -> impl Iterator<Item = (&'a StaticDefinition, ObjectId)> + 'a {
+    precomputed.iter().filter_map(move |(src_id, def)| {
+        let src = state.objects.get(src_id)?;
+        let affected_ok = match def.affected.as_ref() {
             None => src.id == blocker_id,
             Some(filter) => matches_target_filter(
                 state,
@@ -666,24 +718,118 @@ fn blocker_restriction_statics_for<'a>(
                 filter,
                 &FilterContext::from_source(state, src.id),
             ),
-        })
-        .filter(move |(src, def)| {
-            def.condition.as_ref().is_none_or(|condition| {
-                crate::game::layers::evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    src.controller,
-                    src.id,
-                    blocker_id,
-                )
-            })
-        })
+        };
+        if !affected_ok {
+            return None;
+        }
+        let condition_ok = def.condition.as_ref().is_none_or(|condition| {
+            crate::game::layers::evaluate_condition_with_recipient(
+                state,
+                condition,
+                src.controller,
+                src.id,
+                blocker_id,
+            )
+        });
+        condition_ok.then_some((def, *src_id))
+    })
 }
 
-fn blocker_has_cant_block_static(state: &GameState, blocker_id: ObjectId) -> bool {
-    blocker_restriction_statics_for(state, blocker_id)
+/// Precomputed counterpart of `blocker_block_allowed_statics_for`.
+fn blocker_allowed_statics_for_from_precomputed<'a>(
+    state: &'a GameState,
+    blocker_id: ObjectId,
+    precomputed: &'a [(ObjectId, StaticDefinition)],
+) -> impl Iterator<Item = (&'a StaticDefinition, ObjectId)> + 'a {
+    precomputed.iter().filter_map(move |(src_id, def)| {
+        let src = state.objects.get(src_id)?;
+        let affected_ok = match def.affected.as_ref() {
+            None => src.id == blocker_id,
+            Some(filter) => matches_target_filter(
+                state,
+                blocker_id,
+                filter,
+                &FilterContext::from_source(state, src.id),
+            ),
+        };
+        if !affected_ok {
+            return None;
+        }
+        let condition_ok = def.condition.as_ref().is_none_or(|condition| {
+            crate::game::layers::evaluate_condition_with_recipient(
+                state,
+                condition,
+                src.controller,
+                src.id,
+                blocker_id,
+            )
+        });
+        condition_ok.then_some((def, *src_id))
+    })
+}
+
+/// Precomputed counterpart of `must_be_blocked_statics_for_attacker`.
+fn must_be_blocked_statics_for_attacker_from_precomputed<'a>(
+    state: &'a GameState,
+    attacker_id: ObjectId,
+    precomputed: &'a [(ObjectId, StaticDefinition)],
+) -> impl Iterator<Item = (&'a StaticDefinition, ObjectId)> + 'a {
+    precomputed.iter().filter_map(move |(src_id, def)| {
+        let src = state.objects.get(src_id)?;
+        let affected_ok = match def.affected.as_ref() {
+            None => src.id == attacker_id,
+            Some(filter) => matches_target_filter(
+                state,
+                attacker_id,
+                filter,
+                &FilterContext::from_source(state, src.id),
+            ),
+        };
+        if !affected_ok {
+            return None;
+        }
+        let condition_ok = def.condition.as_ref().is_none_or(|condition| {
+            crate::game::layers::evaluate_condition_with_recipient(
+                state,
+                condition,
+                src.controller,
+                src.id,
+                attacker_id,
+            )
+        });
+        condition_ok.then_some((def, *src_id))
+    })
+}
+
+/// CR 509.1b: precomputed-slice variant of `blocker_has_cant_block_static`.
+fn blocker_has_cant_block_static_from_precomputed(
+    state: &GameState,
+    blocker_id: ObjectId,
+    precomputed: &[(ObjectId, StaticDefinition)],
+) -> bool {
+    blocker_restriction_statics_for_from_precomputed(state, blocker_id, precomputed)
         .next()
         .is_some()
+}
+
+/// CR 509.1c: precomputed-slice variant of `attacker_has_must_be_blocked`.
+fn attacker_has_must_be_blocked_from_precomputed(
+    state: &GameState,
+    attacker_id: ObjectId,
+    precomputed: &[(ObjectId, StaticDefinition)],
+) -> bool {
+    must_be_blocked_statics_for_attacker_from_precomputed(state, attacker_id, precomputed)
+        .any(|(def, _)| def.mode == StaticMode::MustBeBlocked)
+}
+
+/// CR 509.1c: precomputed-slice variant of `attacker_has_must_be_blocked_by_all`.
+fn attacker_has_must_be_blocked_by_all_from_precomputed(
+    state: &GameState,
+    attacker_id: ObjectId,
+    precomputed: &[(ObjectId, StaticDefinition)],
+) -> bool {
+    must_be_blocked_statics_for_attacker_from_precomputed(state, attacker_id, precomputed)
+        .any(|(def, _)| def.mode == StaticMode::MustBeBlockedByAll)
 }
 
 /// CR 509.1b + CR 609.4 + CR 702.28b: A creature without shadow normally can't
@@ -706,86 +852,6 @@ fn blocker_can_block_shadow(state: &GameState, blocker: &GameObject) -> bool {
                 ..Default::default()
             },
         )
-}
-
-/// CR 509.1b: Static abilities on the blocker (or on another source whose
-/// `affected` filter matches the blocker) that restrict which attackers it
-/// may block — e.g. "This creature can block only creatures with flying."
-fn blocker_block_allowed_statics_for<'a>(
-    state: &'a GameState,
-    blocker_id: ObjectId,
-) -> impl Iterator<Item = (&'a GameObject, &'a StaticDefinition)> + 'a {
-    super::functioning_abilities::game_functioning_statics(state)
-        .filter(|(_, def)| matches!(def.mode, StaticMode::BlockRestriction { .. }))
-        .filter(move |(src, def)| match def.affected.as_ref() {
-            None => src.id == blocker_id,
-            Some(filter) => matches_target_filter(
-                state,
-                blocker_id,
-                filter,
-                &FilterContext::from_source(state, src.id),
-            ),
-        })
-        .filter(move |(src, def)| {
-            def.condition.as_ref().is_none_or(|condition| {
-                crate::game::layers::evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    src.controller,
-                    src.id,
-                    blocker_id,
-                )
-            })
-        })
-}
-
-/// CR 509.1c: Static abilities that force blockers onto `attacker_id` — e.g.
-/// "must be blocked if able" on the attacker itself, or on an Aura/Equipment
-/// whose `affected` filter matches the enchanted/equipped creature (Predatory
-/// Impetus, Lure). Mirrors [`block_restriction_statics_against`].
-fn must_be_blocked_statics_for_attacker<'a>(
-    state: &'a GameState,
-    attacker_id: ObjectId,
-) -> impl Iterator<Item = (&'a GameObject, &'a StaticDefinition)> + 'a {
-    super::functioning_abilities::battlefield_functioning_statics(state)
-        .filter(|(_, def)| {
-            matches!(
-                def.mode,
-                StaticMode::MustBeBlocked | StaticMode::MustBeBlockedByAll
-            )
-        })
-        .filter(move |(src, def)| match def.affected.as_ref() {
-            None => src.id == attacker_id,
-            Some(filter) => matches_target_filter(
-                state,
-                attacker_id,
-                filter,
-                &FilterContext::from_source(state, src.id),
-            ),
-        })
-        .filter(move |(src, def)| {
-            def.condition.as_ref().is_none_or(|condition| {
-                crate::game::layers::evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    src.controller,
-                    src.id,
-                    attacker_id,
-                )
-            })
-        })
-}
-
-fn attacker_has_must_be_blocked(state: &GameState, attacker_id: ObjectId) -> bool {
-    // CR 509.1c: Check if any active static forces blockers on this attacker.
-    must_be_blocked_statics_for_attacker(state, attacker_id)
-        .any(|(_, def)| def.mode == StaticMode::MustBeBlocked)
-}
-
-fn attacker_has_must_be_blocked_by_all(state: &GameState, attacker_id: ObjectId) -> bool {
-    // CR 509.1c: Check if any active static forces all able creatures to block this attacker.
-    must_be_blocked_statics_for_attacker(state, attacker_id)
-        .any(|(_, def)| def.mode == StaticMode::MustBeBlockedByAll)
 }
 
 /// Validate blocker declarations per CR 509.1.
@@ -838,6 +904,15 @@ pub fn validate_blockers_for_player(
             }
         }
     }
+
+    // Hoist each kind of relevant static ONCE for this whole legality pass. Every
+    // per-blocker / per-attacker / per-battlefield loop below reads from these
+    // slices via the `_from_precomputed` helpers instead of re-walking the
+    // battlefield, turning the O(battlefield²) scan into a single sweep.
+    let blocker_restriction = collect_blocker_restriction_statics(state);
+    let block_restriction = collect_block_restriction_statics(state);
+    let blocker_allowed = collect_blocker_allowed_statics(state);
+    let must_be_blocked = collect_must_be_blocked_statics(state);
 
     // Group assignments by attacker for menace validation and by blocker for
     // per-creature block-capacity checks.
@@ -906,7 +981,7 @@ pub fn validate_blockers_for_player(
         if blocker.has_keyword(&Keyword::Decayed) {
             return Err(format!("{:?} has decayed and can't block", blocker_id));
         }
-        if blocker_has_cant_block_static(state, blocker_id) {
+        if blocker_has_cant_block_static_from_precomputed(state, blocker_id, &blocker_restriction) {
             return Err(format!("{:?} can't block", blocker_id));
         }
 
@@ -927,8 +1002,12 @@ pub fn validate_blockers_for_player(
         // (`EnchantedBy`) `CantBeBlocked*` modes uniformly. The static's own
         // source supplies the `FilterContext` so inner filters like "creatures
         // you control" resolve against the granting permanent's controller.
-        for (src, sd) in block_restriction_statics_against(state, attacker_id) {
-            match &sd.mode {
+        for (def, src_id) in block_restriction_statics_against_from_precomputed(
+            state,
+            attacker_id,
+            &block_restriction,
+        ) {
+            match &def.mode {
                 StaticMode::CantBeBlocked => {
                     return Err(format!(
                         "{:?} cannot block {:?} (can't be blocked)",
@@ -941,7 +1020,7 @@ pub fn validate_blockers_for_player(
                             state,
                             blocker_id,
                             target_filter,
-                            &FilterContext::from_source(state, src.id),
+                            &FilterContext::from_source(state, src_id),
                         ) {
                             return Err(format!(
                                 "{:?} cannot block {:?} (can't be blocked except by {:?})",
@@ -958,7 +1037,7 @@ pub fn validate_blockers_for_player(
                         state,
                         blocker_id,
                         filter,
-                        &FilterContext::from_source(state, src.id),
+                        &FilterContext::from_source(state, src_id),
                     ) =>
                 {
                     return Err(format!(
@@ -1078,15 +1157,17 @@ pub fn validate_blockers_for_player(
         }
 
         // CR 509.1b: blocker-side "can block only <filter>" restrictions.
-        for (src, sd) in blocker_block_allowed_statics_for(state, blocker_id) {
-            let StaticMode::BlockRestriction { filter } = &sd.mode else {
+        for (def, src_id) in
+            blocker_allowed_statics_for_from_precomputed(state, blocker_id, &blocker_allowed)
+        {
+            let StaticMode::BlockRestriction { filter } = &def.mode else {
                 continue;
             };
             if !matches_target_filter(
                 state,
                 attacker_id,
                 filter,
-                &FilterContext::from_source(state, src.id),
+                &FilterContext::from_source(state, src_id),
             ) {
                 return Err(format!(
                     "{blocker_id:?} can block only creatures matching the block restriction"
@@ -1148,7 +1229,8 @@ pub fn validate_blockers_for_player(
     // authority that unifies the menace floor (2) with any MinBlockers floor and
     // is the same value surfaced to the UI via `block_requirements`.
     for (attacker_id, blockers) in &blockers_per_attacker {
-        let required = min_blockers_required(state, *attacker_id);
+        let required =
+            min_blockers_required_from_precomputed(state, *attacker_id, &block_restriction);
         if (blockers.len() as u32) < required {
             return Err(format!(
                 "{:?} must be blocked by {} or more creatures",
@@ -1158,7 +1240,9 @@ pub fn validate_blockers_for_player(
         // CR 509.1b: "can't be blocked by more than N creatures" — a per-creature
         // blocker maximum (Stalking Tiger). Inverse of the menace minimum above;
         // an attacker with both must satisfy both.
-        if let Some(max) = max_blockers_allowed(state, *attacker_id) {
+        if let Some(max) =
+            max_blockers_allowed_from_precomputed(state, *attacker_id, &block_restriction)
+        {
             if (blockers.len() as u32) > max {
                 return Err(format!(
                     "{:?} can't be blocked by more than {} creature(s)",
@@ -1184,7 +1268,8 @@ pub fn validate_blockers_for_player(
             }
             let attacker_id = attacker_info.object_id;
 
-            if !attacker_has_must_be_blocked(state, attacker_id) {
+            if !attacker_has_must_be_blocked_from_precomputed(state, attacker_id, &must_be_blocked)
+            {
                 continue;
             }
 
@@ -1205,7 +1290,14 @@ pub fn validate_blockers_for_player(
                 obj.controller == player
                     && obj.card_types.core_types.contains(&CoreType::Creature)
                     && !obj.tapped
-                    && can_block_pair(state, *id, attacker_id)
+                    && can_block_pair_with_precomputed(
+                        state,
+                        *id,
+                        attacker_id,
+                        &blocker_restriction,
+                        &block_restriction,
+                        &blocker_allowed,
+                    )
             });
 
             if has_available_blocker {
@@ -1230,7 +1322,11 @@ pub fn validate_blockers_for_player(
                 continue;
             }
             let attacker_id = attacker_info.object_id;
-            if !attacker_has_must_be_blocked_by_all(state, attacker_id) {
+            if !attacker_has_must_be_blocked_by_all_from_precomputed(
+                state,
+                attacker_id,
+                &must_be_blocked,
+            ) {
                 continue;
             }
             // Any untapped defender with spare block capacity that could legally
@@ -1248,7 +1344,14 @@ pub fn validate_blockers_for_player(
                 if obj.controller != player
                     || !obj.card_types.core_types.contains(&CoreType::Creature)
                     || obj.tapped
-                    || !can_block_pair(state, *id, attacker_id)
+                    || !can_block_pair_with_precomputed(
+                        state,
+                        *id,
+                        attacker_id,
+                        &blocker_restriction,
+                        &block_restriction,
+                        &blocker_allowed,
+                    )
                 {
                     return false;
                 }
@@ -1307,7 +1410,7 @@ pub fn validate_blockers_for_player(
             if obj.has_keyword(&Keyword::Decayed) {
                 continue;
             }
-            if blocker_has_cant_block_static(state, obj_id) {
+            if blocker_has_cant_block_static_from_precomputed(state, obj_id, &blocker_restriction) {
                 continue;
             }
             // CR 701.35a: Detained creatures can't block.
@@ -1316,7 +1419,15 @@ pub fn validate_blockers_for_player(
             }
             // Check if this creature could legally block any attacker attacking its controller
             let can_block_any = combat.attackers.iter().any(|ai| {
-                ai.defending_player == obj.controller && can_block_pair(state, obj_id, ai.object_id)
+                ai.defending_player == obj.controller
+                    && can_block_pair_with_precomputed(
+                        state,
+                        obj_id,
+                        ai.object_id,
+                        &blocker_restriction,
+                        &block_restriction,
+                        &blocker_allowed,
+                    )
             });
             if can_block_any {
                 return Err(format!("{:?} must block if able (CR 509.1c)", obj_id));
@@ -1355,7 +1466,11 @@ pub fn validate_blockers_for_player(
             if obj.tapped
                 || obj.has_keyword(&Keyword::Decayed)
                 || !obj.detained_by.is_empty()
-                || blocker_has_cant_block_static(state, obj_id)
+                || blocker_has_cant_block_static_from_precomputed(
+                    state,
+                    obj_id,
+                    &blocker_restriction,
+                )
             {
                 continue;
             }
@@ -1374,7 +1489,16 @@ pub fn validate_blockers_for_player(
                 let assigned_to_attacker = assignments
                     .iter()
                     .any(|&(blocker, attacker)| blocker == obj_id && attacker == attacker_id);
-                if !assigned_to_attacker && can_block_pair(state, obj_id, attacker_id) {
+                if !assigned_to_attacker
+                    && can_block_pair_with_precomputed(
+                        state,
+                        obj_id,
+                        attacker_id,
+                        &blocker_restriction,
+                        &block_restriction,
+                        &blocker_allowed,
+                    )
+                {
                     return Err(format!(
                         "{obj_id:?} must block {attacker_id:?} this turn if able (CR 509.1c)"
                     ));
@@ -2830,13 +2954,39 @@ fn land_matches_landwalk_qualifier(land: &GameObject, qualifier: &str) -> bool {
 /// CantBeBlockedBy, Protection, Flying/Reach, Shadow, Fear, Intimidate, Skulk,
 /// Horsemanship, Landwalk, CantBlock/CantAttackOrBlock).
 pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: ObjectId) -> bool {
+    let blocker_restriction = collect_blocker_restriction_statics(state);
+    let block_restriction = collect_block_restriction_statics(state);
+    let blocker_allowed = collect_blocker_allowed_statics(state);
+    can_block_pair_with_precomputed(
+        state,
+        blocker_id,
+        attacker_id,
+        &blocker_restriction,
+        &block_restriction,
+        &blocker_allowed,
+    )
+}
+
+/// Precomputed-slice variant of [`can_block_pair`]: identical legality logic, but
+/// the three static scans read from caller-collected slices instead of re-walking
+/// the battlefield. Hoist [`collect_blocker_restriction_statics`],
+/// [`collect_block_restriction_statics`], and [`collect_blocker_allowed_statics`]
+/// once before any loop that calls this per pair.
+pub fn can_block_pair_with_precomputed(
+    state: &GameState,
+    blocker_id: ObjectId,
+    attacker_id: ObjectId,
+    blocker_restriction: &[(ObjectId, StaticDefinition)],
+    block_restriction: &[(ObjectId, StaticDefinition)],
+    blocker_allowed: &[(ObjectId, StaticDefinition)],
+) -> bool {
     let Some(blocker) = state.objects.get(&blocker_id) else {
         return false;
     };
     let Some(attacker) = state.objects.get(&attacker_id) else {
         return false;
     };
-    if blocker_has_cant_block_static(state, blocker_id) {
+    if blocker_has_cant_block_static_from_precomputed(state, blocker_id, blocker_restriction) {
         return false;
     }
     // CR 702.147a: Decayed means "This creature can't block."
@@ -2847,8 +2997,10 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
     // `affected` filter matches the attacker — covers intrinsic, Equipment-
     // granted, and Aura-granted `CantBeBlocked*` uniformly. Mirrors the
     // declare-blockers validation in `validate_blockers_for_player`.
-    for (src, sd) in block_restriction_statics_against(state, attacker_id) {
-        match &sd.mode {
+    for (def, src_id) in
+        block_restriction_statics_against_from_precomputed(state, attacker_id, block_restriction)
+    {
+        match &def.mode {
             StaticMode::CantBeBlocked => return false,
             StaticMode::CantBeBlockedExceptBy { kind } => match kind {
                 BlockExceptionKind::Quality(target_filter) => {
@@ -2856,7 +3008,7 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
                         state,
                         blocker_id,
                         target_filter,
-                        &FilterContext::from_source(state, src.id),
+                        &FilterContext::from_source(state, src_id),
                     ) {
                         return false;
                     }
@@ -2870,7 +3022,7 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
                     state,
                     blocker_id,
                     filter,
-                    &FilterContext::from_source(state, src.id),
+                    &FilterContext::from_source(state, src_id),
                 ) =>
             {
                 return false;
@@ -2931,15 +3083,17 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
         return false;
     }
     // CR 509.1b: blocker-side "can block only <filter>" restrictions.
-    for (src, sd) in blocker_block_allowed_statics_for(state, blocker_id) {
-        let StaticMode::BlockRestriction { filter } = &sd.mode else {
+    for (def, src_id) in
+        blocker_allowed_statics_for_from_precomputed(state, blocker_id, blocker_allowed)
+    {
+        let StaticMode::BlockRestriction { filter } = &def.mode else {
             continue;
         };
         if !matches_target_filter(
             state,
             attacker_id,
             filter,
-            &FilterContext::from_source(state, src.id),
+            &FilterContext::from_source(state, src_id),
         ) {
             return false;
         }
@@ -2984,6 +3138,12 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
         None => return HashMap::new(),
     };
 
+    // Hoist the three static slices once for the whole O(blockers × attackers)
+    // legality sweep instead of re-walking the battlefield per pair.
+    let blocker_restriction = collect_blocker_restriction_statics(state);
+    let block_restriction = collect_block_restriction_statics(state);
+    let blocker_allowed = collect_blocker_allowed_statics(state);
+
     let mut result = HashMap::new();
     for &blocker_id in &valid_blockers {
         let blocker = match state.objects.get(&blocker_id) {
@@ -2997,7 +3157,16 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
             .iter()
             .filter(|a| a.defending_player == blocker_controller)
             .filter(|a| is_attacker_in_play(state, a.object_id))
-            .filter(|a| can_block_pair(state, blocker_id, a.object_id))
+            .filter(|a| {
+                can_block_pair_with_precomputed(
+                    state,
+                    blocker_id,
+                    a.object_id,
+                    &blocker_restriction,
+                    &block_restriction,
+                    &blocker_allowed,
+                )
+            })
             .map(|a| a.object_id)
             .collect();
         if !valid_targets.is_empty() {
@@ -3034,6 +3203,17 @@ pub fn get_valid_block_targets_for_player(
 /// it and `block_requirements_for_player` surfaces it to the UI, so the count a
 /// player sees can never disagree with the count the engine enforces.
 pub fn min_blockers_required(state: &GameState, attacker_id: ObjectId) -> u32 {
+    let block_restriction = collect_block_restriction_statics(state);
+    min_blockers_required_from_precomputed(state, attacker_id, &block_restriction)
+}
+
+/// Precomputed-slice variant of [`min_blockers_required`]. Hoist
+/// [`collect_block_restriction_statics`] once before any attacker loop.
+pub fn min_blockers_required_from_precomputed(
+    state: &GameState,
+    attacker_id: ObjectId,
+    block_restriction: &[(ObjectId, StaticDefinition)],
+) -> u32 {
     let mut min = 1;
     if state
         .objects
@@ -3042,10 +3222,12 @@ pub fn min_blockers_required(state: &GameState, attacker_id: ObjectId) -> u32 {
     {
         min = min.max(2);
     }
-    for (_src, sd) in block_restriction_statics_against(state, attacker_id) {
+    for (def, _src_id) in
+        block_restriction_statics_against_from_precomputed(state, attacker_id, block_restriction)
+    {
         if let StaticMode::CantBeBlockedExceptBy {
             kind: BlockExceptionKind::MinBlockers { min: n },
-        } = &sd.mode
+        } = &def.mode
         {
             min = min.max(*n);
         }
@@ -3060,8 +3242,19 @@ pub fn min_blockers_required(state: &GameState, attacker_id: ObjectId) -> u32 {
 /// This is the inverse of [`min_blockers_required`]; an attacker carrying both a
 /// minimum and a maximum must satisfy both.
 pub fn max_blockers_allowed(state: &GameState, attacker_id: ObjectId) -> Option<u32> {
-    block_restriction_statics_against(state, attacker_id)
-        .filter_map(|(_src, sd)| match sd.mode {
+    let block_restriction = collect_block_restriction_statics(state);
+    max_blockers_allowed_from_precomputed(state, attacker_id, &block_restriction)
+}
+
+/// Precomputed-slice variant of [`max_blockers_allowed`]. Hoist
+/// [`collect_block_restriction_statics`] once before any attacker loop.
+pub fn max_blockers_allowed_from_precomputed(
+    state: &GameState,
+    attacker_id: ObjectId,
+    block_restriction: &[(ObjectId, StaticDefinition)],
+) -> Option<u32> {
+    block_restriction_statics_against_from_precomputed(state, attacker_id, block_restriction)
+        .filter_map(|(def, _src_id)| match def.mode {
             StaticMode::CantBeBlockedByMoreThan { max } => Some(max),
             _ => None,
         })
@@ -3081,12 +3274,16 @@ pub fn block_requirements_for_player(
         Some(c) => c,
         None => return HashMap::new(),
     };
+    // Hoist the block-restriction slice once for the O(attackers × battlefield)
+    // sweep — invoked from `engine_combat.rs` and `turns.rs` production paths.
+    let block_restriction = collect_block_restriction_statics(state);
     combat
         .attackers
         .iter()
         .filter(|a| a.defending_player == player)
         .filter_map(|a| {
-            let required = min_blockers_required(state, a.object_id);
+            let required =
+                min_blockers_required_from_precomputed(state, a.object_id, &block_restriction);
             (required > 1).then_some((a.object_id, required))
         })
         .collect()
@@ -7400,6 +7597,141 @@ mod tests {
         assert!(
             can_block_pair(&state, drone, flying_attacker),
             "can_block_pair must accept flying attacker"
+        );
+    }
+
+    /// The precomputed `can_block_pair_with_precomputed` path must agree with the
+    /// `can_block_pair` wrapper for a blocker-side BlockRestriction (flying-only):
+    /// reject a ground attacker, accept a flyer. Reverted-fix discrimination: if
+    /// the precomputed variant dropped the `blocker_allowed` slice, the ground
+    /// attacker would be wrongly ACCEPTED, flipping the first assertion.
+    #[test]
+    fn block_restriction_precomputed_slice_rejects_and_accepts_correctly() {
+        use crate::types::ability::StaticDefinition;
+        use crate::types::statics::{block_only_creatures_with_flying_filter, StaticMode};
+
+        let mut state = setup();
+        let ground_attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let flying_attacker = create_creature(&mut state, PlayerId(0), "Bird", 2, 2);
+        state
+            .objects
+            .get_mut(&flying_attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Flying);
+
+        let drone = create_creature(&mut state, PlayerId(1), "Drone", 1, 1);
+        {
+            let drone_obj = state.objects.get_mut(&drone).unwrap();
+            drone_obj.keywords.push(Keyword::Flying);
+            drone_obj.static_definitions.push(
+                StaticDefinition::new(StaticMode::BlockRestriction {
+                    filter: block_only_creatures_with_flying_filter(),
+                })
+                .affected(TargetFilter::SelfRef),
+            );
+        }
+
+        let blocker_restriction = collect_blocker_restriction_statics(&state);
+        let block_restriction = collect_block_restriction_statics(&state);
+        let blocker_allowed = collect_blocker_allowed_statics(&state);
+
+        // The BlockRestriction static must be captured by the collect helper.
+        assert!(
+            !blocker_allowed.is_empty(),
+            "collect_blocker_allowed_statics must capture the flying-only BlockRestriction"
+        );
+
+        let precomputed_ground = can_block_pair_with_precomputed(
+            &state,
+            drone,
+            ground_attacker,
+            &blocker_restriction,
+            &block_restriction,
+            &blocker_allowed,
+        );
+        let precomputed_flyer = can_block_pair_with_precomputed(
+            &state,
+            drone,
+            flying_attacker,
+            &blocker_restriction,
+            &block_restriction,
+            &blocker_allowed,
+        );
+
+        assert!(
+            !precomputed_ground,
+            "precomputed path must reject the ground attacker"
+        );
+        assert!(
+            precomputed_flyer,
+            "precomputed path must accept the flying attacker"
+        );
+        // Wrapper and precomputed path must agree byte-for-byte.
+        assert_eq!(
+            precomputed_ground,
+            can_block_pair(&state, drone, ground_attacker)
+        );
+        assert_eq!(
+            precomputed_flyer,
+            can_block_pair(&state, drone, flying_attacker)
+        );
+    }
+
+    /// Two DISTINCT CantBlock sources both affecting one blocker: the collect
+    /// helper must capture BOTH, and the precomputed cant-block check / pair check
+    /// must report the blocker as unable to block. Reverted-fix discrimination: a
+    /// precomputed variant that re-resolved against only one source, or read the
+    /// wrong `src_id` controller, would still report `true`/blockable for the
+    /// remote-affected source.
+    #[test]
+    fn two_separate_cant_block_sources_both_enforce_from_precomputed() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let blocker = create_creature(&mut state, PlayerId(1), "Wall", 0, 4);
+
+        // Two distinct opponent-controlled sources, each granting CantBlock to
+        // every creature the opponent (PlayerId(1)) controls — both touch the blocker.
+        let source_a = create_creature(&mut state, PlayerId(0), "Suppressor A", 1, 1);
+        let source_b = create_creature(&mut state, PlayerId(0), "Suppressor B", 1, 1);
+        for source in [source_a, source_b] {
+            state
+                .objects
+                .get_mut(&source)
+                .unwrap()
+                .static_definitions
+                .push(
+                    StaticDefinition::new(StaticMode::CantBlock).affected(TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::Opponent),
+                    )),
+                );
+        }
+
+        let blocker_restriction = collect_blocker_restriction_statics(&state);
+        // Both sources must be captured (plus they are the only CantBlock statics).
+        assert_eq!(
+            blocker_restriction.len(),
+            2,
+            "collect_blocker_restriction_statics must capture both CantBlock sources"
+        );
+
+        assert!(
+            blocker_has_cant_block_static_from_precomputed(&state, blocker, &blocker_restriction),
+            "precomputed cant-block check must see the affected blocker"
+        );
+
+        let block_restriction = collect_block_restriction_statics(&state);
+        let blocker_allowed = collect_blocker_allowed_statics(&state);
+        assert!(
+            !can_block_pair_with_precomputed(
+                &state,
+                blocker,
+                attacker,
+                &blocker_restriction,
+                &block_restriction,
+                &blocker_allowed,
+            ),
+            "precomputed pair check must reject a blocker under CantBlock"
         );
     }
 

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 
-use engine::game::combat::{can_block_pair, AttackTarget};
+use engine::game::combat::{
+    can_block_pair, can_block_pair_with_precomputed, collect_block_restriction_statics,
+    collect_blocker_allowed_statics, collect_blocker_restriction_statics, AttackTarget,
+};
 use engine::game::commander::commander_lethal_headroom;
 use engine::game::players;
+use engine::types::ability::StaticDefinition;
 use engine::types::card_type::CoreType;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
@@ -15,6 +19,43 @@ use crate::config::AiProfile;
 use crate::damage_reflection::has_damage_reflection_to_controller;
 use crate::eval::{evaluate_creature, threat_level};
 use crate::projection::{project_to, Projection, ProjectionHorizon};
+
+/// Block-legality static slices collected once per combat decision and threaded
+/// through the per-pair `can_block_pair` checks. Hoisting these out of the
+/// O(battlefield²) attacker/blocker loops avoids re-walking the battlefield's
+/// functioning statics for every candidate pair.
+pub(crate) struct BlockLegalitySlices {
+    blocker_restriction: Vec<(ObjectId, StaticDefinition)>,
+    block_restriction: Vec<(ObjectId, StaticDefinition)>,
+    blocker_allowed: Vec<(ObjectId, StaticDefinition)>,
+}
+
+impl BlockLegalitySlices {
+    pub(crate) fn collect(state: &GameState) -> Self {
+        Self {
+            blocker_restriction: collect_blocker_restriction_statics(state),
+            block_restriction: collect_block_restriction_statics(state),
+            blocker_allowed: collect_blocker_allowed_statics(state),
+        }
+    }
+
+    /// CR 509.1a–b: per-pair block legality against the precomputed slices.
+    pub(crate) fn can_block_pair(
+        &self,
+        state: &GameState,
+        blocker_id: ObjectId,
+        attacker_id: ObjectId,
+    ) -> bool {
+        can_block_pair_with_precomputed(
+            state,
+            blocker_id,
+            attacker_id,
+            &self.blocker_restriction,
+            &self.block_restriction,
+            &self.blocker_allowed,
+        )
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CombatObjective {
@@ -164,6 +205,12 @@ pub fn choose_attackers_with_targets_with_profile(
         profile,
     );
 
+    // Hoist the block-legality static slices once for the whole candidate sweep —
+    // `defender_best_block` runs an O(blockers) `can_block_pair` filter per
+    // candidate, so collecting these per call would re-walk the battlefield's
+    // statics O(candidates × blockers) times.
+    let slices = BlockLegalitySlices::collect(state);
+
     // Determine which creatures should attack (same logic as before)
     let mut attacking_ids = Vec::new();
     for &id in &candidates {
@@ -190,7 +237,7 @@ pub fn choose_attackers_with_targets_with_profile(
         // the defender would never offer — it instead kills the attacker for free
         // with a first-striker or a larger body (gamestate1: a 1/1 animated land
         // sent into a 2/1 first strike).
-        match defender_best_block(state, id, my_value, &opponent_blockers) {
+        match defender_best_block(state, id, my_value, &opponent_blockers, &slices) {
             None => attacking_ids.push(id),
             Some(DefenderBlock {
                 blocker_value,
@@ -1304,6 +1351,9 @@ fn crackback_damage(
     // Without a projection, fall back to current-state filtering.
     let projected_state = projection.map(|p| &p.state);
     let attacker_source = projected_state.unwrap_or(state);
+    // Hoist block-legality statics once for the greedy O(attackers × blockers)
+    // assignment sweep below. `attacker_source` is the only state queried.
+    let slices = BlockLegalitySlices::collect(attacker_source);
     let mut opp_attackers: Vec<(ObjectId, i32)> = opponents
         .iter()
         .flat_map(|&opp| {
@@ -1348,7 +1398,7 @@ fn crackback_damage(
             if used[i] {
                 continue;
             }
-            if !can_block_pair(attacker_source, bid, opp_id) {
+            if !slices.can_block_pair(attacker_source, bid, opp_id) {
                 continue; // skip — still available for other attackers
             }
             used[i] = true;
@@ -1627,11 +1677,12 @@ fn defender_best_block(
     attacker_id: ObjectId,
     attacker_value: f64,
     blockers: &[ObjectId],
+    slices: &BlockLegalitySlices,
 ) -> Option<DefenderBlock> {
     let attacker = state.objects.get(&attacker_id)?;
     blockers
         .iter()
-        .filter(|&&bid| can_block_pair(state, bid, attacker_id))
+        .filter(|&&bid| slices.can_block_pair(state, bid, attacker_id))
         .filter_map(|&bid| {
             let blocker = state.objects.get(&bid)?;
             let blocker_value = evaluate_creature(state, bid);
@@ -2014,6 +2065,35 @@ mod tests {
         assert!(
             !attackers.contains(&small),
             "Should skip 1/1 into 5/5 when life is equal"
+        );
+    }
+
+    /// A 1/1 that would normally NOT attack into a 5/5 blocker is still chosen
+    /// when it carries an unblockable static — the `is_unblockable` short-circuit
+    /// fires before `defender_best_block`. This guards that the hoisted
+    /// `BlockLegalitySlices` path leaves the unblockable-attacker decision
+    /// byte-for-byte identical to the pre-hoist behavior. Reverted-fix
+    /// discrimination: if the slices threading broke the unblockable detection or
+    /// the block sweep, this attacker would be (wrongly) skipped like the plain
+    /// 1/1 in `skips_unprofitable_attack`.
+    #[test]
+    fn unblockable_attacker_still_chosen_with_static_restriction() {
+        use engine::types::ability::StaticDefinition;
+
+        let mut state = setup();
+        let small = add_creature(&mut state, PlayerId(0), "Squirrel", 1, 1, vec![]);
+        state
+            .objects
+            .get_mut(&small)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantBeBlocked));
+        add_creature(&mut state, PlayerId(1), "Giant", 5, 5, vec![]);
+
+        let attackers = choose_attackers(&state, PlayerId(0));
+        assert!(
+            attackers.contains(&small),
+            "an unblockable 1/1 must still attack into a 5/5 blocker"
         );
     }
 

--- a/crates/phase-ai/src/policies/evasion_removal_priority.rs
+++ b/crates/phase-ai/src/policies/evasion_removal_priority.rs
@@ -104,7 +104,10 @@ fn evasion_score(
         return 0.0;
     }
 
-    let can_block = ai_can_block(ctx.state, ctx.ai_player, target_id);
+    // Hoist block-legality statics once for this scoring pass.
+    let slices = crate::combat_ai::BlockLegalitySlices::collect(ctx.state);
+
+    let can_block = ai_can_block(ctx.state, ctx.ai_player, target_id, &slices);
 
     if !can_block {
         (power * mult).min(3.0)
@@ -118,7 +121,7 @@ fn evasion_score(
                     obj.controller == ctx.ai_player
                         && !obj.tapped
                         && obj.card_types.core_types.contains(&CoreType::Creature)
-                        && engine::game::combat::can_block_pair(ctx.state, id, target_id)
+                        && slices.can_block_pair(ctx.state, id, target_id)
                 })
             })
             .count();

--- a/crates/phase-ai/src/policies/strategy_helpers.rs
+++ b/crates/phase-ai/src/policies/strategy_helpers.rs
@@ -191,6 +191,9 @@ pub(crate) fn opponent_lethal_damage(state: &GameState, ai_player: PlayerId) -> 
         })
         .collect();
 
+    // Hoist block-legality statics once for the O(opponents × blockers) sweep.
+    let slices = crate::combat_ai::BlockLegalitySlices::collect(state);
+
     let mut total = 0i32;
     for &obj_id in &state.battlefield {
         let Some(obj) = state.objects.get(&obj_id) else {
@@ -205,7 +208,7 @@ pub(crate) fn opponent_lethal_damage(state: &GameState, ai_player: PlayerId) -> 
         let power = obj.power.unwrap_or(0);
         let can_be_blocked = ai_blocker_ids
             .iter()
-            .any(|&bid| engine::game::combat::can_block_pair(state, bid, obj_id));
+            .any(|&bid| slices.can_block_pair(state, bid, obj_id));
         if can_be_blocked {
             // Blockable creatures contribute half power (some will get through)
             total += power / 2;
@@ -217,14 +220,19 @@ pub(crate) fn opponent_lethal_damage(state: &GameState, ai_player: PlayerId) -> 
 }
 
 /// Whether any of ai_player's untapped creatures can legally block the given creature.
-/// Delegates to the engine's `can_block_pair` for full blocking restriction checks.
-pub(crate) fn ai_can_block(state: &GameState, ai_player: PlayerId, attacker_id: ObjectId) -> bool {
+/// Delegates to the precomputed `can_block_pair` for full blocking restriction checks.
+pub(crate) fn ai_can_block(
+    state: &GameState,
+    ai_player: PlayerId,
+    attacker_id: ObjectId,
+    slices: &crate::combat_ai::BlockLegalitySlices,
+) -> bool {
     state.battlefield.iter().any(|&id| {
         state.objects.get(&id).is_some_and(|obj| {
             obj.controller == ai_player
                 && !obj.tapped
                 && obj.card_types.core_types.contains(&CoreType::Creature)
-                && engine::game::combat::can_block_pair(state, id, attacker_id)
+                && slices.can_block_pair(state, id, attacker_id)
         })
     })
 }


### PR DESCRIPTION
## Problem

Combat block/attack legality is **O(battlefield²)** on large boards. The legal-blocker/attacker validation loops in `combat.rs` iterate all of `state.battlefield`, and for each candidate previously called `blocker_has_cant_block_static` / `block_restriction_statics_against` — each of which invokes the **uncached** `game_functioning_statics` / `battlefield_functioning_statics` iterators (a full battlefield walk + per-object `static_definitions` flat-map, with `matches_target_filter` nested inside).

Profiled on a real checkpoint (The Unbeatable Squirrel Girl deck — **702 Squirrel tokens, 760 battlefield permanents**, turn 39): a human priority pass took **1.77s** for 4 legal actions; AI `choose_action` took **12.8s**. `sample` self-time was dominated by `game_functioning_statics` and the combat block-restriction stack.

## Fix

Hoist the loop-invariant "find statics of the relevant `StaticMode` across the battlefield" step **out** of the per-candidate loops. Collect the small CantBlock / CantBeBlocked\* / BlockRestriction / MustBeBlocked\* sets **once per legality pass** into owned `Vec<(ObjectId, StaticDefinition)>` slices, then per candidate run only the affected-filter + condition check against that tiny precomputed set via `*_from_precomputed` variants.

**Rules-correctness preserved (pure perf refactor):** the precomputed iterators clone `StaticDefinition` but re-resolve the source `ObjectId` **live** each iteration (`state.objects.get(src_id)`), reading only `.id` and a live-re-read `.controller` — so controller-dependent affected-filters and every legality verdict are byte-for-byte identical. Public wrappers (`can_block_pair`, `min_blockers_required`, `max_blockers_allowed`, `block_requirements_for_player`) are retained as thin collect+delegate shims, so the single legality authority and all external callers are unchanged. `phase-ai` threads a `BlockLegalitySlices` snapshot through the AI attacker-selection and block-evaluation paths.

`functioning_abilities.rs` is untouched.

## Measured impact (same checkpoint)

| Metric | Before | After | Δ |
|---|---|---|---|
| raw mean | 275 ms | 92 ms | **−67%** |
| simulation filter | 1.36 s | 399 ms | **−71%** |
| full mean | 1.77 s | 711 ms | **−60%** |
| `choose_action` | 12.8 s | 6.2 s | **−51%** |

## Scope / follow-ups

The residual `choose_action` time is dominated by two **separate, deliberately out-of-scope** costs: the board-global mana-display sweep (the known `dirty-perf` landmine) and per-candidate search simulation. Both warrant their own follow-up tickets and are not addressed here.

## Tests

3 new discriminating tests (precomputed-slice rejection/acceptance, two distinct CantBlock sources both enforced, unblockable attacker still chosen through the real AI path) plus the full existing suite green: 221 engine combat + 62 `combat_ai` + 501 policy tests.

CR annotations: `CR 509.1a/b/c`, `604.1` preserved; the two CantBlock helpers' annotations corrected from `509.1a` (choosing untapped creatures) to `509.1b` (can't-block restrictions).