### PR TITLE
fix(engine,client): Lagrella multi-target selection crash (#4242)

### DIFF
--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -123,7 +123,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
     && waitingFor.data.player === playerId
     && waitingFor.data.scope.type === "Single";
   const currentTargetRefs = isHumanTargetSelection
-    ? waitingFor.data.selection.current_legal_targets
+    ? (waitingFor.data.selection?.current_legal_targets ?? [])
     : isRetargetChoice
       ? waitingFor.data.legal_new_targets
       : [];

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -148,7 +148,7 @@ export function getWaitingForObjectChoiceIds(
   switch (waitingFor?.type) {
     case "TargetSelection":
     case "TriggerTargetSelection":
-      return waitingFor.data.selection.current_legal_targets.flatMap((target) =>
+      return (waitingFor.data.selection?.current_legal_targets ?? []).flatMap((target) =>
         "Object" in target ? [target.Object] : [],
       );
     case "CopyTargetChoice":

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -873,9 +873,15 @@ pub fn choose_target(
         return Ok(TargetSelectionAdvance::Complete(selected_slots));
     }
 
-    Ok(TargetSelectionAdvance::InProgress(
-        build_target_selection_progress(target_slots, constraints, next_slot, selected_slots)?,
-    ))
+    let next_progress =
+        build_target_selection_progress(target_slots, constraints, next_slot, selected_slots)?;
+    if next_progress.current_slot >= target_slots.len() {
+        validate_selected_slot_prefix(target_slots, &next_progress.selected_slots, constraints)?;
+        return Ok(TargetSelectionAdvance::Complete(
+            next_progress.selected_slots,
+        ));
+    }
+    Ok(TargetSelectionAdvance::InProgress(next_progress))
 }
 
 pub fn choose_target_for_ability(
@@ -951,16 +957,28 @@ pub fn choose_target_for_ability(
         return Ok(TargetSelectionAdvance::Complete(selected_slots));
     }
 
-    Ok(TargetSelectionAdvance::InProgress(
-        build_target_selection_progress_for_ability(
+    let next_progress = build_target_selection_progress_for_ability(
+        state,
+        ability,
+        target_slots,
+        constraints,
+        next_slot,
+        selected_slots,
+    )?;
+    if next_progress.current_slot >= target_slots.len() {
+        validate_selected_slots_with_specs(
             state,
             ability,
+            &specs,
             target_slots,
+            &next_progress.selected_slots,
             constraints,
-            next_slot,
-            selected_slots,
-        )?,
-    ))
+        )?;
+        return Ok(TargetSelectionAdvance::Complete(
+            next_progress.selected_slots,
+        ));
+    }
+    Ok(TargetSelectionAdvance::InProgress(next_progress))
 }
 
 pub fn auto_select_targets(
@@ -4159,6 +4177,16 @@ fn build_target_selection_progress(
                 "No legal target combinations available".to_string(),
             ));
         }
+        // CR 115.6: Optional slots with no remaining legal targets are
+        // auto-skipped — do not surface an interactive step with an empty
+        // `current_legal_targets` (the field is omitted on the wire when empty,
+        // which crashes clients that read it unconditionally).
+        return build_target_selection_progress(
+            target_slots,
+            constraints,
+            current_slot + 1,
+            skipped_slots,
+        );
     }
 
     Ok(TargetSelectionProgress {
@@ -4227,6 +4255,18 @@ fn build_target_selection_progress_for_ability(
                 "No legal target combinations available".to_string(),
             ));
         }
+        // CR 115.6: Optional slots with no remaining legal targets are
+        // auto-skipped — do not surface an interactive step with an empty
+        // `current_legal_targets` (the field is omitted on the wire when empty,
+        // which crashes clients that read it unconditionally).
+        return build_target_selection_progress_for_ability(
+            state,
+            ability,
+            target_slots,
+            constraints,
+            current_slot + 1,
+            skipped_slots,
+        );
     }
 
     Ok(TargetSelectionProgress {
@@ -7474,6 +7514,60 @@ mod tests {
         assert!(
             !selected_slots.contains(&Some(TargetRef::Object(second))),
             "skip must not auto-pick later legal targets"
+        );
+    }
+
+    /// CR 115.1 + CR 115.6: After the "controlled by different players"
+    /// constraint exhausts every controller, remaining optional multi-target
+    /// slots must auto-skip instead of pausing with an empty
+    /// `current_legal_targets` (issue #4242 / Lagrella).
+    #[test]
+    fn choose_target_auto_skips_optional_tail_when_constraint_exhausted() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let source = create_creature(&mut state, PlayerId(0), CardId(1), "Lagrella");
+        let p0_creature = create_creature(&mut state, PlayerId(0), CardId(2), "Ally");
+        let p1_creature = create_creature(&mut state, PlayerId(1), CardId(3), "Opp");
+
+        let mut ability = up_to_n_target_creatures(source, PlayerId(0), 3);
+        ability.target_constraints = vec![TargetSelectionConstraint::DifferentObjectControllers];
+        let target_slots = build_target_slots(&state, &ability).expect("target slots");
+        let constraints = ability.target_constraints.clone();
+
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &target_slots, &constraints)
+                .expect("selection should start");
+
+        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
+            &state,
+            &ability,
+            &target_slots,
+            &constraints,
+            &progress,
+            Some(TargetRef::Object(p1_creature)),
+        )
+        .expect("first target should be accepted") else {
+            panic!("expected target selection to continue after first pick");
+        };
+
+        let TargetSelectionAdvance::Complete(selected_slots) = choose_target_for_ability(
+            &state,
+            &ability,
+            &target_slots,
+            &constraints,
+            &progress,
+            Some(TargetRef::Object(p0_creature)),
+        )
+        .expect("second target should auto-complete the optional tail") else {
+            panic!("expected auto-skip to complete after the last controller is used");
+        };
+
+        assert_eq!(
+            selected_slots,
+            vec![
+                Some(TargetRef::Object(p1_creature)),
+                Some(TargetRef::Object(p0_creature)),
+                None,
+            ]
         );
     }
 

