### PR TITLE
feat(parser/layers): SetChosenName + last-chosen readback building blocks (preparatory for as-becomes-attached Equipment choices)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3745,6 +3745,7 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
             format!("set land type {}", land_type.as_subtype_str())
         }
         ContinuousModification::SetChosenBasicLandType => "set chosen land type".into(),
+        ContinuousModification::SetChosenName => "set chosen name".into(),
         ContinuousModification::AssignNoCombatDamage => "assign no combat damage".into(),
         ContinuousModification::RetainPrintedTriggerFromSource {
             source_trigger_index,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1742,9 +1742,29 @@ impl GameObject {
     }
 
     /// Look up a stored creature type choice.
+    ///
+    /// CR 613.7: Reads the LAST `ChosenAttribute::CreatureType`, so that a
+    /// re-choice (which appends to `chosen_attributes`, since the vector is only
+    /// cleared on leave-battlefield) supersedes the prior choice — the most
+    /// recent persisted choice wins. ETB-once cards have a single entry, so the
+    /// last entry equals the first and behavior is unchanged. Kept consistent
+    /// with `chosen_card_name` so a same-clause read of "the last chosen name and
+    /// creature type" (Psychic Paper) reports both halves from the same choice.
     pub fn chosen_creature_type(&self) -> Option<&str> {
-        self.chosen_attributes.iter().find_map(|a| match a {
+        self.chosen_attributes.iter().rev().find_map(|a| match a {
             ChosenAttribute::CreatureType(s) => Some(s.as_str()),
+            _ => None,
+        })
+    }
+
+    /// CR 612.8 + CR 613.7: The most recently chosen card name (Psychic Paper's
+    /// "the last chosen name"). Reads the LAST `ChosenAttribute::CardName` so a
+    /// re-attach that chooses again (which appends, since `chosen_attributes` only
+    /// clears on leave-battlefield) supersedes the prior choice. Read by
+    /// `ContinuousModification::SetChosenName` at Layer 3 evaluation.
+    pub fn chosen_card_name(&self) -> Option<&str> {
+        self.chosen_attributes.iter().rev().find_map(|a| match a {
+            ChosenAttribute::CardName(s) => Some(s.as_str()),
             _ => None,
         })
     }
@@ -2021,6 +2041,44 @@ mod tests {
         obj.chosen_attributes
             .push(ChosenAttribute::Color(ManaColor::Red));
         assert_eq!(obj.chosen_color(), Some(ManaColor::Red));
+    }
+
+    #[test]
+    fn chosen_card_name_returns_last_choice() {
+        // CR 613.7: re-attach appends a second CardName; the most recent wins.
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(100),
+            PlayerId(0),
+            "Psychic Paper".to_string(),
+            Zone::Battlefield,
+        );
+        assert!(obj.chosen_card_name().is_none());
+        obj.chosen_attributes
+            .push(ChosenAttribute::CardName("Llanowar Elves".to_string()));
+        assert_eq!(obj.chosen_card_name(), Some("Llanowar Elves"));
+        obj.chosen_attributes
+            .push(ChosenAttribute::CardName("Grizzly Bears".to_string()));
+        assert_eq!(obj.chosen_card_name(), Some("Grizzly Bears"));
+    }
+
+    #[test]
+    fn chosen_creature_type_returns_last_choice() {
+        // CR 613.7: re-attach appends a second CreatureType; the most recent wins.
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(100),
+            PlayerId(0),
+            "Psychic Paper".to_string(),
+            Zone::Battlefield,
+        );
+        assert!(obj.chosen_creature_type().is_none());
+        obj.chosen_attributes
+            .push(ChosenAttribute::CreatureType("Elf".to_string()));
+        assert_eq!(obj.chosen_creature_type(), Some("Elf"));
+        obj.chosen_attributes
+            .push(ChosenAttribute::CreatureType("Bear".to_string()));
+        assert_eq!(obj.chosen_creature_type(), Some("Bear"));
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4457,6 +4457,21 @@ fn apply_continuous_effect_filtered(
         None
     };
 
+    // Pre-read chosen card name from source (avoids borrow conflict in the loop).
+    // CR 612.8 + CR 613.1c: `SetChosenName` sets the recipient's name to the
+    // granting source's chosen card name. Read once here (the source's most recent
+    // `ChosenAttribute::CardName`) so the per-recipient loop can assign without
+    // re-borrowing `state` — mirrors the `chosen_color` / `chosen_subtype` /
+    // `chosen_card_type` pre-read blocks above.
+    let chosen_card_name = if matches!(effect.modification, ContinuousModification::SetChosenName) {
+        state
+            .objects
+            .get(&effect.source_id)
+            .and_then(|src| src.chosen_card_name().map(str::to_string))
+    } else {
+        None
+    };
+
     // CR 613.1b: For Layer 2 ChangeController, the new controller is the effect's
     // own `controller` field — set authoritatively by the effect that queued the
     // continuous modification (e.g. gain_control passes `ability.controller`,
@@ -4571,6 +4586,15 @@ fn apply_continuous_effect_filtered(
             // follows `CopyValues` in `add_transient_continuous_effect`).
             ContinuousModification::SetName { name } => {
                 obj.name = name.clone();
+            }
+            // CR 612.8 + CR 613.1c: Layer 3 — set the object's name to the
+            // granting source's chosen card name. Per CR 612.8 the object loses
+            // any other names. No-op until a name has been chosen (`chosen_card_name`
+            // pre-read above is `None`), so the printed name is retained.
+            ContinuousModification::SetChosenName => {
+                if let Some(ref name) = chosen_card_name {
+                    obj.name = name.clone();
+                }
             }
             ContinuousModification::AddPower { value } => {
                 if let Some(ref mut p) = obj.power {
@@ -10923,6 +10947,81 @@ mod tests {
         assert!(
             !land.card_types.subtypes.contains(&"Forest".to_string()),
             "Land should no longer have Forest subtype"
+        );
+    }
+
+    /// CR 612.8 + CR 613.7: SetChosenName renames the equipped creature to the
+    /// granting source's chosen card name; with no choice recorded it is a no-op,
+    /// and a re-choice (appended) supersedes the prior name (most recent wins).
+    #[test]
+    fn set_chosen_name_renames_equipped_creature_to_source_choice() {
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = setup();
+        let p0 = PlayerId(0);
+
+        let creature_id = make_creature(&mut state, "Grizzly Bears", 2, 2, p0);
+
+        // An Equipment whose static sets the equipped creature's name to the
+        // Equipment's own chosen card name.
+        let equip_id = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "Psychic Paper".to_string(),
+            Zone::Battlefield,
+        );
+        let ts = state.next_timestamp();
+        {
+            let obj = state.objects.get_mut(&equip_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.card_types.subtypes.push("Equipment".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.timestamp = ts;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EquippedBy]),
+                    ))
+                    .modifications(vec![ContinuousModification::SetChosenName]),
+            );
+        }
+        state.objects.get_mut(&equip_id).unwrap().attached_to = Some(creature_id.into());
+
+        // No choice recorded yet → printed name retained (no-op).
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&creature_id).unwrap().name,
+            "Grizzly Bears",
+            "with no chosen name the equipped creature keeps its printed name"
+        );
+
+        // Record a chosen card name on the Equipment → creature is renamed.
+        state
+            .objects
+            .get_mut(&equip_id)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::CardName("Llanowar Elves".to_string()));
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&creature_id).unwrap().name,
+            "Llanowar Elves",
+            "the equipped creature takes the source's chosen card name"
+        );
+
+        // A re-choice appends; CR 613.7 — the most recent choice wins.
+        state
+            .objects
+            .get_mut(&equip_id)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::CardName("Birds of Paradise".to_string()));
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects.get(&creature_id).unwrap().name,
+            "Birds of Paradise",
+            "the latest chosen card name supersedes the prior one"
         );
     }
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -790,6 +790,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -488,6 +488,7 @@ pub(crate) fn continuous_modification_dynamic_quantity(
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7951,6 +7951,7 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }
@@ -8046,6 +8047,7 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -1083,6 +1083,43 @@ fn parse_all_land_types_modification(text: &str) -> Option<ContinuousModificatio
     })
 }
 
