### PR TITLE
Fix Memory's Journey only allowing one target card (#4255)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5644,6 +5644,12 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
                 value((), alt((tag("all "), tag("each ")))).parse(input)
             })
             .is_some();
+            // CR 115.1d: "shuffle up to N target cards from <zone> into <library>"
+            // (Memory's Journey) carries an "up to N" count on the target slot.
+            // Recover it as a `MultiTargetSpec` so the lowering surfaces N slots;
+            // `parse_target` itself strips the quantifier and only returns the
+            // filter. The mass-move (`all`) form ignores it.
+            let (_, multi_target) = super::strip_optional_target_prefix(after_shuffle);
             let (target, _) = parse_target(after_shuffle);
             let origin = if nom_primitives::scan_contains(lower, "graveyard") {
                 Some(Zone::Graveyard)
@@ -5658,6 +5664,7 @@ pub(super) fn parse_shuffle_ast(text: &str, lower: &str) -> Option<ShuffleImpera
                 target,
                 origin,
                 all,
+                multi_target: if all { None } else { multi_target },
             });
         }
     }
@@ -5740,6 +5747,7 @@ pub(super) fn lower_shuffle_ast(ast: ShuffleImperativeAst) -> ParsedEffectClause
             target,
             origin,
             all,
+            multi_target,
         } => {
             // CR 400.6: "shuffle all <filter> from <zone> into your library"
             // (Elixir) is a mandatory mass move of every eligible object — no
@@ -5774,7 +5782,11 @@ pub(super) fn lower_shuffle_ast(ast: ShuffleImperativeAst) -> ParsedEffectClause
                     enter_with_counters: vec![],
                     face_down_profile: None,
                 };
-                with_shuffle_sub_ability(effect)
+                // CR 115.1d: propagate the "up to N target" count so the cast
+                // surfaces N target slots (Memory's Journey: up to three).
+                let mut clause = with_shuffle_sub_ability(effect);
+                clause.multi_target = multi_target;
+                clause
             }
         }
         ShuffleImperativeAst::Unimplemented { text } => parsed_clause(Effect::Unimplemented {
@@ -14523,6 +14535,47 @@ mod tests {
                 panic!("Expected ChangeZoneToLibrary with EnchantedBy target, got {other:?}")
             }
         }
+    }
+
+    /// Issue #4255 — Memory's Journey: "Target player shuffles up to three
+    /// target cards from their graveyard into their library." The "up to three
+    /// target cards" count must survive onto the `ChangeZone` ability as a
+    /// `MultiTargetSpec` so the cast surfaces three target slots rather than
+    /// one. CR 115.1d. Drives the full `parse_effect_chain` pipeline (subject
+    /// shift → shuffle imperative → lowering) and fails if the count is dropped.
+    #[test]
+    fn memorys_journey_up_to_three_targets_survives_to_change_zone() {
+        let def = super::super::parse_effect_chain(
+            "Target player shuffles up to three target cards from their graveyard into their library.",
+            AbilityKind::Spell,
+        );
+
+        // Walk the sub_ability chain to the ChangeZone(Library) link.
+        fn find_change_zone_multi_target(
+            def: &AbilityDefinition,
+        ) -> Option<Option<MultiTargetSpec>> {
+            if matches!(
+                &*def.effect,
+                Effect::ChangeZone {
+                    destination: Zone::Library,
+                    ..
+                }
+            ) {
+                return Some(def.multi_target.clone());
+            }
+            def.sub_ability
+                .as_deref()
+                .and_then(find_change_zone_multi_target)
+        }
+
+        let multi_target = find_change_zone_multi_target(&def).unwrap_or_else(|| {
+            panic!("expected a ChangeZone(Library) link in the chain, got {def:?}")
+        });
+        assert_eq!(
+            multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 3 })),
+            "the 'up to three target cards' count must surface as a MultiTargetSpec"
+        );
     }
 
     /// CR 400.7 + CR 701.23: Multi-zone same-name exile combinator covers

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13427,6 +13427,13 @@ fn lower_subject_predicate_ast(
                     let mut sub_ability =
                         AbilityDefinition::new(AbilityKind::Spell, clause.effect.clone());
                     sub_ability.sub_ability = clause.sub_ability;
+                    // CR 115.1d: an "up to N target" count on the moved-object
+                    // clause (Memory's Journey — "shuffles up to three target
+                    // cards from their graveyard …") belongs to the inner
+                    // ChangeZone slot, not the singular player `TargetOnly`
+                    // wrapper. Carry it onto the sub-ability so the cast
+                    // surfaces N card slots.
+                    sub_ability.multi_target = clause.multi_target;
                     return ParsedEffectClause {
                         effect: Effect::TargetOnly {
                             target: player_target.clone(),

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1252,10 +1252,16 @@ pub(crate) enum ShuffleImperativeAst {
     /// eligible object moves with no interactive choice (CR 400.6) and the move
     /// stamps `last_effect_count`; when `false` it emits a single
     /// `Effect::ChangeZone`.
+    ///
+    /// CR 115.1d: `multi_target` carries an "up to N target" count ("shuffle up
+    /// to three target cards from your graveyard into your library" — Memory's
+    /// Journey) so the lowering surfaces N target slots instead of one. `None`
+    /// for the single-target form; only meaningful when `all` is `false`.
     TargetedChangeZoneToLibrary {
         target: TargetFilter,
         origin: Option<Zone>,
         all: bool,
+        multi_target: Option<MultiTargetSpec>,
     },
     Unimplemented {
         text: String,


### PR DESCRIPTION
## Summary
Fixes #4255. Memory's Journey reads "Target player shuffles **up to three target cards** from their graveyard into their library," but the engine only surfaced a single target slot.

Root cause: the targeted-shuffle-to-library parser dropped the "up to N target" quantifier. `parse_target` strips the quantifier and returns only the filter, so the `MultiTargetSpec` count was never captured on the `ChangeZone` clause. Additionally, in the subject-shift path ("Target player shuffles …"), the inner `ChangeZone` sub-ability was built without copying the clause's `multi_target`, so even when present the count landed on the singular player `TargetOnly` wrapper instead of the card slot.

## Fix
- Capture the "up to N target" count as a `MultiTargetSpec` in the `TargetedChangeZoneToLibrary` shuffle path via the existing `strip_optional_target_prefix` building block (CR 115.1d).
- Propagate that `multi_target` onto the inner `ChangeZone` sub-ability when a subject-shifted player-target wrapper is built, so the card-target count rides the `ChangeZone` slot rather than the player slot.

The engine already surfaces N target slots and moves all chosen cards when `ChangeZone` carries `multi_target` (cf. the Pit of Offerings flow), so this is purely a parse-time count-propagation fix at the correct seam.

## Files changed
- `crates/engine/src/parser/oracle_ir/ast.rs`
- `crates/engine/src/parser/oracle_effect/imperative.rs`
- `crates/engine/src/parser/oracle_effect/mod.rs`

## CR references
- CR 115.1d — "up to N" target counts (zero-to-N selection)

## Track
Developer

## LLM
Model: claude-opus-4.8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — clean
- `cargo clippy -p engine` — clean
- `cargo test -p engine --lib parser::` — 6703 pass / 0 fail (includes new regression test `memorys_journey_up_to_three_targets_survives_to_change_zone`, which drives the full `parse_effect_chain` pipeline and fails if reverted)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Made with [Cursor](https://cursor.com)