### PR TITLE
fix(client): revert crossOrigin on Scryfall <img> tags (fixes card-art regression)

### DIFF
--- a/client/src/components/card/ArtCropCard.tsx
+++ b/client/src/components/card/ArtCropCard.tsx
@@ -134,9 +134,6 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
               <img
                 src={renderedSrc}
                 alt={cardName}
-                // Load via CORS (Scryfall returns ACAO:*) so art survives a future
-                // COEP: require-corp cross-origin-isolation switch on the app host.
-                crossOrigin="anonymous"
                 draggable={false}
                 className="absolute inset-0 w-full h-full object-cover"
               />

--- a/client/src/components/card/CardImage.tsx
+++ b/client/src/components/card/CardImage.tsx
@@ -7,6 +7,7 @@ import type { TokenImageRef } from "../../adapter/types.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { getBevelBorderStyle } from "./cardFrame.ts";
 import { ManaSymbol } from "../mana/ManaSymbol.tsx";
+import { RichLabel } from "../mana/RichLabel.tsx";
 
 interface CardImageProps {
   cardName: string;
@@ -100,7 +101,7 @@ export function CardImage({
         <div className="text-xs font-semibold text-gray-100 mb-1 truncate">{cardName}</div>
         {resolvedOracleText && (
           <div className="text-[10px] text-gray-300 whitespace-pre-wrap leading-tight overflow-hidden">
-            {resolvedOracleText}
+            <RichLabel text={resolvedOracleText} size="xs" />
           </div>
         )}
       </div>
@@ -115,9 +116,6 @@ export function CardImage({
       <img
         src={renderedSrc}
         alt={renderedAlt}
-        // Load via CORS (Scryfall returns ACAO:*) so card art survives a future
-        // COEP: require-corp cross-origin-isolation switch on the app host.
-        crossOrigin="anonymous"
         draggable={false}
         onError={() => setImageError(true)}
         className={`${baseClasses} shadow-lg object-cover`}

--- a/client/src/components/mana/ManaSymbol.tsx
+++ b/client/src/components/mana/ManaSymbol.tsx
@@ -32,9 +32,6 @@ export function ManaSymbol({
     <img
       src={`${SCRYFALL_SVG_BASE}/${code}.svg`}
       alt={shard}
-      // Load via CORS (svgs.scryfall.io returns ACAO:*) so symbols survive a future
-      // COEP: require-corp cross-origin-isolation switch on the app host.
-      crossOrigin="anonymous"
       className={`inline-block ${SIZE_CLASSES[size]} ${className}`}
       draggable={false}
     />


### PR DESCRIPTION
## Problem

Card art and mana symbols were falling back to **plain text on the whole board** (every card showed its name + oracle text instead of its image).

## Root cause

PR #4343 added `crossOrigin="anonymous"` to the three Scryfall `<img>` components as prep for a future `COEP: require-corp` cross-origin-isolation switch (needed for a `SharedArrayBuffer` shared-memory card DB). That switch to CORS mode is what broke image rendering:

- `crossOrigin` turns each `<img>` into a **CORS** request, which only renders if the response carries `Access-Control-Allow-Origin`.
- Scryfall returns `access-control-allow-origin: *` **only when an `Origin` header is sent**, and — critically — its no-Origin responses carry **no `Vary: Origin`**.
- Browser/Cloudflare caches were filled *before* #4343 from plain **no-CORS** requests, whose stored responses have **no ACAO**. The new CORS requests get served those poisoned cache entries, the CORS check fails, and the image errors into the text fallback.

A cold cache would have loaded fine — which is why this only began after #4343 shipped.

```
curl -sI                         cards.scryfall.io/... → 200, (no ACAO)
curl -sI -H 'Origin: ...preview' cards.scryfall.io/... → 200, access-control-allow-origin: *, vary: Origin
```

The app host (`preview.phase-rs.dev`) has **no COEP/COOP** header, so this is purely the per-`<img>` CORS-mode change.

## Fix

Revert the `crossOrigin` attribute on `CardImage`, `ArtCropCard`, and `ManaSymbol`, restoring the no-CORS loading that worked before. **This change has no remaining purpose** — the COEP/`SharedArrayBuffer` shared-memory card DB it was prepping for was replaced by the game-scoped card-DB subset (#4348), so cross-origin isolation is no longer on the roadmap.

`DeathShatter` and `AudioManager` keep their own self-contained `crossOrigin` (canvas/audio taint needs); the `index.html` Scryfall preconnect `crossorigin` predates #4343 and is left intact.

## Also included: mana symbols in the image-fallback text

While the image fallback exists, its oracle text rendered `{T}`/`{W}`/`{1}` as literal braces. It now routes through `RichLabel` (the same building block `CardPreview` uses), so the fallback shows real mana symbols. Low-visibility after the revert (images load again), but correct.

## Verification

`check-frontend` (TypeScript + ESLint) green. Recommend a hard-reload / private-window check on the preview build to confirm art returns (a cold cache bypasses the poisoned entries).
