### PR TITLE
Fix Court of Cunning milling only the first targeted player (#4252)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4807,6 +4807,66 @@ fn resolve_chain_body(
     // REPLACE, not an append) — both leave `is_some()` true. Comparing the full
     // value catches the replace case correctly (issue #491).
     let pending_continuation_before = state.pending_continuation.clone();
+
+    // CR 603.3d + CR 601.2c: Multi-target-over-`Player` resolution fan-out.
+    // MUST run before the ConditionInstead "instead" swap below: swapping a
+    // `Mill { target: Player }` parent for a `Mill { target: ParentTarget }`
+    // rider (Court of Cunning — "each mill two … mills ten instead") clears
+    // `multi_target` and changes the effect's target filter, which would
+    // otherwise skip this branch and resolve only the first chosen player.
+    if ability.multi_target.is_some()
+        && effect_target_filter(&ability.effect) == Some(&TargetFilter::Player)
+    {
+        let chosen_players: Vec<PlayerId> = ability
+            .targets
+            .iter()
+            .filter_map(|t| match t {
+                TargetRef::Player(pid) => Some(*pid),
+                TargetRef::Object(_) => None,
+            })
+            .collect();
+        if chosen_players.len() != 1 {
+            if chosen_players.is_empty() {
+                events.push(GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::from(&ability.effect),
+                    source_id: ability.source_id,
+                });
+                return Ok(());
+            }
+            let fanout_players: Vec<PlayerId> = crate::game::players::apnap_order(state)
+                .into_iter()
+                .filter(|pid| chosen_players.contains(pid))
+                .collect();
+            let initial_waiting_for = state.waiting_for.clone();
+            for (i, pid) in fanout_players.iter().enumerate() {
+                let mut narrowed = ability.clone();
+                narrowed.targets = vec![TargetRef::Player(*pid)];
+                narrowed.multi_target = None;
+                resolve_ability_chain(state, &narrowed, events, depth + 1)?;
+
+                if state.waiting_for != initial_waiting_for {
+                    let remaining = &fanout_players[i + 1..];
+                    let mut tail: Option<Box<ResolvedAbility>> = None;
+                    for &remaining_pid in remaining.iter().rev() {
+                        let mut remaining_narrowed = ability.clone();
+                        remaining_narrowed.targets = vec![TargetRef::Player(remaining_pid)];
+                        remaining_narrowed.multi_target = None;
+                        if let Some(prev) = tail {
+                            super::ability_utils::append_to_sub_chain(
+                                &mut remaining_narrowed,
+                                *prev,
+                            );
+                        }
+                        tail = Some(Box::new(remaining_narrowed));
+                    }
+                    append_to_pending_continuation(state, tail);
+                    break;
+                }
+            }
+            return Ok(());
+        }
+    }
+
     // CR 608.2e: "Instead" kicker — check if a sub overrides the parent.
     // When condition is met, replace the current ability's effect with the sub's
     // effect, preserving the full resolution flow (tracked sets, continuations).
@@ -5091,87 +5151,6 @@ fn resolve_chain_body(
             }
         }
         return Ok(());
