### PR TITLE
feat(parser): route equal-to and enter-with-counters through full CDA…

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -9158,6 +9158,79 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 1);
     }
 
+    /// CR 117.1: Storm Entity's "for each other spell cast this turn" counts
+    /// all players' spells, not just the controller's, then excludes the
+    /// resolving spell via the parser's `All` scope + `offset: -1` shape.
+    #[test]
+    fn resolve_quantity_other_spells_cast_this_turn_counts_opponent_spells() {
+        fn other_spell_cast_this_turn_expr() -> QuantityExpr {
+            QuantityExpr::ClampMin {
+                inner: Box::new(QuantityExpr::Offset {
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::SpellsCastThisTurn {
+                            scope: CountScope::All,
+                            filter: None,
+                        },
+                    }),
+                    offset: -1,
+                }),
+                minimum: 0,
+            }
+        }
+
+        fn dummy_spell() -> SpellCastRecord {
+            SpellCastRecord {
+                name: String::new(),
+                core_types: vec![CoreType::Instant],
+                supertypes: vec![],
+                subtypes: vec![],
+                keywords: vec![],
+                colors: vec![ManaColor::Red],
+                mana_value: 1,
+                has_x_in_cost: false,
+                from_zone: Zone::Hand,
+                cast_variant: crate::types::game_state::CastingVariant::Normal,
+                was_kicked: false,
+            }
+        }
+
+        let mut state = GameState::new_two_player(42);
+        // Opponent cast a spell earlier this turn.
+        state
+            .spells_cast_this_turn_by_player
+            .insert(PlayerId(1), crate::im::Vector::from(vec![dummy_spell()]));
+        // Controller cast only Storm Entity (the resolving spell).
+        state
+            .spells_cast_this_turn_by_player
+            .insert(PlayerId(0), crate::im::Vector::from(vec![dummy_spell()]));
+
+        let expr = other_spell_cast_this_turn_expr();
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)),
+            1,
+            "opponent's spell must count; resolving Storm Entity excluded by -1"
+        );
+
+        // Controller-only scope would incorrectly yield 0 here (1 own spell − 1).
+        let controller_only = QuantityExpr::ClampMin {
+            inner: Box::new(QuantityExpr::Offset {
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::SpellsCastThisTurn {
+                        scope: CountScope::Controller,
+                        filter: None,
+                    },
+                }),
+                offset: -1,
+            }),
+            minimum: 0,
+        };
+        assert_eq!(
+            resolve_quantity(&state, &controller_only, PlayerId(0), ObjectId(1)),
+            0,
+            "Controller scope must not count opponent spells"
+        );
+    }
+
     #[test]
     fn resolve_quantity_lands_played_this_turn_filters_origin_zone() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -9158,9 +9158,9 @@ mod tests {
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 1);
     }
 
