### PR TITLE
fix(ai): demand-aware mana color selection prevents ManaPayment dead-ends

### DIFF
--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -199,7 +199,7 @@ pub fn compute_hand_color_demand(
 /// requirement. Only the outer cost's colored shards are "reserved": spending one of
 /// those colors on a nested mana-ability sub-cost could leave the outer cost
 /// unpayable, so the nested spend deprioritizes them. Empty for NoCost / Self* costs.
-pub(crate) fn outer_cost_color_demand(cost: &ManaCost) -> ColorDemand {
+pub fn outer_cost_color_demand(cost: &ManaCost) -> ColorDemand {
     let mut demand = [0u32; 5];
     if let ManaCost::Cost { shards, .. } = cost {
         for &shard in shards {

--- a/crates/phase-ai/src/mana_colors.rs
+++ b/crates/phase-ai/src/mana_colors.rs
@@ -6,9 +6,10 @@
 //! (`subtypes` + `abilities`) so a `GameObject` view and a `CardFace` view share
 //! a single implementation, mirroring the `*_parts` pattern in `features`.
 
-use engine::game::mana_payment::land_subtype_to_mana_type;
+use engine::game::mana_payment::{land_subtype_to_mana_type, outer_cost_color_demand, ColorDemand};
 use engine::game::mana_sources::mana_color_to_type;
 use engine::types::ability::{AbilityDefinition, AbilityKind, Effect, ManaProduction};
+use engine::types::game_state::GameState;
 use engine::types::mana::ManaType;
 
 /// Distinct colored-mana types a land can produce, unioning (a) intrinsic mana
@@ -90,5 +91,114 @@ pub(crate) fn collect_mana_production_colors(
 fn push_color(colors: &mut Vec<ManaType>, mana_type: ManaType) {
     if mana_type != ManaType::Colorless && !colors.contains(&mana_type) {
         colors.push(mana_type);
+    }
+}
+
+/// Pick which color a flexible mana source (dual land, Mox Opal, City of Brass)
+/// should produce when answering a `ManaChoicePrompt::SingleColor` *during a
+/// pending cast*. The AI must produce the color the in-flight spell actually
+/// demands, not the first option in the list: tapping a U/R source for {R} when
+/// the spell needs {U} strands the colored pip and dead-ends the ManaPayment.
+///
+/// Returns the first option whose WUBRG colored demand of the pending cast is
+/// nonzero; if none of the options match a demanded color (generic-only cost, no
+/// pending cast), falls back to the first option — identical to the old `first()`
+/// behavior, so this is a strict improvement everywhere.
+///
+/// Limitation: `pending_cast.cost` is the FULL locked outer cost, not decremented
+/// per-pip as colors are produced. Demand is therefore exact for single-colored-pip
+/// costs (the repro: {2}{U}, {5}{U}) and a strict improvement over `first()` for
+/// all costs. Incremental per-pip demand tracking for multi-colored-pip costs
+/// (e.g. {U}{U}{R}, where two blues must be produced before red) is a documented
+/// follow-up, out of scope here.
+pub(crate) fn demand_aware_single_color(
+    options: &[ManaType],
+    state: &GameState,
+) -> Option<ManaType> {
+    let demand: ColorDemand = state
+        .pending_cast
+        .as_deref()
+        .map(|pc| outer_cost_color_demand(&pc.cost))
+        .unwrap_or([0u32; 5]);
+
+    options
+        .iter()
+        .copied()
+        .find(|&opt| match opt {
+            // WUBRG demand slot per color; Colorless has none, so it never
+            // satisfies a colored pip.
+            ManaType::White => demand[0] > 0,
+            ManaType::Blue => demand[1] > 0,
+            ManaType::Black => demand[2] > 0,
+            ManaType::Red => demand[3] > 0,
+            ManaType::Green => demand[4] > 0,
+            ManaType::Colorless => false,
+        })
+        .or_else(|| options.first().copied())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+    use engine::types::game_state::PendingCast;
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::mana::{ManaCost, ManaCostShard};
+    use engine::types::player::PlayerId;
+
+    fn state_with_cost(shards: Vec<ManaCostShard>, generic: u32) -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.pending_cast = Some(Box::new(PendingCast::new(
+            ObjectId(100),
+            CardId(100),
+            ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 0 },
+                    target: TargetFilter::Controller,
+                },
+                Vec::new(),
+                ObjectId(100),
+                PlayerId(0),
+            ),
+            ManaCost::Cost { shards, generic },
+        )));
+        state
+    }
+
+    #[test]
+    fn picks_demanded_blue_over_first_red() {
+        // {2}{U}: a U/R source offered [Red, Blue] must produce Blue (the
+        // demanded color), not Red (the first option).
+        let state = state_with_cost(vec![ManaCostShard::Blue], 2);
+        assert_eq!(
+            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
+            Some(ManaType::Blue)
+        );
+    }
+
+    #[test]
+    fn generic_only_cost_falls_back_to_first() {
+        // {2}: no colored demand, so the first option (Red) is fine.
+        let state = state_with_cost(Vec::new(), 2);
+        assert_eq!(
+            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
+            Some(ManaType::Red)
+        );
+    }
+
+    #[test]
+    fn no_pending_cast_falls_back_to_first() {
+        let state = GameState::new_two_player(42);
+        assert!(state.pending_cast.is_none());
+        assert_eq!(
+            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
+            Some(ManaType::Red)
+        );
+    }
+
+    #[test]
+    fn empty_options_returns_none() {
+        let state = state_with_cost(vec![ManaCostShard::Blue], 2);
+        assert_eq!(demand_aware_single_color(&[], &state), None);
     }
 }

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -14,9 +14,12 @@ use std::collections::HashMap;
 use engine::ai_support::legal_actions;
 use engine::game::combat::AttackTarget;
 use engine::game::engine::{apply, EngineError};
+use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
 use engine::types::{
     CoreType, GameAction, GameState, ObjectId, PayCostKind, Phase, PlayerId, WaitingFor,
 };
+
+use crate::mana_colors::demand_aware_single_color;
 use web_time::{Duration, Instant};
 
 /// How far into the opponent's upcoming turn to project.
@@ -343,7 +346,6 @@ fn resolve_choice(
             ..
         }
         | WaitingFor::ManaPayment { .. }
-        | WaitingFor::ChooseManaColor { .. }
         | WaitingFor::DefilerPayment { .. }
         | WaitingFor::PhyrexianPayment { .. }
         | WaitingFor::CombatTaxPayment { .. }
@@ -356,6 +358,40 @@ fn resolve_choice(
                 .cloned()
                 .ok_or(BailReason::NoLegalManaPayment)?
         }
+
+        // CR 106.3 + CR 608.2d: Mana-color choice during payment. The
+        // SingleColor prompt must produce the color the pending cost demands —
+        // projecting an arbitrary color (the old `actions.first()`) can strand a
+        // colored pip and dead-end the projected ManaPayment, mirroring the live
+        // AI bug fixed in `search.rs`. Combination / AnyCombination keep
+        // first-legal, matching the `fallback_action` shapes.
+        WaitingFor::ChooseManaColor { choice, .. } => match choice {
+            ManaChoicePrompt::SingleColor { options } => demand_aware_single_color(options, state)
+                .map(|color| GameAction::ChooseManaColor {
+                    choice: ManaChoice::SingleColor(color),
+                    count: 1,
+                })
+                .ok_or(BailReason::NoLegalManaPayment)?,
+            ManaChoicePrompt::Combination { options } => options
+                .first()
+                .map(|combo| GameAction::ChooseManaColor {
+                    choice: ManaChoice::Combination(combo.clone()),
+                    count: 1,
+                })
+                .ok_or(BailReason::NoLegalManaPayment)?,
+            ManaChoicePrompt::AnyCombination { count, options } => {
+                // Bail on empty options like the sibling arms, rather than
+                // fabricating a Colorless pip the engine would reject.
+                let color = options
+                    .first()
+                    .copied()
+                    .ok_or(BailReason::NoLegalManaPayment)?;
+                GameAction::ChooseManaColor {
+                    choice: ManaChoice::Combination(vec![color; *count]),
+                    count: 1,
+                }
+            }
+        },
 
         // CR 107.1c + CR 601.2f: X-value projection picks the maximum legal X.
         // Candidates are emitted in `min..=max` order

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -6,7 +6,9 @@ use rand::Rng;
 use engine::ai_support::build_decision_context;
 use engine::types::actions::{AlternativeCastDecision, GameAction, MulliganChoice};
 use engine::types::card_type::CoreType;
-use engine::types::game_state::{CastOfferKind, CostResume, GameState, WaitingFor};
+use engine::types::game_state::{
+    CastOfferKind, CostResume, GameState, ManaChoice, ManaChoicePrompt, WaitingFor,
+};
 use engine::types::identifiers::ObjectId;
 use engine::types::player::PlayerId;
 
@@ -15,6 +17,7 @@ use crate::combat_ai::{choose_attackers_with_targets_with_profile, choose_blocke
 use crate::config::{AiConfig, ThreatAwareness};
 use crate::context::AiContext;
 use crate::features::DeckFeatures;
+use crate::mana_colors::demand_aware_single_color;
 use crate::plan::PlanSnapshot;
 use crate::planner::{
     apply_candidate, build_continuation_planner, PlannerServices, RankedCandidate, SearchBudget,
@@ -159,6 +162,28 @@ pub fn choose_action_with_session(
         let context = build_ai_context_with_session(state, ai_player, config, Arc::clone(session));
         if let Some(action) = deterministic_choice(state, ai_player, config, &[], Some(&context)) {
             return Some(action);
+        }
+    }
+
+    // CR 106.3 + CR 608.2d: Selecting which color a flexible mana source
+    // produces while paying for a spell is mechanical, not a policy judgment —
+    // the AI must produce the color the in-flight cost demands. `candidates.rs`
+    // enumerates *every* color option, so `score_candidates` is always non-empty
+    // and the old `fallback_action` SingleColor arm never fired on the normal
+    // path; the scorer then picked an arbitrary (first-enumerated) color,
+    // tapping a U/R dual for {R} when the spell needed {U} and stranding the pip
+    // (ManaPayment dead-end). This deterministic pre-emption — parallel to the
+    // TributeChoice and SearchChoice pre-emptions above — is the real fix.
+    if let WaitingFor::ChooseManaColor {
+        choice: ManaChoicePrompt::SingleColor { ref options },
+        ..
+    } = state.waiting_for
+    {
+        if let Some(color) = demand_aware_single_color(options, state) {
+            return Some(GameAction::ChooseManaColor {
+                choice: ManaChoice::SingleColor(color),
+                count: 1,
+            });
         }
     }
 
@@ -312,16 +337,29 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
     // Check this before the exhaustive match so every pending-cast variant
     // is covered without repeating CancelCast per-arm.
     if state.waiting_for.has_pending_cast() {
+        // The internal discriminant tag is niche-optimized (non-sequential), so
+        // print the variant *name* (the Debug prefix before its first field) and
+        // the in-flight spell's card name instead — an opaque discriminant alone
+        // is not enough to diagnose which cast/card exposed the gap.
+        let debug = format!("{:?}", state.waiting_for);
+        let variant = debug.split([' ', '{']).next().unwrap_or("<unknown>");
+        // ManaPayment externalizes its PendingCast into `GameState::pending_cast`
+        // rather than the WaitingFor variant, so check both sources.
+        let spell = state
+            .waiting_for
+            .pending_cast_ref()
+            .or(state.pending_cast.as_deref())
+            .and_then(|pc| state.objects.get(&pc.object_id))
+            .map_or("<none>", |obj| obj.name.as_str());
         debug_assert!(
             false,
-            "AI fallback reached during pending cast ({:?}) — \
-             can_cast_object_now has a gap that allowed an uncompletable \
-             cast through. Tighten the pre-cast check rather than relying \
-             on CancelCast recovery.",
-            std::mem::discriminant(&state.waiting_for)
+            "AI fallback reached during pending cast (variant {variant}, spell {spell}) — \
+             can_cast_object_now has a gap that allowed an uncompletable cast through. \
+             Tighten the pre-cast check rather than relying on CancelCast recovery."
         );
         tracing::error!(
-            waiting_for = ?std::mem::discriminant(&state.waiting_for),
+            variant,
+            spell,
             "AI fallback cancelled an uncompletable cast — can_cast_object_now gap"
         );
         return Some(GameAction::CancelCast);
@@ -970,12 +1008,16 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
 
         // Mana-related states: picking a color or paying mana.
         WaitingFor::ChooseManaColor { choice, .. } => {
-            use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
             match choice {
                 ManaChoicePrompt::SingleColor { options } => {
-                    options.first().map(|&color| GameAction::ChooseManaColor {
-                        choice: ManaChoice::SingleColor(color),
-                        count: 1,
+                    // Defense-in-depth: the primary fix is the pre-emption in
+                    // `choose_action_with_session`; this honors the demanded
+                    // color too should this path ever be reached.
+                    demand_aware_single_color(options, state).map(|color| {
+                        GameAction::ChooseManaColor {
+                            choice: ManaChoice::SingleColor(color),
+                            count: 1,
+                        }
                     })
                 }
                 ManaChoicePrompt::Combination { options } => {
@@ -2257,6 +2299,143 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(1);
         let action = choose_action(&state, PlayerId(0), &config, &mut rng);
         assert_eq!(action, Some(GameAction::PassPriority));
+    }
+
+    fn pending_cast_with_cost(
+        shards: Vec<engine::types::mana::ManaCostShard>,
+        generic: u32,
+    ) -> Box<engine::types::game_state::PendingCast> {
+        use engine::types::ability::{QuantityExpr, ResolvedAbility, TargetFilter};
+        use engine::types::game_state::PendingCast;
+        Box::new(PendingCast::new(
+            ObjectId(100),
+            CardId(100),
+            ResolvedAbility::new(
+                engine::types::ability::Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 0 },
+                    target: TargetFilter::Controller,
+                },
+                Vec::new(),
+                ObjectId(100),
+                PlayerId(0),
+            ),
+            engine::types::mana::ManaCost::Cost { shards, generic },
+        ))
+    }
+
+    /// Minimal ChooseManaColor SingleColor state with the given option list and
+    /// pending cast. The `context` is a degenerate `ResolvingEffect` resume — the
+    /// pre-emption never inspects it, only `choice` and `state.pending_cast`.
+    /// Production Improvise/dual repro paths use `ManaChoiceContext::ManaAbility`,
+    /// but the context variant is irrelevant to the pre-emption (which reads only
+    /// `pending_cast` + `options`), so `ResolvingEffect` is used for fixture
+    /// simplicity.
+    fn choose_mana_color_state(
+        options: Vec<ManaType>,
+        pending: Option<Box<engine::types::game_state::PendingCast>>,
+    ) -> GameState {
+        use engine::types::ability::{QuantityExpr, ResolvedAbility, TargetFilter};
+        use engine::types::game_state::{ManaChoiceContext, ManaChoicePrompt};
+        let mut state = make_state();
+        state.pending_cast = pending;
+        let resume = ResolvedAbility::new(
+            engine::types::ability::Effect::Draw {
+                count: QuantityExpr::Fixed { value: 0 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(100),
+            PlayerId(0),
+        );
+        state.waiting_for = WaitingFor::ChooseManaColor {
+            player: PlayerId(0),
+            choice: ManaChoicePrompt::SingleColor { options },
+            context: ManaChoiceContext::ResolvingEffect(Box::new(resume)),
+        };
+        state
+    }
+
+    #[test]
+    fn choose_mana_color_preemption_selects_demanded_color() {
+        // Repro: {2}{U} spell, U/R source offered [Red, Blue]. The AI must
+        // produce Blue (demanded) — the old scorer picked the first-enumerated
+        // color (Red) and stranded the {U} pip into a ManaPayment dead-end.
+        // Drives the PUBLIC choose_action path, not fallback_action.
+        let state = choose_mana_color_state(
+            vec![ManaType::Red, ManaType::Blue],
+            Some(pending_cast_with_cost(
+                vec![engine::types::mana::ManaCostShard::Blue],
+                2,
+            )),
+        );
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(1);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseManaColor {
+                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Blue),
+                count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn choose_mana_color_preemption_selects_demanded_red() {
+        // {1}{R} spell, source offered [Blue, Red] → must produce Red.
+        let state = choose_mana_color_state(
+            vec![ManaType::Blue, ManaType::Red],
+            Some(pending_cast_with_cost(
+                vec![engine::types::mana::ManaCostShard::Red],
+                1,
+            )),
+        );
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(1);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseManaColor {
+                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Red),
+                count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn choose_mana_color_preemption_demanded_color_first() {
+        // Demanded color is first here; paired with selects_demanded_color
+        // (demanded second) this proves demand-driven, not positional.
+        let state = choose_mana_color_state(
+            vec![ManaType::Blue, ManaType::Red],
+            Some(pending_cast_with_cost(
+                vec![engine::types::mana::ManaCostShard::Blue],
+                2,
+            )),
+        );
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(1);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseManaColor {
+                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Blue),
+                count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn choose_mana_color_preemption_no_pending_cast_uses_first() {
+        // No pending cast (e.g. a mana-ability color choice at priority) →
+        // first option, identical to the old behavior.
+        let state = choose_mana_color_state(vec![ManaType::Red, ManaType::Blue], None);
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let mut rng = SmallRng::seed_from_u64(1);
+        assert_eq!(
+            choose_action(&state, PlayerId(0), &config, &mut rng),
+            Some(GameAction::ChooseManaColor {
+                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Red),
+                count: 1,
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
When paying a spell that mixes a colored pip with generic mana (e.g. Metallic
Rebuke {2}{U}, Kappa Cannoneer {5}{U}) using Improvise/Convoke/Delve generic
credit plus color-flexible sources (dual lands, Mox Opal), the AI chose the
color for a flexible source via options.first() — tapping a U/R dual for Red
and stranding the {U} pip. The cast then dead-ended at ManaPayment, tripping
the search.rs invariant guard (recovered via CancelCast, but the AI churned
cast/cancel instead of playing the spell).

The affordability gate and engine auto-tap are correct — the cast IS payable
(tap the dual/Mox for the colored pip, use generic credit for the rest). The
bug was purely the AI's color choice. Fix: add a deterministic ChooseManaColor
pre-emption in choose_action_with_session (parallel to the TributeChoice /
SearchChoice pre-emptions) that picks a color the pending cast's cost still
demands, via outer_cost_color_demand(pending_cast.cost). Shared
demand_aware_single_color helper also backs the fallback_action arm and the
projection rollout, so live play, dead-end recovery, and lookahead agree.
outer_cost_color_demand is promoted pub(crate)->pub for the AI to reuse.

Limitation: pending_cast.cost is the full locked cost (not decremented per
pip), so demand is exact for single-colored-pip costs (the repro) and a strict
improvement over first() everywhere; multi-pip incremental demand is a
documented follow-up.

Also improves the search.rs dead-end diagnostic to print the WaitingFor variant
name + offending spell card name instead of an opaque niche-optimized
discriminant, which is what made this bug diagnosable.

Tests: four ChooseManaColor pre-emption tests pin demand-driven selection
independent of option order; helper unit tests cover generic-only / no-cast /
empty fallbacks. cargo ai-gate: the two Improvise dead-ends (Metallic Rebuke,
Kappa Cannoneer) no longer occur; 0 FAIL, 0 win-loss flips vs baseline.
