### PR TITLE
fix(parser): Adagia token copies gain legendary modifier (#4254)

### DIFF
--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -2676,6 +2676,59 @@ mod tests {
         );
     }
 
+    /// CR 205.4 + CR 707.9d: Adagia, Windswept Bastion class —
+    /// `additional_modifications: [AddSupertype(Legendary)]` grants Legendary
+    /// to a token copy of a non-legendary permanent.
+    #[test]
+    fn copy_token_add_supertype_grants_legendary_to_nonlegendary_source() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Sol Ring".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let s = state.objects.get_mut(&source_id).unwrap();
+            s.base_card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Artifact],
+                subtypes: vec![],
+            };
+            s.card_types = s.base_card_types.clone();
+        }
+
+        let mut events = Vec::new();
+        let ability = ResolvedAbility::new(
+            Effect::CopyTokenOf {
+                target: TargetFilter::Any,
+                owner: TargetFilter::Controller,
+                source_filter: None,
+                enters_attacking: false,
+                tapped: false,
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                extra_keywords: vec![],
+                additional_modifications: vec![ContinuousModification::AddSupertype {
+                    supertype: Supertype::Legendary,
+                }],
+            },
+            vec![TargetRef::Object(source_id)],
+            source_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let token_id = ObjectId(state.next_object_id - 1);
+        let token = state.objects.get(&token_id).unwrap();
+        assert!(token.is_token);
+        assert!(
+            token.card_types.supertypes.contains(&Supertype::Legendary),
+            "token must be Legendary; got {:?}",
+            token.card_types.supertypes
+        );
+    }
+
     /// CR 704.5j + CR 707.9b: Issue #685 regression. When token-copy strips
     /// the Legendary supertype via `additional_modifications`, the legend
     /// rule SBA must NOT prompt the controller to choose which copy to

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -191,6 +191,9 @@ pub(crate) fn parse_except_body<'a>(
     if let Some((rest, modification)) = parse_is_supertype_in_addition(input) {
         return Some((rest, vec![modification]));
     }
+    if let Some((rest, modification)) = parse_is_supertype(input) {
+        return Some((rest, vec![modification]));
+    }
     if let Some((rest, modification)) = parse_isnt_supertype(input) {
         return Some((rest, vec![modification]));
     }
@@ -947,6 +950,9 @@ fn parse_isnt_supertype(input: &str) -> Option<(&str, ContinuousModification)> {
 ///
 /// Sarkhan, Soul Aflame: `"… except its name is ~ and it's legendary in
 /// addition to its other types"` is the canonical case.
+///
+/// Adagia, Windswept Bastion: `"… except it's legendary"` (no "in addition"
+/// suffix) is handled by [`parse_is_supertype`] instead.
 fn parse_is_supertype_in_addition(input: &str) -> Option<(&str, ContinuousModification)> {
     let (rest, _) = alt((
         tag::<_, _, OracleError<'_>>("it's "),
@@ -966,6 +972,26 @@ fn parse_is_supertype_in_addition(input: &str) -> Option<(&str, ContinuousModifi
     ))
     .parse(rest)
     .ok()?;
+    Some((rest, ContinuousModification::AddSupertype { supertype }))
+}
+
+/// CR 205.4 + CR 707.9d: Match `"<subject>'s <supertype>"` without the Sarkhan
+/// "in addition to its other types" suffix. Emits [`ContinuousModification::AddSupertype`].
+///
+/// Adagia, Windswept Bastion: `"create a token that's a copy of target artifact
+/// or enchantment you control, except it's legendary"`.
+fn parse_is_supertype(input: &str) -> Option<(&str, ContinuousModification)> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("it's "),
+        tag("it\u{2019}s "),
+        tag("he's "),
+        tag("he\u{2019}s "),
+        tag("she's "),
+        tag("she\u{2019}s "),
+    ))
+    .parse(input)
+    .ok()?;
+    let (rest, supertype) = parse_supertype_word(rest)?;
     Some((rest, ContinuousModification::AddSupertype { supertype }))
 }
 
@@ -2216,6 +2242,23 @@ mod tests {
         let (_, mods) = parse_except_clause(
             ", except it's legendary in addition to its other types",
             "Card",
+            &ParseContext::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            mods,
+            vec![ContinuousModification::AddSupertype {
+                supertype: Supertype::Legendary,
+            }]
+        );
+    }
+
+    /// CR 205.4 + CR 707.9d: bare "except it's legendary" (Adagia, Windswept Bastion).
+    #[test]
+    fn its_legendary_emits_add_supertype() {
+        let (_, mods) = parse_except_clause(
+            ", except it's legendary",
+            "Adagia, Windswept Bastion",
             &ParseContext::default(),
         )
         .unwrap();


### PR DESCRIPTION
## Summary
- Parse bare `except it's legendary` on token-copy effects (Adagia, Windswept Bastion's 12+ station ability)
- Previously only the Sarkhan-style `in addition to its other types` form was recognized, so `CopyTokenOf` shipped without `AddSupertype(Legendary)`

## Test plan
- [x] `its_legendary_emits_add_supertype` parser unit test
- [x] `copy_token_add_supertype_grants_legendary_to_nonlegendary_source` resolver test
- [ ] CI card-data regen picks up the parser fix for Adagia

Fixes #4254

Made with [Cursor](https://cursor.com)