### PR TITLE
perf(client): game-scoped card-DB subset in AI worker pool (fix iOS Very Hard OOM)

### DIFF
--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadAiPoolCardDb } from "../card-db-subset";
+import type { EngineWorkerClient } from "../engine-worker-client";
+import type { AiWorkerPool } from "../ai-worker-pool";
+
+// The mocked EngineWorkerClient is shared by both the main engine and every AI
+// pool worker (the pool constructs `new EngineWorkerClient()`), so a single
+// mock records the text loaded into pool workers via `loadCardDb(text)`.
+const mockWorkerClient = {
+  initialize: vi.fn().mockResolvedValue(undefined),
+  loadCardDb: vi.fn().mockResolvedValue(100),
+  loadCardDbFromUrl: vi.fn().mockResolvedValue(100),
+  buildAiCardSubset: vi.fn<() => Promise<string>>(),
+  exportState: vi.fn().mockResolvedValue("{}"),
+  restoreState: vi.fn().mockResolvedValue(undefined),
+  getAiScoredCandidates: vi
+    .fn()
+    .mockResolvedValue([[{ type: "PassPriority" }, 1.0]]),
+  getAiAction: vi.fn().mockResolvedValue(null),
+  selectActionFromScores: vi.fn().mockResolvedValue({ type: "PassPriority" }),
+  resetGame: vi.fn().mockResolvedValue(undefined),
+  takeLastPanic: vi.fn().mockResolvedValue(null),
+  dispose: vi.fn(),
+};
+
+vi.mock("../engine-worker-client", () => ({
+  EngineWorkerClient: vi.fn().mockImplementation(function () {
+    return mockWorkerClient;
+  }),
+}));
+
+// ── VM-4: loadAiPoolCardDb dispatch ───────────────────────────────────────
+describe("loadAiPoolCardDb", () => {
+  function makeMocks() {
+    const mainEngine = {
+      buildAiCardSubset: vi.fn<() => Promise<string>>(),
+    } as unknown as EngineWorkerClient & {
+      buildAiCardSubset: ReturnType<typeof vi.fn>;
+    };
+    const aiPool = {
+      loadCardDb: vi.fn().mockResolvedValue(undefined),
+      loadCardDbText: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AiWorkerPool & {
+      loadCardDb: ReturnType<typeof vi.fn>;
+      loadCardDbText: ReturnType<typeof vi.fn>;
+    };
+    return { mainEngine, aiPool };
+  }
+
+  it("escalates a Momir game (kind:full) to the full DB, never the subset", async () => {
+    const { mainEngine, aiPool } = makeMocks();
+    mainEngine.buildAiCardSubset.mockResolvedValue(JSON.stringify({ kind: "full" }));
+
+    await loadAiPoolCardDb("subset", mainEngine, aiPool);
+
+    expect(aiPool.loadCardDb).toHaveBeenCalledOnce();
+    expect(aiPool.loadCardDbText).not.toHaveBeenCalled();
+  });
+
+  it("loads the subset JSON for a bounded (non-Momir) game", async () => {
+    const { mainEngine, aiPool } = makeMocks();
+    const innerJson = '{"Bounded Card":{}}';
+    mainEngine.buildAiCardSubset.mockResolvedValue(
+      JSON.stringify({ kind: "subset", json: innerJson, count: 1 }),
+    );
+
+    await loadAiPoolCardDb("subset", mainEngine, aiPool);
+
+    expect(aiPool.loadCardDbText).toHaveBeenCalledWith(innerJson);
+    expect(aiPool.loadCardDb).not.toHaveBeenCalled();
+  });
+
+  it("mode=full loads the full DB without consulting the engine", async () => {
+    const { mainEngine, aiPool } = makeMocks();
+
+    await loadAiPoolCardDb("full", mainEngine, aiPool);
+
+    expect(aiPool.loadCardDb).toHaveBeenCalledOnce();
+    expect(mainEngine.buildAiCardSubset).not.toHaveBeenCalled();
+    expect(aiPool.loadCardDbText).not.toHaveBeenCalled();
+  });
+});
+
+// ── VM-1: cross-game subset invalidation + rebuild ────────────────────────
+describe("WasmAdapter AI-pool subset lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWorkerClient.getAiScoredCandidates.mockResolvedValue([
+      [{ type: "PassPriority" }, 1.0],
+    ]);
+  });
+
+  it("rebuilds the pool's game-scoped subset after resetGameState (no cross-game leak)", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    const subsetA = JSON.stringify({
+      kind: "subset",
+      json: '{"Game A Card":{}}',
+      count: 1,
+    });
+    const subsetB = JSON.stringify({
+      kind: "subset",
+      json: '{"Game B Card":{}}',
+      count: 1,
+    });
+    mockWorkerClient.buildAiCardSubset
+      .mockResolvedValueOnce(subsetA)
+      .mockResolvedValueOnce(subsetB);
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    await adapter.warmCardDatabase();
+
+    // Game A: first VeryHard Priority request creates the pool + loads subset A.
+    const actionA = await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(actionA).not.toBeNull();
+    const callsA = mockWorkerClient.loadCardDb.mock.calls;
+    const loadedA = callsA[callsA.length - 1][0] as string;
+    expect(loadedA).toContain("Game A Card");
+
+    // Transition to game B: the pool subset is invalidated, instance preserved.
+    await adapter.resetGameState();
+
+    // Game B (disjoint deck): the pool rebuilds with game B's subset.
+    const actionB = await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(actionB).not.toBeNull();
+    const callsB = mockWorkerClient.loadCardDb.mock.calls;
+    const loadedB = callsB[callsB.length - 1][0] as string;
+    // (c) game-B-exclusive card PRESENT; (b) game-A-exclusive card ABSENT.
+    // Revert guard: dropping invalidateCardDb()/the ensureAiPool rebuild branch
+    // leaves the pool loaded with subset A, so both assertions flip.
+    expect(loadedB).toContain("Game B Card");
+    expect(loadedB).not.toContain("Game A Card");
+  });
+});