--- a/crates/engine/tests/integration/issue_4242_lagrella_crash.rs
+++ b/crates/engine/tests/integration/issue_4242_lagrella_crash.rs
@@ -1,0 +1,95 @@
+//! Issue #4242: Lagrella, the Magpie — after choosing targets for the ETB
+//! exile, the client crashed with `can't access property "some", oe is undefined`.
+//!
+//! Root cause: once every controller had been used under the "controlled by
+//! different players" constraint, the remaining optional multi-target slots had
+//! empty `current_legal_targets`. Serde omits empty vecs, so the client read
+//! `undefined` and called `.some()` on it.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LAGRELLA: &str = "When Lagrella enters, exile any number of other target creatures controlled by different players until Lagrella leaves the battlefield. When an exiled card enters under your control this way, put two +1/+1 counters on it.";
+
+fn gwu_mana() -> Vec<ManaUnit> {
+    vec![
+        ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+        ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+        ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+    ]
+}
+
+#[test]
+fn lagrella_etb_exiles_chosen_creatures_after_multi_target_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, gwu_mana());
+
+    let p0_creature = scenario.add_creature(P0, "P0 Ally", 2, 2).id();
+    let p1_creature = scenario.add_creature(P1, "P1 Opp", 2, 2).id();
+    let lagrella = scenario
+        .add_creature_to_hand_from_oracle(P0, "Lagrella, the Magpie", 2, 2, LAGRELLA)
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&lagrella].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: lagrella,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Lagrella");
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "Lagrella ETB must pause on trigger target selection"
+    );
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(p1_creature)),
+        })
+        .expect("choose opponent creature");
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(p0_creature)),
+        })
+        .expect("choose ally creature; optional tail auto-completes");
+
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "targeting must not stall on an empty optional slot"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&p1_creature].zone,
+        Zone::Exile,
+        "opponent creature must be exiled"
+    );
+    assert_eq!(
+        runner.state().objects[&p0_creature].zone,
+        Zone::Exile,
+        "ally creature must be exiled"
+    );
+    assert!(
+        runner.state().objects[&lagrella].zone == Zone::Battlefield,
+        "Lagrella must remain on the battlefield"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -362,6 +362,7 @@ mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
+mod issue_4242_lagrella_crash;
 mod issue_4243_from_the_rubble;
 mod issue_4244_temple_altisaur;
 mod issue_4245_intruder_alarm_untap;


### PR DESCRIPTION
## Summary

Fixes #4242 — playing Lagrella, the Magpie crashed the client after choosing targets for its ETB exile.

## Root cause

Lagrella's ETB uses an "any number of … controlled by different players" multi-target set. After every controller had been used, remaining optional slots had **empty** `current_legal_targets`. Serde omits empty vecs on the wire, so the client received `selection` without that field and called `.some()` on `undefined` (StackEntry / gameStateView).

## Fix

- **Engine:** When building target-selection progress, auto-skip optional slots that have no legal targets under the active constraints, and complete immediately when auto-skip reaches the tail.
- **Client:** Defensively treat omitted `current_legal_targets` as `[]`.

## Tests

- Unit: `choose_target_auto_skips_optional_tail_when_constraint_exhausted`
- Integration: `lagrella_etb_exiles_chosen_creatures_after_multi_target_selection`

Made with [Cursor](https://cursor.com)