### PR TITLE
fix(parser): parse disjunctive unless-pay mana on Lim-Dul's Hex (closes #4442)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22474,7 +22474,7 @@ pub(crate) fn parse_unless_for_each_payment(
 }
 
 /// Parse "where X is this creature's power" and similar dynamic quantity clauses.
-fn parse_where_x_is(text: &str) -> Option<QuantityExpr> {
+pub(super) fn parse_where_x_is(text: &str) -> Option<QuantityExpr> {
     let trimmed = text.trim().trim_start_matches(',').trim();
     let (rest, _) = tag::<_, _, OracleError<'_>>("where x is ")
         .parse(trimmed)

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -23092,7 +23092,11 @@ mod tests {
         let AbilityCost::OneOf { costs } = &unless_pay.cost else {
             panic!("cost should be OneOf, got {:?}", unless_pay.cost);
         };
-        assert_eq!(costs.len(), 2, "OneOf should have two mana branches: {costs:?}");
+        assert_eq!(
+            costs.len(),
+            2,
+            "OneOf should have two mana branches: {costs:?}"
+        );
         assert!(
             matches!(&costs[0], AbilityCost::Mana { .. }),
             "first branch should be Mana, got {:?}",

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2736,40 +2736,6 @@ fn parse_unless_return_to_hand(rest: &str) -> Option<AbilityCost> {
     })
 }
 
-/// Parse "where X is ~'s power" / "where X is this creature's power" etc.
-/// Delegates to `nom_quantity::parse_quantity_ref` for the value reference after
-/// stripping the "where X is" prefix.
-fn parse_where_x_is_trigger(text: &str) -> Option<QuantityExpr> {
-    let trimmed = text.trim().trim_start_matches(',').trim();
-    let (rest, ()) = alt((
-        value((), tag::<_, _, OracleError<'_>>("where x is ")),
-        value((), tag("where X is ")),
-    ))
-    .parse(trimmed)
-    .ok()?;
-    let rest_lower = rest.to_lowercase();
-    // Try nom quantity ref combinator first for common patterns
-    if let Ok((_rem, qty)) = nom_quantity::parse_quantity_ref.parse(&rest_lower) {
-        return Some(QuantityExpr::Ref { qty });
-    }
-    // Fall through to keyword-based matching for less common patterns
-    if scan_contains(&rest_lower, "power") {
-        Some(QuantityExpr::Ref {
-            qty: QuantityRef::Power {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-        })
-    } else if scan_contains(&rest_lower, "toughness") {
-        Some(QuantityExpr::Ref {
-            qty: QuantityRef::Toughness {
-                scope: crate::types::ability::ObjectScope::Source,
-            },
-        })
-    } else {
-        None
-    }
-}
-
 /// CR 603.4: Rewrite any `FilterProp::Another` inside a `TargetFilter` to
 /// `FilterProp::OtherThanTriggerObject` for trigger-scope quantity
 /// comparisons. Recurses through `And`/`Or`/`Not` combinators and `Typed`

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1673,15 +1673,10 @@ fn parse_unless_mana_payment(cost_str: &str) -> Option<AbilityCost> {
         if let Some(quantity) = super::oracle_effect::parse_where_x_is(after_cost) {
             return Some(AbilityCost::ManaDynamic { quantity });
         }
+        let after_x = after_cost.trim().trim_start_matches(',').trim();
+        let after_x_lower = after_x.to_lowercase();
         if tag::<_, _, OracleError<'_>>("where x is ")
-            .parse(
-                after_cost
-                    .trim()
-                    .trim_start_matches(',')
-                    .trim()
-                    .to_lowercase()
-                    .as_str(),
-            )
+            .parse(after_x_lower.as_str())
             .is_ok()
         {
             return None;

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1632,7 +1632,7 @@ fn strip_constraint_sentences(text: &str) -> String {
     }
 }
 
-/// CR 702.24a + CR 118.12a: Parse mana / energy unless-payment tails after
+/// CR 118.12a + CR 107.4: Parse mana / energy unless-payment tails after
 /// "they pay " / "pays ". Disjunctive "{B} or {3}" lowers to `OneOf` of mana
 /// branches (Lim-Dul's Hex); single-mana, dynamic-{X}, and for-each-scaling
 /// forms are unchanged.
@@ -1669,11 +1669,30 @@ fn parse_unless_mana_payment(cost_str: &str) -> Option<AbilityCost> {
     }
 
     if cost_text == "{x}" || cost_text == "{X}" {
-        let remainder = &trimmed[cost_end..];
-        if let Some(quantity) = parse_where_x_is_trigger(remainder) {
+        let after_cost = &trimmed[cost_end..];
+        if let Some(quantity) = super::oracle_effect::parse_where_x_is(after_cost) {
             return Some(AbilityCost::ManaDynamic { quantity });
         }
-        return None;
+        if tag::<_, _, OracleError<'_>>("where x is ")
+            .parse(
+                after_cost
+                    .trim()
+                    .trim_start_matches(',')
+                    .trim()
+                    .to_lowercase()
+                    .as_str(),
+            )
+            .is_ok()
+        {
+            return None;
+        }
+        return Some(AbilityCost::ManaDynamic {
+            quantity: QuantityExpr::Ref {
+                qty: QuantityRef::Variable {
+                    name: "X".to_string(),
+                },
+            },
+        });
     }
 
     let mana_cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_text);
@@ -2390,7 +2409,7 @@ fn parse_unless_they_branch_by_verb(input: &str) -> Option<(AbilityCost, &str)> 
         let (cost, after) = parse_unless_they_discard_cost(rest)?;
         return Some((cost, after));
     }
-    // CR 117.3 + CR 702.24a: "pay(s) {mana}" / "{B} or {3}" disjunction
+    // CR 118.12a + CR 107.4: "pay(s) {mana}" / "{B} or {3}" disjunction
     if let Ok((rest, _)) = alt((tag::<_, _, OracleError<'_>>("pays "), tag("pay "))).parse(input) {
         let boundary = unless_branch_boundary(rest);
         let branch_text = rest[..boundary].trim();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -21,7 +21,6 @@ use super::oracle_nom::filter::{parse_enters_origin_zone, parse_with_property};
 use super::oracle_nom::primitives::{
     self as nom_primitives, scan_contains, scan_preceded, scan_split_at_phrase,
 };
-use super::oracle_nom::quantity as nom_quantity;
 use super::oracle_nom::target::parse_type_phrase as parse_type_phrase_nom;
 use super::oracle_static::parse_commander_subject_filter_prefix;
 use super::oracle_target::{

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1632,6 +1632,64 @@ fn strip_constraint_sentences(text: &str) -> String {
     }
 }
 
+/// CR 702.24a + CR 118.12a: Parse mana / energy unless-payment tails after
+/// "they pay " / "pays ". Disjunctive "{B} or {3}" lowers to `OneOf` of mana
+/// branches (Lim-Dul's Hex); single-mana, dynamic-{X}, and for-each-scaling
+/// forms are unchanged.
+fn parse_unless_mana_payment(cost_str: &str) -> Option<AbilityCost> {
+    let trimmed = cost_str.trim().trim_end_matches('.').trim();
+
+    if let Some(costs) = super::oracle_cost::parse_or_separated_mana_costs(trimmed) {
+        return Some(AbilityCost::OneOf {
+            costs: costs
+                .into_iter()
+                .map(|cost| AbilityCost::Mana { cost })
+                .collect(),
+        });
+    }
+
+    let cost_end = trimmed
+        .find(|c: char| c != '{' && c != '}' && !c.is_alphanumeric())
+        .unwrap_or(trimmed.len());
+    let cost_text = trimmed[..cost_end].trim();
+
+    if cost_text.is_empty() || !cost_text.contains('{') {
+        return None;
+    }
+
+    if let Some((amount, rest)) = super::oracle_effect::parse_fixed_energy_unless_cost(cost_text) {
+        if !rest.trim().is_empty() {
+            return None;
+        }
+        return Some(AbilityCost::PayEnergy {
+            amount: QuantityExpr::Fixed {
+                value: amount as i32,
+            },
+        });
+    }
+
+    if cost_text == "{x}" || cost_text == "{X}" {
+        let remainder = &trimmed[cost_end..];
+        if let Some(quantity) = parse_where_x_is_trigger(remainder) {
+            return Some(AbilityCost::ManaDynamic { quantity });
+        }
+        return None;
+    }
+
+    let mana_cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_text);
+    if mana_cost == crate::types::mana::ManaCost::NoCost
+        || mana_cost == crate::types::mana::ManaCost::zero()
+    {
+        return None;
+    }
+    if let Some(cost) =
+        super::oracle_effect::parse_unless_for_each_payment(&trimmed[cost_end..], &mana_cost)
+    {
+        return Some(cost);
+    }
+    Some(AbilityCost::Mana { cost: mana_cost })
+}
+
 /// CR 118.12: Detect "unless [player] pays {cost}" in trigger effect text.
 /// Returns (cleaned effect text without the unless clause, optional UnlessPayModifier).
 ///
@@ -1766,50 +1824,8 @@ fn extract_unless_pay_modifier(
         );
     }
 
-    // Extract cost symbols
-    let cost_end = cost_str
-        .find(|c: char| c != '{' && c != '}' && !c.is_alphanumeric())
-        .unwrap_or(cost_str.len());
-    let cost_text = cost_str[..cost_end].trim();
-
-    if cost_text.is_empty() || !cost_text.contains('{') {
+    let Some(cost) = parse_unless_mana_payment(cost_str) else {
         return (text.to_string(), None);
-    }
-
-    // Determine the cost type
-    let cost = if let Some((amount, rest)) =
-        super::oracle_effect::parse_fixed_energy_unless_cost(cost_text)
-    {
-        if !rest.trim().is_empty() {
-            return (text.to_string(), None);
-        }
-        AbilityCost::PayEnergy {
-            amount: QuantityExpr::Fixed {
-                value: amount as i32,
-            },
-        }
-    } else if cost_text == "{x}" || cost_text == "{X}" {
-        // Check for "where X is" clause
-        let remainder = &cost_str[cost_end..];
-        if let Some(quantity) = parse_where_x_is_trigger(remainder) {
-            AbilityCost::ManaDynamic { quantity }
-        } else {
-            return (text.to_string(), None);
-        }
-    } else {
-        let mana_cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_text);
-        if mana_cost == crate::types::mana::ManaCost::NoCost
-            || mana_cost == crate::types::mana::ManaCost::zero()
-        {
-            return (text.to_string(), None);
-        }
-        if let Some(cost) =
-            super::oracle_effect::parse_unless_for_each_payment(&cost_str[cost_end..], &mana_cost)
-        {
-            cost
-        } else {
-            AbilityCost::Mana { cost: mana_cost }
-        }
     };
 
     // Payer was already determined by the combinator above.
@@ -2374,8 +2390,13 @@ fn parse_unless_they_branch_by_verb(input: &str) -> Option<(AbilityCost, &str)> 
         let (cost, after) = parse_unless_they_discard_cost(rest)?;
         return Some((cost, after));
     }
-    // CR 119.4: "pay(s) N life"
+    // CR 117.3 + CR 702.24a: "pay(s) {mana}" / "{B} or {3}" disjunction
     if let Ok((rest, _)) = alt((tag::<_, _, OracleError<'_>>("pays "), tag("pay "))).parse(input) {
+        let boundary = unless_branch_boundary(rest);
+        let branch_text = rest[..boundary].trim();
+        if let Some(cost) = parse_unless_mana_payment(branch_text) {
+            return Some((cost, &rest[boundary..]));
+        }
         let (cost, after) = parse_unless_they_pay_life(rest)?;
         return Some((cost, after));
     }
@@ -23057,6 +23078,30 @@ mod tests {
             matches!(unless_pay.cost, AbilityCost::Mana { .. }),
             "cost should be Fixed mana, got {:?}",
             unless_pay.cost
+        );
+    }
+
+    #[test]
+    fn trigger_unless_they_pay_disjunctive_mana_builds_one_of() {
+        let def = parse_trigger_line(
+            "At the beginning of your upkeep, for each player, this enchantment deals 1 damage to that player unless they pay {B} or {3}.",
+            "Lim-Dul's Hex",
+        );
+        let unless_pay = def.unless_pay.as_ref().expect("should have unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::TriggeringPlayer);
+        let AbilityCost::OneOf { costs } = &unless_pay.cost else {
+            panic!("cost should be OneOf, got {:?}", unless_pay.cost);
+        };
+        assert_eq!(costs.len(), 2, "OneOf should have two mana branches: {costs:?}");
+        assert!(
+            matches!(&costs[0], AbilityCost::Mana { .. }),
+            "first branch should be Mana, got {:?}",
+            costs[0]
+        );
+        assert!(
+            matches!(&costs[1], AbilityCost::Mana { .. }),
+            "second branch should be Mana, got {:?}",
+            costs[1]
         );
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4066,6 +4066,11 @@ mod tests {
                 "Counter-Discard",
                 &["Instant"][..],
             ),
+            (
+                "At the beginning of your upkeep, for each player, this enchantment deals 1 damage to that player unless they pay {B} or {3}.",
+                "Lim-Dul's Hex",
+                &["Enchantment"][..],
+            ),
         ] {
             let parsed = parse_named(oracle, name, types);
             assert!(


### PR DESCRIPTION
## Summary

Lim-Dul's Hex (`…unless they pay {B} or {3}.`) was parsing the upkeep damage trigger without the disjunctive unless-payment alternative. The trigger-side unless extractor only read the first mana symbol after `they pay`, so `{B} or {3}` collapsed to a single `{B}` cost (or failed entirely).

This adds `parse_unless_mana_payment`, delegating to the existing `parse_or_separated_mana_costs` building block (same authority as cumulative upkeep / equip disjunctions) before the legacy single-mana path. The shared `parse_unless_they_branch_by_verb` path also recognizes mana branches for chained unless clauses.

## Test plan

- [x] `trigger_unless_they_pay_disjunctive_mana_builds_one_of` — Lim-Dul's Hex `OneOf` unless cost
- [x] `condition_unless_accepts_representative_cards` — Lim-Dul's Hex swallow regression
- [x] Existing unless-pay tests unchanged (single `{2}`, sacrifice-or-discard `OneOf`, etc.)

Closes #4442
