### PR TITLE
fix(parser): parse Dragonfire Blade equip color discount (closes #4425)

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -2843,6 +2843,28 @@ mod tests {
         );
     }
 
+    /// CR 105.1 + CR 601.2f + CR 115.1: Dragonfire Blade — equip cost scales
+    /// with the number of colors on the creature chosen as the equip target.
+    #[test]
+    fn cost_reduction_for_each_color_of_creature_it_targets() {
+        use crate::types::ability::{QuantityExpr, QuantityRef};
+
+        let reduction = try_parse_cost_reduction(
+            "this ability costs {1} less to activate for each color of the creature it targets",
+        )
+        .expect("Dragonfire Blade equip discount should parse");
+        assert_eq!(reduction.amount_per, 1);
+        assert_eq!(reduction.condition, None);
+        assert_eq!(
+            reduction.count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ObjectColorCount {
+                    scope: crate::types::ability::ObjectScope::Target,
+                },
+            },
+        );
+    }
+
     /// #3223: the self cost-reduction *head* recognizer matches both the bare
     /// sentence and a sentence carrying a trailing "if [condition]" tail; it
     /// rejects unrelated effect sentences. Drives the upstream

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -5297,8 +5297,7 @@ mod tests {
     /// CR 105.1 + CR 601.2f + CR 115.1: Dragonfire Blade equip discount.
     #[test]
     fn test_parse_for_each_color_of_creature_it_targets() {
-        let (rest, q) =
-            parse_for_each_clause_ref("color of the creature it targets").unwrap();
+        let (rest, q) = parse_for_each_clause_ref("color of the creature it targets").unwrap();
         assert_eq!(
             q,
             QuantityRef::ObjectColorCount {

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2887,6 +2887,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         parse_for_each_one_life_changed,
         parse_for_each_opponents_life_change,
         parse_counter_added_this_turn_for_each,
+        parse_color_of_object_it_targets_for_each,
         parse_object_colors_for_each,
         parse_object_name_word_count_for_each,
         parse_object_typeline_component_count_for_each,
@@ -3350,6 +3351,21 @@ fn parse_mana_symbols_in_object_mana_cost_for_each(input: &str) -> OracleResult<
     let (rest, scope) = parse_object_possessive_scope(rest)?;
     let (rest, _) = tag(" mana cost").parse(rest)?;
     Ok((rest, QuantityRef::ManaSymbolsInManaCost { scope, color }))
+}
+
+/// CR 105.1 + CR 601.2f + CR 115.1: "for each color[s] of the <type> it
+/// targets" (Dragonfire Blade equip discount). Target-anaphoric color count
+/// for activation cost reduction keyed to the chosen equip target.
+fn parse_color_of_object_it_targets_for_each(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = alt((tag("color of "), tag("colors of "))).parse(input)?;
+    let (rest, scope) = alt((
+        value(ObjectScope::Target, tag("the creature it targets")),
+        value(ObjectScope::Target, tag("the permanent it targets")),
+        value(ObjectScope::Target, tag("a creature it targets")),
+        value(ObjectScope::Target, tag("a permanent it targets")),
+    ))
+    .parse(rest)?;
+    Ok((rest, QuantityRef::ObjectColorCount { scope }))
 }
 
 /// CR 105.1 + CR 105.2: Parse "for each [of] <object>'s colors" into a
@@ -5269,6 +5285,20 @@ mod tests {
         }
 
         let (rest, q) = parse_for_each("for each of that creature's colors").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::ObjectColorCount {
+                scope: crate::types::ability::ObjectScope::Target
+            }
+        );
+        assert_eq!(rest, "");
+    }
+
+    /// CR 105.1 + CR 601.2f + CR 115.1: Dragonfire Blade equip discount.
+    #[test]
+    fn test_parse_for_each_color_of_creature_it_targets() {
+        let (rest, q) =
+            parse_for_each_clause_ref("color of the creature it targets").unwrap();
         assert_eq!(
             q,
             QuantityRef::ObjectColorCount {

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2887,7 +2887,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         parse_for_each_one_life_changed,
         parse_for_each_opponents_life_change,
         parse_counter_added_this_turn_for_each,
-        parse_color_of_object_it_targets_for_each,
+        parse_color_of_object_for_each,
         parse_object_colors_for_each,
         parse_object_name_word_count_for_each,
         parse_object_typeline_component_count_for_each,
@@ -3353,18 +3353,13 @@ fn parse_mana_symbols_in_object_mana_cost_for_each(input: &str) -> OracleResult<
     Ok((rest, QuantityRef::ManaSymbolsInManaCost { scope, color }))
 }
 
-/// CR 105.1 + CR 601.2f + CR 115.1: "for each color[s] of the <type> it
-/// targets" (Dragonfire Blade equip discount). Target-anaphoric color count
-/// for activation cost reduction keyed to the chosen equip target.
-fn parse_color_of_object_it_targets_for_each(input: &str) -> OracleResult<'_, QuantityRef> {
+/// CR 105.1 + CR 601.2f: "for each color[s] of <object>" — scoped object-color
+/// count for cost reductions and similar per-color riders. Delegates object
+/// binding to `parse_object_color_of_scope` (target/enchanted/equipped/it-
+/// targets anaphors).
+fn parse_color_of_object_for_each(input: &str) -> OracleResult<'_, QuantityRef> {
     let (rest, _) = alt((tag("color of "), tag("colors of "))).parse(input)?;
-    let (rest, scope) = alt((
-        value(ObjectScope::Target, tag("the creature it targets")),
-        value(ObjectScope::Target, tag("the permanent it targets")),
-        value(ObjectScope::Target, tag("a creature it targets")),
-        value(ObjectScope::Target, tag("a permanent it targets")),
-    ))
-    .parse(rest)?;
+    let (rest, scope) = parse_object_color_of_scope(rest)?;
     Ok((rest, QuantityRef::ObjectColorCount { scope }))
 }
 
@@ -3492,6 +3487,14 @@ fn parse_object_color_of_scope(input: &str) -> OracleResult<'_, ObjectScope> {
         value(ObjectScope::Target, tag("that creature")),
         value(ObjectScope::Target, tag("that permanent")),
         value(ObjectScope::Target, tag("that planeswalker")),
+        value(
+            ObjectScope::Target,
+            (
+                alt((tag("the "), tag("a "))),
+                alt((tag("creature"), tag("permanent"))),
+                tag(" it targets"),
+            ),
+        ),
         value(ObjectScope::Source, tag("~")),
         value(ObjectScope::Source, tag("this creature")),
         value(ObjectScope::Source, tag("this permanent")),
@@ -5294,14 +5297,32 @@ mod tests {
         assert_eq!(rest, "");
     }
 
-    /// CR 105.1 + CR 601.2f + CR 115.1: Dragonfire Blade equip discount.
+    /// CR 105.1 + CR 601.2f + CR 115.1: generalized "color of <object>" for-each.
     #[test]
-    fn test_parse_for_each_color_of_creature_it_targets() {
+    fn test_parse_for_each_color_of_object() {
         let (rest, q) = parse_for_each_clause_ref("color of the creature it targets").unwrap();
         assert_eq!(
             q,
             QuantityRef::ObjectColorCount {
                 scope: crate::types::ability::ObjectScope::Target
+            }
+        );
+        assert_eq!(rest, "");
+
+        let (rest, q) = parse_for_each_clause_ref("color of target creature").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::ObjectColorCount {
+                scope: crate::types::ability::ObjectScope::Target
+            }
+        );
+        assert_eq!(rest, "");
+
+        let (rest, q) = parse_for_each_clause_ref("colors of the enchanted creature").unwrap();
+        assert_eq!(
+            q,
+            QuantityRef::ObjectColorCount {
+                scope: crate::types::ability::ObjectScope::Recipient
             }
         );
         assert_eq!(rest, "");


### PR DESCRIPTION
## Summary

Dragonfire Blade's Equip rider (`This ability costs {1} less to activate for each color of the creature it targets.`) was not parsed, so the equip activation cost never scaled with the chosen target's colors.

Adds a `parse_color_of_object_it_targets_for_each` combinator for the target-anaphoric `color[s] of the <type> it targets` quantity shape and wires it into the for-each cost-reduction path used by `try_parse_cost_reduction`.

Closes #4425

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

Narrow quantity-parser extension in `oracle_nom/quantity.rs`, following existing `ObjectColorCount` / `parse_object_colors_for_each` patterns. No runtime behavior change beyond attaching the already-supported cost-reduction ref.

## CR references

CR 601.2f — cost reductions reduce the activation cost. CR 105.1 — color count on the equip target. CR 115.1 — "the creature it targets" anaphor binds to the chosen equip target.

## Verification

- `test_parse_for_each_color_of_creature_it_targets` in `oracle_nom/quantity.rs`
- `cost_reduction_for_each_color_of_creature_it_targets` in `oracle_cost.rs`

Model: gpt-5.3-codex
Tier: Standard

## Anchored on

- crates/engine/src/parser/oracle_nom/quantity.rs:3359 — `parse_object_colors_for_each` / `ObjectColorCount` building block
- crates/engine/src/parser/oracle_nom/quantity.rs:3467 — `parse_object_color_of_scope` target-anaphor patterns
- crates/engine/src/parser/oracle_cost.rs:2792 — `cost_reduction_for_each_form_unconditional` for-each cost reduction tests
