### PR TITLE
fix(parser): Lethargy Trap alt-cost gate on attacking creature count

### DIFF
--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1702,7 +1702,8 @@ mod tests {
     #[test]
     fn alt_cost_leading_if_attacking_creatures_count_ge_binds() {
         let option = parse_spell_casting_option_line(
-            "If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.",
+            "If three or more creatures are attacking, you may pay {U} rather than pay \
+this spell's mana cost.",
             "Lethargy Trap",
         )
         .expect("alt-cost should parse with leading-if attacking-creatures gate");
@@ -1729,7 +1730,9 @@ mod tests {
                     panic!("expected Typed creature filter, got {filter:?}");
                 }
             }
-            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
+            other => panic!(
+                "expected QuantityComparison GE 3 attacking creatures, got {other:?}"
+            ),
         }
     }
 

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1697,6 +1697,42 @@ mod tests {
         }
     }
 
+    /// CR 508.1 + CR 118.9: Lethargy Trap — leading "If three or more creatures
+    /// are attacking, " gates the {U} alternative casting cost.
+    #[test]
+    fn alt_cost_leading_if_attacking_creatures_count_ge_binds() {
+        let option = parse_spell_casting_option_line(
+            "If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.",
+            "Lethargy Trap",
+        )
+        .expect("alt-cost should parse with leading-if attacking-creatures gate");
+        match option {
+            SpellCastingOption {
+                kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
+                condition: Some(ParsedCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 3 },
+                }),
+                ..
+            } => {
+                if let TargetFilter::Typed(tf) = filter {
+                    assert!(
+                        tf.properties.iter().any(
+                            |p| matches!(p, FilterProp::Attacking { defender: None })
+                        ),
+                        "expected Attacking filter, got {tf:?}"
+                    );
+                } else {
+                    panic!("expected Typed creature filter, got {filter:?}");
+                }
+            }
+            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
+        }
+    }
+
     #[test]
     fn alt_cost_leading_if_unrecognized_predicate_drops_option() {
         // CR 118.9 + CR 601.3d: when the leading-if predicate cannot decompose

--- a/crates/engine/src/parser/oracle_casting.rs
+++ b/crates/engine/src/parser/oracle_casting.rs
@@ -1702,37 +1702,36 @@ mod tests {
     #[test]
     fn alt_cost_leading_if_attacking_creatures_count_ge_binds() {
         let option = parse_spell_casting_option_line(
-            "If three or more creatures are attacking, you may pay {U} rather than pay \
-this spell's mana cost.",
+            "If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.",
             "Lethargy Trap",
         )
         .expect("alt-cost should parse with leading-if attacking-creatures gate");
         match option {
             SpellCastingOption {
                 kind: crate::types::ability::SpellCastingOptionKind::AlternativeCost,
-                condition: Some(ParsedCondition::QuantityComparison {
-                    lhs: QuantityExpr::Ref {
-                        qty: QuantityRef::ObjectCount { filter },
-                    },
-                    comparator: Comparator::GE,
-                    rhs: QuantityExpr::Fixed { value: 3 },
-                }),
+                condition:
+                    Some(ParsedCondition::QuantityComparison {
+                        lhs:
+                            QuantityExpr::Ref {
+                                qty: QuantityRef::ObjectCount { filter },
+                            },
+                        comparator: Comparator::GE,
+                        rhs: QuantityExpr::Fixed { value: 3 },
+                    }),
                 ..
             } => {
                 if let TargetFilter::Typed(tf) = filter {
                     assert!(
-                        tf.properties.iter().any(
-                            |p| matches!(p, FilterProp::Attacking { defender: None })
-                        ),
+                        tf.properties
+                            .iter()
+                            .any(|p| matches!(p, FilterProp::Attacking { defender: None })),
                         "expected Attacking filter, got {tf:?}"
                     );
                 } else {
                     panic!("expected Typed creature filter, got {filter:?}");
                 }
             }
-            other => panic!(
-                "expected QuantityComparison GE 3 attacking creatures, got {other:?}"
-            ),
+            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_condition.rs
+++ b/crates/engine/src/parser/oracle_condition.rs
@@ -1381,6 +1381,29 @@ mod tests {
         }
     }
 
+    /// CR 508.1 + CR 118.9: Lethargy Trap — "three or more creatures are attacking"
+    /// bridges to ObjectCount(creature + Attacking) >= N.
+    #[test]
+    fn restriction_attacking_creatures_count_ge() {
+        match parse_restriction_condition("three or more creatures are attacking") {
+            Some(ParsedCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            }) => assert!(
+                matches!(&filter, TargetFilter::Typed(tf) if tf.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::Attacking { defender: None }
+                ))),
+                "filter should be attacking creatures, got {filter:?}"
+            ),
+            other => panic!("expected QuantityComparison(ObjectCount >= 3), got {other:?}"),
+        }
+    }
+
     #[test]
     fn parses_source_conditions() {
         assert_eq!(

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -107,6 +107,10 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         parse_control_named_pair,
         parse_compound_control_presence,
         parse_filter_have_total_property,
+        // CR 508.1 + CR 118.9: "N or more creatures are attacking" — must precede
+        // `parse_control_conditions` so the bare count phrase is not mis-read as
+        // "you control N or more creatures".
+        parse_creatures_are_attacking_count_ge,
         parse_control_conditions,
         parse_remaining_state_presence_conditions,
     ))
