### PR TITLE
fix(engine,ai): open CR 601.2g pre-payment mana window for mana+removal activation costs

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11,9 +11,9 @@ use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    CastOfferKind, CastPaymentMode, CastingVariant, CastingVariantChoiceOption, ConvokeMode,
-    CostResume, GameState, NextSpellModifier, PayCostKind, PendingCast, SneakPlacement,
-    SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind, WaitingFor,
+    ActivationResidual, CastOfferKind, CastPaymentMode, CastingVariant, CastingVariantChoiceOption,
+    ConvokeMode, CostResume, GameState, NextSpellModifier, PayCostKind, PendingCast,
+    SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
@@ -11735,24 +11735,6 @@ fn find_waterbend_cost(cost: &AbilityCost) -> Option<&ManaCost> {
     }
 }
 
-/// Walk a cost tree and return the first static `AbilityCost::Mana` leg's
-/// `ManaCost`, if any. Mirrors `find_waterbend_cost` /
-/// `find_non_self_sacrifice_cost`.
-///
-/// Deliberate scope limit (CR 118.4): only `AbilityCost::Mana` (a fully static
-/// `ManaCost`) is matched. `AbilityCost::ManaDynamic` (X-cost) returns `None`,
-/// so an X-cost composite falls through to the unchanged over-approximation in
-/// `can_pay`'s supplemental witness check — no regression, intentional. For a
-/// composite with multiple `Mana` legs, `find_map` returns the first; no
-/// in-scope conditional-mana card has two independent static `Mana` legs.
-pub(super) fn composite_mana_leg(cost: &AbilityCost) -> Option<&ManaCost> {
-    match cost {
-        AbilityCost::Mana { cost } => Some(cost),
-        AbilityCost::Composite { costs } => costs.iter().find_map(composite_mana_leg),
-        _ => None,
-    }
-}
-
 /// Walk a cost tree and return the first non-SelfRef sacrifice `(count, filter)`
 /// found, if any. The `count` is honored so multi-permanent sacrifice costs
 /// ("Sacrifice two creatures:") are modeled correctly.
