### PR TITLE
perf(engine): skip mana-availability clone-storm for {T}/{Q}-only mana abilities

### DIFF
--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1109,6 +1109,16 @@ pub fn can_activate_mana_ability_now(
     {
         return false;
     }
+    // CR 605.3a + CR 106.12 + CR 107.6: When the cheap gate already conclusively
+    // decides payability (no cost, or a {T}/{Q}-only cost whose production +
+    // payment path is infallible), skip the full-state-clone legality
+    // simulation. Eliminates the mana-display board-sweep clone-storm (Cryptolith
+    // Rite granting bare `{T}: Add` to ~700 tokens => ~700 clones/sweep). Mana/
+    // resource/composite costs still simulate — the auto-tap affordability
+    // witness (CR 601.2g) must not flip UNAVAILABLE->AVAILABLE.
+    if mana_sources::cost_conclusively_payable_by_cheap_gate(&ability_def.cost) {
+        return true;
+    }
     can_activate_mana_ability_by_simulation(state, player, source_id, ability_index, ability_def)
 }
 
@@ -4887,6 +4897,217 @@ mod tests {
             N,
             "all six Treasures each produced one red"
         );
+    }
+
+    /// CR 106.12: A tapped `{T}: Add` source can't pay its tap cost, so the cheap
+    /// gate (`mana_ability_ready_without_simulation`) rejects it BEFORE the skip
+    /// shortcut and before any legality clone — A(a).
+    #[test]
+    fn cheap_gate_rejects_tapped_tap_mana_source_without_clone() {
+        let mut state = GameState::new_two_player(42);
+        let dork = make_tap_any_color_creature(&mut state, 9300, PlayerId(0), false);
+        state.objects.get_mut(&dork).unwrap().tapped = true;
+        let def = state.objects.get(&dork).unwrap().abilities[0].clone();
+
+        crate::game::perf_counters::reset();
+        let activatable = can_activate_mana_ability_now(&state, PlayerId(0), dork, 0, &def);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert!(
+            !activatable,
+            "a tapped {{T}} mana source can't pay its tap cost (CR 106.12)"
+        );
+        assert_eq!(
+            snap.state_clone_for_legality, 0,
+            "cheap gate rejects before any legality clone"
+        );
+    }
+
+    /// CR 601.2g: A `Composite{{Tap, Sacrifice}}` mana cost (Treasure) is NOT
+    /// conclusively decided by the cheap gate, so it must still simulate — the
+    /// must-simulate path is preserved (clone >= 1) even though it is activatable.
+    /// A(b). The self-sacrifice is always a legal target, so this does NOT build a
+    /// cost that passes `is_payable` yet fails simulation.
+    #[test]
+    fn composite_tap_sacrifice_still_simulates() {
+        let mut state = GameState::new_two_player(42);
+        let treasure =
+            make_any_color_treasure(&mut state, 9301, PlayerId(0), ManaColor::ALL.to_vec());
+        let def = state.objects.get(&treasure).unwrap().abilities[0].clone();
+
+        crate::game::perf_counters::reset();
+        let activatable = can_activate_mana_ability_now(&state, PlayerId(0), treasure, 0, &def);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert!(
+            activatable,
+            "an untapped Treasure with a legal self-sacrifice is activatable"
+        );
+        assert!(
+            snap.state_clone_for_legality >= 1,
+            "a Composite with a Sacrifice component must still simulate (CR 601.2g)"
+        );
+    }
+
+    /// CR 605.3a + CR 106.12: A ready plain `{T}: Add` source is activatable and
+    /// its `{T}`-only cost is conclusively payable by the cheap gate, so NO
+    /// legality clone is taken — B (revert-failing: pre-fix takes one clone here).
+    #[test]
+    fn plain_tap_mana_source_skips_legality_clone() {
+        let mut state = GameState::new_two_player(42);
+        let dork = make_tap_any_color_creature(&mut state, 9302, PlayerId(0), false);
+        let def = state.objects.get(&dork).unwrap().abilities[0].clone();
+
+        crate::game::perf_counters::reset();
+        let activatable = can_activate_mana_ability_now(&state, PlayerId(0), dork, 0, &def);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert!(activatable, "a ready {{T}}: Add source is activatable");
+        assert_eq!(
+            snap.state_clone_for_legality, 0,
+            "a {{T}}-only mana cost is conclusively payable by the cheap gate — no clone"
+        );
+    }
+
+    /// CR 601.2g: A filter land's `Composite{{Mana, Tap}}` cost still simulates —
+    /// the cheap-gate skip must not apply to mana sub-costs. Affordable pool keeps
+    /// it activatable (behavior preserved). C — behavior-preservation only, so we
+    /// do NOT assert a zero clone count.
+    #[test]
+    fn filter_land_composite_still_activatable_via_simulation() {
+        let mut state = GameState::new_two_player(42);
+        let (ruins, ability) = setup_sunken_ruins(&mut state);
+        seed_pool_with(&mut state, PlayerId(0), ManaType::Black, 1);
+
+        crate::game::perf_counters::reset();
+        let activatable = can_activate_mana_ability_now(&state, PlayerId(0), ruins, 0, &ability);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert!(
+            activatable,
+            "an affordable filter land remains activatable (behavior preserved)"
+        );
+        assert!(
+            snap.state_clone_for_legality >= 1,
+            "a Composite{{Mana, Tap}} cost must still simulate (CR 601.2g)"
+        );
+    }
+
+    /// CR 605.3a: The board-wide mana-display sweep over N untapped `{T}: Add`
+    /// sources takes ZERO legality clones — the headline regression. Pre-fix every
+    /// source cloned + simulated (N clones, the Cryptolith-Rite clone-storm). D.
+    #[test]
+    fn mana_display_sweep_is_clone_free_for_tap_only_sources() {
+        const N: usize = 8;
+        let mut state = GameState::new_two_player(42);
+        for i in 0..N {
+            make_tap_any_color_creature(&mut state, 9400 + i as u64, PlayerId(0), false);
+        }
+        assert_eq!(
+            state.battlefield.len(),
+            N,
+            "board has exactly N {{T}}: Add sources"
+        );
+
+        crate::game::public_state::mark_mana_display_dirty(&mut state);
+        crate::game::perf_counters::reset();
+        crate::game::derived::derive_display_state(&mut state);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert_eq!(
+            snap.mana_display_sweeps, 1,
+            "exactly one board-wide mana sweep"
+        );
+        assert_eq!(
+            snap.mana_display_swept_objects, N as u64,
+            "the sweep visited all N battlefield objects"
+        );
+        assert_eq!(
+            snap.state_clone_for_legality, 0,
+            "no per-source legality clone for {{T}}-only sources (revert-failing: pre-fix = N clones)"
+        );
+    }
+
+    /// Direct classifier unit tests for `AbilityCost::all_components_cheap_gate_covered`
+    /// and the `cost_conclusively_payable_by_cheap_gate` wrapper anchor guard.
+    #[test]
+    fn cheap_gate_cost_classification_units() {
+        assert!(AbilityCost::Tap.all_components_cheap_gate_covered());
+        assert!(AbilityCost::Untap.all_components_cheap_gate_covered());
+        assert!(AbilityCost::Composite {
+            costs: vec![AbilityCost::Tap, AbilityCost::Untap]
+        }
+        .all_components_cheap_gate_covered());
+        assert!(!AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Tap,
+                AbilityCost::Mana {
+                    cost: ManaCost::generic(1)
+                }
+            ]
+        }
+        .all_components_cheap_gate_covered());
+        assert!(!AbilityCost::Mana {
+            cost: ManaCost::generic(1)
+        }
+        .all_components_cheap_gate_covered());
+        // Empty composite is vacuously all()-true at the classifier level...
+        assert!(AbilityCost::Composite { costs: vec![] }.all_components_cheap_gate_covered());
+
+        // ...but the wrapper's {T}/{Q} anchor guards the degenerate empty
+        // Composite, and a None cost is conclusively payable (no cost to pay).
+        assert!(mana_sources::cost_conclusively_payable_by_cheap_gate(&None));
+        assert!(!mana_sources::cost_conclusively_payable_by_cheap_gate(
+            &Some(AbilityCost::Composite { costs: vec![] })
+        ));
+        assert!(mana_sources::cost_conclusively_payable_by_cheap_gate(
+            &Some(AbilityCost::Tap)
+        ));
+    }
+
+    /// Hostile classifier coverage: costs whose every component is NOT a
+    /// tap/untap symbol must NOT be skipped (the wrapper returns false, so the
+    /// caller falls through to full simulation). Mill needs a populated library
+    /// and EffectCost an arbitrary effect, so these are asserted at the
+    /// classifier/wrapper level rather than as full runtime cards; the runtime
+    /// "falls through to simulate" path itself is exercised by
+    /// `composite_tap_sacrifice_still_simulates` (A(b)) and
+    /// `filter_land_composite_still_activatable_via_simulation` (C).
+    #[test]
+    fn cheap_gate_hostile_costs_must_simulate() {
+        let tap_mill = Some(AbilityCost::Composite {
+            costs: vec![AbilityCost::Tap, AbilityCost::Mill { count: 1 }],
+        });
+        assert!(!mana_sources::cost_conclusively_payable_by_cheap_gate(
+            &tap_mill
+        ));
+
+        let effect_cost = Some(AbilityCost::EffectCost {
+            effect: Box::new(Effect::Mana {
+                produced: ManaProduction::Colorless {
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            }),
+        });
+        assert!(!mana_sources::cost_conclusively_payable_by_cheap_gate(
+            &effect_cost
+        ));
+
+        // Bare Mana-only cost (no {T}) — the wrapper's anchor requires a {T}/{Q}
+        // component, so a mana-only cost is never skipped.
+        let mana_only = Some(AbilityCost::Mana {
+            cost: ManaCost::generic(1),
+        });
+        assert!(!mana_sources::cost_conclusively_payable_by_cheap_gate(
+            &mana_only
+        ));
+
+        // None cost is conclusively payable (covered above too) — sanity anchor.
+        assert!(mana_sources::cost_conclusively_payable_by_cheap_gate(&None));
     }
 
     /// CR 302.6 / CR 702.10: A summoning-sick creature's `{T}` mana ability is not a

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -266,6 +266,26 @@ pub(crate) fn has_untap_component(cost: &Option<AbilityCost>) -> bool {
     cost_has_component(cost, |c| matches!(c, AbilityCost::Untap))
 }
 
+/// CR 605.3a + CR 106.12 + CR 107.6: True when paying this mana-ability cost is
+/// conclusively decided by the non-simulating cheap gate, so
+/// `can_activate_mana_ability_now` may skip the full-state legality clone.
+///
+/// Sound only for an infallible production+payment path: no cost (`None`), or a
+/// cost whose every component is the tap/untap symbol. The
+/// `has_tap_component || has_untap_component` anchor documents that the cheap
+/// gate's {T}/{Q} state checks make the skip safe, and guards the degenerate
+/// empty `Composite { costs: [] }`, whose `all()` would otherwise be vacuously
+/// true with no real {T}/{Q} to gate on.
+pub(crate) fn cost_conclusively_payable_by_cheap_gate(cost: &Option<AbilityCost>) -> bool {
+    match cost {
+        None => true,
+        Some(inner) => {
+            (has_tap_component(cost) || has_untap_component(cost))
+                && inner.all_components_cheap_gate_covered()
+        }
+    }
+}
+
 /// CR 701.21: True when paying this ability's cost sacrifices a permanent
 /// (the source itself or another). Matches a bare `Sacrifice` cost and a
 /// `Sacrifice` nested inside a `Composite`, for any target filter.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6643,6 +6643,56 @@ pub enum CostCategory {
 }
 
 impl AbilityCost {
+    /// CR 605.3a + CR 106.12 + CR 107.6: True iff every component of this cost is
+    /// conclusively decided by the non-simulating mana-ability cheap gate
+    /// (`mana_ability_ready_without_simulation`) — i.e. the cost is built solely
+    /// from the tap ({T}) and untap ({Q}) symbols. For such costs the production +
+    /// payment path in `resolve_mana_ability_with_selected_choices` is infallible,
+    /// so the legality clone in `can_activate_mana_ability_now` can be skipped.
+    ///
+    /// `Mana`/`ManaDynamic` are deliberately NOT covered: their payability is decided
+    /// by an auto-tap affordability witness with a known remove-then-tap soundness
+    /// gap (CR 601.2g), so they must still simulate. No wildcard arm — a future
+    /// variant must be classified explicitly.
+    pub fn all_components_cheap_gate_covered(&self) -> bool {
+        match self {
+            AbilityCost::Tap | AbilityCost::Untap => true,
+            AbilityCost::Composite { costs } => costs
+                .iter()
+                .all(AbilityCost::all_components_cheap_gate_covered),
+            // Every other variant is decided by a path the cheap gate does NOT
+            // conclusively settle (mana affordability witness, interactive object
+            // selection, life/resource availability, effect resolution, etc.), so
+            // it must still simulate.
+            AbilityCost::Mana { .. }
+            | AbilityCost::ManaDynamic { .. }
+            | AbilityCost::Loyalty { .. }
+            | AbilityCost::Sacrifice(_)
+            | AbilityCost::PayLife { .. }
+            | AbilityCost::Discard { .. }
+            | AbilityCost::Exile { .. }
+            | AbilityCost::ExileMaterials { .. }
+            | AbilityCost::CollectEvidence { .. }
+            | AbilityCost::TapCreatures { .. }
+            | AbilityCost::RemoveCounter { .. }
+            | AbilityCost::PayEnergy { .. }
+            | AbilityCost::PaySpeed { .. }
+            | AbilityCost::ReturnToHand { .. }
+            | AbilityCost::Unattach
+            | AbilityCost::Mill { .. }
+            | AbilityCost::Exert
+            | AbilityCost::Blight { .. }
+            | AbilityCost::Reveal { .. }
+            | AbilityCost::Behold { .. }
+            | AbilityCost::OneOf { .. }
+            | AbilityCost::Waterbend { .. }
+            | AbilityCost::NinjutsuFamily { .. }
+            | AbilityCost::EffectCost { .. }
+            | AbilityCost::PerCounter { .. }
+            | AbilityCost::Unimplemented { .. } => false,
+        }
+    }
+
     /// CR 702.24a + CR 118.12: True iff this cost can be used as the base
     /// cost for a cumulative-upkeep trigger and then paid by the current
     /// unless-payment pipeline after `PerCounter` expansion.

--- a/crates/phase-ai/src/bin/attack_scaling_bench.rs
+++ b/crates/phase-ai/src/bin/attack_scaling_bench.rs
@@ -1,0 +1,115 @@
+//! Profile combat declaration as the attacker count scales.
+//!
+//! The user couldn't reproduce "slow attacking" interactively, so this builds a
+//! synthetic go-wide board of N vanilla creatures, advances to the
+//! declare-attackers step, and times two things per N:
+//!   1. `get_valid_attacker_ids` — the legality scan the engine runs to build
+//!      the `WaitingFor::DeclareAttackers` snapshot (the read path).
+//!   2. `apply(DeclareAttackers{all})` — declaring every creature at once (the
+//!      write path a player hits when they alpha-strike).
+//!
+//! Printing time vs N exposes any O(n^2) curve directly (doubling N should ~2x
+//! a linear cost; ~4x flags quadratic).
+//!
+//! Build/run with a debug build in an isolated target dir (keeps Tilt's own
+//! target lock uncontended):
+//!   CARGO_TARGET_DIR=/tmp/forge-dbg cargo run \
+//!       -p phase-ai --bin attack_scaling_bench
+//!
+//! The perf counters this prints are profile-independent — only the absolute
+//! per-call times inflate in a debug build. The `profiling` profile compiles
+//! the engine very slowly and contends with Tilt, so prefer the debug build
+//! above unless you specifically need realistic wall-clock numbers.
+
+use std::time::{Duration, Instant};
+
+use engine::game::combat::{
+    get_valid_attack_targets, get_valid_attacker_ids, AttackTarget, CombatState,
+};
+use engine::game::perf_counters;
+use engine::game::scenario::GameScenario;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+fn bench_n(n: usize) {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    for _ in 0..n {
+        scenario.add_vanilla(P0, 1, 1);
+    }
+    let mut runner = scenario.build();
+
+    // Build the DeclareAttackers waiting state directly (mirrors the engine's own
+    // combat tests, combat.rs:4077). `advance_to_combat()` would walk the draw
+    // step, but the synthetic scenario has empty libraries, so the active player
+    // decks out (CR 104.3c) before combat. Setting the state at the
+    // declare-attackers step skips that and isolates the cost we want to measure.
+    {
+        let s = runner.state_mut();
+        s.phase = Phase::DeclareAttackers;
+        s.active_player = P0;
+        s.priority_player = P0;
+        s.combat = Some(CombatState::default());
+    }
+    let valid_attacker_ids = get_valid_attacker_ids(runner.state());
+    let valid_attack_targets = get_valid_attack_targets(runner.state());
+    runner.state_mut().waiting_for = WaitingFor::DeclareAttackers {
+        player: P0,
+        valid_attacker_ids,
+        valid_attack_targets,
+    };
+
+    let at_declare = matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareAttackers { .. }
+    );
+
+    // Isolated read-path timing: the legality scan that builds the snapshot.
+    let start = Instant::now();
+    let valid = get_valid_attacker_ids(runner.state());
+    let scan_dt = start.elapsed();
+
+    let attacks: Vec<(_, AttackTarget)> = valid
+        .iter()
+        .map(|&id| (id, AttackTarget::Player(P1)))
+        .collect();
+    let declared = attacks.len();
+
+    perf_counters::reset();
+    let start = Instant::now();
+    let result = runner.declare_attackers(&attacks);
+    let declare_dt = start.elapsed();
+    let c = perf_counters::snapshot();
+
+    let per_attacker = if declared == 0 {
+        Duration::ZERO
+    } else {
+        declare_dt / declared as u32
+    };
+
+    print!(
+        "N={n:5} at_declare={at_declare:5} valid={declared:5}  \
+         scan={scan_dt:>10.3?}  declare={declare_dt:>10.3?}  per_attacker={per_attacker:>9.3?}  \
+         clones={} layers(full={} inc={}) mana_sweeps={} swept={}",
+        c.state_clone_for_legality,
+        c.layers_full_eval,
+        c.layers_incremental,
+        c.mana_display_sweeps,
+        c.mana_display_swept_objects,
+    );
+    match result {
+        Ok(_) => println!("  -> {}", runner.state().waiting_for.variant_name()),
+        Err(e) => println!("  -> ERR {e:?}"),
+    }
+}
+
+fn main() {
+    println!("debug_assertions = {}", cfg!(debug_assertions));
+    println!();
+    for n in [50usize, 100, 200, 400, 800, 1200] {
+        bench_n(n);
+    }
+}

