### PR TITLE
fix(client): keep GameplayTooltip on-screen near viewport edges

### DIFF
--- a/client/src/components/ui/GameplayTooltip.tsx
+++ b/client/src/components/ui/GameplayTooltip.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 interface GameplayTooltipProps {
   id?: string;
@@ -11,8 +11,62 @@ export function GameplayTooltip({
   children,
   className,
 }: GameplayTooltipProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [shift, setShift] = useState({ x: 0, y: 0 });
+  // Tracks the shift currently applied so each measurement can recover the
+  // tooltip's NATURAL position (rect − shift) and avoid a measure→shift→measure
+  // feedback loop.
+  const shiftRef = useRef({ x: 0, y: 0 });
+
+  // The tooltip is shown purely via CSS `group-hover`; mirror that trigger in
+  // JS so we can measure it only while visible and nudge it back inside the
+  // viewport. Same 8px-margin clamp idiom as `BoardContextMenu`. Listening on
+  // the closest `.group` ancestor — the element the CSS `group-hover` responds
+  // to — keeps this self-contained with no call-site changes.
+  useEffect(() => {
+    const el = ref.current;
+    const trigger = el?.closest(".group");
+    if (!el || !trigger) return;
+
+    const clamp = () => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) return; // not actually visible yet
+      const m = 8;
+      const { x: sx, y: sy } = shiftRef.current;
+      // Natural (un-shifted) edges.
+      const left = r.left - sx;
+      const right = r.right - sx;
+      const top = r.top - sy;
+      const bottom = r.bottom - sy;
+      let x = 0;
+      let y = 0;
+      if (left < m) x = m - left;
+      else if (right > window.innerWidth - m) x = window.innerWidth - m - right;
+      if (top < m) y = m - top;
+      else if (bottom > window.innerHeight - m) y = window.innerHeight - m - bottom;
+      shiftRef.current = { x, y };
+      setShift({ x, y });
+    };
+    const reset = () => {
+      shiftRef.current = { x: 0, y: 0 };
+      setShift({ x: 0, y: 0 });
+    };
+
+    trigger.addEventListener("pointerenter", clamp);
+    trigger.addEventListener("focusin", clamp);
+    trigger.addEventListener("pointerleave", reset);
+    trigger.addEventListener("focusout", reset);
+    return () => {
+      trigger.removeEventListener("pointerenter", clamp);
+      trigger.removeEventListener("focusin", clamp);
+      trigger.removeEventListener("pointerleave", reset);
+      trigger.removeEventListener("focusout", reset);
+    };
+  }, []);
+
   return (
     <span
+      ref={ref}
       id={id}
       role="tooltip"
       className={[
@@ -21,6 +75,11 @@ export function GameplayTooltip({
       ]
         .filter(Boolean)
         .join(" ")}
+      style={
+        shift.x || shift.y
+          ? { transform: `translate(${shift.x}px, ${shift.y}px)` }
+          : undefined
+      }
     >
       {children}
     </span>


### PR DESCRIPTION
## Problem

Board hover tooltips (`GameplayTooltip`) are positioned with pure CSS — `absolute right-0 bottom-full`, fixed `w-64` — with no viewport awareness. For a tooltip whose anchor sits near the left or top screen edge (e.g. the mana rail on the leftmost land), the 256px box extends off-screen and gets clipped (the "Manual" label rendered as "anual").

## Fix

`GameplayTooltip` now measures itself on show and applies a corrective `translate` to nudge it back inside the viewport, using the same 8px-margin clamp idiom as `BoardContextMenu`. This is a building-block fix — every board tooltip benefits, not just the land rail.

Details:
- The tooltip is shown via CSS `group-hover`; the fix mirrors that trigger in JS by listening for `pointerenter`/`focusin` (and resetting on `pointerleave`/`focusout`) on the closest `.group` ancestor — the element `group-hover` itself responds to. No call-site changes.
- Each measurement recovers the tooltip's **natural** position (`rect − currentShift`, tracked in a ref) before computing the correction, avoiding a measure→shift→measure feedback loop.
- The `translate` is applied only when a shift is needed (otherwise no inline style), so the common centered case is untouched.

## Verification

`check-frontend` (TypeScript + ESLint) green.