@@ -11769,18 +11751,21 @@ pub(super) fn find_non_self_sacrifice_cost(cost: &AbilityCost) -> Option<(u32, &
 
 /// Which battlefield-removing non-mana cost leg a composite carries. Each is a
 /// distinct CR keyword action / zone change but all remove a permanent from the
-/// battlefield (CR 701.21a Sacrifice / CR 701.13a Exile / plain bounce), so one
-/// MutationWitness models all three.
+/// battlefield (CR 701.21a Sacrifice / CR 701.13a Exile / plain bounce), so the
+/// mana-leg detour in `handle_activate_ability` treats all three uniformly:
+/// gate the CR 601.2g mana-first hoist when any is present.
 pub(super) enum RemovalKind {
     Sacrifice,
     Exile,
     ReturnToHand,
 }
 
-/// CR 601.2h: first non-self battlefield-removing leg of `cost`, by kind
-/// priority (Sacrifice > Exile > ReturnToHand). Composes the existing per-kind
-/// cost walkers. Returns at most ONE leg (single-leg limit documented at the
-/// `can_pay` call site).
+/// CR 601.2g + CR 601.2h: first non-self battlefield-removing leg of `cost`, by
+/// kind priority (Sacrifice > Exile > ReturnToHand). Composes the existing
+/// per-kind cost walkers. Returns at most ONE leg; it gates the mana-first
+/// detour in `handle_activate_ability` (presence check) — the kind it returns is
+/// not used there because `push_activated_ability_to_stack` re-dispatches on each
+/// per-kind walker after mana payment.
 pub(super) fn find_non_self_battlefield_removal_cost(
     cost: &AbilityCost,
 ) -> Option<(u32, &TargetFilter, RemovalKind)> {
@@ -11810,7 +11795,7 @@ pub(super) fn find_non_self_battlefield_removal_cost(
 /// payable hand-exile composite). A `None` filter is out of scope. The
 /// `SelfRef`-first arm is required: a SelfRef filter may be permanent-implying
 /// and would otherwise pass the battlefield gate.
-fn find_battlefield_exile_cost(cost: &AbilityCost) -> Option<(u32, &TargetFilter)> {
+pub(super) fn find_battlefield_exile_cost(cost: &AbilityCost) -> Option<(u32, &TargetFilter)> {
     match cost {
         AbilityCost::Exile {
             filter: Some(TargetFilter::SelfRef),
@@ -12037,7 +12022,7 @@ fn find_one_of_cost(cost: &AbilityCost) -> Option<&Vec<AbilityCost>> {
     }
 }
 
-fn find_return_to_hand_cost(cost: &AbilityCost) -> Option<(u32, Option<&TargetFilter>)> {
+pub(super) fn find_return_to_hand_cost(cost: &AbilityCost) -> Option<(u32, Option<&TargetFilter>)> {
     match cost {
         // CR 118.12: This helper currently only handles the default
         // battlefield-source shape (`from_zone: None`) and its explicit
@@ -12860,9 +12845,36 @@ pub fn handle_activate_ability(
             // `push_activated_ability_to_stack` must re-surface a non-self discard
             // sub-cost. Only THIS path sets it; the discard-first detour below
             // already pays the discard and resumes with the flag unset.
-            pending_x.x_residual_activation = true;
+            pending_x.activation_residual = ActivationResidual::XMana;
             state.pending_cast = Some(Box::new(pending_x));
             return casting_costs::enter_payment_step(state, player, None, events);
+        }
+
+        // CR 601.2g + CR 601.2h + CR 602.2b: A NON-X mana leg combined with a
+        // non-self battlefield-removal cost (Sacrifice / battlefield Exile /
+        // ReturnToHand) must pay the mana FIRST so the CR 601.2g mana-ability
+        // window opens on the INTACT board — the removal (which can shrink
+        // board-derived mana: Metalcraft/affinity/devotion) is paid LAST. Hoist
+        // the mana leg through `enter_payment_step` and leave the removal tail as
+        // the `ManaLeg` residual, which `push_activated_ability_to_stack`
+        // re-surfaces after mana payment. This MUST run before the
+        // Sacrifice/Exile/ReturnToHand pre-payment detours below, which pay the
+        // removal FIRST (the pre-fix CR 601.2h ordering bug). The gate is
+        // mana-leg-AND-removal: a bare `{N}` or `{N},{T}` has no removal leg
+        // (`find_non_self_battlefield_removal_cost` → None) and a bare
+        // `Sacrifice`/`Exile`/`Return` has no mana leg (`extract_mana_leg` → None);
+        // both fall through to the unchanged paths. SelfRef removal is excluded by
+        // the walkers. `{X}`-mana removals were already caught by the X detour
+        // above, so any mana leg seen here is non-X (mutually exclusive residuals).
+        if find_non_self_battlefield_removal_cost(cost).is_some() {
+            if let Some((mana_cost, remaining)) = casting_costs::extract_mana_leg(cost) {
+                let mut pending_leg = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
+                pending_leg.activation_cost = remaining;
+                pending_leg.activation_ability_index = Some(ability_index);
+                pending_leg.activation_residual = ActivationResidual::ManaLeg;
+                state.pending_cast = Some(Box::new(pending_leg));
+                return casting_costs::enter_payment_step(state, player, None, events);
+            }
         }
 
         if let Some((count, sac_filter)) = find_non_self_sacrifice_cost(cost) {
@@ -28049,6 +28061,390 @@ mod tests {
             }
             other => panic!("expected PayCost ReturnToHand, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // CR 601.2g + CR 601.2h + CR 602.2b: the non-X mana-leg detour pays the mana
+    // leg FIRST (opening the mana-ability window on the INTACT board), then
+    // re-surfaces the non-self battlefield-removal cost (Sacrifice / battlefield
+    // Exile / ReturnToHand) as the residual. These drive `handle_activate_ability`
+    // (the production entry point) with a pre-filled mana pool so the {N} leg
+    // auto-pays, then assert the removal prompt surfaces AFTER the mana is spent.
+    // -----------------------------------------------------------------------
+
+    fn gain_one_life_effect() -> Effect {
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        }
+    }
+
+    /// Claws-of-Gix shape (`{1}, Sacrifice a permanent`). REVERT-FAILING (§4):
+    /// without the mana-leg detour the sacrifice prompt surfaces with the {1} pool
+    /// still full. REVERT-FAILING (§2 Sacrifice arm): without the arm the residual
+    /// sacrifice is silently swallowed by the fall-through and no PayCost surfaces.
+    #[test]
+    fn mana_leg_sacrifice_pays_mana_before_sacrifice_prompt() {
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let fodder = create_object(
+            &mut state,
+            CardId(810),
+            PlayerId(0),
+            "Fodder".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&fodder)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let claws = create_object(
+            &mut state,
+            CardId(811),
+            PlayerId(0),
+            "Claws of Gix".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&claws).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(AbilityKind::Activated, gain_one_life_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Mana {
+                                cost: ManaCost::generic(1),
+                            },
+                            AbilityCost::Sacrifice(SacrificeCost::count(
+                                TargetFilter::Typed(TypedFilter::permanent()),
+                                1,
+                            )),
+                        ],
+                    },
+                ),
+            );
+        }
+
+        let waiting =
+            handle_activate_ability(&mut state, PlayerId(0), claws, 0, &mut Vec::new()).unwrap();
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "{{1}} must be paid before the sacrifice prompt"
+        );
+        assert!(
+            matches!(
+                waiting,
+                WaitingFor::PayCost {
+                    kind: PayCostKind::Sacrifice,
+                    ..
+                }
+            ),
+            "sacrifice prompt must surface after mana payment, got {waiting:?}"
+        );
+        state.waiting_for = waiting;
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![fodder],
+            },
+        )
+        .unwrap();
+        assert!(
+            !state.battlefield.contains(&fodder),
+            "fodder must be sacrificed once selected"
+        );
+    }
+
+    /// Curie shape (`{1}{U}, Exile another artifact you control`). The exile leg
+    /// has `zone: None` + a permanent-implying filter, so it resolves to the
+    /// battlefield (CR 701.13a) and routes to `PayCostKind::ExilePermanent`.
+    /// REVERT-FAILING (§2 battlefield-Exile arm): without the arm the residual
+    /// exile is a silent no-op in the fall-through and the target is never exiled.
+    #[test]
+    fn mana_leg_battlefield_exile_pays_mana_before_exile_prompt() {
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Blue, 1);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let fodder = create_object(
+            &mut state,
+            CardId(820),
+            PlayerId(0),
+            "Artifact Servo".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&fodder)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+        let curie = create_object(
+            &mut state,
+            CardId(821),
+            PlayerId(0),
+            "Curie".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&curie).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(AbilityKind::Activated, gain_one_life_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Mana {
+                                cost: ManaCost::Cost {
+                                    shards: vec![ManaCostShard::Blue],
+                                    generic: 1,
+                                },
+                            },
+                            AbilityCost::Exile {
+                                count: 1,
+                                zone: None,
+                                filter: Some(TargetFilter::Typed(
+                                    TypedFilter::new(TypeFilter::Artifact)
+                                        .controller(ControllerRef::You)
+                                        .properties(vec![FilterProp::Another]),
+                                )),
+                            },
+                        ],
+                    },
+                ),
+            );
+        }
+
+        let waiting =
+            handle_activate_ability(&mut state, PlayerId(0), curie, 0, &mut Vec::new()).unwrap();
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "{{1}}{{U}} must be paid before the exile prompt"
+        );
+        assert!(
+            matches!(
+                waiting,
+                WaitingFor::PayCost {
+                    kind: PayCostKind::ExilePermanent { .. },
+                    ..
+                }
+            ),
+            "battlefield-exile prompt must surface after mana payment, got {waiting:?}"
+        );
+        state.waiting_for = waiting;
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![fodder],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            state.objects[&fodder].zone,
+            Zone::Exile,
+            "selected artifact must be exiled, not the source"
+        );
+    }
+
+    /// Master Transmuter shape (`{U}, {T}, Return an artifact you control`). The
+    /// residual is `Composite[Tap, ReturnToHand]`: the {U} leg is paid first, the
+    /// interactive return surfaces, and the trailing `{T}` is paid by
+    /// `handle_return_to_hand_for_cost`. REVERT-FAILING (§2 ReturnToHand arm):
+    /// without the arm the return is a silent no-op and the artifact is never
+    /// bounced; the source's `{T}` is also never reached as a paid residual.
+    #[test]
+    fn mana_leg_tap_return_pays_mana_then_taps_source_on_return() {
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Blue, 1);
+        let mox = create_object(
+            &mut state,
+            CardId(830),
+            PlayerId(0),
+            "Blue Mox".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&mox)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+        // Non-artifact source: it is not itself a return target.
+        let transmuter = create_object(
+            &mut state,
+            CardId(831),
+            PlayerId(0),
+            "Master Transmuter".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&transmuter).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(AbilityKind::Activated, gain_one_life_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Mana {
+                                cost: ManaCost::Cost {
+                                    shards: vec![ManaCostShard::Blue],
+                                    generic: 0,
+                                },
+                            },
+                            AbilityCost::Tap,
+                            AbilityCost::ReturnToHand {
+                                count: 1,
+                                filter: Some(TargetFilter::Typed(
+                                    TypedFilter::new(TypeFilter::Artifact)
+                                        .controller(ControllerRef::You),
+                                )),
+                                from_zone: None,
+                            },
+                        ],
+                    },
+                ),
+            );
+        }
+
+        let waiting =
+            handle_activate_ability(&mut state, PlayerId(0), transmuter, 0, &mut Vec::new())
+                .unwrap();
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "{{U}} must be paid before the return prompt"
+        );
+        assert!(
+            !state.objects[&transmuter].tapped,
+            "the source's {{T}} is a residual leg, not paid until the return resolves"
+        );
+        assert!(
+            matches!(
+                waiting,
+                WaitingFor::PayCost {
+                    kind: PayCostKind::ReturnToHand,
+                    ..
+                }
+            ),
+            "return prompt must surface after mana payment, got {waiting:?}"
+        );
+        state.waiting_for = waiting;
+        apply_as_current(&mut state, GameAction::SelectCards { cards: vec![mox] }).unwrap();
+        assert!(
+            state.players[0].hand.contains(&mox),
+            "selected artifact must be returned to hand"
+        );
+        assert!(
+            state.objects[&transmuter].tapped,
+            "the trailing {{T}} must be paid by the return-cost handler"
+        );
+    }
+
+    /// Hostile negative: a bare `{1}, {T}` (mana + tap, NO battlefield removal)
+    /// must NOT trip the mana-leg detour — `find_non_self_battlefield_removal_cost`
+    /// returns None, so the activation stays on the unchanged direct path. No
+    /// `PayCost` is surfaced; the source taps for `{T}` and the ability is pushed.
+    #[test]
+    fn mana_leg_detour_skips_vanilla_mana_tap_cost() {
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let source = create_object(
+            &mut state,
+            CardId(840),
+            PlayerId(0),
+            "Vanilla Tapper".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(AbilityKind::Activated, gain_one_life_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Mana {
+                                cost: ManaCost::generic(1),
+                            },
+                            AbilityCost::Tap,
+                        ],
+                    },
+                ),
+            );
+        }
+
+        let waiting =
+            handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new()).unwrap();
+        assert!(
+            !matches!(waiting, WaitingFor::PayCost { .. }),
+            "bare mana+tap must not be intercepted by the mana-leg detour, got {waiting:?}"
+        );
+        assert!(
+            state.objects[&source].tapped,
+            "the {{T}} leg must tap the source on the direct path"
+        );
+        assert_eq!(
+            state
+                .activated_abilities_this_turn
+                .get(&(source, 0))
+                .copied(),
+            Some(1),
+            "the ability must be pushed on the unchanged direct path"
+        );
+    }
+
+    /// Hostile negative: a `{1}, Sacrifice this` (SelfRef) must NOT trip the
+    /// mana-leg detour — the SelfRef exclusion in
+    /// `find_non_self_battlefield_removal_cost` returns None, so no
+    /// `PayCostKind::Sacrifice` is surfaced; the self-sacrifice is paid on the
+    /// unchanged direct path.
+    #[test]
+    fn mana_leg_detour_skips_self_ref_sacrifice_cost() {
+        let mut state = setup_game_at_main_phase();
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let source = create_object(
+            &mut state,
+            CardId(850),
+            PlayerId(0),
+            "Self Sacker".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(AbilityKind::Activated, gain_one_life_effect()).cost(
+                    AbilityCost::Composite {
+                        costs: vec![
+                            AbilityCost::Mana {
+                                cost: ManaCost::generic(1),
+                            },
+                            AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+                        ],
+                    },
+                ),
+            );
+        }
+
+        let waiting =
+            handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new()).unwrap();
+        assert!(
+            !matches!(
+                waiting,
+                WaitingFor::PayCost {
+                    kind: PayCostKind::Sacrifice,
+                    ..
+                }
+            ),
+            "self-ref sacrifice must not be intercepted by the mana-leg detour, got {waiting:?}"
+        );
+        assert!(
+            !state.battlefield.contains(&source),
+            "the self-sacrifice must be paid on the direct path"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -10,9 +10,10 @@ use crate::types::ability::{
 };
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
-    AssistState, CastPaymentMode, CastingVariant, ConvokeMode, CostResume, CounterCostChoice,
-    DistributionUnit, GameState, PayCostKind, PendingCast, PendingDiscardForCostResume,
-    SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot, WaitingFor,
+    ActivationResidual, AssistState, CastPaymentMode, CastingVariant, ConvokeMode, CostResume,
+    CounterCostChoice, DistributionUnit, GameState, PayCostKind, PendingCast,
+    PendingDiscardForCostResume, SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot,
+    WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
@@ -901,7 +902,7 @@ fn finish_pending_cost_or_cast(
             ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
-            pending.x_residual_activation,
+            pending.activation_residual,
             events,
         )?;
         return Ok(drain_deferred_triggers_after_stack_object_announcement(
@@ -1209,7 +1210,7 @@ pub(crate) fn resume_interrupted_cost_payment(
             activation_ability_index,
             pending.ability,
             pending.activation_cost.as_ref(),
-            pending.x_residual_activation,
+            pending.activation_residual,
             events,
         );
     }
@@ -2180,10 +2181,13 @@ pub(super) fn push_activated_ability_to_stack(
     ability_index: usize,
     mut resolved: ResolvedAbility,
     remaining_cost: Option<&crate::types::ability::AbilityCost>,
-    // CR 601.2f + CR 601.2h: POSITIVE signal that the caller took the `{X}`-mana
-    // detour, so `remaining_cost` is the unpaid residual non-mana tail. Threaded
-    // from `PendingCast::x_residual_activation` — set ONLY by that detour.
-    x_residual: bool,
+    // CR 601.2g + CR 601.2h + CR 602.2b: POSITIVE signal of which mana-first
+    // detour the caller took, so `remaining_cost` is the unpaid residual non-mana
+    // tail. Threaded from `PendingCast::activation_residual` — set ONLY by the
+    // `{X}`-mana detour (`XMana` → re-surface the residual non-self DISCARD) and
+    // the non-X mana-leg detour (`ManaLeg` → re-surface the residual non-self
+    // battlefield-removal: Sacrifice / battlefield Exile / ReturnToHand).
+    activation_residual: ActivationResidual,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // Pay any activation-cost tail still outstanding. Cost-selection flows may
@@ -2193,15 +2197,16 @@ pub(super) fn push_activated_ability_to_stack(
         // CR 601.2f + CR 601.2h + CR 701.9a: When the X-mana detour ran first
         // (e.g. the Momir Basic emblem's `{X}, Discard a card` cost), the non-self
         // "discard a card" sub-cost is still OUTSTANDING here AFTER mana payment,
-        // signalled by `x_residual`. In contrast, the discard-FIRST pre-check
-        // detour in `handle_activate_ability` already paid the discard and resumes
-        // with `x_residual == false` and the ORIGINAL cost — its discard sub-cost
-        // is correctly no-op'd by `pay_ability_cost_for_activation` below. Gating
-        // on the positive `x_residual` signal (not the cost shape) avoids
-        // double-charging the discard on that pre-check path even when the cost is
-        // a BARE `Discard` (which would otherwise fail with an empty hand).
-        if let Some((count, filter)) =
-            super::casting::find_non_self_discard(cost).filter(|_| x_residual)
+        // signalled by `ActivationResidual::XMana`. In contrast, the discard-FIRST
+        // pre-check detour in `handle_activate_ability` already paid the discard
+        // and resumes with `None` and the ORIGINAL cost — its discard sub-cost is
+        // correctly no-op'd by `pay_ability_cost_for_activation` below. Gating on
+        // the positive `XMana` signal (not the cost shape) avoids double-charging
+        // the discard on that pre-check path even when the cost is a BARE `Discard`
+        // (which would otherwise fail with an empty hand). Discard is a hand cost,
+        // never a battlefield removal, so the `ManaLeg` detour never produces it.
+        if let Some((count, filter)) = super::casting::find_non_self_discard(cost)
+            .filter(|_| matches!(activation_residual, ActivationResidual::XMana))
         {
             let count =
                 super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
@@ -2227,22 +2232,131 @@ pub(super) fn push_activated_ability_to_stack(
             });
         }
 
+        // CR 601.2g + CR 601.2h + CR 602.2b: When the non-X mana-leg detour ran
+        // first (`ActivationResidual::ManaLeg`), the mana leg was already paid on
+        // the INTACT board (the CR 601.2g window), so the residual tail here is a
+        // non-self battlefield-removal cost still OUTSTANDING. Each arm re-surfaces
+        // the interactive removal exactly as the Discard arm above, storing the
+        // residual in the resumed `PendingCast` so its handler completes payment.
+        // These MUST be hand-rolled rather than left to the
+        // `pay_ability_cost_for_activation` fall-through below: that fall-through
+        // pays a `Tap` leg but is a SILENT `Paid` no-op for a non-self Sacrifice or
+        // Exile (it relies on the pre-payment interception the mana-first hoist
+        // bypassed — see the XMana seam comment below). Mirrors the
+        // Sacrifice/Exile/ReturnToHand pre-payment detours in
+        // `handle_activate_ability`, but triggered AFTER mana payment.
+        if matches!(activation_residual, ActivationResidual::ManaLeg) {
+            if let Some((count, sac_filter)) = super::casting::find_non_self_sacrifice_cost(cost) {
+                let eligible = super::casting::find_eligible_sacrifice_targets(
+                    state, player, source_id, sac_filter,
+                );
+                let (min_count, max_count) =
+                    super::casting::sacrifice_cost_bounds(count, eligible.len());
+                if eligible.len() < min_count {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Not enough eligible permanents to sacrifice".into(),
+                    ));
+                }
+                let mut pending_sac =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_sac.activation_cost = Some(cost.clone());
+                pending_sac.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::Sacrifice,
+                    choices: eligible,
+                    count: max_count,
+                    min_count,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_sac),
+                    },
+                });
+            }
+
+            // CR 701.13a: battlefield exile-as-cost. `ExilePermanent` (NOT
+            // `ExileFromZone`, whose `ExileCostSourceZone` is Hand|Graveyard-only).
+            // Mirrors the battlefield exile additional-cost arm in
+            // `pay_additional_cost`.
+            if let Some((count, exile_filter)) = super::casting::find_battlefield_exile_cost(cost) {
+                let effective_filter =
+                    super::cost_payability::exile_cost_effective_filter(Some(exile_filter));
+                let eligible = super::cost_payability::eligible_exile_cost_objects(
+                    state,
+                    player,
+                    source_id,
+                    Zone::Battlefield,
+                    effective_filter.as_ref(),
+                    count,
+                );
+                if eligible.len() < count as usize {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Not enough eligible permanents to exile".into(),
+                    ));
+                }
+                let mut pending_exile =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_exile.activation_cost = Some(cost.clone());
+                pending_exile.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ExilePermanent {
+                        filter: Some(exile_filter.clone()),
+                    },
+                    choices: eligible,
+                    count: count as usize,
+                    min_count: count as usize,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_exile),
+                    },
+                });
+            }
+
+            // Plain battlefield bounce (Master Transmuter `{U}, {T}, Return ...`).
+            // The residual stored here is `Composite[Tap, ReturnToHand]`; the
+            // trailing Tap is paid by `handle_return_to_hand_for_cost` (which pays
+            // the stored `activation_cost`), and ReturnToHand is a no-op there
+            // because the handler performs the chosen return itself.
+            if let Some((count, rth_filter)) = super::casting::find_return_to_hand_cost(cost) {
+                let eligible = super::casting::find_eligible_return_to_hand_targets(
+                    state, player, source_id, rth_filter,
+                );
+                if eligible.len() < count as usize {
+                    return Err(EngineError::ActionNotAllowed(
+                        "No eligible permanents to return".into(),
+                    ));
+                }
+                let mut pending_return =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_return.activation_cost = Some(cost.clone());
+                pending_return.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ReturnToHand,
+                    choices: eligible,
+                    count: count as usize,
+                    min_count: 0,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_return),
+                    },
+                });
+            }
+        }
+
         // CR 118.3 + CR 601.2h: The `{X}`-mana detour (`extract_x_mana_cost` in
         // `handle_activate_ability`) hoists X-first and leaves the residual tail
         // here, but ONLY the non-self `Discard` arm above re-surfaces an
