### PR TITLE
Add False Peace

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2879,10 +2879,15 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             target,
             step,
             count,
+            scope,
         } => {
             d.push(("player".into(), fmt_target(target)));
             d.push(("step".into(), format!("{step:?}")));
-            if !matches!(
+            // CR 614.10 + CR 614.10a: surface the turn-scoped variant; the
+            // occurrence-scoped default keeps the existing rows unchanged.
+            if matches!(scope, crate::types::ability::SkipScope::AllOfNextTurn) {
+                d.push(("scope".into(), "all of next turn".into()));
+            } else if !matches!(
                 count,
                 crate::types::ability::QuantityExpr::Fixed { value: 1 }
             ) {

--- a/crates/engine/src/game/effects/skip_next_step.rs
+++ b/crates/engine/src/game/effects/skip_next_step.rs
@@ -3,7 +3,7 @@ use crate::types::ability::{
     Effect, EffectError, EffectKind, ResolvedAbility, SkipScope, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{CombatPhaseSkipState, GameState};
+use crate::types::game_state::GameState;
 
 /// CR 614.10a: "Skip your next N [step] steps." — increments the per-player
 /// step-skip counter for the named step. The turn system consumes the counter
@@ -39,17 +39,19 @@ pub fn resolve(
     let idx = player.0 as usize;
     match scope {
         // CR 614.10 + CR 614.10a: turn-scoped skip (False Peace / Empty City
-        // Ruse). Arm the turn-bound combat-skip marker as Pending; it ignores
-        // `count` (turn-binding subsumes counting) and does NOT touch
-        // `steps_to_skip`. The marker waits past skipped turns and binds to the
-        // player's first non-skipped turn in `start_next_turn`.
+        // Ruse). Each resolution arms one independent skip, so increment the
+        // per-player `pending` count rather than overwriting — two skips aimed
+        // at the same player before their next turn must skip combat on their
+        // next *two* non-skipped turns. It ignores `count` (turn-binding subsumes
+        // counting) and does NOT touch `steps_to_skip`. Each pending skip waits
+        // past skipped turns and binds to a non-skipped turn in `start_next_turn`.
         SkipScope::AllOfNextTurn => {
             if idx >= state.combat_phase_skip_next_turn.len() {
                 state
                     .combat_phase_skip_next_turn
                     .resize_with(idx + 1, Default::default);
             }
-            state.combat_phase_skip_next_turn[idx] = CombatPhaseSkipState::Pending;
+            state.combat_phase_skip_next_turn[idx].pending += 1;
         }
         // CR 614.10a: occurrence-scoped skip — increment the per-player step
         // counter; the turn system consumes it when the step would occur.
@@ -79,6 +81,7 @@ pub fn resolve(
 mod tests {
     use super::*;
     use crate::types::ability::{AbilityKind, QuantityExpr, SpellContext, StepSkipTarget};
+    use crate::types::game_state::CombatPhaseSkipState;
     use crate::types::identifiers::ObjectId;
     use crate::types::phase::Phase;
     use crate::types::player::PlayerId;
@@ -197,8 +200,8 @@ mod tests {
         assert!(skips.get(&Phase::Draw).is_none(), "Draw must not be set");
     }
 
-    /// CR 614.10 + CR 614.10a: an `AllOfNextTurn` combat skip arms the
-    /// turn-scoped marker as `Pending` and must NOT write the per-step
+    /// CR 614.10 + CR 614.10a: an `AllOfNextTurn` combat skip arms one pending
+    /// turn-scoped skip (no turn bound yet) and must NOT write the per-step
     /// `steps_to_skip` counter (turn-binding subsumes counting).
     #[test]
     fn all_of_next_turn_arms_pending_and_leaves_steps_empty() {
@@ -214,8 +217,11 @@ mod tests {
 
         assert_eq!(
             state.combat_phase_skip_next_turn[0],
-            CombatPhaseSkipState::Pending,
-            "AllOfNextTurn must arm Pending"
+            CombatPhaseSkipState {
+                pending: 1,
+                active: false
+            },
+            "AllOfNextTurn must arm exactly one pending skip and bind no turn yet"
         );
         // steps_to_skip must stay empty — turn-scope does not use the counter.
         assert!(
@@ -229,5 +235,31 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    /// CR 614.10a: two `AllOfNextTurn` skips aimed at the same player before
+    /// their next turn are independent — they accumulate to `pending: 2` rather
+    /// than collapsing to one (each will bind to a separate non-skipped turn).
+    #[test]
+    fn stacked_all_of_next_turn_skips_accumulate_pending() {
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+        let ability = make_ability_scoped(
+            StepSkipTarget::CombatPhase,
+            QuantityExpr::Fixed { value: 1 },
+            SkipScope::AllOfNextTurn,
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.combat_phase_skip_next_turn[0],
+            CombatPhaseSkipState {
+                pending: 2,
+                active: false
+            },
+            "two stacked turn-scoped skips must accumulate, not overwrite"
+        );
     }
 }

--- a/crates/engine/src/game/effects/skip_next_step.rs
+++ b/crates/engine/src/game/effects/skip_next_step.rs
@@ -1,9 +1,9 @@
 use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+    Effect, EffectError, EffectKind, ResolvedAbility, SkipScope, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{CombatPhaseSkipState, GameState};
 
 /// CR 614.10a: "Skip your next N [step] steps." — increments the per-player
 /// step-skip counter for the named step. The turn system consumes the counter
@@ -17,6 +17,7 @@ pub fn resolve(
         target,
         step,
         count,
+        scope,
     } = &ability.effect
     else {
         return Err(EffectError::MissingParam(
@@ -35,14 +36,34 @@ pub fn resolve(
         }
     };
 
-    let n = resolve_quantity(state, count, ability.controller, ability.source_id).max(0) as u32;
-    if n > 0 {
-        let idx = player.0 as usize;
-        if idx >= state.steps_to_skip.len() {
-            state.steps_to_skip.resize_with(idx + 1, Default::default);
+    let idx = player.0 as usize;
+    match scope {
+        // CR 614.10 + CR 614.10a: turn-scoped skip (False Peace / Empty City
+        // Ruse). Arm the turn-bound combat-skip marker as Pending; it ignores
+        // `count` (turn-binding subsumes counting) and does NOT touch
+        // `steps_to_skip`. The marker waits past skipped turns and binds to the
+        // player's first non-skipped turn in `start_next_turn`.
+        SkipScope::AllOfNextTurn => {
+            if idx >= state.combat_phase_skip_next_turn.len() {
+                state
+                    .combat_phase_skip_next_turn
+                    .resize_with(idx + 1, Default::default);
+            }
+            state.combat_phase_skip_next_turn[idx] = CombatPhaseSkipState::Pending;
         }
-        for step in step.constituent_steps() {
-            *state.steps_to_skip[idx].entry(*step).or_default() += n;
+        // CR 614.10a: occurrence-scoped skip — increment the per-player step
+        // counter; the turn system consumes it when the step would occur.
+        SkipScope::NextOccurrence => {
+            let n =
+                resolve_quantity(state, count, ability.controller, ability.source_id).max(0) as u32;
+            if n > 0 {
+                if idx >= state.steps_to_skip.len() {
+                    state.steps_to_skip.resize_with(idx + 1, Default::default);
+                }
+                for step in step.constituent_steps() {
+                    *state.steps_to_skip[idx].entry(*step).or_default() += n;
+                }
+            }
         }
     }
 
@@ -63,11 +84,20 @@ mod tests {
     use crate::types::player::PlayerId;
 
     fn make_ability(step: StepSkipTarget, count: QuantityExpr) -> ResolvedAbility {
+        make_ability_scoped(step, count, SkipScope::NextOccurrence)
+    }
+
+    fn make_ability_scoped(
+        step: StepSkipTarget,
+        count: QuantityExpr,
+        scope: SkipScope,
+    ) -> ResolvedAbility {
         ResolvedAbility {
             effect: Effect::SkipNextStep {
                 target: TargetFilter::Controller,
                 step,
                 count,
+                scope,
             },
             controller: PlayerId(0),
             original_controller: None,
@@ -165,5 +195,39 @@ mod tests {
         // Non-combat steps must not be touched.
         assert!(skips.get(&Phase::Untap).is_none(), "Untap must not be set");
         assert!(skips.get(&Phase::Draw).is_none(), "Draw must not be set");
+    }
+
+    /// CR 614.10 + CR 614.10a: an `AllOfNextTurn` combat skip arms the
+    /// turn-scoped marker as `Pending` and must NOT write the per-step
+    /// `steps_to_skip` counter (turn-binding subsumes counting).
+    #[test]
+    fn all_of_next_turn_arms_pending_and_leaves_steps_empty() {
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+        let ability = make_ability_scoped(
+            StepSkipTarget::CombatPhase,
+            QuantityExpr::Fixed { value: 1 },
+            SkipScope::AllOfNextTurn,
+        );
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.combat_phase_skip_next_turn[0],
+            CombatPhaseSkipState::Pending,
+            "AllOfNextTurn must arm Pending"
+        );
+        // steps_to_skip must stay empty — turn-scope does not use the counter.
+        assert!(
+            state.steps_to_skip.is_empty() || state.steps_to_skip[0].is_empty(),
+            "AllOfNextTurn must not write steps_to_skip"
+        );
+        assert!(events.iter().any(|e| matches!(
+            e,
+            GameEvent::EffectResolved {
+                kind: EffectKind::SkipNextStep,
+                ..
+            }
+        )));
     }
 }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -16,7 +16,7 @@ use super::filter::{
     matches_target_filter_on_damage_record_source, FilterContext,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, PendingReplacement, WaitingFor};
+use crate::types::game_state::{CombatPhaseSkipState, GameState, PendingReplacement, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
 use crate::types::player::PlayerId;
@@ -44,6 +44,13 @@ const UMBRA_ARMOR_DESTROY_INDEX: usize = usize::MAX - 2;
 /// not a battlefield `ReplacementDefinition`, but it must still participate in
 /// CR 616 ordering against AddCounter replacements such as Doubling Season.
 const COMPLEATED_LOYALTY_INDEX: usize = usize::MAX - 3;
+/// CR 614.10 + CR 614.10a: Turn-scoped combat-phase skip (False Peace / Empty
+/// City Ruse — "skips all combat phases of their next turn"). The skip effect
+/// leaves no battlefield object, so it is a virtual BeginPhase replacement keyed
+/// on the affected player (whose `PlayerId` is encoded into the sentinel
+/// `source` `ObjectId`). It is armed by `GameState::combat_phase_skip_next_turn`
+/// being `Active` for the active player on a combat phase.
+const TURN_SCOPED_COMBAT_SKIP_INDEX: usize = usize::MAX - 4;
 
 /// CR 109.4 + CR 108.4a: Cards outside the battlefield/stack have no
 /// controller; if an effect asks for a card's controller, use its owner
@@ -75,6 +82,20 @@ fn umbra_armor_replacement_id(aura_id: ObjectId) -> ReplacementId {
 
 fn is_umbra_armor_replacement(rid: ReplacementId) -> bool {
     rid.index == UMBRA_ARMOR_DESTROY_INDEX
+}
+
+/// CR 614.10 + CR 614.10a: virtual replacement id for the turn-scoped combat
+/// skip. The affected `PlayerId` is encoded into the sentinel `ObjectId` the
+/// same way `compleated_replacement_id` carries its host object id.
+fn turn_scoped_combat_skip_replacement_id(player: PlayerId) -> ReplacementId {
+    ReplacementId {
+        source: ObjectId(player.0 as u64),
+        index: TURN_SCOPED_COMBAT_SKIP_INDEX,
+    }
+}
+
+fn is_turn_scoped_combat_skip_replacement(rid: ReplacementId) -> bool {
+    rid.index == TURN_SCOPED_COMBAT_SKIP_INDEX
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -549,6 +570,10 @@ fn replacement_choice_label(repl: &ReplacementDefinition) -> String {
 fn replacement_choice_label_for_rid(state: &GameState, rid: ReplacementId) -> String {
     if is_compleated_replacement(rid) {
         return "Compleated: enter with fewer loyalty counters".to_string();
+    }
+    if is_turn_scoped_combat_skip_replacement(rid) {
+        // CR 614.10: mandatory skip — static label, never offered as a choice.
+        return "Skip combat phase".to_string();
     }
     if is_umbra_armor_replacement(rid) {
         return state
@@ -4259,6 +4284,30 @@ pub fn find_applicable_replacements(
         }
     }
 
+    // CR 614.10 + CR 614.10a + CR 506.1: Turn-scoped combat-phase skip (False
+    // Peace / Empty City Ruse). When the active player has an `Active`
+    // turn-scoped combat skip and a combat-phase step is beginning, expose the
+    // virtual skip candidate so the CR 616 pipeline prevents the phase. Scoped
+    // strictly to the active (begin-phase) player + combat steps so it never
+    // over-matches; it persists for the whole turn (no `already_applied`
+    // consumption beyond the standard per-event guard).
+    if let ProposedEvent::BeginPhase {
+        player_id, phase, ..
+    } = event
+    {
+        if phase.is_combat()
+            && state
+                .combat_phase_skip_next_turn
+                .get(player_id.0 as usize)
+                == Some(&CombatPhaseSkipState::Active)
+        {
+            let rid = turn_scoped_combat_skip_replacement_id(*player_id);
+            if !event.already_applied(&rid) {
+                candidates.push(rid);
+            }
+        }
+    }
+
     // CR 614.12: Self-replacement effects on a card entering the battlefield.
     // apply even though the card isn't on the battlefield yet. We must scan the
     // entering card in addition to battlefield/command zone permanents.
@@ -5281,6 +5330,17 @@ fn apply_single_replacement(
         return apply_umbra_armor_replacement(state, proposed, rid, events);
     }
 
+    // CR 614.10 + CR 614.10a: Turn-scoped combat-phase skip — "skip [the combat
+    // phase]" is "instead of beginning it, do nothing." Yield `Prevented` so the
+    // pipeline turns the BeginPhase event into `ReplacementResult::Prevented`,
+    // which `advance_phase` consumes by not entering the phase. The marker is NOT
+    // consumed here: it persists `Active` for the whole turn so every combat
+    // phase that turn (including extra combat phases) is prevented; it is cleared
+    // at the start of the player's following turn in `start_next_turn`.
+    if is_turn_scoped_combat_skip_replacement(rid) {
+        return Err(ApplyResult::Prevented);
+    }
+
     // CR 615.3: Pending damage prevention shields use sentinel ObjectId(0).
     // Look up from game-state-level registry instead of object replacement_definitions.
     let repl_def_ref = if rid.source == ObjectId(0) {
@@ -5769,6 +5829,12 @@ fn candidate_materiality(
             field: EventField::Count,
             commute: CommuteClass::Subtractive,
         };
+    }
+
+    // CR 614.10: the turn-scoped combat skip fully prevents the BeginPhase event,
+    // so it is unconditional like the umbra-armor / shield-counter destroy.
+    if is_turn_scoped_combat_skip_replacement(rid) {
+        return CandidateMateriality::Unconditional;
     }
 
     match shield_counter_replacement_kind(rid) {

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -16,7 +16,7 @@ use super::filter::{
     matches_target_filter_on_damage_record_source, FilterContext,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{CombatPhaseSkipState, GameState, PendingReplacement, WaitingFor};
+use crate::types::game_state::{GameState, PendingReplacement, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
 use crate::types::player::PlayerId;
@@ -4299,7 +4299,7 @@ pub fn find_applicable_replacements(
             && state
                 .combat_phase_skip_next_turn
                 .get(player_id.0 as usize)
-                == Some(&CombatPhaseSkipState::Active)
+                .is_some_and(|skip| skip.active)
         {
             let rid = turn_scoped_combat_skip_replacement_id(*player_id);
             if !event.already_applied(&rid) {

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -7,8 +7,7 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::format::GameFormat;
 use crate::types::game_state::{
-    AutoPassMode, CombatPhaseSkipState, GameState, PendingCounterAddition, PendingEffectResolved,
-    WaitingFor,
+    AutoPassMode, GameState, PendingCounterAddition, PendingEffectResolved, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
@@ -609,17 +608,16 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.attacked_defenders_this_turn.clear();
     state.creature_attacked_defenders_this_turn.clear();
     state.combat_phases_started_this_turn = 0;
-    // CR 614.10 + CR 614.10a + CR 500.11: Clear a turn-scoped combat skip that
-    // was `Active` on this player's PREVIOUS (now-ended) turn. `idx` is the
-    // player whose turn is beginning here; if their slot is still `Active` it was
-    // bound and consumed by their last turn, so the skip is satisfied and this
-    // new turn has normal combat. Only an `Active` slot is cleared here — a
-    // still-`Pending` skip has not yet bound to a turn and must survive (and will
-    // be promoted to `Active` below if this is its first non-skipped turn).
-    if state.combat_phase_skip_next_turn.get(idx) == Some(&CombatPhaseSkipState::Active) {
-        if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
-            *slot = CombatPhaseSkipState::None;
-        }
+    // CR 614.10 + CR 614.10a + CR 500.11: A turn-scoped combat skip that was
+    // bound (`active`) to this player's PREVIOUS (now-ended) turn is satisfied —
+    // release the binding so this new turn has normal combat unless another
+    // pending skip rebinds below. `idx` is the player whose turn is beginning.
+    // Only the `active` binding is cleared — any still-`pending` skips have not
+    // yet bound to a turn and must survive (CR 614.10a: the second of two stacked
+    // skips waits for the next occurrence), to be promoted below if this turn
+    // isn't itself skipped.
+    if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
+        slot.active = false;
     }
     state.end_steps_started_this_turn = 0;
     state.creatures_attacked_this_turn.clear();
@@ -689,16 +687,18 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
         player.bending_types_this_turn.clear();
     }
 
-    // CR 614.10 + CR 614.10a + CR 500.11: Promote a turn-scoped combat skip from
-    // `Pending` to `Active` now that the active player's first non-skipped turn
-    // has actually begun. This runs AFTER the per-turn reset region (so the
-    // `Active` slot it sets is not immediately re-cleared) and AFTER the
-    // `turns_to_skip` fast-path early-return above (so per CR 614.10a the skip
-    // binds only to a turn that isn't itself skipped). While `Active`, the
-    // replacement layer prevents every combat phase of this turn.
-    if state.combat_phase_skip_next_turn.get(idx) == Some(&CombatPhaseSkipState::Pending) {
-        if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
-            *slot = CombatPhaseSkipState::Active;
+    // CR 614.10 + CR 614.10a + CR 500.11: Bind one pending turn-scoped combat
+    // skip to this turn now that the active player's first non-skipped turn has
+    // actually begun. This runs AFTER the per-turn reset region (so the `active`
+    // flag it sets is not immediately re-cleared) and AFTER the `turns_to_skip`
+    // fast-path early-return above (so per CR 614.10a the skip binds only to a
+    // turn that isn't itself skipped). Consume one `pending` skip and mark the
+    // turn `active`; any remaining pending skips wait for subsequent turns. While
+    // `active`, the replacement layer prevents every combat phase of this turn.
+    if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
+        if slot.pending > 0 {
+            slot.pending -= 1;
+            slot.active = true;
         }
     }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -7,7 +7,8 @@ use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
 use crate::types::format::GameFormat;
 use crate::types::game_state::{
-    AutoPassMode, GameState, PendingCounterAddition, PendingEffectResolved, WaitingFor,
+    AutoPassMode, CombatPhaseSkipState, GameState, PendingCounterAddition, PendingEffectResolved,
+    WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
@@ -608,6 +609,18 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
     state.attacked_defenders_this_turn.clear();
     state.creature_attacked_defenders_this_turn.clear();
     state.combat_phases_started_this_turn = 0;
+    // CR 614.10 + CR 614.10a + CR 500.11: Clear a turn-scoped combat skip that
+    // was `Active` on this player's PREVIOUS (now-ended) turn. `idx` is the
+    // player whose turn is beginning here; if their slot is still `Active` it was
+    // bound and consumed by their last turn, so the skip is satisfied and this
+    // new turn has normal combat. Only an `Active` slot is cleared here — a
+    // still-`Pending` skip has not yet bound to a turn and must survive (and will
+    // be promoted to `Active` below if this is its first non-skipped turn).
+    if state.combat_phase_skip_next_turn.get(idx) == Some(&CombatPhaseSkipState::Active) {
+        if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
+            *slot = CombatPhaseSkipState::None;
+        }
+    }
     state.end_steps_started_this_turn = 0;
     state.creatures_attacked_this_turn.clear();
     state.attacker_declarations_this_turn.clear();
@@ -674,6 +687,19 @@ pub fn start_next_turn(state: &mut GameState, events: &mut Vec<GameEvent>) {
         player.cards_drawn_this_step = 0;
         player.speed_trigger_used_this_turn = false;
         player.bending_types_this_turn.clear();
+    }
+
+    // CR 614.10 + CR 614.10a + CR 500.11: Promote a turn-scoped combat skip from
+    // `Pending` to `Active` now that the active player's first non-skipped turn
+    // has actually begun. This runs AFTER the per-turn reset region (so the
+    // `Active` slot it sets is not immediately re-cleared) and AFTER the
+    // `turns_to_skip` fast-path early-return above (so per CR 614.10a the skip
+    // binds only to a turn that isn't itself skipped). While `Active`, the
+    // replacement layer prevents every combat phase of this turn.
+    if state.combat_phase_skip_next_turn.get(idx) == Some(&CombatPhaseSkipState::Pending) {
+        if let Some(slot) = state.combat_phase_skip_next_turn.get_mut(idx) {
+            *slot = CombatPhaseSkipState::Active;
+        }
     }
 
     // CR 302.6: At the start of a player's turn, any permanent they have

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -98,10 +98,10 @@ use crate::types::ability::{
     PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount, PreventionScope,
     ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementCondition,
     ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RevealUntilDisposition,
-    RoundingMode, SharedQuality, SharedQualityRelation, StaticCondition, StaticDefinition,
-    StepSkipTarget, SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode,
-    ThisWayCause, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
-    UntilCondition, ZoneOwner,
+    RoundingMode, SharedQuality, SharedQualityRelation, SkipScope, StaticCondition,
+    StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange, TargetFilter,
+    TargetSelectionMode, ThisWayCause, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -6863,6 +6863,7 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
                 target: TargetFilter::Controller,
                 step,
                 count: QuantityExpr::Fixed { value: 1 },
+                scope: SkipScope::NextOccurrence,
             }));
         }
     }
@@ -6896,6 +6897,7 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
                 target,
                 step,
                 count: QuantityExpr::Fixed { value: 1 },
+                scope: SkipScope::NextOccurrence,
             }));
         }
     }
@@ -6912,13 +6914,30 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
     let (after_verb_lower, _) = alt((tag::<_, _, OracleError<'_>>(" skips "), tag(" skip ")))
         .parse(after_target_lower)
         .ok()?;
-    let (after_next_lower, _) = alt((
-        tag::<_, _, OracleError<'_>>("their next "),
-        tag("your next "),
+
+    // CR 614.10 + CR 614.10a: recognize the turn-scoped variant ("skips all
+    // combat phases of their next turn" — False Peace / Empty City Ruse) before
+    // the occurrence-scoped ("their/your next <step>") tail. The turn-scoped
+    // branch binds a `CombatPhase` skip to the player's entire next turn
+    // (`AllOfNextTurn`); the occurrence-scoped branch keeps the single-step
+    // `NextOccurrence` behavior.
+    let ((step, scope), rest) = if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>("all combat phases of their next turn"),
+        tag("all combat phases of your next turn"),
     ))
     .parse(after_verb_lower)
-    .ok()?;
-    let (rest, step) = parse_skip_step_name(after_next_lower).ok()?;
+    {
+        ((StepSkipTarget::CombatPhase, SkipScope::AllOfNextTurn), rest)
+    } else {
+        let (after_next_lower, _) = alt((
+            tag::<_, _, OracleError<'_>>("their next "),
+            tag("your next "),
+        ))
+        .parse(after_verb_lower)
+        .ok()?;
+        let (rest, step) = parse_skip_step_name(after_next_lower).ok()?;
+        ((step, SkipScope::NextOccurrence), rest)
+    };
     if !rest.trim().trim_end_matches('.').is_empty() {
         return None;
     }
@@ -6927,6 +6946,7 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
         target,
         step,
         count: QuantityExpr::Fixed { value: 1 },
+        scope,
     }))
 }
 
@@ -51244,10 +51264,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(target, &TargetFilter::Controller);
         assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
         assert_eq!(
@@ -51266,10 +51288,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(target, &TargetFilter::Player);
         assert_eq!(step, &StepSkipTarget::Step(Phase::Draw));
         assert_eq!(
@@ -51293,10 +51317,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(target, &TargetFilter::TriggeringPlayer);
         assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
         assert_eq!(
@@ -51315,10 +51341,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(target, &TargetFilter::ParentTarget);
         assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
         assert_eq!(
@@ -51337,10 +51365,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(target, &TargetFilter::DefendingPlayer);
         assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
         assert_eq!(
@@ -51362,10 +51392,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         assert_eq!(
             target,
             &TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent))
@@ -51375,6 +51407,55 @@ mod tests {
             count,
             &crate::types::ability::QuantityExpr::Fixed { value: 1 }
         );
+    }
+
+    /// CR 614.10 + CR 614.10a: "Target player skips all combat phases of their
+    /// next turn." — False Peace (POR). Turn-scoped combat skip: target Player,
+    /// CombatPhase step, `AllOfNextTurn` scope.
+    #[test]
+    fn false_peace_skips_all_combat_phases_of_next_turn() {
+        let def = parse_effect_chain(
+            "Target player skips all combat phases of their next turn.",
+            AbilityKind::Spell,
+        );
+        let Effect::SkipNextStep {
+            target,
+            step,
+            scope,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected SkipNextStep, got {:?}", def.effect);
+        };
+        assert_eq!(target, &TargetFilter::Player);
+        assert_eq!(step, &StepSkipTarget::CombatPhase);
+        assert_eq!(scope, &SkipScope::AllOfNextTurn);
+    }
+
+    /// CR 614.10 + CR 614.10a: "Target opponent skips all combat phases of their
+    /// next turn." — Empty City Ruse (PTK). Turn-scoped combat skip: target
+    /// Opponent, CombatPhase step, `AllOfNextTurn` scope.
+    #[test]
+    fn empty_city_ruse_skips_all_combat_phases_of_next_turn() {
+        let def = parse_effect_chain(
+            "Target opponent skips all combat phases of their next turn.",
+            AbilityKind::Spell,
+        );
+        let Effect::SkipNextStep {
+            target,
+            step,
+            scope,
+            ..
+        } = &*def.effect
+        else {
+            panic!("expected SkipNextStep, got {:?}", def.effect);
+        };
+        assert_eq!(
+            target,
+            &TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent))
+        );
+        assert_eq!(step, &StepSkipTarget::CombatPhase);
+        assert_eq!(scope, &SkipScope::AllOfNextTurn);
     }
 
     /// CR 500.11: "That player skips their next combat phase" — Blinding Angel's
@@ -51390,10 +51471,12 @@ mod tests {
             target,
             step,
             count,
+            scope,
         } = &*def.effect
         else {
             panic!("expected SkipNextStep, got {:?}", def.effect);
         };
+        assert_eq!(scope, &SkipScope::NextOccurrence);
         // "That player" without trigger context defaults to ParentTarget.
         assert_eq!(target, &TargetFilter::ParentTarget);
         assert_eq!(step, &StepSkipTarget::CombatPhase);

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -100,8 +100,8 @@ use crate::types::ability::{
     ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RevealUntilDisposition,
     RoundingMode, SharedQuality, SharedQualityRelation, SkipScope, StaticCondition,
     StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange, TargetFilter,
-    TargetSelectionMode, ThisWayCause, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier, UntilCondition, ZoneOwner,
+    TargetSelectionMode, ThisWayCause, TriggerCondition, TriggerDefinition, TypeFilter,
+    TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -6927,7 +6927,10 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
     ))
     .parse(after_verb_lower)
     {
-        ((StepSkipTarget::CombatPhase, SkipScope::AllOfNextTurn), rest)
+        (
+            (StepSkipTarget::CombatPhase, SkipScope::AllOfNextTurn),
+            rest,
+        )
     } else {
         let (after_next_lower, _) = alt((
             tag::<_, _, OracleError<'_>>("their next "),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7563,6 +7563,31 @@ impl StepSkipTarget {
     }
 }
 
+/// CR 614.10 + CR 614.10a: How long a skip effect persists.
+///
+/// CR 614.10: "Skip [something]" is a replacement effect equivalent to
+/// "instead of doing [something], do nothing." A skip can be scoped to either a
+/// single next occurrence of a step (`NextOccurrence`) or to *every* occurrence
+/// within the player's next non-skipped turn (`AllOfNextTurn`, e.g. False Peace
+/// / Empty City Ruse: "skips all combat phases of their next turn"). Per
+/// CR 614.10a, an "all of next turn" skip lands on the first turn that isn't
+/// itself skipped (it waits past skipped turns), and — unlike a finite-count
+/// skip — it suppresses *every* combat phase that turn, including extra combat
+/// phases created that turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipScope {
+    /// CR 614.10a: skip the single next occurrence of the named step; satisfied
+    /// once that occurrence is skipped. This is the only scope that interacts
+    /// with a finite `count`.
+    #[default]
+    NextOccurrence,
+    /// CR 614.10 + CR 614.10a: skip every occurrence of the named phase across
+    /// the player's entire next non-skipped turn. Turn-binding subsumes
+    /// counting, so this scope ignores any finite `count`.
+    AllOfNextTurn,
+}
+
 /// CR 115.1: Whether the `Bounce` effect selects its affected object at
 /// cast/activation time ("target", locked) or at resolution time (controller-
 /// scoped filter like "a creature you control" — Whitemane Lion).
@@ -10170,6 +10195,15 @@ pub enum Effect {
         step: StepSkipTarget,
         #[serde(default = "default_quantity_one")]
         count: QuantityExpr,
+        /// CR 614.10 + CR 614.10a: scope of the skip. `NextOccurrence` (default)
+        /// uses the finite `count` and consumes the per-player step counter at the
+        /// relevant turn-flow boundary. `AllOfNextTurn` binds the skip to the
+        /// player's entire next non-skipped turn via the turn-scoped combat-skip
+        /// state machine and is **mutually exclusive** with a finite `count` —
+        /// turn-binding subsumes counting, so `count` is ignored when
+        /// `scope == AllOfNextTurn`.
+        #[serde(default)]
+        scope: SkipScope,
     },
     /// CR 500.8: Add an additional step or phase after the specified anchor phase.
     /// Uses a LIFO stack on GameState.extra_phases. `followed_by` entries are pushed

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -156,6 +156,30 @@ pub enum AssistState {
     Committed { helper: PlayerId, generic: u32 },
 }
 
+/// CR 614.10 + CR 614.10a: Turn-scoped combat-phase skip lifecycle for a single
+/// player. Backs `GameState::combat_phase_skip_next_turn` (False Peace / Empty
+/// City Ruse: "skips all combat phases of their next turn").
+///
+/// State machine, advanced in `start_next_turn`:
+/// `None` --(skip effect resolves)--> `Pending`
+///   --(player's first non-skipped turn begins, CR 614.10a)--> `Active`
+///   --(that turn ends; player's following turn begins)--> `None`.
+///
+/// While `Active`, a virtual replacement effect prevents every combat phase of
+/// the bound turn (CR 614.10: "skip" == "instead of doing this, do nothing").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CombatPhaseSkipState {
+    /// No turn-scoped combat skip armed for this player.
+    #[default]
+    None,
+    /// CR 614.10a: a skip is armed but has not yet attached to a turn; it waits
+    /// past any skipped turns and binds to the player's first non-skipped turn.
+    Pending,
+    /// The bound (non-skipped) turn is in progress; combat phases are prevented.
+    Active,
+}
+
 /// CR 400.7: Snapshot of an object's characteristics at the time it left a public zone.
 /// Used for event-context resolution when the object is no longer in its original zone.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -5897,6 +5921,24 @@ pub struct GameState {
     /// is consumed only when the named step would otherwise happen.
     #[serde(default)]
     pub steps_to_skip: Vec<HashMap<Phase, u32>>,
+
+    /// CR 614.10 + CR 614.10a: Per-player turn-scoped combat-phase skip state.
+    /// Drives "skips all combat phases of their next turn" (False Peace / Empty
+    /// City Ruse). Unlike `steps_to_skip` (a finite per-step counter), this is a
+    /// turn-bound marker resolved as a virtual replacement effect on every combat
+    /// phase of the bound turn.
+    ///
+    /// State machine (per active player, advanced in `start_next_turn`):
+    /// - `Pending`: set when the skip effect resolves; the skip is *armed* but
+    ///   has not yet attached to a turn. Per CR 614.10a it waits past any
+    ///   skipped turns and binds to the player's first non-skipped turn.
+    /// - `Active`: promoted from `Pending` once the player's bound (non-skipped)
+    ///   turn actually begins. While `Active`, the replacement layer prevents
+    ///   every combat phase that turn (including extra combat phases).
+    /// - `None`: cleared at the start of the player's *following* turn, after the
+    ///   bound turn has ended. A turn that was `Active` becomes `None`.
+    #[serde(default)]
+    pub combat_phase_skip_next_turn: Vec<CombatPhaseSkipState>,
     #[serde(default)]
     pub scheduled_turn_controls: Vec<ScheduledTurnControl>,
 
@@ -7439,6 +7481,7 @@ impl GameState {
             extra_turns: Vec::new(),
             turns_to_skip: vec![0; player_count as usize],
             steps_to_skip: vec![HashMap::new(); player_count as usize],
+            combat_phase_skip_next_turn: vec![CombatPhaseSkipState::None; player_count as usize],
             scheduled_turn_controls: Vec::new(),
             extra_phases: Vec::new(),
             seat_order,
@@ -7908,6 +7951,7 @@ impl PartialEq for GameState {
             && self.extra_turns == other.extra_turns
             && self.turns_to_skip == other.turns_to_skip
             && self.steps_to_skip == other.steps_to_skip
+            && self.combat_phase_skip_next_turn == other.combat_phase_skip_next_turn
             && self.scheduled_turn_controls == other.scheduled_turn_controls
             && self.extra_phases == other.extra_phases
             && self.seat_order == other.seat_order

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -160,24 +160,32 @@ pub enum AssistState {
 /// player. Backs `GameState::combat_phase_skip_next_turn` (False Peace / Empty
 /// City Ruse: "skips all combat phases of their next turn").
 ///
-/// State machine, advanced in `start_next_turn`:
-/// `None` --(skip effect resolves)--> `Pending`
-///   --(player's first non-skipped turn begins, CR 614.10a)--> `Active`
-///   --(that turn ends; player's following turn begins)--> `None`.
+/// CR 614.10a: stacked skips are independent — two resolved effects make the
+/// player skip combat on their next *two* non-skipped turns ("one effect will be
+/// satisfied in skipping the first occurrence, while the other will remain"). So
+/// the model is a count, not a tri-state: `pending` is the number of armed skips
+/// not yet bound to a turn, and `active` marks the player's current turn as a
+/// bound skip turn. The axes are orthogonal — while a turn is `active`, further
+/// `pending` skips wait for subsequent turns.
 ///
-/// While `Active`, a virtual replacement effect prevents every combat phase of
+/// Lifecycle, advanced in `start_next_turn` for the player whose turn begins:
+/// - a skip effect resolves -> `pending += 1`
+/// - that player's previous bound turn ended -> `active = false` (skip satisfied)
+/// - this turn isn't itself skipped and `pending > 0` -> `pending -= 1`, `active = true`
+///
+/// While `active`, a virtual replacement effect prevents every combat phase of
 /// the bound turn (CR 614.10: "skip" == "instead of doing this, do nothing").
+/// `Default` (`pending: 0`, `active: false`) is "no skip armed".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CombatPhaseSkipState {
-    /// No turn-scoped combat skip armed for this player.
-    #[default]
-    None,
-    /// CR 614.10a: a skip is armed but has not yet attached to a turn; it waits
-    /// past any skipped turns and binds to the player's first non-skipped turn.
-    Pending,
-    /// The bound (non-skipped) turn is in progress; combat phases are prevented.
-    Active,
+pub struct CombatPhaseSkipState {
+    /// CR 614.10a: armed turn-scoped combat skips that have not yet bound to a
+    /// turn; each waits past skipped turns for its own non-skipped turn.
+    #[serde(default)]
+    pub pending: u32,
+    /// True while the player's current turn is a bound combat-skip turn; the
+    /// replacement layer prevents every combat phase of that turn.
+    #[serde(default)]
+    pub active: bool,
 }
 
 /// CR 400.7: Snapshot of an object's characteristics at the time it left a public zone.
@@ -7481,7 +7489,10 @@ impl GameState {
             extra_turns: Vec::new(),
             turns_to_skip: vec![0; player_count as usize],
             steps_to_skip: vec![HashMap::new(); player_count as usize],
-            combat_phase_skip_next_turn: vec![CombatPhaseSkipState::None; player_count as usize],
+            combat_phase_skip_next_turn: vec![
+                CombatPhaseSkipState::default();
+                player_count as usize
+            ],
             scheduled_turn_controls: Vec::new(),
             extra_phases: Vec::new(),
             seat_order,

--- a/crates/engine/tests/false_peace_skips_all_combat_phases.rs
+++ b/crates/engine/tests/false_peace_skips_all_combat_phases.rs
@@ -1,0 +1,237 @@
+//! False Peace (POR) / Empty City Ruse (PTK): "Target player/opponent skips all
+//! combat phases of their next turn."
+//!
+//! These tests drive the REAL phase-flow pipeline (`start_next_turn` +
+//! `advance_phase`) rather than inspecting store contents, so they fail if the
+//! §5 replacement applier/injection or the §4 turn-flow promotion/clear is
+//! reverted.
+//!
+//! Runtime model (CR 614.10 + CR 614.10a + CR 500.11):
+//! - The effect arms `GameState::combat_phase_skip_next_turn[P] = Pending`.
+//! - `start_next_turn` promotes `Pending -> Active` on P's first NON-skipped
+//!   turn (CR 614.10a: it waits past skipped turns).
+//! - While `Active`, a virtual BeginPhase replacement prevents every combat
+//!   phase that turn (including extra combat phases).
+//! - `start_next_turn` clears `Active -> None` at the start of P's following
+//!   turn, so combat is normal again.
+
+use engine::game::effects::skip_next_step;
+use engine::game::turns::{advance_phase, start_next_turn};
+use engine::types::ability::{
+    Effect, QuantityExpr, ResolvedAbility, SkipScope, StepSkipTarget, TargetFilter, TargetRef,
+};
+use engine::types::game_state::{CombatPhaseSkipState, ExtraPhase, GameState};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+/// Build the False Peace effect: a turn-scoped combat skip targeting `player`.
+/// The target player (not the controller) drives resolution.
+fn skip_all_combat_ability(player: PlayerId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::SkipNextStep {
+            target: TargetFilter::Player,
+            step: StepSkipTarget::CombatPhase,
+            count: QuantityExpr::Fixed { value: 1 },
+            scope: SkipScope::AllOfNextTurn,
+        },
+        vec![TargetRef::Player(player)],
+        ObjectId(999),
+        PlayerId(0),
+    )
+}
+
+/// Resolve the effect to arm the Pending marker for `player`.
+fn arm_skip(state: &mut GameState, player: PlayerId) {
+    let ability = skip_all_combat_ability(player);
+    let mut events = Vec::new();
+    skip_next_step::resolve(state, &ability, &mut events).expect("skip resolves");
+    assert_eq!(
+        state.combat_phase_skip_next_turn[player.0 as usize],
+        CombatPhaseSkipState::Pending,
+        "effect must arm Pending"
+    );
+}
+
+/// Drive `advance_phase` from PreCombatMain and report the phase the active
+/// player lands in after the (possibly-skipped) combat phase, plus the
+/// combat-phase counter for the turn.
+fn run_combat_segment(state: &mut GameState) -> (Phase, u32) {
+    state.phase = Phase::PreCombatMain;
+    state.combat_phases_started_this_turn = 0;
+    let mut events = Vec::new();
+    advance_phase(state, &mut events);
+    (state.phase, state.combat_phases_started_this_turn)
+}
+
+/// (a) The bound turn never enters any combat step: advancing from PreCombatMain
+/// lands directly in PostCombatMain and `combat_phases_started_this_turn` stays
+/// 0. Fails if the applier/injection is reverted (combat would run normally).
+#[test]
+fn bound_turn_skips_all_combat_phases() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+
+    // Arm for P1 (who becomes active after start_next_turn) and promote.
+    arm_skip(&mut state, PlayerId(1));
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::Active,
+        "Pending must promote to Active on the bound turn"
+    );
+
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(
+        phase,
+        Phase::PostCombatMain,
+        "combat must be skipped straight to postcombat main"
+    );
+    assert_eq!(combats, 0, "no combat phase may begin on the bound turn");
+}
+
+/// (b) An EXTRA combat phase scheduled that turn is ALSO skipped. This
+/// discriminates the turn-scope (AllOfNextTurn) from a finite count:1 skip —
+/// a count:1 skip would consume on the first combat and let the extra one run.
+#[test]
+fn extra_combat_phase_on_bound_turn_is_also_skipped() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    arm_skip(&mut state, PlayerId(1));
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, PlayerId(1));
+
+    // Schedule an extra combat phase after EndCombat (Aurelia/Najeela pattern).
+    // When the main combat is skipped, the phase cascade still reaches EndCombat
+    // (skipped), which pops this extra entry and inserts an extra BeginCombat —
+    // which, because the marker is Active, is ALSO prevented. A finite count:1
+    // skip would have been consumed by the first combat and let this one run.
+    state.extra_phases.push(ExtraPhase {
+        anchor: Phase::EndCombat,
+        phase: Phase::BeginCombat,
+    });
+
+    // Single segment drives the whole combat cascade including the extra combat.
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(
+        combats, 0,
+        "neither the main nor the extra combat phase may begin while Active"
+    );
+    assert_eq!(
+        phase,
+        Phase::PostCombatMain,
+        "after both combats are skipped, the turn reaches postcombat main"
+    );
+    assert!(
+        state.extra_phases.is_empty(),
+        "the extra combat phase entry was consumed (and skipped), not left pending"
+    );
+}
+
+/// (c) CR 614.10a wait: with `turns_to_skip[P] > 0` AND a Pending combat skip,
+/// the combat skip lands on P's first NON-skipped turn, not the skipped one.
+#[test]
+fn combat_skip_waits_past_a_skipped_turn() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+
+    // P1 will skip their next whole turn AND has a pending combat skip.
+    arm_skip(&mut state, PlayerId(1));
+    state.turns_to_skip[1] = 1;
+
+    // start_next_turn: P1's turn is skipped entirely (turns_to_skip fast-path),
+    // recursing to P0's turn. The combat skip must NOT bind to the skipped turn.
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(
+        state.active_player,
+        PlayerId(0),
+        "P1's turn was skipped; active returns to P0"
+    );
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::Pending,
+        "combat skip must still be Pending — it did not bind to the skipped turn"
+    );
+
+    // P0's turn (active now) has no marker -> normal combat.
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(phase, Phase::BeginCombat);
+    assert_eq!(combats, 1, "P0 has normal combat");
+
+    // Advance to P1's next (non-skipped) turn: now the combat skip binds.
+    state.phase = Phase::Cleanup;
+    let mut events2 = Vec::new();
+    start_next_turn(&mut state, &mut events2);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::Active,
+        "combat skip binds to P1's first non-skipped turn"
+    );
+    let (phase2, combats2) = run_combat_segment(&mut state);
+    assert_eq!(phase2, Phase::PostCombatMain, "P1's combat is now skipped");
+    assert_eq!(combats2, 0);
+}
+
+/// (d) Cleared after one turn: the turn AFTER the bound turn has normal combat.
+#[test]
+fn marker_clears_after_bound_turn() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    arm_skip(&mut state, PlayerId(1));
+
+    // P1's bound turn (combat skipped).
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::Active
+    );
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(phase, Phase::PostCombatMain);
+    assert_eq!(combats, 0);
+
+    // P0's turn.
+    state.phase = Phase::Cleanup;
+    let mut events2 = Vec::new();
+    start_next_turn(&mut state, &mut events2);
+    assert_eq!(state.active_player, PlayerId(0));
+
+    // P1's NEXT turn: the marker was cleared at the start of this following turn.
+    state.phase = Phase::Cleanup;
+    let mut events3 = Vec::new();
+    start_next_turn(&mut state, &mut events3);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::None,
+        "marker must be cleared after the bound turn"
+    );
+    let (phase2, combats2) = run_combat_segment(&mut state);
+    assert_eq!(phase2, Phase::BeginCombat, "P1 has normal combat again");
+    assert_eq!(combats2, 1);
+}
+
+/// (e) Negative: a player with no marker plays normal combat — guards against
+/// the virtual replacement over-matching.
+#[test]
+fn player_without_marker_has_normal_combat() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::None
+    );
+
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(phase, Phase::BeginCombat, "no marker -> normal combat");
+    assert_eq!(combats, 1);
+}

--- a/crates/engine/tests/false_peace_skips_all_combat_phases.rs
+++ b/crates/engine/tests/false_peace_skips_all_combat_phases.rs
@@ -7,13 +7,15 @@
 //! reverted.
 //!
 //! Runtime model (CR 614.10 + CR 614.10a + CR 500.11):
-//! - The effect arms `GameState::combat_phase_skip_next_turn[P] = Pending`.
-//! - `start_next_turn` promotes `Pending -> Active` on P's first NON-skipped
-//!   turn (CR 614.10a: it waits past skipped turns).
-//! - While `Active`, a virtual BeginPhase replacement prevents every combat
+//! - Each effect arms one `pending` skip on `combat_phase_skip_next_turn[P]`.
+//! - `start_next_turn` binds one pending skip (`pending -= 1`, `active = true`)
+//!   on P's first NON-skipped turn (CR 614.10a: it waits past skipped turns).
+//! - While `active`, a virtual BeginPhase replacement prevents every combat
 //!   phase that turn (including extra combat phases).
-//! - `start_next_turn` clears `Active -> None` at the start of P's following
-//!   turn, so combat is normal again.
+//! - `start_next_turn` releases the binding (`active = false`) at the start of
+//!   P's following turn; combat is normal again unless another pending skip
+//!   rebinds. So two stacked skips skip combat on P's next two non-skipped turns
+//!   (CR 614.10a: stacked "skip next" effects are independently satisfied).
 
 use engine::game::effects::skip_next_step;
 use engine::game::turns::{advance_phase, start_next_turn};
@@ -41,16 +43,21 @@ fn skip_all_combat_ability(player: PlayerId) -> ResolvedAbility {
     )
 }
 
-/// Resolve the effect to arm the Pending marker for `player`.
+/// Resolve the effect to arm one more pending skip for `player`. Safe to call
+/// repeatedly (CR 614.10a stacking) — each call increments `pending` by one and
+/// must not bind a turn on its own.
 fn arm_skip(state: &mut GameState, player: PlayerId) {
+    let before = state.combat_phase_skip_next_turn[player.0 as usize].pending;
     let ability = skip_all_combat_ability(player);
     let mut events = Vec::new();
     skip_next_step::resolve(state, &ability, &mut events).expect("skip resolves");
+    let slot = state.combat_phase_skip_next_turn[player.0 as usize];
     assert_eq!(
-        state.combat_phase_skip_next_turn[player.0 as usize],
-        CombatPhaseSkipState::Pending,
-        "effect must arm Pending"
+        slot.pending,
+        before + 1,
+        "effect must arm one more pending skip"
     );
+    assert!(!slot.active, "arming alone must not bind a turn");
 }
 
 /// Drive `advance_phase` from PreCombatMain and report the phase the active
@@ -79,8 +86,11 @@ fn bound_turn_skips_all_combat_phases() {
     assert_eq!(state.active_player, PlayerId(1));
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::Active,
-        "Pending must promote to Active on the bound turn"
+        CombatPhaseSkipState {
+            pending: 0,
+            active: true
+        },
+        "the pending skip must bind (active) on the bound turn"
     );
 
     let (phase, combats) = run_combat_segment(&mut state);
@@ -153,8 +163,11 @@ fn combat_skip_waits_past_a_skipped_turn() {
     );
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::Pending,
-        "combat skip must still be Pending — it did not bind to the skipped turn"
+        CombatPhaseSkipState {
+            pending: 1,
+            active: false
+        },
+        "combat skip must still be pending — it did not bind to the skipped turn"
     );
 
     // P0's turn (active now) has no marker -> normal combat.
@@ -169,7 +182,10 @@ fn combat_skip_waits_past_a_skipped_turn() {
     assert_eq!(state.active_player, PlayerId(1));
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::Active,
+        CombatPhaseSkipState {
+            pending: 0,
+            active: true
+        },
         "combat skip binds to P1's first non-skipped turn"
     );
     let (phase2, combats2) = run_combat_segment(&mut state);
@@ -190,7 +206,10 @@ fn marker_clears_after_bound_turn() {
     assert_eq!(state.active_player, PlayerId(1));
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::Active
+        CombatPhaseSkipState {
+            pending: 0,
+            active: true
+        }
     );
     let (phase, combats) = run_combat_segment(&mut state);
     assert_eq!(phase, Phase::PostCombatMain);
@@ -209,7 +228,7 @@ fn marker_clears_after_bound_turn() {
     assert_eq!(state.active_player, PlayerId(1));
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::None,
+        CombatPhaseSkipState::default(),
         "marker must be cleared after the bound turn"
     );
     let (phase2, combats2) = run_combat_segment(&mut state);
@@ -228,10 +247,98 @@ fn player_without_marker_has_normal_combat() {
     assert_eq!(state.active_player, PlayerId(1));
     assert_eq!(
         state.combat_phase_skip_next_turn[1],
-        CombatPhaseSkipState::None
+        CombatPhaseSkipState::default()
     );
 
     let (phase, combats) = run_combat_segment(&mut state);
     assert_eq!(phase, Phase::BeginCombat, "no marker -> normal combat");
     assert_eq!(combats, 1);
+}
+
+/// (f) CR 614.10a (the regression guard for stacked skips): two `AllOfNextTurn`
+/// skips aimed at the same player before their next turn make that player skip
+/// combat on their next TWO non-skipped turns — one effect is satisfied by the
+/// first skipped turn, the other waits and binds to the second. This FAILS on
+/// the original single-marker model, which collapsed both into one skipped turn.
+#[test]
+fn two_stacked_skips_skip_combat_on_next_two_turns() {
+    let mut state = GameState::new_two_player(42);
+    state.active_player = PlayerId(0);
+
+    // Two False Peace effects resolve at P1 before their next turn.
+    arm_skip(&mut state, PlayerId(1));
+    arm_skip(&mut state, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState {
+            pending: 2,
+            active: false
+        },
+        "two stacked skips accumulate to pending: 2"
+    );
+
+    // P1's first turn: one skip binds, combat skipped, one still pending.
+    let mut events = Vec::new();
+    start_next_turn(&mut state, &mut events);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState {
+            pending: 1,
+            active: true
+        },
+        "first turn binds one skip; the second remains pending"
+    );
+    let (phase, combats) = run_combat_segment(&mut state);
+    assert_eq!(phase, Phase::PostCombatMain);
+    assert_eq!(combats, 0, "P1's first turn skips combat");
+
+    // P0's intervening turn (no marker -> normal combat).
+    state.phase = Phase::Cleanup;
+    let mut events2 = Vec::new();
+    start_next_turn(&mut state, &mut events2);
+    assert_eq!(state.active_player, PlayerId(0));
+
+    // P1's SECOND turn: the first binding released, the second skip now binds.
+    state.phase = Phase::Cleanup;
+    let mut events3 = Vec::new();
+    start_next_turn(&mut state, &mut events3);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState {
+            pending: 0,
+            active: true
+        },
+        "second skip binds to P1's next turn (CR 614.10a)"
+    );
+    let (phase2, combats2) = run_combat_segment(&mut state);
+    assert_eq!(
+        phase2,
+        Phase::PostCombatMain,
+        "P1's second turn also skips combat"
+    );
+    assert_eq!(combats2, 0);
+
+    // P0's turn, then P1's THIRD turn: both skips satisfied -> normal combat.
+    state.phase = Phase::Cleanup;
+    let mut events4 = Vec::new();
+    start_next_turn(&mut state, &mut events4);
+    assert_eq!(state.active_player, PlayerId(0));
+    state.phase = Phase::Cleanup;
+    let mut events5 = Vec::new();
+    start_next_turn(&mut state, &mut events5);
+    assert_eq!(state.active_player, PlayerId(1));
+    assert_eq!(
+        state.combat_phase_skip_next_turn[1],
+        CombatPhaseSkipState::default(),
+        "both skips satisfied; marker cleared"
+    );
+    let (phase3, combats3) = run_combat_segment(&mut state);
+    assert_eq!(
+        phase3,
+        Phase::BeginCombat,
+        "P1's third turn has normal combat"
+    );
+    assert_eq!(combats3, 1);
 }


### PR DESCRIPTION
## Summary
Adds engine support for **False Peace** (POR, S99) and its class sibling **Empty City Ruse** (PTK, TLE): "Target {player|opponent} skips all combat phases of their next turn." Implemented as a turn-scoped combat-phase skip that prevents every combat phase of the affected player's next non-skipped turn — including extra combat phases created during that turn (CR 500.8).

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/game/effects/skip_next_step.rs
- crates/engine/src/game/turns.rs
- crates/engine/src/game/replacement.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/game/coverage.rs
- crates/engine/tests/false_peace_skips_all_combat_phases.rs (new)

## CR references
- `CR 614.10` — "skip" is a replacement effect ("instead of doing X, do nothing")
- `CR 614.10a` — a "next" occurrence waits for the first occurrence that isn't itself skipped (Pending→Active binding)
- `CR 500.11` — skipping a phase/step is proceeding past it as though it didn't exist (drives `advance_phase`'s prevent-and-recurse)
- `CR 506.1` — the combat phase comprises five steps (skip scope covers all combat-step BeginPhase events)

