### PR TITLE
fix(engine): Sanar Vivid reveal stays in library for per-color exile (#4253)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -12,9 +12,9 @@ use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityKind, CardTypeSetSource, ControllerRef,
     CopyRetargetPermission, CostPaidObjectSnapshot, Effect, EffectError, EffectKind,
     EffectOutcomeSignal, EffectScope, FilterProp, OpponentMayScope, PlayerFilter, PlayerScope,
-    QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility, SacrificeCost,
-    SacrificeRequirement, SharedQuality, SharedQualityRelation, SubAbilityLink, TapStateChange,
-    TargetFilter, TargetRef, ThisWayCause,
+    QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility, RevealUntilDisposition,
+    SacrificeCost, SacrificeRequirement, SharedQuality, SharedQualityRelation, SubAbilityLink,
+    TapStateChange, TargetFilter, TargetRef, ThisWayCause,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -3433,8 +3433,7 @@ fn affected_objects_from_events(
         // CR 701.20b: reveal-only RevealUntil (Sanar) publishes the full revealed
         // pile from `CardsRevealed` — no zone changes occurred.
         Effect::RevealUntil {
-            kept_destination: Zone::Library,
-            rest_destination: Zone::Library,
+            matched_disposition: RevealUntilDisposition::RevealOnly,
             ..
         } => events
             .iter()

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3430,6 +3430,20 @@ fn affected_objects_from_events(
             })
             .flat_map(|ids| ids.iter().copied())
             .collect(),
+        // CR 701.20b: reveal-only RevealUntil (Sanar) publishes the full revealed
+        // pile from `CardsRevealed` — no zone changes occurred.
+        Effect::RevealUntil {
+            kept_destination: Zone::Library,
+            rest_destination: Zone::Library,
+            ..
+        } => events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::CardsRevealed { card_ids, .. } => Some(card_ids.as_slice()),
+                _ => None,
+            })
+            .flat_map(|ids| ids.iter().copied())
+            .collect(),
         _ => {
             let dest_zone = match effect {
                 Effect::ChangeZone { destination, .. }

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -153,6 +153,17 @@ pub fn resolve(
     // Store revealed IDs for downstream reference.
     state.last_revealed_ids = all_revealed;
 
+    // CR 701.20b: reveal-only until-loop — cards stay in the library zone when
+    // both destinations are Library (Sanar: per-color exile follows from among
+    // the revealed cards still in the library).
+    if kept_destination == Zone::Library && rest_destination == Zone::Library {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::RevealUntil,
+            source_id: ability.source_id,
+        });
+        return Ok(());
+    }
+
     // CR 701.20a + CR 608.2c: "You may put that card onto the battlefield" — when
     // the kept destination is a controller choice and a hit was found, pause for
     // `WaitingFor::RevealUntilKeptChoice`. The choice handler routes the hit card,

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -153,10 +153,9 @@ pub fn resolve(
     // Store revealed IDs for downstream reference.
     state.last_revealed_ids = all_revealed;
 
-    // CR 701.20b: reveal-only until-loop — cards stay in the library zone when
-    // both destinations are Library (Sanar: per-color exile follows from among
-    // the revealed cards still in the library).
-    if kept_destination == Zone::Library && rest_destination == Zone::Library {
+    // CR 701.20b: reveal-only until-loop — cards stay in their zones (Sanar's
+    // Vivid draws nothing to hand before per-color exile from the library).
+    if matches!(matched_disposition, RevealUntilDisposition::RevealOnly) {
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::RevealUntil,
             source_id: ability.source_id,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18081,6 +18081,7 @@ pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
     }
     let ir = parse_effect_chain_ir(text, kind, &mut ParseContext::default());
     let mut def = lower_effect_chain_ir(&ir);
+    sequence::patch_reveal_until_for_library_category_exile(&mut def);
     fold_speed_floor_sentences(&mut def);
     def
 }
@@ -18110,6 +18111,7 @@ pub(crate) fn parse_effect_chain_with_context(
     }
     let ir = parse_effect_chain_ir(text, kind, ctx);
     let mut def = lower_effect_chain_ir(&ir);
+    sequence::patch_reveal_until_for_library_category_exile(&mut def);
     fold_speed_floor_sentences(&mut def);
     def
 }
@@ -23191,7 +23193,7 @@ mod tests {
         AbilityCondition, AbilityCost, AggregateFunction, BounceSelection, CardTypeSetSource,
         CastVariantPaid, ChoiceType, ChosenSubtypeKind, CombatRelation, CombatRelationSubject,
         Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope,
-        DoublePTMode, Duration, FilterProp, LibraryPosition, LinkedExileScope, ManaContribution,
+        DoublePTMode, Duration, FilterProp, IterationCategory, LibraryPosition, LinkedExileScope, ManaContribution,
         ManaProduction, ObjectProperty, ObjectScope, PermissionGrantee, PlayerFilter,
         PlayerRelation, PreventionScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
         SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter, TypedFilter,
@@ -48780,6 +48782,48 @@ mod tests {
         assert!(
             matches!(&type_filters[..], [TypeFilter::Non(inner)] if matches!(**inner, TypeFilter::Land)),
             "filter must be nonland, got {type_filters:?}"
+        );
+    }
+
+    /// CR 701.20b + CR 608.2c: Sanar's full Vivid tail — reveal-until must keep
+    /// the pile in the library for the per-color exile loop.
+    #[test]
+    fn sanar_vivid_reveal_until_keeps_library_pile_for_per_color_exile() {
+        let def = parse_effect_chain(
+            "Reveal cards from the top of your library until you reveal X nonland cards, \
+             where X is the number of colors among permanents you control. \
+             For each of those colors, you may exile a card of that color from among the revealed cards. \
+             Then shuffle. You may cast the exiled cards this turn.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::RevealUntil {
+                    kept_destination: Zone::Library,
+                    rest_destination: Zone::Library,
+                    ..
+                }
+            ),
+            "Sanar reveal-until must not route hits to hand; got {:?}",
+            def.effect
+        );
+        let exile = def
+            .sub_ability
+            .as_ref()
+            .expect("Sanar must chain into per-color exile");
+        assert!(
+            matches!(
+                exile.effect.as_ref(),
+                Effect::ForEachCategoryExile {
+                    category: IterationCategory::Color,
+                    zone: Zone::Library,
+                    up_to: true,
+                    ..
+                }
+            ),
+            "expected ForEachCategoryExile, got {:?}",
+            exile.effect
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -23193,11 +23193,11 @@ mod tests {
         AbilityCondition, AbilityCost, AggregateFunction, BounceSelection, CardTypeSetSource,
         CastVariantPaid, ChoiceType, ChosenSubtypeKind, CombatRelation, CombatRelationSubject,
         Comparator, ContinuousModification, ControllerRef, CopyRetargetPermission, CountScope,
-        DoublePTMode, Duration, FilterProp, IterationCategory, LibraryPosition, LinkedExileScope, ManaContribution,
-        ManaProduction, ObjectProperty, ObjectScope, PermissionGrantee, PlayerFilter,
-        PlayerRelation, PreventionScope, PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef,
-        SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter, TypedFilter,
-        ZoneRef,
+        DoublePTMode, Duration, FilterProp, IterationCategory, LibraryPosition, LinkedExileScope,
+        ManaContribution, ManaProduction, ObjectProperty, ObjectScope, PermissionGrantee,
+        PlayerFilter, PlayerRelation, PreventionScope, PtStat, PtValue, PtValueScope, QuantityExpr,
+        QuantityRef, SearchSelectionConstraint, SharedQuality, TargetChoiceTiming, TypeFilter,
+        TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::game_state::{DistributionUnit, TargetSelectionConstraint};

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -48800,12 +48800,13 @@ mod tests {
             matches!(
                 &*def.effect,
                 Effect::RevealUntil {
+                    matched_disposition: RevealUntilDisposition::RevealOnly,
                     kept_destination: Zone::Library,
                     rest_destination: Zone::Library,
                     ..
                 }
             ),
-            "Sanar reveal-until must not route hits to hand; got {:?}",
+            "Sanar reveal-until must stay reveal-only in the library, got {:?}",
             def.effect
         );
         let exile = def

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -355,6 +355,30 @@ fn append_definition_to_sub_chain(ability: &mut AbilityDefinition, mut next: Abi
     }
 }
 
+/// CR 701.20b + CR 608.2c: When a `RevealUntil` chains into library-scoped
+/// `ForEachCategoryExile` (Sanar's Vivid), the reveal step must not route hits
+/// to hand — the per-color exile reads from among cards still in the library.
+pub(super) fn patch_reveal_until_for_library_category_exile(def: &mut AbilityDefinition) {
+    if let Some(sub) = def.sub_ability.as_mut() {
+        patch_reveal_until_for_library_category_exile(sub);
+        if let (
+            Effect::RevealUntil {
+                kept_destination,
+                rest_destination,
+                ..
+            },
+            Effect::ForEachCategoryExile {
+                zone: Zone::Library,
+                ..
+            },
+        ) = (&mut *def.effect, &*sub.effect)
+        {
+            *kept_destination = Zone::Library;
+            *rest_destination = Zone::Library;
+        }
+    }
+}
+
 fn deepest_effect(ability: &AbilityDefinition) -> &Effect {
     let mut cursor = ability;
     while let Some(sub) = cursor.sub_ability.as_deref() {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -363,6 +363,7 @@ pub(super) fn patch_reveal_until_for_library_category_exile(def: &mut AbilityDef
         patch_reveal_until_for_library_category_exile(sub);
         if let (
             Effect::RevealUntil {
+                matched_disposition,
                 kept_destination,
                 rest_destination,
                 ..
@@ -373,6 +374,7 @@ pub(super) fn patch_reveal_until_for_library_category_exile(def: &mut AbilityDef
             },
         ) = (&mut *def.effect, &*sub.effect)
         {
+            *matched_disposition = RevealUntilDisposition::RevealOnly;
             *kept_destination = Zone::Library;
             *rest_destination = Zone::Library;
         }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7328,6 +7328,9 @@ pub enum RevealUntilDisposition {
     /// revealed card goes to `rest_destination` (CR 401.4 random bottom when
     /// `rest_destination == Library`).
     ChooseAnyNumber,
+    /// CR 701.20b: Reveal without changing zones — cards stay in the library
+    /// for a downstream per-color exile (Sanar's Vivid).
+    RevealOnly,
 }
 
 impl RevealUntilDisposition {

--- a/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
+++ b/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
@@ -44,7 +44,7 @@ fn sanar_vivid_chain(source: ObjectId) -> ResolvedAbility {
                 properties: vec![],
             }),
             count: distinct_colors_count(),
-            matched_disposition: RevealUntilDisposition::KeepEach,
+            matched_disposition: RevealUntilDisposition::RevealOnly,
             kept_destination: Zone::Library,
             rest_destination: Zone::Library,
             enter_tapped: EtbTapState::Unspecified,
@@ -77,6 +77,7 @@ fn sanar_vivid_parses_library_reveal_then_per_color_exile() {
         matches!(
             &*def.effect,
             Effect::RevealUntil {
+                matched_disposition: RevealUntilDisposition::RevealOnly,
                 kept_destination: Zone::Library,
                 rest_destination: Zone::Library,
                 ..

--- a/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
+++ b/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
@@ -12,7 +12,7 @@ use engine::game::scenario::{GameScenario, P0};
 use engine::parser::oracle_effect::parse_effect_chain;
 use engine::types::ability::{
     AbilityKind, Chooser, ControllerRef, Effect, IterationCategory, QuantityExpr, QuantityRef,
-    ResolvedAbility, RevealUntilDisposition, TargetFilter, TypedFilter, TypeFilter,
+    ResolvedAbility, RevealUntilDisposition, TargetFilter, TypeFilter, TypedFilter,
 };
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
@@ -128,12 +128,7 @@ fn sanar_vivid_per_color_exile_offers_revealed_library_cards() {
         .get_mut(&white_perm)
         .unwrap()
         .color = vec![ManaColor::White];
-    runner
-        .state_mut()
-        .objects
-        .get_mut(&red_perm)
-        .unwrap()
-        .color = vec![ManaColor::Red];
+    runner.state_mut().objects.get_mut(&red_perm).unwrap().color = vec![ManaColor::Red];
 
     for (id, core) in [
         (red_spell, CoreType::Sorcery),
@@ -176,9 +171,7 @@ fn sanar_vivid_per_color_exile_offers_revealed_library_cards() {
                 "WUBRG iteration offers the white sorcery first while it remains in the library"
             );
         }
-        other => panic!(
-            "expected ChooseFromZoneChoice for the first color member, got {other:?}"
-        ),
+        other => panic!("expected ChooseFromZoneChoice for the first color member, got {other:?}"),
     }
 
     assert_eq!(

--- a/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
+++ b/crates/engine/tests/integration/issue_4253_sanar_vivid.rs
@@ -1,0 +1,194 @@
+//! Regression for GitHub issue #4253 — Sanar, Innovative First-Year's Vivid
+//! ability revealed nonlands into hand before the per-color exile loop, so
+//! `ForEachCategoryExile` saw an empty Library pool.
+//!
+//! CR 701.20b: revealed cards stay in the library until an effect moves them.
+//! Sanar's "for each of those colors, you may exile a card of that color from
+//! among the revealed cards" requires the reveal-until step to leave the pile
+//! in the library.
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, Chooser, ControllerRef, Effect, IterationCategory, QuantityExpr, QuantityRef,
+    ResolvedAbility, RevealUntilDisposition, TargetFilter, TypedFilter, TypeFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::{EtbTapState, Zone};
+
+const SANAR_VIVID_ORACLE: &str = "Reveal cards from the top of your library until you reveal X \
+nonland cards, where X is the number of colors among permanents you control. For each of those \
+colors, you may exile a card of that color from among the revealed cards. Then shuffle. You may \
+cast the exiled cards this turn.";
+
+fn distinct_colors_count() -> QuantityExpr {
+    QuantityExpr::Ref {
+        qty: QuantityRef::DistinctColorsAmongPermanents {
+            filter: TargetFilter::Typed(TypedFilter::permanent().controller(ControllerRef::You)),
+        },
+    }
+}
+
+fn sanar_vivid_chain(source: ObjectId) -> ResolvedAbility {
+    let mut ability = ResolvedAbility::new(
+        Effect::RevealUntil {
+            player: TargetFilter::Controller,
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Non(Box::new(TypeFilter::Land))],
+                controller: None,
+                properties: vec![],
+            }),
+            count: distinct_colors_count(),
+            matched_disposition: RevealUntilDisposition::KeepEach,
+            kept_destination: Zone::Library,
+            rest_destination: Zone::Library,
+            enter_tapped: EtbTapState::Unspecified,
+            enters_attacking: false,
+            kept_optional_to: None,
+            enters_under: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::ForEachCategoryExile {
+            category: IterationCategory::Color,
+            zone: Zone::Library,
+            chooser: Chooser::Controller,
+            up_to: true,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+    ability
+}
+
+#[test]
+fn sanar_vivid_parses_library_reveal_then_per_color_exile() {
+    let def = parse_effect_chain(SANAR_VIVID_ORACLE, AbilityKind::Spell);
+    assert!(
+        matches!(
+            &*def.effect,
+            Effect::RevealUntil {
+                kept_destination: Zone::Library,
+                rest_destination: Zone::Library,
+                ..
+            }
+        ),
+        "reveal-until must keep the pile in the library, got {:?}",
+        def.effect
+    );
+    let exile = def
+        .sub_ability
+        .as_ref()
+        .expect("Vivid must chain into per-color exile");
+    assert!(
+        matches!(
+            exile.effect.as_ref(),
+            Effect::ForEachCategoryExile {
+                category: IterationCategory::Color,
+                zone: Zone::Library,
+                up_to: true,
+                ..
+            }
+        ),
+        "expected ForEachCategoryExile, got {:?}",
+        exile.effect
+    );
+}
+
+#[test]
+fn sanar_vivid_per_color_exile_offers_revealed_library_cards() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let white_perm = scenario.add_creature(P0, "White Bear", 2, 2).id();
+    let red_perm = scenario.add_creature(P0, "Red Bear", 2, 2).id();
+
+    // Library top → bottom: land, red sorcery, land, white sorcery.
+    let _bottom = scenario.add_card_to_library_top(P0, "Bottom Marker");
+    let white_spell = scenario.add_card_to_library_top(P0, "White Bolt");
+    let _land2 = scenario.add_card_to_library_top(P0, "Land Two");
+    let red_spell = scenario.add_card_to_library_top(P0, "Red Bolt");
+    let _land1 = scenario.add_card_to_library_top(P0, "Land One");
+
+    let source = scenario.add_creature(P0, "Sanar Source", 1, 1).id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&white_perm)
+        .unwrap()
+        .color = vec![ManaColor::White];
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&red_perm)
+        .unwrap()
+        .color = vec![ManaColor::Red];
+
+    for (id, core) in [
+        (red_spell, CoreType::Sorcery),
+        (white_spell, CoreType::Sorcery),
+        (_land1, CoreType::Land),
+        (_land2, CoreType::Land),
+    ] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types = vec![core];
+    }
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&red_spell)
+        .unwrap()
+        .color = vec![ManaColor::Red];
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&white_spell)
+        .unwrap()
+        .color = vec![ManaColor::White];
+
+    let ability = sanar_vivid_chain(source);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Sanar Vivid chain must resolve through per-color exile");
+
+    match &runner.state().waiting_for {
+        WaitingFor::ChooseFromZoneChoice { cards, up_to, .. } => {
+            assert!(*up_to, "you may exile is optional per color");
+            assert_eq!(
+                cards,
+                &vec![white_spell],
+                "WUBRG iteration offers the white sorcery first while it remains in the library"
+            );
+        }
+        other => panic!(
+            "expected ChooseFromZoneChoice for the first color member, got {other:?}"
+        ),
+    }
+
+    assert_eq!(
+        runner.state().objects[&red_spell].zone,
+        Zone::Library,
+        "revealed cards must stay in the library until exiled"
+    );
+    assert_eq!(
+        runner.state().objects[&white_spell].zone,
+        Zone::Library,
+        "revealed cards must stay in the library until exiled"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -367,6 +367,7 @@ mod issue_4248_room_cast_both_halves;
 mod issue_4249_elspeth_divine_visitation;
 mod issue_4250_octavia_cost_reduction;
 mod issue_4251_mad_wizards_lair;
+mod issue_4253_sanar_vivid;
 mod issue_4271_birthing_ritual_cmc_filter;
 mod issue_4272_birthing_ritual_etb_triggers;
 mod issue_536_six_grants_retrace;


### PR DESCRIPTION
## Summary
- Sanar's Vivid ability revealed nonlands into hand before `ForEachCategoryExile`, so the per-color exile loop saw an empty Library pool
- Parser now patches `RevealUntil → ForEachCategoryExile` chains to keep both destinations in the library
- Runtime `RevealUntil` skips zone moves when kept/rest are both Library (CR 701.20b reveal-only)

## Test plan
- [x] `sanar_vivid_reveal_until_keeps_library_pile_for_per_color_exile` parser test
- [x] `issue_4253_sanar_vivid` integration tests (parse + runtime per-color prompt)
- [ ] CI

Fixes #4253

Made with [Cursor](https://cursor.com)