-        // interactive cost. A residual non-self SACRIFICE or non-self EXILE would
-        // otherwise fall through to `pay_ability_cost_for_activation`, where both
-        // are silent `Paid` no-ops (they rely on the pre-payment
-        // SacrificeForCost / ExileForCost WaitingFor interception that the X-first
-        // hoist bypassed) — silently SKIPPING the cost. No current card has an
-        // `{X} + non-self-sacrifice/exile` activated ability (corpus scan = zero),
-        // and this was already broken pre-hoist (X→0), so this is not a
-        // regression — but a silent cost-swallow must not ship. Fail LOUDLY here.
-        // A future `{X} + non-self-sacrifice/exile` activated ability must extend
-        // this residual detour with Sacrifice/Exile arms mirroring the Discard arm
-        // above (route to `WaitingFor::PayCost { kind: Sacrifice | ExileFromZone }`
-        // with the residual stored in the resumed pending).
-        if x_residual
+        // interactive cost for the XMana path. A residual non-self SACRIFICE or
+        // non-self EXILE would otherwise fall through to
+        // `pay_ability_cost_for_activation`, where both are silent `Paid` no-ops
+        // (they rely on the pre-payment SacrificeForCost / ExileForCost WaitingFor
+        // interception that the X-first hoist bypassed) — silently SKIPPING the
+        // cost. No current card has an `{X} + non-self-sacrifice/exile` activated
+        // ability (corpus scan = zero), and this was already broken pre-hoist
+        // (X→0), so this is not a regression — but a silent cost-swallow must not
+        // ship. Fail LOUDLY here. This gate is XMana-only: the ManaLeg path's
+        // non-self sacrifice/exile is already handled by the arms above (it never
+        // reaches here), and the two residual variants are mutually exclusive.
+        if matches!(activation_residual, ActivationResidual::XMana)
             && (super::casting::find_non_self_sacrifice_cost(cost).is_some()
                 || super::casting::find_non_self_exile(cost).is_some())
         {
@@ -7587,7 +7701,7 @@ pub fn finalize_mana_payment(
                 ability_index,
                 pending.ability,
                 pending.activation_cost.as_ref(),
-                pending.x_residual_activation,
+                pending.activation_residual,
                 events,
             );
         }
