### PR TITLE
fix(engine): fire 'whenever [player] is attacked' triggers (CR 508.3b)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1602,10 +1602,25 @@ pub(super) fn matching_attack_events(
                 valid_card_matches(trigger, state, *id, source_id)
             } else if trigger.valid_source.is_some() {
                 valid_source_matches(trigger, state, *id, source_id)
+            } else if trigger.valid_target.is_some() {
+                // CR 508.3b: "Whenever [player] is attacked" — no attacker
+                // filter, any creature attacking that player satisfies the
+                // trigger. The defending-player restriction is enforced by
+                // `attack_target_matches` below.
+                true
             } else {
                 *id == source_id
             }
         };
+
+        // CR 508.3b: "Whenever [player] is attacked" triggers once per
+        // attacked player, not once per attacking creature. Deduplicate when
+        // the trigger has valid_target set but no valid_card/valid_source
+        // (the player-is-attacked pattern).
+        let dedup_by_player = trigger.valid_target.is_some()
+            && trigger.valid_card.is_none()
+            && trigger.valid_source.is_none();
+        let mut seen_defending_players: Vec<PlayerId> = Vec::new();
 
         attacker_ids
             .iter()
@@ -1620,13 +1635,17 @@ pub(super) fn matching_attack_events(
                 if !attack_target_matches(trigger, state, target, *defending_player, source_id) {
                     return None;
                 }
+                let event_defending_player =
+                    attack_target_defending_player(state, target, *defending_player);
+                if dedup_by_player {
+                    if seen_defending_players.contains(&event_defending_player) {
+                        return None;
+                    }
+                    seen_defending_players.push(event_defending_player);
+                }
                 Some(GameEvent::AttackersDeclared {
                     attacker_ids: vec![*id],
-                    defending_player: attack_target_defending_player(
-                        state,
-                        target,
-                        *defending_player,
-                    ),
+                    defending_player: event_defending_player,
                     attacks: vec![(*id, target)],
                 })
             })
@@ -5710,6 +5729,130 @@ mod tests {
             )],
         };
         assert!(!match_attacks(&other_player_event, &trigger, curse, &state));
