### PR TITLE
perf(client): skip AI worker pool on mobile (fix iOS VeryHard OOM)

### DIFF
--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -18,6 +18,27 @@ import { EngineWorkerClient } from "./engine-worker-client";
 import { AiWorkerPool } from "./ai-worker-pool";
 import type { AiCardDataMode } from "./card-db-subset";
 import { DEFAULT_AI_CARD_DATA_MODE, loadAiPoolCardDb } from "./card-db-subset";
+
+/**
+ * True on handheld browsers whose per-tab memory ceiling cannot hold the main
+ * WASM engine instance plus the 2–4 pooled AI instances. Every iOS browser is
+ * WebKit and shares one per-tab budget, so N copies of the full ~48MB engine
+ * module silently OOM-reload the tab. Desktop browsers have GB-scale ceilings
+ * and return false. Used by `ensureAiPool` to skip the pool on these devices.
+ *
+ * iPadOS 13+ reports the desktop `MacIntel` platform, so it is distinguished by
+ * its touch support rather than the user-agent string.
+ */
+function isMemoryConstrainedDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  const isIOS =
+    /iP(hone|od|ad)/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const isAndroidPhone = /Android/.test(ua) && /Mobile/.test(ua);
+  return isIOS || isAndroidPhone;
+}
+
 /**
  * Flatten the `ClientGameState { state, derived }` wire envelope produced
  * by the engine's WASM getters into the store-side `GameState` shape with
@@ -356,6 +377,13 @@ export class WasmAdapter implements EngineAdapter {
       return this.aiPool;
     }
     if (this.aiPoolFailed) return null;
+    // Skip the AI worker pool on memory-constrained handhelds (iOS WebKit in
+    // particular): the main engine instance plus 2–4 pooled instances each hold
+    // a full ~48MB WASM module and exceed the per-tab memory ceiling, silently
+    // OOM-reloading the tab. VeryHard then falls through to the single-worker
+    // path below (getAiAction), which runs the same fixed-budget beam search;
+    // the pool only adds cross-seed rollout-variance averaging, not search depth.
+    if (isMemoryConstrainedDevice()) return null;
     try {
       const cores = navigator.hardwareConcurrency ?? 0;
       const count = Math.max(2, Math.min(cores - 1, 4));


### PR DESCRIPTION
## Problem

Hosting/playing a **VeryHard** AI game on iOS Safari still silently OOM-reloads the tab, even after the game-scoped card-DB subset (#4348). Medium/Hard (which use only the single main engine worker) are smooth at the same card data footprint.

## Root cause

The subset fix removed the duplicated card *data* on the AI pool workers, but not the duplicated WASM *module code*. Each engine instance independently calls wasm-bindgen `init()` (`engine-worker.ts`), compiling and holding its own copy of the ~48 MB (release) engine module. VeryHard spins up the AI worker pool — sized by **CPU cores, not opponent count** (`max(2, min(cores-1, 4))`) — so a single-opponent VeryHard game still instantiates 2–4 extra engine instances:

```
main worker   ~48 MB code + ~90 MB full DB   ≈ 138 MB   (this is the smooth Medium footprint)
+ AI pool ×2–4  ~48 MB code each (+ tiny subset)         + 96 … 192 MB
```

`~234–330 MB` of duplicated module code exceeds WebKit's per-tab ceiling → silent OOM reload. By differential: Medium (no pool) is smooth; VeryHard adds only the pool; therefore the pool's per-instance footprint is the cause.

## Fix

Skip the AI worker pool on memory-constrained handhelds (iOS WebKit, Android phones) in `ensureAiPool` — the single authority that constructs the pool. VeryHard then falls through to the **already-existing** single-worker path (`this.engine.getAiAction`), collapsing the footprint back to the ~138 MB regime that's proven smooth at Medium. No new code paths; it reuses the pool's existing "pool unavailable" fallback.

## Why this is safe for AI quality

The pool does **root parallelism by averaging** (`AiWorkerPool.mergeScores`): each worker runs the *same* fixed-budget **beam search** (`phase-ai/src/search.rs`: "beam-ordered frontier search with rollout-backed leaves") with a different RNG seed, and scores are averaged per action. The beam frontier is deterministic; only the **leaf rollouts** are stochastic. So the pool is a variance-reduction **ensemble**, not a work-splitter:

- **Latency unchanged (often better on mobile):** each pool worker already ran one full budgeted beam search; the single worker runs the same one. Dropping the pool removes the per-worker state fan-out (2.5 MB+ × N) and CPU contention between N concurrent searches.
- **Quality cost is narrow:** slightly more rollout-noise in leaf valuations (no cross-seed averaging). No loss of search depth or breadth — the deterministic frontier is identical.

Desktop browsers (GB-scale per-tab ceilings) are unaffected and keep the pool.

## Verification

`check-frontend` (TypeScript + ESLint) green. On-device confirmation pending: a VeryHard game on the deployed preview should no longer OOM-reload on iOS.