@@ -7768,7 +7882,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 ability_index,
                 pending.ability,
                 pending.activation_cost.as_ref(),
-                pending.x_residual_activation,
+                pending.activation_residual,
                 events,
             );
         }
@@ -8078,19 +8192,26 @@ pub fn pending_activation_cost_has_x(state: &GameState, source_id: ObjectId) -> 
 /// Returns `Some((mana_cost, remaining))` where `mana_cost` is the extracted
 /// Mana cost and `remaining` is the rest of the cost (None if the whole cost
 /// was the Mana sub-cost). Returns `None` if no X mana cost is present.
-pub fn extract_x_mana_cost(
+/// Predicate core of [`extract_x_mana_cost`] / [`extract_mana_leg`]: extract the
+/// first static `AbilityCost::Mana` leg whose `ManaCost` satisfies `accept`,
+/// returning the extracted cost plus the residual non-mana tail (None when the
+/// whole cost was the mana leg). The `accept` predicate selects WHICH mana leg
+/// is hoisted: `cost_has_x` (X-mana detour) vs. `|_| true` (any non-X mana leg
+/// detour). Behavior is byte-identical to the former `extract_x_mana_cost` body.
+fn extract_mana_leg_matching(
     cost: &crate::types::ability::AbilityCost,
+    accept: impl Fn(&crate::types::mana::ManaCost) -> bool + Copy,
 ) -> Option<(
     crate::types::mana::ManaCost,
     Option<crate::types::ability::AbilityCost>,
 )> {
     use crate::types::ability::AbilityCost;
     match cost {
-        AbilityCost::Mana { cost: mana } if cost_has_x(mana) => Some((mana.clone(), None)),
+        AbilityCost::Mana { cost: mana } if accept(mana) => Some((mana.clone(), None)),
         AbilityCost::Composite { costs } => {
             let idx = costs
                 .iter()
-                .position(|sub| matches!(sub, AbilityCost::Mana { cost: m } if cost_has_x(m)))?;
+                .position(|sub| matches!(sub, AbilityCost::Mana { cost: m } if accept(m)))?;
             let mut remaining = costs.clone();
             let AbilityCost::Mana { cost: extracted } = remaining.remove(idx) else {
                 unreachable!("position guarantees Mana variant")
@@ -8104,6 +8225,29 @@ pub fn extract_x_mana_cost(
         }
         _ => None,
     }
+}
+
+pub fn extract_x_mana_cost(
+    cost: &crate::types::ability::AbilityCost,
+) -> Option<(
+    crate::types::mana::ManaCost,
+    Option<crate::types::ability::AbilityCost>,
+)> {
+    extract_mana_leg_matching(cost, cost_has_x)
+}
+
+/// CR 601.2g + CR 601.2h + CR 602.2b: extract the first static `AbilityCost::Mana`
+/// leg (X or not) so it can be paid FIRST, opening the mana-ability window on the
+/// intact board before a non-mana battlefield-removal cost shrinks it. Used by
+/// the non-X mana-leg detour in `handle_activate_ability`; the residual tail is
+/// stored in `PendingCast::activation_cost` and re-surfaced after mana payment.
+pub fn extract_mana_leg(
+    cost: &crate::types::ability::AbilityCost,
+) -> Option<(
+    crate::types::mana::ManaCost,
+    Option<crate::types::ability::AbilityCost>,
+)> {
+    extract_mana_leg_matching(cost, |_| true)
 }
 
 #[cfg(test)]
@@ -8453,7 +8597,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         }
     }
 
@@ -12589,7 +12733,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         };
 
         let result = pay_additional_cost(
@@ -12716,7 +12860,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         };
 
         let mut events = Vec::new();
@@ -12812,7 +12956,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         };
 
         // Exactly one card is required. Selecting two must fail.
@@ -12897,7 +13041,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         };
 
         // `red` is not in the legal-cards list, so the cost handler must reject
@@ -13015,7 +13159,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         };
 
         let result = pay_additional_cost(
@@ -15884,7 +16028,7 @@ its replicate cost was paid.)\nDraw a card.";
         );
         // The X-mana sub-cost has already been extracted/paid by the detour; the
         // residual handed to `push_activated_ability_to_stack` is the non-self
-        // sacrifice, flagged as the X-residual path (`x_residual = true`).
+        // sacrifice, flagged as the X-residual path (`ActivationResidual::XMana`).
         let residual = AbilityCost::Sacrifice(SacrificeCost::count(
             TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
             1,
@@ -15897,7 +16041,7 @@ its replicate cost was paid.)\nDraw a card.";
             0,
             resolved,
             Some(&residual),
-            true,
+            ActivationResidual::XMana,
             &mut events,
         );
     }

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1023,135 +1023,6 @@ fn pay_ability_cost_inner(
     Ok(PaymentOutcome::Paid)
 }
 
-/// A minimal board mutation modeled on a throwaway clone by the activation-time
-/// supplemental affordability check (`composite_removal_mana_witness_exists`).
-///
-/// Each variant names a concrete way the live cost-payment path mutates the
-/// board *before* the residual mana leg is paid, so the affordability oracle can
-/// re-derive remaining-board mana on the post-mutation state instead of the
-/// (over-approximating) intact board.
-enum MutationWitness {
-    /// Remove the carried permanent(s) from the battlefield. Models every
-    /// battlefield-removing non-mana cost leg — CR 701.21a Sacrifice (→ owner's
-    /// graveyard), CR 701.13a Exile (→ exile), or a plain bounce (→ owner's
-    /// hand) — since only the battlefield removal affects the remaining-board
-    /// mana the oracle re-derives; the destination zone is irrelevant. The
-    /// `(ObjectId, PlayerId)` pairs are the witness object and its owner.
-    RemoveFromBattlefield(Vec<(ObjectId, PlayerId)>),
-}
-
-/// Apply a [`MutationWitness`] to a throwaway clone.
-///
-/// INVARIANT (CR 613.1): any witness that removes or moves a board permanent
-/// MUST leave `layers_dirty` non-`Clean`, so the downstream payability oracle's
-/// `flush_layers` (in `can_pay_effect_mana_cost_after_auto_tap`) re-derives the
-/// continuous effects (affinity-style cost reductions, granted mana abilities,
-/// devotion) whose values depend on board population. `zones::remove_from_zone`
-/// does NOT mark layers dirty, so `layers::mark_layers_full` is mandatory here.
-fn apply_mutation_witness(sim: &mut GameState, witness: &MutationWitness) {
-    match witness {
-        MutationWitness::RemoveFromBattlefield(removals) => {
-            // CR 701.21a / CR 701.13a / plain bounce: remove from the
-            // battlefield. The destination-zone add is intentionally omitted —
-            // the destination is irrelevant to the remaining-board mana the
-            // oracle re-derives below; only the battlefield removal matters.
-            for &(id, owner) in removals {
-                super::zones::remove_from_zone(sim, id, Zone::Battlefield, owner);
-            }
-            // CR 613.1: re-derive continuous effects against the post-removal
-            // board on the downstream `flush_layers`. Mandatory — see the
-            // function-level invariant above.
-            super::layers::mark_layers_full(sim);
-        }
-    }
-}
-
-/// Enumerate the single-witness mutation set for the supplemental affordability
-/// check. Gated on a non-self single-permanent battlefield-removing leg
-/// (`find_non_self_battlefield_removal_cost` — Sacrifice / Exile-from-bf /
-/// ReturnToHand-from-bf): for `count == 1`, emit one singleton
-/// `RemoveFromBattlefield` witness per eligible permanent (the existential
-/// candidates).
-///
-/// For `count > 1` (or no non-self removal leg) this returns an empty `Vec` —
-/// the caller MUST treat an empty set as "out of scope, do not reject" rather
-/// than feeding it into `.any()` (which would wrongly yield `false`). See the
-/// wiring in [`can_pay`].
-fn mutation_witness_set(
-    state: &GameState,
-    payer: PlayerId,
-    source_id: ObjectId,
-    cost: &AbilityCost,
-) -> Vec<MutationWitness> {
-    use super::casting::RemovalKind;
-    let Some((count, filter, kind)) = super::casting::find_non_self_battlefield_removal_cost(cost)
-    else {
-        return Vec::new();
-    };
-    if count != 1 {
-        // count > 1 deferred (AMENDMENT 1).
-        return Vec::new();
-    }
-    // Exhaustive match (no wildcard): a future removal kind must force a
-    // deliberate arm here.
-    let ids = match kind {
-        RemovalKind::Sacrifice => {
-            super::casting::find_eligible_sacrifice_targets(state, payer, source_id, filter)
-        }
-        RemovalKind::ReturnToHand => super::casting::find_eligible_return_to_hand_targets(
-            state,
-            payer,
-            source_id,
-            Some(filter),
-        ),
-        // For `Zone::Battlefield` the `count` arg to `eligible_exile_cost_objects`
-        // is ignored (only the Library arm uses `take(count)`), so this
-        // enumerates ALL eligible battlefield objects; passing `1` does not cap
-        // the existential search.
-        RemovalKind::Exile => super::cost_payability::eligible_exile_cost_objects(
-            state,
-            payer,
-            source_id,
-            Zone::Battlefield,
-            Some(filter),
-            1,
-        ),
-    };
-    ids.into_iter()
-        .filter_map(|id| {
-            state
-                .objects
-                .get(&id)
-                .map(|obj| MutationWitness::RemoveFromBattlefield(vec![(id, obj.owner)]))
-        })
-        .collect()
-}
-
-/// CR 601.2h: single-witness monotonic existential affordability check for the
-/// "conditional static mana leg + non-self single battlefield-removal" composite
-/// shape (Sacrifice / Exile-from-bf / ReturnToHand-from-bf).
-///
-/// The composite is genuinely payable iff THERE EXISTS one eligible removal
-/// whose application (on a throwaway clone) leaves the static mana leg payable.
-/// First-success early-return: `.any()` stops at the first witness that keeps
-/// the mana payable.
-fn composite_removal_mana_witness_exists(
-    state: &GameState,
-    payer: PlayerId,
-    source_id: ObjectId,
-    cost: &AbilityCost,
-    mana: &crate::types::mana::ManaCost,
-) -> bool {
-    mutation_witness_set(state, payer, source_id, cost)
-        .iter()
-        .any(|witness| {
-            crate::game::perf_counters::record_state_clone_for_legality();
-            let mut sim = state.clone();
-            apply_mutation_witness(&mut sim, witness);
-            can_pay_effect_mana_cost_after_auto_tap(&sim, payer, source_id, mana)
-        })
-}
-
 /// CR 118.3 + CR 601.2h: The single affordability authority. Returns whether
 /// `payer` could pay `cost` right now in the active [`PaymentScope`].
 ///
