### PR TITLE
feat(tests): Curse of Conformity — base P/T 3/3 + remove creature types (enchanted player)

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20400,3 +20400,58 @@ fn static_creatures_enchanted_player_controls_attack_each_combat_if_able() {
         ))
     );
 }
+
+#[test]
+fn static_nonlegendary_creatures_enchanted_player_controls_base_pt_and_lose_types() {
+    // Curse of Conformity: "Nonlegendary creatures enchanted player controls
+    // have base power and toughness 3/3 and lose all creature types."
+    // CR 613.4b (layer 7b base P/T), CR 205.1a (creature type removal),
+    // CR 303.4b (enchanted player scope).
+    let def = parse_static_line(
+        "Nonlegendary creatures enchanted player controls have base power and toughness 3/3 \
+         and lose all creature types.",
+    )
+    .expect("Curse of Conformity oracle must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    // Filter: nonlegendary creatures enchanted player controls.
+    let tf = match &def.affected {
+        Some(TargetFilter::Typed(tf)) => tf,
+        other => panic!("expected Typed filter, got {other:?}"),
+    };
+    assert!(
+        tf.type_filters.contains(&TypeFilter::Creature),
+        "must filter on Creature"
+    );
+    assert_eq!(
+        tf.controller,
+        Some(ControllerRef::EnchantedPlayer),
+        "must scope to enchanted player"
+    );
+    assert!(
+        tf.properties.contains(&FilterProp::NotSupertype {
+            value: Supertype::Legendary,
+        }),
+        "must exclude legendary creatures"
+    );
+    // Modifications: SetPower{3}, SetToughness{3}, RemoveAllSubtypes{Creature}.
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetPower { value: 3 }),
+        "must set power to 3, got {:?}",
+        def.modifications
+    );
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::SetToughness { value: 3 }),
+        "must set toughness to 3, got {:?}",
+        def.modifications
+    );
+    assert!(
+        def.modifications
+            .contains(&ContinuousModification::RemoveAllSubtypes {
+                set: crate::types::card_type::SubtypeSet::Creature,
+            }),
+        "must remove all creature types, got {:?}",
+        def.modifications
+    );
+}