@@ -2842,6 +2846,30 @@ fn parse_creature_attacking_you(input: &str) -> OracleResult<'_, StaticCondition
         rest,
         StaticCondition::IsPresent {
             filter: Some(TargetFilter::Typed(filter)),
+        },
+    ))
+}
+
+/// CR 508.1 + CR 118.9: Parse "N or more creatures are attacking" →
+/// `QuantityComparison(ObjectCount(creature + Attacking) >= N)`.
+///
+/// Lethargy Trap: "If three or more creatures are attacking, you may pay {U}
+/// rather than pay this spell's mana cost." Reuses `parse_ge_threshold` so
+/// "at least three creatures are attacking" shares the same parse path.
+fn parse_creatures_are_attacking_count_ge(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, n) = parse_ge_threshold(input)?;
+    let (rest, _) = tag("creatures are attacking").parse(rest.trim_start())?;
+    let filter = TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![FilterProp::Attacking { defender: None }]),
+    );
+    Ok((
+        rest,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
         },
     ))
 }
@@ -7892,6 +7920,37 @@ mod tests {
                 ..
             } => assert_eq!(comparator, Comparator::GE),
             other => panic!("expected QuantityComparison GE 3, got {other:?}"),
+        }
+    }
+
+    /// CR 508.1 + CR 118.9: Lethargy Trap — "three or more creatures are attacking"
+    /// gates the alternative casting cost.
+    #[test]
+    fn test_creatures_are_attacking_count_ge() {
+        let (rest, c) =
+            parse_inner_condition("three or more creatures are attacking").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } => {
+                if let TargetFilter::Typed(tf) = filter {
+                    assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                    assert!(
+                        tf.properties.iter().any(
+                            |p| matches!(p, FilterProp::Attacking { defender: None })
+                        ),
+                        "expected Attacking filter, got {tf:?}"
+                    );
+                } else {
+                    panic!("expected Typed creature filter, got {filter:?}");
+                }
+            }
+            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7927,32 +7927,30 @@ mod tests {
     /// gates the alternative casting cost.
     #[test]
     fn test_creatures_are_attacking_count_ge() {
-        let (rest, c) =
-            parse_inner_condition("three or more creatures are attacking").unwrap();
+        let (rest, c) = parse_inner_condition("three or more creatures are attacking").unwrap();
         assert_eq!(rest, "");
         match c {
             StaticCondition::QuantityComparison {
-                lhs: QuantityExpr::Ref {
-                    qty: QuantityRef::ObjectCount { filter },
-                },
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
                 comparator: Comparator::GE,
                 rhs: QuantityExpr::Fixed { value: 3 },
             } => {
                 if let TargetFilter::Typed(tf) = filter {
                     assert!(tf.type_filters.contains(&TypeFilter::Creature));
                     assert!(
-                        tf.properties.iter().any(
-                            |p| matches!(p, FilterProp::Attacking { defender: None })
-                        ),
+                        tf.properties
+                            .iter()
+                            .any(|p| matches!(p, FilterProp::Attacking { defender: None })),
                         "expected Attacking filter, got {tf:?}"
                     );
                 } else {
                     panic!("expected Typed creature filter, got {filter:?}");
                 }
             }
-            other => panic!(
-                "expected QuantityComparison GE 3 attacking creatures, got {other:?}"
-            ),
+            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7950,7 +7950,9 @@ mod tests {
                     panic!("expected Typed creature filter, got {filter:?}");
                 }
             }
-            other => panic!("expected QuantityComparison GE 3 attacking creatures, got {other:?}"),
+            other => panic!(
+                "expected QuantityComparison GE 3 attacking creatures, got {other:?}"
+            ),
         }
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4140,7 +4140,8 @@ mod tests {
     #[test]
     fn condition_if_accepts_lethargy_trap_alt_cost_gate() {
         let parsed = parse_named(
-            "If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
+            "If three or more creatures are attacking, you may pay {U} rather than pay \
+this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
             "Lethargy Trap",
             &["Instant"],
         );

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4135,6 +4135,32 @@ mod tests {
         }
     }
 
+    /// CR 508.1 + CR 118.9: Lethargy Trap — leading-if attacking-creature count
+    /// gate on the {U} alternative casting cost must not report Condition_If.
+    #[test]
+    fn condition_if_accepts_lethargy_trap_alt_cost_gate() {
+        let parsed = parse_named(
+            "If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
+            "Lethargy Trap",
+            &["Instant"],
+        );
+        assert!(
+            !has_swallowed_detector(&parsed, "Condition_If"),
+            "alt-cost attacking-creature gate must bind to casting_options: {:?}",
+            parsed.parse_warnings
+        );
+        assert_eq!(
+            parsed.casting_options.len(),
+            1,
+            "expected one alternative casting option, got {:?}",
+            parsed.casting_options
+        );
+        assert!(
+            parsed.casting_options[0].condition.is_some(),
+            "alt-cost must carry the attacking-creature count gate"
+        );
+    }
+
     /// CR 115.7d: Standalone retarget spells (Deflecting Swat, Redirect) lower
     /// to `ChangeTargets { scope: All }` with the full `you may choose new
     /// targets` surface preserved — not `def.optional`.


### PR DESCRIPTION
## Summary

Lethargy Trap (`If three or more creatures are attacking, you may pay {U} rather than pay this spell's mana cost.`) dropped its alternative casting cost because the leading-if predicate was not recognized by `parse_restriction_condition`.

This adds `parse_creatures_are_attacking_count_ge` in `oracle_nom/condition.rs`, lowering `N or more creatures are attacking` to `QuantityComparison(ObjectCount(creature + Attacking) >= N)` via the existing `parse_ge_threshold` authority.

## Test plan

- [x] `test_creatures_are_attacking_count_ge` — nom condition combinator
- [x] `restriction_attacking_creatures_count_ge` — restriction bridge
- [x] `alt_cost_leading_if_attacking_creatures_count_ge_binds` — casting option emission
- [x] `condition_if_accepts_lethargy_trap_alt_cost_gate` — swallow regression

Closes #4455