--- a/client/src/adapter/ai-worker-pool.ts
+++ b/client/src/adapter/ai-worker-pool.ts
@@ -42,6 +42,26 @@ export class AiWorkerPool {
     this.cardDbLoaded = true;
   }
 
+  /**
+   * Load a pre-built game-scoped card-DB subset (small JSON) into every worker
+   * instead of each fetching+parsing the full ~93MB corpus. Used by the AI pool
+   * for bounded games to stay within the iOS WebKit memory ceiling.
+   */
+  async loadCardDbText(text: string): Promise<void> {
+    await Promise.all(this.workers.map((w) => w.loadCardDb(text)));
+    this.cardDbLoaded = true;
+  }
+
+  /**
+   * Mark the pool's card DB stale so the next `ensureCardDb`/`ensureAiPool`
+   * rebuilds this game's subset. The worker instances are preserved; only the
+   * loaded-flag is flipped (the subset is game-scoped and must be rebuilt
+   * per game).
+   */
+  invalidateCardDb(): void {
+    this.cardDbLoaded = false;
+  }
+
   get isCardDbLoaded(): boolean {
     return this.cardDbLoaded;
   }

--- a/client/src/adapter/card-db-subset.ts
+++ b/client/src/adapter/card-db-subset.ts
@@ -1,0 +1,47 @@
+/**
+ * AI-worker card-database loading strategy.
+ *
+ * iOS PvE worker pools spin up several WASM engine instances. If each fetched
+ * and parsed the full ~93MB card-data corpus they would OOM WebKit. The MAIN
+ * engine worker keeps the full database; the AI pool instead loads a
+ * game-scoped subset built by the engine (`build_ai_card_subset`). Games whose
+ * card universe is not statically bounded (today: Momir) escalate to the full
+ * database on AI workers.
+ */
+import type { EngineWorkerClient } from "./engine-worker-client";
+import type { AiWorkerPool } from "./ai-worker-pool";
+import type { AiCardSubsetResult } from "./types";
+
+export type AiCardDataMode = "auto" | "subset" | "full";
+export const DEFAULT_AI_CARD_DATA_MODE: AiCardDataMode = "auto";
+
+/**
+ * Load the AI worker pool's card database according to `mode`.
+ *
+ * INVARIANT: `mainEngine` is the MAIN `EngineWorkerClient` (full CARD_DB + live
+ * GAME_STATE). `buildAiCardSubset()` is called ONLY here, on `mainEngine` —
+ * never on a pool worker (pool workers carry only the subset and may have no
+ * game state).
+ *
+ * - `full`: every pool worker fetches+parses the full corpus.
+ * - `auto`/`subset`: the engine builds this game's subset on the main worker;
+ *   a `full` result (unbounded universe, e.g. Momir) falls back to the full DB.
+ */
+export async function loadAiPoolCardDb(
+  mode: AiCardDataMode,
+  mainEngine: EngineWorkerClient,
+  aiPool: AiWorkerPool,
+): Promise<void> {
+  if (mode === "full") {
+    await aiPool.loadCardDb();
+    return;
+  }
+  const result: AiCardSubsetResult = JSON.parse(
+    await mainEngine.buildAiCardSubset(),
+  );
+  if (result.kind === "full") {
+    await aiPool.loadCardDb();
+  } else {
+    await aiPool.loadCardDbText(result.json);
+  }
+}

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -112,6 +112,15 @@ export class EngineWorkerClient {
     return this.request<unknown>({ type: "evaluateDeckCompatibility", request });
   }
 
