### PR TITLE
fix(client): collapse identical-token board sacrifice picker to a single quantity action (#4375)

### DIFF
--- a/client/src/components/board/GroupedPermanent.tsx
+++ b/client/src/components/board/GroupedPermanent.tsx
@@ -509,27 +509,44 @@ function BoardChoiceGroupControls({
   const selectedInGroup = eligibleIds.filter((id) => selectedCardIds.includes(id));
   const maxSelection = boardChoiceMaxSelection(choice);
 
-  const toggleId = (id: ObjectId) => {
-    const selected = new Set(selectedInGroup);
-    if (selected.has(id)) {
-      selected.delete(id);
-    } else if (maxSelection == null || selectedForChoice.length < maxSelection) {
-      selected.add(id);
-    }
-    setGroupSelectedCards(groupIds, eligibleIds.filter((eligibleId) => selected.has(eligibleId)));
-  };
+  // Every eligible id in a collapsed group is visually identical to the others
+  // (same name, P/T, counters, keywords, tap/flip state — that's why they're
+  // stacked). Distinguishing them with a #1..#N list (the old UI) forced the
+  // player to pick among indistinguishable tokens, e.g. choosing which of five
+  // Food tokens to sacrifice. Resolve by quantity instead.
 
+  // Immediate single pick: nothing to distinguish — resolve with one click on a
+  // labelled action button using the first eligible id.
   if (isBoardChoiceImmediate(choice)) {
     return (
-      <ObjectChoiceList
-        eligibleIds={eligibleIds}
-        onChoose={(id) => {
-          dispatchAction(buildBoardChoiceAction(choice, [id]));
+      <button
+        type="button"
+        className="w-full rounded bg-sky-700 px-2 py-1.5 font-bold text-white hover:bg-sky-600"
+        onClick={() => {
+          dispatchAction(buildBoardChoiceAction(choice, [eligibleIds[0]]));
           onClose();
         }}
-      />
+      >
+        {t(`boardChoice.actions.${choice.intent}`)}
+      </button>
     );
   }
+
+  // Multi-select: a quantity stepper that maps to the first N eligible ids.
+  // The cap accounts for selections already made in other groups so the
+  // choice-wide count limit can't be exceeded.
+  const selectedOutsideGroup = Math.max(
+    0,
+    selectedForChoice.length - selectedInGroup.length,
+  );
+  const groupCeiling =
+    maxSelection == null ? eligibleIds.length : Math.max(0, maxSelection - selectedOutsideGroup);
+  const effectiveMax = Math.min(eligibleIds.length, groupCeiling);
+
+  const setCount = (n: number) => {
+    const clamped = Math.max(0, Math.min(n, effectiveMax));
+    setGroupSelectedCards(groupIds, eligibleIds.slice(0, clamped));
+  };
 
   const canConfirm = canConfirmBoardChoice(choice, selectedForChoice, objects);
   const requiredPower =
@@ -541,12 +558,10 @@ function BoardChoiceGroupControls({
 
   return (
     <div className="space-y-2">
-      <ObjectToggleList
-        eligibleIds={eligibleIds}
-        objects={objects}
-        selectedIds={selectedInGroup}
-        showPower={choice.selection.type === "totalPowerAtLeast"}
-        onToggle={toggleId}
+      <CountPickerControls
+        count={selectedInGroup.length}
+        max={effectiveMax}
+        onChange={setCount}
       />
       <div className="text-center text-[11px] text-slate-300">
         {power == null
@@ -641,46 +656,6 @@ function ObjectChoiceList({ eligibleIds, onChoose }: ObjectChoiceListProps) {
           #{index + 1}
         </button>
       ))}
-    </div>
-  );
-}
-
-interface ObjectToggleListProps {
-  eligibleIds: ObjectId[];
-  objects: Record<ObjectId, GameObject> | undefined;
-  selectedIds: ObjectId[];
-  showPower: boolean;
-  onToggle: (id: ObjectId) => void;
-}
-
-function ObjectToggleList({
-  eligibleIds,
-  objects,
-  selectedIds,
-  showPower,
-  onToggle,
-}: ObjectToggleListProps) {
-  return (
-    <div className="grid max-h-48 grid-cols-2 gap-1 overflow-auto">
-      {eligibleIds.map((id, index) => {
-        const selected = selectedIds.includes(id);
-        const power = Math.max(objects?.[id]?.power ?? 0, 0);
-        return (
-          <button
-            key={id}
-            type="button"
-            className={`rounded px-2 py-1 font-semibold ${
-              selected
-                ? "bg-sky-500 text-sky-950"
-                : "bg-slate-800 hover:bg-slate-700"
-            }`}
-            onClick={() => onToggle(id)}
-          >
-            #{index + 1}
-            {showPower ? ` (${power})` : ""}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/client/src/components/board/GroupedPermanent.tsx
+++ b/client/src/components/board/GroupedPermanent.tsx
@@ -518,12 +518,17 @@ function BoardChoiceGroupControls({
   // Immediate single pick: nothing to distinguish — resolve with one click on a
   // labelled action button using the first eligible id.
   if (isBoardChoiceImmediate(choice)) {
+    // Guard against an empty eligible list: the picker only opens when there is
+    // at least one eligible id, but defending here avoids ever dispatching an
+    // action with an undefined id payload.
+    const firstId = eligibleIds[0];
+    if (firstId === undefined) return null;
     return (
       <button
         type="button"
         className="w-full rounded bg-sky-700 px-2 py-1.5 font-bold text-white hover:bg-sky-600"
         onClick={() => {
-          dispatchAction(buildBoardChoiceAction(choice, [eligibleIds[0]]));
+          dispatchAction(buildBoardChoiceAction(choice, [firstId]));
           onClose();
         }}
       >

--- a/client/src/components/board/__tests__/GroupedPermanent.test.tsx
+++ b/client/src/components/board/__tests__/GroupedPermanent.test.tsx
@@ -274,11 +274,79 @@ describe("GroupedPermanentDisplay collapsed creature groups", () => {
     renderGroup({ boardChoiceObjectIds: new Set([1, 2, 3]) });
 
     fireEvent.click(screen.getByRole("button", { name: "Choose Saproling token" }));
-    fireEvent.click(screen.getByRole("button", { name: "#2" }));
+    // All eligible creatures in a collapsed group are visually identical, so the
+    // picker resolves with a single labelled action instead of a #1..#N list.
+    fireEvent.click(screen.getByRole("button", { name: "Station" }));
 
     expect(dispatchAction).toHaveBeenCalledWith({
       type: "ActivateStation",
-      data: { spacecraft_id: 42, creature_id: 2 },
+      data: { spacecraft_id: 42, creature_id: 1 },
+    });
+  });
+
+  it("sacrifices one of many identical tokens with a single action (no #1-#N list) — #4375", () => {
+    const waitingFor: WaitingFor = {
+      type: "EffectZoneChoice",
+      data: {
+        player: 0,
+        cards: [1, 2, 3, 4, 5],
+        count: 1,
+        source_id: 99,
+        effect_kind: "Sacrifice",
+        zone: "Battlefield",
+        destination: null,
+      },
+    } as unknown as WaitingFor;
+    useGameStore.setState({
+      gameState: makeState(waitingFor),
+      waitingFor,
+    });
+    renderGroup({ boardChoiceObjectIds: new Set([1, 2, 3, 4, 5]) });
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose Saproling token" }));
+
+    // No numbered per-token list — the indistinguishable tokens collapse to one
+    // action button labelled by intent.
+    expect(screen.queryByRole("button", { name: "#1" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "#5" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Sacrifice" }));
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [1] },
+    });
+  });
+
+  it("picks a quantity of identical tokens via the stepper for a multi sacrifice — #4375", () => {
+    const waitingFor: WaitingFor = {
+      type: "EffectZoneChoice",
+      data: {
+        player: 0,
+        cards: [1, 2, 3, 4, 5],
+        count: 2,
+        source_id: 99,
+        effect_kind: "Sacrifice",
+        zone: "Battlefield",
+        destination: null,
+      },
+    } as unknown as WaitingFor;
+    useGameStore.setState({
+      gameState: makeState(waitingFor),
+      waitingFor,
+    });
+    renderGroup({ boardChoiceObjectIds: new Set([1, 2, 3, 4, 5]) });
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose Saproling token" }));
+
+    // Count stepper replaces the #1..#N toggle grid.
+    expect(screen.queryByRole("button", { name: "#1" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "+1" }));
+    fireEvent.click(screen.getByRole("button", { name: "+1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [1, 2] },
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #4375 

Replaces the numbered `#1`–`#N` picker for sacrificing/returning/exiling among many identical tokens (e.g. 5 Food tokens for Cauldron Familiar) with a single labelled action (immediate pick) or a `−1/+1/All/None` quantity stepper (multi-select), since collapsed-group tokens are visually indistinguishable.
## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why:

> Frontend-only change in `client/src/components/board/GroupedPermanent.tsx` (board picker UX). No `crates/engine/` game logic, parser, effects, resolver, targeting, or rules behavior is touched — the dispatched `SelectCards`/`ActivateStation` actions and their payloads are unchanged; only the selection UI that produces them changes.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver, targeting, rules behavior — is expected to go through `/engine-implementer`. The "not used" box is for changes that genuinely fall outside that scope.

## CR references

None — UI-only change, no rules logic.

## Verification

- `tsc -p tsconfig.app.json --noEmit` — clean
- `eslint src/components/board/` — clean
- `vitest run` — **1604 passed** (9/9 in `GroupedPermanent.test.tsx`, including the updated immediate-choice test and two new #4375 tests: single-token sacrifice resolves via one "Sacrifice" button; multi sacrifice uses the `+1` stepper → `Confirm`)