## Track
Non-developer

## LLM
Model: claude-opus-4-8
Thinking: high

Tier: Frontier

## Anchored on
- crates/engine/src/game/replacement.rs:65 — existing `compleated_replacement_id` object-less *virtual* replacement sentinel pattern (Compleated/Umbra Armor); the turn-scoped combat skip mirrors it with `turn_scoped_combat_skip_replacement_id` + candidate injection + applier dispatch, since a resolved sorcery leaves no battlefield object to host a `ReplacementDefinition`.
- crates/engine/src/game/turns.rs:488 — existing per-player `turns_to_skip` skip lifecycle in `start_next_turn`; the `CombatPhaseSkipState` Pending→Active→clear lifecycle is ordered relative to this same fast-path so the skip binds to the first non-skipped turn (CR 614.10a).
- crates/engine/src/parser/oracle_effect/mod.rs:6851 — existing `try_parse_skip_next_step` occurrence-scoped nom arm; extended with a turn-scoped `alt((tag(...), tag(...)))` branch using the same combinator family (no string dispatch).
- crates/engine/src/types/game_state.rs:5918 — existing `turns_to_skip` / `steps_to_skip` per-player `Vec` store convention; `combat_phase_skip_next_turn: Vec<CombatPhaseSkipState>` mirrors it (serde-default, `GameState::eq`, `GameState::new` init).

