### PR TITLE
Fix mobile action rail overlap on game page

### DIFF
--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1064,8 +1064,10 @@ function GamePageContent({
 
   const isReconnecting = reconnectState.status !== "idle";
   const topOverlayOffsetPx = reconnectState.status === "idle" ? 0 : 56;
+  const playerRowHeight = "min(0.18 * (100dvh - var(--game-top-overlay-offset, 0px)), 150px)";
   const gamePageStyle = {
     "--game-top-overlay-offset": `${topOverlayOffsetPx}px`,
+    "--player-row-height": playerRowHeight,
   } as CSSProperties;
   const playerZoneRailStyle: ZoneRailStyle = isMobile
     ? { "--card-w": "28px", "--card-h": "39px" }
@@ -1073,7 +1075,6 @@ function GamePageContent({
   const pileSize = isMobile
     ? { width: "38px", height: "53px" }
     : { width: "clamp(45px, 4.5vw, 70px)", height: "clamp(63px, 6.3vw, 98px)" };
-  const playerRowHeight = "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)";
   const showFlowHelpNudge =
     !dismissedFlowHelpNudge &&
     !helpSheetOpen &&
@@ -1244,7 +1245,7 @@ function GamePageContent({
             rather than shoving the hand up. */}
         <div
           className="relative min-w-0 self-end overflow-visible"
-          style={{ height: playerRowHeight }}
+          style={{ height: "var(--player-row-height)" }}
           data-flex-zone="player-row"
         >
           <div className="flex items-end justify-center">
@@ -1296,7 +1297,7 @@ function GamePageContent({
         className="fixed z-30 flex flex-col items-end gap-1.5"
         style={{
           bottom: isMobile
-            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + ${playerRowHeight})`
+            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + var(--player-row-height))`
             : "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
           // Anchor box-scale to the docked corner so it grows inward, not off-screen.

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1073,6 +1073,7 @@ function GamePageContent({
   const pileSize = isMobile
     ? { width: "38px", height: "53px" }
     : { width: "clamp(45px, 4.5vw, 70px)", height: "clamp(63px, 6.3vw, 98px)" };
+  const playerRowHeight = "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)";
   const showFlowHelpNudge =
     !dismissedFlowHelpNudge &&
     !helpSheetOpen &&
@@ -1243,7 +1244,7 @@ function GamePageContent({
             rather than shoving the hand up. */}
         <div
           className="relative min-w-0 self-end overflow-visible"
-          style={{ height: "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)" }}
+          style={{ height: playerRowHeight }}
           data-flex-zone="player-row"
         >
           <div className="flex items-end justify-center">
@@ -1294,7 +1295,9 @@ function GamePageContent({
         resizeCorner="bl"
         className="fixed z-30 flex flex-col items-end gap-1.5"
         style={{
-          bottom: "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
+          bottom: isMobile
+            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + ${playerRowHeight})`
+            : "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
           // Anchor box-scale to the docked corner so it grows inward, not off-screen.
           transformOrigin: "bottom right",


### PR DESCRIPTION
## Summary
- Fix mobile action rail overlap on the game page when viewport is narrow.
- On mobile, move the fixed action rail upward by the same player-row height used for the hand/zone row.
- Keep desktop action rail placement unchanged.

## Why
On mobile, controls share the same bottom viewport region as the hand and commander zones. This can cause overlap and missed taps. Lifting the mobile rail by the computed row height prevents collisions without affecting desktop layout.

## Validation
- `pnpm -C client exec eslint src/pages/GamePage.tsx`
- `pnpm -C client exec vitest run src/pages/__tests__/GamePage.bracketViolation.test.tsx`

Closes #4174