--- a/crates/phase-ai/src/bin/pass_priority_bench.rs
+++ b/crates/phase-ai/src/bin/pass_priority_bench.rs
@@ -1,0 +1,101 @@
+//! Time `apply(PassPriority)` on a saved GameState.
+//!
+//! The legal-actions bench measures the *read* path (enumerating candidates).
+//! This measures the *write* path a human hits when they click "pass": one
+//! `engine::game::apply(state, actor, PassPriority)` call, including the
+//! post-action finalizers (auto-pass loop, rules-state, display-state mana
+//! sweep). Reports per-call timing and the perf counters each call accrued.
+//!
+//! Build/run with a debug build in an isolated target dir (keeps Tilt's own
+//! target lock uncontended):
+//!   CARGO_TARGET_DIR=/tmp/forge-dbg cargo run \
+//!       -p phase-ai --bin pass_priority_bench -- path/to/state.json
+//!
+//! The perf counters this prints are profile-independent — only the absolute
+//! per-call times inflate in a debug build. The `profiling` profile compiles
+//! the engine very slowly and contends with Tilt, so prefer the debug build
+//! above unless you specifically need realistic wall-clock numbers.
+
+use std::fs;
+use std::time::Instant;
+
+use engine::game::engine::apply;
+use engine::game::perf_counters;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::player::PlayerId;
+use phase_ai::saved_state::load_saved_game_state;
+
+fn actor_for(state: &GameState) -> PlayerId {
+    state
+        .waiting_for
+        .acting_player()
+        .unwrap_or(state.active_player)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "/tmp/gs39.json".to_string());
+    let steps = args
+        .windows(2)
+        .find_map(|w| {
+            (w[0] == "--steps")
+                .then(|| w[1].parse::<u32>().ok())
+                .flatten()
+        })
+        .unwrap_or(8);
+
+    let raw = fs::read_to_string(&path).expect("read state file");
+    let base = load_saved_game_state(&raw).expect("parse saved state");
+
+    println!("debug_assertions = {}", cfg!(debug_assertions));
+    println!("path = {path}");
+    println!("objects = {}", base.objects.len());
+    println!("battlefield = {}", base.battlefield.len());
+    println!("players = {}", base.players.len());
+    println!("phase = {:?}", base.phase);
+    println!("waiting_for = {}", base.waiting_for.variant_name());
+    println!();
+
+    // Walk forward applying PassPriority repeatedly, fresh clone each step so we
+    // measure a single apply in isolation and can attribute counters to it.
+    println!("=== per-step apply(PassPriority) ===");
+    let mut state = base.clone();
+    for step in 0..steps {
+        let actor = actor_for(&state);
+        let before_variant = state.waiting_for.variant_name();
+        if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
+            println!("step {step}: game over, stopping");
+            break;
+        }
+
+        perf_counters::reset();
+        let start = Instant::now();
+        let result = apply(&mut state, actor, GameAction::PassPriority);
+        let dt = start.elapsed();
+        let c = perf_counters::snapshot();
+
+        match result {
+            Ok(_) => {
+                println!(
+                    "step {step:2}: actor={actor:?} {before_variant} -> {:<18} {dt:>10.3?}  \
+                     layers(full={} inc={} esc={}) mana_sweeps={} swept_objs={}",
+                    state.waiting_for.variant_name(),
+                    c.layers_full_eval,
+                    c.layers_incremental,
+                    c.layers_escalated,
+                    c.mana_display_sweeps,
+                    c.mana_display_swept_objects,
+                    dt = dt,
+                );
+            }
+            Err(e) => {
+                println!("step {step:2}: actor={actor:?} {before_variant} ERR {e:?} ({dt:?})");
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Passing priority takes **hundreds of seconds** on large mana-source boards. Repro: an Unbeatable Squirrel Girl deck with **702 Squirrel tokens + Cryptolith Rite** (grants every creature `{T}: Add one mana`), 760 battlefield permanents.

The board-global mana-availability sweep (`derived.rs::derive_display_state`) calls `can_activate_mana_ability_now` for every battlefield mana source, and that function **always** ran `can_activate_mana_ability_by_simulation`, which does a full `GameState` clone per source. With ~700 mana-source Squirrels that's ~700 full-state clones per sweep. Measured: one `apply(PassPriority)` = 1 sweep / 760 swept objects ≈ 350s (debug; perf counters exact).

This is original behavior (present since the repo's genesis commit), surfaced by the card pool — it's the out-of-scope residual that the combat-legality fix (#4312) flagged as the `dirty-perf` mana landmine.

## Fix

The cheap pre-gate `mana_ability_ready_without_simulation` is a strict superset of `activate_mana_ability`'s entry guard (it additionally verifies tapped/untapped state, summoning sickness, and mana payability). So the clone-simulation only earns its keep for the cost-payment step of **composite/resource** costs.

- New `AbilityCost::all_components_cheap_gate_covered` — exhaustive, **no wildcard** (a future variant forces a compile-time classification): only `Tap`, `Untap`, and recursive `Composite` are covered.
- New `cost_conclusively_payable_by_cheap_gate` wrapper — `None`, or a `{T}`/`{Q}`-anchored cost of only tap/untap components. The anchor guards the degenerate empty `Composite`.
- `can_activate_mana_ability_now`: after the cheap gate passes, skip the clone and return `true` when conclusively decided.

**Conservative by design:** `Mana`/`ManaDynamic` and every resource/composite cost still simulate, so behavior is byte-identical there. Mana riders deliberately keep simulating to avoid the CR 601.2g affordability-witness soundness gap.

## Verification

- `cargo clippy -p engine --all-targets` + `-p phase-ai --bins`: clean.
- `cargo test -p engine --lib mana_abilities`: 118 passed (7 new).
- Discriminating tests: bare `{T}: Add` → available with **0 clones**; the real `derive_display_state` board sweep over N tap-only sources → **0 clones** (revert-failing: pre-fix = N); `Composite{Tap,Sacrifice}` and filter-land `Composite{Mana,Tap}` still simulate (≥1 clone, behavior preserved).

CR 605.3a / CR 106.12 / CR 107.6 / CR 601.2g (grep-verified).

## Also included

Two dev-only perf bench binaries (`pass_priority_bench`, `attack_scaling_bench`) used to diagnose this, mirroring `legal_actions_bench`.