### PR TITLE
chore(client): mark Scryfall <img> tags crossOrigin=anonymous (prep for COEP cross-origin isolation)

### DIFF
--- a/client/src/components/card/ArtCropCard.tsx
+++ b/client/src/components/card/ArtCropCard.tsx
@@ -134,6 +134,9 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
               <img
                 src={renderedSrc}
                 alt={cardName}
+                // Load via CORS (Scryfall returns ACAO:*) so art survives a future
+                // COEP: require-corp cross-origin-isolation switch on the app host.
+                crossOrigin="anonymous"
                 draggable={false}
                 className="absolute inset-0 w-full h-full object-cover"
               />

--- a/client/src/components/card/CardImage.tsx
+++ b/client/src/components/card/CardImage.tsx
@@ -115,6 +115,9 @@ export function CardImage({
       <img
         src={renderedSrc}
         alt={renderedAlt}
+        // Load via CORS (Scryfall returns ACAO:*) so card art survives a future
+        // COEP: require-corp cross-origin-isolation switch on the app host.
+        crossOrigin="anonymous"
         draggable={false}
         onError={() => setImageError(true)}
         className={`${baseClasses} shadow-lg object-cover`}

--- a/client/src/components/mana/ManaSymbol.tsx
+++ b/client/src/components/mana/ManaSymbol.tsx
@@ -32,6 +32,9 @@ export function ManaSymbol({
     <img
       src={`${SCRYFALL_SVG_BASE}/${code}.svg`}
       alt={shard}
+      // Load via CORS (svgs.scryfall.io returns ACAO:*) so symbols survive a future
+      // COEP: require-corp cross-origin-isolation switch on the app host.
+      crossOrigin="anonymous"
       className={`inline-block ${SIZE_CLASSES[size]} ${className}`}
       draggable={false}
     />


### PR DESCRIPTION
## What

Add `crossOrigin="anonymous"` to the three components that render cross-origin Scryfall `<img>` tags:

- `CardImage.tsx` — card art (`cards.scryfall.io`) and the face-down back (`backs.scryfall.io`)
- `ArtCropCard.tsx` — art-crop card faces (`cards.scryfall.io`)
- `ManaSymbol.tsx` — mana-symbol SVGs (`svgs.scryfall.io`)

## Why

Prep for a future **`COEP: require-corp`** cross-origin-isolation switch on the app host, which is the prerequisite for `SharedArrayBuffer` → a single shared WASM card DB (the fix for iOS mobile OOM, where ~5 WASM instances each hold a ~92 MB copy and blow past WebKit's per-tab memory ceiling).

Under `require-corp`, a plain no-CORS cross-origin `<img>` is **blocked**. The fix is purely client-side: load the image as a CORS request (`crossOrigin`), which the server must answer with `Access-Control-Allow-Origin`. Verified all three hosts already do:

```
$ curl -sI -H 'Origin: https://app.phase-rs.dev' https://cards.scryfall.io/... → access-control-allow-origin: *
$ curl -sI -H 'Origin: https://app.phase-rs.dev' https://backs.scryfall.io/... → access-control-allow-origin: *
$ curl -sI -H 'Origin: https://app.phase-rs.dev' https://svgs.scryfall.io/...  → access-control-allow-origin: *
```

## Safety / no behavior change today

- Scryfall returns `ACAO: *`, so the images load **unchanged** right now — no header is being flipped in this PR.
- The only side effect today is that the fetched images become canvas-taint-free.
- `index.html` already declares `<link rel="preconnect" ... crossorigin>` for `cards`/`backs.scryfall.io`, so the CORS connection is already anticipated.
- Audio (`AudioManager`) and the canvas shatter effect (`DeathShatter`) already set `crossOrigin="anonymous"`; this brings the remaining image render paths in line.

The `COEP: require-corp` header itself is **intentionally not included here** — it's a prod-wide enforcement switch with no benefit until the shared-memory work lands, and it has an unresolved interaction with the PWA service worker. It will be enabled separately alongside that work.

## Test plan

- `pnpm run type-check` ✅
- `pnpm exec eslint` on the 3 files ✅ (no issues)
- Images render unchanged in PvE/PvP (Scryfall ACAO confirmed via curl).