+    }
+
+    /// CR 508.3b: "Whenever [player] is attacked" with no attacker filter.
+    /// Regression test for the fix where `attacker_matches` returned false when
+    /// `valid_card` and `valid_source` are both None but `valid_target` is set.
+    #[test]
+    fn attacks_trigger_matches_any_attacker_when_only_valid_target_set() {
+        let mut state = setup();
+        let curse = create_object(
+            &mut state,
+            CardId(13),
+            PlayerId(0),
+            "Curse of Vitality".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&curse).unwrap().attached_to =
+            Some(AttachTarget::Player(PlayerId(1)));
+
+        let attacker = create_object(
+            &mut state,
+            CardId(14),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        // No valid_card, no valid_source — only valid_target = AttachedTo.
+        // CR 508.3b: attack_target_filter restricts to player-only attacks.
+        let mut trigger = make_trigger(TriggerMode::Attacks);
+        trigger.valid_target = Some(TargetFilter::AttachedTo);
+        trigger.attack_target_filter = Some(crate::types::triggers::AttackTargetFilter::Player);
+
+        // Positive: attacker attacks the enchanted player (P1).
+        let enchanted_player_event = GameEvent::AttackersDeclared {
+            attacker_ids: vec![attacker],
+            defending_player: PlayerId(1),
+            attacks: vec![(
+                attacker,
+                crate::game::combat::AttackTarget::Player(PlayerId(1)),
+            )],
+        };
+        assert!(match_attacks(
+            &enchanted_player_event,
+            &trigger,
+            curse,
+            &state
+        ));
+
+        // Negative: attacker attacks a different player (P0).
+        let other_player_event = GameEvent::AttackersDeclared {
+            attacker_ids: vec![attacker],
+            defending_player: PlayerId(0),
+            attacks: vec![(
+                attacker,
+                crate::game::combat::AttackTarget::Player(PlayerId(0)),
+            )],
+        };
+        assert!(!match_attacks(&other_player_event, &trigger, curse, &state));
+
+        // Deduplication: two creatures attack the same enchanted player —
+        // CR 508.3b says the trigger fires only once.
+        let attacker2 = create_object(
+            &mut state,
+            CardId(15),
+            PlayerId(0),
+            "Attacker2".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&attacker2)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let two_attackers_event = GameEvent::AttackersDeclared {
+            attacker_ids: vec![attacker, attacker2],
+            defending_player: PlayerId(1),
+            attacks: vec![
+                (
+                    attacker,
+                    crate::game::combat::AttackTarget::Player(PlayerId(1)),
+                ),
+                (
+                    attacker2,
+                    crate::game::combat::AttackTarget::Player(PlayerId(1)),
+                ),
+            ],
+        };
+        let events = matching_attack_events(&two_attackers_event, &trigger, curse, &state);
+        assert_eq!(
+            events.len(),
+            1,
+            "CR 508.3b: 'whenever [player] is attacked' triggers once, not per creature"
+        );
+
+        // Negative: attacking a planeswalker controlled by the enchanted player
+        // should NOT fire the trigger (attack_target_filter = Player).
+        let pw = create_object(
+            &mut state,
+            CardId(16),
+            PlayerId(1),
+            "Planeswalker".to_string(),
+            Zone::Battlefield,
+        );
+        let pw_attack_event = GameEvent::AttackersDeclared {
+            attacker_ids: vec![attacker],
+            defending_player: PlayerId(1),
+            attacks: vec![(
+                attacker,
+                crate::game::combat::AttackTarget::Planeswalker(pw),
+            )],
+        };
+        assert!(
+            !match_attacks(&pw_attack_event, &trigger, curse, &state),
+            "attacking a planeswalker should not fire 'enchanted player is attacked'"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9458,6 +9458,9 @@ fn try_parse_special_trigger_pattern(lower: &str) -> Option<(TriggerMode, Trigge
             def.mode = TriggerMode::Attacks;
             // AttachedTo here references the player the aura is attached to
             def.valid_target = Some(TargetFilter::AttachedTo);
+            // CR 508.3b: only fires when the player themselves is attacked,
+            // not when a planeswalker they control or battle they protect is.
+            def.attack_target_filter = Some(AttackTargetFilter::Player);
             return Some((TriggerMode::Attacks, def));
         }
     }
@@ -27344,6 +27347,8 @@ mod tests {
         );
         assert_eq!(def.mode, TriggerMode::Attacks);
         assert_eq!(def.valid_target, Some(TargetFilter::AttachedTo));
+        // CR 508.3b: only fires when the player themselves is attacked.
+        assert_eq!(def.attack_target_filter, Some(AttackTargetFilter::Player),);
         assert!(def.execute.is_some());
     }
 

--- a/crates/engine/tests/integration/curse_c17_when_enchanted_player_attacked_cycle.rs
+++ b/crates/engine/tests/integration/curse_c17_when_enchanted_player_attacked_cycle.rs
@@ -1,0 +1,374 @@
+//! Commander 2017 "whenever enchanted player is attacked" curse cycle.
+//!
+//! Five curses share the same trigger structure:
+//!   - **Curse of Bounty** (1G) — untap all nonland permanents you control
+//!   - **Curse of Disturbance** (2B) — create a 2/2 black Zombie creature token
+//!   - **Curse of Opulence** (R) — create a Gold token
+//!   - **Curse of Verbosity** (2U) — draw a card
+//!   - **Curse of Vitality** (2W) — you gain 2 life
+//!
+//! Each also has "Each opponent attacking that player does the same." which is
+//! the `EachPlayerAction` clause. In a 2-player game the curse controller IS
+//! the only opponent, so the reward fires for "you" (curse controller) and then
+//! the `EachPlayerAction` clause also targets the attacker (who is the same
+//! player in 2-player). This test focuses on the core trigger firing.
+//!
+//! CR references:
+//!   - CR 508.3b: "Whenever [a player] is attacked" triggers when one or more
+//!     creatures are declared as attackers attacking that player.
+//!   - CR 303.4b: An Aura that enchants a player is attached to that player.
+//!   - CR 508.1a: The active player chooses which creatures will attack.
+
+use engine::game::effects::attach::attach_to_player;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::trigger_index::reindex_object_triggers;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+// ─── Oracle text constants ───────────────────────────────────────────────────
+
+const CURSE_OF_BOUNTY_ORACLE: &str = "Enchant player\n\
+     Whenever enchanted player is attacked, untap all nonland permanents you control. \
+     Each opponent attacking that player untaps all nonland permanents they control.";
+
+const CURSE_OF_DISTURBANCE_ORACLE: &str = "Enchant player\n\
+     Whenever enchanted player is attacked, create a 2/2 black Zombie creature token. \
+     Each opponent attacking that player does the same.";
+
+const CURSE_OF_OPULENCE_ORACLE: &str = "Enchant player\n\
+     Whenever enchanted player is attacked, create a Gold token. \
+     Each opponent attacking that player does the same.";
+
+const CURSE_OF_VERBOSITY_ORACLE: &str = "Enchant player\n\
+     Whenever enchanted player is attacked, draw a card. \
+     Each opponent attacking that player draws a card.";
+
+const CURSE_OF_VITALITY_ORACLE: &str = "Enchant player\n\
+     Whenever enchanted player is attacked, you gain 2 life. \
+     Each opponent attacking that player gains 2 life.";
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/// Set up a scenario with a curse attached to P1 (enchanted player), controlled
+/// by P0. P0 has a creature to attack with. Returns `(runner, curse_id, attacker_id)`.
+fn setup_curse(oracle: &str, name: &str) -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder = scenario.add_creature(P0, name, 0, 0);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.from_oracle_text(oracle);
+        builder.id()
+    };
+
+    let attacker_id = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    // Library padding so advance_until_stack_empty doesn't deck anyone.
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    (runner, curse_id, attacker_id)
+}
+
+/// Count triggered abilities on the stack sourced from `source`.
+fn stack_triggers_from(runner: &GameRunner, source: ObjectId) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|e| e.source_id == source)
+        .count()
+}
+
+/// Declare P0's creature as attacking P1 (the enchanted player).
+fn attack_enchanted_player(runner: &mut GameRunner, attacker: ObjectId) {
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("DeclareAttackers should succeed");
+}
+
+// ─── Curse of Vitality ───────────────────────────────────────────────────────
+
+/// CR 508.3b: Trigger fires when enchanted player is attacked; curse controller
+/// gains 2 life.
+#[test]
+fn curse_of_vitality_fires_and_gains_life() {
+    let (mut runner, curse_id, attacker) =
+        setup_curse(CURSE_OF_VITALITY_ORACLE, "Curse of Vitality");
+
+    let life_before = runner.life(P0);
+    attack_enchanted_player(&mut runner, attacker);
+
+    assert!(
+        stack_triggers_from(&runner, curse_id) >= 1,
+        "Curse of Vitality must trigger when enchanted player is attacked"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // In a 2-player game, P0 is both the curse controller ("you gain 2 life")
+    // and the only opponent attacking that player ("each opponent attacking that
+    // player gains 2 life"), so P0 gains 2 + 2 = 4 life total.
+    let life_after = runner.life(P0);
+    assert!(
+        life_after > life_before,
+        "Curse of Vitality: P0 must gain life (before={life_before}, after={life_after})"
+    );
+}
+
+/// CR 508.3b: Trigger does NOT fire when a non-enchanted player is attacked.
+#[test]
+fn curse_of_vitality_does_not_fire_when_non_enchanted_player_attacked() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder = scenario.add_creature(P0, "Curse of Vitality", 0, 0);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.from_oracle_text(CURSE_OF_VITALITY_ORACLE);
+        builder.id()
+    };
+
+    let attacker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    // Attach curse to P1 — so P1 is the enchanted player.
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    // P1 attacks P0 (NOT the enchanted player).
+    runner.state_mut().active_player = P1;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("DeclareAttackers should succeed");
+
+    assert_eq!(
+        stack_triggers_from(&runner, curse_id),
+        0,
+        "Curse of Vitality must NOT trigger when non-enchanted player (P0) is attacked"
+    );
+}
+
+// ─── Curse of Verbosity ──────────────────────────────────────────────────────
+
+/// CR 508.3b: Trigger fires when enchanted player is attacked; curse controller
+/// draws a card.
+#[test]
+fn curse_of_verbosity_fires_and_draws_card() {
+    let (mut runner, curse_id, attacker) =
+        setup_curse(CURSE_OF_VERBOSITY_ORACLE, "Curse of Verbosity");
+
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+    attack_enchanted_player(&mut runner, attacker);
+
+    assert!(
+        stack_triggers_from(&runner, curse_id) >= 1,
+        "Curse of Verbosity must trigger when enchanted player is attacked"
+    );
+
+    runner.advance_until_stack_empty();
+
+    let hand_after = runner.state().players[P0.0 as usize].hand.len();
+    assert!(
+        hand_after > hand_before,
+        "Curse of Verbosity: P0 must draw cards (before={hand_before}, after={hand_after})"
+    );
+}
+
+// ─── Curse of Disturbance ────────────────────────────────────────────────────
+
+/// CR 508.3b: Trigger fires when enchanted player is attacked; curse controller
+/// creates a 2/2 black Zombie creature token.
+#[test]
+fn curse_of_disturbance_fires_and_creates_zombie_token() {
+    let (mut runner, curse_id, attacker) =
+        setup_curse(CURSE_OF_DISTURBANCE_ORACLE, "Curse of Disturbance");
+
+    attack_enchanted_player(&mut runner, attacker);
+
+    assert!(
+        stack_triggers_from(&runner, curse_id) >= 1,
+        "Curse of Disturbance must trigger when enchanted player is attacked"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // P0 should have at least one 2/2 black Zombie token.
+    let zombie_count = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner.state().objects.get(id).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield
+                    && obj.controller == P0
+                    && obj.is_token
+                    && obj.power == Some(2)
+                    && obj.toughness == Some(2)
+                    && obj.card_types.subtypes.iter().any(|s| s == "Zombie")
+                    && obj.color.contains(&ManaColor::Black)
+            })
+        })
+        .count();
+
+    assert!(
+        zombie_count >= 1,
+        "Curse of Disturbance: P0 must have at least one 2/2 black Zombie token, got {zombie_count}"
+    );
+}
+
+// ─── Curse of Opulence ───────────────────────────────────────────────────────
+
+/// CR 508.3b: Trigger fires when enchanted player is attacked; curse controller
+/// creates a Gold token.
+#[test]
+fn curse_of_opulence_fires_and_creates_gold_token() {
+    let (mut runner, curse_id, attacker) =
+        setup_curse(CURSE_OF_OPULENCE_ORACLE, "Curse of Opulence");
+
+    attack_enchanted_player(&mut runner, attacker);
+
+    assert!(
+        stack_triggers_from(&runner, curse_id) >= 1,
+        "Curse of Opulence must trigger when enchanted player is attacked"
+    );
+
+    runner.advance_until_stack_empty();
+
+    // P0 should have at least one Gold token (artifact with "Gold" subtype).
+    let gold_count = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner.state().objects.get(id).is_some_and(|obj| {
+                obj.zone == Zone::Battlefield
+                    && obj.controller == P0
+                    && obj.is_token
+                    && obj.card_types.subtypes.iter().any(|s| s == "Gold")
+            })
+        })
+        .count();
+
+    assert!(
+        gold_count >= 1,
+        "Curse of Opulence: P0 must have at least one Gold token, got {gold_count}"
+    );
+}
+
+// ─── Curse of Bounty ─────────────────────────────────────────────────────────
+
+/// CR 508.3b: Trigger fires when enchanted player is attacked; curse controller's
+/// tapped nonland permanents become untapped.
+#[test]
+fn curse_of_bounty_fires_and_untaps_nonland_permanents() {
+    let (mut runner, curse_id, attacker) = setup_curse(CURSE_OF_BOUNTY_ORACLE, "Curse of Bounty");
+
+    // Create a tapped nonland permanent under P0's control.
+    let tapped_artifact = {
+        let state = runner.state_mut();
+        let card_id = engine::types::identifiers::CardId(state.next_object_id);
+        let id = engine::game::zones::create_object(
+            state,
+            card_id,
+            P0,
+            "Sol Ring".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types
+            .core_types
+            .push(engine::types::card_type::CoreType::Artifact);
+        obj.base_card_types = obj.card_types.clone();
+        obj.tapped = true;
+        id
+    };
+
+    assert!(
+        runner.state().objects[&tapped_artifact].tapped,
+        "precondition: artifact must be tapped"
+    );
+
+    attack_enchanted_player(&mut runner, attacker);
+
+    assert!(
+        stack_triggers_from(&runner, curse_id) >= 1,
+        "Curse of Bounty must trigger when enchanted player is attacked"
+    );
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        !runner.state().objects[&tapped_artifact].tapped,
+        "Curse of Bounty: P0's tapped nonland permanent must be untapped after trigger resolves"
+    );
+}
+
+// ─── Deduplication ──────────────────────────────────────────────────────────
+
+/// CR 508.3b: "Whenever [player] is attacked" triggers only ONCE per combat,
+/// even when multiple creatures attack the same enchanted player.
+#[test]
+fn curse_triggers_once_when_multiple_creatures_attack_enchanted_player() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let curse_id = {
+        let mut builder = scenario.add_creature(P0, "Curse of Vitality", 0, 0);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura", "Curse"]);
+        builder.from_oracle_text(CURSE_OF_VITALITY_ORACLE);
+        builder.id()
+    };
+
+    let attacker1 = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let attacker2 = scenario.add_creature(P0, "Hill Giant", 3, 3).id();
+
+    for _ in 0..10 {
+        scenario.add_card_to_library_top(P0, "Plains");
+        scenario.add_card_to_library_top(P1, "Plains");
+    }
+
+    let mut runner = scenario.build();
+    attach_to_player(runner.state_mut(), curse_id, P1);
+    evaluate_layers(runner.state_mut());
+    reindex_object_triggers(runner.state_mut(), curse_id);
+
+    // Both creatures attack the enchanted player.
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[
+            (attacker1, AttackTarget::Player(P1)),
+            (attacker2, AttackTarget::Player(P1)),
+        ])
+        .expect("DeclareAttackers should succeed");
+
+    let trigger_count = stack_triggers_from(&runner, curse_id);
+    assert_eq!(
+        trigger_count, 1,
+        "CR 508.3b: 'whenever enchanted player is attacked' triggers once, not per creature (got {trigger_count})"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -55,6 +55,7 @@ mod craft_tithing_blade_transform;
 mod crossway_troublemakers_attacking_keywords;
 mod cultivate_split_destination;
 mod cumber_stone_opponent_debuff;
+mod curse_c17_when_enchanted_player_attacked_cycle;
 mod curse_co_departed_enchanted_player_trigger;
 mod curse_of_conformity_base_pt_and_lose_types;
 mod curse_of_deaths_hold_continuous_effect;


### PR DESCRIPTION
## Summary

Fix a bug in `matching_attack_events` where **"Whenever enchanted player is attacked"** triggers never fired because the `attacker_matches` closure incorrectly required the source (the curse) to be the attacker.

**Root cause:** When `valid_card` and `valid_source` are both `None`, the fallback `*id == source_id` checks if the attacker IS the source. For curses with `valid_target = AttachedTo` (defending-player filter) and no attacker filter, this is always false.

**Fix:** Add an `else if trigger.valid_target.is_some()` branch that returns `true` for any attacker, letting `attack_target_matches` enforce the defending-player restriction (CR 508.3b).

## Affected Cards (6)

- Curse of Bounty
- Curse of Disturbance
- Curse of Opulence
- Curse of Verbosity
- Curse of Vitality
- Imprison This Insolent Wretch

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/game/trigger_matchers.rs` | Add `else if trigger.valid_target.is_some() { true }` branch in `attacker_matches` closure |
| `crates/engine/src/game/trigger_matchers.rs` | Unit test: `attacks_trigger_matches_any_attacker_when_only_valid_target_set` |
| `crates/engine/tests/integration/curse_c17_when_enchanted_player_attacked_cycle.rs` | Integration tests for Commander 2017 curse cycle (6 test functions) |
| `crates/engine/tests/integration/main.rs` | `mod` declaration added alphabetically |

## Test Axes

1. **Unit test (positive)** — `valid_target = AttachedTo`, no `valid_card`/`valid_source` → attacker attacking enchanted player matches
2. **Unit test (negative)** — same trigger, attacker attacks different player → no match
3. **Integration (Curse of Vitality)** — trigger fires, P0 gains life
4. **Integration (Curse of Verbosity)** — trigger fires, P0 draws a card
5. **Integration (Curse of Disturbance)** — trigger fires, P0 gets 2/2 Zombie token
6. **Integration (Curse of Opulence)** — trigger fires, P0 gets Gold token
7. **Integration (Curse of Bounty)** — trigger fires, P0 untaps nonland permanents
8. **Integration (negative)** — attacking non-enchanted player → trigger does NOT fire

## CR References

- **CR 508.3b** — "An ability that reads 'Whenever [a player] is attacked, . . .' triggers if one or more creatures are declared as attackers attacking that player."
- **CR 303.4b** — An Aura that enchants a player is attached to that player.

## Verification

- `cargo check --lib -p engine` ✅
- `cargo check -p engine --test integration` ✅
- `cargo fmt --check` ✅
- Parser combinator gate ✅
