### PR TITLE
fix(engine): Temple Altisaur prevents all but 1 damage to Dinosaurs

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1072,6 +1072,60 @@ fn damage_done_applier(
                         applied,
                     });
                 }
+                PreventionAmount::AllBut(keep) => {
+                    let redirected_amount = damage_amount.saturating_sub(keep);
+                    if redirected_amount == 0 {
+                        return ApplyResult::Modified(ProposedEvent::Damage {
+                            source_id,
+                            target,
+                            amount: damage_amount,
+                            is_combat,
+                            applied,
+                        });
+                    }
+                    consume_prevention_shield(state, rid, None);
+                    if let Some(new_target) = new_recipient.filter(|_| redirected_amount > 0) {
+                        let redirected_event = ProposedEvent::Damage {
+                            source_id,
+                            target: new_target,
+                            amount: redirected_amount,
+                            is_combat,
+                            applied: applied.clone(),
+                        };
+                        match replace_event(state, redirected_event, events) {
+                            ReplacementResult::Execute(event) => {
+                                let ctx = super::effects::deal_damage::DamageContext::from_source(
+                                    state, source_id,
+                                )
+                                .unwrap_or_else(|| {
+                                    let controller = state
+                                        .objects
+                                        .get(&source_id)
+                                        .map(|obj| obj.controller)
+                                        .unwrap_or(PlayerId(0));
+                                    super::effects::deal_damage::DamageContext::fallback(
+                                        source_id, controller,
+                                    )
+                                });
+                                let _ = super::effects::deal_damage::apply_damage_after_replacement(
+                                    state, &ctx, event, is_combat, events,
+                                );
+                            }
+                            ReplacementResult::Prevented => {}
+                            ReplacementResult::NeedsChoice(_) => {
+                                state.pending_replacement = None;
+                            }
+                        }
+                    }
+                    let remaining_amount = damage_amount.saturating_sub(redirected_amount);
+                    return ApplyResult::Modified(ProposedEvent::Damage {
+                        source_id,
+                        target,
+                        amount: remaining_amount,
+                        is_combat,
+                        applied,
+                    });
+                }
                 PreventionAmount::Next(n) => {
                     let redirected_amount = damage_amount.min(n);
                     let remaining_amount = damage_amount.saturating_sub(redirected_amount);
@@ -1201,6 +1255,29 @@ fn damage_done_applier(
                     if let Some(tally) = state.combat_prevention_tally.as_mut() {
                         *tally.entry(rid).or_insert(0) += prevented_amount as i32;
                         accumulated_in_batch = true;
+                    }
+                }
+                PreventionAmount::AllBut(keep) => {
+                    // CR 615.1a: "Prevent all but N" — continuous shield like
+                    // `All`, but only the excess above `keep` is prevented.
+                    let remaining_damage = dmg.min(keep);
+                    prevented_amount = dmg.saturating_sub(remaining_damage);
+                    if prevented_amount == 0 {
+                        result = ApplyResult::Modified(ProposedEvent::Damage {
+                            source_id,
+                            target: target.clone(),
+                            amount: dmg,
+                            is_combat,
+                            applied,
+                        });
+                    } else {
+                        result = ApplyResult::Modified(ProposedEvent::Damage {
+                            source_id,
+                            target: target.clone(),
+                            amount: remaining_damage,
+                            is_combat,
+                            applied,
+                        });
                     }
                 }
                 PreventionAmount::Next(n) => {

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1072,59 +1072,19 @@ fn damage_done_applier(
                         applied,
                     });
                 }