@@ -1217,34 +1088,15 @@ pub(crate) fn can_pay(
             if !dry_run_ok {
                 return false;
             }
-            // CR 601.2f / CR 602.2b: an activated ability's activation cost is the
-            // analog of a spell's mana cost, so the CR 601.2h ordering applies.
-            // CR 601.2h: the live path pays the non-mana leg FIRST and mana LAST;
-            // the dry-run above no-ops the leg, over-approving whenever the leg
-            // shrinks board mana (Metalcraft/affinity/devotion). Supplement with
-            // a single-witness existence check across Sacrifice / Exile-from-bf /
-            // ReturnToHand-from-bf.
-            //
-            // SINGLE-LEG LIMIT: find_non_self_battlefield_removal_cost returns at
-            // most ONE removal leg. A Composite carrying TWO removal legs
-            // (Sacrifice + Exile) is modeled as removing only one — fewer
-            // removals over-approximate remaining mana, so this can only
-            // false-APPROVE (preserves the no-new-dead-end direction). The
-            // shipped Sacrifice version had the same single-leg limit.
-            if let (Some(mana), Some((count, _, _))) = (
-                super::casting::composite_mana_leg(cost),
-                super::casting::find_non_self_battlefield_removal_cost(cost),
-            ) {
-                if count == 1 {
-                    return composite_removal_mana_witness_exists(
-                        state, payer, source_id, cost, mana,
-                    );
-                }
-                // AMENDMENT 1: count > 1 is OUT OF SCOPE — fall through to the
-                // unchanged `true` below (preserves today's over-approximation;
-                // a count >= 2 conditional-mana-base removal is a vanishingly
-                // rare tracked follow-up). MUST NOT reject count > 1 here.
-            }
+            // CR 601.2g + CR 601.2f / CR 602.2b: an activated ability's activation
+            // cost is the analog of a spell's mana cost, so the CR 601.2g/601.2h
+            // ordering applies. The mana-leg detour in `handle_activate_ability`
+            // now pays the mana leg FIRST (opening the CR 601.2g mana-ability
+            // window on the INTACT board) and the non-mana battlefield-removal leg
+            // LAST. The dry-run above therefore matches the live path exactly —
+            // both pay mana on the intact board — so no supplemental
+            // remove-then-recheck witness is needed; the former over-approximation
+            // is now the correct verdict.
             true
         }
         PaymentScope::Resolution { ability } => can_pay_resolution(state, payer, cost, ability),
@@ -1936,26 +1788,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Composite "{N}, Sacrifice a permanent" supplemental affordability check
-    // (CR 601.2h ordering: live path pays sacrifice FIRST, mana LAST). The
-    // helpers below build the Claws-of-Gix / Mox-Opal-Metalcraft minimal board.
+    // Composite "{N}, <battlefield-removal>" mana-first affordability (CR 601.2g
+    // / CR 601.2h ordering: the mana-leg detour pays mana FIRST on the intact
+    // board, the removal LAST). The helpers below build the Claws-of-Gix /
+    // Mox-Opal-Metalcraft minimal board.
     // -----------------------------------------------------------------------
-
-    /// Budget for `record_state_clone_for_legality` calls on the PAYABLE witness
-    /// path. Three CONSTANT clones, none scaling with the eligible-set size K:
-    ///   1. the existing `can_pay` dry-run clone;
-    ///   2. the first (and, via first-success early-return, ONLY) witness clone in
-    ///      `composite_removal_mana_witness_exists`;
-    ///   3. one mana-ability simulation clone
-    ///      (`can_activate_mana_ability_by_simulation`) when that single witness's
-    ///      `can_pay_effect_mana_cost_after_auto_tap` evaluates the Mox's tap mana
-    ///      ability — fixed per-witness overhead, examined once.
-    ///
-    /// It is intentionally NOT 1 (the dry run alone), NOT O(N) per candidate, and
-    /// NOT the full eligible-set size K. With a WIDE board (K = 7) an O(N) check
-    /// would record ~K+ clones; the bound of 3 proves the `.any()` short-circuits
-    /// at the first witness that keeps the mana payable.
-    const WITNESS_CLONE_BUDGET: u64 = 3;
 
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, ActivationRestriction, Comparator, ContinuousModification,
@@ -2031,21 +1868,24 @@ mod tests {
         }
     }
 
-    /// V1 (dead-end gone): Metalcraft-only board — exactly 3 artifacts including
-    /// Mox Opal (the only {1} source) + Claws. Sacrificing ANY artifact drops to
-    /// 2 → Metalcraft off → residual {1} unpayable. CR 601.2h / CR 118.3.
-    /// REVERT-FAILING: without the supplemental block this asserts `true` (the
-    /// dry-run pays {1} first on the intact 3-artifact board).
+    /// V1 (mana-first → payable): Metalcraft-only board — exactly 3 artifacts
+    /// including Mox Opal (the only {1} source) + Claws. CR 601.2g / CR 601.2h:
+    /// the mana-leg detour pays {1} FIRST while all 3 artifacts are intact
+    /// (Metalcraft holds → Mox produces {1}); the sacrifice is paid LAST. So the
+    /// composite IS payable even though sacrificing afterwards drops below
+    /// Metalcraft — the mana was already in the pool. Reverting the mana-first
+    /// detour restores the sacrifice-first ordering, which dead-ends here.
     #[test]
-    fn claws_metalcraft_only_board_is_dead_end_unpayable() {
+    fn claws_metalcraft_only_board_is_payable_mana_first() {
         let mut scenario = GameScenario::new();
         metalcraft_mox(&mut scenario);
         plain_artifact(&mut scenario, "Artifact A");
         let claws = plain_artifact(&mut scenario, "Claws of Gix");
-        // 3 artifacts on board; Mox makes {1} only while Metalcraft holds.
+        // 3 artifacts on board; Mox makes {1} while Metalcraft holds, and the
+        // mana-first window pays {1} before the sacrifice shrinks the board.
         assert!(
-            !can_pay_activation(&scenario.state, claws, &claws_cost()),
-            "every sacrifice drops to 2 artifacts → Metalcraft off → {{1}} unpayable"
+            can_pay_activation(&scenario.state, claws, &claws_cost()),
+            "mana paid first on the intact 3-artifact board → payable"
         );
     }
 
@@ -2071,19 +1911,19 @@ mod tests {
         );
     }
 
-    /// V5 (unpayable): EVERY eligible sacrifice breaks the sole {1} producer →
-    /// `false`. Same as V1 but stated as the existential-failure case: 3
-    /// artifacts, the only producer is the Metalcraft Mox, no sacrifice keeps the
-    /// count at 3.
+    /// V5 (mana-first → payable): even though EVERY eligible sacrifice would break
+    /// the sole {1} producer, CR 601.2g pays {1} from the Mox on the intact
+    /// 3-artifact board BEFORE the sacrifice, so the composite is payable. The
+    /// post-sacrifice board state is irrelevant once the mana is in the pool.
     #[test]
