### PR TITLE
perf(engine): hoist O(N^2) static-ability scans out of combat/untap legality loops

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -18,6 +18,58 @@ use crate::types::statics::{
 };
 use crate::types::zones::Zone;
 
+/// CR 604.1: loop-invariant presence facts for the combat-restriction statics.
+///
+/// Combat legality loops iterate N battlefield permanents and, per permanent,
+/// call `check_static_ability` — itself an O(N) `game_functioning_statics`
+/// sweep — making each loop O(N^2). `compute` does ONE sweep up front and
+/// records, for each restriction mode, whether any functioning static of that
+/// mode exists. The per-permanent `check_static_ability` call is then gated
+/// behind the matching flag: when the flag is false the call would `continue`
+/// past every definition and return false anyway (`check_static_ability`
+/// rejects on `def.mode != mode` first), so `flag && check_static_ability(..)`
+/// is byte-identical to the original call while skipping the redundant scan.
+///
+/// Representation: five named compile-time presence flags, NOT a no-bool-flags
+/// anti-pattern — these are five independent existence facts, not one
+/// choice-encoding bool. An `EnumSet` is rejected because `enumset` is not a
+/// workspace dependency and `StaticMode` is not fieldless (it carries data
+/// variants such as `MaxUntapPerType { filter, max }` and `Other(String)`).
+/// Five named flags read clearer than a runtime set lookup.
+struct CombatStaticGates {
+    has_cant_attack: bool,
+    has_cant_attack_or_block: bool,
+    has_must_attack: bool,
+    has_goad: bool,
+    has_can_attack_with_defender: bool,
+}
+
+impl CombatStaticGates {
+    /// One `game_functioning_statics` sweep computing all five presence flags.
+    /// Does NOT increment the static-full-scan perf counter: this is the single
+    /// intended hoisted sweep, not a per-element legality scan.
+    fn compute(state: &GameState) -> Self {
+        let mut gates = CombatStaticGates {
+            has_cant_attack: false,
+            has_cant_attack_or_block: false,
+            has_must_attack: false,
+            has_goad: false,
+            has_can_attack_with_defender: false,
+        };
+        for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
+            match def.mode {
+                StaticMode::CantAttack => gates.has_cant_attack = true,
+                StaticMode::CantAttackOrBlock => gates.has_cant_attack_or_block = true,
+                StaticMode::MustAttack => gates.has_must_attack = true,
+                StaticMode::Goaded => gates.has_goad = true,
+                StaticMode::CanAttackWithDefender => gates.has_can_attack_with_defender = true,
+                _ => {}
+            }
+        }
+        gates
+    }
+}
+
 /// CR 702.19: Which trample variant applies to combat damage assignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TrampleKind {
@@ -381,6 +433,10 @@ pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Resul
         }
     }
 
+    // CR 604.1: hoist the combat-restriction existence gates once before the
+    // per-attacker scan (collapses O(N^2) to O(N)).
+    let gates = CombatStaticGates::compute(state);
+
     for &id in attacker_ids {
         let obj = state
             .objects
@@ -423,14 +479,15 @@ pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Resul
             let can_attack_with_defender =
                 super::functioning_abilities::active_static_definitions(state, obj)
                     .any(|sd| sd.mode == StaticMode::CanAttackWithDefender)
-                    || crate::game::static_abilities::check_static_ability(
-                        state,
-                        StaticMode::CanAttackWithDefender,
-                        &crate::game::static_abilities::StaticCheckContext {
-                            target_id: Some(id),
-                            ..Default::default()
-                        },
-                    );
+                    || (gates.has_can_attack_with_defender
+                        && crate::game::static_abilities::check_static_ability(
+                            state,
+                            StaticMode::CanAttackWithDefender,
+                            &crate::game::static_abilities::StaticCheckContext {
+                                target_id: Some(id),
+                                ..Default::default()
+                            },
+                        ));
             if !can_attack_with_defender {
                 return Err(format!("{:?} has Defender", id));
             }
@@ -446,21 +503,25 @@ pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Resul
                 sd.mode,
                 StaticMode::CantAttack | StaticMode::CantAttackOrBlock
             ) && sd.attack_defended.is_none()
-        }) || crate::game::static_abilities::check_static_ability(
-            state,
-            StaticMode::CantAttack,
-            &crate::game::static_abilities::StaticCheckContext {
-                target_id: Some(id),
-                ..Default::default()
-            },
-        ) || crate::game::static_abilities::check_static_ability(
-            state,
-            StaticMode::CantAttackOrBlock,
-            &crate::game::static_abilities::StaticCheckContext {
-                target_id: Some(id),
-                ..Default::default()
-            },
-        ) {
+        }) || (gates.has_cant_attack
+            && crate::game::static_abilities::check_static_ability(
+                state,
+                StaticMode::CantAttack,
+                &crate::game::static_abilities::StaticCheckContext {
+                    target_id: Some(id),
+                    ..Default::default()
+                },
+            ))
+            || (gates.has_cant_attack_or_block
+                && crate::game::static_abilities::check_static_ability(
+                    state,
+                    StaticMode::CantAttackOrBlock,
+                    &crate::game::static_abilities::StaticCheckContext {
+                        target_id: Some(id),
+                        ..Default::default()
+                    },
+                ))
+        {
             return Err(format!("{:?} can't attack", id));
         }
 