--- a/crates/engine/tests/integration/curse_of_conformity_base_pt_and_lose_types.rs
+++ b/crates/engine/tests/integration/curse_of_conformity_base_pt_and_lose_types.rs
@@ -1,0 +1,198 @@
+//! Curse of Conformity — "Nonlegendary creatures enchanted player controls have
+//! base power and toughness 3/3 and lose all creature types."
+//!
+//! Runtime regression coverage for the continuous static that combines:
+//!   - **base P/T set** (layer 7b, CR 613.4b) — overrides printed P/T to 3/3,
+//!   - **remove all creature types** (layer 4, CR 205.1a + CR 613.1d),
+//!   - **nonlegendary filter** — legendary creatures are excluded,
+//!   - **enchanted-player scope** — only the enchanted player's creatures are
+//!     affected (CR 303.4b).
+//!
+//! Drives the REAL parse → synthesis → layer pipeline and reads back the
+//! EFFECTIVE post-`evaluate_layers` state — a runtime test, not an AST-shape
+//! test.
+
+use engine::game::effects::attach::attach_to_player;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+/// Oracle text for Curse of Conformity (Innistrad: Crimson Vow).
+const CURSE_OF_CONFORMITY: &str =
+    "Nonlegendary creatures enchanted player controls have base power and toughness 3/3 \
+     and lose all creature types.";
+
+fn effective_pt(runner: &mut GameRunner, id: ObjectId) -> (i32, i32) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&id];
+    (
+        obj.power.expect("creature has power"),
+        obj.toughness.expect("creature has toughness"),
+    )
+}
+
+fn has_subtype(runner: &GameRunner, id: ObjectId, subtype: &str) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("object present")
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(subtype))
+}
+
+/// CR 613.4b + CR 205.1a: Nonlegendary creature under the enchanted player
+/// gets base 3/3 and loses all creature types.
+#[test]
+fn curse_of_conformity_sets_base_pt_and_removes_creature_types() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Create the curse as an enchantment on the battlefield under P0's control.
+    let curse = {
+        let mut builder =
+            scenario.add_creature_from_oracle(P0, "Curse of Conformity", 0, 0, CURSE_OF_CONFORMITY);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.id()
+    };
+
+    // Enchanted player's nonlegendary creature — a 1/1 Elf.
+    let elf = {
+        let mut builder = scenario.add_creature(P1, "Llanowar Elves", 1, 1);
+        builder.with_subtypes(vec!["Elf", "Druid"]);
+        builder.id()
+    };
+
+    // Enchanted player's legendary creature — should NOT be affected.
+    let legend = {
+        let mut builder = scenario.add_creature(P1, "Thalia, Guardian of Thraben", 2, 1);
+        builder.as_legendary();
+        builder.with_subtypes(vec!["Human", "Soldier"]);
+        builder.id()
+    };
+
+    // Controller's own nonlegendary creature — outside the enchanted player filter.
+    let ally = {
+        let mut builder = scenario.add_creature(P0, "Grizzly Bears", 2, 2);
+        builder.with_subtypes(vec!["Bear"]);
+        builder.id()
+    };
+
+    let mut runner = scenario.build();
+
+    // Seed all_creature_types so RemoveAllSubtypes has a set to check against.
+    runner.state_mut().all_creature_types = vec![
+        "Bear".to_string(),
+        "Druid".to_string(),
+        "Elf".to_string(),
+        "Human".to_string(),
+        "Soldier".to_string(),
+    ];
+
+    // Attach the curse to P1 (the enchanted player).
+    attach_to_player(runner.state_mut(), curse, P1);
+
+    // CR 613.4b: nonlegendary creature under enchanted player → base 3/3.
+    assert_eq!(
+        effective_pt(&mut runner, elf),
+        (3, 3),
+        "nonlegendary creature under enchanted player must become 3/3"
+    );
+
+    // CR 205.1a: creature types removed.
+    assert!(
+        !has_subtype(&runner, elf, "Elf"),
+        "Elf subtype must be removed"
+    );
+    assert!(
+        !has_subtype(&runner, elf, "Druid"),
+        "Druid subtype must be removed"
+    );
+
+    // Legendary creature is excluded from the filter.
+    assert_eq!(
+        effective_pt(&mut runner, legend),
+        (2, 1),
+        "legendary creature must NOT be affected by Curse of Conformity"
+    );
+    assert!(
+        has_subtype(&runner, legend, "Human"),
+        "legendary creature must retain its creature types"
+    );
+
+    // Controller's own creature is excluded (wrong controller).
+    assert_eq!(
+        effective_pt(&mut runner, ally),
+        (2, 2),
+        "curse controller's own creature must NOT be affected"
+    );
+    assert!(
+        has_subtype(&runner, ally, "Bear"),
+        "curse controller's creature must retain its creature types"
+    );
+}
+
+/// CR 611.3: The continuous effect ends when its source leaves the battlefield.
+#[test]
+fn curse_of_conformity_effect_ends_when_source_leaves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse = {
+        let mut builder =
+            scenario.add_creature_from_oracle(P0, "Curse of Conformity", 0, 0, CURSE_OF_CONFORMITY);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.id()
+    };
+
+    let elf = {
+        let mut builder = scenario.add_creature(P1, "Llanowar Elves", 1, 1);
+        builder.with_subtypes(vec!["Elf", "Druid"]);
+        builder.id()
+    };
+
+    let mut runner = scenario.build();
+
+    runner.state_mut().all_creature_types = vec!["Druid".to_string(), "Elf".to_string()];
+
+    attach_to_player(runner.state_mut(), curse, P1);
+
+    // Baseline: affected.
+    assert_eq!(
+        effective_pt(&mut runner, elf),
+        (3, 3),
+        "baseline: nonlegendary creature is 3/3 while curse is present"
+    );
+    assert!(
+        !has_subtype(&runner, elf, "Elf"),
+        "baseline: Elf subtype removed while curse is present"
+    );
+
+    // Remove the curse from the battlefield.
+    {
+        let state = runner.state_mut();
+        state.battlefield.retain(|&id| id != curse);
+        state.objects.remove(&curse);
+    }
+
+    // CR 611.3: effect ends.
+    assert_eq!(
+        effective_pt(&mut runner, elf),
+        (1, 1),
+        "creature reverts to base 1/1 once the curse is gone"
+    );
+    assert!(
+        has_subtype(&runner, elf, "Elf"),
+        "creature regains Elf subtype once the curse is gone"
+    );
+    assert!(
+        has_subtype(&runner, elf, "Druid"),
+        "creature regains Druid subtype once the curse is gone"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -56,6 +56,7 @@ mod crossway_troublemakers_attacking_keywords;
 mod cultivate_split_destination;
 mod cumber_stone_opponent_debuff;
 mod curse_co_departed_enchanted_player_trigger;
+mod curse_of_conformity_base_pt_and_lose_types;
 mod curse_of_deaths_hold_continuous_effect;
 mod curse_of_the_nightly_hunt_must_attack;
 mod curse_of_the_restless_dead_land_enters_trigger;


### PR DESCRIPTION
## Summary

Test-only PR proving the **Curse of Conformity** oracle text parses and applies correctly at runtime.

**Oracle text:** "Nonlegendary creatures enchanted player controls have base power and toughness 3/3 and lose all creature types."

No parser or engine code changes — the card is already fully parsed in `data/mtgish-cards.json`.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/parser/oracle_static/tests.rs` | Parser unit test: verifies `parse_static_line` produces `StaticMode::Continuous` with `NotSupertype(Legendary)` + `Creature` + `ControllerRef::EnchantedPlayer` filter, and `SetPower{3}` + `SetToughness{3}` + `RemoveAllSubtypes{Creature}` modifications |
| `crates/engine/tests/integration/curse_of_conformity_base_pt_and_lose_types.rs` | Runtime integration test (2 functions) driving `evaluate_layers` end-to-end |
| `crates/engine/tests/integration/main.rs` | `mod` declaration added alphabetically |

## Test Axes

1. **Positive** — nonlegendary creature under enchanted player becomes 3/3 and loses all creature types
2. **Negative (legendary exclusion)** — legendary creature under enchanted player is unaffected
3. **Negative (wrong controller)** — curse controller's own creature is unaffected
4. **Source-leaves** — removing the curse reverts the creature to its printed P/T and restores creature types

## CR References

- **CR 613.4b** — layer 7b base P/T set
- **CR 205.1a** — creature type removal
- **CR 613.1d** — type-changing effects (layer 4)
- **CR 303.4b** — enchanted player scope
- **CR 611.3** — continuous effect ends when source leaves

## Verification

- `cargo check --lib` ✅
- `cargo check -p engine --test integration` ✅
- `cargo test -p engine --test integration curse_of_conformity` — 2 passed ✅
- `cargo fmt` — clean ✅
- `scripts/check-parser-combinators.sh` — passed ✅