-    fn claws_every_sacrifice_breaks_producer_is_unpayable() {
+    fn claws_every_sacrifice_breaks_producer_is_payable_mana_first() {
         let mut scenario = GameScenario::new();
         metalcraft_mox(&mut scenario);
         plain_artifact(&mut scenario, "Filler 1");
         let claws = plain_artifact(&mut scenario, "Claws of Gix");
         assert!(
-            !can_pay_activation(&scenario.state, claws, &claws_cost()),
-            "no witness preserves Metalcraft → unpayable"
+            can_pay_activation(&scenario.state, claws, &claws_cost()),
+            "{{1}} paid from the Mox before the sacrifice → payable"
         );
     }
 
@@ -2123,39 +1963,11 @@ mod tests {
         );
     }
 
-    /// V8 (clone-bound): WIDE board (Mox + 6 plain artifacts). On the PAYABLE
-    /// path the existential check must short-circuit at the first witness that
-    /// keeps the mana payable, so the legality-clone delta stays within
-    /// `WITNESS_CLONE_BUDGET` — NOT O(eligible-set-size).
-    #[test]
-    fn claws_payable_path_is_clone_bounded() {
-        let mut scenario = GameScenario::new();
-        metalcraft_mox(&mut scenario);
-        // 6 plain artifacts → 7 artifacts total; sacrificing any one leaves 6
-        // (>= 3) → Metalcraft holds, so the FIRST witness already succeeds.
-        for i in 0..6 {
-            plain_artifact(&mut scenario, &format!("Filler {i}"));
-        }
-        let claws = plain_artifact(&mut scenario, "Claws of Gix");
-        crate::game::perf_counters::reset();
-        let payable = can_pay_activation(&scenario.state, claws, &claws_cost());
-        let delta = crate::game::perf_counters::snapshot().state_clone_for_legality;
-        assert!(
-            payable,
-            "wide board → first witness keeps Metalcraft → payable"
-        );
-        assert!(
-            delta <= WITNESS_CLONE_BUDGET,
-            "payable path must short-circuit: {delta} clones > budget {WITNESS_CLONE_BUDGET}"
-        );
-    }
-
-    /// V10 (no count>1 regression): a `Composite[{1}, Sacrifice TWO permanents]`
-    /// must NOT be rejected by the supplemental check (AMENDMENT 1: count > 1 is
-    /// out of scope and falls through to the unchanged `true`), even on a board
-    /// where sacrificing would break the conditional mana source. This pins the
-    /// count==1 guard: the dry-run already approves it (mana paid first), and the
-    /// witness block must leave that verdict byte-identical.
+    /// V10 (count>1 still payable): a `Composite[{1}, Sacrifice TWO permanents]`
+    /// is payable on a board where sacrificing would break the conditional mana
+    /// source, because CR 601.2g pays {1} on the intact board before either
+    /// sacrifice. The mana-first detour is count-agnostic — it pays the mana leg
+    /// regardless of how many permanents the removal leg sacrifices.
     #[test]
     fn claws_sacrifice_two_count_gt_one_not_rejected() {
         let mut scenario = GameScenario::new();
@@ -2179,24 +1991,20 @@ mod tests {
         );
     }
 
-    /// B1 (mark_layers_full discriminator — MANDATORY): a LAYER-APPLIED mana
-    /// source. The Mox grants its own `{T}: Add {1}` mana ability via a
-    /// continuous `StaticDefinition` (`ContinuousModification::GrantAbility`)
-    /// gated by `StaticCondition::QuantityComparison(artifacts >= 3)` — the
-    /// def-index "as long as" gate re-evaluated every layer recompute. Unlike
+    /// B1 (layer-granted mana source, mana-first → payable): the Mox grants its
+    /// own `{T}: Add {1}` mana ability via a continuous `StaticDefinition`
+    /// (`ContinuousModification::GrantAbility`) gated by
+    /// `StaticCondition::QuantityComparison(artifacts >= 3)`. Unlike
     /// `metalcraft_mox` (live-eval `activation_restrictions`), the granted ability
     /// only appears in `obj.abilities` after `flush_layers` re-derives layer 6.
     ///
-    /// Sacrificing an artifact drops the count to 2; the witness applies the
-    /// removal and `mark_layers_full`, so the downstream
-    /// `can_pay_effect_mana_cost_after_auto_tap` re-derives layers, the granted
-    /// `{T}: Add {1}` disappears, and the residual `{1}` is unpayable →
-    /// `can_pay == false`.
-    ///
-    /// This test FAILS if `mark_layers_full` is omitted from
-    /// `apply_mutation_witness`: the clone's `layers_dirty` stays `Clean`, the
-    /// downstream `flush_layers` no-ops, the stale granted ability persists, and
-    /// the check over-approves to `true`.
+    /// CR 601.2g / CR 601.2h: the mana-leg detour pays {1} from the granted
+    /// ability while all 3 artifacts are intact (the grant is live), and the
+    /// sacrifice is paid LAST. So the composite is payable even though sacrificing
+    /// afterwards would drop below Metalcraft and the layer reflush would remove
+    /// the grant — that post-removal board is irrelevant once the mana is paid.
+    /// Reverting the mana-first detour restores sacrifice-first ordering, which
+    /// dead-ends here (the granted {1} is gone before mana payment).
     #[test]
     fn claws_layer_granted_mana_requires_layer_reflush() {
         let mut scenario = GameScenario::new();
@@ -2246,19 +2054,18 @@ mod tests {
         );
 
         assert!(
-            !can_pay_activation(&scenario.state, claws, &claws_cost()),
-            "sacrifice drops to 2 artifacts → layer reflush removes granted {{1}} → unpayable"
+            can_pay_activation(&scenario.state, claws, &claws_cost()),
+            "granted {{1}} paid on the intact 3-artifact board before the sacrifice → payable"
         );
     }
 
     /// BLOCKER-1 regression (CR 117.1 + CR 701.13a): a `Composite[{N}, Exile a
     /// CARD]` whose exile leg has `zone: None` and a NON-permanent filter must
-    /// classify to `Zone::Hand`, so the battlefield-removal walker returns
-    /// `None` and the supplemental witness block is SKIPPED — the composite keeps
-    /// the unchanged dry-run verdict (payable) and is NOT falsely rejected. If
-    /// `find_battlefield_exile_cost` wrongly routed a hand-exile here, the
-    /// witness set (battlefield objects matching the card filter, excluding the
-    /// source) would be empty and `can_pay` would flip to `false`.
+    /// classify to `Zone::Hand`, so the battlefield-removal walker returns `None`
+    /// and the mana-leg detour is NOT triggered — the composite keeps its
+    /// payable dry-run verdict. This pins the walker's hand-vs-battlefield
+    /// classification: if `find_battlefield_exile_cost` wrongly routed a
+    /// hand-exile here, the detour would mis-fire on a non-battlefield cost.
     #[test]
     fn hand_exile_composite_not_routed_to_battlefield_removal() {
         use crate::types::ability::TypeFilter;
@@ -2288,7 +2095,7 @@ mod tests {
             "hand-exile leg must not be treated as a battlefield removal"
         );
         // can_pay keeps the dry-run verdict: NoCost mana + no-op activation-scope
-        // exile → payable, and the skipped witness block must not reject it.
+        // exile → payable; the hand-exile leg never triggers the mana-leg detour.
         let mut scenario = GameScenario::new();
         let src = scenario.add_creature(P0, "Jhoira", 0, 1).id();
         scenario.add_card_to_hand(P0, "Some Card");
@@ -2298,11 +2105,11 @@ mod tests {
         );
     }
 
-    /// Row 4 (count > 1 exile fall-through, AMENDMENT 1): a
-    /// `Composite[{1}, Exile TWO artifacts from the battlefield]` on a board where
-    /// the only `{1}` source is Metalcraft-gated must NOT be rejected — count > 1
-    /// is out of scope and falls through to the unchanged `true`. Mirrors the
-    /// count==2 sacrifice guard (`claws_sacrifice_two_count_gt_one_not_rejected`).
+    /// Row 4 (count > 1 exile still payable): a `Composite[{1}, Exile TWO
+    /// artifacts from the battlefield]` on a board where the only `{1}` source is
+    /// Metalcraft-gated is payable, because CR 601.2g pays {1} on the intact board
+    /// before either exile. The mana-first detour is count-agnostic. Mirrors the
+    /// count==2 sacrifice case (`claws_sacrifice_two_count_gt_one_not_rejected`).
     #[test]
     fn exile_two_count_gt_one_not_rejected() {
         use crate::types::ability::TypeFilter;
@@ -2324,7 +2131,7 @@ mod tests {
         };
         assert!(
             can_pay_activation(&scenario.state, src, &cost_two),
-            "count > 1 exile composite falls through to today's over-approximation (true)"
+            "{{1}} paid on the intact board before the exiles → payable"
         );
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -12604,7 +12604,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: crate::types::game_state::ActivationResidual::None,
         }));
         state.waiting_for = WaitingFor::ManaPayment {
             player: PlayerId(0),
@@ -12991,7 +12991,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: crate::types::game_state::CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: crate::types::game_state::ActivationResidual::None,
         }));
         state.waiting_for = WaitingFor::ManaPayment {
             player: PlayerId(0),

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3368,7 +3368,7 @@ pub(super) fn handle_resolution_choice(
                         ability_index,
                         pending.ability,
                         pending.activation_cost.as_ref(),
-                        pending.x_residual_activation,
+                        pending.activation_residual,
                         events,
                     )?;
                 } else {

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -941,7 +941,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: crate::types::game_state::AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: crate::types::game_state::ActivationResidual::None,
         })
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1664,6 +1664,36 @@ pub enum CastPaymentMode {
     Manual,
 }
 
