### PR TITLE
feat(import): exclude Moxfield maybeboard from URL deck imports

### DIFF
--- a/lobby-worker/src/import-deck.ts
+++ b/lobby-worker/src/import-deck.ts
@@ -176,11 +176,7 @@ interface MoxfieldDeck {
   sideboard?: Record<string, MoxfieldEntry>;
   commanders?: Record<string, MoxfieldEntry>;
   companions?: Record<string, MoxfieldEntry>;
-  maybeboard?: Record<string, MoxfieldEntry>;
 }
-
-/** Moxfield board ids that must never enter an imported deck (test hands / wishlists). */
-const MOXFIELD_EXCLUDED_BOARD_IDS = new Set(["maybeboard"]);
 
 // Resolve a board's entry map by key, accepting both the nested v2 shape
 // (`boards.<key>.cards`) and the flat top-level shape (`deck.<key>`).
@@ -225,7 +221,7 @@ function sectionsEmpty(sections: DeckSections): boolean {
 function projectMoxfield(deck: MoxfieldDeck): { text: string; empty: boolean } {
   // Only commander/main/sideboard/companion boards are imported. Moxfield's
   // `maybeboard` (and Archidekt's Maybeboard category) are test-deck slots —
-  // see MOXFIELD_EXCLUDED_BOARD_IDS and classifyArchidektCard.
+  // see classifyArchidektCard for Archidekt exclusion.
   const sections: DeckSections = {
     commander: moxfieldBoardToCards(moxfieldBoard(deck, "commanders")),
     main: moxfieldBoardToCards(moxfieldBoard(deck, "mainboard")),

--- a/lobby-worker/src/import-deck.ts
+++ b/lobby-worker/src/import-deck.ts
@@ -176,7 +176,11 @@ interface MoxfieldDeck {
   sideboard?: Record<string, MoxfieldEntry>;
   commanders?: Record<string, MoxfieldEntry>;
   companions?: Record<string, MoxfieldEntry>;
+  maybeboard?: Record<string, MoxfieldEntry>;
 }
+
+/** Moxfield board ids that must never enter an imported deck (test hands / wishlists). */
+const MOXFIELD_EXCLUDED_BOARD_IDS = new Set(["maybeboard"]);
 
 // Resolve a board's entry map by key, accepting both the nested v2 shape
 // (`boards.<key>.cards`) and the flat top-level shape (`deck.<key>`).
@@ -219,6 +223,9 @@ function sectionsEmpty(sections: DeckSections): boolean {
 }
 
 function projectMoxfield(deck: MoxfieldDeck): { text: string; empty: boolean } {
+  // Only commander/main/sideboard/companion boards are imported. Moxfield's
+  // `maybeboard` (and Archidekt's Maybeboard category) are test-deck slots —
+  // see MOXFIELD_EXCLUDED_BOARD_IDS and classifyArchidektCard.
   const sections: DeckSections = {
     commander: moxfieldBoardToCards(moxfieldBoard(deck, "commanders")),
     main: moxfieldBoardToCards(moxfieldBoard(deck, "mainboard")),

--- a/lobby-worker/test/import-deck.test.mjs
+++ b/lobby-worker/test/import-deck.test.mjs
@@ -180,6 +180,30 @@ test("Moxfield: projects v2 nested boards (boards.<key>.cards)", async () => {
   assert.match(text, /\[Main\]\n1 Sol Ring/);
 });
 
+test("Moxfield: maybeboard board is excluded from import", async () => {
+  mockUpstream({
+    name: "Testing",
+    boards: {
+      commanders: { cards: {} },
+      mainboard: {
+        cards: {
+          a: { quantity: 1, card: { name: "Sol Ring" } },
+        },
+      },
+      maybeboard: {
+        cards: {
+          b: { quantity: 1, card: { name: "Mana Crypt" } },
+        },
+      },
+      sideboard: { cards: {} },
+      companions: { cards: {} },
+    },
+  });
+  const text = await (await call("https://moxfield.com/decks/maybe")).text();
+  assert.match(text, /Sol Ring/);
+  assert.ok(!text.includes("Mana Crypt"));
+});
+
 test("Moxfield: sideboard-only deck is not rejected as empty", async () => {
   mockUpstream({
     name: "SB only",


### PR DESCRIPTION
## Summary
- Document that Moxfield `maybeboard` boards are intentionally excluded from URL imports (parity with Archidekt Maybeboard handling)
- Add regression test ensuring maybeboard cards are not pulled into the deck text

Fixes #2464

## Test plan
- [x] `node --test lobby-worker/test/import-deck.test.mjs` (in CI)
- [ ] Import a Moxfield deck with a populated maybeboard and confirm only main/commander/sideboard cards appear

Model: Composer

Made with [Cursor](https://cursor.com)