### PR TITLE
Fix granted extra blocker statics

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -6275,6 +6275,110 @@ mod tests {
     }
 
     #[test]
+    fn brave_the_sands_extra_blockers_grant_tracks_controller() {
+        use crate::game::layers::evaluate_layers;
+        use crate::parser::oracle_static::parse_static_line_multi;
+
+        let mut state = setup();
+        let brave_card_id = CardId(state.next_object_id);
+        let brave = create_object(
+            &mut state,
+            brave_card_id,
+            PlayerId(1),
+            "Brave the Sands".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        for def in parse_static_line_multi(
+            "Each creature you control can block an additional creature each combat.",
+        ) {
+            let obj = state.objects.get_mut(&brave).unwrap();
+            std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def.clone());
+            obj.static_definitions.push(def);
+        }
+
+        let p0_attacker1 = create_creature(&mut state, PlayerId(0), "P0 Bear A", 2, 2);
+        let p0_attacker2 = create_creature(&mut state, PlayerId(0), "P0 Bear B", 2, 2);
+        let p1_attacker1 = create_creature(&mut state, PlayerId(1), "P1 Bear A", 2, 2);
+        let p1_attacker2 = create_creature(&mut state, PlayerId(1), "P1 Bear B", 2, 2);
+        let p1_blocker = create_creature(&mut state, PlayerId(1), "P1 Guard", 1, 4);
+        let p0_blocker = create_creature(&mut state, PlayerId(0), "P0 Guard", 1, 4);
+
+        evaluate_layers(&mut state);
+
+        state.combat = Some(CombatState {
+            attackers: vec![
+                AttackerInfo::attacking_player(p0_attacker1, PlayerId(1)),
+                AttackerInfo::attacking_player(p0_attacker2, PlayerId(1)),
+            ],
+            ..Default::default()
+        });
+        assert!(
+            validate_blockers(
+                &state,
+                &[(p1_blocker, p0_attacker1), (p1_blocker, p0_attacker2)]
+            )
+            .is_ok(),
+            "Brave controlled by player 1 must grant their creature one extra block"
+        );
+
+        state.combat = Some(CombatState {
+            attackers: vec![
+                AttackerInfo::attacking_player(p1_attacker1, PlayerId(0)),
+                AttackerInfo::attacking_player(p1_attacker2, PlayerId(0)),
+            ],
+            ..Default::default()
+        });
+        assert!(
+            validate_blockers(
+                &state,
+                &[(p0_blocker, p1_attacker1), (p0_blocker, p1_attacker2)]
+            )
+            .is_err(),
+            "Brave controlled by player 1 must not grant player 0's creature"
+        );
+
+        let mut state = setup();
+        let brave_card_id = CardId(state.next_object_id);
+        let brave = create_object(
+            &mut state,
+            brave_card_id,
+            PlayerId(0),
+            "Brave the Sands".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        );
+        for def in parse_static_line_multi(
+            "Each creature you control can block an additional creature each combat.",
+        ) {
+            let obj = state.objects.get_mut(&brave).unwrap();
+            std::sync::Arc::make_mut(&mut obj.base_static_definitions).push(def.clone());
+            obj.static_definitions.push(def);
+        }
+
+        let p1_attacker1 = create_creature(&mut state, PlayerId(1), "P1 Bear A", 2, 2);
+        let p1_attacker2 = create_creature(&mut state, PlayerId(1), "P1 Bear B", 2, 2);
+        let p0_blocker = create_creature(&mut state, PlayerId(0), "P0 Guard", 1, 4);
+
+        evaluate_layers(&mut state);
+
+        state.combat = Some(CombatState {
+            attackers: vec![
+                AttackerInfo::attacking_player(p1_attacker1, PlayerId(0)),
+                AttackerInfo::attacking_player(p1_attacker2, PlayerId(0)),
+            ],
+            ..Default::default()
+        });
+        assert!(
+            validate_blockers_for_player(
+                &state,
+                PlayerId(0),
+                &[(p0_blocker, p1_attacker1), (p0_blocker, p1_attacker2)]
+            )
+            .is_ok(),
+            "Brave controlled by player 0 must grant their creature one extra block"
+        );
+    }
+
+    #[test]
     fn max_blockers_each_combat_counts_previous_defending_players() {
         let mut state = GameState::new(FormatConfig::standard(), 3, 42);
         state.turn_number = 2;

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -294,8 +294,6 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     // quote is required: scan_contains only matches at word starts, and "legend"
     // is glued to its opening quote ("legend) in the Oracle text.
     "\"legend rule\" doesn't apply",
-    "can block an additional",
-    "can block any number",
     "play an additional land",
     "play two additional lands",
     "triggers an additional time",
@@ -441,6 +439,10 @@ pub(crate) fn is_static_pattern(lower: &str) -> bool {
     }
 
     if super::oracle_static::is_tiered_enters_with_additional_counters_static(lower) {
+        return true;
+    }
+
+    if super::oracle_static::is_extra_blockers_static_candidate(lower) {
         return true;
     }
 

--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -67,23 +67,15 @@ fn parse_digit_number(input: &str) -> OracleResult<'_, u32> {
 /// "a"/"an" require a word boundary after the match (whitespace, punctuation, or
 /// end-of-input) to prevent false matches on words like "another" or "anyone".
 ///
-/// Supports multiples of ten from thirty through ninety, plus "one hundred",
-/// for cards like Lux Artillery ("thirty or more counters") and Hundred-Handed
-/// One. Compound forms like "twenty-one" are not currently printed in Oracle
-/// text — add them here if that changes.
+/// Supports multiples of ten from thirty through ninety, hyphenated compounds
+/// from twenty-one through ninety-nine, plus "one hundred".
 fn parse_english_number(input: &str) -> OracleResult<'_, u32> {
     // Longest-match-first ordering within shared prefixes (e.g. "fourteen" before "four").
     // Split into multiple alt groups to stay within nom's 21-element tuple limit.
     alt((
         value(100u32, tag("one hundred")),
-        value(90, tag("ninety")),
-        value(80, tag("eighty")),
-        value(70, tag("seventy")),
-        value(60, tag("sixty")),
-        value(50, tag("fifty")),
-        value(40, tag("forty")),
-        value(30, tag("thirty")),
-        value(20, tag("twenty")),
+        parse_hyphenated_english_number,
+        parse_english_tens,
     ))
     .or(alt((
         value(19u32, tag("nineteen")),
@@ -109,6 +101,43 @@ fn parse_english_number(input: &str) -> OracleResult<'_, u32> {
         value(1, tag("one")),
         parse_article_number,
     )))
+    .parse(input)
+}
+
+fn parse_english_tens(input: &str) -> OracleResult<'_, u32> {
+    alt((
+        value(90u32, tag("ninety")),
+        value(80, tag("eighty")),
+        value(70, tag("seventy")),
+        value(60, tag("sixty")),
+        value(50, tag("fifty")),
+        value(40, tag("forty")),
+        value(30, tag("thirty")),
+        value(20, tag("twenty")),
+    ))
+    .parse(input)
+}
+
+fn parse_english_one_to_nine(input: &str) -> OracleResult<'_, u32> {
+    alt((
+        value(9u32, tag("nine")),
+        value(8, tag("eight")),
+        value(7, tag("seven")),
+        value(6, tag("six")),
+        value(5, tag("five")),
+        value(4, tag("four")),
+        value(3, tag("three")),
+        value(2, tag("two")),
+        value(1, tag("one")),
+    ))
+    .parse(input)
+}
+
+fn parse_hyphenated_english_number(input: &str) -> OracleResult<'_, u32> {
+    map(
+        (parse_english_tens, tag("-"), parse_english_one_to_nine),
+        |(tens, _, ones)| tens + ones,
+    )
     .parse(input)
 }
 
