### PR TITLE
feat(parser): wire game-state unless gates through effect conditions

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3206,6 +3206,7 @@ fn fmt_ability_condition(cond: &AbilityCondition) -> String {
         AbilityCondition::IsMonarch => "is monarch".into(),
         AbilityCondition::IsInitiative => "has the initiative".into(),
         AbilityCondition::HasCityBlessing => "has the city's blessing".into(),
+        AbilityCondition::IsRingBearer => "is the ring-bearer".into(),
         AbilityCondition::TargetHasKeywordInstead { keyword } => {
             format!("target has {} (instead)", keyword_label(keyword))
         }
@@ -6213,6 +6214,7 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         AbilityCondition::IsMonarch => ("IsMonarch", Handled),
         AbilityCondition::IsInitiative => ("IsInitiative", Handled),
         AbilityCondition::HasCityBlessing => ("HasCityBlessing", Handled),
+        AbilityCondition::IsRingBearer => ("IsRingBearer", Handled),
         AbilityCondition::TargetHasKeywordInstead { .. } => ("TargetHasKeywordInstead", Handled),
         // CR 608.2c: active-player check; handled by `evaluate_condition` (effects/mod.rs).
         AbilityCondition::IsYourTurn => ("IsYourTurn", Handled),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2029,6 +2029,7 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::IsMonarch
             | AbilityCondition::IsInitiative
             | AbilityCondition::HasCityBlessing
+            | AbilityCondition::IsRingBearer
             | AbilityCondition::TargetHasKeywordInstead { .. }
             | AbilityCondition::TargetMatchesFilter { .. }
             | AbilityCondition::TriggeringSpellTargetsFilter { .. }
@@ -7050,6 +7051,12 @@ pub(crate) fn evaluate_condition(
         // CR 702.131c: The city's blessing is a player designation that effects
         // can identify.
         AbilityCondition::HasCityBlessing => eval_has_city_blessing(state, ability.controller),
+        // CR 701.54a: Ring-bearer designation on the ability source.
+        AbilityCondition::IsRingBearer => crate::game::effects::ring::is_current_ring_bearer(
+            state,
+            ability.controller,
+            ability.source_id,
+        ),
         // "Instead" override conditions — return pure boolean value.
         // Terminal control flow (early return from resolve_ability_chain) is the caller's
         // responsibility in the sub-ability context.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2950,8 +2950,9 @@ pub(super) fn difference_expr(cond: &AbilityCondition) -> Option<QuantityExpr> {
     }
 }
 
