### PR TITLE
perf(client): MP-host validates guest decks via worker card DB (fix iOS OOM)

### DIFF
--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -29,7 +29,6 @@ import type {
   SeatView,
 } from "../multiplayer/seatTypes";
 import type { BrokerClient } from "../services/brokerClient";
-import { evaluateDeckCompatibilityJs } from "../services/engineRuntime";
 import {
   clearP2PHostSession,
   type PersistedP2PHostSession,
@@ -870,7 +869,12 @@ export class P2PHostAdapter implements EngineAdapter {
       if (this.pregameSeatState.seats[pid]?.type !== "JoinedHuman") return;
 
       try {
-        const result = await evaluateDeckCompatibilityJs({
+        // Validate against the worker engine's already-resident card DB
+        // (`checkDeckCompatibility` self-ensures it). Using the main-thread
+        // `engineRuntime` instance instead would parse a SECOND full ~93 MB
+        // card DB into the page — doubling host footprint past iOS Safari's
+        // per-tab memory ceiling and silently OOM-reloading the host tab.
+        const result = await this.wasm.checkDeckCompatibility({
           main_deck: deck.main_deck,
           sideboard: deck.sideboard,
           commander: deck.commander ?? [],


### PR DESCRIPTION
## Problem

Hosting a P2P 1v1 game on iOS Safari silently OOM-reloads the tab, while PvE at the same card-DB footprint is smooth.

## Root cause

The client runs **two** WASM instances: the gameplay engine in a Web Worker (holds the full ~93 MB card DB) and a *second* main-thread instance (`services/engineRuntime.ts`) that serves card search / rulings / deck-compat. When a guest joins, the host validates their deck via the **main-thread** path:

```
p2p-adapter.ts  validateGuestDeck → evaluateDeckCompatibilityJs (engineRuntime, main thread)
                → ensureCardDatabase() → fetch + load_card_database  ← SECOND resident ~93 MB
```

`ensureCardDatabase` caches its DB for the page's lifetime, so the host ends up holding **~186 MB** (worker 93 + main-thread 93) against iOS Safari's per-tab ceiling. PvE only loads the main-thread copy *conditionally* (oracle-text fallback / card inspect), so it stays at ~93 MB. Server-relayed MP (`ws-adapter`) validates server-side and never loads a second client DB — consistent with the bug being P2P-host-specific.

## Fix

Route guest-deck validation through the worker the host **already owns**, which has the card DB resident for gameplay:

```diff
- const result = await evaluateDeckCompatibilityJs({ … });   // main-thread, 2nd DB
+ const result = await this.wasm.checkDeckCompatibility({ … }); // worker's resident DB
```

Same Rust function (`evaluate_deck_compatibility_js`), identical request shape — a pure transport redirect. Host footprint drops back to ~93 MB, matching PvE. The now-unused `engineRuntime` import is removed (TypeScript would fail on any lingering reference — it compiled clean).

## Confidence

Mechanism confirmed at the code level (single call site; worker path already exists). That ~186 MB is the exact iOS ceiling trigger is a strong inference, not yet on-device-verified.

## Verification

`check-frontend` (TypeScript + ESLint) green.