+/// One characteristic listed in an "its `<X>` is/are the last chosen `<X>`"
+/// clause. Parser-local — maps to the chosen-attribute read modification(s) for
+/// that characteristic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LastChosenCharacteristic {
+    Name,
+    CreatureType,
+}
+
+/// CR 612.8 + CR 205.1a / CR 613.1d: Parse the SUBJECT list of an "its
+/// `<characteristics>` is/are the last chosen `<characteristics>`" clause
+/// (Psychic Paper: "its name and creature type are the last chosen name and
+/// creature type"). The mandatory `"its "` prefix distinguishes this clause from
+/// the `"it can't be blocked"` restriction anaphor. The subject characteristic
+/// list drives the emitted modifications; the trailing object list ("the last
+/// chosen name and creature type") is the read source and is left unconsumed.
+/// One `alt()` per axis (separator, characteristic) rather than enumerating the
+/// cross-product, per the combinator-composition mandate.
+fn parse_last_chosen_characteristic_list(
+    input: &str,
+) -> OracleResult<'_, Vec<LastChosenCharacteristic>> {
+    preceded(
+        tag("its "),
+        terminated(
+            separated_list1(
+                alt((tag(", and "), tag(" and "), tag(", "))),
+                alt((
+                    value(LastChosenCharacteristic::CreatureType, tag("creature type")),
+                    value(LastChosenCharacteristic::Name, tag("name")),
+                )),
+            ),
+            (alt((tag(" is "), tag(" are "))), tag("the last chosen ")),
+        ),
+    )
+    .parse(input)
+}
+
 pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModification> {
     // Strip "where X is [quantity]" before parsing modifications,
     // but only if the text doesn't contain quoted abilities (which have their
@@ -1249,6 +1286,39 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
         || nom_primitives::scan_contains(unquoted_lower.as_str(), "are every creature type")
     {
         modifications.push(ContinuousModification::AddAllCreatureTypes);
+    }
+
+    // CR 612.8 (name, Layer 3) + CR 205.1a / CR 613.1d (creature type, Layer 4):
+    // "its <characteristics> is/are the last chosen <characteristics>" — set each
+    // listed characteristic to the granting source's persisted ChosenAttribute
+    // (Psychic Paper). `split_keyword_list` shreds this clause across its commas
+    // and "and"s, so it is recognized HERE on the intact predicate, ahead of the
+    // keyword-list path. It is a distinct clause type (not a restriction, so no
+    // overlap with `parse_restriction_modes`). Built for the class of "its <X> is
+    // the last chosen <X>" equipment-choice readbacks, not the single card.
+    if let Some(characteristics) = nom_primitives::scan_at_word_boundaries(
+        unquoted_lower.as_str(),
+        parse_last_chosen_characteristic_list,
+    ) {
+        for characteristic in characteristics {
+            match characteristic {
+                LastChosenCharacteristic::Name => {
+                    modifications.push(ContinuousModification::SetChosenName);
+                }
+                LastChosenCharacteristic::CreatureType => {
+                    // CR 205.1a + CR 613.1d: setting a creature's creature type
+                    // REPLACES its existing creature subtypes (Layer 4), so remove
+                    // all current creature subtypes before adding the chosen one.
+                    // Emission order is the intra-layer timestamp order (CR 613.7a).
+                    modifications.push(ContinuousModification::RemoveAllSubtypes {
+                        set: SubtypeSet::Creature,
+                    });
+                    modifications.push(ContinuousModification::AddChosenSubtype {
+                        kind: ChosenSubtypeKind::CreatureType,
+                    });
+                }
+            }
+        }
     }
 
     // CR 613.4c: Scan for "get +X/+X" / "gets +X/+X" anywhere in the text
@@ -1473,6 +1543,21 @@ pub(crate) fn push_grant_clause_modifications(
     let part_trimmed = part.trim().trim_end_matches('.');
     let (part_without_duration, _) = strip_trailing_duration(part_trimmed);
     let part_trimmed = part_without_duration.trim().trim_end_matches('.');
+    let part_lower = part_trimmed.to_lowercase();
+
+    // CR 509.1b: A compound equipped/enchanted-creature grant lists restriction
+    // conjuncts with an anaphoric subject ("…, it can't be blocked, …" — Psychic
+    // Paper). Strip a leading subject-anaphor so the bare predicate reaches the
+    // single restriction authority (`parse_restriction_modes`) already called at
+    // this fn's tail — no second `CantBeBlocked` detector. `tag("it ")` is
+    // word-boundary-safe (it never matches "its …"). Keywords / "can't be the
+    // target" grants never begin with these anaphors, so the strip leaves
+    // `map_keyword` / `classify_cant_be_targeted` unaffected. Mirrors the
+    // anaphor-strip idiom in oracle_static/shared.rs.
+    let part_trimmed = nom_tag_lower(part_trimmed, &part_lower, "it ")
+        .or_else(|| nom_tag_lower(part_trimmed, &part_lower, "this creature "))
+        .or_else(|| nom_tag_lower(part_trimmed, &part_lower, "they "))
+        .unwrap_or(part_trimmed);
     let part_lower = part_trimmed.to_lowercase();
 
     // CR 702: Check for dynamic "keyword X" with "where X is [qty]"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5957,6 +5957,83 @@ fn static_control_creature_with_power_le() {
     ));
 }
 
