### PR TITLE
fix(parser): assemble 3+ color prenominal disjunction filters

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3361,9 +3361,24 @@ fn parse_combat_relation_suffix(text: &str) -> Option<(FilterProp, usize)> {
 /// then verifies a trailing space exists (color as adjective, not standalone).
 fn parse_color_prefix(text: &str) -> Option<(FilterProp, usize)> {
     let (rest, color) = nom_primitives::parse_color(text).ok()?;
-    // Must be followed by a space (color adjective prefix, not standalone color word).
-    let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest).ok()?;
-    let consumed = text.len() - rest.len();
+    // CR 105.1: A color word is an adjective prefix only when a separator
+    // follows, so a bare color word ("whiteness") never matches. Two separators
+    // are accepted:
+    //   * a trailing space — the ordinary "white creature" prefix (consumed);
+    //   * a comma — the color-list continuation "white, blue, or black
+    //     creature", where the comma is left in place for the `TYPE_SEPARATORS`
+    //     recursion to consume as a ", " / ", or " disjunction separator. That
+    //     recursion + `distribute_core_type_to_or` then assemble the ≥3-color
+    //     prenominal chain into the same Or-of-legs shape the 2-color "green or
+    //     white creature" form already produces, with the core type backfilled
+    //     onto every color-only leg.
+    let consumed = if let Ok((after_space, _)) = tag::<_, _, OracleError<'_>>(" ").parse(rest) {
+        text.len() - after_space.len()
+    } else if rest.starts_with(',') {
+        text.len() - rest.len()
+    } else {
+        return None;
+    };
     Some((FilterProp::HasColor { color }, consumed))
 }
 
@@ -9894,16 +9909,61 @@ mod tests {
     }
 
     #[test]
