### PR TITLE
fix(parser): parse Enchant creature without flying Aura targets (closes #4440)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/enchant.rs
+++ b/crates/engine/src/parser/oracle_nom/enchant.rs
@@ -20,8 +20,8 @@ use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AttachmentKind, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter,
 };
-use crate::types::keywords::Keyword;
 use crate::types::card_type::{noncreature_subtype_set, SubtypeSet};
+use crate::types::keywords::Keyword;
 
 /// CR 702.5a: One enchantable core-type or supported subtype token. Core
 /// types and established basic-land subtype legs stay as literal nom arms;

--- a/crates/engine/src/parser/oracle_nom/enchant.rs
+++ b/crates/engine/src/parser/oracle_nom/enchant.rs
@@ -15,10 +15,12 @@ use nom::combinator::value;
 use nom::Parser;
 
 use super::error::OracleResult;
+use crate::parser::oracle_target::parse_without_keyword_suffix;
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AttachmentKind, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter,
 };
+use crate::types::keywords::Keyword;
 use crate::types::card_type::{noncreature_subtype_set, SubtypeSet};
 
 /// CR 702.5a: One enchantable core-type or supported subtype token. Core
@@ -189,6 +191,7 @@ pub(crate) fn parse_enchant_target_full(input: &str) -> OracleResult<'_, TargetF
     let (input, type_legs) = parse_enchant_type_list(input)?;
     let (input, controller) = opt(parse_enchant_controller_suffix).parse(input)?;
     let (input, attachment) = opt(parse_enchant_attachment_qualifier).parse(input)?;