@@ -1057,6 +1086,14 @@ mod tests {
         assert_eq!(parse_number("sixty").unwrap().1, 60);
         assert_eq!(parse_number("seventy").unwrap().1, 70);
         assert_eq!(parse_number("eighty").unwrap().1, 80);
+        assert_eq!(parse_number("ninety").unwrap().1, 90);
+        assert_eq!(parse_number("one hundred").unwrap().1, 100);
+    }
+
+    #[test]
+    fn test_parse_number_hyphenated_words() {
+        assert_eq!(parse_number("twenty-one").unwrap().1, 21);
+        assert_eq!(parse_number("ninety-nine").unwrap().1, 99);
         assert_eq!(parse_number("ninety").unwrap().1, 90);
         assert_eq!(parse_number("one hundred").unwrap().1, 100);
     }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2609,20 +2609,9 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "can block an additional creature" / "can block any number" (CR 509.1b) ---
-    if nom_primitives::scan_contains(tp.lower, "can block any number") {
-        return Some(
-            StaticDefinition::new(StaticMode::ExtraBlockers { count: None })
-                .affected(TargetFilter::SelfRef)
-                .description(text.to_string()),
-        );
-    }
-    if nom_primitives::scan_contains(tp.lower, "can block an additional") {
-        return Some(
-            StaticDefinition::new(StaticMode::ExtraBlockers { count: Some(1) })
-                .affected(TargetFilter::SelfRef)
-                .description(text.to_string()),
-        );
+    // --- "can block an additional creature" / "can block any number" ---
+    if let Some(def) = parse_extra_blockers_static(&text) {
+        return Some(def);
     }
 
     // --- "play an additional land" / "play two additional lands" ---

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -407,6 +407,116 @@ pub(crate) fn parse_rule_static_separator_nom(input: &str) -> OracleResult<'_, (
     .parse(input)
 }
 