@@ -1374,6 +1435,13 @@ pub fn validate_blockers_for_player(
         // player's declaration.
         // If a defending creature has MustBlock and isn't assigned as a blocker,
         // verify it couldn't legally block any attacker.
+        // CR 604.1: hoist the MustBlock existence gate once before iterating N
+        // permanents so the per-permanent `check_static_ability` re-scan is
+        // skipped when no functioning MustBlock static exists (O(N^2) -> O(N)).
+        let has_must_block_static =
+            super::functioning_abilities::any_functioning_static_mode(state, |m| {
+                matches!(m, StaticMode::MustBlock)
+            });
         for &obj_id in &state.battlefield {
             let Some(obj) = state.objects.get(&obj_id) else {
                 continue;
@@ -1390,14 +1458,15 @@ pub fn validate_blockers_for_player(
             let has_must_block =
                 super::functioning_abilities::active_static_definitions(state, obj)
                     .any(|sd| sd.mode == StaticMode::MustBlock)
-                    || crate::game::static_abilities::check_static_ability(
-                        state,
-                        StaticMode::MustBlock,
-                        &crate::game::static_abilities::StaticCheckContext {
-                            target_id: Some(obj_id),
-                            ..Default::default()
-                        },
-                    );
+                    || (has_must_block_static
+                        && crate::game::static_abilities::check_static_ability(
+                            state,
+                            StaticMode::MustBlock,
+                            &crate::game::static_abilities::StaticCheckContext {
+                                target_id: Some(obj_id),
+                                ..Default::default()
+                            },
+                        ));
             if !has_must_block {
                 continue;
             }
@@ -1902,6 +1971,19 @@ fn creature_must_attack_with_attackable_players(
     obj_id: ObjectId,
     attackable_players: &[PlayerId],
 ) -> bool {
+    // Single-permanent entry: compute the loop-invariant gates once, then
+    // delegate. The single batch caller (`declare_attackers_with_bands`) reuses
+    // its already-hoisted gates via the `_gated` form below.
+    let gates = CombatStaticGates::compute(state);
+    creature_must_attack_with_attackable_players_gated(state, obj_id, attackable_players, &gates)
+}
+
+fn creature_must_attack_with_attackable_players_gated(
+    state: &GameState,
+    obj_id: ObjectId,
+    attackable_players: &[PlayerId],
+    gates: &CombatStaticGates,
+) -> bool {
     let Some(obj) = state.objects.get(&obj_id) else {
         return false;
     };
@@ -1916,16 +1998,17 @@ fn creature_must_attack_with_attackable_players(
     // cross-permanent static (e.g., "All creatures attack each combat if able").
     let has_must_attack = super::functioning_abilities::active_static_definitions(state, obj)
         .any(|sd| sd.mode == StaticMode::MustAttack)
-        || crate::game::static_abilities::check_static_ability(
-            state,
-            StaticMode::MustAttack,
-            &crate::game::static_abilities::StaticCheckContext {
-                target_id: Some(obj_id),
-                ..Default::default()
-            },
-        );
+        || (gates.has_must_attack
+            && crate::game::static_abilities::check_static_ability(
+                state,
+                StaticMode::MustAttack,
+                &crate::game::static_abilities::StaticCheckContext {
+                    target_id: Some(obj_id),
+                    ..Default::default()
+                },
+            ));
     // CR 701.15b: Goaded creatures must attack each combat if able.
-    let is_goaded = !goading_players_for_creature(state, obj_id).is_empty();
+    let is_goaded = !goading_players_for_creature_gated(state, obj_id, gates.has_goad).is_empty();
     let has_attackable_must_attack_player = must_attack_players_for_creature(state, obj)
         .iter()
         .any(|player| attackable_players.contains(player));
@@ -1942,14 +2025,15 @@ fn creature_must_attack_with_attackable_players(
         let can_attack_with_defender =
             super::functioning_abilities::active_static_definitions(state, obj)
                 .any(|sd| sd.mode == StaticMode::CanAttackWithDefender)
-                || crate::game::static_abilities::check_static_ability(
-                    state,
-                    StaticMode::CanAttackWithDefender,
-                    &crate::game::static_abilities::StaticCheckContext {
-                        target_id: Some(obj_id),
-                        ..Default::default()
-                    },
-                );
+                || (gates.has_can_attack_with_defender
+                    && crate::game::static_abilities::check_static_ability(
+                        state,
+                        StaticMode::CanAttackWithDefender,
+                        &crate::game::static_abilities::StaticCheckContext {
+                            target_id: Some(obj_id),
+                            ..Default::default()
+                        },
+                    ));
         if !can_attack_with_defender {
             return false;
         }
@@ -2215,13 +2299,22 @@ pub fn declare_attackers_with_bands(
         validate_attack_band_declarations(state, attacks, bands)?;
     }
     let attackable_players = attackable_player_targets(state);
+    // CR 604.1: hoist the combat-restriction existence gates once; every
+    // per-permanent / per-attacker static check below reuses them so each loop
+    // stays O(N) instead of O(N^2).
+    let gates = CombatStaticGates::compute(state);
 
     // CR 508.1d / CR 701.15b: Creatures that must attack each combat if able.
     // `creature_must_attack` is the single authority for the requirement +
     // exemption logic; this loop only adds the "already declared?" check and
     // the rejection error text.
     for &obj_id in &state.battlefield {
-        if !creature_must_attack_with_attackable_players(state, obj_id, &attackable_players) {
+        if !creature_must_attack_with_attackable_players_gated(
+            state,
+            obj_id,
+            &attackable_players,
+            &gates,
+        ) {
             continue;
         }
         // Already declared as attacker — constraint satisfied
@@ -2230,7 +2323,7 @@ pub fn declare_attackers_with_bands(
         }
         // Creature could legally attack but wasn't declared.
         // CR 701.15b: goad-specific error text; CR 508.1d otherwise.
-        if !goading_players_for_creature(state, obj_id).is_empty() {
+        if !goading_players_for_creature_gated(state, obj_id, gates.has_goad).is_empty() {
             return Err(format!(
                 "{:?} is goaded and must attack this combat if able (CR 701.15b)",
                 obj_id
@@ -2314,23 +2407,27 @@ pub fn declare_attackers_with_bands(
     // CR 508.1d: Scoped remote CantAttack (Eriette — enchanted creatures can't
     // attack you or planeswalkers you control).
     for (attacker_id, target) in attacks {
-        if crate::game::static_abilities::check_static_ability(
-            state,
-            StaticMode::CantAttack,
-            &crate::game::static_abilities::StaticCheckContext {
-                target_id: Some(*attacker_id),
-                attack_target: Some(*target),
-                ..Default::default()
-            },
-        ) || crate::game::static_abilities::check_static_ability(
-            state,
-            StaticMode::CantAttackOrBlock,
-            &crate::game::static_abilities::StaticCheckContext {
-                target_id: Some(*attacker_id),
-                attack_target: Some(*target),
-                ..Default::default()
-            },
-        ) {
+        if (gates.has_cant_attack
+            && crate::game::static_abilities::check_static_ability(
+                state,
+                StaticMode::CantAttack,
+                &crate::game::static_abilities::StaticCheckContext {
+                    target_id: Some(*attacker_id),
+                    attack_target: Some(*target),
+                    ..Default::default()
+                },
+            ))
+            || (gates.has_cant_attack_or_block
+                && crate::game::static_abilities::check_static_ability(
+                    state,
+                    StaticMode::CantAttackOrBlock,
+                    &crate::game::static_abilities::StaticCheckContext {
+                        target_id: Some(*attacker_id),
+                        attack_target: Some(*target),
+                        ..Default::default()
+                    },
+                ))
+        {
             return Err(format!(
                 "{attacker_id:?} can't attack {target:?} (CR 508.1d attack restriction)"
             ));
@@ -2412,7 +2509,8 @@ pub fn declare_attackers_with_bands(
     // actually attack.
     for (attacker_id, target) in attacks {
         if let AttackTarget::Player(defending_pid) = target {
-            let goading_players = goading_players_for_creature(state, *attacker_id);
+            let goading_players =
+                goading_players_for_creature_gated(state, *attacker_id, gates.has_goad);
             if goading_players.is_empty() {
                 continue;
             }
@@ -2581,22 +2679,47 @@ pub(crate) fn goading_players_for_creature(
     state: &GameState,
     creature_id: ObjectId,
 ) -> HashSet<PlayerId> {
+    goading_players_for_creature_gated(
+        state,
+        creature_id,
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::Goaded)
+        }),
+    )
+}
+
+/// Loop-invariant-gated form of [`goading_players_for_creature`].
+///
+/// CR 701.15b: with no functioning `Goaded` static, only the directly-goaded
+/// `goaded_by` set applies, so combat loops that have already hoisted the
+/// existence gate pass `has_goad_static = false` to skip the O(N) sweep. When
+/// `true`, the exact existing sweep runs unchanged. The gate is computed over
+/// `game_functioning_statics` (a superset of `battlefield_active_statics` for
+/// `Goaded`), so it never produces a false negative.
+pub(crate) fn goading_players_for_creature_gated(
+    state: &GameState,
+    creature_id: ObjectId,
+    has_goad_static: bool,
+) -> HashSet<PlayerId> {
     let mut players = state
         .objects
         .get(&creature_id)
         .map(|obj| obj.goaded_by.clone())
         .unwrap_or_default();
 
-    for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
-        if def.mode != StaticMode::Goaded {
-            continue;
-        }
-        let Some(affected) = &def.affected else {
-            continue;
-        };
-        let ctx = FilterContext::from_source(state, source.id);
-        if matches_target_filter(state, creature_id, affected, &ctx) {
-            players.insert(source.controller);
+    if has_goad_static {
+        crate::game::perf_counters::record_static_full_scan();
+        for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
+            if def.mode != StaticMode::Goaded {
+                continue;
+            }
+            let Some(affected) = &def.affected else {
+                continue;
+            };
+            let ctx = FilterContext::from_source(state, source.id);
+            if matches_target_filter(state, creature_id, affected, &ctx) {
+                players.insert(source.controller);
+            }
         }
     }
 
@@ -2749,6 +2872,9 @@ pub fn has_summoning_sickness(obj: &GameObject) -> bool {
 /// CR 702.26b: Phased-out creatures can't attack.
 pub fn get_valid_attacker_ids(state: &GameState) -> Vec<ObjectId> {
     let active = state.active_player;
+    // CR 604.1: hoist the combat-restriction existence gates once before the
+    // per-permanent scan (collapses O(N^2) to O(N)).
+    let gates = CombatStaticGates::compute(state);
 
     state
         .battlefield_phased_in_ids()
@@ -2761,14 +2887,15 @@ pub fn get_valid_attacker_ids(state: &GameState) -> Vec<ObjectId> {
                 && (!obj.has_keyword(&Keyword::Defender)
                     || super::functioning_abilities::active_static_definitions(state, obj)
                         .any(|sd| sd.mode == StaticMode::CanAttackWithDefender)
-                    || crate::game::static_abilities::check_static_ability(
-                        state,
-                        StaticMode::CanAttackWithDefender,
-                        &crate::game::static_abilities::StaticCheckContext {
-                            target_id: Some(*id),
-                            ..Default::default()
-                        },
-                    ))
+                    || (gates.has_can_attack_with_defender
+                        && crate::game::static_abilities::check_static_ability(
+                            state,
+                            StaticMode::CanAttackWithDefender,
+                            &crate::game::static_abilities::StaticCheckContext {
+                                target_id: Some(*id),
+                                ..Default::default()
+                            },
+                        )))
                 && !super::functioning_abilities::active_static_definitions(state, obj).any(|sd| {
                     matches!(
                         sd.mode,
@@ -2778,22 +2905,24 @@ pub fn get_valid_attacker_ids(state: &GameState) -> Vec<ObjectId> {
                 // CR 508.1 + CR 101.2 + CR 109.5: remote CantAttack statics
                 // (Angelic Arbiter restricting opponents' creatures) resolved via
                 // the shared `check_static_ability` building block.
-                && !crate::game::static_abilities::check_static_ability(
-                    state,
-                    StaticMode::CantAttack,
-                    &crate::game::static_abilities::StaticCheckContext {
-                        target_id: Some(*id),
-                        ..Default::default()
-                    },
-                )
-                && !crate::game::static_abilities::check_static_ability(
-                    state,
-                    StaticMode::CantAttackOrBlock,
-                    &crate::game::static_abilities::StaticCheckContext {
-                        target_id: Some(*id),
-                        ..Default::default()
-                    },
-                )
+                && !(gates.has_cant_attack
+                    && crate::game::static_abilities::check_static_ability(
+                        state,
+                        StaticMode::CantAttack,
+                        &crate::game::static_abilities::StaticCheckContext {
+                            target_id: Some(*id),
+                            ..Default::default()
+                        },
+                    ))
+                && !(gates.has_cant_attack_or_block
+                    && crate::game::static_abilities::check_static_ability(
+                        state,
+                        StaticMode::CantAttackOrBlock,
+                        &crate::game::static_abilities::StaticCheckContext {
+                            target_id: Some(*id),
+                            ..Default::default()
+                        },
+                    ))
                 // CR 302.6: delegate to the single authority for summoning
                 // sickness — folds in Haste at query time without duplicating
                 // the flag/keyword logic here.
@@ -3542,6 +3671,9 @@ pub fn prune_attackers_not_in_play(state: &mut GameState) {
 pub fn has_potential_attackers(state: &GameState) -> bool {
     let active = state.active_player;
     let turn = state.turn_number;
+    // CR 604.1: hoist the combat-restriction existence gates once before the
+    // per-permanent scan (collapses O(N^2) to O(N)).
+    let gates = CombatStaticGates::compute(state);
 
     state.battlefield.iter().any(|id| {
         state
@@ -3554,14 +3686,15 @@ pub fn has_potential_attackers(state: &GameState) -> bool {
                     && (!obj.has_keyword(&Keyword::Defender)
                         || super::functioning_abilities::active_static_definitions(state, obj)
                             .any(|sd| sd.mode == StaticMode::CanAttackWithDefender)
-                        || crate::game::static_abilities::check_static_ability(
-                            state,
-                            StaticMode::CanAttackWithDefender,
-                            &crate::game::static_abilities::StaticCheckContext {
-                                target_id: Some(*id),
-                                ..Default::default()
-                            },
-                        ))
+                        || (gates.has_can_attack_with_defender
+                            && crate::game::static_abilities::check_static_ability(
+                                state,
+                                StaticMode::CanAttackWithDefender,
+                                &crate::game::static_abilities::StaticCheckContext {
+                                    target_id: Some(*id),
+                                    ..Default::default()
+                                },
+                            )))
                     && !super::functioning_abilities::active_static_definitions(state, obj).any(
                         |sd| {
                             matches!(
@@ -3572,22 +3705,24 @@ pub fn has_potential_attackers(state: &GameState) -> bool {
                     )
                     // CR 508.1 + CR 101.2 + CR 109.5: remote CantAttack statics
                     // (Angelic Arbiter) resolved via `check_static_ability`.
-                    && !crate::game::static_abilities::check_static_ability(
-                        state,
-                        StaticMode::CantAttack,
-                        &crate::game::static_abilities::StaticCheckContext {
-                            target_id: Some(*id),
-                            ..Default::default()
-                        },
-                    )
-                    && !crate::game::static_abilities::check_static_ability(
-                        state,
-                        StaticMode::CantAttackOrBlock,
-                        &crate::game::static_abilities::StaticCheckContext {
-                            target_id: Some(*id),
-                            ..Default::default()
-                        },
-                    )
+                    && !(gates.has_cant_attack
+                        && crate::game::static_abilities::check_static_ability(
+                            state,
+                            StaticMode::CantAttack,
+                            &crate::game::static_abilities::StaticCheckContext {
+                                target_id: Some(*id),
+                                ..Default::default()
+                            },
+                        ))
+                    && !(gates.has_cant_attack_or_block
+                        && crate::game::static_abilities::check_static_ability(
+                            state,
+                            StaticMode::CantAttackOrBlock,
+                            &crate::game::static_abilities::StaticCheckContext {
+                                target_id: Some(*id),
+                                ..Default::default()
+                            },
+                        ))
                     && (obj.has_keyword(&Keyword::Haste)
                         || obj.entered_battlefield_turn.is_some_and(|etb| etb < turn))
             })
@@ -3674,6 +3809,108 @@ mod tests {
         obj.chosen_attributes
             .push(crate::types::ability::ChosenAttribute::Player(protector));
         id
+    }
+
+    /// CR 604.1: a restriction-free board of K active-player attackers must NOT
+    /// trigger any whole-battlefield `check_static_ability` scan in
+    /// `get_valid_attacker_ids` — the `CombatStaticGates` hoist gates every
+    /// per-permanent scan off. Reverting the gate makes `static_full_scans`
+    /// jump to O(K) (2 scans per vanilla creature here — CantAttack and
+    /// CantAttackOrBlock; CanAttackWithDefender is short-circuited by
+    /// `!Defender`), failing the `== 0` assertion.
+    #[test]
+    fn get_valid_attacker_ids_no_static_scan_on_vanilla_board() {
+        let mut state = setup();
+        let ids: Vec<ObjectId> = (0..8)
+            .map(|i| create_creature(&mut state, PlayerId(0), &format!("Bear {i}"), 2, 2))
+            .collect();
+
+        crate::game::perf_counters::reset();
+        let valid = get_valid_attacker_ids(&state);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert_eq!(valid.len(), ids.len(), "all vanilla creatures can attack");
+        assert_eq!(
+            scans, 0,
+            "no static-ability whole-board scan on a vanilla board"
+        );
+    }
+
+    /// CR 604.1: `has_potential_attackers` gates the same three per-permanent
+    /// scans behind the hoisted existence flags.
+    #[test]
+    fn has_potential_attackers_no_static_scan_on_vanilla_board() {
+        let mut state = setup();
+        for i in 0..8 {
+            create_creature(&mut state, PlayerId(0), &format!("Bear {i}"), 2, 2);
+        }
+
+        crate::game::perf_counters::reset();
+        let any = has_potential_attackers(&state);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(any, "vanilla untapped creatures are potential attackers");
+        assert_eq!(
+            scans, 0,
+            "no static-ability whole-board scan on a vanilla board"
+        );
+    }
+
+    /// CR 604.1: declaring K vanilla attackers exercises Sites 2A/2B/2C/2D
+    /// (validate_attackers, the must-attack loop, the scoped CantAttack loop and
+    /// the goad-redirect loop). With no functioning combat-restriction static,
+    /// the single hoisted `CombatStaticGates` sweep gates every per-permanent /
+    /// per-attacker `check_static_ability` off, so the declaration costs zero
+    /// whole-board scans. Reverting any gate restores O(K) scans.
+    #[test]
+    fn declare_attackers_no_static_scan_on_vanilla_board() {
+        let mut state = setup();
+        let ids: Vec<ObjectId> = (0..8)
+            .map(|i| create_creature(&mut state, PlayerId(0), &format!("Bear {i}"), 2, 2))
+            .collect();
+        let attacks: Vec<(ObjectId, AttackTarget)> = ids
+            .iter()
+            .map(|id| (*id, AttackTarget::Player(PlayerId(1))))
+            .collect();
+
+        crate::game::perf_counters::reset();
+        let mut events = Vec::new();
+        let result = declare_attackers_with_bands(&mut state, &attacks, &[], &mut events);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            result.is_ok(),
+            "declaring vanilla attackers is legal: {result:?}"
+        );
+        assert_eq!(
+            scans, 0,
+            "no static-ability whole-board scan on a vanilla declaration"
+        );
+    }
+
+    /// CR 604.1: the `validate_blockers_for_player` MustBlock loop gates its
+    /// per-permanent scan behind a hoisted `any_functioning_static_mode`
+    /// existence check, so validating an empty block on a vanilla board costs
+    /// zero whole-board scans.
+    #[test]
+    fn validate_blockers_no_static_scan_on_vanilla_board() {
+        let mut state = setup();
+        for i in 0..8 {
+            create_creature(&mut state, PlayerId(1), &format!("Wall {i}"), 0, 4);
+        }
+
+        crate::game::perf_counters::reset();
+        let result = validate_blockers_for_player(&state, PlayerId(1), &[]);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            result.is_ok(),
+            "an empty block is legal with no must-block: {result:?}"
+        );
+        assert_eq!(
+            scans, 0,
+            "no static-ability whole-board scan with no MustBlock static"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -207,6 +207,20 @@ pub fn game_functioning_statics(
         })
 }
 
+/// CR 604.1: loop-invariant existence gate. True iff any currently-functioning
+/// static (battlefield permanent or CR 114.4 command-zone emblem; CR 702.26b
+/// phased-out excluded) has a mode matching `predicate`. Combat/untap legality
+/// loops hoist this ONCE before iterating N permanents so the per-permanent
+/// `check_static_ability` re-scan (itself O(N)) is skipped when no such static
+/// exists, collapsing O(N^2) to O(N). When one exists the loop falls through to
+/// the exact existing per-permanent check, so verdicts are unchanged.
+pub fn any_functioning_static_mode(
+    state: &GameState,
+    predicate: impl Fn(&StaticMode) -> bool,
+) -> bool {
+    game_functioning_statics(state).any(|(_, def)| predicate(&def.mode))
+}
+
 /// Like `battlefield_active_statics` but WITHOUT condition filtering.
 ///
 /// Applies only the CR 702.26b phased-out gate and the CR 114.4

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct PerfCounterSnapshot {
     pub state_clone_for_legality: u64,
+    pub static_full_scans: u64,
     pub layers_full_eval: u64,
     pub layers_incremental: u64,
     pub layers_escalated: u64,
@@ -30,6 +31,7 @@ thread_local! {
     /// `AtomicU64`: that reintroduces the parallel-test flakiness this replaces.
     static COUNTERS: Cell<PerfCounterSnapshot> = const { Cell::new(PerfCounterSnapshot {
         state_clone_for_legality: 0,
+        static_full_scans: 0,
         layers_full_eval: 0,
         layers_incremental: 0,
         layers_escalated: 0,
@@ -54,6 +56,14 @@ fn with_mut(f: impl FnOnce(&mut PerfCounterSnapshot)) {
 
 pub fn record_state_clone_for_legality() {
     with_mut(|s| s.state_clone_for_legality += 1);
+}
+
+/// Counts every whole-battlefield / command-zone static sweep done for legality
+/// (each `check_static_ability` call). Combat/untap legality loops hoist a
+/// once-computed existence gate to drive this toward zero, collapsing O(N^2)
+/// per-loop scans to O(N).
+pub fn record_static_full_scan() {
+    with_mut(|s| s.static_full_scans += 1);
 }
 
 pub fn record_layers_full_eval() {

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -662,6 +662,10 @@ pub fn check_static_ability(
     mode: StaticMode,
     context: &StaticCheckContext,
 ) -> bool {
+    // Perf: this is the O(N) whole-battlefield sweep that combat/untap legality
+    // loops hoist an existence gate in front of (see
+    // `functioning_abilities::any_functioning_static_mode`).
+    crate::game::perf_counters::record_static_full_scan();
     // CR 114.4: Abilities of emblems function in the command zone.
     // Check both battlefield objects and command zone emblems. The functioning
     // gate is applied before context-specific condition evaluation below.

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -831,6 +831,14 @@ pub fn execute_untap_with_choices(
     // SpecificObject transients; this loop covers the printed-static and
     // filter-scoped-transient classes so the actual untap agrees with the
     // cap-prompt group built by `untap_excluded_ids`.
+    // CR 502.3 + CR 604.1: hoist the CantUntap existence gate once before the
+    // per-permanent scan so the O(N) `check_static_ability` re-scan is skipped
+    // for every permanent when no functioning CantUntap static exists
+    // (O(N^2) -> O(N) on the every-turn untap step).
+    let has_cant_untap_static =
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::CantUntap)
+        });
     let intrinsic_cant_untap: HashSet<ObjectId> = state
         .battlefield
         .iter()
@@ -840,18 +848,20 @@ pub fn execute_untap_with_choices(
                 .objects
                 .get(id)
                 .is_some_and(|obj| obj.controller == active)
-                && (super::static_abilities::check_static_ability(
-                    state,
-                    StaticMode::CantUntap,
-                    &super::static_abilities::StaticCheckContext {
-                        target_id: Some(*id),
-                        ..Default::default()
-                    },
-                ) || super::static_abilities::transient_grants_static_mode_to_object(
-                    state,
-                    *id,
-                    &StaticMode::CantUntap,
-                ))
+                && ((has_cant_untap_static
+                    && super::static_abilities::check_static_ability(
+                        state,
+                        StaticMode::CantUntap,
+                        &super::static_abilities::StaticCheckContext {
+                            target_id: Some(*id),
+                            ..Default::default()
+                        },
+                    ))
+                    || super::static_abilities::transient_grants_static_mode_to_object(
+                        state,
+                        *id,
+                        &StaticMode::CantUntap,
+                    ))
         })
         .collect();
 
@@ -1047,6 +1057,13 @@ pub fn max_untap_subset_prompt(
     player: PlayerId,
     chosen_not_to_untap: &HashSet<ObjectId>,
 ) -> Option<(Vec<ObjectId>, usize)> {
+    // CR 502.3: with no `MaxUntapPerType` cap in play there is nothing to prompt,
+    // so bail before the O(N) `untap_excluded_ids` CantUntap scan — the common
+    // every-turn case has no cap and would otherwise pay for a scan whose result
+    // is discarded.
+    if max_untap_restrictions(state).is_empty() {
+        return None;
+    }
     let cant_untap = untap_excluded_ids(state, player);
     for (filter, max) in max_untap_restrictions(state) {
         let group =
@@ -1085,6 +1102,12 @@ fn untap_excluded_ids(state: &GameState, player: PlayerId) -> HashSet<ObjectId> 
             }
         })
         .collect();
+    // CR 502.3 + CR 604.1: hoist the CantUntap existence gate once before the
+    // per-permanent scan (O(N^2) -> O(N) when no functioning CantUntap exists).
+    let has_cant_untap_static =
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::CantUntap)
+        });
     for id in state.battlefield.iter().copied() {
         let Some(obj) = state.objects.get(&id) else {
             continue;
@@ -1094,14 +1117,15 @@ fn untap_excluded_ids(state: &GameState, player: PlayerId) -> HashSet<ObjectId> 
         }
         // CR 502.3 + CR 604.1: permanent-sourced printed/static CantUntap
         // (including attached-subject Aura restrictions).
-        let intrinsic = super::static_abilities::check_static_ability(
-            state,
-            StaticMode::CantUntap,
-            &super::static_abilities::StaticCheckContext {
-                target_id: Some(id),
-                ..Default::default()
-            },
-        );
+        let intrinsic = has_cant_untap_static
+            && super::static_abilities::check_static_ability(
+                state,
+                StaticMode::CantUntap,
+                &super::static_abilities::StaticCheckContext {
+                    target_id: Some(id),
+                    ..Default::default()
+                },
+            );
         // CR 502.3 + CR 611.1: filter-scoped transient CantUntap (a spell/effect
         // installing "creatures don't untap …" by typed/filter target rather
         // than a single SpecificObject). Build for the whole class so any such
@@ -3853,7 +3877,13 @@ mod tests {
         attach_to(&mut state, aura, host);
 
         let mut events = Vec::new();
+        // CR 604.1: a functioning CantUntap static IS present, so the hoisted
+        // existence gate is true and the per-permanent `check_static_ability`
+        // scan MUST still run — proving the gate does not suppress real scans on
+        // the gate=true path.
+        crate::game::perf_counters::reset();
         execute_untap(&mut state, &mut events);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
 
         assert!(
             state.objects[&host].tapped,
@@ -3864,6 +3894,10 @@ mod tests {
                 matches!(event, GameEvent::PermanentUntapped { object_id } if *object_id == host)
             }),
             "skipped untap must not emit PermanentUntapped"
+        );
+        assert!(
+            scans > 0,
+            "gate=true path must still run the real per-permanent CantUntap scan"
         );
     }
 
@@ -3901,6 +3935,88 @@ mod tests {
         obj.card_types.core_types.push(CoreType::Creature);
         obj.tapped = true;
         id
+    }
+
+    /// CR 502.3 + CR 604.1: GAP-1 guard. The every-turn untap of K tapped
+    /// active-player permanents on a restriction-free board must NOT perform any
+    /// whole-battlefield `check_static_ability` scan — the hoisted CantUntap
+    /// existence gate is false, so the per-permanent scan is skipped. Reverting
+    /// the gate restores O(K) scans, failing the `== 0` assertion. Drives the
+    /// production `execute_untap`, not the prompt helper.
+    #[test]
+    fn execute_untap_no_static_scan_on_vanilla_board() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        let ids: Vec<ObjectId> = (0..8)
+            .map(|i| create_tapped_creature(&mut state, 100 + i, &format!("Bear {i}")))
+            .collect();
+
+        crate::game::perf_counters::reset();
+        let mut events = Vec::new();
+        execute_untap(&mut state, &mut events);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        for id in &ids {
+            assert!(!state.objects[id].tapped, "vanilla permanent must untap");
+        }
+        assert_eq!(
+            scans, 0,
+            "no static-ability whole-board scan on a vanilla untap"
+        );
+    }
+
+    /// CR 502.3 + CR 604.1: with a `MaxUntapPerType` cap present but no
+    /// functioning CantUntap static, `max_untap_subset_prompt` reaches
+    /// `untap_excluded_ids`, whose per-permanent CantUntap scan is gated off by
+    /// the hoisted existence flag — so building the over-cap group costs zero
+    /// whole-board scans even though it does NOT bail early.
+    #[test]
+    fn max_untap_subset_prompt_no_cant_untap_scan_with_cap() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        let smoke = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Smoke".to_string(),
+            Zone::Battlefield,
+        );
+        install_max_untap_one_creature_static(&mut state, smoke);
+        create_tapped_creature(&mut state, 2, "Bear A");
+        create_tapped_creature(&mut state, 3, "Bear B");
+
+        crate::game::perf_counters::reset();
+        let prompt = max_untap_subset_prompt(&state, PlayerId(0), &HashSet::new());
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            prompt.is_some(),
+            "two tapped creatures exceed the cap of one"
+        );
+        assert_eq!(
+            scans, 0,
+            "no CantUntap whole-board scan when no such static exists"
+        );
+    }
+
+    /// CR 502.3: with no `MaxUntapPerType` cap in play, `max_untap_subset_prompt`
+    /// bails before the `untap_excluded_ids` CantUntap scan — proving the
+    /// early-return short-circuit. Reverting the bail makes the scan run over the
+    /// tapped board, raising `static_full_scans` above zero.
+    #[test]
+    fn max_untap_subset_prompt_bails_without_cap_no_scan() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        for i in 0..8 {
+            create_tapped_creature(&mut state, 200 + i, &format!("Bear {i}"));
+        }
+
+        crate::game::perf_counters::reset();
+        let prompt = max_untap_subset_prompt(&state, PlayerId(0), &HashSet::new());
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(prompt.is_none(), "no cap means nothing to prompt");
+        assert_eq!(scans, 0, "bail short-circuits before any whole-board scan");
     }
 
     /// CR 502.3: With a Smoke-class cap of one creature and two tapped


### PR DESCRIPTION
## Problem

On a large token board (Unbeatable Squirrel Girl: 702 Squirrels + Cryptolith Rite, ~760 battlefield permanents), declaring attackers and passing priority crawled. Root cause: several combat/untap legality operations are **O(N²)** in battlefield size — each loops over N permanents and calls `check_static_ability` (itself an O(N) `game_functioning_statics` sweep) per element.

`GameState` uses `im` persistent collections, so cloning is O(1) — the cost is the repeated full-battlefield static scans, not memory.

## Fix — early-gating (byte-identical)

Hoist a single "does any functioning static of MODE exist?" existence check before each loop, and gate the per-element scan behind it. Because `check_static_ability` returns `false` when no static of that mode exists (it `continue`s on `def.mode != mode`), `gate && check_static_ability(MODE, ctx)` is **byte-identical** to the original call: when the gate is false the call would have returned false anyway; when true, the **exact** original call runs with its full CR gate stack intact (affected filter, condition, `attack_defended` scope CR 508.1d, `per_player_condition` CR 101.2/109.5). Precompute was rejected precisely because it would force re-implementing those matchers.

No verdict changes. No serialized-state change.

### New building blocks (engine only)
- `any_functioning_static_mode` — the loop-invariant existence gate primitive (CR 604.1).
- `CombatStaticGates::compute` — one `game_functioning_statics` sweep → 5 attack-restriction existence flags, shared across the attacker seams.
- `goading_players_for_creature_gated` / gated must-attack helper — skip the goad sweep when no `Goaded` static exists, still returning the base `goaded_by` set (CR 701.15b).
- `static_full_scans` perf counter — incremented at the sole scan authority (`check_static_ability`), so revert-failing tests assert the per-element scan count stays 0 on restriction-free boards.

### Gated seams
`get_valid_attacker_ids`, `has_potential_attackers`, `validate_attackers`, `declare_attackers_with_bands` (must-attack / scoped CantAttack / goad redirect), `validate_blockers_for_player` (MustBlock), `execute_untap_with_choices` + `untap_excluded_ids` (CantUntap), and a `max_untap_subset_prompt` early-bail. The untap path was the every-turn O(N²) — its regression guard drives the production `execute_untap`, not a prompt helper.

## Tests
Revert-failing `static_full_scans == 0` guards per seam, plus gate=true behavior tests (scoped/per-player CantAttack, MustBlock, CantUntap held tapped with `scans > 0`, goad redirect) proving no restriction is dropped.

Verification: `cargo fmt` clean, `clippy -p engine --all-targets` clean, `cargo test -p engine --lib` = 13690 passed / 0 failed.

## Deferred (Tier-2 follow-ups)
- `blocker_can_block_shadow` (CanBlockShadow — pairwise/cold path, needs a different precompute shape).
- The AI single-permanent `creature_must_attack` wrapper (recomputes gates per call in AI enumerators; strictly faster than pre-fix, not a regression).
- Separately found O(N²): auto-pass `legal_actions` re-enumeration, `taps_for_mana_aura_bonus`, crew/saddle/station eligibility, `expand_granted_activated_abilities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