-    /// CR 117.1: Storm Entity's "for each other spell cast this turn" counts
-    /// all players' spells, not just the controller's, then excludes the
-    /// resolving spell via the parser's `All` scope + `offset: -1` shape.
+    /// Storm Entity's "for each other spell cast this turn": `CountScope::All`
+    /// plus offset −1 must count opponent spells while excluding the resolving
+    /// spell.
     #[test]
     fn resolve_quantity_other_spells_cast_this_turn_counts_opponent_spells() {
         fn other_spell_cast_this_turn_expr() -> QuantityExpr {

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -510,16 +510,19 @@ fn parse_counter_equal_to(
         return Ok((rest, qty));
     }
 
-    // CR 706.2: event-context back-reference fallback ("equal to the result").
+    // CR 107.1b: Composed dynamic quantities ("equal to twice …", "equal to
+    // the greatest … among …") live in the CDA grammar, not the nom leaf ref
+    // table. Isolate the phrase up to the first clause boundary so trailing
+    // ", then …" clauses stay in the remainder.
     let (after_equal, _) = tag("equal to ").parse(input)?;
-    // Isolate the quantity phrase from any trailing clause via a nom combinator
-    // (take everything up to the first clause separator). Event-context phrases
-    // are short and clause-final in the counter templates that reach this
-    // fallback; the tail after the separator is preserved as the remainder so a
-    // following clause (", then …") is never swallowed.
     let (_, phrase) =
         take_till::<_, _, OracleError<'_>>(|c| c == ',' || c == '.').parse(after_equal)?;
     let phrase = phrase.trim_end();
+    if let Some(expr) = crate::parser::oracle_quantity::parse_cda_quantity(phrase) {
+        return Ok((&after_equal[phrase.len()..], expr));
+    }
+
+    // CR 706.2: event-context back-reference fallback ("equal to the result").
     match crate::parser::oracle_quantity::parse_event_context_quantity(phrase) {
         // Remainder starts immediately after the consumed phrase (before any
         // trailing whitespace), preserving the original clause boundary.

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -6878,9 +6878,10 @@ pub(crate) fn parse_counter_suffix_body_combinator(
 /// its mana value") AND for the post-token "create a … token and put[s] a
 /// number of <type> counters on it equal to <quantity>" form (Oversimplify,
 /// Fractal Anomaly class). Delegates the quantity to the shared
-/// `parse_quantity_ref` building block so any "<verb> a number of X
-/// counters … equal to …" card parses through the same combinator. CR 614.1c
-/// is the authorizing rule for "enters with counters" replacement effects.
+/// `parse_cda_quantity` building block so any "<verb> a number of X
+/// counters … equal to …" card parses composed dynamic quantities
+/// (twice/half/aggregate/difference), not just bare refs. CR 614.1c is the
+/// authorizing rule for "enters with counters" replacement effects.
 pub(crate) fn parse_dynamic_counter_suffix_body(
     input: &str,
 ) -> nom::IResult<&str, (CounterType, QuantityExpr), OracleError<'_>> {
@@ -6890,10 +6891,16 @@ pub(crate) fn parse_dynamic_counter_suffix_body(
     let (rest, _) = tag(" counter").parse(rest)?;
     let (rest, _) = nom::combinator::opt(tag::<_, _, OracleError<'_>>("s")).parse(rest)?;
     let (rest, _) = tag(" on it equal to ").parse(rest)?;
-    // Quantity: delegate to the shared quantity-ref combinator. Consume the
-    // full clause (including any trailing period) so callers see it consumed.
-    let (_, qty) = nom_quantity::parse_quantity_ref_complete(rest)?;
-    Ok(("", (counter_type, QuantityExpr::Ref { qty })))
+    // Quantity: delegate to the full CDA quantity grammar so composed forms
+    // (twice/half/aggregate/difference/sum) parse in enter-with-counters slots.
+    let qty_text = rest.trim_end_matches('.').trim();
+    let Some(qty) = parse_cda_quantity(qty_text) else {
+        return Err(nom::Err::Failure(OracleError::new(
+            rest,
+            nom::error::ErrorKind::Fail,
+        )));
+    };
+    Ok(("", (counter_type, qty)))
 }
 
 #[cfg(test)]
@@ -6906,8 +6913,9 @@ mod tests {
     };
     use crate::parser::oracle_util::TextPair;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, DelayedTriggerCondition, Duration, Effect, ObjectScope,
-        PtValue, QuantityExpr, QuantityRef, TargetFilter, TriggerDefinition,
+        AbilityDefinition, AbilityKind, AggregateFunction, DelayedTriggerCondition, Duration,
+        Effect, ObjectProperty, ObjectScope, PtValue, QuantityExpr, QuantityRef, TargetFilter,
+        TriggerDefinition,
     };
     use crate::types::counter::CounterType;
     use crate::types::phase::Phase;
@@ -7077,6 +7085,27 @@ mod tests {
     fn plain_this_turn_not_owned_by_value_quantity() {
         assert!(!value_quantity_clause_owns_this_turn_suffix(
             "creatures you control get +1/+1 this turn"
+        ));
+    }
+
+    /// CR 614.1c: dynamic enter-with-counters suffix accepts composed quantities.
+    #[test]
+    fn dynamic_counter_suffix_parses_aggregate_equal_to() {
+        use super::parse_dynamic_counter_suffix_body;
+        let (_, (counter_type, count)) = parse_dynamic_counter_suffix_body(
+            "a number of +1/+1 counters on it equal to the greatest mana value among cards in exile",
+        )
+        .unwrap();
+        assert_eq!(counter_type, CounterType::Plus1Plus1);
+        assert!(matches!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::ManaValue,
+                    ..
+                }
+            }
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23878,13 +23878,25 @@ mod tests {
     }
 
     #[test]
-    fn counter_suffix_body_dynamic_count_rejects_partial_quantity_tail() {
-        assert!(
-            parse_counter_suffix_body_combinator(
-                "a number of time counters on it equal to its mana value plus one",
-            )
-            .is_err(),
-            "partial quantity tail must not parse as bare ObjectManaValue"
+    fn counter_suffix_body_dynamic_count_parses_its_mana_value_plus_one() {
+        // CR 107.1b: composed "equal to" tails (offset/sum/multiply) must parse
+        // through the full CDA grammar — not silently truncate at the first ref.
+        let (rest, (counter, count)) = parse_counter_suffix_body_combinator(
+            "a number of time counters on it equal to its mana value plus one",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(counter, crate::types::counter::CounterType::Time);
+        assert_eq!(
+            count,
+            QuantityExpr::Offset {
+                inner: Box::new(QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectManaValue {
+                        scope: ObjectScope::Recipient,
+                    },
+                }),
+                offset: 1,
+            },
         );
     }
 

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2132,11 +2132,11 @@ pub(crate) fn parse_for_each_clause_expr(clause: &str) -> Option<QuantityExpr> {
     parse_for_each_clause_expr_with_parser(clause, parse_for_each_clause)
 }
 
-/// CR 117.1: "other spell(s) cast this turn" — all spells cast this turn by
-/// any player, excluding the resolving spell (Storm Entity class). Composes
-/// `SpellsCastThisTurn { scope: All }` with offset −1, clamped at zero
-/// (CR 107.1b). Uses `All` (not `Controller`) because Oracle text counts
-/// every other spell, including opponents'.
+/// "Other spell(s) cast this turn" (Storm Entity class): all spells cast this
+/// turn by any player, excluding the resolving spell. Composes
+/// `SpellsCastThisTurn { scope: All }` with offset −1, clamped at zero.
+/// Uses `All` (not `Controller`) because Oracle text counts every other
+/// spell, including opponents'.
 fn parse_other_spells_cast_this_turn_for_each(clause: &str) -> Option<QuantityExpr> {
     let (rest, _) = (
         tag::<_, _, OracleError<'_>>("other "),

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2132,9 +2132,11 @@ pub(crate) fn parse_for_each_clause_expr(clause: &str) -> Option<QuantityExpr> {
     parse_for_each_clause_expr_with_parser(clause, parse_for_each_clause)
 }
 
-/// CR 117.1: "other spell(s) cast this turn" — spells the controller cast
-/// this turn excluding the resolving spell (Storm Entity class). Composes
-/// `SpellsCastThisTurn` with offset −1, clamped at zero (CR 107.1b).
+/// CR 117.1: "other spell(s) cast this turn" — all spells cast this turn by
+/// any player, excluding the resolving spell (Storm Entity class). Composes
+/// `SpellsCastThisTurn { scope: All }` with offset −1, clamped at zero
+/// (CR 107.1b). Uses `All` (not `Controller`) because Oracle text counts
+/// every other spell, including opponents'.
 fn parse_other_spells_cast_this_turn_for_each(clause: &str) -> Option<QuantityExpr> {
     let (rest, _) = (
         tag::<_, _, OracleError<'_>>("other "),
@@ -2150,7 +2152,7 @@ fn parse_other_spells_cast_this_turn_for_each(clause: &str) -> Option<QuantityEx
         inner: Box::new(QuantityExpr::Offset {
             inner: Box::new(QuantityExpr::Ref {
                 qty: QuantityRef::SpellsCastThisTurn {
-                    scope: CountScope::Controller,
+                    scope: CountScope::All,
                     filter: None,
                 },
             }),
@@ -4666,19 +4668,21 @@ mod tests {
     #[test]
     fn for_each_other_spells_cast_this_turn() {
         let qty = parse_for_each_clause_expr("other spell cast this turn").unwrap();
-        assert!(matches!(
+        assert_eq!(
             qty,
             QuantityExpr::ClampMin {
-                inner,
-                minimum: 0,
-            } if matches!(
-                *inner,
-                QuantityExpr::Offset {
+                inner: Box::new(QuantityExpr::Offset {
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::SpellsCastThisTurn {
+                            scope: CountScope::All,
+                            filter: None,
+                        },
+                    }),
                     offset: -1,
-                    ..
-                }
-            )
-        ));
+                }),
+                minimum: 0,
+            },
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -829,6 +829,23 @@ pub(crate) fn parse_cda_quantity_with_context(
         }
     }
 
+    // CR 208.1 / CR 107.1: General "the difference between A and B" over any
+    // two independently parsed quantity expressions. The unsigned `.abs()`
+    // resolution is an Oracle templating convention (cf. the P/T arm above).
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("the difference between ").parse(text) {
+        if let Ok((_, (left_text, right_text))) = nom_primitives::split_once_on(rest, " and ") {
+            if let (Some(left), Some(right)) = (
+                parse_cda_quantity_with_context(left_text.trim(), ctx),
+                parse_cda_quantity_with_context(right_text.trim(), ctx),
+            ) {
+                return Some(QuantityExpr::Difference {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                });
+            }
+        }
+    }
+
     if let Ok((rest, qty)) = nom_quantity::parse_quantity_ref.parse(text) {
         if rest.is_empty() {
             return Some(QuantityExpr::Ref {
@@ -2115,6 +2132,34 @@ pub(crate) fn parse_for_each_clause_expr(clause: &str) -> Option<QuantityExpr> {
     parse_for_each_clause_expr_with_parser(clause, parse_for_each_clause)
 }
 
+/// CR 117.1: "other spell(s) cast this turn" — spells the controller cast
+/// this turn excluding the resolving spell (Storm Entity class). Composes
+/// `SpellsCastThisTurn` with offset −1, clamped at zero (CR 107.1b).
+fn parse_other_spells_cast_this_turn_for_each(clause: &str) -> Option<QuantityExpr> {
+    let (rest, _) = (
+        tag::<_, _, OracleError<'_>>("other "),
+        alt((tag("spell"), tag("spells"))),
+        tag(" cast this turn"),
+    )
+        .parse(clause.trim())
+        .ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(QuantityExpr::ClampMin {
+        inner: Box::new(QuantityExpr::Offset {
+            inner: Box::new(QuantityExpr::Ref {
+                qty: QuantityRef::SpellsCastThisTurn {
+                    scope: CountScope::Controller,
+                    filter: None,
+                },
+            }),
+            offset: -1,
+        }),
+        minimum: 0,
+    })
+}
+
 pub(crate) fn parse_for_each_clause_expr_with_context(
     clause: &str,
     ctx: &ParseContext,
@@ -2134,6 +2179,10 @@ fn parse_for_each_clause_expr_with_parser(
     use nom::multi::separated_list1;
 
     let clause = clause.trim().trim_end_matches('.');
+
+    if let Some(expr) = parse_other_spells_cast_this_turn_for_each(clause) {
+        return Some(expr);
+    }
 
     if let Ok((rest, expr)) = parse_target_hand_type_or_color_clause(clause) {
         if rest.is_empty() {
@@ -4603,6 +4652,33 @@ mod tests {
             }
             other => panic!("Expected Multiply, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cda_quantity_difference_between_two_counts() {
+        let qty = parse_cda_quantity(
+            "the difference between the number of cards in your hand and the number of cards in your graveyard",
+        )
+        .unwrap();
+        assert!(matches!(qty, QuantityExpr::Difference { .. }));
+    }
+
+    #[test]
+    fn for_each_other_spells_cast_this_turn() {
+        let qty = parse_for_each_clause_expr("other spell cast this turn").unwrap();
+        assert!(matches!(
+            qty,
+            QuantityExpr::ClampMin {
+                inner,
+                minimum: 0,
+            } if matches!(
+                *inner,
+                QuantityExpr::Offset {
+                    offset: -1,
+                    ..
+                }
+            )
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -440,9 +440,9 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
             ));
         }
     }
-    // CR 107.1b: "equal to <quantity ref>" — composes the existing
-    // QuantityRef parser into the count-position. Strips the prefix, hands
-    // the trimmed tail to the shared `parse_quantity_ref` building block.
+    // CR 107.1b: "equal to <quantity expr>" — delegate to the shared
+    // `parse_cda_quantity` grammar so composed forms (twice/half/offset/sum/
+    // difference/max/aggregate) parse in count positions, not just bare refs.
     if let Some(((), rest_lower)) = super::oracle_nom::bridge::nom_on_lower(text, &lower, |i| {
         nom::combinator::value(
             (),
@@ -451,8 +451,8 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
         .parse(i)
     }) {
         let trimmed = rest_lower.trim_end_matches('.').trim_end();
-        if let Some(qty) = super::oracle_quantity::parse_quantity_ref(trimmed) {
-            return Some((QuantityExpr::Ref { qty }, ""));
+        if let Some(expr) = parse_cda_quantity(trimmed) {
+            return Some((expr, ""));
         }
     }
 
@@ -2506,6 +2506,33 @@ mod tests {
             other => panic!("expected Multiply, got {other:?}"),
         }
         assert_eq!(rest, "stun counters");
+    }
+
+    /// CR 107.1b: "equal to" in count positions must compose full quantity
+    /// expressions, not just bare `QuantityRef` leaves (Tormented Thoughts /
+    /// Ulamog enter-with-counters class).
+    #[test]
+    fn parse_count_expr_equal_to_composed_quantity() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
+
+        let (qty, rest) =
+            parse_count_expr("equal to twice the number of creatures you control").unwrap();
+        assert!(matches!(qty, QuantityExpr::Multiply { factor: 2, .. }));
+        assert!(rest.is_empty());
+
+        let (qty, rest) =
+            parse_count_expr("equal to the greatest mana value among cards in exile").unwrap();
+        assert!(matches!(
+            qty,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::ManaValue,
+                    ..
+                }
+            }
+        ));
+        assert!(rest.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extend the dynamic quantity parser so composed `QuantityExpr` forms (twice/half, aggregates, difference, offset) are recognized wherever Oracle text uses `"equal to …"` or enter-with-counters scaling — closing a large slice of `Swallow:DynamicQty` coverage gaps without new engine types.

The runtime already supports `Multiply`, `Difference`, `Max`, `DivideRounded`, etc.; the bug was parser paths that only delegated to bare `QuantityRef` leaves.

## Changes

- **`parse_count_expr`** (`oracle_util.rs`): `"equal to …"` now delegates to `parse_cda_quantity` instead of `parse_quantity_ref`, so effect count positions accept composed quantities (e.g. `"equal to twice the number of creatures you control"`, `"equal to the greatest mana value among cards in exile"`).
- **`parse_dynamic_counter_suffix_body`** (`lower.rs`): enter-with-counters suffix `"a number of … counters on it equal to …"` uses the full CDA grammar (Ulamog / Oversimplify / Storm Entity class).
- **Generalized difference** (`oracle_quantity.rs`): `"the difference between A and B"` parses over any two CDA-quantity operands, not only power/toughness.
- **Other spells for-each** (`oracle_quantity.rs`): `"other spell(s) cast this turn"` scales as `SpellsCastThisTurn − 1`, clamped at 0 (Storm Entity ETB counters).
- **Counter equal-to fallback** (`counter.rs`): tries `parse_cda_quantity` before the event-context fallback for composed `"equal to …"` phrases in counter paths.

## Test plan

- [x] `parse_count_expr_equal_to_composed_quantity`
- [x] `cda_quantity_difference_between_two_counts`
- [x] `for_each_other_spells_cast_this_turn`
- [x] `dynamic_counter_suffix_parses_aggregate_equal_to`
- [ ] Regenerate / diff coverage report for `Swallow:DynamicQty` reduction
- [ ] Spot-check: Ulamog ETB counters, Storm Entity, Tormented Thoughts discard count, Oversimplify Fractal tokens
