### PR TITLE
perf(engine): hoist loop-invariant battlefield scans in priority/mana/crew/combat paths (Tier 2)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3093,6 +3093,33 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
 
     // CR 702.61a: Crew/Saddle/Station are activated abilities — blocked by split second.
     if !split_second_active {
+        // Loop-invariant hoist: the set of this player's untapped creatures (and
+        // the crew-eligible subset) is identical for every Vehicle/Mount/
+        // Spacecraft, so compute it once instead of re-scanning the whole
+        // battlefield per permanent. Each per-permanent check below still applies
+        // its own `cid != obj_id` self-exclusion, so behavior is byte-identical.
+        crate::game::perf_counters::record_crew_eligibility_scan();
+        let untapped_creatures: Vec<ObjectId> = state
+            .battlefield
+            .iter()
+            .copied()
+            .filter(|&cid| {
+                state.objects.get(&cid).is_some_and(|c| {
+                    c.controller == player
+                        && !c.tapped
+                        && c.card_types.core_types.contains(&CoreType::Creature)
+                })
+            })
+            .collect();
+        // CR 702.122a: Crew additionally excludes creatures with a "can't crew"
+        // static (card-identity authority `object_has_cant_crew`, which depends
+        // only on the creature id). Saddle/Station have no such restriction.
+        let crew_eligible: Vec<ObjectId> = untapped_creatures
+            .iter()
+            .copied()
+            .filter(|&cid| !crate::game::static_abilities::object_has_cant_crew(state, cid))
+            .collect();
+
         // CR 702.122a: Crew actions for Vehicles (keyword action, not ActivateAbility).
         // Unlike Equip/Saddle, Crew has no "Activate only as a sorcery" restriction —
         // it can be activated any time the controller has priority.
@@ -3112,17 +3139,9 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                             {
                                 break;
                             }
-                            let has_eligible = state.battlefield.iter().any(|&cid| {
-                                cid != obj_id
-                                    && state.objects.get(&cid).is_some_and(|c| {
-                                        c.controller == player
-                                            && !c.tapped
-                                            && c.card_types.core_types.contains(&CoreType::Creature)
-                                            && !crate::game::static_abilities::object_has_cant_crew(
-                                                state, cid,
-                                            )
-                                    })
-                            });
+                            // CR 702.122a: a Vehicle can't crew itself, so exclude
+                            // `obj_id` (a crewed Vehicle is an artifact creature).
+                            let has_eligible = crew_eligible.iter().any(|&cid| cid != obj_id);
                             if has_eligible {
                                 actions.push(candidate(
                                     GameAction::CrewVehicle {
@@ -3156,14 +3175,10 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                     {
                         continue;
                     }
-                    let has_eligible = state.battlefield.iter().any(|&cid| {
-                        cid != obj_id
-                            && state.objects.get(&cid).is_some_and(|c| {
-                                c.controller == player
-                                    && !c.tapped
-                                    && c.card_types.core_types.contains(&CoreType::Creature)
-                            })
-                    });
+                    // CR 702.171a: Saddle taps "any number of OTHER untapped
+                    // creatures", so the Mount can't saddle itself — preserve the
+                    // `cid != obj_id` self-skip.
+                    let has_eligible = untapped_creatures.iter().any(|&cid| cid != obj_id);
                     if has_eligible {
                         actions.push(candidate(
                             GameAction::SaddleMount {
@@ -3195,14 +3210,10 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
                     {
                         continue;
                     }
-                    let has_eligible = state.battlefield.iter().any(|&cid| {
-                        cid != obj_id
-                            && state.objects.get(&cid).is_some_and(|c| {
-                                c.controller == player
-                                    && !c.tapped
-                                    && c.card_types.core_types.contains(&CoreType::Creature)
-                            })
-                    });
+                    // CR 702.184a: Station taps "ANOTHER untapped creature you
+                    // control", so the Spacecraft can't station itself — preserve
+                    // the `cid != obj_id` self-skip.
+                    let has_eligible = untapped_creatures.iter().any(|&cid| cid != obj_id);
                     if has_eligible {
                         actions.push(candidate(
                             GameAction::ActivateStation {
@@ -3526,10 +3537,20 @@ fn attacker_actions(
     // requirements independently rather than obeying the CR 508.1d maximum, so
     // no target this builder picks can survive filtering. Fixing that is a
     // validator concern (CR 508.1d max-satisfaction), not a generator one.
+    // Loop-invariant hoist: `attackable_player_targets` depends only on `state`
+    // (immutable during this filter), so compute it once instead of per creature
+    // inside `creature_must_attack`. Mirrors `declare_attackers_with_bands`.
+    let attackable = crate::game::combat::attackable_player_targets(state);
     let forced: Vec<(ObjectId, AttackTarget)> = valid_attacker_ids
         .iter()
         .copied()
-        .filter(|&id| crate::game::combat::creature_must_attack(state, id))
+        .filter(|&id| {
+            crate::game::combat::creature_must_attack_with_attackable_players(
+                state,
+                id,
+                &attackable,
+            )
+        })
         .filter_map(|id| {
             let obj = state.objects.get(&id)?;
             let must_attack_players =
@@ -4520,6 +4541,212 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ── Item C: crew/saddle/station eligibility hoist ───────────────────────
+
+    fn crew_priority_state() -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.stack.clear();
+        state
+    }
+
+    fn add_crew_vehicle(state: &mut GameState, id: u64, controller: PlayerId) -> ObjectId {
+        let v = create_object(
+            state,
+            CardId(id),
+            controller,
+            "Vehicle".into(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&v).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.keywords.push(Keyword::Crew {
+            power: 1,
+            once_per_turn: None,
+        });
+        v
+    }
+
+    fn add_untapped_creature(state: &mut GameState, id: u64, controller: PlayerId) -> ObjectId {
+        let c = create_object(
+            state,
+            CardId(id),
+            controller,
+            "Creature".into(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&c).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(2);
+        c
+    }
+
+    fn has_crew(actions: &[CandidateAction]) -> bool {
+        actions
+            .iter()
+            .any(|a| matches!(a.action, GameAction::CrewVehicle { .. }))
+    }
+
+    fn has_saddle(actions: &[CandidateAction]) -> bool {
+        actions
+            .iter()
+            .any(|a| matches!(a.action, GameAction::SaddleMount { .. }))
+    }
+
+    /// Item C (revert-failing perf): the crew/saddle/station eligibility pass
+    /// scans the battlefield ONCE per `priority_actions` call, independent of the
+    /// number of Vehicles. Pre-fix each Vehicle re-scanned the whole battlefield
+    /// (V scans).
+    #[test]
+    fn crew_eligibility_scanned_once_regardless_of_vehicle_count() {
+        let mut state = crew_priority_state();
+        for i in 0..4 {
+            add_crew_vehicle(&mut state, 100 + i, PlayerId(0));
+        }
+        add_untapped_creature(&mut state, 200, PlayerId(0));
+        add_untapped_creature(&mut state, 201, PlayerId(0));
+
+        crate::game::perf_counters::reset();
+        let _ = priority_actions(&state, PlayerId(0));
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert_eq!(
+            snap.crew_eligibility_scans, 1,
+            "one eligibility scan for all Vehicles (revert-failing: pre-fix = V)"
+        );
+    }
+
+    /// Item C behavior: Crew is offered iff an untapped, non-cant-crew OTHER
+    /// creature exists.
+    #[test]
+    fn crew_offered_only_with_eligible_other_creature() {
+        let mut state = crew_priority_state();
+        add_crew_vehicle(&mut state, 100, PlayerId(0));
+        assert!(
+            !has_crew(&priority_actions(&state, PlayerId(0))),
+            "no creatures → no Crew offer"
+        );
+
+        let creature = add_untapped_creature(&mut state, 200, PlayerId(0));
+        assert!(
+            has_crew(&priority_actions(&state, PlayerId(0))),
+            "an untapped creature enables the Crew offer"
+        );
+
+        state.objects.get_mut(&creature).unwrap().tapped = true;
+        assert!(
+            !has_crew(&priority_actions(&state, PlayerId(0))),
+            "a tapped-only board offers no Crew"
+        );
+    }
+
+    /// Item C behavior (set divergence): when every other untapped creature
+    /// can't crew, the Crew offer is suppressed but the Saddle offer (which has
+    /// no cant-crew restriction) survives — `crew_eligible` is empty while
+    /// `untapped_creatures` is not. This is exactly the case where the two
+    /// precomputed sets diverge.
+    #[test]
+    fn cant_crew_creatures_block_crew_but_not_saddle() {
+        let mut state = crew_priority_state();
+        add_crew_vehicle(&mut state, 100, PlayerId(0));
+
+        // A Saddle Mount that is itself a creature but can't crew.
+        let mount = create_object(
+            &mut state,
+            CardId(101),
+            PlayerId(0),
+            "Mount".into(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&mount).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.keywords.push(Keyword::Saddle(1));
+            obj.static_definitions.push(StaticDefinition::new(
+                crate::types::statics::StaticMode::CantCrew,
+            ));
+        }
+
+        // A second untapped creature, also can't crew — so `crew_eligible` is
+        // empty, but it still provides a non-self saddler for the Mount.
+        let creature = add_untapped_creature(&mut state, 200, PlayerId(0));
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(
+                crate::types::statics::StaticMode::CantCrew,
+            ));
+
+        let actions = priority_actions(&state, PlayerId(0));
+        assert!(
+            !has_crew(&actions),
+            "every untapped creature can't crew → no Crew offer"
+        );
+        assert!(
+            has_saddle(&actions),
+            "Saddle has no cant-crew restriction — still offered (sets diverge)"
+        );
+    }
+
+    /// Item C behavior (self-exclusion): a Vehicle that is itself the only
+    /// untapped creature can't crew itself (`cid != obj_id`).
+    #[test]
+    fn crew_self_exclusion_when_vehicle_is_only_untapped_creature() {
+        let mut state = crew_priority_state();
+        let vehicle = add_crew_vehicle(&mut state, 100, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&vehicle).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(4);
+        }
+
+        assert!(
+            !has_crew(&priority_actions(&state, PlayerId(0))),
+            "a Vehicle can't crew itself (self-exclusion preserved)"
+        );
+    }
+
+    /// Item E (revert-failing perf): the engine AI attacker enumeration computes
+    /// the attackable-player set ONCE for the whole forced-attacker filter, not
+    /// once per candidate creature. Pre-fix each creature's `creature_must_attack`
+    /// recomputed it (K sweeps).
+    #[test]
+    fn attacker_candidates_sweep_attackable_players_once() {
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::DeclareAttackers;
+        state.active_player = PlayerId(0);
+        let mut ids = Vec::new();
+        for i in 0..3 {
+            let c = create_object(
+                &mut state,
+                CardId(300 + i),
+                PlayerId(0),
+                "Goaded".into(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&c).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.goaded_by.insert(PlayerId(1));
+            ids.push(c);
+        }
+        let targets = vec![AttackTarget::Player(PlayerId(1))];
+
+        crate::game::perf_counters::reset();
+        let _ = attacker_actions(&state, PlayerId(0), &ids, &targets);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert_eq!(
+            snap.attackable_player_sweeps, 1,
+            "one attackable-player sweep for the whole enumeration (revert-failing: pre-fix = K)"
+        );
     }
 
     #[test]

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -869,6 +869,20 @@ fn target_selection_actions_without_simulation(state: &GameState) -> Option<Vec<
     Some(actions)
 }
 
+/// The flat priority-action list: validated candidate actions minus mana
+/// abilities. This is the single authority for the non-target-selection action
+/// body so the auto-pass probe (`priority_player_has_meaningful_action`) and
+/// `legal_actions_full` cannot drift. Auto-pass consumes only this list; it does
+/// not need the spell-cost map or the grouped per-object map that
+/// `legal_actions_full` additionally builds.
+pub fn flat_priority_actions(state: &GameState) -> Vec<GameAction> {
+    validated_candidate_actions(state)
+        .into_iter()
+        .map(|candidate| candidate.action)
+        .filter(|action| !action.is_mana_ability())
+        .collect()
+}
+
 /// Returns legal actions, spell costs, AND a per-permanent action grouping.
 ///
 /// `legal_actions_by_object` maps each permanent (or hand-zone card) to the
@@ -877,16 +891,8 @@ fn target_selection_actions_without_simulation(state: &GameState) -> Option<Vec<
 /// flat `actions` list; auto-pass consumes the flat list, while board
 /// interaction consumes the grouped map.
 pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
-    let actions: Vec<GameAction> =
-        if let Some(actions) = target_selection_actions_without_simulation(state) {
-            actions
-        } else {
-            validated_candidate_actions(state)
-                .into_iter()
-                .map(|candidate| candidate.action)
-                .filter(|action| !action.is_mana_ability())
-                .collect()
-        };
+    let actions: Vec<GameAction> = target_selection_actions_without_simulation(state)
+        .unwrap_or_else(|| flat_priority_actions(state));
 
     // Build spell costs map. The frontend display layer needs the
     // engine-effective cost (after Affinity / ReduceCost / commander tax / etc.)
@@ -900,6 +906,7 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
     // statics) but applies every cost-modifying static the cast pipeline would.
     let mut spell_costs = HashMap::new();
     if let WaitingFor::Priority { player } = &state.waiting_for {
+        crate::game::perf_counters::record_legal_actions_spell_cost_sweep();
         // Zone pre-filter is performance-only: skips the battlefield/stack/library
         // walk that has no chance of yielding a castable spell. Eligibility
         // (controller, foreign-cast permissions, zone) is decided centrally by
@@ -1073,6 +1080,10 @@ pub(super) fn activatable_object_mana_actions_for_player(
     state: &GameState,
     player: PlayerId,
 ) -> Vec<GameAction> {
+    // Loop-invariant hoist: the TapsForMana trigger-source list is identical for
+    // every land in this board-global sweep, so compute it once instead of
+    // re-scanning the whole battlefield per land inside `land_mana_options`.
+    let aura_sources = mana_sources::taps_for_mana_trigger_sources(state);
     let mut actions = Vec::new();
     for &obj_id in &state.battlefield {
         let Some(obj) = state.objects.get(&obj_id) else {
@@ -1084,7 +1095,12 @@ pub(super) fn activatable_object_mana_actions_for_player(
 
         let mut handled_indices = HashSet::new();
         if obj.card_types.core_types.contains(&CoreType::Land) {
-            let options = mana_sources::activatable_land_mana_options(state, obj_id, player);
+            let options = mana_sources::activatable_land_mana_options_indexed(
+                state,
+                obj_id,
+                player,
+                &aura_sources,
+            );
             if options.len() == 1
                 && options
                     .first()

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6520,6 +6520,11 @@ fn auto_tap_mana_sources_inner(
         ManaCost::Cost { shards, generic } => (shards.as_slice(), *generic),
     };
 
+    // Loop-invariant hoist: the TapsForMana trigger-source list is identical for
+    // every land in this board-global sweep, so compute it once instead of
+    // re-scanning the whole battlefield per land inside `land_mana_options`.
+    let aura_sources = mana_sources::taps_for_mana_trigger_sources(state);
+
     // Build list of activatable mana options for ALL permanents this player controls.
     // CR 605.1b: Non-land permanents can have mana abilities.
     let mut available: Vec<ManaSourceOption> = state
@@ -6538,7 +6543,12 @@ fn auto_tap_mana_sources_inner(
             // payable from the current pool; Phase 3 pays those sub-costs from
             // other selected sources before resolving the paid mana ability.
             if obj.card_types.core_types.contains(&CoreType::Land) {
-                Some(mana_sources::auto_tap_land_mana_options(state, oid, player))
+                Some(mana_sources::auto_tap_land_mana_options_indexed(
+                    state,
+                    oid,
+                    player,
+                    &aura_sources,
+                ))
             } else {
                 Some(mana_sources::auto_tap_mana_options(state, oid, player))
             }

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1870,7 +1870,8 @@ pub fn creature_must_attack(state: &GameState, obj_id: ObjectId) -> bool {
     creature_must_attack_with_attackable_players(state, obj_id, &attackable_players)
 }
 
-fn attackable_player_targets(state: &GameState) -> Vec<PlayerId> {
+pub fn attackable_player_targets(state: &GameState) -> Vec<PlayerId> {
+    crate::game::perf_counters::record_attackable_player_sweep();
     get_valid_attack_targets(state)
         .into_iter()
         .filter_map(|target| match target {
@@ -1897,7 +1898,7 @@ pub(crate) fn must_attack_players_for_creature(
         .collect()
 }
 
-fn creature_must_attack_with_attackable_players(
+pub fn creature_must_attack_with_attackable_players(
     state: &GameState,
     obj_id: ObjectId,
     attackable_players: &[PlayerId],

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -453,7 +453,10 @@ fn active_until_stack_empty_requester(state: &GameState) -> Option<PlayerId> {
 fn priority_player_has_meaningful_action(state: &GameState) -> bool {
     let mut probe = state.clone();
     probe.auto_pass.clear();
-    let actions = crate::ai_support::legal_actions(&probe);
+    // The probe always has `waiting_for == Priority` at both call sites, so the
+    // flat priority-action path is byte-identical to what `legal_actions` yielded
+    // — it drops only the unused spell-cost object-walk and grouped-map build.
+    let actions = crate::ai_support::flat_priority_actions(&probe);
     crate::ai_support::has_meaningful_priority_action(&probe, &actions)
 }
 
@@ -844,6 +847,43 @@ mod auto_pass_decision_tests {
         assert!(
             state.auto_pass.contains_key(&PlayerId(0)),
             "requester's session stays active while waiting on opponent action"
+        );
+    }
+
+    /// Item A (revert-failing perf): the auto-pass meaningful-action probe takes
+    /// the flat priority-action path, which skips the `legal_actions_full`
+    /// spell-cost object-walk entirely. Pre-fix the probe called
+    /// `legal_actions` → `legal_actions_full`, bumping the spell-cost sweep
+    /// counter once per probe; post-fix it does zero sweeps. The probe still
+    /// detects the meaningful activated ability (byte-identical verdict).
+    #[test]
+    fn priority_probe_skips_spell_cost_sweep() {
+        let mut state = priority_state();
+        push_simple_stack_entry(&mut state, 30_000, PlayerId(1));
+        add_non_mana_activated_artifact(&mut state, PlayerId(0));
+
+        crate::game::perf_counters::reset();
+        let meaningful = priority_player_has_meaningful_action(&state);
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert!(
+            meaningful,
+            "probe detects the castable Draw activation (verdict preserved)"
+        );
+        assert_eq!(
+            snap.legal_actions_spell_cost_sweeps, 0,
+            "flat probe path takes no spell-cost sweep (revert-failing: pre-fix = 1)"
+        );
+    }
+
+    /// Item A behavior parity: with only `PassPriority` available the probe
+    /// reports no meaningful action, identical to pre-change.
+    #[test]
+    fn priority_probe_false_when_only_pass_available() {
+        let state = priority_state();
+        assert!(
+            !priority_player_has_meaningful_action(&state),
+            "an empty board with only PassPriority has no meaningful action"
         );
     }
 

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -466,15 +466,40 @@ pub fn activatable_land_mana_options(
     object_id: ObjectId,
     controller: PlayerId,
 ) -> Vec<ManaSourceOption> {
-    land_mana_options(state, object_id, controller, true, true)
+    land_mana_options(state, object_id, controller, true, true, None)
 }
 
-pub(crate) fn auto_tap_land_mana_options(
+/// Indexed arity of `activatable_land_mana_options`: the board-global
+/// activatable sweep precomputes the TapsForMana trigger-source list once
+/// (`taps_for_mana_trigger_sources`) and threads it through each land, avoiding
+/// a per-land full-battlefield scan. Byte-identical to the per-land form.
+pub(crate) fn activatable_land_mana_options_indexed(
     state: &GameState,
     object_id: ObjectId,
     controller: PlayerId,
+    aura_sources: &[ObjectId],
 ) -> Vec<ManaSourceOption> {
-    land_mana_options(state, object_id, controller, true, false)
+    land_mana_options(state, object_id, controller, true, true, Some(aura_sources))
+}
+
+/// Auto-tap land mana options for the board-global cost sweep. The sweep
+/// precomputes the TapsForMana trigger-source list once
+/// (`taps_for_mana_trigger_sources`) and threads it through each land, avoiding
+/// a per-land full-battlefield scan. Byte-identical to a per-land form.
+pub(crate) fn auto_tap_land_mana_options_indexed(
+    state: &GameState,
+    object_id: ObjectId,
+    controller: PlayerId,
+    aura_sources: &[ObjectId],
+) -> Vec<ManaSourceOption> {
+    land_mana_options(
+        state,
+        object_id,
+        controller,
+        true,
+        false,
+        Some(aura_sources),
+    )
 }
 
 /// Return display pips for a land based on mana abilities that are currently
@@ -1286,6 +1311,11 @@ fn land_mana_options(
     controller: PlayerId,
     require_untapped: bool,
     require_current_payability: bool,
+    // Precomputed TapsForMana trigger-source list for the board-global sweeps;
+    // `None` means compute it for this land (single-land / display / test
+    // callers). Byte-identical either way — the indexed and full scans visit the
+    // same trigger-bearing permanents.
+    aura_sources: Option<&[ObjectId]>,
 ) -> Vec<ManaSourceOption> {
     let Some(obj) = state.objects.get(&object_id) else {
         return Vec::new();
@@ -1354,7 +1384,11 @@ fn land_mana_options(
     // mana ability at resolution time. `atomic_combination` includes the full
     // output (land + aura) for planner coverage checks; `production_override_for_option`
     // caps it to the land's own portion when dispatching the land's own ability.
-    for (aura_id, aura_choices) in taps_for_mana_aura_bonus(state, object_id, controller) {
+    let aura_bonus = match aura_sources {
+        Some(sources) => taps_for_mana_aura_bonus_indexed(state, object_id, controller, sources),
+        None => taps_for_mana_aura_bonus(state, object_id, controller),
+    };
+    for (aura_id, aura_choices) in aura_bonus {
         // aura_choices: [ManaType; N] where N=1 for Fixed, N=5 for any-color.
         // Cross-product: replace each option with N options (one per choice).
         options = options
@@ -1896,13 +1930,49 @@ pub(crate) fn opponent_land_color_options(
 /// Callers use `aura_object_id` to build `taps_for_mana_overrides` on the
 /// resulting `ManaSourceOption` so the resolver can thread the chosen color
 /// into the aura's triggered mana ability at inline resolution time.
+/// Battlefield objects carrying at least one `TapsForMana` trigger. The hot
+/// board-global auto-tap / activatable sweeps compute this list ONCE before
+/// their per-land loop and thread it into `taps_for_mana_aura_bonus_indexed`,
+/// turning a per-land full-battlefield scan into a per-land walk over only the
+/// (usually tiny) set of trigger-bearing permanents.
+pub(crate) fn taps_for_mana_trigger_sources(state: &GameState) -> Vec<ObjectId> {
+    crate::game::perf_counters::record_mana_aura_trigger_scan();
+    state
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|object_id| {
+            state.objects.get(object_id).is_some_and(|obj| {
+                obj.trigger_definitions
+                    .iter_all()
+                    .any(|trigger| trigger.mode == TriggerMode::TapsForMana)
+            })
+        })
+        .collect()
+}
+
 pub(crate) fn taps_for_mana_aura_bonus(
     state: &GameState,
     land_id: ObjectId,
     controller: PlayerId,
 ) -> Vec<(ObjectId, Vec<ManaType>)> {
+    let sources = taps_for_mana_trigger_sources(state);
+    taps_for_mana_aura_bonus_indexed(state, land_id, controller, &sources)
+}
+
+/// Indexed arity of `taps_for_mana_aura_bonus`: iterates only the precomputed
+/// `sources` (trigger-bearing permanents) instead of the whole battlefield.
+/// Byte-identical to the full scan — preserves the `land_id` self-skip, the
+/// per-source `taps_for_mana_card_matches` card-identity authority, and the
+/// deliberate absence of a controller filter (Aura-Theft semantics).
+pub(crate) fn taps_for_mana_aura_bonus_indexed(
+    state: &GameState,
+    land_id: ObjectId,
+    controller: PlayerId,
+    sources: &[ObjectId],
+) -> Vec<(ObjectId, Vec<ManaType>)> {
     let mut per_aura: Vec<(ObjectId, Vec<ManaType>)> = Vec::new();
-    for &object_id in state.battlefield.iter() {
+    for &object_id in sources.iter() {
         // Skip the land itself — we're looking for OTHER permanents whose
         // TapsForMana trigger fires when `land_id` is tapped.
         if object_id == land_id {
@@ -3469,6 +3539,92 @@ mod tests {
         assert!(taps_for_mana_aura_bonus(&state, forest, PlayerId(0)).is_empty());
     }
 
+    /// Item B (revert-failing perf): the board-global auto-tap sweep computes the
+    /// TapsForMana trigger-source list ONCE before its per-land loop, not once
+    /// per land. With K lands and one Wild-Growth aura, exactly one
+    /// battlefield trigger-source scan runs. Pre-fix every land re-scanned the
+    /// whole battlefield inside `land_mana_options` (K scans).
+    #[test]
+    fn auto_tap_sweep_scans_aura_sources_once() {
+        const K: u64 = 5;
+        let mut state = GameState::new_two_player(42);
+        let mut forests = Vec::new();
+        for i in 0..K {
+            let forest = create_object(
+                &mut state,
+                CardId(100 + i),
+                PlayerId(0),
+                "Forest".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&forest).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Forest".to_string());
+            obj.entered_battlefield_turn = Some(0);
+            forests.push(forest);
+        }
+        attach_taps_for_mana_aura(&mut state, forests[0], PlayerId(0), ManaColor::Green);
+
+        let cost = crate::types::mana::ManaCost::Cost {
+            shards: Vec::new(),
+            generic: 2,
+        };
+        let mut events = Vec::new();
+        crate::game::perf_counters::reset();
+        crate::game::casting_costs::auto_tap_mana_sources(
+            &mut state,
+            PlayerId(0),
+            &cost,
+            &mut events,
+            None,
+        );
+        let snap = crate::game::perf_counters::snapshot();
+
+        assert_eq!(
+            snap.mana_aura_trigger_scans, 1,
+            "one trigger-source scan for the whole sweep (revert-failing: pre-fix = K)"
+        );
+    }
+
+    /// Item B byte-identical: the indexed arity over a precomputed source list
+    /// detects exactly the same auras as the full wrapper, including the
+    /// deliberate no-controller-filter (an opponent-controlled aura still folds
+    /// in, Aura-Theft semantics) and two-auras-on-one-land.
+    #[test]
+    fn taps_for_mana_aura_bonus_indexed_matches_full_scan_with_two_auras() {
+        let mut state = GameState::new_two_player(42);
+        let forest = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&forest).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Forest".to_string());
+            obj.entered_battlefield_turn = Some(1);
+        }
+        // One opponent-controlled aura (no controller filter) + one own aura.
+        attach_taps_for_mana_aura(&mut state, forest, PlayerId(1), ManaColor::Green);
+        attach_taps_for_mana_aura(&mut state, forest, PlayerId(0), ManaColor::Blue);
+
+        let full = taps_for_mana_aura_bonus(&state, forest, PlayerId(0));
+        let sources = taps_for_mana_trigger_sources(&state);
+        let indexed = taps_for_mana_aura_bonus_indexed(&state, forest, PlayerId(0), &sources);
+
+        assert_eq!(
+            full.len(),
+            2,
+            "both auras fold in regardless of controller (no controller filter)"
+        );
+        assert_eq!(
+            full, indexed,
+            "indexed arity is byte-identical to the full wrapper"
+        );
+    }
+
     /// Issue #4265 regression: `auto_tap_land_mana_options` for a Forest
     /// enchanted by Wild Growth must return a single `atomic_combination`
     /// containing `[Green, Green]` so the autotap planner treats the whole
@@ -3494,7 +3650,8 @@ mod tests {
         let wild_growth =
             attach_taps_for_mana_aura(&mut state, forest, PlayerId(0), ManaColor::Green);
 
-        let options = auto_tap_land_mana_options(&state, forest, PlayerId(0));
+        let sources = taps_for_mana_trigger_sources(&state);
+        let options = auto_tap_land_mana_options_indexed(&state, forest, PlayerId(0), &sources);
         assert_eq!(options.len(), 1, "one option per tap");
         let opt = &options[0];
         assert_eq!(opt.mana_type, ManaType::Green);
@@ -3694,7 +3851,8 @@ mod tests {
         }
         let fertile_ground = attach_any_color_aura(&mut state, forest, PlayerId(0));
 
-        let options = auto_tap_land_mana_options(&state, forest, PlayerId(0));
+        let sources = taps_for_mana_trigger_sources(&state);
+        let options = auto_tap_land_mana_options_indexed(&state, forest, PlayerId(0), &sources);
         // Forest subtype fallback = one base option {G}.
         // Fertile Ground fans out × 5 → five options.
         assert_eq!(options.len(), 5, "Forest + Fertile Ground = 5 options");

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -14,6 +14,10 @@ pub struct PerfCounterSnapshot {
     pub stack_batched_entries: u64,
     pub stack_inert_noop_batches: u64,
     pub stack_inert_noop_entries: u64,
+    pub legal_actions_spell_cost_sweeps: u64,
+    pub mana_aura_trigger_scans: u64,
+    pub crew_eligibility_scans: u64,
+    pub attackable_player_sweeps: u64,
 }
 
 thread_local! {
@@ -41,6 +45,10 @@ thread_local! {
         stack_batched_entries: 0,
         stack_inert_noop_batches: 0,
         stack_inert_noop_entries: 0,
+        legal_actions_spell_cost_sweeps: 0,
+        mana_aura_trigger_scans: 0,
+        crew_eligibility_scans: 0,
+        attackable_player_sweeps: 0,
     }) };
 }
 
@@ -96,6 +104,22 @@ pub fn record_stack_inert_noop_batch(entries: u32) {
         s.stack_inert_noop_batches += 1;
         s.stack_inert_noop_entries += u64::from(entries);
     });
+}
+
+pub fn record_legal_actions_spell_cost_sweep() {
+    with_mut(|s| s.legal_actions_spell_cost_sweeps += 1);
+}
+
+pub fn record_mana_aura_trigger_scan() {
+    with_mut(|s| s.mana_aura_trigger_scans += 1);
+}
+
+pub fn record_crew_eligibility_scan() {
+    with_mut(|s| s.crew_eligibility_scans += 1);
+}
+
+pub fn record_attackable_player_sweep() {
+    with_mut(|s| s.attackable_player_sweeps += 1);
 }
 
 pub fn snapshot() -> PerfCounterSnapshot {

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -173,10 +173,20 @@ pub fn choose_attackers_with_targets_with_profile(
     // attackers or the engine rejects the whole declaration. Partition them out
     // and union them back unconditionally — value heuristics only apply to the
     // free choices. `creature_must_attack` is the engine's single authority.
+    // Loop-invariant hoist: `attackable_player_targets` depends only on `state`
+    // (immutable during this filter), so compute it once instead of per creature
+    // inside `creature_must_attack`.
+    let attackable = engine::game::combat::attackable_player_targets(state);
     let mandatory: Vec<ObjectId> = candidates
         .iter()
         .copied()
-        .filter(|&id| engine::game::combat::creature_must_attack(state, id))
+        .filter(|&id| {
+            engine::game::combat::creature_must_attack_with_attackable_players(
+                state,
+                id,
+                &attackable,
+            )
+        })
         .collect();
 
     let preferred_opponent = preferred_attack_opponent(state, player, &opponents, &candidates);
@@ -1838,6 +1848,43 @@ mod tests {
         obj.keywords = keywords;
         obj.entered_battlefield_turn = Some(1);
         id
+    }
+
+    /// Item E (revert-failing perf): the must-attack partition computes the
+    /// attackable-player set ONCE, so the number of `attackable_player_targets`
+    /// sweeps does NOT scale with the goaded-creature count. Pre-fix each
+    /// goaded creature's `creature_must_attack` recomputed it, so the sweep count
+    /// grew with K.
+    fn goaded_attacker_sweep_count(num_goaded: usize) -> u64 {
+        let mut state = setup();
+        state.phase = engine::types::phase::Phase::DeclareAttackers;
+        for _ in 0..num_goaded {
+            let id = add_creature(&mut state, PlayerId(0), "Goaded", 2, 2, vec![]);
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .goaded_by
+                .insert(PlayerId(1));
+        }
+        engine::game::perf_counters::reset();
+        let _ = choose_attackers(&state, PlayerId(0));
+        engine::game::perf_counters::snapshot().attackable_player_sweeps
+    }
+
+    #[test]
+    fn attacker_choice_sweeps_attackable_players_independent_of_goaded_count() {
+        let one = goaded_attacker_sweep_count(1);
+        let many = goaded_attacker_sweep_count(4);
+        assert!(
+            one >= 1,
+            "the must-attack partition must actually sweep (non-degenerate fixture)"
+        );
+        assert_eq!(
+            one, many,
+            "attackable-player sweeps must not scale with goaded count \
+             (revert-failing: pre-fix grows as K)"
+        );
     }
 
     // --- Issue #2514: crackback_damage blocker reuse (CR 509.1) ---


### PR DESCRIPTION
## What

Tier-2 follow-up to the combat/untap static-scan hoist (#4445). Four board-composition-specific O(N²) sites, each a *collecting/scanning* computation that depends only on `state` (immutable across the loop) but was recomputed per battlefield permanent. Each is collapsed to O(N) by a loop-invariant hoist. **All four are byte-identical** (pure perf hoists, no semantic change); each adds a thread-local perf counter and a revert-failing test asserting the hoisted work now runs O(1) times instead of O(N).

These compound with #4445 on pathological boards (e.g. Unbeatable Squirrel Girl: 702 Squirrels + Cryptolith Rite).

## Items

**A — auto-pass meaningful-action probe** (`engine.rs`, `ai_support/mod.rs`)
Extracts `flat_priority_actions()` as the single authority for the non-target-selection priority-action body. `legal_actions_full` wraps it; the auto-pass probe `priority_player_has_meaningful_action` now calls it directly instead of `legal_actions`, dropping the unused spell-cost object-walk + grouped per-object map. Both probe sites are `waiting_for == Priority`, where the target-selection path returns `None`, so the verdict is byte-identical. The `legal_actions_spell_cost_sweeps` counter sits on the *divergent* `legal_actions_full` branch → probe takes 0 sweeps. CR 117.1.

**B — mana-aura tap bonus** (`mana_sources.rs`, `casting_costs.rs`, `ai_support/mod.rs`)
Board-global auto-tap / activatable sweeps hoist `taps_for_mana_trigger_sources()` once and thread `Option<&[ObjectId]>` through `land_mana_options` (`None` = per-land compute for display/single/test callers, byte-identical). Preserves the `land_id` self-skip, the per-source `taps_for_mana_card_matches` card-identity check, and the deliberate **no controller filter** (Aura-Theft semantics). CR 605.1b / 106.12a.

**C — AI crew/saddle/station candidates** (`ai_support/candidates.rs`)
Precomputes `untapped_creatures` and `crew_eligible` (minus `object_has_cant_crew`) once instead of rescanning the battlefield per Vehicle/Mount/Spacecraft. Crew uses `crew_eligible`; Saddle/Station use the base set. The `cid != obj_id` self-exclusion is preserved on all three (not collapsed to `!is_empty()`). CR 702.122a (Crew) / 702.171a (Saddle) / 702.184a (Station).

**E — AI must-attack partition** (`combat.rs`, `ai_support/candidates.rs`, `phase-ai/combat_ai.rs`)
Both AI attacker filters hoist `attackable_player_targets()` once instead of recomputing it per goaded creature inside `creature_must_attack`; they call the batched `creature_must_attack_with_attackable_players`. CR 508.1d.

## Verification

- `cargo fmt --all` clean
- `cargo clippy -p engine -p phase-ai --all-targets` clean (0 warnings)
- `cargo test -p engine -p phase-ai --lib` — 14804 passed, 0 failed, 14 ignored
- Independent `/review-impl` pass: all byte-identical claims verified against source; the only findings were two CR mis-citations (Saddle/Station), now fixed.

## Tests

Each item adds a revert-failing test driving a production entry point (`priority_actions`, `attacker_actions`, `choose_attackers`, `auto_tap_mana_sources`, `priority_player_has_meaningful_action`) and asserting the perf invariant via the new counters — none are manual-state shape tests. Item B/C/E also assert behavioral equivalence (full vs indexed scan; sets-diverge for crew vs saddle; sweep count independent of K).