## Verification
Local verification skipped — see CI status checks.

Implementation pipeline run: engine-planner → review-engine-plan (2 rounds to clean) → executor → independent review-impl (clean, fresh-context cross-check on the diff only). The review-impl pass verified the five integration tests in `crates/engine/tests/false_peace_skips_all_combat_phases.rs` drive the real `advance_phase`/`start_next_turn` pipeline and are discriminating (fail on revert of the consumption seam): bound-turn skips all combat; an extra combat phase that turn is also skipped (proves turn-scope ≠ count:1); the skip waits past a separately-skipped turn (CR 614.10a); the marker clears after one turn; and a player with no marker has normal combat (over-match guard).

## Scope Expansion
The card initially appeared parser-only, but tracing revealed the combat-phase branch of `Effect::SkipNextStep` was inert at runtime — the per-player `steps_to_skip` counter is consumed only at Untap/Upkeep/Draw, never at any combat step (the `begin_phase` replacement seam only honored object-sourced `StaticMode::SkipStep` statics). This PR therefore adds the missing runtime infrastructure as a reusable building block: a typed per-player turn-scoped combat-skip store (`CombatPhaseSkipState`), its arm/promote/clear lifecycle in `start_next_turn`, and an object-less virtual `BeginPhase` replacement candidate (mirroring the existing Compleated/Umbra-Armor sentinel pattern) that prevents combat phases through the existing CR 616/CR 500.11 pipeline. The pre-existing occurrence-scoped combat skip (Stonehorn Dignitary, Blinding Angel — "skips their next combat phase") remains inert at runtime and is intentionally left unchanged (documented follow-up) to keep this change surgical; it is not regressed.

## Validation Failures
None.

## CI Failures
None.
