### PR TITLE
fix(engine): generalize composite-cost affordability witness to Exile/ReturnToHand-from-battlefield (AI dead-end)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11761,6 +11761,69 @@ pub(super) fn find_non_self_sacrifice_cost(cost: &AbilityCost) -> Option<(u32, &
     }
 }
 
+/// Which battlefield-removing non-mana cost leg a composite carries. Each is a
+/// distinct CR keyword action / zone change but all remove a permanent from the
+/// battlefield (CR 701.21a Sacrifice / CR 701.13a Exile / plain bounce), so one
+/// MutationWitness models all three.
+pub(super) enum RemovalKind {
+    Sacrifice,
+    Exile,
+    ReturnToHand,
+}
+
+/// CR 601.2h: first non-self battlefield-removing leg of `cost`, by kind
+/// priority (Sacrifice > Exile > ReturnToHand). Composes the existing per-kind
+/// cost walkers. Returns at most ONE leg (single-leg limit documented at the
+/// `can_pay` call site).
+pub(super) fn find_non_self_battlefield_removal_cost(
+    cost: &AbilityCost,
+) -> Option<(u32, &TargetFilter, RemovalKind)> {
+    if let Some((n, f)) = find_non_self_sacrifice_cost(cost) {
+        return Some((n, f, RemovalKind::Sacrifice));
+    }
+    if let Some((n, f)) = find_battlefield_exile_cost(cost) {
+        return Some((n, f, RemovalKind::Exile));
+    }
+    if let Some((n, Some(f))) = find_return_to_hand_cost(cost) {
+        // Mirror the Sacrifice/Exile SelfRef exclusion: a self-bounce is the
+        // source's own removal, not a board-shrinking non-mana leg in the
+        // CR 601.2h ordering sense. Recognizing it would let the lone witness
+        // remove the source and false-REJECT a self-bounce whose mana leg the
+        // source itself feeds.
+        if !matches!(f, TargetFilter::SelfRef) {
+            return Some((n, f, RemovalKind::ReturnToHand));
+        }
+    }
+    None
+}
+
+/// CR 701.13a: first non-self Exile leg whose *effective* source zone is the
+/// battlefield, reusing the live zone classifier
+/// `cost_payability::exile_cost_effective_zone` (a `zone: None` + non-permanent
+/// filter resolves to Hand and MUST NOT route here — that would false-reject a
+/// payable hand-exile composite). A `None` filter is out of scope. The
+/// `SelfRef`-first arm is required: a SelfRef filter may be permanent-implying
+/// and would otherwise pass the battlefield gate.
+fn find_battlefield_exile_cost(cost: &AbilityCost) -> Option<(u32, &TargetFilter)> {
+    match cost {
+        AbilityCost::Exile {
+            filter: Some(TargetFilter::SelfRef),
+            ..
+        } => None,
+        AbilityCost::Exile {
+            count,
+            zone,
+            filter,
+        } if super::cost_payability::exile_cost_effective_zone(*zone, filter.as_ref())
+            == Zone::Battlefield =>
+        {
+            filter.as_ref().map(|f| (*count, f))
+        }
+        AbilityCost::Composite { costs } => costs.iter().find_map(find_battlefield_exile_cost),
+        _ => None,
+    }
+}
+
 pub(crate) fn find_non_self_discard(
     cost: &AbilityCost,
 ) -> Option<(&QuantityExpr, Option<&TargetFilter>)> {

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1024,17 +1024,20 @@ fn pay_ability_cost_inner(
 }
 
 /// A minimal board mutation modeled on a throwaway clone by the activation-time
-/// supplemental affordability check (`composite_sacrifice_mana_witness_exists`).
+/// supplemental affordability check (`composite_removal_mana_witness_exists`).
 ///
 /// Each variant names a concrete way the live cost-payment path mutates the
 /// board *before* the residual mana leg is paid, so the affordability oracle can
 /// re-derive remaining-board mana on the post-mutation state instead of the
 /// (over-approximating) intact board.
 enum MutationWitness {
-    /// CR 701.21a: Sacrifice the carried permanent(s) — each is removed from the
-    /// battlefield to its owner's graveyard. The `(ObjectId, PlayerId)` pairs are
-    /// the witness object and its owner.
-    Sacrifice(Vec<(ObjectId, PlayerId)>),
+    /// Remove the carried permanent(s) from the battlefield. Models every
+    /// battlefield-removing non-mana cost leg — CR 701.21a Sacrifice (→ owner's
+    /// graveyard), CR 701.13a Exile (→ exile), or a plain bounce (→ owner's
+    /// hand) — since only the battlefield removal affects the remaining-board
+    /// mana the oracle re-derives; the destination zone is irrelevant. The
+    /// `(ObjectId, PlayerId)` pairs are the witness object and its owner.
+    RemoveFromBattlefield(Vec<(ObjectId, PlayerId)>),
 }
 
 /// Apply a [`MutationWitness`] to a throwaway clone.
@@ -1047,11 +1050,11 @@ enum MutationWitness {
 /// does NOT mark layers dirty, so `layers::mark_layers_full` is mandatory here.
 fn apply_mutation_witness(sim: &mut GameState, witness: &MutationWitness) {
     match witness {
-        MutationWitness::Sacrifice(removals) => {
-            // CR 701.21a: battlefield → graveyard. The graveyard add is
-            // intentionally omitted — the destination zone is irrelevant to the
-            // remaining-board mana the oracle re-derives below; only the
-            // battlefield removal matters.
+        MutationWitness::RemoveFromBattlefield(removals) => {
+            // CR 701.21a / CR 701.13a / plain bounce: remove from the
+            // battlefield. The destination-zone add is intentionally omitted —
+            // the destination is irrelevant to the remaining-board mana the
+            // oracle re-derives below; only the battlefield removal matters.
             for &(id, owner) in removals {
                 super::zones::remove_from_zone(sim, id, Zone::Battlefield, owner);
             }
@@ -1064,11 +1067,13 @@ fn apply_mutation_witness(sim: &mut GameState, witness: &MutationWitness) {
 }
 
 /// Enumerate the single-witness mutation set for the supplemental affordability
-/// check. Gated on a non-self single-permanent sacrifice leg
-/// (`find_non_self_sacrifice_cost`): for `count == 1`, emit one singleton
-/// `Sacrifice` witness per eligible permanent (the existential candidates).
+/// check. Gated on a non-self single-permanent battlefield-removing leg
+/// (`find_non_self_battlefield_removal_cost` — Sacrifice / Exile-from-bf /
+/// ReturnToHand-from-bf): for `count == 1`, emit one singleton
+/// `RemoveFromBattlefield` witness per eligible permanent (the existential
+/// candidates).
 ///
-/// For `count > 1` (or no non-self sacrifice leg) this returns an empty `Vec` —
+/// For `count > 1` (or no non-self removal leg) this returns an empty `Vec` —
 /// the caller MUST treat an empty set as "out of scope, do not reject" rather
 /// than feeding it into `.any()` (which would wrongly yield `false`). See the
 /// wiring in [`can_pay`].
@@ -1078,31 +1083,59 @@ fn mutation_witness_set(
     source_id: ObjectId,
     cost: &AbilityCost,
 ) -> Vec<MutationWitness> {
-    let Some((count, filter)) = super::casting::find_non_self_sacrifice_cost(cost) else {
+    use super::casting::RemovalKind;
+    let Some((count, filter, kind)) = super::casting::find_non_self_battlefield_removal_cost(cost)
+    else {
         return Vec::new();
     };
     if count != 1 {
+        // count > 1 deferred (AMENDMENT 1).
         return Vec::new();
     }
-    super::casting::find_eligible_sacrifice_targets(state, payer, source_id, filter)
-        .into_iter()
+    // Exhaustive match (no wildcard): a future removal kind must force a
+    // deliberate arm here.
+    let ids = match kind {
+        RemovalKind::Sacrifice => {
+            super::casting::find_eligible_sacrifice_targets(state, payer, source_id, filter)
+        }
+        RemovalKind::ReturnToHand => super::casting::find_eligible_return_to_hand_targets(
+            state,
+            payer,
+            source_id,
+            Some(filter),
+        ),
+        // For `Zone::Battlefield` the `count` arg to `eligible_exile_cost_objects`
+        // is ignored (only the Library arm uses `take(count)`), so this
+        // enumerates ALL eligible battlefield objects; passing `1` does not cap
+        // the existential search.
+        RemovalKind::Exile => super::cost_payability::eligible_exile_cost_objects(
+            state,
+            payer,
+            source_id,
+            Zone::Battlefield,
+            Some(filter),
+            1,
+        ),
+    };
+    ids.into_iter()
         .filter_map(|id| {
             state
                 .objects
                 .get(&id)
-                .map(|obj| MutationWitness::Sacrifice(vec![(id, obj.owner)]))
+                .map(|obj| MutationWitness::RemoveFromBattlefield(vec![(id, obj.owner)]))
         })
         .collect()
 }
 
 /// CR 601.2h: single-witness monotonic existential affordability check for the
-/// "conditional static mana leg + non-self single-sacrifice" composite shape.
+/// "conditional static mana leg + non-self single battlefield-removal" composite
+/// shape (Sacrifice / Exile-from-bf / ReturnToHand-from-bf).
 ///
-/// The composite is genuinely payable iff THERE EXISTS one eligible sacrifice
-/// whose removal (applied on a throwaway clone) leaves the static mana leg
-/// payable. First-success early-return: `.any()` stops at the first witness that
-/// keeps the mana payable.
-fn composite_sacrifice_mana_witness_exists(
+/// The composite is genuinely payable iff THERE EXISTS one eligible removal
+/// whose application (on a throwaway clone) leaves the static mana leg payable.
+/// First-success early-return: `.any()` stops at the first witness that keeps
+/// the mana payable.
+fn composite_removal_mana_witness_exists(
     state: &GameState,
     payer: PlayerId,
     source_id: ObjectId,
@@ -1186,26 +1219,30 @@ pub(crate) fn can_pay(
             }
             // CR 601.2f / CR 602.2b: an activated ability's activation cost is the
             // analog of a spell's mana cost, so the CR 601.2h ordering applies.
-            // CR 601.2h: the live path pays the sacrifice FIRST and the mana
-            // LAST. The dry-run above pays mana first (board intact) and no-ops a
-            // non-self sacrifice, so it over-approves a "{N}, Sacrifice a
-            // permanent" cost whose only {N} source is gated on the sacrificed
-            // board (Mox Opal Metalcraft / affinity-style reductions). CR 118.3:
-            // supplement the dry run with a single-witness monotonic existence
-            // check for that exact shape — does ANY eligible sacrifice leave the
-            // mana leg payable on the post-sacrifice board?
-            if let (Some(mana), Some((count, _))) = (
+            // CR 601.2h: the live path pays the non-mana leg FIRST and mana LAST;
+            // the dry-run above no-ops the leg, over-approving whenever the leg
+            // shrinks board mana (Metalcraft/affinity/devotion). Supplement with
+            // a single-witness existence check across Sacrifice / Exile-from-bf /
+            // ReturnToHand-from-bf.
+            //
+            // SINGLE-LEG LIMIT: find_non_self_battlefield_removal_cost returns at
+            // most ONE removal leg. A Composite carrying TWO removal legs
+            // (Sacrifice + Exile) is modeled as removing only one — fewer
+            // removals over-approximate remaining mana, so this can only
+            // false-APPROVE (preserves the no-new-dead-end direction). The
+            // shipped Sacrifice version had the same single-leg limit.
+            if let (Some(mana), Some((count, _, _))) = (
                 super::casting::composite_mana_leg(cost),
-                super::casting::find_non_self_sacrifice_cost(cost),
+                super::casting::find_non_self_battlefield_removal_cost(cost),
             ) {
                 if count == 1 {
-                    return composite_sacrifice_mana_witness_exists(
+                    return composite_removal_mana_witness_exists(
                         state, payer, source_id, cost, mana,
                     );
                 }
                 // AMENDMENT 1: count > 1 is OUT OF SCOPE — fall through to the
                 // unchanged `true` below (preserves today's over-approximation;
-                // a count >= 2 conditional-mana-base sacrifice is a vanishingly
+                // a count >= 2 conditional-mana-base removal is a vanishingly
                 // rare tracked follow-up). MUST NOT reject count > 1 here.
             }
             true
@@ -1908,7 +1945,7 @@ mod tests {
     /// path. Three CONSTANT clones, none scaling with the eligible-set size K:
     ///   1. the existing `can_pay` dry-run clone;
     ///   2. the first (and, via first-success early-return, ONLY) witness clone in
-    ///      `composite_sacrifice_mana_witness_exists`;
+    ///      `composite_removal_mana_witness_exists`;
     ///   3. one mana-ability simulation clone
     ///      (`can_activate_mana_ability_by_simulation`) when that single witness's
     ///      `can_pay_effect_mana_cost_after_auto_tap` evaluates the Mox's tap mana
@@ -2211,6 +2248,141 @@ mod tests {
         assert!(
             !can_pay_activation(&scenario.state, claws, &claws_cost()),
             "sacrifice drops to 2 artifacts → layer reflush removes granted {{1}} → unpayable"
+        );
+    }
+
+    /// BLOCKER-1 regression (CR 117.1 + CR 701.13a): a `Composite[{N}, Exile a
+    /// CARD]` whose exile leg has `zone: None` and a NON-permanent filter must
+    /// classify to `Zone::Hand`, so the battlefield-removal walker returns
+    /// `None` and the supplemental witness block is SKIPPED — the composite keeps
+    /// the unchanged dry-run verdict (payable) and is NOT falsely rejected. If
+    /// `find_battlefield_exile_cost` wrongly routed a hand-exile here, the
+    /// witness set (battlefield objects matching the card filter, excluding the
+    /// source) would be empty and `can_pay` would flip to `false`.
+    #[test]
+    fn hand_exile_composite_not_routed_to_battlefield_removal() {
+        use crate::types::ability::TypeFilter;
+        let card_filter = TargetFilter::Typed(TypedFilter::new(TypeFilter::Card));
+        // Classifier: a `zone: None` + non-permanent (Card) filter is Hand, not
+        // Battlefield — the exact false-reject guard documented at the walker.
+        assert_eq!(
+            crate::game::cost_payability::exile_cost_effective_zone(None, Some(&card_filter)),
+            Zone::Hand,
+            "zone:None + Card filter must classify to Hand"
+        );
+        let cost = AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Mana {
+                    cost: ManaCost::NoCost,
+                },
+                AbilityCost::Exile {
+                    count: 1,
+                    zone: None,
+                    filter: Some(card_filter),
+                },
+            ],
+        };
+        // The battlefield-removal walker must NOT match a hand-exile leg.
+        assert!(
+            crate::game::casting::find_non_self_battlefield_removal_cost(&cost).is_none(),
+            "hand-exile leg must not be treated as a battlefield removal"
+        );
+        // can_pay keeps the dry-run verdict: NoCost mana + no-op activation-scope
+        // exile → payable, and the skipped witness block must not reject it.
+        let mut scenario = GameScenario::new();
+        let src = scenario.add_creature(P0, "Jhoira", 0, 1).id();
+        scenario.add_card_to_hand(P0, "Some Card");
+        assert!(
+            can_pay_activation(&scenario.state, src, &cost),
+            "hand-exile composite must keep its unchanged (payable) dry-run verdict"
+        );
+    }
+
+    /// Row 4 (count > 1 exile fall-through, AMENDMENT 1): a
+    /// `Composite[{1}, Exile TWO artifacts from the battlefield]` on a board where
+    /// the only `{1}` source is Metalcraft-gated must NOT be rejected — count > 1
+    /// is out of scope and falls through to the unchanged `true`. Mirrors the
+    /// count==2 sacrifice guard (`claws_sacrifice_two_count_gt_one_not_rejected`).
+    #[test]
+    fn exile_two_count_gt_one_not_rejected() {
+        use crate::types::ability::TypeFilter;
+        let mut scenario = GameScenario::new();
+        metalcraft_mox(&mut scenario);
+        plain_artifact(&mut scenario, "Filler 1");
+        let src = plain_artifact(&mut scenario, "Exiler");
+        let cost_two = AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Mana {
+                    cost: ManaCost::generic(1),
+                },
+                AbilityCost::Exile {
+                    count: 2,
+                    zone: Some(Zone::Battlefield),
+                    filter: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact))),
+                },
+            ],
+        };
+        assert!(
+            can_pay_activation(&scenario.state, src, &cost_two),
+            "count > 1 exile composite falls through to today's over-approximation (true)"
+        );
+    }
+
+    /// Row 5 (Discard excluded): a `Composite[{1}, Discard a card]` is NOT a
+    /// battlefield removal — discard shrinks the hand, never the board, so it can
+    /// never change board-derived mana. The walker must return `None` (proven
+    /// no-op, deliberately out of scope).
+    #[test]
+    fn discard_leg_is_not_battlefield_removal() {
+        let cost = AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Mana {
+                    cost: ManaCost::generic(1),
+                },
+                AbilityCost::Discard {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    filter: None,
+                    selection: CardSelectionMode::Chosen,
+                    self_scope: DiscardSelfScope::FromHand,
+                },
+            ],
+        };
+        assert!(
+            crate::game::casting::find_non_self_battlefield_removal_cost(&cost).is_none(),
+            "Discard must not be treated as a battlefield removal"
+        );
+    }
+
+    /// Row 6 (self-ref excluded): a self-referential Exile or Sacrifice leg
+    /// (Scavenge/Suspend-style self-exile, "Sacrifice this") is the source's own
+    /// removal, not a board-shrinking non-mana leg in the CR 601.2h ordering
+    /// sense — the walker must return `None` for both. The SelfRef-first arm in
+    /// `find_battlefield_exile_cost` exists precisely because a SelfRef filter can
+    /// be permanent-implying and would otherwise pass the battlefield gate.
+    #[test]
+    fn self_ref_removal_legs_are_out_of_scope() {
+        let self_exile = AbilityCost::Exile {
+            count: 1,
+            zone: None,
+            filter: Some(TargetFilter::SelfRef),
+        };
+        assert!(
+            crate::game::casting::find_non_self_battlefield_removal_cost(&self_exile).is_none(),
+            "self-exile leg must not be treated as a battlefield removal"
+        );
+        let self_sacrifice = AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1));
+        assert!(
+            crate::game::casting::find_non_self_battlefield_removal_cost(&self_sacrifice).is_none(),
+            "self-sacrifice leg must not be treated as a battlefield removal"
+        );
+        let self_return = AbilityCost::ReturnToHand {
+            count: 1,
+            filter: Some(TargetFilter::SelfRef),
+            from_zone: None,
+        };
+        assert!(
+            crate::game::casting::find_non_self_battlefield_removal_cost(&self_return).is_none(),
+            "self-bounce leg must not be treated as a battlefield removal"
         );
     }
 

--- a/crates/phase-ai/tests/scenarios.rs
+++ b/crates/phase-ai/tests/scenarios.rs
@@ -698,3 +698,295 @@ fn scenario_claws_of_gix_no_witness_board_never_proposes_activation() {
         "no-witness board must not dead-end the AI loop"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Battlefield-removal generalization of the Claws-of-Gix witness (CR 601.2h):
+// the same dead-end (the non-mana leg is paid FIRST and shrinks board mana) now
+// also covers Exile-from-battlefield (CR 701.13a, Curie) and ReturnToHand-from-
+// battlefield (plain bounce, Master Transmuter). Each removes a permanent the
+// only {U} source depends on, so over-approving `can_pay` would surface an
+// unactivatable ability and dead-end the AI loop.
+// ---------------------------------------------------------------------------
+
+/// `{T}: Add {U}` mana ability. When `metalcraft` is set the ability is gated by
+/// a live-eval "control 3+ artifacts" `ActivationRestriction::RequiresCondition`
+/// (the Mox-Opal model); otherwise it is unconditional.
+fn blue_mox_def(metalcraft: bool) -> engine::types::ability::AbilityDefinition {
+    use engine::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Comparator,
+        ControllerRef, ParsedCondition, QuantityRef, TypeFilter, TypedFilter,
+    };
+    use engine::types::mana::ManaColor;
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Mana {
+            produced: engine::types::ManaProduction::Fixed {
+                colors: vec![ManaColor::Blue],
+                contribution: engine::types::ability::ManaContribution::Base,
+            },
+            restrictions: vec![],
+            grants: vec![],
+            expiry: None,
+            target: None,
+        },
+    )
+    .cost(AbilityCost::Tap);
+    if metalcraft {
+        def.activation_restrictions
+            .push(ActivationRestriction::RequiresCondition {
+                condition: Some(ParsedCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(
+                                TypedFilter::new(TypeFilter::Artifact)
+                                    .controller(ControllerRef::You),
+                            ),
+                        },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 3 },
+                }),
+            });
+    }
+    def
+}
+
+/// Curie-style activated ability: `{1}{U}, Exile another nontoken artifact you
+/// control: gain 1 life` (effect stubbed to GainLife). The exile leg has
+/// `zone: None` + an artifact (permanent-implying) filter, so the live zone
+/// classifier resolves it to the battlefield (CR 701.13a). The building block
+/// under test is "exile-from-battlefield as a cost shrinks board mana"; the
+/// scenario fixtures are pure artifacts (the builder's `as_artifact` drops the
+/// creature type), so the filter matches "another nontoken artifact" rather than
+/// Curie's printed "artifact creature" — the witness mechanic is identical.
+fn curie_def() -> engine::types::ability::AbilityDefinition {
+    use engine::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, FilterProp, TypeFilter,
+        TypedFilter,
+    };
+    use engine::types::mana::{ManaCost, ManaCostShard};
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+    )
+    .cost(AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Blue],
+                    generic: 1,
+                },
+            },
+            AbilityCost::Exile {
+                count: 1,
+                zone: None,
+                filter: Some(TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Artifact)
+                        .controller(ControllerRef::You)
+                        .properties(vec![FilterProp::Another, FilterProp::NonToken]),
+                )),
+            },
+        ],
+    })
+}
+
+/// Master Transmuter's activated ability: `{U}, {T}, Return an artifact you
+/// control to its owner's hand: gain 1 life` (effect stubbed to GainLife). The
+/// return leg has `from_zone: None` (battlefield bounce, CR 118.3).
+fn master_transmuter_def() -> engine::types::ability::AbilityDefinition {
+    use engine::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, TypeFilter, TypedFilter,
+    };
+    use engine::types::mana::{ManaCost, ManaCostShard};
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+    )
+    .cost(AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Blue],
+                    generic: 0,
+                },
+            },
+            AbilityCost::Tap,
+            AbilityCost::ReturnToHand {
+                count: 1,
+                filter: Some(TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Artifact).controller(ControllerRef::You),
+                )),
+                from_zone: None,
+            },
+        ],
+    })
+}
+
+/// Set the runner into a P0-priority main-phase decision point (mirrors the
+/// Claws scenarios).
+fn put_p0_on_priority(runner: &mut engine::game::scenario::GameRunner) {
+    let state = runner.state_mut();
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+}
+
+/// Whether `legal_actions` surfaces an `ActivateAbility` whose source is `id`.
+fn activation_legal_for(state: &engine::types::game_state::GameState, id: ObjectId) -> bool {
+    use engine::types::actions::GameAction;
+    engine::ai_support::legal_actions(state)
+        .iter()
+        .any(|a| matches!(a, GameAction::ActivateAbility { source_id, .. } if *source_id == id))
+}
+
+/// Curie EXILE dead-end (CR 601.2h / CR 701.13a): exactly 3 artifacts
+/// (Metalcraft blue Mox = sole {U} source, Curie, and the lone exile target) +
+/// a Forest for the generic {1}. Exiling the only legal target drops the
+/// artifact count to 2 → Metalcraft off → no {U} → the `{1}{U}` leg is unpayable
+/// on the post-exile board. REVERT-FAILING: with the Sacrifice-only walker the
+/// exile leg is invisible to the supplemental check, `can_pay` over-approves on
+/// the intact 3-artifact board, and `legal_actions` surfaces the dead-end Curie
+/// activation. The non-vacuity control is `scenario_curie_exile_witness_*`,
+/// where a 4th artifact keeps Metalcraft live and the activation IS legal —
+/// proving the `{1}{U}` leg is payable on the intact board.
+#[test]
+fn scenario_curie_exile_no_witness_board_is_illegal() {
+    let mut scenario = GameScenario::new();
+    {
+        let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
+        mox.as_artifact();
+        mox.with_ability_definition(blue_mox_def(true));
+    }
+    // The lone exile target: another nontoken artifact.
+    {
+        let mut tgt = scenario.add_creature(P0, "Artifact Servo", 1, 1);
+        tgt.as_artifact();
+    }
+    // A Forest pays the generic {1}; it is NOT a {U} source.
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Green);
+    let curie = {
+        let mut curie = scenario.add_creature(P0, "Curie", 2, 2);
+        curie.as_artifact();
+        curie.with_ability_definition(curie_def());
+        curie.id()
+    };
+
+    let mut runner = scenario.build();
+    put_p0_on_priority(&mut runner);
+
+    assert!(
+        !activation_legal_for(runner.state(), curie),
+        "every exile drops below Metalcraft → {{1}}{{U}} unpayable → activation must be illegal"
+    );
+}
+
+/// Curie EXILE witness control (non-vacuity): same board as the dead-end test
+/// plus a 4th artifact, so exiling the target leaves 3 artifacts → Metalcraft
+/// stays live → the Mox keeps making {U} → a witness exists → the activation is
+/// legal. This proves the `{1}{U}` leg is payable on the intact board, so the
+/// dead-end test's illegality is the removal-shrink discriminator, not a vacuous
+/// unpayable cost.
+#[test]
+fn scenario_curie_exile_witness_board_is_legal() {
+    let mut scenario = GameScenario::new();
+    {
+        let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
+        mox.as_artifact();
+        mox.with_ability_definition(blue_mox_def(true));
+    }
+    {
+        let mut tgt = scenario.add_creature(P0, "Artifact Servo", 1, 1);
+        tgt.as_artifact();
+    }
+    // A 4th artifact keeps Metalcraft live after any single exile.
+    {
+        let mut filler = scenario.add_creature(P0, "Artifact Filler", 0, 1);
+        filler.as_artifact();
+    }
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Green);
+    let curie = {
+        let mut curie = scenario.add_creature(P0, "Curie", 2, 2);
+        curie.as_artifact();
+        curie.with_ability_definition(curie_def());
+        curie.id()
+    };
+
+    let mut runner = scenario.build();
+    put_p0_on_priority(&mut runner);
+
+    assert!(
+        activation_legal_for(runner.state(), curie),
+        "exiling the target leaves 3 artifacts → Metalcraft holds → activation must be legal"
+    );
+}
+
+/// Master Transmuter RETURN dead-end (CR 601.2h / CR 118.3): the sole artifact
+/// the player controls is the sole {U} source (an unconditional blue Mox), and
+/// it is therefore the only legal "return an artifact you control" target. The
+/// Transmuter source is a NON-artifact creature, so it is not itself a return
+/// target. Returning the Mox is the only witness, and it removes the {U}, so the
+/// `{U}` leg is unpayable on the post-return board. REVERT-FAILING: the
+/// Sacrifice-only walker never recognized a ReturnToHand leg, so `can_pay`
+/// over-approves and `legal_actions` surfaces the dead-end activation. The
+/// non-vacuity control is `scenario_master_transmuter_witness_board_is_legal`.
+#[test]
+fn scenario_master_transmuter_return_no_witness_board_is_illegal() {
+    let mut scenario = GameScenario::new();
+    {
+        let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
+        mox.as_artifact();
+        mox.with_ability_definition(blue_mox_def(false));
+    }
+    // Non-artifact source carrying the ability → not a return target itself.
+    let transmuter = {
+        let mut t = scenario.add_creature(P0, "Master Transmuter", 1, 1);
+        t.with_ability_definition(master_transmuter_def());
+        t.id()
+    };
+
+    let mut runner = scenario.build();
+    put_p0_on_priority(&mut runner);
+
+    assert!(
+        !activation_legal_for(runner.state(), transmuter),
+        "returning the sole {{U}} source leaves {{U}} unpayable → activation must be illegal"
+    );
+}
+
+/// Master Transmuter RETURN witness control (non-vacuity): same board plus a
+/// basic Island (an unconditional {U} source that is NOT an artifact, so it is
+/// not a return target). Returning the Mox still leaves the Island's {U}, so a
+/// witness exists and the activation is legal — proving the `{U}` leg is payable
+/// on the intact board and the dead-end test's illegality is the removal-shrink
+/// discriminator.
+#[test]
+fn scenario_master_transmuter_witness_board_is_legal() {
+    let mut scenario = GameScenario::new();
+    {
+        let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
+        mox.as_artifact();
+        mox.with_ability_definition(blue_mox_def(false));
+    }
+    // A second, non-artifact {U} source that survives returning the Mox.
+    scenario.add_basic_land(P0, engine::types::mana::ManaColor::Blue);
+    let transmuter = {
+        let mut t = scenario.add_creature(P0, "Master Transmuter", 1, 1);
+        t.with_ability_definition(master_transmuter_def());
+        t.id()
+    };
+
+    let mut runner = scenario.build();
+    put_p0_on_priority(&mut runner);
+
+    assert!(
+        activation_legal_for(runner.state(), transmuter),
+        "the Island keeps {{U}} available after the return → activation must be legal"
+    );
+}


