### PR TITLE
fix(parser): Limited Resources gates CantPlayLand on lands-on-battlefield count

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2560,11 +2560,18 @@ pub(crate) fn parse_static_line_inner(
         || nom_primitives::scan_contains(tp.lower, "cannot play lands")
     {
         let affected = parse_player_scope_filter(&tp);
-        return Some(
-            StaticDefinition::new(StaticMode::Other("CantPlayLand".to_string()))
-                .affected(affected)
-                .description(text.to_string()),
-        );
+        let mut def = StaticDefinition::new(StaticMode::Other("CantPlayLand".to_string()))
+            .affected(affected)
+            .description(text.to_string());
+        // CR 611.3a: a trailing "as long as <condition>" gates the restriction
+        // (Limited Resources: "... as long as ten or more lands are on the
+        // battlefield"). Without this the prohibition applied unconditionally.
+        if let Some((_, condition_tp)) = tp.split_around(" as long as ") {
+            if let Some(condition) = parse_static_condition(condition_tp.original) {
+                def = def.condition(condition);
+            }
+        }
+        return Some(def);
     }
 
     // --- "can't win the game" / "can't lose the game" (CR 104.3a/b) ---

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -370,6 +370,21 @@ pub(crate) fn parse_damage_not_removed_during_cleanup(
     )
 }
 
+/// Split a trailing " as long as <condition>" rider off a static line, returning
+/// the condition text when present (combinator form, no string-method dispatch).
+fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
+    opt(preceded(
+        (
+            take_until::<_, _, OracleError<'_>>(" as long as "),
+            tag(" as long as "),
+        ),
+        rest,
+    ))
+    .parse(lower)
+    .ok()
+    .and_then(|(_, condition)| condition)
+}
+
 pub(crate) fn parse_static_line_inner(
     text: &str,
     inverted: InvertedAsLongAs,
@@ -2560,18 +2575,18 @@ pub(crate) fn parse_static_line_inner(
         || nom_primitives::scan_contains(tp.lower, "cannot play lands")
     {
         let affected = parse_player_scope_filter(&tp);
-        let mut def = StaticDefinition::new(StaticMode::Other("CantPlayLand".to_string()))
+        let def = StaticDefinition::new(StaticMode::Other("CantPlayLand".to_string()))
             .affected(affected)
             .description(text.to_string());
         // CR 611.3a: a trailing "as long as <condition>" gates the restriction
         // (Limited Resources: "... as long as ten or more lands are on the
-        // battlefield"). Without this the prohibition applied unconditionally.
-        if let Some((_, condition_tp)) = tp.split_around(" as long as ") {
-            if let Some(condition) = parse_static_condition(condition_tp.original) {
-                def = def.condition(condition);
-            }
-        }
-        return Some(def);
+        // battlefield"). If the rider is present but its condition is NOT
+        // recognized, leave the whole line unsupported (return None) rather than
+        // marking it a CantPlayLand enforced unconditionally.
+        return match split_trailing_as_long_as(tp.lower) {
+            Some(condition_text) => Some(def.condition(parse_static_condition(condition_text)?)),
+            None => Some(def),
+        };
     }
 
     // --- "can't win the game" / "can't lose the game" (CR 104.3a/b) ---

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1409,6 +1409,11 @@ pub(crate) fn parse_static_condition(text: &str) -> Option<StaticCondition> {
         return Some(condition);
     }
 
+    // "[N] or more [type] are on the battlefield" (Limited Resources)
+    if let Some(condition) = parse_count_on_battlefield_condition(tp.lower) {
+        return Some(condition);
+    }
+
     // "the chosen color is [color]"
     if let Some(color_name) = nom_tag_lower(tp.lower, tp.lower, "the chosen color is ") {
         let trimmed = color_name.trim().trim_end_matches('.');
@@ -1728,6 +1733,40 @@ pub(crate) fn parse_color_list(text: &str) -> Option<Vec<crate::types::mana::Man
     }
 
     None
+}
+
+/// CR 611.3a: "[N] or more [type] are on the battlefield" → a count
+/// `QuantityComparison` (Limited Resources: "ten or more lands are on the
+/// battlefield"). Modeled as `ObjectCount(type) >= N`; the gate is then attached
+/// by the shared "as long as <condition>" machinery to the host static.
+pub(crate) fn parse_count_on_battlefield_condition(lower: &str) -> Option<StaticCondition> {
+    count_on_battlefield_condition(lower)
+        .ok()
+        .and_then(|(rest, cond)| rest.trim().is_empty().then_some(cond))
+}
+
+fn count_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (input, n) = nom_primitives::parse_number(input)?;
+    let (input, _) = tag(" or more ").parse(input)?;
+    let (input, type_text) = take_until(" are on the battlefield").parse(input)?;
+    let (input, _) = tag(" are on the battlefield").parse(input)?;
+    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
+        return Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok((
+        input,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
+        },
+    ))
 }
 
 /// Parse "the number of [quantity] is [comparator] [quantity]" into a QuantityComparison.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -178,14 +178,30 @@ fn limited_resources_cant_play_land_gated_on_ten_lands() {
     };
     assert_eq!(*comparator, Comparator::GE);
     assert_eq!(*rhs, QuantityExpr::Fixed { value: 10 });
