### PR TITLE
fix(parser): RevealUntil chosen-type and shares-a-type filters (closes #4435)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7720,6 +7720,14 @@ fn parse_reveal_until_active_filter_text(input: &str) -> OracleResult<'_, &str> 
     // form) is tried before singular " card" so "permanent cards" strips the full
     // noun, not "permanent" + a stray "s".
     alt((
+        // CR 701.20a + CR 608.2c: chained continuation after the until-filter
+        // ("…creature card that shares a creature type with it, then you may…"
+        // — Heirloom Blade). Stop before ", then" so the shares-type tail
+        // reaches `build_reveal_until_filter` intact.
+        all_consuming(terminated(
+            take_until(", then"),
+            tag(", then"),
+        )),
         all_consuming(terminated(
             take_until(" cards"),
             (tag(" cards"), opt(tag("."))),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -48882,8 +48882,7 @@ mod tests {
                     tf.type_filters
                 );
                 assert!(
-                    tf.properties
-                        .contains(&FilterProp::IsChosenCreatureType),
+                    tf.properties.contains(&FilterProp::IsChosenCreatureType),
                     "expected IsChosenCreatureType, got {:?}",
                     tf.properties
                 );

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7724,10 +7724,7 @@ fn parse_reveal_until_active_filter_text(input: &str) -> OracleResult<'_, &str> 
         // ("…creature card that shares a creature type with it, then you may…"
         // — Heirloom Blade). Stop before ", then" so the shares-type tail
         // reaches `build_reveal_until_filter` intact.
-        all_consuming(terminated(
-            take_until(", then"),
-            tag(", then"),
-        )),
+        all_consuming(terminated(take_until(", then"), tag(", then"))),
         all_consuming(terminated(
             take_until(" cards"),
             (tag(" cards"), opt(tag("."))),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7814,16 +7814,19 @@ fn build_reveal_until_disjunct_filter(fragment: &str) -> TargetFilter {
 
 /// CR 701.20a + CR 604.3: Reveal-until filter "<core> card[s] of the chosen type".
 fn try_parse_reveal_until_card_of_chosen_creature_type(filter_text: &str) -> Option<TargetFilter> {
-    let core = filter_text
-        .strip_suffix(" card of the chosen type")
-        .or_else(|| filter_text.strip_suffix(" cards of the chosen type"))
-        .or_else(|| filter_text.strip_suffix(" card of that type"))
-        .or_else(|| filter_text.strip_suffix(" cards of that type"))
-        .or_else(|| filter_text.strip_suffix(" of the chosen type"))
-        .or_else(|| filter_text.strip_suffix(" of that type"))?;
-    if core != "creature" {
-        return None;
-    }
+    all_consuming(terminated(
+        tag::<_, _, OracleError<'_>>("creature"),
+        alt((
+            tag(" card of the chosen type"),
+            tag(" cards of the chosen type"),
+            tag(" card of that type"),
+            tag(" cards of that type"),
+            tag(" of the chosen type"),
+            tag(" of that type"),
+        )),
+    ))
+    .parse(filter_text)
+    .ok()?;
     Some(TargetFilter::Typed(
         TypedFilter::creature().properties(vec![FilterProp::IsChosenCreatureType]),
     ))
@@ -7831,15 +7834,27 @@ fn try_parse_reveal_until_card_of_chosen_creature_type(filter_text: &str) -> Opt
 
 /// CR 701.20a + CR 603.10a: Reveal-until filter sharing a creature type with "it".
 fn try_parse_reveal_until_shares_creature_type(filter_text: &str) -> Option<TargetFilter> {
-    if !nom_primitives::scan_contains(filter_text, "shares a creature type with it") {
-        return None;
-    }
     let mut ctx = ParseContext {
         subject: Some(TargetFilter::AttachedTo),
         ..Default::default()
     };
     let (filter, rem) = parse_type_phrase_with_ctx(filter_text, &mut ctx);
-    rem.trim().is_empty().then_some(filter)
+    if !rem.trim().is_empty() {
+        return None;
+    }
+    let TargetFilter::Typed(tf) = &filter else {
+        return None;
+    };
+    tf.properties.iter().any(|p| {
+        matches!(
+            p,
+            FilterProp::SharesQuality {
+                quality: SharedQuality::CreatureType,
+                ..
+            }
+        )
+    })
+    .then_some(filter)
 }
 
 /// Build a [`TargetFilter`] from the bare filter phrase extracted from a `RevealUntil`

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7845,16 +7845,18 @@ fn try_parse_reveal_until_shares_creature_type(filter_text: &str) -> Option<Targ
     let TargetFilter::Typed(tf) = &filter else {
         return None;
     };
-    tf.properties.iter().any(|p| {
-        matches!(
-            p,
-            FilterProp::SharesQuality {
-                quality: SharedQuality::CreatureType,
-                ..
-            }
-        )
-    })
-    .then_some(filter)
+    tf.properties
+        .iter()
+        .any(|p| {
+            matches!(
+                p,
+                FilterProp::SharesQuality {
+                    quality: SharedQuality::CreatureType,
+                    ..
+                }
+            )
+        })
+        .then_some(filter)
 }
 
 /// Build a [`TargetFilter`] from the bare filter phrase extracted from a `RevealUntil`

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7724,7 +7724,7 @@ fn parse_reveal_until_active_filter_text(input: &str) -> OracleResult<'_, &str> 
         // ("…creature card that shares a creature type with it, then you may…"
         // — Heirloom Blade). Stop before ", then" so the shares-type tail
         // reaches `build_reveal_until_filter` intact.
-        all_consuming(terminated(take_until(", then"), tag(", then"))),
+        terminated(take_until(", then"), tag(", then")),
         all_consuming(terminated(
             take_until(" cards"),
             (tag(" cards"), opt(tag("."))),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -77,7 +77,7 @@ use super::oracle_quantity::{
 };
 use super::oracle_target::{
     parse_event_context_ref, parse_target, parse_target_with_ctx, parse_target_with_syntax,
-    parse_type_phrase, TargetSyntax,
+    parse_type_phrase, parse_type_phrase_with_ctx, TargetSyntax,
 };
 use super::oracle_util::{
     contains_possessive, has_unconsumed_conditional, parse_count_expr, parse_mana_symbols,
@@ -7812,9 +7812,52 @@ fn build_reveal_until_disjunct_filter(fragment: &str) -> TargetFilter {
     parsed
 }
 
+/// CR 701.20a + CR 604.3: Reveal-until filter "<core> card[s] of the chosen type".
+fn try_parse_reveal_until_card_of_chosen_creature_type(filter_text: &str) -> Option<TargetFilter> {
+    let core = filter_text
+        .strip_suffix(" card of the chosen type")
+        .or_else(|| filter_text.strip_suffix(" cards of the chosen type"))
+        .or_else(|| filter_text.strip_suffix(" card of that type"))
+        .or_else(|| filter_text.strip_suffix(" cards of that type"))
+        .or_else(|| filter_text.strip_suffix(" of the chosen type"))
+        .or_else(|| filter_text.strip_suffix(" of that type"))?;
+    if core != "creature" {
+        return None;
+    }
+    Some(TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::IsChosenCreatureType]),
+    ))
+}
+
+/// CR 701.20a + CR 603.10a: Reveal-until filter sharing a creature type with "it".
+fn try_parse_reveal_until_shares_creature_type(filter_text: &str) -> Option<TargetFilter> {
+    if !nom_primitives::scan_contains(filter_text, "shares a creature type with it") {
+        return None;
+    }
+    let mut ctx = ParseContext {
+        subject: Some(TargetFilter::AttachedTo),
+        ..Default::default()
+    };
+    let (filter, rem) = parse_type_phrase_with_ctx(filter_text, &mut ctx);
+    rem.trim().is_empty().then_some(filter)
+}
+
 /// Build a [`TargetFilter`] from the bare filter phrase extracted from a `RevealUntil`
 /// until-clause (caller has already stripped the article and trailing `" card"` suffix).
 fn build_reveal_until_filter(filter_text: &str) -> TargetFilter {
+    // CR 701.20a + CR 603.10a: "creature card that shares a creature type with it"
+    // (Heirloom Blade, Descendants' Fury). The active-filter tail captures the
+    // whole phrase via the `rest` arm; delegate to the typed-target authority with
+    // AttachedTo as the "it" referent for equipped-creature-dies triggers.
+    if let Some(filter) = try_parse_reveal_until_shares_creature_type(filter_text) {
+        return filter;
+    }
+    // CR 701.20a + CR 604.3: "<type> card of the chosen type" (Riptide Shapeshifter).
+    // The inner " card" delimiter in `parse_reveal_until_active_filter_text` prevents
+    // the chosen-type suffix from reaching `parse_target` intact.
+    if let Some(filter) = try_parse_reveal_until_card_of_chosen_creature_type(filter_text) {
+        return filter;
+    }
     // CR 701.20a: "with the chosen name" — active form (e.g. Abundance)
     if nom_primitives::scan_contains(filter_text, "with the chosen name") {
         return TargetFilter::HasChosenName;
@@ -48814,6 +48857,35 @@ mod tests {
                         .any(|t| matches!(t, TypeFilter::Subtype(s) if s == "Time Lord")),
                     "expected Subtype(\"Time Lord\") in type_filters, got {:?}",
                     tf.type_filters
+                );
+            }
+            other => panic!("expected RevealUntil, got {other:?}"),
+        }
+    }
+
+    /// CR 701.20a + CR 604.3: Riptide Shapeshifter — "until you reveal a creature
+    /// card of the chosen type" must gate on the source's chosen creature type.
+    #[test]
+    fn reveal_until_creature_card_of_chosen_type() {
+        let def = parse_effect_chain(
+            "Reveal cards from the top of your library until you reveal a creature card of the chosen type. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
+            AbilityKind::Activated,
+        );
+        match &*def.effect {
+            Effect::RevealUntil { filter, .. } => {
+                let TargetFilter::Typed(tf) = filter else {
+                    panic!("expected Typed filter, got {filter:?}");
+                };
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Creature),
+                    "expected Creature, got {:?}",
+                    tf.type_filters
+                );
+                assert!(
+                    tf.properties
+                        .contains(&FilterProp::IsChosenCreatureType),
+                    "expected IsChosenCreatureType, got {:?}",
+                    tf.properties
                 );
             }
             other => panic!("expected RevealUntil, got {other:?}"),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -40,8 +40,7 @@ use crate::types::ability::{
     CoinFlipResult, Comparator, ControllerRef, CounterTriggerFilter, DamageKindFilter,
     DestinationConstraint, Effect, FilterProp, ObjectScope, OriginConstraint, ParsedCondition,
     PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
-    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality,
-    StaticCondition,
+    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition,
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -40,7 +40,8 @@ use crate::types::ability::{
     CoinFlipResult, Comparator, ControllerRef, CounterTriggerFilter, DamageKindFilter,
     DestinationConstraint, Effect, FilterProp, ObjectScope, OriginConstraint, ParsedCondition,
     PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
-    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition,
+    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality,
+    StaticCondition,
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
@@ -20497,6 +20498,31 @@ mod tests {
         assert_eq!(def.origin, Some(Zone::Battlefield));
         assert_eq!(def.destination, Some(Zone::Graveyard));
         assert_eq!(def.valid_card, Some(TargetFilter::AttachedTo));
+    }
+
+    #[test]
+    fn trigger_heirloom_blade_reveal_until_shares_creature_type() {
+        let def = parse_trigger_line(
+            "Whenever equipped creature dies, reveal cards from the top of your library until you reveal a creature card that shares a creature type with it, then you may put that card into your hand and the rest on the bottom of your library in a random order.",
+            "Heirloom Blade",
+        );
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        let Effect::RevealUntil { filter, .. } = def.execute.as_ref().unwrap().effect.as_ref()
+        else {
+            panic!("expected RevealUntil, got {:?}", def.execute);
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::SharesQuality {
+                quality: SharedQuality::CreatureType,
+                reference: Some(reference),
+                ..
+            } if matches!(reference.as_ref(), TargetFilter::AttachedTo)
+        )));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -20520,7 +20520,7 @@ mod tests {
                 quality: SharedQuality::CreatureType,
                 reference: Some(reference),
                 ..
-            } if matches!(reference.as_ref(), TargetFilter::AttachedTo)
+            } if matches!(reference.as_ref(), TargetFilter::TriggeringSource)
         )));
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4042,16 +4042,6 @@ mod tests {
                 &["Instant"][..],
             ),
             (
-                "Reveal cards from the top of your library until you reveal a creature card of the chosen type. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
-                "Riptide Shapeshifter",
-                &["Creature"][..],
-            ),
-            (
-                "Whenever equipped creature dies, reveal cards from the top of your library until you reveal a creature card that shares a creature type with it, then you may put that card into your hand and the rest on the bottom of your library in a random order.",
-                "Heirloom Blade",
-                &["Artifact"][..],
-            ),
-            (
                 "This creature can't attack unless defending player is poisoned.",
                 "Chained Throatseeker",
                 &["Creature"][..],
@@ -4081,6 +4071,34 @@ mod tests {
             assert!(
                 !has_swallowed_detector(&parsed, "Condition_Unless"),
                 "{name} should not swallow unless clause"
+            );
+        }
+    }
+
+    /// CR 701.20a + CR 604.3: Reveal-until chosen-type and shares-a-type filters
+    /// must parse without any swallowed-clause warnings (Riptide Shapeshifter,
+    /// Heirloom Blade).
+    #[test]
+    fn reveal_until_chosen_type_and_shares_type_do_not_swallow() {
+        for (oracle, name, types) in [
+            (
+                "Reveal cards from the top of your library until you reveal a creature card of the chosen type. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
+                "Riptide Shapeshifter",
+                &["Creature"][..],
+            ),
+            (
+                "Whenever equipped creature dies, reveal cards from the top of your library until you reveal a creature card that shares a creature type with it, then you may put that card into your hand and the rest on the bottom of your library in a random order.",
+                "Heirloom Blade",
+                &["Artifact"][..],
+            ),
+        ] {
+            let parsed = parse_named(oracle, name, types);
+            assert!(
+                parsed.parse_warnings.iter().all(|warning| {
+                    !matches!(warning, OracleDiagnostic::SwallowedClause { .. })
+                }),
+                "{name} must not trigger any swallowed clause warnings: {:?}",
+                parsed.parse_warnings
             );
         }
     }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4042,6 +4042,16 @@ mod tests {
                 &["Instant"][..],
             ),
             (
+                "Reveal cards from the top of your library until you reveal a creature card of the chosen type. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",
+                "Riptide Shapeshifter",
+                &["Creature"][..],
+            ),
+            (
+                "Whenever equipped creature dies, reveal cards from the top of your library until you reveal a creature card that shares a creature type with it, then you may put that card into your hand and the rest on the bottom of your library in a random order.",
+                "Heirloom Blade",
+                &["Artifact"][..],
+            ),
+            (
                 "This creature can't attack unless defending player is poisoned.",
                 "Chained Throatseeker",
                 &["Creature"][..],


### PR DESCRIPTION
## Summary

Reveal-until filters of the form "creature card of the chosen type" (Riptide Shapeshifter) and "creature card that shares a creature type with it" (Heirloom Blade) were not modeled correctly. The active-filter extractor stopped at the first `" card"`, dropping the chosen-type suffix, and the shares-a-type anaphor was not bound to `AttachedTo`.

This extends `build_reveal_until_filter` with dedicated handlers for both shapes.

Closes #4435

Part of #3042 (reveal-until parser coverage).

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — narrow `build_reveal_until_filter` extension plus unit/swallow-check regression.

## CR references

CR 701.20a — reveal until a matching card is found.
CR 604.3 — chosen creature type on Riptide Shapeshifter.

## Verification

* `reveal_until_creature_card_of_chosen_type` asserts `IsChosenCreatureType` on the filter.
* `trigger_heirloom_blade_reveal_until_shares_creature_type` asserts `SharesQuality(CreatureType)` referencing `AttachedTo`.
* Swallow-check entries for Riptide Shapeshifter and Heirloom Blade oracle fragments.

Model: gpt-5.3-codex
Tier: Standard

## Anchored on

* crates/engine/src/parser/oracle_effect/mod.rs — `build_reveal_until_filter`
* crates/engine/src/parser/oracle_trigger.rs — equipped-creature dies trigger test
* crates/engine/src/parser/swallow_check.rs — oracle regression list