+/// CR 601.2g + CR 601.2h + CR 602.2b: POSITIVE signal of which "mana first,
+/// non-mana cost last" detour a pending activation took, so
+/// `push_activated_ability_to_stack` knows whether `activation_cost` is the
+/// still-unpaid residual non-mana tail and which interactive sub-cost to
+/// re-surface. Replaces the former `x_residual_activation: bool`.
+///
+/// - `None`: no detour ran (direct path; `activation_cost`, if any, is the full
+///   cost handled by the standard payment fall-through).
+/// - `XMana`: the `{X}`-mana detour (`extract_x_mana_cost`) ran first; the
+///   residual is the non-self DISCARD tail still outstanding after mana payment.
+/// - `ManaLeg`: the non-X mana-leg detour ran first (CR 601.2g window opened on
+///   the intact board); the residual is a non-self battlefield-removal tail
+///   (Sacrifice / battlefield Exile / ReturnToHand) still outstanding after
+///   mana payment.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum ActivationResidual {
+    #[default]
+    None,
+    XMana,
+    ManaLeg,
+}
+
+impl ActivationResidual {
+    /// `true` iff no residual detour was taken. Used as the serde
+    /// `skip_serializing_if` predicate so the default does not hit the wire.
+    pub fn is_none(&self) -> bool {
+        matches!(self, ActivationResidual::None)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingCast {
     pub object_id: ObjectId,
@@ -1780,17 +1810,17 @@ pub struct PendingCast {
     /// the generic amount they will pay at `finalize_cast`.
     #[serde(default)]
     pub assist_state: AssistState,
-    /// CR 601.2f + CR 601.2h: POSITIVE signal that this pending activation took
-    /// the `{X}`-mana detour (`extract_x_mana_cost` ran first), so its
-    /// `activation_cost` is the RESIDUAL non-mana tail that has NOT yet been
-    /// paid. `push_activated_ability_to_stack` re-surfaces a non-self discard
-    /// sub-cost only when this is set — the discard-FIRST detour leaves it
-    /// `false` because it already paid the discard before resuming. Set ONLY by
-    /// the X-residual detour in `handle_activate_ability`. Skipped on the wire
-    /// only when `false`; serialized when `true` so an activation paused
-    /// mid-payment keeps the signal across a multiplayer save/restore.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub x_residual_activation: bool,
+    /// CR 601.2g + CR 601.2h + CR 602.2b: POSITIVE signal of which "mana first,
+    /// non-mana cost last" detour this pending activation took, so its
+    /// `activation_cost` residual tail is paid correctly after mana payment. See
+    /// [`ActivationResidual`]. Set ONLY by the X-residual and mana-leg detours in
+    /// `handle_activate_ability`; the discard/sacrifice-FIRST detours leave it
+    /// `None` because they already paid the non-mana cost before resuming.
+    /// Skipped on the wire when `None` (legacy saves deserialize to `None`);
+    /// serialized otherwise so an activation paused mid-payment keeps the signal
+    /// across a multiplayer save/restore.
+    #[serde(default, skip_serializing_if = "ActivationResidual::is_none")]
+    pub activation_residual: ActivationResidual,
 }
 
 fn default_origin_zone() -> Zone {
@@ -1843,7 +1873,7 @@ impl PendingCast {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         }
     }
 
@@ -8467,7 +8497,7 @@ mod tests {
                 cancel_restore_prepared_source: None,
                 payment_mode: CastPaymentMode::Auto,
                 assist_state: AssistState::NotOffered,
-                x_residual_activation: false,
+                activation_residual: ActivationResidual::None,
             })
         }
 
@@ -8806,7 +8836,7 @@ mod tests {
             cancel_restore_prepared_source: None,
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
-            x_residual_activation: false,
+            activation_residual: ActivationResidual::None,
         });
         let choose_x = WaitingFor::ChooseXValue {
             player: PlayerId(0),

--- a/crates/phase-ai/tests/scenarios.rs
+++ b/crates/phase-ai/tests/scenarios.rs
@@ -502,13 +502,14 @@ fn emrakul_ai_control_runs_for_controlled_human() {
 }
 
 // ---------------------------------------------------------------------------
-// Claws of Gix dead-end regression (CR 601.2h ordering — sacrifice paid FIRST,
-// {1} LAST). The composite "{1}, Sacrifice a permanent" was over-approved by
-// `costs::can_pay` when the only {1} source (Mox Opal Metalcraft) needed the
-// sacrificed artifact to stay countable — every `SelectCards` candidate then
-// failed `apply_as_current`, leaving an empty scored set and a `fallback_action`
-// debug_assert panic. The supplemental witness check now rejects the activation
-// when no sacrifice preserves the mana source.
+// Claws of Gix dead-end regression (CR 601.2g/601.2h ordering — mana paid FIRST,
+// removal LAST). The composite "{1}, Sacrifice a permanent" used to pay the
+// sacrifice FIRST, so when the only {1} source (Mox Opal Metalcraft) needed the
+// sacrificed artifact to stay countable, the residual {1} became unpayable —
+// every `SelectCards` candidate failed `apply_as_current`, leaving an empty
+// scored set and a `fallback_action` debug_assert panic. The mana-leg detour now
+// pays {1} on the INTACT board (the CR 601.2g window) before the sacrifice, so
+// the activation is legal and the loop completes.
 // ---------------------------------------------------------------------------
 
 /// Build a `{T}: Add {1}` mana ability gated by Metalcraft-style live-eval
@@ -624,15 +625,18 @@ fn scenario_claws_of_gix_witness_board_does_not_dead_end() {
     );
 }
 
-/// V3 sibling (no-witness): board with exactly 3 artifacts (Mox + one plain
-/// artifact + Claws — itself an artifact) so EVERY eligible sacrifice drops the
-/// artifact count to 2 → Metalcraft off → no witness preserves the {1}. The AI
-/// must NOT propose the Claws activation (it would dead-end), and the loop must
-/// still complete without panic. The fix makes `choose_action` never surface a
-/// Claws `ActivateAbility` candidate here.
+/// V3 sibling (mana-first, formerly the "no-witness" dead-end): board with
+/// exactly 3 artifacts (Mox + one plain artifact + Claws — itself an artifact),
+/// so EVERY eligible sacrifice would drop the artifact count to 2 → Metalcraft
+/// off. CR 601.2g pays {1} from the Mox on the INTACT 3-artifact board BEFORE the
+/// sacrifice, so the Claws activation is LEGAL and the AI loop completes it
+/// without dead-ending. REVERT-FAILING: reverting the mana-first detour restores
+/// the sacrifice-first ordering, where `can_pay` is rejected (or the activation
+/// dead-ends), so `legal_actions` no longer surfaces the Claws activation and the
+/// pending-cost loop panics at `search.rs` "AI fallback reached during pending
+/// cast (variant PayCost, spell Claws of Gix)" — the baseline seed-19057 abort.
 #[test]