+/// CR 509.1b: An anaphoric "it can't be blocked" conjunct riding in a compound
+/// equipped-creature grant ("has ward {1}, it can't be blocked" — Psychic Paper)
+/// must reach the single restriction authority despite the leading "it " anaphor,
+/// so the can't-be-blocked restriction is not silently dropped. Building-block
+/// test: the sibling ward keyword stays intact and the bare restriction lands.
+#[test]
+fn parse_continuous_modifications_anaphoric_cant_be_blocked_conjunct() {
+    let mods = parse_continuous_modifications("has ward {1}, it can't be blocked");
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Ward(_)
+            }
+        )),
+        "ward conjunct preserved, got {mods:?}"
+    );
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddStaticMode {
+                mode: StaticMode::CantBeBlocked
+            }
+        )),
+        "anaphoric can't-be-blocked conjunct must not be dropped, got {mods:?}"
+    );
+}
+
+/// CR 612.8: "its name is the last chosen name" sets the recipient's name to the
+/// granting source's chosen card name (Layer 3) — emits `SetChosenName`.
+#[test]
+fn parse_continuous_modifications_its_name_is_last_chosen_name() {
+    let mods = parse_continuous_modifications("its name is the last chosen name");
+    assert_eq!(mods, vec![ContinuousModification::SetChosenName]);
+}
+
+/// CR 205.1a + CR 613.1d: "its creature type is the last chosen creature type"
+/// replaces the recipient's creature subtypes with the chosen creature type
+/// (Layer 4) — remove-all then add-chosen, in that emission order.
+#[test]
+fn parse_continuous_modifications_its_creature_type_is_last_chosen() {
+    let mods = parse_continuous_modifications("its creature type is the last chosen creature type");
+    assert_eq!(
+        mods,
+        vec![
+            ContinuousModification::RemoveAllSubtypes {
+                set: SubtypeSet::Creature
+            },
+            ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType
+            },
+        ]
+    );
+}
+
+/// CR 612.8 + CR 205.1a: The combined Psychic Paper clause "its name and creature
+/// type are the last chosen name and creature type" emits all three
+/// modifications, with the creature-type remove-all preceding its add-chosen.
+#[test]
+fn parse_continuous_modifications_its_name_and_creature_type_last_chosen() {
+    let mods = parse_continuous_modifications(
+        "its name and creature type are the last chosen name and creature type",
+    );
+    assert_eq!(
+        mods,
+        vec![
+            ContinuousModification::SetChosenName,
+            ContinuousModification::RemoveAllSubtypes {
+                set: SubtypeSet::Creature
+            },
+            ContinuousModification::AddChosenSubtype {
+                kind: ChosenSubtypeKind::CreatureType
+            },
+        ]
+    );
+}
+
 #[test]
 fn static_lands_you_control_have() {
     let def = parse_static_line("Lands you control have 'Forests'.").unwrap();

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -17604,6 +17604,15 @@ pub enum ContinuousModification {
     /// is derived from the subtype in `mana_sources.rs` (CR 305.6), so no explicit
     /// mana grant is needed here.
     SetChosenBasicLandType,
+    /// CR 612.8 + CR 613.1c: A continuous effect that sets the object's name to
+    /// the granting source's chosen card name (Layer 3, text-changing). Reads the
+    /// source's `ChosenAttribute::CardName` at layer-evaluation time; per CR 612.8
+    /// the object loses any names it had and has only the chosen name. The
+    /// chosen-read sibling of the literal `SetName` (which is a Layer-1 copy
+    /// override, CR 707.9b), mirroring how `AddChosenColor` is the chosen-read
+    /// sibling of `SetColor`. Used by "its name is the last chosen name" (Psychic
+    /// Paper). Unit variant: the read source is implicitly `ChosenAttribute::CardName`.
+    SetChosenName,
     /// CR 707.9a: Retain a printed triggered ability from the source object's
     /// printed trigger list at the given index. Used by "becomes a copy of <X>,
     /// except it has this ability" patterns (Irma Part-Time Mutant, Cryptoplasm,

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -81,6 +81,9 @@ impl ContinuousModification {
             // CR 707.9b + CR 613.1a: Copy-effect name override applies in Layer 1
             // after CopyValues, per timestamp order within the layer.
             ContinuousModification::SetName { .. } => Layer::Copy,
+            // CR 612.8 + CR 613.1c: Setting an object's name to the source's
+            // chosen card name is a text-changing effect — Layer 3.
+            ContinuousModification::SetChosenName => Layer::Text,
             ContinuousModification::AddPower { .. }
             | ContinuousModification::AddToughness { .. }
             | ContinuousModification::AddDynamicPower { .. }
@@ -256,6 +259,8 @@ mod tests {
             .layer(),
             Layer::Copy
         );
+        // CR 612.8 + CR 613.1c: SetChosenName is a text-changing effect (Layer 3).
+        assert_eq!(ContinuousModification::SetChosenName.layer(), Layer::Text);
         assert_eq!(
             ContinuousModification::AddPower { value: 1 }.layer(),
             Layer::ModifyPT

--- a/crates/phase-ai/src/policies/x_reference.rs
+++ b/crates/phase-ai/src/policies/x_reference.rs
@@ -211,6 +211,7 @@ fn continuous_modification_references_x(modification: &ContinuousModification) -
         | ContinuousModification::ChangeController
         | ContinuousModification::SetBasicLandType { .. }
         | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
         | ContinuousModification::AddSupertype { .. }


### PR DESCRIPTION
## Summary
Preparatory building-block PR for Psychic Paper / Sanctuary Blade style Equipment readbacks. This does **not** close those cards: the as-becomes-attached choice seam remains a follow-up because modeling it as `TriggerMode::Attached` was rules-incorrect.

## Files changed
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/game_object.rs
- crates/engine/src/game/layers.rs
- crates/engine/src/game/printed_cards.rs
- crates/engine/src/game/quantity.rs
- crates/engine/src/parser/oracle_effect/lower.rs
- crates/engine/src/parser/oracle_static/keyword_grant.rs
- crates/engine/src/parser/oracle_static/tests.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/types/layers.rs
- crates/phase-ai/src/policies/x_reference.rs

## CR references
- CR 205.1a
- CR 509.1b
- CR 612.8
- CR 613.1c
- CR 613.1d
- CR 613.7

## Track
Developer

## LLM
Model: Codex GPT-5 (maintainer repair pass)
Thinking: high

## Verification
- `cargo fmt --all` — clean during maintainer repair pass
- `git diff --check` — clean during maintainer repair pass
- pre-commit parser combinator gate — passed when committing the reconstructed branch
- Branch merged current `origin/main` and was pushed with `--no-verify`; no direct cargo build/test was run in this pass.

## Follow-up
The as-becomes-attached replacement/attachment seam remains required before Psychic Paper or Sanctuary Blade should be marked supported.
