### PR TITLE
fix(engine): Intruder Alarm untap after token from discard

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2586,13 +2586,39 @@ pub(super) fn handle_resolution_choice(
             // action, so batch this discard's observer triggers (Waste Not,
             // Megrim, Bone Miser) across the `DiscardChoice` pause — exactly
             // as the `Sacrifice` branch does for dies-triggers.
-            if let Some(outcome) = batch_or_drain_observer_triggers(
-                state,
-                events,
-                events_before_effect,
-                events_after_move,
-            ) {
-                return Ok(outcome);
+            //
+            // CR 603.6a: A reflexive continuation stashed behind this interactive
+            // discard (e.g. Shorikai's "then create a Pilot creature token")
+            // emits ZoneChanged/TokenCreated during `finish_with_continuation`.
+            // Collect BOTH the discard slice and the continuation slice into
+            // `deferred_triggers` before a single drain — the discard slice must
+            // stay bounded to the move itself, but an early drain after only the
+            // discard slice would return `WaitingForWithInlineTriggers` and skip
+            // the continuation slice entirely (issue #4245).
+            for (start, end) in [
+                (events_before_effect, events_after_move),
+                (events_after_move, events.len()),
+            ] {
+                if end <= start {
+                    continue;
+                }
+                let trigger_events: Vec<GameEvent> = events[start..end]
+                    .iter()
+                    .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
+                    .cloned()
+                    .collect();
+                if !trigger_events.is_empty() {
+                    super::triggers::collect_triggers_into_deferred(state, &trigger_events);
+                }
+            }
+
+            if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                if let Some(wf) = super::triggers::drain_deferred_trigger_queue(state, events) {
+                    return Ok(ResolutionChoiceOutcome::WaitingFor(wf));
+                }
+                return Ok(ResolutionChoiceOutcome::WaitingForWithInlineTriggers(
+                    waiting_for,
+                ));
             }
             ResolutionChoiceOutcome::WaitingFor(waiting_for)
         }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2587,7 +2587,7 @@ pub(super) fn handle_resolution_choice(
             // Megrim, Bone Miser) across the `DiscardChoice` pause — exactly
             // as the `Sacrifice` branch does for dies-triggers.
             //
-            // CR 603.6a: A reflexive continuation stashed behind this interactive
+            // CR 608.2c: A sequential continuation stashed behind this interactive
             // discard (e.g. Shorikai's "then create a Pilot creature token")
             // emits ZoneChanged/TokenCreated during `finish_with_continuation`.
             // Collect BOTH the discard slice and the continuation slice into

--- a/crates/engine/tests/integration/issue_4245_intruder_alarm_untap.rs
+++ b/crates/engine/tests/integration/issue_4245_intruder_alarm_untap.rs
@@ -1,0 +1,113 @@
+//! Issue #4245: Intruder Alarm must untap creatures when a creature token enters.
+//!
+//! Shorikai's activated ability creates a Pilot creature token. Intruder Alarm's
+//! "Whenever a creature enters, untap all creatures" must fire and untap tapped
+//! creatures (Shorikai itself is a Vehicle and is not affected).
+
+use engine::game::casting::activated_ability_definitions;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::Effect;
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const INTRUDER_ALARM: &str =
+    "Creatures don't untap during their controllers' untap steps.\nWhenever a creature enters, untap all creatures.";
+
+const SHORIKAI: &str = "{1}, {T}: Draw two cards, then discard a card. Create a 1/1 colorless Pilot creature token with \"This token crews Vehicles as though its power were 2 greater.\"";
+
+fn colorless_mana(count: usize) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn resolve_stack(runner: &mut engine::game::scenario::GameRunner) {
+    for _ in 0..40 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        runner.resolve_top();
+    }
+}
+
+#[test]
+fn intruder_alarm_untaps_creatures_when_pilot_token_enters_from_shorikai() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Library A", "Library B", "Library C", "Library D"]);
+    let _alarm = scenario
+        .add_creature(P0, "Intruder Alarm", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(INTRUDER_ALARM)
+        .id();
+    let shorikai = scenario
+        .add_creature(P0, "Shorikai, Genesis Engine", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Vehicle"])
+        .from_oracle_text(SHORIKAI)
+        .id();
+    let tapped_bear = scenario.add_creature(P0, "Tapped Bear", 2, 2).id();
+    let _hand_card = scenario.add_creature_to_hand(P0, "Discard Fodder", 1, 1).id();
+    scenario.with_mana_pool(P0, colorless_mana(1));
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.objects.get_mut(&tapped_bear).unwrap().tapped = true;
+    }
+
+    let ability_index = activated_ability_definitions(runner.state(), shorikai)
+        .into_iter()
+        .next()
+        .expect("Shorikai activated ability")
+        .0;
+    runner
+        .activate(shorikai, ability_index)
+        .resolve();
+
+    // Discard prompt for Shorikai's ability.
+    if let engine::types::game_state::WaitingFor::DiscardChoice { .. } =
+        runner.state().waiting_for
+    {
+        let hand_card = runner.state().players[P0.0 as usize].hand[0];
+        runner
+            .act(GameAction::SelectCards {
+                cards: vec![hand_card],
+            })
+            .expect("discard for Shorikai");
+    }
+
+    resolve_stack(&mut runner);
+
+    assert!(
+        !runner.state().objects[&tapped_bear].tapped,
+        "Intruder Alarm must untap creatures when the Pilot token enters"
+    );
+    assert!(
+        runner.state().objects[&shorikai].tapped,
+        "Shorikai is a Vehicle, not a creature, and must remain tapped"
+    );
+}
+
+#[test]
+fn intruder_alarm_trigger_is_changes_zone_untap_all() {
+    let mut scenario = GameScenario::new();
+    let alarm = scenario
+        .add_creature(P0, "Intruder Alarm", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(INTRUDER_ALARM)
+        .id();
+    let runner = scenario.build();
+
+    let trigger = &runner.state().objects[&alarm].trigger_definitions[0];
+    match &*trigger.execute.as_ref().expect("execute").effect {
+        Effect::SetTapState {
+            scope: engine::types::ability::EffectScope::All,
+            state: engine::types::ability::TapStateChange::Untap,
+            ..
+        } => {}
+        other => panic!("expected untap-all trigger, got {other:?}"),
+    }
+}

--- a/crates/engine/tests/integration/issue_4245_intruder_alarm_untap.rs
+++ b/crates/engine/tests/integration/issue_4245_intruder_alarm_untap.rs
@@ -49,7 +49,9 @@ fn intruder_alarm_untaps_creatures_when_pilot_token_enters_from_shorikai() {
         .from_oracle_text(SHORIKAI)
         .id();
     let tapped_bear = scenario.add_creature(P0, "Tapped Bear", 2, 2).id();
-    let _hand_card = scenario.add_creature_to_hand(P0, "Discard Fodder", 1, 1).id();
+    let _hand_card = scenario
+        .add_creature_to_hand(P0, "Discard Fodder", 1, 1)
+        .id();
     scenario.with_mana_pool(P0, colorless_mana(1));
 
     let mut runner = scenario.build();
@@ -63,13 +65,10 @@ fn intruder_alarm_untaps_creatures_when_pilot_token_enters_from_shorikai() {
         .next()
         .expect("Shorikai activated ability")
         .0;
-    runner
-        .activate(shorikai, ability_index)
-        .resolve();
+    runner.activate(shorikai, ability_index).resolve();
 
     // Discard prompt for Shorikai's ability.
-    if let engine::types::game_state::WaitingFor::DiscardChoice { .. } =
-        runner.state().waiting_for
+    if let engine::types::game_state::WaitingFor::DiscardChoice { .. } = runner.state().waiting_for
     {
         let hand_card = runner.state().players[P0.0 as usize].hand[0];
         runner

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -358,6 +358,7 @@ mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
+mod issue_4245_intruder_alarm_untap;
 mod issue_4249_elspeth_divine_visitation;
 mod issue_4271_birthing_ritual_cmc_filter;
 mod issue_4272_birthing_ritual_etb_triggers;


### PR DESCRIPTION
## Summary

Fixes #4245 — Intruder Alarm's "Whenever a creature enters, untap all creatures" did not fire when a creature token was created by an effect that paused on an interactive discard (e.g. Shorikai's activated ability).

## Root cause

The `DiscardChoice` resolution path batches observer triggers inline because it bypasses `run_post_action_pipeline`. It only scanned events from the discard move itself (`events_before_effect..events_after_move`), then returned `WaitingForWithInlineTriggers` after draining. Continuation effects stashed behind the discard (create token, etc.) emit `ZoneChanged` during `finish_with_continuation`, which sits after `events_after_move` and was never collected.

## Changes

- After `finish_with_continuation`, collect observer triggers from both the discard slice and the continuation slice into `deferred_triggers`, then drain once.
- Add integration regression: Intruder Alarm + Shorikai Pilot token via interactive discard.

## Test plan

- [x] `cargo test -p engine --test integration intruder_alarm`
- [x] `cargo test -p engine --lib if_you_do_draw` (discard continuation regressions)
- [x] `cargo clippy -p engine -- -D warnings`


Made with [Cursor](https://cursor.com)