+    let (input, without_keyword) = parse_enchant_without_keyword_suffix(input)?;
 
     let mut typed = TypedFilter {
         type_filters: type_legs,
@@ -200,5 +203,40 @@ pub(crate) fn parse_enchant_target_full(input: &str) -> OracleResult<'_, TargetF
     if let Some(prop) = attachment {
         typed.properties.push(prop);
     }
+    typed.properties.extend(without_keyword);
     Ok((input, TargetFilter::Typed(typed)))
+}
+
+/// CR 702.5a + CR 702.9: Optional trailing "without [keyword]" qualifier on an
+/// enchant line (Trapped in the Tower, Roots). Delegates to the shared target
+/// suffix authority so Aura legal-target sets match `parse_type_phrase`.
+fn parse_enchant_without_keyword_suffix(input: &str) -> OracleResult<'_, Vec<FilterProp>> {
+    match parse_without_keyword_suffix(input) {
+        Some((props, consumed)) => Ok((&input[consumed..], props)),
+        None => Ok((input, Vec::new())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// CR 702.5a + CR 702.9: Trapped in the Tower — "Enchant creature without flying".
+    #[test]
+    fn parse_enchant_target_creature_without_flying() {
+        let (rest, filter) =
+            parse_enchant_target_full("creature without flying").expect("must parse");
+        assert!(rest.is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+        assert!(
+            tf.properties.iter().any(
+                |p| matches!(p, FilterProp::WithoutKeyword { value } if *value == Keyword::Flying)
+            ),
+            "expected WithoutKeyword(Flying), got {:?}",
+            tf.properties
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_nom/enchant.rs
+++ b/crates/engine/src/parser/oracle_nom/enchant.rs
@@ -21,7 +21,6 @@ use crate::types::ability::{
     AttachmentKind, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{noncreature_subtype_set, SubtypeSet};
-use crate::types::keywords::Keyword;
 
 /// CR 702.5a: One enchantable core-type or supported subtype token. Core
 /// types and established basic-land subtype legs stay as literal nom arms;
@@ -220,6 +219,7 @@ fn parse_enchant_without_keyword_suffix(input: &str) -> OracleResult<'_, Vec<Fil
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::keywords::Keyword;
 
     /// CR 702.5a + CR 702.9: Trapped in the Tower — "Enchant creature without flying".
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -4420,7 +4420,7 @@ fn parse_keyword_suffix(text: &str) -> Option<(KeywordSuffix, usize)> {
 /// Parse "without [keyword]" suffix — negated keyword filter.
 /// Handles "without flying", "without first strike", etc.
 /// Parallels `parse_keyword_suffix` but emits `WithoutKeyword`.
-fn parse_without_keyword_suffix(text: &str) -> Option<(Vec<FilterProp>, usize)> {
+pub(crate) fn parse_without_keyword_suffix(text: &str) -> Option<(Vec<FilterProp>, usize)> {
     let trimmed = text.trim_start();
     let leading_ws = text.len() - trimmed.len();
     let (after_without, _) = tag::<_, _, OracleError<'_>>("without ")

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4103,6 +4103,33 @@ mod tests {
         }
     }
 
+    /// CR 702.5a + CR 702.9: Aura enchant lines with "without [keyword]" must not
+    /// fall through as unknown Enchant targets (Trapped in the Tower, Roots).
+    #[test]
+    fn enchant_creature_without_flying_do_not_swallow() {
+        for (oracle, name, types) in [
+            (
+                "Enchant creature without flying\nEnchanted creature can't attack or block, and its activated abilities can't be activated.",
+                "Trapped in the Tower",
+                &["Enchantment", "Aura"][..],
+            ),
+            (
+                "Enchant creature without flying\nEnchanted creature can't block.",
+                "Roots",
+                &["Enchantment", "Aura"][..],
+            ),
+        ] {
+            let parsed = parse_named(oracle, name, types);
+            assert!(
+                parsed.parse_warnings.iter().all(|warning| {
+                    !matches!(warning, OracleDiagnostic::SwallowedClause { .. })
+                }),
+                "{name} must not trigger any swallowed clause warnings: {:?}",
+                parsed.parse_warnings
+            );
+        }
+    }
+
     /// CR 115.7d: Standalone retarget spells (Deflecting Swat, Redirect) lower
     /// to `ChangeTargets { scope: All }` with the full `you may choose new
     /// targets` surface preserved — not `def.optional`.

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1708,6 +1708,11 @@ fn parse_enchant_target(s: &str) -> Option<TargetFilter> {
     // another Aura attached to it" (Daybreak Coronet) narrows the legal target
     // set to objects that already carry an attachment of the named kind.
     let (rest, attachment) = opt(parse_enchant_attachment_qualifier).parse(rest).ok()?;
+    let (rest, without_keyword) =
+        match crate::parser::oracle_target::parse_without_keyword_suffix(rest) {
+            Some((props, consumed)) => (&rest[consumed..], props),
+            None => (rest, Vec::new()),
+        };
     if !rest.trim().is_empty() {
         return None;
     }
@@ -1728,6 +1733,7 @@ fn parse_enchant_target(s: &str) -> Option<TargetFilter> {
     if let Some(prop) = attachment {
         props.push(prop);
     }
+    props.extend(without_keyword);
     let mut filter = TypedFilter::new(type_filter.unwrap_or(TypeFilter::Card));
     if !props.is_empty() {
         filter = filter.properties(props);
@@ -3643,6 +3649,25 @@ mod tests {
 
     /// Regression guard: a plain "Enchant creature" must NOT acquire an
     /// attachment predicate — only the explicit qualifier adds `HasAttachment`.
+    /// CR 702.5a + CR 702.9: Trapped in the Tower / Roots — "Enchant creature
+    /// without flying" must lower to `WithoutKeyword(Flying)` on the Aura target.
+    #[test]
+    fn parse_enchant_creature_without_flying() {
+        use super::super::ability::TypeFilter;
+        let enchant = Keyword::from_str("Enchant:creature without flying").unwrap();
+        let Keyword::Enchant(TargetFilter::Typed(tf)) = enchant else {
+            panic!("expected Typed; got {enchant:?}")
+        };
+        assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        assert!(
+            tf.properties.iter().any(
+                |p| matches!(p, FilterProp::WithoutKeyword { value } if *value == Keyword::Flying)
+            ),
+            "expected WithoutKeyword(Flying); got {:?}",
+            tf.properties
+        );
+    }
+
     #[test]
     fn parse_enchant_plain_creature_has_no_attachment_predicate() {
         use super::super::ability::AttachmentKind;


### PR DESCRIPTION
## Summary

Auras with `Enchant creature without flying` (Trapped in the Tower, Roots) failed to parse the enchant restriction because the shared enchant-target parsers required the phrase to end after the type leg. The trailing `without flying` suffix was left unconsumed and the `Enchant:` keyword target fell through as unrecognized.

This delegates the suffix to the existing `parse_without_keyword_suffix` authority (same as `parse_type_phrase`) in both `parse_enchant_target` (MTGJSON `FromStr` path) and `parse_enchant_target_full` (Oracle-line / return-as-Aura path).

Closes #4440

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

Narrow parser extension wiring an existing `WithoutKeyword` suffix combinator into the shared enchant-target parsers. No runtime or AST behavior change beyond correct Aura legal-target filters.

## CR references

CR 702.5a — Aura enchant restriction defines legal targets.
CR 702.9 — Flying; `without flying` is a negated keyword restriction on the enchantable object set.

## Verification

- `parse_enchant_creature_without_flying` in `types/keywords.rs` (FromStr path).
- `parse_enchant_target_creature_without_flying` in `oracle_nom/enchant.rs` (combinator path).
- Swallow-check regression for Trapped in the Tower and Roots oracle fragments.

Model: gpt-5.3-codex
Tier: Standard

## Anchored on

- crates/engine/src/parser/oracle_target.rs — `parse_without_keyword_suffix` and `parse_type_phrase_creature_without_flying`
- crates/engine/src/parser/oracle_nom/enchant.rs — `parse_enchant_target_full` composition pattern (attachment qualifier suffix)