+fn parse_extra_blockers_creature_noun(input: &str) -> OracleResult<'_, ()> {
+    value((), (tag(" creature"), opt(tag("s")))).parse(input)
+}
+
+pub(crate) fn parse_extra_blockers_count_phrase(input: &str) -> OracleResult<'_, Option<u32>> {
+    alt((
+        value(None, tag("any number of creatures")),
+        map(
+            preceded(
+                tag("an additional "),
+                terminated(
+                    nom_primitives::parse_number,
+                    parse_extra_blockers_creature_noun,
+                ),
+            ),
+            Some,
+        ),
+        value(
+            Some(1),
+            (
+                tag("additional creature"),
+                opt(tag::<_, _, OracleError<'_>>("s")),
+            ),
+        ),
+        map(
+            terminated(
+                nom_primitives::parse_number,
+                (
+                    tag(" additional creature"),
+                    opt(tag::<_, _, OracleError<'_>>("s")),
+                ),
+            ),
+            Some,
+        ),
+    ))
+    .parse(input)
+}
+
+fn parse_extra_blockers_tail(input: &str) -> OracleResult<'_, Option<u32>> {
+    let (input, count) = parse_extra_blockers_count_phrase(input)?;
+    let (input, _) = opt(alt((
+        tag::<_, _, OracleError<'_>>(" each combat"),
+        tag(" this combat"),
+        tag(" this turn"),
+    )))
+    .parse(input)?;
+    Ok((input, count))
+}
+
+fn parse_can_block_extra_blockers_predicate(input: &str) -> OracleResult<'_, Option<u32>> {
+    preceded(tag("can block "), parse_extra_blockers_tail).parse(input)
+}
+
+fn parse_and_can_block_extra_blockers_predicate(input: &str) -> OracleResult<'_, Option<u32>> {
+    preceded(tag("and "), parse_can_block_extra_blockers_predicate).parse(input)
+}
+
+fn extra_blockers_static_definition(
+    affected: TargetFilter,
+    mode: StaticMode,
+    text: &str,
+) -> StaticDefinition {
+    if matches!(affected, TargetFilter::SelfRef) {
+        StaticDefinition::new(mode)
+            .affected(affected)
+            .description(text.to_string())
+    } else {
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(vec![ContinuousModification::AddStaticMode { mode }])
+            .description(text.to_string())
+    }
+}
+
+fn parse_subject_trailing_conjunction(input: &str) -> OracleResult<'_, ()> {
+    value((), all_consuming((take_until(" and"), tag(" and")))).parse(input)
+}
+
+pub(crate) fn parse_extra_blockers_static(text: &str) -> Option<StaticDefinition> {
+    let lower = text.to_lowercase();
+    let (before, count, rest) =
+        nom_primitives::scan_preceded(&lower, parse_can_block_extra_blockers_predicate)?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let subject_len = before
+        .trim_end_matches(|ch: char| ch == ',' || ch.is_whitespace())
+        .len();
+    let subject = text[..subject_len].trim();
+    if subject.is_empty() {
+        return None;
+    }
+    let subject_lower = lower[..subject_len].trim();
+    if parse_subject_trailing_conjunction(subject_lower).is_ok() {
+        return None;
+    }
+    let affected = parse_rule_static_subject_filter(subject).unwrap_or(TargetFilter::SelfRef);
+    Some(extra_blockers_static_definition(
+        affected,
+        StaticMode::ExtraBlockers { count },
+        text,
+    ))
+}
+
+pub(crate) fn is_extra_blockers_static_candidate(lower: &str) -> bool {
+    parse_extra_blockers_static(lower).is_some()
+}
+
 /// CR 702.3b + CR 611.3a + CR 613: Decompose `"<predicate_1> and can attack
 /// as though <pronoun> didn't have defender[ as long as <cond>]"` into two
 /// independent `StaticDefinition`s sharing the same `affected` + `condition`.