+    fn or_color_disjunction_three_colors_backfills_core_type() {
+        // ≥3-color prenominal disjunction class: "target white, blue, or black
+        // creature". Unlike the 2-color "green or white creature" form (which the
+        // bare " or " `TYPE_SEPARATORS` arm assembles), the inner legs here are
+        // comma-separated bare color words ("blue,"). `parse_color_prefix` now
+        // accepts a color followed by a comma, so the leading color is consumed
+        // and the ", " / ", or " separators drive the same recursion; the
+        // [Any]-typed color-only legs are then backfilled to [Creature] by
+        // `distribute_core_type_to_or`. This pins the full parse pipeline (the
+        // surface assembly the distributor-only test below cannot reach).
+        let (f, rest) = parse_target("target white, blue, or black creature");
+        assert_eq!(rest.trim(), "");
+        let TargetFilter::Or { filters } = f else {
+            panic!("expected Or filter, got {f:?}");
+        };
+        assert_eq!(filters.len(), 3, "expected 3-way OR, got {filters:#?}");
+        // Every leg must carry exactly [Creature] (the white/blue legs were [Any]).
+        for (i, leg) in filters.iter().enumerate() {
+            let tf = typed_leg(leg).unwrap_or_else(|| panic!("leg {i} not Typed: {leg:?}"));
+            assert_eq!(
+                tf.type_filters,
+                vec![TypeFilter::Creature],
+                "leg {i} must be [Creature], got {:?}",
+                tf.type_filters
+            );
+        }
+        assert_eq!(
+            leg_color(&filters[0]),
+            Some(ManaColor::White),
+            "leg 0 = white"
+        );
+        assert_eq!(
+            leg_color(&filters[1]),
+            Some(ManaColor::Blue),
+            "leg 1 = blue"
+        );
+        assert_eq!(
+            leg_color(&filters[2]),
+            Some(ManaColor::Black),
+            "leg 2 = black"
+        );
+    }
+
+    #[test]
     fn distribute_core_type_to_or_backfills_every_flat_any_leg() {
         // Building-block test: `merge_or_filters` flattens nested `Or`s, so a
         // ≥3-disjunct list arrives at `distribute_core_type_to_or` as flat
         // siblings. Drive the distributor directly with a flat 3-leg Or in which
         // two legs are the deferred-type `[Any]` shape (color-only) and the last
         // carries the concrete `[Creature]`. EVERY `[Any]` leg must inherit
-        // `[Creature]`; the type-bearing leg is untouched. (The surface parser
-        // does not yet assemble a ≥3 color-only disjunction — comma/no-comma color
-        // chains are a separate gap — so we pin the distributor at its own seam,
-        // which is exactly the level `merge_or_filters` feeds.)
+        // `[Creature]`; the type-bearing leg is untouched. The surface parser now
+        // assembles ≥3-color prenominal chains (see
+        // `or_color_disjunction_three_colors_backfills_core_type`); this test pins
+        // the distributor at its own seam — exactly the level `merge_or_filters`
+        // feeds — independent of the surface grammar.
         let any_leg = |color: ManaColor| {
             TargetFilter::Typed(TypedFilter {
                 type_filters: vec![TypeFilter::Any],

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3374,7 +3374,8 @@ fn parse_color_prefix(text: &str) -> Option<(FilterProp, usize)> {
     //     onto every color-only leg.
     let consumed = if let Ok((after_space, _)) = tag::<_, _, OracleError<'_>>(" ").parse(rest) {
         text.len() - after_space.len()
-    } else if rest.starts_with(',') {
+    } else if peek(tag::<_, _, OracleError<'_>>(",")).parse(rest).is_ok() {
+        // Comma left in place for the `TYPE_SEPARATORS` recursion to consume.
         text.len() - rest.len()
     } else {
         return None;


### PR DESCRIPTION
## Summary

Teaches the target-filter parser to assemble prenominal color disjunctions of
**three or more** colors — e.g. `target white, blue, or black creature`. These
previously collapsed to a typeless/colorless `[Any]` filter, silently dropping
the color restriction so that *any* creature became a legal target.

## Problem

`parse_color_prefix` only recognized a color word when it was immediately
followed by a **space** (`"white creature"`). In a comma-separated color list
the inner legs are followed by a comma (`"blue,"` in
`"white, blue, or black creature"`), so the prefix check failed.

As a result:

- **2-color** prenominal disjunctions (`"green or white creature"`) already
  worked — the bare `" or "` arm of the `TYPE_SEPARATORS` recursion assembled
  them into an `Or` of legs, with `distribute_core_type_to_or` backfilling the
  core type onto the color-only leg.
- **3+-color** prenominal disjunctions fell through entirely. The leading
  `"white,"` was never consumed as a color, the comma never reached the
  `", "` / `", or "` separator recursion, and the phrase degraded to a bare
  `[Any]` filter with **no color restriction at all** — a green creature would
  have been a legal `"white, blue, or black creature"` target.

The repo already documented this as a known gap (the strict-failure comment on
`distribute_core_type_to_or_backfills_every_flat_any_leg`:
_"The surface parser does not yet assemble a ≥3 color-only disjunction — comma/no-comma color chains are a separate gap"_).

## Fix

Relax `parse_color_prefix` (a single building-block change) to accept a color
word followed by **either**:

- a trailing space — the ordinary `"white creature"` prefix (consumed), or
- a comma — the color-list continuation, with the comma **left in place** so the
  existing `", "` / `", or "` disjunction separator consumes it.

That's the whole change. The existing `TYPE_SEPARATORS` recursion +
`distribute_core_type_to_or` machinery then assemble the chain into the **same
`Or`-of-legs shape** the 2-color form already produces, backfilling the concrete
core type onto every color-only leg. **No new AST shape is introduced**, and the
relative-clause form (`"creature that's white, blue, or black"`) was already
handled by `parse_color_disjunction`, so both surfaces are now consistent.

### Resulting parse

`target white, blue, or black creature` →

Or [
Typed { Creature, [HasColor White] },
Typed { Creature, [HasColor Blue]  },
Typed { Creature, [HasColor Black] },
]


## Rules

- **CR 105.1** — color is a characteristic; a color word is an adjective on the
  object it describes.
- **CR 109.2** — a type-word object description restricts to objects of that type.

(type_filters are ANDed in `game/filter.rs`, so backfilling `Creature` onto each
color leg is what keeps the filter from matching noncreature permanents.)

## Testing

- Added a building-block test
  (`or_color_disjunction_three_colors_backfills_core_type`) driving the full
  `parse_target` pipeline for the 3-color prenominal class, asserting a 3-way
  `Or` with each leg carrying `[Creature]` + its color.
- Updated the now-stale gap comment on the distributor-only test.
- **`cargo test -p engine` parser suite: 6740 passed, 0 failed** — including the
  three existing 2-color disjunction tests (Deathmark / Tidebinder /
  Self-Inflicted Wound), confirming no regression.
- `cargo fmt --all` clean.

## Scope

One file (`crates/engine/src/parser/oracle_target.rs`), +67/−7. Pure parser
change — no engine, frontend, or AI surface touched.

