### PR TITLE
feat(changelog): publish #151 (iOS crash fixes, deck folders & Rooms)

### DIFF
--- a/client/public/changelog-meta.json
+++ b/client/public/changelog-meta.json
@@ -1,3 +1,3 @@
 {
-  "latestId": 150
+  "latestId": 151
 }

--- a/client/public/changelog.json
+++ b/client/public/changelog.json
@@ -1,6 +1,20 @@
 {
   "entries": [
     {
+      "id": 151,
+      "date": "2026-06-26",
+      "title": "iOS crash fixes, deck folders & Rooms",
+      "tags": [
+        "new-cards",
+        "card-fixes",
+        "gameplay",
+        "interface",
+        "multiplayer"
+      ],
+      "body": "✨ New Cards & Mechanics\n• Rooms now play both halves — the second door of a Room split card is finally castable (Spiked Corridor // Torture Pit and other Rooms)\n• Curse of Conformity works — it sets the enchanted player's creatures to base 3/3 and strips their other creature types\n• Mad Wizard's Lair (Dungeon of the Mad Mage, room 8) now resolves instead of doing nothing\n\n🛠️ Cards That Now Work Right\n• Octavia, Living Thesis only gets her cost reduction with eight or more instants/sorceries in your graveyard — no more turn-two Octavia from an empty graveyard\n• Court of Cunning now mills every targeted player, not just the first\n• From the Rubble correctly reanimates creatures from your graveyard\n• Well Rested's untap trigger now gives the life gain and card draw to the Aura's controller\n• Braids, Arisen Nightmare no longer runs its life-loss and draw tail when you decline your own sacrifice\n• Sanar Vivid keeps revealed cards in your library for its per-color exile\n• Committing a crime now triggers on damage that doesn't target, such as a Desert ping to an opponent\n• Token copies made \"except it's legendary\" now actually become legendary (Adagia, Windswept Bastion)\n• The Commander 2017 curse cycle now fires its \"whenever the enchanted player is attacked\" abilities (Curse of Bounty, Curse of Disturbance, Curse of Opulence, Curse of Verbosity, Curse of Vitality, Imprison This Insolent Wretch)\n• Equipment and Aura \"whenever equipped creature attacks\" triggers can now target the defending player (Greatsword of Tyr)\n\n⚔️ Combat & Gameplay\n• Lifelink now gains life once when a single source hits multiple targets at once (several blockers, or trample to a blocker plus the player), so \"whenever you gain life\" abilities trigger once instead of several times (Blech, Loafing Pest)\n• Wide boards no longer stall during combat — removed a slowdown that grew sharply with the number of creatures in play\n\n🖥️ Interface\n• New \"What's New\" panel — release notes now live in the app behind the sparkle icon, with search, pagination, and an unread badge\n• Organize your decks into folders in My Decks — create, rename, and assign decks to folders\n• Fixed out-of-memory crashes on iOS — Very Hard AI and large card pools no longer reload the tab on iPhone and iPad\n• Moxfield maybeboard cards are no longer pulled in when importing a deck by URL\n• Board hover tooltips now stay on screen near the edges of the window\n• Fixed a card-art regression where some cached images showed text instead of the picture\n\n🌐 Multiplayer\n• Fixed an out-of-memory crash for the multiplayer host when validating a guest's deck on iOS",
+      "discordUrl": "https://discord.com/channels/1485498006781427802/1486432040332296424/1520112115816599743"
+    },
+    {
       "id": 150,
       "date": "2026-06-25",
       "title": "Stability fixes: graveyard-choice softlock & engine panics",

--- a/scripts/changelog/state.json
+++ b/scripts/changelog/state.json
@@ -1,3 +1,4 @@
 {
-  "lastTip": "e624793d42a456ba26b2bf179d6762690cb435a8"
+  "lastTip": "0c263fa12ab957e5d95167c2e2028ee588d11393",
+  "lastPostedId": 151
 }

--- a/scripts/post-changelog.ts
+++ b/scripts/post-changelog.ts
@@ -69,19 +69,38 @@ const channelId =
   args.find((a) => !a.startsWith("-")) ?? Bun.env.ANNOUNCEMENTS_CHANNEL_ID;
 
 /**
- * Pack lines into ≤limit-char chunks without ever splitting a line, so a bullet
- * or section header is never torn across two Discord messages. Changelog lines
- * are short (bullets, section headers), so per-line < limit always holds.
+ * Pack the post into ≤limit-char chunks, preferring to break at blank-line
+ * (section) boundaries so a "✨ Section" header is never stranded at the end of
+ * a message away from its bullets. Sections are packed whole; a single section
+ * larger than the limit falls back to line-packing (still never tearing a line)
+ * so it always fits.
  */
 function chunk(content: string, limit = DISCORD_MAX): string[] {
   const chunks: string[] = [];
   let current = "";
-  for (const line of content.split("\n")) {
-    if (current && current.length + 1 + line.length > limit) {
+
+  // Line-pack a single over-limit section, continuing from `current`.
+  const linePack = (block: string) => {
+    for (const line of block.split("\n")) {
+      if (current && current.length + 1 + line.length > limit) {
+        chunks.push(current);
+        current = line;
+      } else {
+        current = current ? `${current}\n${line}` : line;
+      }
+    }
+  };
+
+  for (const block of content.split("\n\n")) {
+    const sep = current ? 2 : 0; // the "\n\n" rejoining this block to current
+    if (current && current.length + sep + block.length > limit) {
       chunks.push(current);
-      current = line;
+      current = "";
+    }
+    if (block.length > limit) {
+      linePack(block);
     } else {
-      current = current ? `${current}\n${line}` : line;
+      current = current ? `${current}\n\n${block}` : block;
     }
   }
   if (current) chunks.push(current);


### PR DESCRIPTION
New-only batch since entry #150: mobile iOS out-of-memory fixes, lifelink
once-per-source and 'when a player is attacked' combat rules, Moxfield
maybeboard import exclusion, deck folders, the in-app What's New panel, and a
batch of card fixes (Rooms, Curse of Conformity, Octavia, Court of Cunning,
Braids, From the Rubble, and more). Posted to #announcements (entry linked via
discordUrl); generation watermark advanced to origin/main.

Also makes post-changelog.ts chunker section-aware: it breaks long posts at
blank-line section boundaries instead of mid-section, so an emoji section header
is never stranded at the end of a Discord message away from its bullets.