@@ -570,35 +680,14 @@ pub(crate) fn try_split_and_must_attack_block(text: &str) -> Option<Vec<StaticDe
 /// the remainder for the first conjunct, then clone its `affected`/`condition`
 /// onto the companion `ExtraBlockers` definition.
 pub(crate) fn try_split_and_can_block_additional(text: &str) -> Option<Vec<StaticDefinition>> {
-    type VE<'a> = OracleError<'a>;
     let lower = text.to_lowercase();
 
-    let (before, count, _rest) = nom_primitives::scan_preceded(&lower, |i: &str| {
-        let (i, _) = tag::<_, _, VE>("and can block ").parse(i)?;
-        // CR 107.1c: "any number of creatures" → unbounded (None); otherwise a
-        // numeric count of additional creatures ("an"/"a" → 1, "two" → 2, …).
-        let (i, count): (&str, Option<u32>) = if let Ok((after, _)) = (
-            tag::<_, _, VE>("any"),
-            tag::<_, _, VE>(" number of creatures"),
-        )
-            .parse(i)
-        {
-            (after, None)
-        } else {
-            let (after_n, n) = nom_primitives::parse_number(i)?;
-            let (after_kw, _) = tag::<_, _, VE>(" additional creature").parse(after_n)?;
-            let (after_s, _) = opt(tag::<_, _, VE>("s")).parse(after_kw)?;
-            (after_s, Some(n))
-        };
-        // Optional trailing duration phrase ("each combat", "this combat", …).
-        let (i, _) = opt(alt((
-            tag::<_, _, VE>(" each combat"),
-            tag::<_, _, VE>(" this combat"),
-            tag::<_, _, VE>(" this turn"),
-        )))
-        .parse(i)?;
-        Ok((i, count))
-    })?;
+    let (before, count, rest) =
+        nom_primitives::scan_preceded(&lower, parse_and_can_block_extra_blockers_predicate)?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
 
     let cut_end = before
         .trim_end_matches(|ch: char| ch == ',' || ch.is_whitespace())
@@ -614,9 +703,8 @@ pub(crate) fn try_split_and_can_block_additional(text: &str) -> Option<Vec<Stati
 
     let affected = defs[0].affected.clone()?;
     let condition = defs[0].condition.clone();
-    let mut companion = StaticDefinition::new(StaticMode::ExtraBlockers { count })
-        .affected(affected)
-        .description(text.to_string());
+    let mut companion =
+        extra_blockers_static_definition(affected, StaticMode::ExtraBlockers { count }, text);
     if let Some(condition) = condition {
         companion = companion.condition(condition);
     }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -138,7 +138,7 @@ pub(crate) use cost_mod::{
     parse_alternative_keyword_cost, parse_cast_spells_alternative_cost_multi,
     parse_collect_evidence_alt_cost, parse_spells_alternative_cost,
 };
-pub(crate) use evasion::classify_block_exception;
+pub(crate) use evasion::{classify_block_exception, is_extra_blockers_static_candidate};
 pub(crate) use keyword_grant::{
     classify_quoted_inner, parse_chosen_qualifier_subject, parse_continuous_modifications,
     parse_quoted_ability_modifications, split_keyword_list,

--- a/crates/engine/src/parser/oracle_static/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_static/snapshot_tests.rs
@@ -31,6 +31,15 @@ fn static_granted_keyword() {
 }
 
 #[test]
+fn static_extra_blockers_group_grant() {
+    let def = parse_static_line(
+        "Each creature you control can block an additional creature each combat.",
+    )
+    .unwrap();
+    insta::assert_json_snapshot!("static_extra_blockers_group_grant", &def);
+}
+
+#[test]
 fn static_tiered_enters_with_additional_counters() {
     let defs = parse_static_line_multi(
         "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.",

--- a/crates/engine/src/parser/oracle_static/snapshots/engine__parser__oracle_static__snapshot_tests__static_extra_blockers_group_grant.snap
+++ b/crates/engine/src/parser/oracle_static/snapshots/engine__parser__oracle_static__snapshot_tests__static_extra_blockers_group_grant.snap
@@ -1,0 +1,31 @@
+---
+source: crates/engine/src/parser/oracle_static/snapshot_tests.rs
+expression: "&def"
+---
+{
+  "mode": "Continuous",
+  "affected": {
+    "type": "Typed",
+    "type_filters": [
+      "Creature"
+    ],
+    "controller": "You",
+    "properties": []
+  },
+  "modifications": [
+    {
+      "type": "AddStaticMode",
+      "mode": {
+        "ExtraBlockers": {
+          "count": 1
+        }
+      }
+    }
+  ],
+  "condition": null,
+  "affected_zone": null,
+  "effect_zone": null,
+  "active_zones": [],
+  "characteristic_defining": false,
+  "description": "Each creature you control can block an additional creature each combat."
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -169,9 +169,14 @@ fn extra_blockers_static_splits_from_keyword_grant() {
     );
     let extra = defs
         .iter()
-        .find(|d| matches!(d.mode, StaticMode::ExtraBlockers { .. }))
-        .expect("expected an ExtraBlockers static def");
-    assert_eq!(extra.mode, StaticMode::ExtraBlockers { count: Some(1) });
+        .find(|d| {
+            d.modifications
+                .contains(&ContinuousModification::AddStaticMode {
+                    mode: StaticMode::ExtraBlockers { count: Some(1) },
+                })
+        })
+        .expect("expected an AddStaticMode ExtraBlockers carrier");
+    assert_eq!(extra.mode, StaticMode::Continuous);
     match &extra.affected {
         Some(TargetFilter::Typed(tf)) => {
             assert_eq!(tf.controller, Some(ControllerRef::You));
@@ -191,6 +196,101 @@ fn extra_blockers_static_splits_from_keyword_grant() {
 fn extra_blockers_static_self_reference_stays_selfref() {
     let def = parse_static_line("~ can block an additional creature.").expect("static def");
     assert_eq!(def.mode, StaticMode::ExtraBlockers { count: Some(1) });
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+}
+
+#[test]
+fn extra_blockers_count_phrase_handles_hyphenated_and_any() {
+    assert_eq!(
+        super::evasion::parse_extra_blockers_count_phrase("any number of creatures").unwrap(),
+        ("", None)
+    );
+    assert_eq!(
+        super::evasion::parse_extra_blockers_count_phrase("an additional creature").unwrap(),
+        ("", Some(1))
+    );
+    assert_eq!(
+        super::evasion::parse_extra_blockers_count_phrase("two additional creatures").unwrap(),
+        ("", Some(2))
+    );
+    assert_eq!(
+        super::evasion::parse_extra_blockers_count_phrase("ninety-nine additional creatures")
+            .unwrap(),
+        ("", Some(99))
+    );
+    assert_eq!(
+        super::evasion::parse_extra_blockers_count_phrase("an additional ninety-nine creatures")
+            .unwrap(),
+        ("", Some(99))
+    );
+}
+
+#[test]
+fn brave_current_oracle_extra_blockers_is_granted_to_creatures() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "Creatures you control have vigilance.\nEach creature you control can block an additional creature each combat.",
+        "Brave the Sands",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+    let extra = parsed
+        .statics
+        .iter()
+        .find(|d| {
+            d.modifications
+                .contains(&ContinuousModification::AddStaticMode {
+                    mode: StaticMode::ExtraBlockers { count: Some(1) },
+                })
+        })
+        .expect("Brave must grant ExtraBlockers through a continuous carrier");
+    assert_eq!(extra.mode, StaticMode::Continuous);
+    match &extra.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "extra-block grant must affect creatures, got {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("ExtraBlockers carrier must affect creatures you control, got {other:?}"),
+    }
+}
+
+#[test]
+fn hundred_handed_one_monstrous_compound_preserves_conditioned_self_extra_blockers() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "Vigilance\n{3}{W}{W}{W}: Monstrosity 3.\nAs long as Hundred-Handed One is monstrous, it has reach and can block an additional ninety-nine creatures each combat.",
+        "Hundred-Handed One",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let extra = parsed
+        .statics
+        .iter()
+        .find(|d| d.mode == (StaticMode::ExtraBlockers { count: Some(99) }))
+        .expect("monstrous static must grant ninety-nine extra blockers");
+    assert_eq!(extra.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(extra.condition, Some(StaticCondition::SourceIsMonstrous));
+    assert!(
+        parsed.statics.iter().any(|d| {
+            d.condition == Some(StaticCondition::SourceIsMonstrous)
+                && d.modifications
+                    .contains(&ContinuousModification::AddKeyword {
+                        keyword: Keyword::Reach,
+                    })
+        }),
+        "monstrous compound must preserve the reach grant, got {:?}",
+        parsed.statics
+    );
+}
+
+#[test]
+fn self_can_block_any_number_stays_direct_extra_blockers() {
+    let def = parse_static_line("~ can block any number of creatures.").expect("static def");
+    assert_eq!(def.mode, StaticMode::ExtraBlockers { count: None });
     assert_eq!(def.affected, Some(TargetFilter::SelfRef));
 }
 


### PR DESCRIPTION
Fixes #1806.

Summary:
- Parse group-granted extra-blocker abilities as continuous grants that add `ExtraBlockers` to affected creatures.
- Support hyphenated English number counts such as `ninety-nine` for Hundred-Handed One.
- Add parser, snapshot, generated card-data, and runtime coverage for granted extra-blocker statics.

Local verification:
- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- Tilt: `clippy`, `test-engine`, `card-data` all green on the main checkout.