### PR TITLE
feat(changelog): auto-publish announcement-channel posts to followers

### DIFF
--- a/scripts/lib/discord.ts
+++ b/scripts/lib/discord.ts
@@ -161,6 +161,33 @@ export async function createMessage(
   return posted;
 }
 
+// PATCH /channels/{channel.id}/messages/{message.id} — edit the bot's own message.
+export async function editMessage(
+  channelId: string,
+  messageId: string,
+  content: string,
+): Promise<void> {
+  await discordRequest<DiscordPostedMessage>(
+    "PATCH",
+    `/channels/${channelId}/messages/${messageId}`,
+    { content },
+  );
+}
+
+// POST /channels/{channel.id}/messages/{message.id}/crosspost — publish a message
+// from an Announcement/News channel (type 5) to all servers following it.
+// Authoring the message only requires SEND_MESSAGES (MANAGE_MESSAGES is needed
+// only to crosspost someone else's message).
+export async function crosspostMessage(
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  await discordRequest<DiscordPostedMessage>(
+    "POST",
+    `/channels/${channelId}/messages/${messageId}/crosspost`,
+  );
+}
+
 export async function fetchActiveThreads(
   guildId: string,
   channelId: string,

--- a/scripts/post-changelog.ts
+++ b/scripts/post-changelog.ts
@@ -29,7 +29,7 @@
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { createMessage } from "./lib/discord.ts";
+import { createMessage, crosspostMessage, discordGet } from "./lib/discord.ts";
 
 interface ChangelogEntry {
   id: number;
@@ -120,10 +120,10 @@ if (!Bun.env.DISCORD_BOT_TOKEN || !channelId) {
   process.exit(0);
 }
 
-let firstMessageId: string | undefined;
+const postedIds: string[] = [];
 for (const content of messages) {
   const posted = await createMessage(channelId, content);
-  firstMessageId ??= posted.id;
+  postedIds.push(posted.id);
 }
 
 // Record the watermark so a re-run is a no-op.
@@ -131,12 +131,25 @@ state.lastPostedId = entry.id;
 writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`);
 
 // Link the in-app entry back to the announcement (only possible with a guild id).
-if (Bun.env.DISCORD_GUILD_ID && firstMessageId && !entry.discordUrl) {
-  entry.discordUrl = `https://discord.com/channels/${Bun.env.DISCORD_GUILD_ID}/${channelId}/${firstMessageId}`;
+if (Bun.env.DISCORD_GUILD_ID && postedIds[0] && !entry.discordUrl) {
+  entry.discordUrl = `https://discord.com/channels/${Bun.env.DISCORD_GUILD_ID}/${channelId}/${postedIds[0]}`;
   writeFileSync(CHANGELOG_PATH, `${JSON.stringify({ entries }, null, 2)}\n`);
+}
+
+// Auto-publish: an Announcement/News channel (type 5) can crosspost each message
+// to follower servers — the "Share with your followers?" the Discord client
+// prompts for, done automatically. Other channel types have nothing to publish.
+const channel = await discordGet<{ type: number }>(`/channels/${channelId}`);
+let published = 0;
+if (channel.type === 5) {
+  for (const id of postedIds) {
+    await crosspostMessage(channelId, id);
+    published += 1;
+  }
 }
 
 console.log(
   `Posted entry #${entry.id} "${entry.title}" to #announcements as ${messages.length} message(s)` +
+    `${published ? `, published ${published} to followers` : ""}` +
     `${entry.discordUrl ? ` (linked ${entry.discordUrl})` : ""}.`,
 );


### PR DESCRIPTION
After posting, crosspost each message when the target is an Announcement/News
channel (type 5) — the 'Share with your followers?' the Discord client prompts
for, done automatically. Authoring the message only needs SEND_MESSAGES, so no
extra permission is required.

Adds reusable editMessage + crosspostMessage helpers to scripts/lib/discord.ts.