+  /**
+   * Build the game-scoped AI card-DB subset for THIS game. Returns the
+   * serialized `AiCardSubsetResult` tagged union (parse with `JSON.parse`).
+   * Called ONLY on the MAIN engine client (full CARD_DB + live GAME_STATE).
+   */
+  async buildAiCardSubset(): Promise<string> {
+    return this.request<string>({ type: "buildAiCardSubset" });
+  }
+
   async initializeGame(
     deckData: unknown | null,
     seed: number,

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -20,6 +20,7 @@ import init, {
   restore_game_state,
   resume_multiplayer_host_state,
   load_card_database,
+  build_ai_card_subset,
   evaluate_deck_compatibility_js,
   apply_seat_mutation,
   export_game_state_json,
@@ -72,6 +73,7 @@ type EngineRequest =
   | { type: "resumeMultiplayerHostState"; id: number; stateJson: string }
   | { type: "exportState"; id: number }
   | { type: "loadCardDbFromUrl"; id: number }
+  | { type: "buildAiCardSubset"; id: number }
   | { type: "evaluateDeckCompatibility"; id: number; request: unknown }
   | { type: "resetGame"; id: number }
   | { type: "setMultiplayerMode"; id: number; enabled: boolean }
@@ -136,6 +138,19 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
         const count = load_card_database(text);
         cardDbLoaded = true;
         result(msg.id, count);
+        break;
+      }
+
+      case "buildAiCardSubset": {
+        if (!cardDbLoaded) {
+          error(
+            msg.id,
+            "Card database not loaded. Call loadCardDb or loadCardDbFromUrl first.",
+          );
+          break;
+        }
+        // Returns the serialized AiCardSubsetResult tagged union as a string.
+        result(msg.id, build_ai_card_subset());
         break;
       }
 

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2276,6 +2276,16 @@ export interface BatchResolveResult {
   total: number;
 }
 
+/**
+ * Engine-built game-scoped AI card-DB subset descriptor (the `build_ai_card_subset`
+ * WASM export, serialized as a tagged union). `full` means the game's card
+ * universe is not statically bounded (today: Momir) and AI workers must load the
+ * full database; `subset` carries the minimal card-data JSON for this game.
+ */
+export type AiCardSubsetResult =
+  | { kind: "full" }
+  | { kind: "subset"; json: string; count: number };
+
 export interface EngineAdapter {
   initialize(): Promise<void>;
   initializeGame(

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -16,6 +16,8 @@ import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstima
 import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
 import { AiWorkerPool } from "./ai-worker-pool";
+import type { AiCardDataMode } from "./card-db-subset";
+import { DEFAULT_AI_CARD_DATA_MODE, loadAiPoolCardDb } from "./card-db-subset";
 /**
  * Flatten the `ClientGameState { state, derived }` wire envelope produced
  * by the engine's WASM getters into the store-side `GameState` shape with
@@ -109,6 +111,11 @@ export class WasmAdapter implements EngineAdapter {
   private aiPool: AiWorkerPool | null = null;
   private aiPoolFailed = false;
 
+  // How the AI worker pool loads its card database. `auto`/`subset` load an
+  // engine-built game-scoped subset (escalating to full for unbounded games
+  // like Momir); `full` loads the entire corpus into every pool worker.
+  private aiCardDataMode: AiCardDataMode = DEFAULT_AI_CARD_DATA_MODE;
+
   // Fallback: direct WASM on main thread (only used if Worker fails)
   private fallback: MainThreadFallback | null = null;
 
@@ -170,9 +177,11 @@ export class WasmAdapter implements EngineAdapter {
           console.log(`Card database loaded: ${count} cards`);
         }
         this.cardDbLoaded = true;
-        // Also load into AI pool if it's already initialized
-        if (this.aiPool && !this.aiPool.isCardDbLoaded) {
-          await this.aiPool.loadCardDb();
+        // Also load into AI pool if it's already initialized. AI-pool workers
+        // get the game-scoped subset (built on the main engine), not the full
+        // corpus, unless the mode is `full` or the universe is unbounded.
+        if (this.engine && this.aiPool && !this.aiPool.isCardDbLoaded) {
+          await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
         }
       } catch (err) {
         console.warn("Failed to load card database:", err);
@@ -338,15 +347,22 @@ export class WasmAdapter implements EngineAdapter {
 
 /** Lazy AI pool init — only created on first VeryHard request. */
   private async ensureAiPool(): Promise<AiWorkerPool | null> {
-    if (this.aiPool) return this.aiPool;
+    if (this.aiPool) {
+      // The pool's subset is game-scoped: after `resetGameState` invalidated it,
+      // rebuild this game's subset (the pool instance is preserved across games).
+      if (this.cardDbLoaded && this.engine && !this.aiPool.isCardDbLoaded) {
+        await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
+      }
+      return this.aiPool;
+    }
     if (this.aiPoolFailed) return null;
     try {
       const cores = navigator.hardwareConcurrency ?? 0;
       const count = Math.max(2, Math.min(cores - 1, 4));
       this.aiPool = new AiWorkerPool(count);
       await this.aiPool.initialize();
-      if (this.cardDbLoaded) {
-        await this.aiPool.loadCardDb();
+      if (this.cardDbLoaded && this.engine) {
+        await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
       }
       return this.aiPool;
     } catch {
@@ -444,13 +460,20 @@ export class WasmAdapter implements EngineAdapter {
   /**
    * Clear the WASM game state without terminating the worker.
    *
-   * Preserves the WASM instance (with V8 TurboFan optimizations), card database,
-   * and AI worker pool. Any in-flight AI computation on the old state will
-   * short-circuit with an error rather than running a full search.
+   * Preserves the WASM instance (with V8 TurboFan optimizations), the main
+   * worker's full card database, and the AI worker pool INSTANCE. In
+   * subset/auto mode the pool's game-scoped subset is invalidated so the next
+   * `ensureAiPool`/`ensureCardDb` rebuilds it for the new game; in full mode the
+   * pool's full DB is preserved (it's game-independent). Any in-flight AI
+   * computation on the old state will short-circuit with an error rather than
+   * running a full search.
    */
   async resetGameState(): Promise<void> {
     if (this.engine) {
       await this.engine.resetGame();
+    }
+    if (this.aiCardDataMode !== "full") {
+      this.aiPool?.invalidateCardDb();
     }
   }
 

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -9,6 +9,19 @@
 export function apply_seat_mutation(state_json: string, mutation_json: string): any;
 
 /**
+ * Build a game-scoped AI card-database subset from the loaded full database and
+ * the live game state, serialized as the `AiCardSubsetResult` tagged union
+ * (`{"kind":"full"}` or `{"kind":"subset","json":...,"count":N}`). The MAIN
+ * worker (full CARD_DB + live GAME_STATE) calls this; the AI worker pool loads
+ * the returned subset so its WASM instances don't each parse the full ~93MB
+ * corpus. Returns `{"kind":"full"}` defensively when the database or game state
+ * is absent (the engine is the single authority for this fallback — see
+ * `card_subset::build_ai_card_subset_or_full`). The game state is taken out of
+ * and restored to the thread-local on every path.
+ */
+export function build_ai_card_subset(): string;
+
+/**
  * Classify a deck's archetype (Aggro / Midrange / Control / Combo / Ramp) using
  * `phase_ai::DeckProfile::analyze`. The engine is the single authority for archetype
  * classification — the frontend must not compute this from card lists itself.
@@ -330,6 +343,7 @@ export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembl
 export interface InitOutput {
     readonly memory: WebAssembly.Memory;
     readonly apply_seat_mutation: (a: number, b: number, c: number, d: number) => [number, number, number];
+    readonly build_ai_card_subset: () => [number, number, number, number];
     readonly classify_deck_js: (a: any) => [number, number, number];
     readonly commanderPartnerCandidates: (a: number, b: number, c: any) => [number, number, number];
     readonly deckCopyLimit: (a: number, b: number) => any;

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -226,6 +226,32 @@ pub fn load_card_database(json_str: &str) -> Result<u32, JsValue> {
     Ok(count)
 }
 
+/// Build a game-scoped AI card-database subset from the loaded full database and
+/// the live game state, serialized as the `AiCardSubsetResult` tagged union
+/// (`{"kind":"full"}` or `{"kind":"subset","json":...,"count":N}`). The MAIN
+/// worker (full CARD_DB + live GAME_STATE) calls this; the AI worker pool loads
+/// the returned subset so its WASM instances don't each parse the full ~93MB
+/// corpus. Returns `{"kind":"full"}` defensively when the database or game state
+/// is absent (the engine is the single authority for this fallback — see
+/// `card_subset::build_ai_card_subset_or_full`). The game state is taken out of
+/// and restored to the thread-local on every path.
+#[wasm_bindgen]
+pub fn build_ai_card_subset() -> Result<String, JsValue> {
+    let result = CARD_DB.with(|db_cell| {
+        let db_ref = db_cell.borrow();
+        GAME_STATE.with(|gs_cell| {
+            let state_opt = gs_cell.take();
+            let r = engine::game::card_subset::build_ai_card_subset_or_full(
+                state_opt.as_ref(),
+                db_ref.as_ref(),
+            );
+            gs_cell.set(state_opt);
+            r
+        })
+    });
+    serde_json::to_string(&result).map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
 /// Look up a card face by name from the loaded card database.
 /// Returns the serialized `CardFace` (keywords, abilities, triggers, static_abilities,
 /// replacements, card_type, oracle_text, etc.) or null if not found.

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::path::PathBuf;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::bracket_lists::{BracketLists, BracketSignals};
 use super::legality::{normalize_legalities, CardLegalities, LegalityFormat, LegalityStatus};
@@ -138,6 +138,42 @@ impl CardDatabase {
     pub fn get_face_by_name(&self, name: &str) -> Option<&CardFace> {
         let key = self.lookup_key(name);
         self.face_index.get(&key)
+    }
+
+    /// Emit a card-data export JSON containing ONLY the named faces, suitable for
+    /// `from_json_str`. Reconstructs each `CardExportEntry` from the in-memory
+    /// indices. Legalities are intentionally empty: AI workers never run a
+    /// deck-legality check, and the built DB retains only the normalized
+    /// `legalities` form (there is no raw `HashMap<String, String>` source to
+    /// re-emit — see `from_export_entries`).
+    pub fn export_subset_json(&self, names: &std::collections::BTreeSet<String>) -> String {
+        let mut out: HashMap<String, CardExportEntry> = HashMap::with_capacity(names.len());
+        for name in names {
+            let key = self.lookup_key(name);
+            let Some(face) = self.face_index.get(&key) else {
+                continue;
+            };
+            let layout = face
+                .scryfall_oracle_id
+                .as_deref()
+                .and_then(|id| self.layout_index.get(id).copied())
+                .and_then(layout_kind_to_str)
+                .map(str::to_string);
+            let entry = CardExportEntry {
+                face: face.clone(),
+                legalities: HashMap::new(),
+                layout,
+                printings: self.printings_index.get(&key).cloned().unwrap_or_default(),
+                rulings: self.rulings_index.get(&key).cloned().unwrap_or_default(),
+                bracket_signals: self
+                    .bracket_signals_by_name
+                    .get(&key)
+                    .copied()
+                    .unwrap_or_default(),
+            };
+            out.insert(face.name.clone(), entry);
+        }
+        serde_json::to_string(&out).expect("CardExportEntry serialization is infallible")
     }
 
     /// Resolve a face by its Scryfall oracle id. Used as a fallback when a
@@ -438,7 +474,7 @@ fn fold_card_name_key(name: &str) -> String {
     folded
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct CardExportEntry {
     #[serde(flatten)]
     face: CardFace,
@@ -471,6 +507,24 @@ fn layout_kind_requires_multiple_faces(layout_kind: LayoutKind) -> bool {
             | LayoutKind::Omen
             | LayoutKind::Prepare
     )
+}
+
+/// Exhaustive inverse of `map_layout_str`: runtime `LayoutKind` → the MTGJSON
+/// layout string `from_export_entries` expects. `Single` has no string form
+/// (single-face cards carry no layout discriminant). No wildcard arm, so a new
+/// `LayoutKind` variant forces a compile error here until it is mapped.
+fn layout_kind_to_str(kind: LayoutKind) -> Option<&'static str> {
+    match kind {
+        LayoutKind::Modal => Some("modal_dfc"),
+        LayoutKind::Transform => Some("transform"),
+        LayoutKind::Adventure => Some("adventure"),
+        LayoutKind::Meld => Some("meld"),
+        LayoutKind::Split => Some("split"),
+        LayoutKind::Flip => Some("flip"),
+        LayoutKind::Omen => Some("omen"),
+        LayoutKind::Prepare => Some("prepare"),
+        LayoutKind::Single => None,
+    }
 }
 
 /// Convert MTGJSON layout string to runtime `LayoutKind`.

--- a/crates/engine/src/game/card_subset.rs
+++ b/crates/engine/src/game/card_subset.rs
@@ -1,0 +1,430 @@
+//! Game-scoped AI card-database subset.
+//!
+//! iOS PvE worker pools spin up several WASM engine instances, each of which
+//! would otherwise parse the full ~93MB card-data corpus and OOM WebKit. The
+//! main worker keeps the full database; AI-pool workers instead receive a
+//! subset containing only the faces THIS game can reach. Games whose card
+//! universe is not statically bounded (today: Momir, whose token pool is the
+//! entire creature corpus) escalate to the full database on AI workers.
+
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+
+use crate::database::card_db::CardDatabase;
+use crate::game::printed_cards::build_conjure_registry;
+use crate::types::format::GameFormat;
+use crate::types::game_state::GameState;
+
+/// Why a game cannot use a bounded AI card subset and must ship the full DB.
+/// Open enum: add a variant + one `game_requires_full_card_db` arm for any
+/// future whole-corpus mechanic. Never special-case a card.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum FullDbReason {
+    /// CR 707.2 + CR 202.3: Momir seeds its random-token pool from the ENTIRE
+    /// creature corpus, keyed by mana value, at rehydrate (printed_cards.rs:1334;
+    /// `momir_pool_faces` is `#[serde(skip)]`). The emblem creates a token that's
+    /// a copy (CR 707.2) of a random creature card with the chosen mana value
+    /// (CR 202.3). A subset DB yields a tiny, wrong pool, so Momir games use the
+    /// full DB on AI workers.
+    Momir,
+}
+
+/// Result of building an AI-worker card subset for one game. `Full` means the
+/// caller must load the full database instead (the universe is unbounded).
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AiCardSubsetResult {
+    Full,
+    Subset { json: String, count: usize },
+}
+
+/// `Some(reason)` when this game's card universe is not statically bounded and
+/// AI workers must load the full database instead of a subset.
+pub fn game_requires_full_card_db(state: &GameState) -> Option<FullDbReason> {
+    match state.format_config.format {
+        // CR 707.2 + CR 202.3: see `FullDbReason::Momir`.
+        GameFormat::Momir => Some(FullDbReason::Momir),
+        _ => None,
+    }
+}
+
+/// Every card-face name an AI worker could need for THIS game: every object's
+/// printed face, every deck-pool entry, the transitive Conjure closure, and the
+/// oracle-id siblings (other faces/printings) of all of the above.
+pub fn collect_game_card_universe(state: &GameState, db: &CardDatabase) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+
+    // 1. Every object that carries a printed face.
+    for obj in state.objects.values() {
+        if let Some(pref) = &obj.printed_ref {
+            names.insert(pref.face_name.clone());
+        }
+    }
+
+    // 2. Every deck-pool entry (registered + current; main/sideboard/commander/signature).
+    for pool in &state.deck_pools {
+        for arc in [
+            &pool.registered_main,
+            &pool.current_main,
+            &pool.registered_sideboard,
+            &pool.current_sideboard,
+            &pool.registered_commander,
+            &pool.current_commander,
+            &pool.registered_signature_spell,
+            &pool.current_signature_spell,
+        ] {
+            for entry in arc.iter() {
+                names.insert(entry.card.name.clone());
+            }
+        }
+    }
+
+    // 3. Transitive Conjure closure — reuse the existing building block.
+    let (registry, collected) = build_conjure_registry(state, db);
+    names.extend(registry.into_keys());
+    names.extend(collected);
+
+    // 4. oracle_id siblings: other face(s)/printings of every name so far, so a
+    //    DFC front pulls in its back face (and vice versa) and every printing is
+    //    available to the AI workers.
+    let snapshot: Vec<String> = names.iter().cloned().collect();
+    for name in snapshot {
+        if let Some(face) = db.get_face_by_name(&name) {
+            if let Some(oracle_id) = face.scryfall_oracle_id.as_deref() {
+                if let Some(siblings) = db.oracle_id_index.get(oracle_id) {
+                    names.extend(siblings.iter().cloned());
+                }
+            }
+        }
+    }
+
+    names
+}
+
+/// Build the AI-worker card subset for this game, or signal `Full` when the
+/// universe is unbounded (Momir).
+pub fn build_ai_card_subset(state: &GameState, db: &CardDatabase) -> AiCardSubsetResult {
+    if game_requires_full_card_db(state).is_some() {
+        return AiCardSubsetResult::Full;
+    }
+    let names = collect_game_card_universe(state, db);
+    let json = db.export_subset_json(&names);
+    AiCardSubsetResult::Subset {
+        count: names.len(),
+        json,
+    }
+}
+
+/// Defensive entry point for the WASM transport: when either the card database
+/// or the game state is absent, AI workers must fall back to the full database
+/// (a subset cannot be computed). Centralizing the `None`-handling keeps the
+/// transport layer a thin pass-through.
+pub fn build_ai_card_subset_or_full(
+    state: Option<&GameState>,
+    db: Option<&CardDatabase>,
+) -> AiCardSubsetResult {
+    match (state, db) {
+        (Some(state), Some(db)) => build_ai_card_subset(state, db),
+        _ => AiCardSubsetResult::Full,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::deck_loading::DeckEntry;
+    use crate::game::printed_cards::printed_ref_from_face;
+    use crate::game::zones::create_object;
+    use crate::types::card::CardFace;
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::format::FormatConfig;
+    use crate::types::game_state::{GameState, PlayerDeckPool};
+    use crate::types::identifiers::CardId;
+    use crate::types::mana::{ManaCost, ManaCostShard};
+    use crate::types::player::PlayerId;
+    use crate::types::zones::Zone;
+    use std::sync::Arc;
+
+    fn creature_face(name: &str, oracle_id: &str) -> CardFace {
+        CardFace {
+            name: name.to_string(),
+            card_type: CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            },
+            mana_cost: ManaCost::Cost {
+                shards: vec![ManaCostShard::Green],
+                generic: 2,
+            },
+            scryfall_oracle_id: Some(oracle_id.to_string()),
+            ..CardFace::default()
+        }
+    }
+
+    /// Serialize a face into a `CardExportEntry`-shaped JSON value, then layer on
+    /// the export-only fields (layout/printings/rulings/bracket_signals).
+    fn entry_value(
+        face: &CardFace,
+        layout: Option<&str>,
+        printings: &[&str],
+        rulings: &[(&str, &str)],
+        game_changer: bool,
+    ) -> serde_json::Value {
+        let mut v = serde_json::to_value(face).unwrap();
+        if let Some(layout) = layout {
+            v["layout"] = serde_json::json!(layout);
+        }
+        if !printings.is_empty() {
+            v["printings"] = serde_json::json!(printings);
+        }
+        if !rulings.is_empty() {
+            v["rulings"] = serde_json::Value::Array(
+                rulings
+                    .iter()
+                    .map(|(date, text)| serde_json::json!({ "date": date, "text": text }))
+                    .collect(),
+            );
+        }
+        v["bracket_signals"] = serde_json::json!({
+            "game_changer": game_changer,
+            "mass_land_denial": false,
+            "extra_turn": false,
+            "efficient_tutor": false,
+        });
+        v
+    }
+
+    /// VM-2: the four universe sources (battlefield object, deck-pool entry,
+    /// Conjure-closure card, DFC) all resolve in the emitted subset, INCLUDING
+    /// the DFC back face reached only via the oracle-id sibling step. A card
+    /// present in none of the four sources is absent.
+    #[test]
+    fn subset_covers_all_four_sources_plus_dfc_back_face() {
+        let battlefield = creature_face("Battlefield Guy", "bf-oracle");
+        let library = creature_face("Library Card", "lib-oracle");
+        let conjured = creature_face("Conjured Token", "conjure-oracle");
+        let mut spellbook_src = creature_face("Spellbook Source", "spellbook-oracle");
+        spellbook_src.metadata.spellbook = vec!["Conjured Token".to_string()];
+        // DFC: front + back share one oracle id; front carries the transform layout.
+        let dfc_front = creature_face("Dfc Front", "dfc-oracle");
+        let dfc_back = creature_face("Dfc Back", "dfc-oracle");
+        let unrelated = creature_face("Unrelated Card", "unrelated-oracle");
+
+        let export = serde_json::json!({
+            "Battlefield Guy": entry_value(&battlefield, None, &[], &[], false),
+            "Library Card": entry_value(&library, None, &[], &[], false),
+            "Conjured Token": entry_value(&conjured, None, &[], &[], false),
+            "Spellbook Source": entry_value(&spellbook_src, None, &[], &[], false),
+            "Dfc Front": entry_value(&dfc_front, Some("transform"), &[], &[], false),
+            "Dfc Back": entry_value(&dfc_back, None, &[], &[], false),
+            "Unrelated Card": entry_value(&unrelated, None, &[], &[], false),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("export db parses");
+
+        let mut state = GameState::new_two_player(7);
+
+        // Source 1: a battlefield object carrying the printed face.
+        let bf_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Battlefield Guy".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&bf_id).unwrap().printed_ref = printed_ref_from_face(&battlefield);
+
+        // Source 3 seed: a battlefield object whose spellbook conjures "Conjured Token".
+        let sb_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Spellbook Source".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&sb_id).unwrap().printed_ref = printed_ref_from_face(&spellbook_src);
+
+        // Source 4: the DFC front face is in the library deck pool.
+        // Source 2: a library deck-pool entry.
+        state.deck_pools.push(PlayerDeckPool {
+            player: PlayerId(0),
+            current_main: Arc::new(vec![
+                DeckEntry {
+                    card: library.clone(),
+                    count: 1,
+                },
+                DeckEntry {
+                    card: dfc_front.clone(),
+                    count: 1,
+                },
+            ]),
+            ..Default::default()
+        });
+
+        let result = build_ai_card_subset(&state, &db);
+        let AiCardSubsetResult::Subset { json, .. } = result else {
+            panic!("non-Momir game must yield a Subset");
+        };
+        let subset = CardDatabase::from_json_str(&json).expect("subset parses");
+
+        for name in [
+            "Battlefield Guy",
+            "Library Card",
+            "Conjured Token",
+            "Spellbook Source",
+            "Dfc Front",
+        ] {
+            assert!(
+                subset.get_face_by_name(name).is_some(),
+                "subset must contain {name}"
+            );
+        }
+        // Revert guard: dropping the oracle-id-sibling step drops this back face.
+        assert!(
+            subset.get_face_by_name("Dfc Back").is_some(),
+            "DFC back face must be pulled in via the oracle-id sibling step"
+        );
+        // Negative: a card in none of the four sources is absent.
+        assert!(
+            subset.get_face_by_name("Unrelated Card").is_none(),
+            "an unreferenced card must NOT be in the subset"
+        );
+    }
+
+    /// VM-3: Momir games escalate to the full DB; the identical objects in a
+    /// non-Momir format yield a subset.
+    #[test]
+    fn momir_format_escalates_to_full_db() {
+        let creature = creature_face("Pool Beast", "pool-oracle");
+        let export = serde_json::json!({
+            "Pool Beast": entry_value(&creature, None, &[], &[], false),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("export db parses");
+
+        let mut state = GameState::new_two_player(7);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Pool Beast".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().printed_ref = printed_ref_from_face(&creature);
+
+        // Non-Momir: subset.
+        assert!(
+            matches!(
+                build_ai_card_subset(&state, &db),
+                AiCardSubsetResult::Subset { .. }
+            ),
+            "non-Momir game must yield a Subset"
+        );
+
+        // Revert guard: removing the Momir arm of game_requires_full_card_db
+        // would make this a Subset instead of Full.
+        state.format_config = FormatConfig::momir();
+        assert!(
+            matches!(build_ai_card_subset(&state, &db), AiCardSubsetResult::Full),
+            "Momir game must escalate to the full DB"
+        );
+    }
+
+    /// VM-5: the defensive transport entry returns Full when state or db is
+    /// absent (a subset cannot be computed without both).
+    #[test]
+    fn missing_state_or_db_falls_back_to_full() {
+        let creature = creature_face("Pool Beast", "pool-oracle");
+        let export = serde_json::json!({
+            "Pool Beast": entry_value(&creature, None, &[], &[], false),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("export db parses");
+        let state = GameState::new_two_player(7);
+
+        assert!(matches!(
+            build_ai_card_subset_or_full(None, Some(&db)),
+            AiCardSubsetResult::Full
+        ));
+        assert!(matches!(
+            build_ai_card_subset_or_full(Some(&state), None),
+            AiCardSubsetResult::Full
+        ));
+        assert!(matches!(
+            build_ai_card_subset_or_full(None, None),
+            AiCardSubsetResult::Full
+        ));
+        // Positive control: both present + non-Momir → Subset.
+        assert!(matches!(
+            build_ai_card_subset_or_full(Some(&state), Some(&db)),
+            AiCardSubsetResult::Subset { .. }
+        ));
+    }
+
+    /// VM-6: `export_subset_json` round-trips every per-card index — layout,
+    /// printings, rulings, and bracket signals — for the named faces, and a
+    /// single-face card round-trips with no layout.
+    #[test]
+    fn export_subset_json_round_trips_all_indices() {
+        let dfc_front = creature_face("Rich Front", "rich-oracle");
+        let dfc_back = creature_face("Rich Back", "rich-oracle");
+        let single = creature_face("Plain Card", "plain-oracle");
+
+        let export = serde_json::json!({
+            "Rich Front": entry_value(
+                &dfc_front,
+                Some("transform"),
+                &["TST", "TS2"],
+                &[("2024-01-01", "A ruling.")],
+                true,
+            ),
+            "Rich Back": entry_value(&dfc_back, None, &[], &[], false),
+            "Plain Card": entry_value(&single, None, &[], &[], false),
+        })
+        .to_string();
+        let db = CardDatabase::from_json_str(&export).expect("export db parses");
+
+        let names: BTreeSet<String> = ["Rich Front", "Rich Back", "Plain Card"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let subset_json = db.export_subset_json(&names);
+        let subset = CardDatabase::from_json_str(&subset_json).expect("subset parses");
+
+        // Layout: the DFC front keeps its transform layout (keyed by oracle id).
+        assert_eq!(
+            subset.layout_index.get("rich-oracle").copied(),
+            db.layout_index.get("rich-oracle").copied(),
+            "DFC layout must round-trip"
+        );
+        assert!(
+            subset.layout_index.contains_key("rich-oracle"),
+            "transform layout must survive export"
+        );
+        // Printings / rulings / bracket signals round-trip (keyed by lowercase name).
+        assert_eq!(
+            subset.printings_for("Rich Front"),
+            db.printings_for("Rich Front")
+        );
+        assert_eq!(
+            subset.rulings_for("Rich Front"),
+            db.rulings_for("Rich Front")
+        );
+        assert_eq!(
+            subset.bracket_signals_for("Rich Front").game_changer,
+            db.bracket_signals_for("Rich Front").game_changer
+        );
+        assert!(
+            subset.bracket_signals_for("Rich Front").game_changer,
+            "game_changer signal must survive export"
+        );
+        // Single-face card: no layout, still round-trips as a face.
+        assert!(
+            !subset.layout_index.contains_key("plain-oracle"),
+            "single-face card must carry no layout"
+        );
+        assert!(subset.get_face_by_name("Plain Card").is_some());
+    }
+}

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -10,6 +10,7 @@ pub mod blitz;
 #[path = "blitz_tests.rs"]
 mod blitz_tests;
 pub mod bracket_estimate;
+pub mod card_subset;
 pub mod casting;
 pub(crate) mod casting_costs;
 pub(crate) mod casting_targets;

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1169,7 +1169,7 @@ fn collect_seed_conjure_names(state: &GameState, db: &CardDatabase) -> Vec<Strin
 /// conjure names (a conjured card may itself conjure another) to a fixpoint.
 /// Returns the registry plus every conjure name encountered along the way (used
 /// by the debug-only walker-coverage safety net).
-fn build_conjure_registry(
+pub(crate) fn build_conjure_registry(
     state: &GameState,
     db: &CardDatabase,
 ) -> (HashMap<String, CardFace>, Vec<String>) {


### PR DESCRIPTION
## Problem

iOS Safari silently OOM-reloads PvE **Very Hard** tabs. The AI worker pool (`wasm-adapter.ts ensureAiPool`) spawns up to 4 WASM instances, and **each** parses the full ~93 MB / 35,396-card card database → ~465 MB resident, over WebKit's per-tab memory ceiling → the tab reloads with no console error.

## Fix

AI-pool workers now load an engine-built, **game-scoped subset** (~1–2 MB) — only the cards this game can reference: every object's printed face + all deck pools (main/sideboard/commander/signature) + the transitive Conjure closure + oracle-id face siblings. The **main** worker keeps the full DB (the human player's "name a card" autocomplete needs the full name list).

Games whose card universe isn't statically bounded **auto-escalate** AI workers back to the full DB. Today the only such class is **Momir**, whose token pool is seeded from the entire creature corpus at rehydrate (verified the only whole-corpus dependency; `all_creature_types` and `all_card_names` were proven bounded/safe).

**Footprint: ~1×93 MB + up to 4×~1–2 MB ≈ 100 MB (was ~465 MB).**

## Design

- The subset is built **in the engine** — new `game/card_subset.rs` (`collect_game_card_universe` + `build_ai_card_subset`) + `CardDatabase::export_subset_json` + a `build_ai_card_subset` WASM export that reads the main worker's full `CARD_DB` + live `GAME_STATE`. Completeness reuses the runtime's own `build_conjure_registry` / DFC-back-face walks, so the subset can't drift from what the engine actually looks up mid-game.
- Global **`AiCardDataMode`** flag (`auto` | `subset` | `full`) in the adapter; `subset` still escalates Momir (non-overridable correctness floor).
- The pool's per-game subset is **invalidated on `resetGameState`** so each new game rebuilds its own (fixes the cross-game cache-staleness hole the old game-agnostic full-DB cache hid).

## Tests (6 discriminating, all revert-failing)

- **VM-2** subset covers all 4 sources + DFC back face (each source uniquely reachable); negative: unrelated card absent.
- **VM-3** Momir → `Full`; non-Momir → `Subset`.
- **VM-5** missing state/DB → `Full` (defensive); positive control → `Subset`.
- **VM-6** `export_subset_json` round-trips layout/printings/rulings/bracket-signals.
- **VM-1** two sequential disjoint-deck Very Hard games: game B rebuilds its subset; game-A-only card absent, game-B-only card present.
- **VM-4** flag dispatch: `full`→`loadCardDb`, `subset`→`loadCardDbText`.

## Verification

`cargo fmt` clean; Tilt green: `clippy` (-D warnings), `test-engine` (15550 pass), `wasm`, `card-data`, `check-frontend`, `test-frontend` (incl. 4 new). Passed two plan-review rounds + one clean implementation review.

## Out of scope

The multiplayer-host reload (separate — a PvP host runs ~1×93 MB with no AI pool yet PvE-medium at the same footprint is smooth, so likely not card-DB memory) and the rejected shared-memory / `SharedArrayBuffer` approach.

CR 707.2 + CR 202.3 annotate the Momir escalation.
