### PR TITLE
fix(parser): Molten Influence unless-have-deal-damage (closes #4429)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21996,12 +21996,15 @@ fn parse_deal_damage_to_them_tail(input: &str) -> Option<()> {
 }
 
 /// CR 118.12a: "unless [that object's|its] controller has [~] deal N damage to
-/// them" (Blazing Salvo, Lava Blister) — the controller may take the damage
-/// instead of the primary effect.
+/// them" (Blazing Salvo, Lava Blister, Molten Influence) — the controller may
+/// take the damage instead of the primary effect.
 fn parse_unless_have_deal_damage_cost(after_unless: &str) -> Option<AbilityCost> {
     let (rest, _) = alt((
         tag::<_, _, OracleError<'_>>("that creature's controller has "),
         tag("its controller has "),
+        tag("that permanent's controller has "),
+        tag("that land's controller has "),
+        tag("that spell's controller has "),
     ))
     .parse(after_unless)
     .ok()?;
@@ -28224,6 +28227,35 @@ mod tests {
                     ..
                 } => {}
                 other => panic!("expected DealDamage 6 to payer, got {other:?}"),
+            },
+            other => panic!("expected EffectCost, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn molten_influence_unless_have_deal_damage() {
+        let def = parse_effect_chain(
+            "Counter target instant or sorcery spell unless that spell's controller has Molten Influence deal 4 damage to them.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(*def.effect, Effect::Counter { .. }),
+            "primary should counter the spell, got {:?}",
+            def.effect
+        );
+        let unless_pay = def
+            .unless_pay
+            .as_ref()
+            .expect("Molten Influence must attach unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::ParentTargetController);
+        match &unless_pay.cost {
+            AbilityCost::EffectCost { effect } => match effect.as_ref() {
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 4 },
+                    target: TargetFilter::Player,
+                    ..
+                } => {}
+                other => panic!("expected DealDamage 4 to payer, got {other:?}"),
             },
             other => panic!("expected EffectCost, got {other:?}"),
         }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21917,6 +21917,11 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
             return Some(cost);
         }
     }
+    // CR 118.12a: "unless [target's controller] has [~] deal N damage to them"
+    // (Molten Influence and other counter spells with damage alternatives).
+    if let Some(cost) = parse_unless_have_deal_damage_cost(after_unless) {
+        return Some(cost);
+    }
     // CR 118.12 / CR 119.4 / CR 608.2c: non-mana alternative costs — "pays N
     // life", "sacrifices a [filter]", "discards a card", and `or`-disjunctions
     // thereof. Normalize the counter subject to the "they" pronoun the shared

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4037,6 +4037,11 @@ mod tests {
                 &["Instant"][..],
             ),
             (
+                "Counter target instant or sorcery spell unless that spell's controller has Molten Influence deal 4 damage to them.",
+                "Molten Influence",
+                &["Instant"][..],
+            ),
+            (
                 "This creature can't attack unless defending player is poisoned.",
                 "Chained Throatseeker",
                 &["Creature"][..],


### PR DESCRIPTION
## Summary

Molten Influence (`Counter target instant or sorcery spell unless that spell's controller has Molten Influence deal 4 damage to them.`) was missing parser support for the `that spell's controller has` unless-have-deal-damage anaphor, so the counter resolved without the damage alternative.

This extends `parse_unless_have_deal_damage_cost` with `that spell's controller has` (and related possessive-controller prefixes). Runtime unless-payment for `AbilityCost::EffectCost { DealDamage }` already landed in #4421.

Closes #4429

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — narrow parser extension plus unit/swallow-check regression.

## CR references

CR 118.12a — unless-pay alternative: the spell's controller may have Molten Influence deal 4 damage instead of the counter resolving.

## Verification

* `molten_influence_unless_have_deal_damage` parser unit test attaches `unless_pay` with `ParentTargetController` payer and `DealDamage` 4.
* Swallow-check entry for Molten Influence oracle text.

Model: gpt-5.3-codex
Tier: Standard

## Anchored on

* crates/engine/src/parser/oracle_effect/mod.rs — `parse_unless_have_deal_damage_cost`
* crates/engine/src/parser/swallow_check.rs — oracle regression list
