### PR TITLE
perf(engine): hoist shadow-block existence gate + per-controller granted-ability cache (Tier 2b)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -907,6 +907,7 @@ fn attacker_has_must_be_blocked_by_all_from_precomputed(
 /// from the blocker, and remote affected filters are resolved through the shared
 /// static-ability checker.
 fn blocker_can_block_shadow(state: &GameState, blocker: &GameObject) -> bool {
+    crate::game::perf_counters::record_combat_shadow_block_scan();
     super::functioning_abilities::active_static_definitions(state, blocker)
         .any(|sd| sd.mode == StaticMode::CanBlockShadow)
         || crate::game::static_abilities::check_static_ability(
@@ -917,6 +918,20 @@ fn blocker_can_block_shadow(state: &GameState, blocker: &GameObject) -> bool {
                 ..Default::default()
             },
         )
+}
+
+// CR 604.1: static abilities are continuously "on"; if NO functioning
+// CanBlockShadow static exists anywhere (the loop-invariant existence gate),
+// both the blocker's intrinsic static scan and the remote check_static_ability
+// sweep return false, so this is byte-identical to the full predicate while
+// skipping the O(N) per-blocker sweep. CR 509.1b/609.4/702.28b: a CanBlockShadow
+// static lifts the shadow block restriction for the affected blocker.
+fn blocker_can_block_shadow_gated(
+    state: &GameState,
+    blocker: &GameObject,
+    can_block_shadow_exists: bool,
+) -> bool {
+    can_block_shadow_exists && blocker_can_block_shadow(state, blocker)
 }
 
 /// Validate blocker declarations per CR 509.1.
@@ -978,6 +993,14 @@ pub fn validate_blockers_for_player(
     let block_restriction = collect_block_restriction_statics(state);
     let blocker_allowed = collect_blocker_allowed_statics(state);
     let must_be_blocked = collect_must_be_blocked_statics(state);
+    // CR 604.1: loop-invariant existence gate for the shadow block-lift (CR
+    // 509.1b/609.4/702.28b). Hoisted once so the per-blocker shadow scan below
+    // and every `can_block_pair_with_precomputed` call skip the O(N)
+    // `check_static_ability` sweep when no `CanBlockShadow` static exists.
+    let can_block_shadow_exists =
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::CanBlockShadow)
+        });
 
     // Group assignments by attacker for menace validation and by blocker for
     // per-creature block-capacity checks.