-fn scenario_claws_of_gix_no_witness_board_never_proposes_activation() {
-    use engine::types::actions::GameAction;
+fn scenario_claws_of_gix_mana_first_board_proposes_and_completes() {
     let mut scenario = GameScenario::new();
     {
         let mut mox = scenario.add_creature(P0, "Mox Opal", 0, 0);
@@ -641,7 +645,8 @@ fn scenario_claws_of_gix_no_witness_board_never_proposes_activation() {
     }
     // One plain artifact; with the Mox and the (artifact) Claws this is exactly
     // 3 artifacts. Sacrificing ANY of the three drops the count to 2 → no
-    // Metalcraft → the {1} leg is unpayable on every post-sacrifice board.
+    // Metalcraft → the {1} leg would be unpayable AFTER the sacrifice, but the
+    // mana-first detour pays it on the intact board before that.
     {
         let mut a = scenario.add_creature(P0, "Artifact 0", 0, 1);
         a.as_artifact();
@@ -662,26 +667,14 @@ fn scenario_claws_of_gix_no_witness_board_never_proposes_activation() {
         state.waiting_for = WaitingFor::Priority { player: P0 };
     }
 
-    // REVERT-FAILING: with the supplemental check removed, `can_pay` over-approves
-    // this no-witness board, `choose_action` surfaces the Claws activation, the AI
-    // begins it, and the pending-cost loop panics at `search.rs` "AI fallback
-    // reached during pending cast (variant PayCost, spell Claws of Gix)" — exactly
-    // the baseline seed-19057 abort. Driving the full loop is what reproduces that
-    // dead-end (a top-level `choose_action` pass does not), so the assertion is
-    // non-panic plus first-step never being the Claws activation.
-    let first_action = {
-        let config = create_config(AiDifficulty::VeryHard, Platform::Native);
-        let mut rng = SmallRng::seed_from_u64(19057);
-        choose_action(runner.state(), P0, &config, &mut rng)
-    };
+    // The activation is now legal because the {1} is paid on the intact board.
     assert!(
-        !matches!(
-            first_action,
-            Some(GameAction::ActivateAbility { source_id, .. }) if source_id == claws
-        ),
-        "AI must not propose the dead-end Claws activation on a no-witness board, got {first_action:?}"
+        activation_legal_for(runner.state(), claws),
+        "mana-first pays {{1}} on the intact 3-artifact board → Claws activation must be legal"
     );
 
+    // Driving the full loop must COMPLETE without reaching the `fallback_action`
+    // dead-end panic.
     let ai_players = HashSet::from([P0]);
     let ai_configs = HashMap::from([(P0, create_config(AiDifficulty::VeryHard, Platform::Native))]);
     let mut ai_rng = SmallRng::seed_from_u64(19057);
@@ -695,17 +688,17 @@ fn scenario_claws_of_gix_no_witness_board_never_proposes_activation() {
     );
     assert!(
         results.len() <= 200,
-        "no-witness board must not dead-end the AI loop"
+        "mana-first board must not dead-end the AI loop"
     );
 }
 
 // ---------------------------------------------------------------------------
-// Battlefield-removal generalization of the Claws-of-Gix witness (CR 601.2h):
-// the same dead-end (the non-mana leg is paid FIRST and shrinks board mana) now
-// also covers Exile-from-battlefield (CR 701.13a, Curie) and ReturnToHand-from-
-// battlefield (plain bounce, Master Transmuter). Each removes a permanent the
-// only {U} source depends on, so over-approving `can_pay` would surface an
-// unactivatable ability and dead-end the AI loop.
+// Battlefield-removal generalization of the Claws-of-Gix mana-first fix
+// (CR 601.2g/601.2h): the same ordering applies to Exile-from-battlefield
+// (CR 701.13a, Curie) and ReturnToHand-from-battlefield (plain bounce, Master
+// Transmuter). Each removal would shrink the board the only {U} source depends
+// on, so paying the mana FIRST (intact board) keeps the activation legal and
+// avoids the dead-end the removal-first ordering produced.
 // ---------------------------------------------------------------------------
 
 /// `{T}: Add {U}` mana ability. When `metalcraft` is set the ability is gated by
@@ -846,18 +839,16 @@ fn activation_legal_for(state: &engine::types::game_state::GameState, id: Object
         .any(|a| matches!(a, GameAction::ActivateAbility { source_id, .. } if *source_id == id))
 }
 
-/// Curie EXILE dead-end (CR 601.2h / CR 701.13a): exactly 3 artifacts
+/// Curie EXILE mana-first (CR 601.2g / CR 701.13a): exactly 3 artifacts
 /// (Metalcraft blue Mox = sole {U} source, Curie, and the lone exile target) +
-/// a Forest for the generic {1}. Exiling the only legal target drops the
-/// artifact count to 2 → Metalcraft off → no {U} → the `{1}{U}` leg is unpayable
-/// on the post-exile board. REVERT-FAILING: with the Sacrifice-only walker the
-/// exile leg is invisible to the supplemental check, `can_pay` over-approves on
-/// the intact 3-artifact board, and `legal_actions` surfaces the dead-end Curie
-/// activation. The non-vacuity control is `scenario_curie_exile_witness_*`,
-/// where a 4th artifact keeps Metalcraft live and the activation IS legal —
-/// proving the `{1}{U}` leg is payable on the intact board.
+/// a Forest for the generic {1}. The mana-leg detour pays `{1}{U}` FIRST while
+/// all 3 artifacts are intact (Metalcraft holds → the Mox makes {U}); the exile
+/// is paid LAST. So the activation is LEGAL even though exiling afterwards drops
+/// below Metalcraft. REVERT-FAILING: reverting the mana-first detour restores the
+/// exile-first ordering, which dead-ends here, so `legal_actions` would no longer
+/// surface the Curie activation.
 #[test]
-fn scenario_curie_exile_no_witness_board_is_illegal() {
+fn scenario_curie_exile_mana_first_board_is_legal() {
     let mut scenario = GameScenario::new();
     {
         let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
@@ -882,8 +873,8 @@ fn scenario_curie_exile_no_witness_board_is_illegal() {
     put_p0_on_priority(&mut runner);
 
     assert!(
-        !activation_legal_for(runner.state(), curie),
-        "every exile drops below Metalcraft → {{1}}{{U}} unpayable → activation must be illegal"
+        activation_legal_for(runner.state(), curie),
+        "{{1}}{{U}} paid on the intact 3-artifact board before the exile → activation must be legal"
     );
 }
 
@@ -927,17 +918,18 @@ fn scenario_curie_exile_witness_board_is_legal() {
     );
 }
 
-/// Master Transmuter RETURN dead-end (CR 601.2h / CR 118.3): the sole artifact
+/// Master Transmuter RETURN mana-first (CR 601.2g / CR 118.3): the sole artifact
 /// the player controls is the sole {U} source (an unconditional blue Mox), and
 /// it is therefore the only legal "return an artifact you control" target. The
 /// Transmuter source is a NON-artifact creature, so it is not itself a return
-/// target. Returning the Mox is the only witness, and it removes the {U}, so the
-/// `{U}` leg is unpayable on the post-return board. REVERT-FAILING: the
-/// Sacrifice-only walker never recognized a ReturnToHand leg, so `can_pay`
-/// over-approves and `legal_actions` surfaces the dead-end activation. The
-/// non-vacuity control is `scenario_master_transmuter_witness_board_is_legal`.
+/// target. CR 601.2g pays `{U}` by tapping the Mox FIRST (the intact-board mana
+/// window), then the {T} and the return are paid LAST — so the activation is
+/// LEGAL even though the only return target is the {U} source. REVERT-FAILING:
+/// reverting the mana-first detour restores the return-first ordering, where
+/// bouncing the Mox leaves `{U}` unpayable and `legal_actions` drops the
+/// activation.
 #[test]
-fn scenario_master_transmuter_return_no_witness_board_is_illegal() {
+fn scenario_master_transmuter_return_mana_first_board_is_legal() {
     let mut scenario = GameScenario::new();
     {
         let mut mox = scenario.add_creature(P0, "Blue Mox", 0, 0);
@@ -955,8 +947,8 @@ fn scenario_master_transmuter_return_no_witness_board_is_illegal() {
     put_p0_on_priority(&mut runner);
 
     assert!(
-        !activation_legal_for(runner.state(), transmuter),
-        "returning the sole {{U}} source leaves {{U}} unpayable → activation must be illegal"
+        activation_legal_for(runner.state(), transmuter),
+        "{{U}} paid by tapping the Mox before the return → activation must be legal"
     );
 }
 


### PR DESCRIPTION
Activated abilities whose cost is `{mana} + non-self board-removal` (Claws of Gix
`{1}, Sacrifice a permanent`; Curie `{1}{U}, Exile another artifact`; Master Transmuter
`{U},{T}, Return an artifact`) paid the removal leg BEFORE tapping mana. When the removed
permanent fed the mana leg (Metalcraft Mox / sole source), removal-first shrank board mana
and the activation dead-ended — surfacing as an AI fallback panic (variant PayCost, Claws
of Gix) in the affinity-mirror gate.

CR 601.2g ("mana abilities must be activated before costs are paid") requires the mana
window to open on the intact board. Hoist the mana leg via a new non-X detour in
handle_activate_ability (slot after the X-mana detour, before the sacrifice-first
interception), pay mana through enter_payment_step, then re-surface the removal leg as a
residual paid by three new arms in push_activated_ability_to_stack (Sacrifice / battlefield
ExilePermanent / ReturnToHand), mirroring the existing Discard arm.

Because execution now pays mana-first on the intact board, the affordability dry-run
(can_pay) agrees without simulation, so the speculative witness is retired:
composite_removal_mana_witness_exists + its orphan cascade (mutation_witness_set,
apply_mutation_witness, enum MutationWitness, composite_mana_leg, WITNESS_CLONE_BUDGET) are
deleted; RemovalKind and find_non_self_battlefield_removal_cost are kept.

- Promote PendingCast.x_residual_activation: bool -> typed ActivationResidual
  {None, XMana, ManaLeg}; XMana keeps the loud-fail seam, ManaLeg routes to the new arms,
  mutually exclusive so they never cross.
- Factor extract_x_mana_cost into a predicate core (extract_mana_leg_matching); add
  extract_mana_leg; extract_x_mana_cost stays behaviorally byte-identical.
- Flip three witness-era dead-end tests to payable (CR-correct: tap Mox while Metalcraft
  holds, then sacrifice); genuine resource-shortfall negatives stay unpayable.

ai-gate (paired-seed): 0 FAIL, 0 NEW dead-ends, 0 win-loss flips; the affinity-mirror
avg-turn WARN is the expected drift from the AI now taking these now-affordable activations.

Phase 2 (spell additional-cost path; count>1 removal) deferred.
