### PR TITLE
fix(engine): apply mass force-block to all matching creatures (Predatory Rampage)

### DIFF
--- a/crates/engine/src/game/effects/force_block.rs
+++ b/crates/engine/src/game/effects/force_block.rs
@@ -237,7 +237,7 @@ mod tests {
         assert_eq!(must_block_count, 2, "Should create one effect per target");
     }
 
-    /// CR 509.1g (issue #4233): a non-targeted mass force-block — Predatory
+    /// CR 509.1c (issue #4233): a non-targeted mass force-block — Predatory
     /// Rampage's "Each creature your opponents control blocks this turn if able"
     /// — carries no chosen targets; the requirement must be applied to every
     /// creature its `target` filter resolves to, not silently to no one (the

--- a/crates/engine/src/game/effects/force_block.rs
+++ b/crates/engine/src/game/effects/force_block.rs
@@ -1,6 +1,7 @@
+use crate::game::targeting::resolved_object_ids_for_filter;
 use crate::types::ability::{
-    ContinuousModification, Duration, EffectError, EffectKind, ResolvedAbility, TargetFilter,
-    TargetRef,
+    ContinuousModification, Duration, Effect, EffectError, EffectKind, ResolvedAbility,
+    TargetFilter,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -16,11 +17,23 @@ use crate::types::statics::StaticMode;
 /// Note: `MustBlock` (creature must block any attacker), `MustBlockAttacker`
 /// (creature must block one specific attacker), and `MustBeBlocked` (creature
 /// must be blocked by others) are three distinct requirements (CR 509.1c).
+///
+/// The requirement applies to every creature the effect's `target` filter
+/// resolves to — a single chosen target ("target creature blocks this turn if
+/// able") or an entire non-targeted set ("each creature your opponents control
+/// blocks this turn if able", Predatory Rampage). `resolved_object_ids_for_filter`
+/// returns the explicit chosen target(s) when present and otherwise expands the
+/// filter across the battlefield, mirroring `force_attack` (CR 508.1d).
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
+    let target_filter = match &ability.effect {
+        Effect::ForceBlock { target } => target,
+        _ => return Ok(()),
+    };
+
     let source_is_active_attacker = state.combat.as_ref().is_some_and(|combat| {
         combat
             .attackers
@@ -39,23 +52,21 @@ pub fn resolve(
         StaticMode::MustBlock
     };
 
-    for target in &ability.targets {
-        if let TargetRef::Object(obj_id) = target {
-            // CR 509.1c: Requirements that creatures must block are checked during
-            // the declare blockers step.
-            if !state.objects.contains_key(obj_id) {
-                continue;
-            }
-
-            state.add_transient_continuous_effect(
-                ability.source_id,
-                ability.controller,
-                Duration::UntilEndOfTurn,
-                TargetFilter::SpecificObject { id: *obj_id },
-                vec![ContinuousModification::AddStaticMode { mode: mode.clone() }],
-                None,
-            );
+    for obj_id in resolved_object_ids_for_filter(state, ability, target_filter) {
+        // CR 509.1c: Requirements that creatures must block are checked during
+        // the declare blockers step.
+        if !state.objects.contains_key(&obj_id) {
+            continue;
         }
+
+        state.add_transient_continuous_effect(
+            ability.source_id,
+            ability.controller,
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: obj_id },
+            vec![ContinuousModification::AddStaticMode { mode: mode.clone() }],
+            None,
+        );
     }
 
     events.push(GameEvent::EffectResolved {
@@ -70,7 +81,7 @@ mod tests {
     use super::*;
     use crate::game::combat::{AttackerInfo, CombatState};
     use crate::game::zones::create_object;
-    use crate::types::ability::{Effect, TargetRef};
+    use crate::types::ability::{ControllerRef, Effect, TargetRef, TypedFilter};
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
     use crate::types::zones::Zone;
@@ -224,5 +235,89 @@ mod tests {
             })
             .count();
         assert_eq!(must_block_count, 2, "Should create one effect per target");
+    }
+
+    /// CR 509.1g (issue #4233): a non-targeted mass force-block — Predatory
+    /// Rampage's "Each creature your opponents control blocks this turn if able"
+    /// — carries no chosen targets; the requirement must be applied to every
+    /// creature its `target` filter resolves to, not silently to no one (the
+    /// resolver previously only walked the empty `ability.targets`).
+    #[test]
+    fn force_block_mass_filter_applies_to_all_matching_creatures() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Predatory Rampage".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_a = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opp Bear A".to_string(),
+            Zone::Battlefield,
+        );
+        let opp_b = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opp Bear B".to_string(),
+            Zone::Battlefield,
+        );
+        let own = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "My Bear".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [opp_a, opp_b, own] {
+            state.objects.get_mut(&id).unwrap().card_types.core_types =
+                vec![crate::types::card_type::CoreType::Creature];
+        }
+
+        // Non-targeted: filter = "creatures your opponents control", no targets.
+        let ability = ResolvedAbility::new(
+            Effect::ForceBlock {
+                target: TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::Opponent),
+                ),
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let forced: std::collections::HashSet<_> = state
+            .transient_continuous_effects
+            .iter()
+            .filter(|ce| {
+                ce.modifications.iter().any(|m| {
+                    matches!(
+                        m,
+                        ContinuousModification::AddStaticMode {
+                            mode: StaticMode::MustBlock,
+                        }
+                    )
+                })
+            })
+            .filter_map(|ce| match ce.affected {
+                TargetFilter::SpecificObject { id } => Some(id),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            forced.contains(&opp_a) && forced.contains(&opp_b),
+            "both opponents' creatures must be forced to block, got {forced:?}"
+        );
+        assert!(
+            !forced.contains(&own),
+            "the caster's own creature must not be forced to block"
+        );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -4871,7 +4871,7 @@ mod tests {
         assert_eq!(strip_trailing_additive_adverb("also"), "also");
     }
 
-    /// CR 509.1g (issue #4233): "Each creature your opponents control blocks this
+    /// CR 509.1c (issue #4233): "Each creature your opponents control blocks this
     /// turn if able" (Predatory Rampage) is a non-targeted mass requirement — it
     /// must lower to a `ForceBlock` whose `target` filter selects every opponent
     /// creature, with NO target prompt (so it does not ask the caster to pick one

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -4871,6 +4871,32 @@ mod tests {
         assert_eq!(strip_trailing_additive_adverb("also"), "also");
     }
 
+    /// CR 509.1g (issue #4233): "Each creature your opponents control blocks this
+    /// turn if able" (Predatory Rampage) is a non-targeted mass requirement — it
+    /// must lower to a `ForceBlock` whose `target` filter selects every opponent
+    /// creature, with NO target prompt (so it does not ask the caster to pick one
+    /// creature). The resolver then expands the filter at resolution.
+    #[test]
+    fn each_opponent_creature_blocks_if_able_is_non_targeted_mass_force_block() {
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "Each creature your opponents control blocks this turn if able.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            def.target_prompt.is_none(),
+            "mass force-block must not request a target, got {:?}",
+            def.target_prompt
+        );
+        let Effect::ForceBlock { target } = &*def.effect else {
+            panic!("expected ForceBlock, got {:?}", def.effect);
+        };
+        let TargetFilter::Typed(filter) = target else {
+            panic!("expected a typed mass filter, got {target:?}");
+        };
+        assert_eq!(filter.controller, Some(ControllerRef::Opponent));
+        assert!(filter.type_filters.contains(&TypeFilter::Creature));
+    }
+
     /// CR 702.3b: the subjectless conjunct recognizer accepts every grammatical
     /// shape the sequence splitter can leave behind ("this turn" optional, both
     /// "it"/"they" pronoun forms, optional trailing period) and rejects unrelated


### PR DESCRIPTION
Fixes #4233.

## Summary

Predatory Rampage — *"Creatures you control get +3/+3 until end of turn. **Each creature your opponents control blocks this turn if able.**"* — did not force the opponents' creatures to block. (The report described it as "asks for a single target, and only that one blocks".)

## Root cause

The native parser already lowers the second sentence **correctly** to a non-targeted mass effect:

```
ForceBlock { target: Typed { type_filters: [Creature], controller: Opponent } }   // no target prompt
```

The bug is in the resolver. `force_block::resolve` only walked the chosen `ability.targets`, which is **empty** for a non-targeted effect — so the must-block requirement was applied to no creature (and could never cover the whole set). Its sibling `force_attack::resolve` already handles the mass case by resolving the effect's `target` filter via `resolved_object_ids_for_filter`; `force_block` simply never adopted that pattern.

## Fix

`force_block::resolve` now resolves the effect's `target` filter through `resolved_object_ids_for_filter` (CR 509.1g), the same helper `force_attack` uses (CR 508.1d). That helper returns the explicit chosen target(s) when present and otherwise expands the filter across the battlefield, so:

- **single-target** ("Target creature blocks this turn if able") — unchanged (the chosen target matches the filter and is returned),
- **source-referential Provoke** ("block this creature if able") — unchanged,
- **mass** ("each creature your opponents control blocks this turn if able") — now forces **every** matching creature to block.

Builds for the class (every "each <filter> blocks this turn if able" effect), not just Predatory Rampage.

CR 509.1c / 509.1g (block requirements), CR 508.1d (the analogous force-attack resolution this mirrors).

## Tests

- `force_block_mass_filter_applies_to_all_matching_creatures` (engine): a non-targeted `ForceBlock { Typed(creature, Opponent) }` with empty `targets` forces **both** opponents' creatures to block (`MustBlock`) and leaves the caster's own creature alone.
- `each_opponent_creature_blocks_if_able_is_non_targeted_mass_force_block` (parser): the Predatory Rampage sentence lowers to `ForceBlock` with an opponent-creature filter and **no** target prompt.
- Existing `force_block` resolver tests (single target, multi-target, Provoke) and parser tests still pass.
- `cargo fmt --all`, `cargo clippy -p engine -- -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC3pKwdStMrxXkfzRG7xZx


---
_Generated by [Claude Code](https://claude.ai/code)_