-                PreventionAmount::AllBut(keep) => {
-                    let redirected_amount = damage_amount.saturating_sub(keep);
-                    if redirected_amount == 0 {
-                        return ApplyResult::Modified(ProposedEvent::Damage {
-                            source_id,
-                            target,
-                            amount: damage_amount,
-                            is_combat,
-                            applied,
-                        });
-                    }
-                    consume_prevention_shield(state, rid, None);
-                    if let Some(new_target) = new_recipient.filter(|_| redirected_amount > 0) {
-                        let redirected_event = ProposedEvent::Damage {
-                            source_id,
-                            target: new_target,
-                            amount: redirected_amount,
-                            is_combat,
-                            applied: applied.clone(),
-                        };
-                        match replace_event(state, redirected_event, events) {
-                            ReplacementResult::Execute(event) => {
-                                let ctx = super::effects::deal_damage::DamageContext::from_source(
-                                    state, source_id,
-                                )
-                                .unwrap_or_else(|| {
-                                    let controller = state
-                                        .objects
-                                        .get(&source_id)
-                                        .map(|obj| obj.controller)
-                                        .unwrap_or(PlayerId(0));
-                                    super::effects::deal_damage::DamageContext::fallback(
-                                        source_id, controller,
-                                    )
-                                });
-                                let _ = super::effects::deal_damage::apply_damage_after_replacement(
-                                    state, &ctx, event, is_combat, events,
-                                );
-                            }
-                            ReplacementResult::Prevented => {}
-                            ReplacementResult::NeedsChoice(_) => {
-                                state.pending_replacement = None;
-                            }
-                        }
-                    }
-                    let remaining_amount = damage_amount.saturating_sub(redirected_amount);
-                    return ApplyResult::Modified(ProposedEvent::Damage {
-                        source_id,
-                        target,
-                        amount: remaining_amount,
-                        is_combat,
-                        applied,
-                    });
+                PreventionAmount::AllBut(_) => {
+                    // CR 615.1a vs CR 614.9: `AllBut` is exclusively a *prevention*
+                    // amount ("prevent all but N damage", Temple Altisaur) and is
+                    // never produced for a redirection shield — `redirection_shield`
+                    // defaults a missing amount to `PreventionAmount::All` and every
+                    // other redirect constructor uses `PreventionAmount::Next`.
+                    // Inventing a partial-redirect rule here would violate CR 614.9
+                    // (an illegal recipient must make the redirection do nothing
+                    // rather than silently drop the excess), so this state is
+                    // treated as impossible rather than guessed at.
+                    unreachable!(
+                        "PreventionAmount::AllBut is never assigned to a ShieldKind::Redirection"
+                    )
                 }
                 PreventionAmount::Next(n) => {
                     let redirected_amount = damage_amount.min(n);
@@ -1258,8 +1218,13 @@ fn damage_done_applier(
                     }
                 }
                 PreventionAmount::AllBut(keep) => {
-                    // CR 615.1a: "Prevent all but N" — continuous shield like
-                    // `All`, but only the excess above `keep` is prevented.
+                    // CR 615.1a + CR 615.6: "Prevent all but N damage" is a
+                    // continuous prevention shield like `All`, but only the
+                    // excess above `keep` is prevented; the first `keep` points
+                    // of each damage event are still dealt. Like `All`, it is
+                    // duration-bound (not depletion-based per CR 615.7), so the
+                    // shield is never consumed here and re-fires for every damage
+                    // event within its lifetime.
                     let remaining_damage = dmg.min(keep);
                     prevented_amount = dmg.saturating_sub(remaining_damage);
                     if prevented_amount == 0 {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4451,30 +4451,33 @@ fn parse_prevent_effect(text: &str) -> Effect {
         nom_primitives::scan_preceded(rest, crate::parser::oracle_nom::duration::parse_duration)
             .map(|(_, d, _)| d);
 
-    // Determine amount: "all damage" vs "all but N" vs "the next N damage"
-    let amount = if let Some(after_all_but) =
-        crate::parser::oracle_util::strip_after(&lower, "prevent all but ")
-    {
-        let n = crate::parser::oracle_util::parse_number(after_all_but)
-            .map(|(n, _)| n)
-            .unwrap_or(1);
-        PreventionAmount::AllBut(n)
-    } else if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
-        PreventionAmount::All
-    } else if let Ok((after_next, _)) = tag::<_, _, OracleError<'_>>("the next ").parse(rest) {
-        let n = nom_primitives::parse_number
-            .parse(after_next)
-            .map(|(_, n)| n)
-            .unwrap_or(1);
-        PreventionAmount::Next(n)
-    } else {
-        // Fallback: try to extract a number
-        let n = nom_primitives::parse_number
-            .parse(rest)
-            .map(|(_, n)| n)
-            .unwrap_or(1);
-        PreventionAmount::Next(n)
-    };
+    // Determine amount: "all damage" vs "all but N" vs "the next N damage".
+    // CR 615.1a: decompose the prevention amount from the LOCAL parser stream
+    // (`rest`, positioned just past "prevent ") with nom combinators. "all but "
+    // must be tried before the bare "all " arm because it shares that prefix.
+    let amount =
+        if let Ok((after_all_but, _)) = tag::<_, _, OracleError<'_>>("all but ").parse(rest) {
+            let n = nom_primitives::parse_number
+                .parse(after_all_but)
+                .map(|(_, n)| n)
+                .unwrap_or(1);
+            PreventionAmount::AllBut(n)
+        } else if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
+            PreventionAmount::All
+        } else if let Ok((after_next, _)) = tag::<_, _, OracleError<'_>>("the next ").parse(rest) {
+            let n = nom_primitives::parse_number
+                .parse(after_next)
+                .map(|(_, n)| n)
+                .unwrap_or(1);
+            PreventionAmount::Next(n)
+        } else {
+            // Fallback: try to extract a number
+            let n = nom_primitives::parse_number
+                .parse(rest)
+                .map(|(_, n)| n)
+                .unwrap_or(1);
+            PreventionAmount::Next(n)
+        };
 
     // CR 609.7 + CR 615.2: prevention scoped to a chosen source (a targeted
     // spell). "Prevent all damage target instant or sorcery spell would deal

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4451,8 +4451,15 @@ fn parse_prevent_effect(text: &str) -> Effect {
         nom_primitives::scan_preceded(rest, crate::parser::oracle_nom::duration::parse_duration)
             .map(|(_, d, _)| d);
 
-    // Determine amount: "all damage" vs "the next N damage"
-    let amount = if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
+    // Determine amount: "all damage" vs "all but N" vs "the next N damage"
+    let amount = if let Some(after_all_but) =
+        crate::parser::oracle_util::strip_after(&lower, "prevent all but ")
+    {
+        let n = crate::parser::oracle_util::parse_number(after_all_but)
+            .map(|(n, _)| n)
+            .unwrap_or(1);
+        PreventionAmount::AllBut(n)
+    } else if tag::<_, _, OracleError<'_>>("all ").parse(rest).is_ok() {
         PreventionAmount::All
     } else if let Ok((after_next, _)) = tag::<_, _, OracleError<'_>>("the next ").parse(rest) {
         let n = nom_primitives::parse_number

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -6183,7 +6183,11 @@ pub(super) fn apply_where_x_effect_expression(
             // where-X binding (Arachnogenesis: token count uses where-X;
             // prevention is blanket).
             if let Some(expr) = where_x_expression {
-                if !matches!(amount, crate::types::ability::PreventionAmount::All) {
+                if !matches!(
+                    amount,
+                    crate::types::ability::PreventionAmount::All
+                        | crate::types::ability::PreventionAmount::AllBut(_)
+                ) {
                     *amount_dynamic = parse_where_x_quantity_expression(expr);
                 }
             }

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -6907,8 +6907,17 @@ fn parse_damage_prevention_replacement(
     // CR 615.7: "prevent the next N damage" → specific shield amount
     // CR 615.1a: "prevent all but N of that damage" → leave N through (Temple Altisaur)
     // CR 615.1a: "prevent all damage" → prevent everything
-    let amount = if let Some(rest) = strip_after(working_lower, "prevent all but ") {
-        let (n, _) = parse_number(rest)?;
+    //
+    // CR 615.1a: Decompose "all but <number>" from the local position
+    // immediately following the "prevent " verb rather than scanning the whole
+    // clause, so a sibling phrase elsewhere in the text can't be mis-bound as
+    // the amount. The bare "all" arm below must stay ordered after this one
+    // because it shares the "all" prefix.
+    let after_prevent = strip_after(working_lower, "prevent ");
+    let amount = if let Some((after_all_but, _)) =
+        after_prevent.and_then(|s| tag::<_, _, OracleError<'_>>("all but ").parse(s).ok())
+    {
+        let (n, _) = parse_number(after_all_but)?;
         PreventionAmount::AllBut(n)
     } else if nom_primitives::scan_contains(working_lower, "prevent all") {
         PreventionAmount::All

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -6905,8 +6905,12 @@ fn parse_damage_prevention_replacement(
 
     // --- 1. Extract prevention amount ---
     // CR 615.7: "prevent the next N damage" → specific shield amount
+    // CR 615.1a: "prevent all but N of that damage" → leave N through (Temple Altisaur)
     // CR 615.1a: "prevent all damage" → prevent everything
-    let amount = if nom_primitives::scan_contains(working_lower, "prevent all") {
+    let amount = if let Some(rest) = strip_after(working_lower, "prevent all but ") {
+        let (n, _) = parse_number(rest)?;
+        PreventionAmount::AllBut(n)
+    } else if nom_primitives::scan_contains(working_lower, "prevent all") {
         PreventionAmount::All
     } else if let Some(rest) = strip_after(working_lower, "prevent the next ") {
         // Uses oracle_util::parse_number (not nom directly) because it handles "X" → 0
@@ -7091,8 +7095,13 @@ fn parse_damage_prevention_replacement(
 /// to the recipient phrase without consuming the comma + imperative, leaving
 /// the follow-up extractor (`extract_prevention_followup`) to claim it.
 fn parse_damage_recipient_valid_card_filter(working_lower: &str) -> Option<TargetFilter> {
+    parse_damage_recipient_after_prefix(working_lower, "dealt to ")
+        .or_else(|| parse_damage_recipient_after_prefix(working_lower, "would deal damage to "))
+}
+
+fn parse_damage_recipient_after_prefix(working_lower: &str, prefix: &str) -> Option<TargetFilter> {
     nom_primitives::scan_at_word_boundaries(working_lower, |input| {
-        let (after_to, _) = tag::<_, _, OracleError<'_>>("dealt to ").parse(input)?;
+        let (after_to, _) = tag::<_, _, OracleError<'_>>(prefix).parse(input)?;
         let (filter, rest) = parse_type_phrase(after_to);
         if matches!(filter, TargetFilter::Any) {
             return Err(nom::Err::Error(OracleError::new(
@@ -8586,6 +8595,43 @@ mod tests {
                 def.damage_target_filter.is_none(),
                 "must not use broad CreatureOnly damage_target_filter: {text}"
             );
+        }
+    }
+
+    /// CR 615.1a: Temple Altisaur — "If a source would deal damage to another
+    /// Dinosaur you control, prevent all but 1 of that damage."
+    #[test]
+    fn temple_altisaur_all_but_one_prevention_and_dinosaur_recipient() {
+        let def = parse_replacement_line(
+            "If a source would deal damage to another Dinosaur you control, prevent all but 1 of that damage.",
+            "Temple Altisaur",
+        )
+        .expect("Temple Altisaur should parse as damage prevention");
+
+        assert_eq!(
+            def.shield_kind,
+            ShieldKind::Prevention {
+                amount: PreventionAmount::AllBut(1)
+            }
+        );
+
+        let valid_card = def
+            .valid_card
+            .as_ref()
+            .expect("recipient filter must parse from 'would deal damage to'");
+        match valid_card {
+            TargetFilter::Typed(tf) => {
+                assert!(
+                    tf.type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Dinosaur")),
+                    "expected Dinosaur subtype filter, got {:?}",
+                    tf.type_filters
+                );
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(tf.properties.contains(&FilterProp::Another));
+            }
+            other => panic!("expected Typed recipient filter, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -671,6 +671,8 @@ pub enum PreventionAmount {
     Next(u32),
     /// "Prevent all damage"
     All,
+    /// "Prevent all but N of that damage" (Temple Altisaur)
+    AllBut(u32),
 }
 
 /// CR 614.9: Recipient of a one-shot damage-redirection effect — the

--- a/crates/engine/tests/integration/issue_4244_temple_altisaur.rs
+++ b/crates/engine/tests/integration/issue_4244_temple_altisaur.rs
@@ -32,7 +32,7 @@ fn damage_ability(
 #[test]
 fn temple_altisaur_prevents_all_but_one_to_other_dinosaurs_you_control() {
     let mut scenario = GameScenario::new();
-    let _temple = scenario
+    let temple = scenario
         .add_creature_from_oracle(P0, "Temple Altisaur", 3, 4, TEMPLE_ALTISAUR)
         .id();
     let ally_dino = scenario
@@ -42,7 +42,7 @@ fn temple_altisaur_prevents_all_but_one_to_other_dinosaurs_you_control() {
     let source = scenario.add_creature(P1, "Damage Source", 5, 5).id();
     let mut runner = scenario.build();
 
-    let repl = &runner.state().objects[&_temple].replacement_definitions[0];
+    let repl = &runner.state().objects[&temple].replacement_definitions[0];
     assert!(
         matches!(
             repl.shield_kind,
@@ -56,11 +56,10 @@ fn temple_altisaur_prevents_all_but_one_to_other_dinosaurs_you_control() {
     let valid_card = repl.valid_card.as_ref().expect("recipient filter required");
     match valid_card {
         TargetFilter::Typed(tf) => {
-            assert!(
-                tf.type_filters
-                    .iter()
-                    .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Dinosaur"))
-            );
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Dinosaur")));
             assert!(tf.properties.contains(&FilterProp::Another));
         }
         other => panic!("expected typed dinosaur recipient filter, got {other:?}"),
@@ -98,5 +97,26 @@ fn temple_altisaur_prevents_all_but_one_to_other_dinosaurs_you_control() {
         runner.life(P0),
         p0_life_before - 5,
         "Temple Altisaur must not reduce damage dealt to players"
+    );
+
+    // CR 615.1a: the "another Dinosaur" restriction excludes Temple Altisaur
+    // itself, so damage dealt to the Temple is taken in full.
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Object(temple), 5),
+        &mut events,
+    )
+    .expect("damage to Temple Altisaur itself resolves");
+    assert_eq!(
+        runner.state().objects[&temple].damage_marked,
+        5,
+        "Temple Altisaur must not prevent damage dealt to itself (\"another\")"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, GameEvent::DamagePrevented { .. })),
+        "no damage should be prevented when the Temple itself is the recipient"
     );
 }

--- a/crates/engine/tests/integration/issue_4244_temple_altisaur.rs
+++ b/crates/engine/tests/integration/issue_4244_temple_altisaur.rs
@@ -1,0 +1,102 @@
+//! Issue #4244: Temple Altisaur must prevent all but 1 damage dealt to other
+//! Dinosaurs you control, and must not affect damage to other permanents or players.
+
+use engine::game::effects::deal_damage;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{
+    Effect, FilterProp, PreventionAmount, QuantityExpr, ResolvedAbility, ShieldKind, TargetFilter,
+    TargetRef, TypeFilter,
+};
+use engine::types::events::GameEvent;
+
+const TEMPLE_ALTISAUR: &str =
+    "If a source would deal damage to another Dinosaur you control, prevent all but 1 of that damage.";
+
+fn damage_ability(
+    source_id: engine::types::identifiers::ObjectId,
+    target: TargetRef,
+    amount: i32,
+) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: amount },
+            target: TargetFilter::Any,
+            damage_source: None,
+        },
+        vec![target],
+        source_id,
+        P1,
+    )
+}
+
+#[test]
+fn temple_altisaur_prevents_all_but_one_to_other_dinosaurs_you_control() {
+    let mut scenario = GameScenario::new();
+    let _temple = scenario
+        .add_creature_from_oracle(P0, "Temple Altisaur", 3, 4, TEMPLE_ALTISAUR)
+        .id();
+    let ally_dino = scenario
+        .add_creature(P0, "Ally Dinosaur", 2, 2)
+        .with_subtypes(vec!["Dinosaur"])
+        .id();
+    let source = scenario.add_creature(P1, "Damage Source", 5, 5).id();
+    let mut runner = scenario.build();
+
+    let repl = &runner.state().objects[&_temple].replacement_definitions[0];
+    assert!(
+        matches!(
+            repl.shield_kind,
+            ShieldKind::Prevention {
+                amount: PreventionAmount::AllBut(1)
+            }
+        ),
+        "Temple Altisaur must install an AllBut(1) prevention shield, got {:?}",
+        repl.shield_kind
+    );
+    let valid_card = repl.valid_card.as_ref().expect("recipient filter required");
+    match valid_card {
+        TargetFilter::Typed(tf) => {
+            assert!(
+                tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Dinosaur"))
+            );
+            assert!(tf.properties.contains(&FilterProp::Another));
+        }
+        other => panic!("expected typed dinosaur recipient filter, got {other:?}"),
+    }
+
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Object(ally_dino), 5),
+        &mut events,
+    )
+    .expect("damage to allied dinosaur resolves");
+
+    assert_eq!(
+        runner.state().objects[&ally_dino].damage_marked,
+        1,
+        "5 damage to another dinosaur must be reduced to 1"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, GameEvent::DamagePrevented { amount: 4, .. })),
+        "must prevent 4 of the 5 damage"
+    );
+
+    let p0_life_before = runner.life(P0);
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, TargetRef::Player(P0), 5),
+        &mut events,
+    )
+    .expect("damage to player resolves");
+    assert_eq!(
+        runner.life(P0),
+        p0_life_before - 5,
+        "Temple Altisaur must not reduce damage dealt to players"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -358,6 +358,7 @@ mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
+mod issue_4244_temple_altisaur;
 mod issue_4249_elspeth_divine_visitation;
 mod issue_4271_birthing_ritual_cmc_filter;
 mod issue_4272_birthing_ritual_etb_triggers;


### PR DESCRIPTION
## Summary

Fixes #4244 — Temple Altisaur was preventing **all** damage to other Dinosaurs you control instead of leaving 1 damage through.

## Root cause

The damage-prevention parser treated `"prevent all but 1 of that damage"` as blanket `"prevent all"` (`PreventionAmount::All`). The recipient filter also failed to parse from the `"would deal damage to another Dinosaur you control"` wording, so the shield was not scoped to allied Dinosaurs.

## Changes

- Add `PreventionAmount::AllBut(u32)` for continuous "prevent all but N" shields (CR 615.1a)
- Parse `"prevent all but N"` before the generic `"prevent all"` branch
- Extend recipient filter parsing to handle `"would deal damage to …"` clauses
- Apply partial prevention in the damage replacement applier (reduce event amount, emit `DamagePrevented` for the prevented portion)
- Add parser + integration regression tests

## Verification

- [x] `cargo test -p engine temple_altisaur`
- [x] `cargo clippy -p engine -- -D warnings`
- [x] `./scripts/check-parser-combinators.sh`

Track: Developer

Made with [Cursor](https://cursor.com)