-    }
-
-    // CR 603.3d + CR 601.2c: Multi-target-over-`Player` resolution fan-out.
-    // An "any number of target players each <verb>" trigger/spell announces a
-    // variable number of player targets when it goes on the stack (CR 601.2c,
-    // reached for triggers via CR 603.3d). The chosen player set lands in
-    // `ability.targets` as `TargetRef::Player` entries with `multi_target` set.
-    // Single-player-recipient effect handlers (`Discard`, `Mill`, `LoseLife`)
-    // resolve for only the FIRST `TargetRef::Player`, so without this branch a
-    // selection of two players discards only one. This fan-out is the missing
-    // iteration layer — a structural mirror of the `player_scope` loop above —
-    // recursing once per chosen player with `targets` narrowed to that one
-    // player and `multi_target` cleared.
-    if ability.multi_target.is_some()
-        && effect_target_filter(&ability.effect) == Some(&TargetFilter::Player)
-    {
-        let chosen_players: Vec<PlayerId> = ability
-            .targets
-            .iter()
-            .filter_map(|t| match t {
-                TargetRef::Player(pid) => Some(*pid),
-                TargetRef::Object(_) => None,
-            })
-            .collect();
-        if chosen_players.len() != 1 {
-            // CR 601.2c: "any number of target players" permits zero targets.
-            // CR 608.2c: An ability resolving with zero chosen player targets
-            // does nothing — emit `EffectResolved` and stop BEFORE
-            // `resolve_effect`, whose `resolve_player_for_context_ref`
-            // controller fallback would otherwise wrongly resolve for the
-            // ability's controller. Exactly one chosen player falls through to
-            // the unchanged single-recipient fast path; only zero or >=2 are
-            // handled here.
-            if chosen_players.is_empty() {
-                events.push(GameEvent::EffectResolved {
-                    kind: crate::types::ability::EffectKind::from(&ability.effect),
-                    source_id: ability.source_id,
-                });
-                return Ok(());
-            }
-            // CR 101.4 + CR 608.2c: Resolve the effect once per chosen player in
-            // APNAP order — each player's `<verb>` (and its `sub_ability`, e.g.
-            // Tinybones' `Mill` + `LoseLife`) is one instruction applied to
-            // multiple subjects, followed in turn order.
-            let fanout_players: Vec<PlayerId> = crate::game::players::apnap_order(state)
-                .into_iter()
-                .filter(|pid| chosen_players.contains(pid))
-                .collect();
-            let initial_waiting_for = state.waiting_for.clone();
-            for (i, pid) in fanout_players.iter().enumerate() {
-                let mut narrowed = ability.clone();
-                narrowed.targets = vec![TargetRef::Player(*pid)];
-                narrowed.multi_target = None;
-                resolve_ability_chain(state, &narrowed, events, depth + 1)?;
-
-                // CR 608.2c: If an inner effect paused on a player choice (e.g.
-                // `WaitingFor::DiscardChoice` when a targeted player must pick
-                // which card to discard), stash the remaining players as a
-                // continuation chain and break — they resume via
-                // `drain_pending_continuation` after the choice resolves.
-                if state.waiting_for != initial_waiting_for {
-                    let remaining = &fanout_players[i + 1..];
-                    let mut tail: Option<Box<ResolvedAbility>> = None;
-                    for &remaining_pid in remaining.iter().rev() {
-                        let mut remaining_narrowed = ability.clone();
-                        remaining_narrowed.targets = vec![TargetRef::Player(remaining_pid)];
-                        remaining_narrowed.multi_target = None;
-                        if let Some(prev) = tail {
-                            super::ability_utils::append_to_sub_chain(
-                                &mut remaining_narrowed,
-                                *prev,
-                            );
-                        }
-                        tail = Some(Box::new(remaining_narrowed));
-                    }
-                    append_to_pending_continuation(state, tail);
-                    break;
-                }
-            }
-            return Ok(());
-        }
     }
 
     // CR 608.2c + CR 608.2d + CR 109.4: Resolution-time target binding for a

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4809,6 +4809,17 @@ fn resolve_chain_body(
     let pending_continuation_before = state.pending_continuation.clone();
 
     // CR 603.3d + CR 601.2c: Multi-target-over-`Player` resolution fan-out.
+    // An "any number of target players each <verb>" trigger/spell announces a
+    // variable number of player targets when it goes on the stack (CR 601.2c,
+    // reached for triggers via CR 603.3d). The chosen player set lands in
+    // `ability.targets` as `TargetRef::Player` entries with `multi_target` set.
+    // Single-player-recipient effect handlers (`Discard`, `Mill`, `LoseLife`)
+    // resolve for only the FIRST `TargetRef::Player`, so without this branch a
+    // selection of two players discards only one. This fan-out is the missing
+    // iteration layer — a structural mirror of the `player_scope` loop above —
+    // recursing once per chosen player with `targets` narrowed to that one
+    // player and `multi_target` cleared.
+    //
     // MUST run before the ConditionInstead "instead" swap below: swapping a
     // `Mill { target: Player }` parent for a `Mill { target: ParentTarget }`
     // rider (Court of Cunning — "each mill two … mills ten instead") clears
@@ -4826,6 +4837,14 @@ fn resolve_chain_body(
             })
             .collect();
         if chosen_players.len() != 1 {
+            // CR 601.2c: "any number of target players" permits zero targets.
+            // CR 608.2c: An ability resolving with zero chosen player targets
+            // does nothing — emit `EffectResolved` and stop BEFORE
+            // `resolve_effect`, whose `resolve_player_for_context_ref`
+            // controller fallback would otherwise wrongly resolve for the
+            // ability's controller. Exactly one chosen player falls through to
+            // the unchanged single-recipient fast path; only zero or >=2 are
+            // handled here.
             if chosen_players.is_empty() {
                 events.push(GameEvent::EffectResolved {
                     kind: crate::types::ability::EffectKind::from(&ability.effect),
@@ -4833,6 +4852,10 @@ fn resolve_chain_body(
                 });
                 return Ok(());
             }
+            // CR 101.4 + CR 608.2c: Resolve the effect once per chosen player in
+            // APNAP order — each player's `<verb>` (and its `sub_ability`, e.g.
+            // Tinybones' `Mill` + `LoseLife`) is one instruction applied to
+            // multiple subjects, followed in turn order.
             let fanout_players: Vec<PlayerId> = crate::game::players::apnap_order(state)
                 .into_iter()
                 .filter(|pid| chosen_players.contains(pid))
@@ -4844,6 +4867,11 @@ fn resolve_chain_body(
                 narrowed.multi_target = None;
                 resolve_ability_chain(state, &narrowed, events, depth + 1)?;
 
+                // CR 608.2c: If an inner effect paused on a player choice (e.g.
+                // `WaitingFor::DiscardChoice` when a targeted player must pick
+                // which card to discard), stash the remaining players as a
+                // continuation chain and break — they resume via
+                // `drain_pending_continuation` after the choice resolves.
                 if state.waiting_for != initial_waiting_for {
                     let remaining = &fanout_players[i + 1..];
                     let mut tail: Option<Box<ResolvedAbility>> = None;

--- a/crates/engine/tests/integration/court_of_cunning_multi_target_mill.rs
+++ b/crates/engine/tests/integration/court_of_cunning_multi_target_mill.rs
@@ -9,7 +9,8 @@
 //! CR 603.3d + CR 601.2c: the upkeep trigger's controller chooses any number
 //! of target players as the ability goes on the stack.
 //! CR 101.4 + CR 608.2c: the effect resolves once per chosen player.
-//! CR 614.1 ("instead") + CR 603.4 monarch designation (CR 725).
+//! CR 614.1 + CR 608.2c: the "mills ten instead" rider replaces the mill
+//! during resolution. CR 725: monarch designation gates that rider.
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::TargetRef;

--- a/crates/engine/tests/integration/court_of_cunning_multi_target_mill.rs
+++ b/crates/engine/tests/integration/court_of_cunning_multi_target_mill.rs
@@ -1,0 +1,135 @@
+//! Issue #4252 — Court of Cunning: "any number of target players each mill two
+//! cards. If you're the monarch, each of those players mills ten cards
+//! instead." The reported symptom was that only the FIRST selected target
+//! actually milled. This is the dedicated regression deliverable the issue
+//! asks for: it drives the REAL upkeep-trigger pipeline (multi-target player
+//! selection → fan-out → mill), asserting every targeted player mills, and
+//! covering the monarch "mills ten instead" branch.
+//!
+//! CR 603.3d + CR 601.2c: the upkeep trigger's controller chooses any number
+//! of target players as the ability goes on the stack.
+//! CR 101.4 + CR 608.2c: the effect resolves once per chosen player.
+//! CR 614.1 ("instead") + CR 603.4 monarch designation (CR 725).
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+/// Court of Cunning's printed Oracle text — byte-identical to
+/// `client/public/card-data.json` and MTGJSON `AtomicCards.json`.
+const COURT_OF_CUNNING: &str = "When Court of Cunning enters, you become the monarch.\n\
+     At the beginning of your upkeep, any number of target players each mill two cards. \
+     If you're the monarch, each of those players mills ten cards instead.";
+
+fn graveyard_count(runner: &engine::game::scenario::GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .map(|p| p.graveyard.len())
+        .expect("player exists")
+}
+
+/// Build a 2-player game with Court of Cunning already on P0's battlefield and
+/// a 15-card library for every player. `monarch` seeds the monarch designation
+/// directly (the ETB "you become the monarch" trigger does not fire for a
+/// scenario-seeded permanent).
+fn build_runner(monarch: Option<PlayerId>) -> engine::game::scenario::GameRunner {
+    let library: Vec<&str> = (0..15).map(|_| "Library Card").collect();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    for &pid in &[P0, P1] {
+        scenario.with_library_top(pid, &library);
+    }
+    scenario
+        .add_creature(P0, "Court of Cunning", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(COURT_OF_CUNNING);
+
+    let mut runner = scenario.build();
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().monarch = monarch;
+    runner
+}
+
+/// Drive to P0's upkeep so the trigger fires, then select both players as
+/// targets. Returns once the stack has emptied and targets were selected.
+fn fire_and_target_both(runner: &mut engine::game::scenario::GameRunner) {
+    runner.advance_to_upkeep();
+
+    let mut targets_selected = false;
+    let mut guard = 0;
+    loop {
+        guard += 1;
+        assert!(guard < 50, "stuck at {:?}", runner.state().waiting_for);
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Player(P0), TargetRef::Player(P1)],
+                    })
+                    .expect("selecting two player targets must succeed");
+                targets_selected = true;
+                runner.advance_until_stack_empty();
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() && targets_selected => {
+                return;
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority at upkeep");
+            }
+            _ if targets_selected && runner.state().stack.is_empty() => return,
+            other => panic!(
+                "unexpected state while driving Court of Cunning upkeep (selected={targets_selected}): {other:?}"
+            ),
+        }
+    }
+}
+
+/// CR 101.4: With no monarch, each of the two targeted players mills two cards.
+/// Before the fix, only the first selected target milled.
+#[test]
+fn court_of_cunning_non_monarch_mills_two_for_each_targeted_player() {
+    let mut runner = build_runner(None);
+    fire_and_target_both(&mut runner);
+
+    assert_eq!(
+        graveyard_count(&runner, P0),
+        2,
+        "P0 (targeted) must mill two cards"
+    );
+    assert_eq!(
+        graveyard_count(&runner, P1),
+        2,
+        "P1 (targeted) must mill two cards — not just the first target"
+    );
+}
+
+/// CR 614.1 + CR 725: When the controller is the monarch, every targeted player
+/// mills ten cards instead — and the "instead" replacement applies to each
+/// fanned-out player, not only the first.
+#[test]
+fn court_of_cunning_monarch_mills_ten_for_each_targeted_player() {
+    let mut runner = build_runner(Some(P0));
+    fire_and_target_both(&mut runner);
+
+    assert_eq!(
+        graveyard_count(&runner, P0),
+        10,
+        "P0 (targeted, controller is monarch) must mill ten cards"
+    );
+    assert_eq!(
+        graveyard_count(&runner, P1),
+        10,
+        "P1 (targeted) must also mill ten cards — not just the first target"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -49,6 +49,7 @@ mod copy_token_except_keyword_and_quoted_ability;
 mod council_of_four_nth_per_turn;
 mod counter_double_redirect_choice;
 mod counter_spell_zone_redirect;
+mod court_of_cunning_multi_target_mill;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
 mod crossway_troublemakers_attacking_keywords;


### PR DESCRIPTION
## Summary
Fixes #4252. Court of Cunning's upkeep reads "any number of target players each mill two cards. If you're the monarch, each of those players mills ten cards instead." When multiple players were targeted, only the first player milled — especially visible when the controller was the monarch (10-card mill on P0, zero on everyone else).

## Root cause
The multi-target-over-`Player` fan-out in `resolve_chain_body` ran **after** the `ConditionInstead` "instead" swap. Swapping the parent `Mill { target: Player }` for the monarch rider's `Mill { target: ParentTarget }` cleared `multi_target` and changed the effect's target filter, so the fan-out branch was skipped and `ParentTarget` resolved only against the first entry in `ability.targets`.

## Fix
Move the fan-out block to the top of `resolve_chain_body`, before the instead swap. Each narrowed per-player iteration then runs the full chain (including the monarch swap) independently.

## Files changed
- `crates/engine/src/game/effects/mod.rs`
- `crates/engine/tests/integration/court_of_cunning_multi_target_mill.rs`
- `crates/engine/tests/integration/main.rs`

## CR references
- CR 601.2c — multi-target player selection at announcement
- CR 608.2c — resolve once per chosen player; `ConditionInstead` swap semantics
- CR 614.1 — "instead" replacement (monarch mills ten)
- CR 725 — monarch designation

## Track
Developer

## LLM
Model: claude-opus-4.8
Thinking: high

## Verification
- `cargo fmt -p engine` — clean
- `cargo clippy -p engine --lib` — clean
- `cargo test -p engine --test integration court_of_cunning` — 2 pass / 0 fail
- `cargo test -p engine --test integration tinybones` — 5 pass / 0 fail (fan-out regression guard)

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.

Made with [Cursor](https://cursor.com)