### PR DESCRIPTION
Extends the Sacrifice-only composite-cost affordability witness (PR #4335) to
the full class of battlefield-removing non-mana cost legs at count==1: Exile
from the battlefield (CR 701.13a) and ReturnToHand from the battlefield (plain
bounce, CR 118.3), alongside the shipped Sacrifice (CR 701.21a).

Root cause (unchanged from #4335): the CR 601.2h cost-ordering asymmetry. The
live payment path pays the non-mana leg FIRST and the mana leg LAST; the dry-run
in costs::can_pay (PaymentScope::Activation) pays mana first on the intact board
and no-ops the non-mana leg, so it over-approves whenever paying that leg shrinks
board mana production (Mox Opal Metalcraft / affinity / devotion). The AI then
surfaces an ActivateAbility it cannot complete and dead-ends (e.g. Curie,
Emergent Intelligence '{1}{U}, Exile another nontoken artifact you control' when
the only {U} source is a Metalcraft-gated Mox the exile turns off).

Implementation (engine affordability oracle only; no parser/frontend/AST-wire
changes):
- casting.rs: new module-private RemovalKind { Sacrifice, Exile, ReturnToHand }
  dispatch enum; find_non_self_battlefield_removal_cost composes the three
  existing per-kind cost walkers (priority Sacrifice > Exile > ReturnToHand,
  returns at most one leg); find_battlefield_exile_cost gates on the live
  cost_payability::exile_cost_effective_zone classifier == Zone::Battlefield
  (so a zone:None + non-permanent filter that resolves to Hand is NOT routed
  into the battlefield-only witness search -- avoids a false-reject). All three
  arms exclude TargetFilter::SelfRef (self-removal is out of scope).
- costs.rs: MutationWitness::Sacrifice -> RemoveFromBattlefield (one variant
  models all three kinds -- only battlefield removal affects re-derived board
  mana; destination zone is irrelevant); apply_mutation_witness preserves the
  CR 613.1 layers::mark_layers_full invariant; mutation_witness_set kind-
  dispatches eligibility (exhaustive match) to the existing
  find_eligible_sacrifice_targets / find_eligible_return_to_hand_targets /
  eligible_exile_cost_objects helpers; can_pay gate preserves count==1 ?
  existential : true (AMENDMENT 1 -- count>1 deferred for all kinds, never
  rejected).

Scope: count>1 deferred (single-witness monotonic existential doesn't extend to
combinatorial subsets). Discard excluded by construction (hand->graveyard never
reduces auto-tap board mana). Single-leg limit (find_map matches one removal
leg) documented at the can_pay call site -- modeling fewer removals can only
false-APPROVE, preserving the no-new-dead-end direction.

Tests: 4 paired discriminating runtime scenarios (Curie exile + Master
Transmuter return, each no-witness->illegal + witness-control->legal, driving
ai_support::legal_actions); 4 costs.rs unit tests (hand-exile not routed,
count>1 fall-through, Discard excluded, self-ref all-kinds excluded). ai-gate:
0 FAIL, 0 NEW dead-ends, 0 win-loss flips (1 WARN: affinity-mirror avg-turn
drift, explained by the AI correctly declining now-rejected uncompletable
activations).