+    let QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount { filter },
+    } = lhs
+    else {
+        panic!("expected ObjectCount lhs, got {lhs:?}");
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("expected a Typed land filter, got {filter:?}");
+    };
+    assert_eq!(tf.type_filters, vec![TypeFilter::Land]);
+}
+
+/// CR 305.1: An "as long as <unrecognized condition>" rider on "can't play
+/// lands" must NOT collapse to an unconditionally-enforced CantPlayLand — the
+/// line stays unsupported (honest) rather than prohibiting land plays always.
+#[test]
+fn cant_play_land_unrecognized_gate_stays_unsupported() {
+    let defs = parse_static_line_multi("Players can't play lands as long as the sky is green.");
     assert!(
-        matches!(
-            lhs,
-            QuantityExpr::Ref {
-                qty: QuantityRef::ObjectCount { .. },
-            }
-        ) && format!("{lhs:?}").contains("Land"),
-        "expected ObjectCount over lands, got {lhs:?}"
+        !defs
+            .iter()
+            .any(|d| matches!(&d.mode, StaticMode::Other(n) if n == "CantPlayLand")),
+        "an unrecognized gate must not produce an unconditional CantPlayLand, got {:?}",
+        defs.iter().map(|d| &d.mode).collect::<Vec<_>>()
     );
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -152,6 +152,43 @@ fn permanent_subject_protection_still_continuous() {
     );
 }
 
+/// CR 305.1 + CR 611.3a: Limited Resources — "Players can't play lands as long
+/// as ten or more lands are on the battlefield." must gate the CantPlayLand
+/// prohibition on a count condition (lands on battlefield >= 10) rather than
+/// dropping it and prohibiting land plays unconditionally.
+#[test]
+fn limited_resources_cant_play_land_gated_on_ten_lands() {
+    let defs = parse_static_line_multi(
+        "Players can't play lands as long as ten or more lands are on the battlefield.",
+    );
+    let cant = defs
+        .iter()
+        .find(|d| matches!(&d.mode, StaticMode::Other(n) if n == "CantPlayLand"))
+        .expect("expected a CantPlayLand static");
+    let Some(StaticCondition::QuantityComparison {
+        lhs,
+        comparator,
+        rhs,
+    }) = &cant.condition
+    else {
+        panic!(
+            "expected a QuantityComparison gate, got {:?}",
+            cant.condition
+        );
+    };
+    assert_eq!(*comparator, Comparator::GE);
+    assert_eq!(*rhs, QuantityExpr::Fixed { value: 10 });
+    assert!(
+        matches!(
+            lhs,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { .. },
+            }
+        ) && format!("{lhs:?}").contains("Land"),
+        "expected ObjectCount over lands, got {lhs:?}"
+    );
+}
+
 /// CR 509.1b: Brave the Sands — "Creatures you control have vigilance and can
 /// block an additional creature each combat." must decompose into BOTH the
 /// vigilance grant AND an `ExtraBlockers` grant affecting creatures you control.


### PR DESCRIPTION
## Problem

*Limited Resources* — "Players can't play lands **as long as ten or more lands are on the battlefield**." — parsed to a `CantPlayLand` static with `condition: null`. The "as long as ten or more lands are on the battlefield" gate was silently dropped, so the prohibition applied **unconditionally** instead of only once ten lands are on the battlefield.

## Fix

- Add a clean nom parser `parse_count_on_battlefield_condition` for "`<N>` or more `<type>` are on the battlefield" → `ObjectCount(type) >= N` (reuses `parse_number` / `parse_type_phrase`), wired into `parse_static_condition`.
- In the `CantPlayLand` arm, strip a trailing "as long as `<condition>`" and attach it to the static.

## Result

`Limited Resources` now gates the land-play prohibition on `ObjectCount(Land) >= 10` instead of dropping the condition.

## Tests

- New regression `limited_resources_cant_play_land_gated_on_ten_lands` asserts the `CantPlayLand` static carries the `lands-on-battlefield >= 10` gate.
- `oracle_static` suite (885) passes; `fmt --check`, `clippy`, and the parser gate are clean.