@@ -1152,7 +1175,10 @@ pub fn validate_blockers_for_player(
         let blocker_has_shadow = blocker.has_keyword(&Keyword::Shadow);
         // CR 509.1b + CR 609.4 + CR 702.28b: a `CanBlockShadow` static lifts the
         // shadow restriction for this blocker (Heartwood Dryad, Wall of Diffusion).
-        if attacker_has_shadow && !blocker_has_shadow && !blocker_can_block_shadow(state, blocker) {
+        if attacker_has_shadow
+            && !blocker_has_shadow
+            && !blocker_can_block_shadow_gated(state, blocker, can_block_shadow_exists)
+        {
             return Err(format!(
                 "{:?} cannot block {:?} (shadow can only be blocked by shadow)",
                 blocker_id, attacker_id
@@ -1362,6 +1388,7 @@ pub fn validate_blockers_for_player(
                         &blocker_restriction,
                         &block_restriction,
                         &blocker_allowed,
+                        can_block_shadow_exists,
                     )
             });
 
@@ -1416,6 +1443,7 @@ pub fn validate_blockers_for_player(
                         &blocker_restriction,
                         &block_restriction,
                         &blocker_allowed,
+                        can_block_shadow_exists,
                     )
                 {
                     return false;
@@ -1500,6 +1528,7 @@ pub fn validate_blockers_for_player(
                         &blocker_restriction,
                         &block_restriction,
                         &blocker_allowed,
+                        can_block_shadow_exists,
                     )
             });
             if can_block_any {
@@ -1570,6 +1599,7 @@ pub fn validate_blockers_for_player(
                         &blocker_restriction,
                         &block_restriction,
                         &blocker_allowed,
+                        can_block_shadow_exists,
                     )
                 {
                     return Err(format!(
@@ -3089,6 +3119,11 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
     let blocker_restriction = collect_blocker_restriction_statics(state);
     let block_restriction = collect_block_restriction_statics(state);
     let blocker_allowed = collect_blocker_allowed_statics(state);
+    // CR 604.1: shadow block-lift existence gate (CR 509.1b/609.4/702.28b).
+    let can_block_shadow_exists =
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::CanBlockShadow)
+        });
     can_block_pair_with_precomputed(
         state,
         blocker_id,
@@ -3096,6 +3131,7 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
         &blocker_restriction,
         &block_restriction,
         &blocker_allowed,
+        can_block_shadow_exists,
     )
 }
 
@@ -3113,6 +3149,7 @@ pub fn can_block_pair_with_precomputed(
     blocker_restriction: &[(ObjectId, StaticDefinition)],
     block_restriction: &[(ObjectId, StaticDefinition)],
     blocker_allowed: &[(ObjectId, StaticDefinition)],
+    can_block_shadow_exists: bool,
 ) -> bool {
     let Some(blocker) = state.objects.get(&blocker_id) else {
         return false;
@@ -3184,7 +3221,10 @@ pub fn can_block_pair_with_precomputed(
     let blocker_has_shadow = blocker.has_keyword(&Keyword::Shadow);
     // CR 509.1b + CR 609.4 + CR 702.28b: a `CanBlockShadow` static lifts the
     // shadow restriction for this blocker (Heartwood Dryad, Wall of Diffusion).
-    if attacker_has_shadow && !blocker_has_shadow && !blocker_can_block_shadow(state, blocker) {
+    if attacker_has_shadow
+        && !blocker_has_shadow
+        && !blocker_can_block_shadow_gated(state, blocker, can_block_shadow_exists)
+    {
         return false;
     }
     if !attacker_has_shadow && blocker_has_shadow {
@@ -3277,6 +3317,12 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
     let blocker_restriction = collect_blocker_restriction_statics(state);
     let block_restriction = collect_block_restriction_statics(state);
     let blocker_allowed = collect_blocker_allowed_statics(state);
+    // CR 604.1: shadow block-lift existence gate (CR 509.1b/609.4/702.28b),
+    // hoisted once for the whole O(blockers × attackers) sweep.
+    let can_block_shadow_exists =
+        super::functioning_abilities::any_functioning_static_mode(state, |m| {
+            matches!(m, StaticMode::CanBlockShadow)
+        });
 
     let mut result = HashMap::new();
     for &blocker_id in &valid_blockers {
@@ -3299,6 +3345,7 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
                     &blocker_restriction,
                     &block_restriction,
                     &blocker_allowed,
+                    can_block_shadow_exists,
                 )
             })
             .map(|a| a.object_id)
@@ -5425,6 +5472,93 @@ mod tests {
             .keywords
             .push(Keyword::Shadow);
         assert!(validate_blockers(&state, &[(shadow_blocker, normal_attacker)]).is_err());
+    }
+
+    /// CR 604.1 + CR 509.1b/609.4/702.28b: with NO functioning `CanBlockShadow`
+    /// static anywhere, the hoisted existence gate short-circuits every
+    /// per-blocker shadow scan, so a shadow attacker facing K non-shadow blockers
+    /// costs ZERO `blocker_can_block_shadow` full-body executions while remaining
+    /// byte-identical (no non-shadow creature can block the shadow attacker).
+    /// Reverting the gate restores the O(K) per-blocker `check_static_ability`
+    /// sweep, flipping the `combat_shadow_block_scans == 0` assertion to K.
+    #[test]
+    fn get_valid_block_targets_no_shadow_scan_when_no_can_block_shadow_static() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Shadow Strider", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Shadow);
+
+        // K=8 non-shadow defending creatures (PlayerId(1)).
+        for i in 0..8 {
+            create_creature(&mut state, PlayerId(1), &format!("Bear {i}"), 2, 2);
+        }
+
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+
+        crate::game::perf_counters::reset();
+        let targets = get_valid_block_targets(&state);
+        let scans = crate::game::perf_counters::snapshot().combat_shadow_block_scans;
+
+        assert_eq!(
+            scans, 0,
+            "no CanBlockShadow static exists, so the gate must skip every per-blocker shadow scan"
+        );
+        assert!(
+            targets.is_empty(),
+            "no non-shadow creature can legally block the shadow attacker; got {targets:?}"
+        );
+    }
+
+    /// CR 604.1 + CR 509.1b/609.4/702.28b equivalence: when a functioning
+    /// `CanBlockShadow` static DOES exist, the gate is true and the full
+    /// predicate runs, so the affected non-shadow creature is a legal blocker for
+    /// the shadow attacker while plain non-shadow creatures are not. This proves
+    /// the gate-true path preserves the shadow-lift (the gate is a pure
+    /// existence short-circuit, not a behavior change).
+    #[test]
+    fn get_valid_block_targets_honors_can_block_shadow_static() {
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Shadow Strider", 2, 2);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Shadow);
+
+        let plain = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let dryad = create_creature(&mut state, PlayerId(1), "Heartwood Dryad", 2, 2);
+        state
+            .objects
+            .get_mut(&dryad)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CanBlockShadow).affected(TargetFilter::SelfRef),
+            );
+
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+
+        let targets = get_valid_block_targets(&state);
+        assert_eq!(
+            targets.get(&dryad).map(Vec::as_slice),
+            Some([attacker].as_slice()),
+            "the CanBlockShadow creature must be able to block the shadow attacker"
+        );
+        assert!(
+            !targets.contains_key(&plain),
+            "a plain non-shadow creature still cannot block the shadow attacker; got {targets:?}"
+        );
     }
 
     #[test]
@@ -8012,6 +8146,8 @@ mod tests {
             "collect_blocker_allowed_statics must capture the flying-only BlockRestriction"
         );
 
+        // No CanBlockShadow static on this board, so the shadow-lift gate is false.
+        let can_block_shadow_exists = false;
         let precomputed_ground = can_block_pair_with_precomputed(
             &state,
             drone,
@@ -8019,6 +8155,7 @@ mod tests {
             &blocker_restriction,
             &block_restriction,
             &blocker_allowed,
+            can_block_shadow_exists,
         );
         let precomputed_flyer = can_block_pair_with_precomputed(
             &state,
@@ -8027,6 +8164,7 @@ mod tests {
             &blocker_restriction,
             &block_restriction,
             &blocker_allowed,
+            can_block_shadow_exists,
         );
 
         assert!(
@@ -8100,6 +8238,8 @@ mod tests {
                 &blocker_restriction,
                 &block_restriction,
                 &blocker_allowed,
+                // No CanBlockShadow static on this board.
+                false,
             ),
             "precomputed pair check must reject a blocker under CantBlock"
         );

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2848,6 +2848,15 @@ fn expand_granted_activated_abilities(
     let mut out = Vec::new();
     let mut provider_ids: Vec<ObjectId> = state.objects.keys().copied().collect();
     provider_ids.sort_unstable_by_key(|id| id.0);
+    // CR 109.5: the provider `source` filter resolves through a context built
+    // purely from the (constant) host id and the recipient's controller — the
+    // recipient id is NOT part of it. So the matching-provider set is identical
+    // for every recipient sharing a controller. Memoize it per controller so
+    // the O(recipients × objects) filter sweep collapses to O(controllers ×
+    // objects). The recipient-equality self-skip stays per-recipient at
+    // emission (CR 613.1f), keeping the emitted set byte-identical.
+    let mut providers_by_controller: std::collections::HashMap<PlayerId, Vec<ObjectId>> =
+        std::collections::HashMap::new();
     for &recipient_id in &state.battlefield {
         if !crate::game::filter::matches_target_filter(
             state,
@@ -2874,21 +2883,30 @@ fn expand_granted_activated_abilities(
         // (Agatha's Soul Cauldron grants creatures-you-control the abilities of
         // *its own* exiled creature cards) only the host id finds the exile
         // links while "you" still tracks the recipient's controller.
-        let provider_ctx = crate::game::filter::FilterContext::from_source_with_controller(
-            host_source_id,
-            recipient_controller,
-        );
+        let matching = providers_by_controller
+            .entry(recipient_controller)
+            .or_insert_with(|| {
+                let provider_ctx = crate::game::filter::FilterContext::from_source_with_controller(
+                    host_source_id,
+                    recipient_controller,
+                );
+                provider_ids
+                    .iter()
+                    .copied()
+                    .filter(|&provider_id| {
+                        crate::game::perf_counters::record_granted_ability_provider_scan();
+                        crate::game::filter::matches_target_filter(
+                            state,
+                            provider_id,
+                            source,
+                            &provider_ctx,
+                        )
+                    })
+                    .collect()
+            });
         let mut next_mod_index = 0usize;
-        for &provider_id in &provider_ids {
+        for &provider_id in matching.iter() {
             if provider_id == recipient_id {
-                continue;
-            }
-            if !crate::game::filter::matches_target_filter(
-                state,
-                provider_id,
-                source,
-                &provider_ctx,
-            ) {
                 continue;
             }
             let Some(provider) = state.objects.get(&provider_id) else {
@@ -9394,6 +9412,205 @@ mod tests {
             "hand provider must NOT donate: expected 1 grant (from bf_provider), \
              got {grant_count} (hand_provider donated a duplicate)"
         );
+    }
+
+    /// CR 109.5 + CR 604.1: `expand_granted_activated_abilities` memoizes the
+    /// matching-provider set per recipient controller. With K recipients sharing
+    /// ONE controller, the provider filter sweep runs exactly once (M scans, one
+    /// per object), and every recipient still gains each provider's activated
+    /// ability. Reverting the per-controller cache restores the K×M sweep,
+    /// flipping the `granted_ability_provider_scans == M` assertion.
+    #[test]
+    fn granted_activated_abilities_scan_providers_once_per_controller() {
+        use crate::types::game_state::{ExileLink, ExileLinkKind};
+
+        let mut state = setup();
+
+        // Host cauldron-like artifact (NOT a creature, so not a recipient of its
+        // own grant) carrying "creatures you control have all activated abilities
+        // of all cards exiled with this".
+        let host = create_object(
+            &mut state,
+            CardId(800),
+            PlayerId(0),
+            "Soul Cauldron".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions = vec![StaticDefinition::continuous()
+                .affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::You),
+                ))
+                .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                    source: TargetFilter::ExiledBySource,
+                }])]
+            .into();
+        }
+
+        // K=8 recipient creatures, all controlled by player 0.
+        let recipients: Vec<ObjectId> = (0..8)
+            .map(|i| make_creature(&mut state, &format!("Recipient {i}"), 1, 1, PlayerId(0)))
+            .collect();
+
+        // Two exiled provider cards, each carrying one distinct activated ability,
+        // both tracked by the host.
+        let mut provider_abilities = Vec::new();
+        for i in 0..2 {
+            let provider = create_object(
+                &mut state,
+                CardId(810 + i),
+                PlayerId(0),
+                format!("Exiled Source {i}"),
+                Zone::Exile,
+            );
+            let ability = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed {
+                        value: 2 + i as i32,
+                    },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Tap);
+            Arc::make_mut(&mut state.objects.get_mut(&provider).unwrap().abilities)
+                .push(ability.clone());
+            state.exile_links.push(ExileLink {
+                exiled_id: provider,
+                source_id: host,
+                kind: ExileLinkKind::TrackedBySource,
+            });
+            provider_abilities.push(ability);
+        }
+
+        let m = state.objects.len() as u64;
+        let affected = TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You));
+        let source = TargetFilter::ExiledBySource;
+
+        // Single deterministic invocation of the seam so the per-pass scan count
+        // is unambiguous (evaluate_layers re-runs the expansion each pass; this
+        // isolates one pass). Single controller ⟹ exactly M provider scans.
+        crate::game::perf_counters::reset();
+        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source);
+        let scans = crate::game::perf_counters::snapshot().granted_ability_provider_scans;
+        assert_eq!(
+            scans, m,
+            "single controller must scan the provider set exactly once (M objects)"
+        );
+        // 8 recipients × 2 provider abilities = 16 grant effects.
+        assert_eq!(
+            effects.len(),
+            16,
+            "every recipient gains both provider abilities"
+        );
+
+        // Behavioral equivalence through the production entry point.
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        for &recipient in &recipients {
+            let obj = state.objects.get(&recipient).unwrap();
+            for ability in &provider_abilities {
+                assert!(
+                    obj.abilities.iter().any(|a| a == ability),
+                    "each recipient must gain every exiled provider's activated ability"
+                );
+            }
+        }
+    }
+
+    /// CR 109.5: the provider cache is keyed per controller, not over-collapsed.
+    /// Two recipients with DIFFERENT controllers force TWO full provider sweeps
+    /// (2×M scans), and each still receives the controller-independent
+    /// `ExiledBySource` provider abilities. Reverting the cache key to a single
+    /// shared entry would under-count to M.
+    #[test]
+    fn granted_activated_abilities_scan_per_distinct_controller() {
+        use crate::types::game_state::{ExileLink, ExileLinkKind};
+
+        let mut state = setup();
+
+        // Host grants to ALL creatures (no controller restriction) so recipients
+        // of either controller match the affected filter.
+        let host = create_object(
+            &mut state,
+            CardId(800),
+            PlayerId(0),
+            "Soul Cauldron".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions = vec![StaticDefinition::continuous()
+                .affected(TargetFilter::Typed(TypedFilter::creature()))
+                .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                    source: TargetFilter::ExiledBySource,
+                }])]
+            .into();
+        }
+
+        // One recipient per controller.
+        let recipient_p0 = make_creature(&mut state, "Recipient P0", 1, 1, PlayerId(0));
+        let recipient_p1 = make_creature(&mut state, "Recipient P1", 1, 1, PlayerId(1));
+
+        let provider = create_object(
+            &mut state,
+            CardId(810),
+            PlayerId(0),
+            "Exiled Source".to_string(),
+            Zone::Exile,
+        );
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                player: TargetFilter::Controller,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        Arc::make_mut(&mut state.objects.get_mut(&provider).unwrap().abilities)
+            .push(ability.clone());
+        state.exile_links.push(ExileLink {
+            exiled_id: provider,
+            source_id: host,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+
+        let m = state.objects.len() as u64;
+        let affected = TargetFilter::Typed(TypedFilter::creature());
+        let source = TargetFilter::ExiledBySource;
+
+        // Single deterministic invocation: two distinct recipient controllers ⟹
+        // two cache entries ⟹ two full provider sweeps (2×M scans).
+        crate::game::perf_counters::reset();
+        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source);
+        let scans = crate::game::perf_counters::snapshot().granted_ability_provider_scans;
+        assert_eq!(
+            scans,
+            2 * m,
+            "two distinct controllers must each trigger one full provider sweep"
+        );
+        // 2 recipients × 1 provider ability = 2 grant effects.
+        assert_eq!(
+            effects.len(),
+            2,
+            "each controller's recipient gains the provider ability"
+        );
+
+        // Behavioral equivalence through the production entry point.
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        for recipient in [recipient_p0, recipient_p1] {
+            let obj = state.objects.get(&recipient).unwrap();
+            assert!(
+                obj.abilities.iter().any(|a| a == &ability),
+                "each controller's recipient must gain the exiled provider's ability"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -19,6 +19,8 @@ pub struct PerfCounterSnapshot {
     pub mana_aura_trigger_scans: u64,
     pub crew_eligibility_scans: u64,
     pub attackable_player_sweeps: u64,
+    pub combat_shadow_block_scans: u64,
+    pub granted_ability_provider_scans: u64,
 }
 
 thread_local! {
@@ -51,6 +53,8 @@ thread_local! {
         mana_aura_trigger_scans: 0,
         crew_eligibility_scans: 0,
         attackable_player_sweeps: 0,
+        combat_shadow_block_scans: 0,
+        granted_ability_provider_scans: 0,
     }) };
 }
 
@@ -72,6 +76,24 @@ pub fn record_state_clone_for_legality() {
 /// per-loop scans to O(N).
 pub fn record_static_full_scan() {
     with_mut(|s| s.static_full_scans += 1);
+}
+
+/// Counts every full-body execution of `blocker_can_block_shadow` (each a
+/// whole-battlefield `check_static_ability(CanBlockShadow)` sweep). The combat
+/// block-legality loops hoist a once-computed `CanBlockShadow` existence gate to
+/// drive this toward zero, collapsing the O(attackers×blockers×N) per-blocker
+/// scan to O(N) when no such static exists.
+pub fn record_combat_shadow_block_scan() {
+    with_mut(|s| s.combat_shadow_block_scans += 1);
+}
+
+/// Counts every per-provider `matches_target_filter` evaluation done while
+/// populating the per-controller provider cache in
+/// `expand_granted_activated_abilities`. Memoizing the matching-provider set by
+/// recipient controller collapses the O(recipients×objects) filter sweep to
+/// O(controllers×objects).
+pub fn record_granted_ability_provider_scan() {
+    with_mut(|s| s.granted_ability_provider_scans += 1);
 }
 
 pub fn record_layers_full_eval() {

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -28,6 +28,9 @@ pub(crate) struct BlockLegalitySlices {
     blocker_restriction: Vec<(ObjectId, StaticDefinition)>,
     block_restriction: Vec<(ObjectId, StaticDefinition)>,
     blocker_allowed: Vec<(ObjectId, StaticDefinition)>,
+    // CR 604.1: shadow block-lift existence gate (CR 509.1b/609.4/702.28b),
+    // hoisted once so per-pair legality skips the O(N) CanBlockShadow sweep.
+    can_block_shadow_exists: bool,
 }
 
 impl BlockLegalitySlices {
@@ -36,6 +39,10 @@ impl BlockLegalitySlices {
             blocker_restriction: collect_blocker_restriction_statics(state),
             block_restriction: collect_block_restriction_statics(state),
             blocker_allowed: collect_blocker_allowed_statics(state),
+            can_block_shadow_exists:
+                engine::game::functioning_abilities::any_functioning_static_mode(state, |m| {
+                    matches!(m, StaticMode::CanBlockShadow)
+                }),
         }
     }
 
@@ -53,6 +60,7 @@ impl BlockLegalitySlices {
             &self.blocker_restriction,
             &self.block_restriction,
             &self.blocker_allowed,
+            self.can_block_shadow_exists,
         )
     }
 }


### PR DESCRIPTION
## What

Final two items (d, f) of the loop-invariant-hoist performance campaign (#4437 / #4445 / #4448). Both are **byte-identical** (pure hoist / memoization, no rules change); each adds a thread-local perf counter and a revert-failing test driving a production entry point, plus equivalence and hostile siblings.

## Items

**f — `blocker_can_block_shadow`** (`combat.rs`, `perf_counters.rs`, `phase-ai/combat_ai.rs`)
Ran a full `game_functioning_statics` sweep per blocker inside per-attacker × per-blocker block-legality loops → O(attackers × blockers × N) on shadow-heavy boards. Hoist a once-computed `CanBlockShadow` existence gate (`any_functioning_static_mode`) per loop-owner and thread it through a new `blocker_can_block_shadow_gated` arity. Byte-identical because the gate's `game_functioning_statics` universe is a strict superset of both sub-checks (`active_static_definitions` + remote `check_static_ability`), so gate-false ⟹ the full predicate is already false. Threaded through all engine prod + test callers of `can_block_pair_with_precomputed` and the phase-ai `BlockLegalitySlices` mirror struct. CR 509.1b / 609.4 / 702.28b / 604.1.

**d — `expand_granted_activated_abilities`** (`layers.rs`, `perf_counters.rs`)
Re-filtered *all* objects per battlefield recipient → O(recipients × objects) for `GrantAllActivatedAbilitiesOf` hosts (Agatha's Soul Cauldron class). The provider-match context (`from_source_with_controller`) depends only on the recipient's **controller**, not its identity, so memoize the matching-provider set per controller in a `HashMap<PlayerId, Vec<ObjectId>>` → O(controllers × objects). Sorted provider order, per-recipient self-skip at emission, and `next_mod_index` are preserved, so emission order and every `mod_index` are byte-identical. CR 109.5 / 604.1 / 613.1f.

## Verification

- `cargo fmt --all` clean
- `cargo clippy -p engine -p phase-ai --all-targets` clean (0 warnings; confirms the cross-crate `BlockLegalitySlices` threading compiles)
- `cargo test -p engine -p phase-ai --lib` — 14820 passed, 0 failed, 14 ignored (after rebase onto current main incl. #4448)
- Independent `/review-impl` pass: PASS, ship-ready, zero findings; both byte-identity proofs reconfirmed against shipped code, full CR audit clean.

## Tests

- f: `get_valid_block_targets_no_shadow_scan_when_no_can_block_shadow_static` (revert-failing: `combat_shadow_block_scans == 0`, no legal blockers) + `get_valid_block_targets_honors_can_block_shadow_static` (gate-true equivalence: a `CanBlockShadow` creature blocks the shadow attacker, plain ones don't).
- d: `granted_activated_abilities_scan_providers_once_per_controller` (revert-failing: `granted_ability_provider_scans == M` single controller, + equivalence via `evaluate_layers`) + `granted_activated_abilities_scan_per_distinct_controller` (hostile: `== 2*M` for two controllers, proving the cache key isn't over-collapsed).