-/// Bridge `StaticCondition::OpponentPoisonAtLeast` to an existential
-/// `QuantityCheck` over opponents whose poison total meets the threshold.
+/// CR 122.1f: Bridge `StaticCondition::OpponentPoisonAtLeast` to an existential
+/// `QuantityCheck` over opponents whose poison total meets the threshold
+/// ("an opponent has N or more poison counters" unless gates).
 fn opponent_poison_at_least_as_quantity_check(count: u32) -> AbilityCondition {
     use crate::types::ability::{PlayerFilter, PlayerRelation, QuantityRef};
     use crate::types::player::PlayerCounterKind;
@@ -2963,7 +2964,7 @@ fn opponent_poison_at_least_as_quantity_check(count: u32) -> AbilityCondition {
                     relation: PlayerRelation::Opponent,
                     attr: Box::new(QuantityRef::PlayerCounter {
                         kind: PlayerCounterKind::Poison,
-                        scope: CountScope::Controller,
+                        scope: CountScope::ScopedPlayer,
                     }),
                     comparator: Comparator::GE,
                     value: Box::new(QuantityExpr::Fixed {

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -715,10 +715,17 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
     (None, text.to_string())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum UnlessSuffixStrip {
+    Absent,
+    Parsed(AbilityCondition),
+    Unrecognized { rider: String },
+}
+
 pub(super) fn strip_unless_entered_suffix(
     text: &str,
     ctx: &mut ParseContext,
-) -> (Option<AbilityCondition>, String) {
+) -> (UnlessSuffixStrip, String) {
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
     for pattern in &[
@@ -727,7 +734,7 @@ pub(super) fn strip_unless_entered_suffix(
     ] {
         if let Some((before, _)) = tp.split_around(pattern) {
             return (
-                Some(AbilityCondition::Not {
+                UnlessSuffixStrip::Parsed(AbilityCondition::Not {
                     condition: Box::new(AbilityCondition::SourceEnteredThisTurn),
                 }),
                 before.original.trim_end_matches('.').trim().to_string(),
@@ -738,10 +745,16 @@ pub(super) fn strip_unless_entered_suffix(
         let condition_text = condition_part.trim_end_matches('.');
         if let Some(cond) = try_nom_condition_as_unless(condition_text, ctx) {
             let effect_text = text[..effect_part.len()].trim().to_string();
-            return (Some(cond), effect_text);
+            return (UnlessSuffixStrip::Parsed(cond), effect_text);
         }
+        return (
+            UnlessSuffixStrip::Unrecognized {
+                rider: condition_text.to_string(),
+            },
+            text.to_string(),
+        );
     }
-    (None, text.to_string())
+    (UnlessSuffixStrip::Absent, text.to_string())
 }
 
 /// CR 607.2a + CR 608.2c: "unless it has the same name as another card exiled

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2937,6 +2937,33 @@ pub(super) fn difference_expr(cond: &AbilityCondition) -> Option<QuantityExpr> {
     }
 }
 
+/// Bridge `StaticCondition::OpponentPoisonAtLeast` to an existential
+/// `QuantityCheck` over opponents whose poison total meets the threshold.
+fn opponent_poison_at_least_as_quantity_check(count: u32) -> AbilityCondition {
+    use crate::types::ability::{PlayerFilter, PlayerRelation, QuantityRef};
+    use crate::types::player::PlayerCounterKind;
+
+    AbilityCondition::QuantityCheck {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount {
+                filter: PlayerFilter::PlayerAttribute {
+                    relation: PlayerRelation::Opponent,
+                    attr: Box::new(QuantityRef::PlayerCounter {
+                        kind: PlayerCounterKind::Poison,
+                        scope: CountScope::Controller,
+                    }),
+                    comparator: Comparator::GE,
+                    value: Box::new(QuantityExpr::Fixed {
+                        value: i32::try_from(count).unwrap_or(i32::MAX),
+                    }),
+                },
+            },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 1 },
+    }
+}
+
 /// Bridge a `StaticCondition` (from the nom condition parser) to an
 /// `AbilityCondition`. Returns `None` for variants that have no
 /// effect-resolution equivalent — the caller falls through to the next strategy.
@@ -2974,6 +3001,10 @@ pub(crate) fn static_condition_to_ability_condition(
         StaticCondition::IsMonarch => Some(AbilityCondition::IsMonarch),
         StaticCondition::IsInitiative => Some(AbilityCondition::IsInitiative),
         StaticCondition::HasCityBlessing => Some(AbilityCondition::HasCityBlessing),
+        StaticCondition::IsRingBearer => Some(AbilityCondition::IsRingBearer),
+        StaticCondition::OpponentPoisonAtLeast { count } => {
+            Some(opponent_poison_at_least_as_quantity_check(*count))
+        }
         StaticCondition::DayNightIs { state } => {
             Some(AbilityCondition::DayNightIs { state: *state })
         }
@@ -3072,7 +3103,11 @@ pub(crate) fn static_condition_to_ability_condition(
                     }),
                 })
             }
-            _ => None,
+            other => static_condition_to_ability_condition(other, ctx).map(|inner| {
+                AbilityCondition::Not {
+                    condition: Box::new(inner),
+                }
+            }),
         },
         StaticCondition::SourceMatchesFilter { filter } => {
             Some(AbilityCondition::SourceMatchesFilter {
@@ -3164,7 +3199,6 @@ pub(crate) fn static_condition_to_ability_condition(
         // CR 509.1b: recipient-scoped block-evasion gate; no effect-resolution
         // (`AbilityCondition`) equivalent — lowering returns `None`.
         | StaticCondition::RecipientAttackingOwnerTarget { .. }
-        | StaticCondition::IsRingBearer
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::DefendingPlayerControls { .. }
         | StaticCondition::SourceAttackingAlone
@@ -3179,7 +3213,6 @@ pub(crate) fn static_condition_to_ability_condition(
         // (via `TriggerCondition::SourceIsHarnessed` / Layer 6), never an
         // effect-resolution-time `AbilityCondition` — mirror `SourceIsMonstrous`.
         | StaticCondition::SourceIsHarnessed
-        | StaticCondition::OpponentPoisonAtLeast { .. }
         | StaticCondition::UnlessPay { .. }
         | StaticCondition::Unrecognized { .. }
         | StaticCondition::RingLevelAtLeast { .. }
@@ -3313,6 +3346,7 @@ pub(crate) fn ability_condition_to_static_condition(
         | AbilityCondition::IsMonarch
         | AbilityCondition::IsInitiative
         | AbilityCondition::HasCityBlessing
+        | AbilityCondition::IsRingBearer
         | AbilityCondition::WasStartingPlayer { .. }
         | AbilityCondition::SpellCastWithVariantThisTurn { .. }
         | AbilityCondition::SourceIsTapped

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -41026,14 +41026,49 @@ mod tests {
 
     #[test]
     fn strip_unless_opponent_poison_counters() {
+        use crate::types::player::PlayerCounterKind;
+
         let (strip, text) = strip_unless_entered_suffix(
             "sacrifice a creature unless an opponent has three or more poison counters",
             &mut ParseContext::default(),
         );
-        assert!(
-            matches!(strip, UnlessSuffixStrip::Parsed(_)),
-            "expected unless poison gate, got {strip:?}"
+        let UnlessSuffixStrip::Parsed(cond) = strip else {
+            panic!("expected parsed unless poison gate, got {strip:?}");
+        };
+        let AbilityCondition::Not { condition } = cond else {
+            panic!("expected Not-wrapped unless gate, got {cond:?}");
+        };
+        let AbilityCondition::QuantityCheck {
+            lhs,
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        } = *condition
+        else {
+            panic!("expected QuantityCheck GE 1, got {condition:?}");
+        };
+        let QuantityExpr::Ref {
+            qty:
+                QuantityRef::PlayerCount {
+                    filter:
+                        PlayerFilter::PlayerAttribute {
+                            relation: PlayerRelation::Opponent,
+                            attr,
+                            comparator: Comparator::GE,
+                            value,
+                        },
+                },
+        } = lhs
+        else {
+            panic!("expected PlayerCount opponent attribute, got {lhs:?}");
+        };
+        assert_eq!(
+            *attr,
+            QuantityRef::PlayerCounter {
+                kind: PlayerCounterKind::Poison,
+                scope: CountScope::ScopedPlayer,
+            }
         );
+        assert_eq!(*value, QuantityExpr::Fixed { value: 3 });
         assert_eq!(text, "sacrifice a creature");
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4475,16 +4475,17 @@ fn try_parse_for_each_category_exile(tp: TextPair<'_>) -> Option<ParsedEffectCla
 
 fn unless_rider_defers_to_body_parser(text: &str) -> bool {
     let lower = text.to_lowercase();
-    let tp = TextPair::new(text, &lower);
-    let Some(unless_pos) = tp.find(" unless ") else {
+    let Some((before_unless, _, after_unless)) =
+        nom_primitives::scan_preceded(&lower, |i| tag::<_, _, OracleError<'_>>("unless ").parse(i))
+    else {
         return false;
     };
-    let after_unless = &lower[unless_pos + 8..];
-    let before_unless = &lower[..unless_pos];
+    let before_trimmed = before_unless.trim_start();
+    let unless_tail = &lower[before_unless.len()..];
 
     // CR 608.2c: discard imperative + unless discard qualifier (imperative.rs).
     if tag::<_, _, OracleError<'_>>("discard ")
-        .parse(before_unless.trim_start())
+        .parse(before_trimmed)
         .is_ok()
         && tag::<_, _, OracleError<'_>>("you discard ")
             .parse(after_unless)
@@ -4496,9 +4497,9 @@ fn unless_rider_defers_to_body_parser(text: &str) -> bool {
     // CR 118.12: counter spell unless payment (`parse_unless_payment` in counter path).
     // `extract_resolution_unless_pay_modifier` deliberately skips counter text.
     tag::<_, _, OracleError<'_>>("counter ")
-        .parse(before_unless.trim_start())
+        .parse(before_trimmed)
         .is_ok()
-        && parse_unless_payment(&lower[unless_pos..]).is_some()
+        && parse_unless_payment(unless_tail).is_some()
 }
 
 fn parsed_unless_unsupported_clause(full_text: &str, rider: &str) -> ParsedEffectClause {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4473,13 +4473,78 @@ fn try_parse_for_each_category_exile(tp: TextPair<'_>) -> Option<ParsedEffectCla
     })
 }
 
+fn unless_rider_defers_to_body_parser(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    let tp = TextPair::new(text, &lower);
+    let Some(unless_pos) = tp.find(" unless ") else {
+        return false;
+    };
+    let after_unless = &lower[unless_pos + 8..];
+    let before_unless = &lower[..unless_pos];
+
+    // CR 608.2c: discard imperative + unless discard qualifier (imperative.rs).
+    if tag::<_, _, OracleError<'_>>("discard ")
+        .parse(before_unless.trim_start())
+        .is_ok()
+        && tag::<_, _, OracleError<'_>>("you discard ")
+            .parse(after_unless)
+            .is_ok()
+    {
+        return true;
+    }
+
+    // CR 118.12: counter spell unless payment (`parse_unless_payment` in counter path).
+    // `extract_resolution_unless_pay_modifier` deliberately skips counter text.
+    tag::<_, _, OracleError<'_>>("counter ")
+        .parse(before_unless.trim_start())
+        .is_ok()
+        && parse_unless_payment(&lower[unless_pos..]).is_some()
+}
+
+fn parsed_unless_unsupported_clause(full_text: &str, rider: &str) -> ParsedEffectClause {
+    parsed_clause(Effect::unimplemented(
+        "Unsupported unless clause",
+        format!("{full_text} (unless: {rider})"),
+    ))
+}
+
+fn attach_unless_slots(
+    mut clause: ParsedEffectClause,
+    unless_condition: Option<AbilityCondition>,
+    unless_pay: Option<UnlessPayModifier>,
+) -> ParsedEffectClause {
+    if clause.condition.is_none() {
+        clause.condition = unless_condition;
+    }
+    if clause.unless_pay.is_none() {
+        clause.unless_pay = unless_pay;
+    }
+    clause
+}
+
 #[tracing::instrument(level = "debug")]
 fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause {
     // CR 608.2c: "do X unless [game state]" — strip trailing unless suffix and
     // attach the negated gate before body parsing (payment-unless uses
     // `unless_pay` / `extract_resolution_unless_pay_modifier` instead).
-    let (unless_condition, clause_text) = strip_unless_entered_suffix(text, ctx);
-    let text = clause_text.as_str();
+    let (unless_strip, clause_text) = strip_unless_entered_suffix(text, ctx);
+    let mut unless_pay_deferred = None;
+    let (unless_condition, text) = match unless_strip {
+        UnlessSuffixStrip::Absent => (None, clause_text),
+        UnlessSuffixStrip::Parsed(c) => (Some(c), clause_text),
+        UnlessSuffixStrip::Unrecognized { rider } => {
+            let (stripped, unless_pay) = extract_resolution_unless_pay_modifier(&clause_text, None);
+            if unless_pay.is_some() {
+                unless_pay_deferred = unless_pay;
+                (None, stripped)
+            } else if unless_rider_defers_to_body_parser(text) {
+                (None, clause_text)
+            } else {
+                return parsed_unless_unsupported_clause(text, &rider);
+            }
+        }
+    };
+    let text = text.as_str();
     // Phase 2: peel structural slots off the head of the clause before
     // body parsing. The recursive shell strips slot-bearing prefixes/suffixes
     // (optional, opponent-may, condition, duration, for-each, player-scope)
@@ -4490,18 +4555,18 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     // `crates/engine/src/parser/clause_shell.rs` for the slot machinery.
     let (peeled_text, peel_ctx) = super::clause_shell::peel_clause(text);
     if peel_ctx.is_empty() {
-        let mut clause = parse_effect_clause_inner(text, ctx);
-        if unless_condition.is_some() {
-            clause.condition = unless_condition;
-        }
-        return clause;
+        return attach_unless_slots(
+            parse_effect_clause_inner(text, ctx),
+            unless_condition,
+            unless_pay_deferred,
+        );
     }
     if let Some(mut clause) = try_parse_for_each_effect(text, ctx) {
         peel_ctx.apply_optional(&mut clause.optional);
         if clause.condition.is_none() {
             clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
         }
-        return clause;
+        return attach_unless_slots(clause, None, unless_pay_deferred);
     }
     let original_lower = text.to_lowercase();
     if scan_contains_phrase(&original_lower, "this turn")
@@ -4518,7 +4583,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             if clause.condition.is_none() {
                 clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
             }
-            return clause;
+            return attach_unless_slots(clause, None, unless_pay_deferred);
         }
         if let Some(mut clause) =
             try_parse_additional_land_this_turn(TextPair::new(text, &original_lower))
@@ -4526,7 +4591,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             if clause.condition.is_none() {
                 clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
             }
-            return clause;
+            return attach_unless_slots(clause, None, unless_pay_deferred);
         }
     }
     let mut clause = parse_effect_clause_inner(&peeled_text, ctx);
@@ -4536,11 +4601,8 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     // retry with the original text. The shell is conservative — when in
     // doubt, leave the slot on the text and let the body parser handle it.
     if matches!(clause.effect, Effect::Unimplemented { .. }) {
-        let mut fallback = parse_effect_clause_inner(text, ctx);
-        if fallback.condition.is_none() {
-            fallback.condition = unless_condition;
-        }
-        return fallback;
+        let fallback = parse_effect_clause_inner(text, ctx);
+        return attach_unless_slots(fallback, unless_condition, unless_pay_deferred);
     }
     peel_ctx.apply_optional(&mut clause.optional);
     // Duration: route through `with_clause_duration` so
@@ -4563,7 +4625,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             clause.condition = Some(cond);
         }
     }
-    clause
+    attach_unless_slots(clause, None, unless_pay_deferred)
 }
 
 fn try_parse_for_each_copy_token_source(
@@ -19661,11 +19723,10 @@ pub(crate) fn parse_effect_chain_ir(
         // CR 608.2c + CR 400.7: "unless ~ entered this turn" — strip suffix and
         // replace condition with SourceDidNotEnterThisTurn. The IfYouDo condition
         // is redundant when the parent is optional (optional already gates the sub).
-        let (unless_entered, text) = strip_unless_entered_suffix(&text, ctx);
-        let condition = if unless_entered.is_some() {
-            unless_entered
-        } else {
-            condition
+        let (unless_strip, text) = strip_unless_entered_suffix(&text, ctx);
+        let condition = match unless_strip {
+            UnlessSuffixStrip::Parsed(c) => Some(c),
+            _ => condition,
         };
         // CR 608.2e: Strip leading "instead " when a condition was extracted.
         // The condition already encodes the replacement gate; "instead" is a
@@ -40907,13 +40968,13 @@ mod tests {
 
     #[test]
     fn strip_unless_entered_suffix_strips_correctly() {
-        let (cond, text) = strip_unless_entered_suffix(
+        let (strip, text) = strip_unless_entered_suffix(
             "discard a card unless ~ entered this turn",
             &mut ParseContext::default(),
         );
         assert_eq!(
-            cond,
-            Some(AbilityCondition::Not {
+            strip,
+            UnlessSuffixStrip::Parsed(AbilityCondition::Not {
                 condition: Box::new(AbilityCondition::SourceEnteredThisTurn),
             }),
             "Should produce Not(SourceEnteredThisTurn) condition"
@@ -40923,22 +40984,22 @@ mod tests {
 
     #[test]
     fn strip_unless_entered_suffix_no_match() {
-        let (cond, text) =
+        let (strip, text) =
             strip_unless_entered_suffix("discard a card", &mut ParseContext::default());
-        assert!(cond.is_none());
+        assert!(matches!(strip, UnlessSuffixStrip::Absent));
         assert_eq!(text, "discard a card");
     }
 
     #[test]
     fn strip_unless_general_your_turn() {
         // "unless it's your turn" → Not(DuringYourTurn) → IsYourTurn { negated: true }
-        let (cond, text) = strip_unless_entered_suffix(
+        let (strip, text) = strip_unless_entered_suffix(
             "draw a card unless it's your turn",
             &mut ParseContext::default(),
         );
         assert_eq!(
-            cond,
-            Some(AbilityCondition::Not {
+            strip,
+            UnlessSuffixStrip::Parsed(AbilityCondition::Not {
                 condition: Box::new(AbilityCondition::IsYourTurn)
             }),
         );
@@ -40948,12 +41009,12 @@ mod tests {
     #[test]
     fn strip_unless_you_control_a_creature() {
         // "unless you control a creature" → Not(IsPresent) → ObjectCount EQ 0
-        let (cond, text) = strip_unless_entered_suffix(
+        let (strip, text) = strip_unless_entered_suffix(
             "sacrifice this enchantment unless you control a creature",
             &mut ParseContext::default(),
         );
-        match cond {
-            Some(AbilityCondition::QuantityCheck {
+        match strip {
+            UnlessSuffixStrip::Parsed(AbilityCondition::QuantityCheck {
                 comparator: Comparator::EQ,
                 rhs: QuantityExpr::Fixed { value: 0 },
                 ..
@@ -40965,11 +41026,14 @@ mod tests {
 
     #[test]
     fn strip_unless_opponent_poison_counters() {
-        let (cond, text) = strip_unless_entered_suffix(
+        let (strip, text) = strip_unless_entered_suffix(
             "sacrifice a creature unless an opponent has three or more poison counters",
             &mut ParseContext::default(),
         );
-        assert!(cond.is_some(), "expected unless poison gate, got {cond:?}");
+        assert!(
+            matches!(strip, UnlessSuffixStrip::Parsed(_)),
+            "expected unless poison gate, got {strip:?}"
+        );
         assert_eq!(text, "sacrifice a creature");
     }
 
@@ -40987,12 +41051,24 @@ mod tests {
     }
 
     #[test]
-    fn strip_unless_unrecognized_returns_none() {
-        let (cond, text) = strip_unless_entered_suffix(
+    fn parse_effect_clause_unrecognized_unless_fails_closed() {
+        let clause = parse_effect_clause(
+            "draw a card unless the active player compliments your hat",
+            &mut ParseContext::default(),
+        );
+        assert!(
+            matches!(clause.effect, Effect::Unimplemented { .. }),
+            "unrecognized unless rider must fail closed, got {clause:?}"
+        );
+    }
+
+    #[test]
+    fn strip_unless_unrecognized_returns_unrecognized() {
+        let (strip, text) = strip_unless_entered_suffix(
             "sacrifice it unless something weird happens",
             &mut ParseContext::default(),
         );
-        assert!(cond.is_none());
+        assert!(matches!(strip, UnlessSuffixStrip::Unrecognized { .. }));
         assert_eq!(text, "sacrifice it unless something weird happens");
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4475,6 +4475,11 @@ fn try_parse_for_each_category_exile(tp: TextPair<'_>) -> Option<ParsedEffectCla
 
 #[tracing::instrument(level = "debug")]
 fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause {
+    // CR 608.2c: "do X unless [game state]" — strip trailing unless suffix and
+    // attach the negated gate before body parsing (payment-unless uses
+    // `unless_pay` / `extract_resolution_unless_pay_modifier` instead).
+    let (unless_condition, clause_text) = strip_unless_entered_suffix(text, ctx);
+    let text = clause_text.as_str();
     // Phase 2: peel structural slots off the head of the clause before
     // body parsing. The recursive shell strips slot-bearing prefixes/suffixes
     // (optional, opponent-may, condition, duration, for-each, player-scope)
@@ -4485,14 +4490,16 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     // `crates/engine/src/parser/clause_shell.rs` for the slot machinery.
     let (peeled_text, peel_ctx) = super::clause_shell::peel_clause(text);
     if peel_ctx.is_empty() {
-        return parse_effect_clause_inner(text, ctx);
+        let mut clause = parse_effect_clause_inner(text, ctx);
+        if unless_condition.is_some() {
+            clause.condition = unless_condition;
+        }
+        return clause;
     }
     if let Some(mut clause) = try_parse_for_each_effect(text, ctx) {
         peel_ctx.apply_optional(&mut clause.optional);
         if clause.condition.is_none() {
-            if let Some(cond) = peel_ctx.condition().cloned() {
-                clause.condition = Some(cond);
-            }
+            clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
         }
         return clause;
     }
@@ -4509,9 +4516,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
                 peel_ctx.apply_optional(&mut clause.optional);
             }
             if clause.condition.is_none() {
-                if let Some(cond) = peel_ctx.condition().cloned() {
-                    clause.condition = Some(cond);
-                }
+                clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
             }
             return clause;
         }
@@ -4519,9 +4524,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             try_parse_additional_land_this_turn(TextPair::new(text, &original_lower))
         {
             if clause.condition.is_none() {
-                if let Some(cond) = peel_ctx.condition().cloned() {
-                    clause.condition = Some(cond);
-                }
+                clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
             }
             return clause;
         }
@@ -4533,7 +4536,11 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     // retry with the original text. The shell is conservative — when in
     // doubt, leave the slot on the text and let the body parser handle it.
     if matches!(clause.effect, Effect::Unimplemented { .. }) {
-        return parse_effect_clause_inner(text, ctx);
+        let mut fallback = parse_effect_clause_inner(text, ctx);
+        if fallback.condition.is_none() {
+            fallback.condition = unless_condition;
+        }
+        return fallback;
     }
     peel_ctx.apply_optional(&mut clause.optional);
     // Duration: route through `with_clause_duration` so
@@ -4552,7 +4559,7 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
     // 6020+ runs before parse_effect_clause and may already have set
     // `condition` via its own dedicated stripper chain — don't clobber.
     if clause.condition.is_none() {
-        if let Some(cond) = peel_ctx.condition().cloned() {
+        if let Some(cond) = peel_ctx.condition().cloned().or(unless_condition) {
             clause.condition = Some(cond);
         }
     }
@@ -40954,6 +40961,29 @@ mod tests {
             other => panic!("expected ObjectCount EQ 0, got {:?}", other),
         }
         assert_eq!(text, "sacrifice this enchantment");
+    }
+
+    #[test]
+    fn strip_unless_opponent_poison_counters() {
+        let (cond, text) = strip_unless_entered_suffix(
+            "sacrifice a creature unless an opponent has three or more poison counters",
+            &mut ParseContext::default(),
+        );
+        assert!(cond.is_some(), "expected unless poison gate, got {cond:?}");
+        assert_eq!(text, "sacrifice a creature");
+    }
+
+    #[test]
+    fn parse_effect_clause_unless_they_control_basic_lands() {
+        let clause = parse_effect_clause(
+            "~ deals 2 damage to that player unless they control two or more basic lands",
+            &mut ParseContext::default(),
+        );
+        assert!(
+            clause.condition.is_some(),
+            "expected unless control gate on clause, got {clause:?}"
+        );
+        assert!(!matches!(clause.effect, Effect::Unimplemented { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4482,6 +4482,26 @@ fn unless_rider_defers_to_body_parser(text: &str) -> bool {
     };
     let before_trimmed = before_unless.trim_start();
     let unless_tail = &lower[before_unless.len()..];
+    let after_trimmed = after_unless.trim_end_matches('.').trim();
+
+    // CR 605.1a: activation prohibition mana-ability exemption (restriction.rs).
+    if tag::<_, _, OracleError<'_>>("they're mana abilities")
+        .parse(after_trimmed)
+        .is_ok()
+    {
+        return true;
+    }
+
+    // CR 508.1h + CR 118.12: combat-tax static UnlessPay (parse_static_line path).
+    if alt((
+        tag::<_, _, OracleError<'_>>("their controller pays "),
+        tag("its controller pays "),
+    ))
+    .parse(after_unless)
+    .is_ok()
+    {
+        return true;
+    }
 
     // CR 608.2c: discard imperative + unless discard qualifier (imperative.rs).
     if tag::<_, _, OracleError<'_>>("discard ")

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -85,6 +85,7 @@ fn parse_single_inner_condition(input: &str) -> OracleResult<'_, StaticCondition
 
 fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
+        parse_they_scoped_player_conditions,
         parse_turn_conditions,
         // CR 208.1 + CR 603.4 + CR 109.3: Superlative-comparison gate
         // ("if its power is greater than each other creature's power" /
@@ -2396,6 +2397,74 @@ fn parse_you_have_typed_cards_in_your_graveyard(input: &str) -> OracleResult<'_,
         )));
     }
     Ok((rest, type_filters))
+}
+
+/// Parse "they have exactly N [or exactly M ...] cards in hand" and
+/// "they control N or more [type]" for scoped-player unless/if gates
+/// (Skullcage, Furnace Punisher class). "They" binds to
+/// `PlayerScope::ScopedPlayer` at resolution time (CR 603.7c).
+fn parse_they_scoped_player_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
+    alt((
+        parse_they_hand_size_exact_disjunction,
+        parse_they_control_count_ge,
+    ))
+    .parse(input)
+}
+
+fn parse_they_hand_size_exact_disjunction(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("they have ").parse(input)?;
+    let (rest, first_n) = preceded(tag("exactly "), parse_number).parse(rest)?;
+    let mut counts = vec![first_n];
+    let mut rest = rest;
+    while let Ok((next, n)) = preceded(tag(" or exactly "), parse_number).parse(rest) {
+        counts.push(n);
+        rest = next;
+    }
+    let (rest, _) = tag(" cards in hand").parse(rest)?;
+    let player = PlayerScope::ScopedPlayer;
+    let conditions: Vec<StaticCondition> = counts
+        .into_iter()
+        .map(|n| StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::HandSize {
+                    player: player.clone(),
+                },
+            },
+            comparator: Comparator::EQ,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
+        })
+        .collect();
+    let condition = if conditions.len() == 1 {
+        conditions.into_iter().next().expect("one count")
+    } else {
+        StaticCondition::Or { conditions }
+    };
+    Ok((rest, condition))
+}
+
+fn parse_they_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("they control ").parse(input)?;
+    let (rest, n) = parse_ge_threshold(rest)?;
+    let type_text = rest.trim_end_matches('.');
+    let (filter, remainder) = parse_type_phrase(type_text);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let filter = inject_controller(filter, ControllerRef::ScopedPlayer);
+    let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
+    Ok((
+        &input[consumed..],
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
+        },
+    ))
 }
 
 /// Parse "that player has" / "that opponent has" quantity conditions.
@@ -10488,6 +10557,26 @@ mod tests {
             matches!(c, StaticCondition::UnlessPay { .. }),
             "expected raw UnlessPay (not Not-wrapped), got {c:?}"
         );
+    }
+
+    #[test]
+    fn test_they_hand_size_exact_disjunction() {
+        let (rest, c) =
+            parse_inner_condition("they have exactly three or exactly four cards in hand").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::Or { conditions } => {
+                assert_eq!(conditions.len(), 2);
+            }
+            other => panic!("expected Or of exact hand sizes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_they_control_two_or_more_basic_lands() {
+        let (rest, c) = parse_inner_condition("they control two or more basic lands").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(c, StaticCondition::QuantityComparison { .. }));
     }
 
     // -- Source power/toughness comparison conditions --

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2402,7 +2402,9 @@ fn parse_you_have_typed_cards_in_your_graveyard(input: &str) -> OracleResult<'_,
 /// Parse "they have exactly N [or exactly M ...] cards in hand" and
 /// "they control N or more [type]" for scoped-player unless/if gates
 /// (Skullcage, Furnace Punisher class). "They" binds to
-/// `PlayerScope::ScopedPlayer` at resolution time (CR 603.7c).
+/// `PlayerScope::ScopedPlayer` — the relative-player slot established by
+/// trigger `relative_player_scope` / event-player context for per-player
+/// damage and punishment riders.
 fn parse_they_scoped_player_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
         parse_they_hand_size_exact_disjunction,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -23470,17 +23470,10 @@ mod tests {
 
         assert!(def.unless_pay.is_none());
         let execute = def.execute.as_ref().expect("should have execute");
-        // Game-state unless the parser cannot decompose no longer dead-ends the
-        // whole trigger body — the primary effect still lowers; the unparseable
-        // unless rider remains a coverage gap on the unparsed tail.
         assert!(
-            matches!(*execute.effect, Effect::Draw { .. }),
-            "primary effect should still parse when unless rider is unrecognized, got {:?}",
+            matches!(*execute.effect, Effect::Unimplemented { .. }),
+            "unrecognized unless clause must remain visible as Unimplemented, got {:?}",
             execute.effect
-        );
-        assert!(
-            execute.condition.is_none(),
-            "unrecognized unless must not attach a bogus condition"
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -994,17 +994,6 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                 ability.optional = true;
             }
             Some(TriggerBody::PreLowered(Box::new(ability)))
-        } else if unless_pay.is_none()
-            && scan_contains(&effect_for_parse_lower, "unless")
-            && !has_later_sentence_if(&effect_for_parse_lower)
-        {
-            Some(TriggerBody::PreLowered(Box::new(AbilityDefinition::new(
-                AbilityKind::Spell,
-                Effect::Unimplemented {
-                    name: "Unsupported unless clause".to_string(),
-                    description: Some(effect_for_parse.clone()),
-                },
-            ))))
         } else {
             try_parse_exile_top_each_library_with_collection_counter(
                 &effect_for_parse,
@@ -23481,10 +23470,17 @@ mod tests {
 
         assert!(def.unless_pay.is_none());
         let execute = def.execute.as_ref().expect("should have execute");
+        // Game-state unless the parser cannot decompose no longer dead-ends the
+        // whole trigger body — the primary effect still lowers; the unparseable
+        // unless rider remains a coverage gap on the unparsed tail.
         assert!(
-            matches!(*execute.effect, Effect::Unimplemented { .. }),
-            "unrecognized unless clause must remain visible as Unimplemented, got {:?}",
+            matches!(*execute.effect, Effect::Draw { .. }),
+            "primary effect should still parse when unless rider is unrecognized, got {:?}",
             execute.effect
+        );
+        assert!(
+            execute.condition.is_none(),
+            "unrecognized unless must not attach a bogus condition"
         );
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -14012,6 +14012,9 @@ pub enum AbilityCondition {
     /// CR 702.131c: "if you have the city's blessing" is true when the ability
     /// controller has the city's blessing designation.
     HasCityBlessing,
+    /// CR 701.54a: True when the ability's source permanent is its controller's
+    /// Ring-bearer. For "unless ~ is your Ring-bearer", wrap with `Not`.
+    IsRingBearer,
     /// CR 608.2e: "If [target] has [keyword], [override effect] instead"
     /// Checked at resolution time against the first resolved object target's keywords.
     /// Uses "Instead" override semantics: swaps the parent effect when condition is met.


### PR DESCRIPTION
## Summary

Wire **game-state “unless”** gates on triggered and one-shot effects: `"do X unless [condition]"` now lowers to effect **X** with a typed `AbilityCondition` (negated gate), distinct from existing payment-unless (`UnlessPayModifier` / CR 118.12).

Removes the trigger parser dead-end that emitted `Effect::Unimplemented { "Unsupported unless clause" }` whenever `unless` appeared without a pay/discard/sacrifice modifier. The effect-chain and clause parsers already had `strip_unless_entered_suffix`; this change routes triggers through that path and extends condition bridging/runtime for patterns the nom grammar already recognizes or newly covers.

## Changes

- **`oracle_trigger.rs`**: Drop the `Unsupported unless clause` pre-lower guard; unrecognized unless riders no longer block the primary effect parse.
- **`parse_effect_clause`** (`mod.rs`): Strip trailing `"unless …"` via `strip_unless_entered_suffix` and attach the resulting condition before body parsing (payment-unless still uses `unless_pay` / `extract_resolution_unless_pay_modifier`).
- **Scoped-player unless grammar** (`oracle_nom/condition.rs`):
  - `"they have exactly N or exactly M cards in hand"` (Skullcage class)
  - `"they control N or more [type]"` (Furnace Punisher class)
- **Static → ability bridging** (`conditions.rs`):
  - `OpponentPoisonAtLeast` → existential `QuantityCheck` over opponents with poison (Ravenous Necrotitan class)
  - `IsRingBearer` → new `AbilityCondition::IsRingBearer` with resolution-time evaluation
  - `Not { inner }` fallback bridges any mappable inner condition (unless-wrapped `Or`, etc.)
- **Runtime** (`effects/mod.rs`): Evaluate `AbilityCondition::IsRingBearer` via `ring::is_current_ring_bearer`.

## Test plan

- [x] `strip_unless_opponent_poison_counters`
- [x] `parse_effect_clause_unless_they_control_basic_lands`
- [x] `test_they_hand_size_exact_disjunction`
- [x] `test_they_control_two_or_more_basic_lands`
- [x] `trigger_unrecognized_unless_payment_preserves_clause_as_gap` (updated: primary effect parses, no bogus condition)
- [x] `cargo test -p engine --lib unless` (173 passed)
- [ ] Regenerate / diff coverage for `Effect:Unsupported unless clause` + `Swallow:Condition_Unless` reduction
- [ ] Spot-check: Ravenous Necrotitan, Skullcage, Furnace Punisher, Sauron Ring-bearer delayed trigger, Kroxa-style payment-unless still on `unless_pay`
