### PR TITLE
fix(parser): Decoy Gambit unless-have-you-draw alternative

### DIFF
--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1067,6 +1067,25 @@ pub(super) fn handle_unless_payment(
                         return Ok(action_result(events, state.waiting_for.clone()));
                     }
                 }
+                // CR 118.12a + CR 121.3a: "unless its controller has you draw a
+                // card" (Decoy Gambit) — the payer has the spell's controller
+                // draw instead of the primary bounce. `OriginalController` on
+                // the inner `Draw` target survives via `pending_effect`.
+                Effect::Draw { .. } => {
+                    let mut draw_ability = pending_effect.as_ref().clone();
+                    draw_ability.effect = *effect.clone();
+                    draw_ability.unless_pay = None;
+                    draw_ability.sub_ability = None;
+                    if let Err(e) = effects::draw::resolve(state, &draw_ability, events) {
+                        return Err(EngineError::InvalidAction(format!("{e:?}")));
+                    }
+                    if matches!(
+                        state.waiting_for,
+                        WaitingFor::ReplacementChoice { .. }
+                    ) {
+                        return Ok(action_result(events, state.waiting_for.clone()));
+                    }
+                }
                 _ => payment_failed = true,
             },
             AbilityCost::Unimplemented { .. } => {
@@ -1929,6 +1948,76 @@ mod tests {
             .expect("unless-pay-life should resolve");
         // Player paid 3 life — life total drops by 3, gain-life effect skipped.
         assert_eq!(state.players[0].life, 17);
+    }
+
+    /// CR 118.12a + CR 121.3a: "unless its controller has you draw a card"
+    /// routes the draw to the spell's original controller and suppresses the
+    /// primary bounce when the cost is paid.
+    #[test]
+    fn unless_have_you_draw_cost_resolves_for_original_controller() {
+        let mut state = GameState::new_two_player(42);
+        let creature = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(1),
+            "Target Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let _library_card = create_object(
+            &mut state,
+            CardId(20),
+            PlayerId(0),
+            "Library Top".to_string(),
+            Zone::Library,
+        );
+
+        let mut pending = ResolvedAbility::new(
+            Effect::Bounce {
+                target: TargetFilter::Any,
+                destination: None,
+                selection: Default::default(),
+            },
+            vec![TargetRef::Object(creature)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        pending.set_original_controller_recursive(PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(1),
+            cost: AbilityCost::EffectCost {
+                effect: Box::new(Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::OriginalController,
+                }),
+            },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        let waiting_for = state.waiting_for.clone();
+        handle_unless_payment(&mut state, waiting_for, true, &mut events)
+            .expect("unless-have-you-draw should resolve");
+
+        assert_eq!(
+            state.objects[&creature].zone,
+            Zone::Battlefield,
+            "paying the unless cost must suppress the bounce"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            1,
+            "paying the unless cost must draw for the spell's original controller"
+        );
+        assert!(
+            state
+                .objects
+                .values()
+                .any(|obj| obj.zone == Zone::Hand && obj.name == "Library Top"),
+            "the drawn card must come from the caster's library"
+        );
     }
 
     /// CR 118.12a + CR 701.21: Unless-sacrifice costs are payer-relative.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22142,8 +22142,8 @@ fn parse_unless_have_you_draw_cost(after_unless: &str) -> Option<AbilityCost> {
     .parse(after_unless)
     .ok()?;
     all_consuming(terminated(
-        tag("you draw a card"),
-        opt(tag(".")),
+        tag::<_, _, OracleError<'_>>("you draw a card"),
+        opt(tag::<_, _, OracleError<'_>>(".")),
     ))
     .parse(rest)
     .ok()?;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21987,6 +21987,12 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
     if let Some(cost) = parse_unless_have_deal_damage_cost(after_unless) {
         return Some(cost);
     }
+    // CR 118.12a + CR 121.3a: "unless its controller has you draw a card"
+    // (Decoy Gambit) — the controller may have the spell's controller draw
+    // instead of the primary effect.
+    if let Some(cost) = parse_unless_have_you_draw_cost(after_unless) {
+        return Some(cost);
+    }
     // CR 118.12 / CR 119.4 / CR 608.2c: non-mana alternative costs — "pays N
     // life", "sacrifices a [filter]", "discards a card", and `or`-disjunctions
     // thereof. Normalize the counter subject to the "they" pronoun the shared
@@ -22122,6 +22128,33 @@ fn parse_unless_have_deal_damage_cost(after_unless: &str) -> Option<AbilityCost>
     })
 }
 
+/// CR 118.12a + CR 121.3a: "unless [that object's|its] controller has you draw
+/// a card" (Decoy Gambit) — the targeted permanent's controller may have the
+/// spell's controller draw instead of the primary effect. "You" is the printed
+/// controller (`OriginalController`), not the payer.
+fn parse_unless_have_you_draw_cost(after_unless: &str) -> Option<AbilityCost> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("that creature's controller has "),
+        tag("its controller has "),
+        tag("that permanent's controller has "),
+        tag("that spell's controller has "),
+    ))
+    .parse(after_unless)
+    .ok()?;
+    all_consuming(terminated(
+        tag("you draw a card"),
+        opt(tag(".")),
+    ))
+    .parse(rest)
+    .ok()?;
+    Some(AbilityCost::EffectCost {
+        effect: Box::new(Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::OriginalController,
+        }),
+    })
+}
+
 fn extract_resolution_unless_pay_modifier(
     text: &str,
     player_scope: Option<&PlayerFilter>,
@@ -22164,6 +22197,16 @@ fn extract_resolution_unless_pay_modifier(
         nom_primitives::scan_preceded(&lower, |i| tag::<_, _, OracleError<'_>>("unless ").parse(i))
     {
         if let Some(cost) = parse_unless_have_deal_damage_cost(after_unless_lower) {
+            let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost,
+                    payer: TargetFilter::ParentTargetController,
+                }),
+            );
+        }
+        if let Some(cost) = parse_unless_have_you_draw_cost(after_unless_lower) {
             let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
             return (
                 cleaned,
@@ -28400,6 +28443,35 @@ mod tests {
                     ..
                 } => {}
                 other => panic!("expected DealDamage 6 to payer, got {other:?}"),
+            },
+            other => panic!("expected EffectCost, got {other:?}"),
+        }
+    }
+
+    /// CR 118.12a + CR 121.3a: Decoy Gambit — bounce unless controller has you draw.
+    #[test]
+    fn decoy_gambit_unless_have_you_draw_a_card() {
+        let def = parse_effect_chain(
+            "Return target creature to its owner's hand unless its controller has you draw a card.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(*def.effect, Effect::ChangeZone { .. }),
+            "primary effect should remain ChangeZone, got {:?}",
+            def.effect
+        );
+        let unless_pay = def
+            .unless_pay
+            .as_ref()
+            .expect("Decoy Gambit bounce line must attach unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::ParentTargetController);
+        match &unless_pay.cost {
+            AbilityCost::EffectCost { effect } => match effect.as_ref() {
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::OriginalController,
+                } => {}
+                other => panic!("expected Draw 1 to OriginalController, got {other:?}"),
             },
             other => panic!("expected EffectCost, got {other:?}"),
         }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -28456,8 +28456,8 @@ mod tests {
             AbilityKind::Spell,
         );
         assert!(
-            matches!(*def.effect, Effect::ChangeZone { .. }),
-            "primary effect should remain ChangeZone, got {:?}",
+            matches!(*def.effect, Effect::Bounce { .. }),
+            "primary effect should remain Bounce, got {:?}",
             def.effect
         );
         let unless_pay = def

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4071,6 +4071,11 @@ mod tests {
                 "Lim-Dul's Hex",
                 &["Enchantment"][..],
             ),
+            (
+                "Return target creature to its owner's hand unless its controller has you draw a card.",
+                "Decoy Gambit Bounce",
+                &["Instant"][..],
+            ),
         ] {
             let parsed = parse_named(oracle, name, types);
             assert!(

--- a/crates/engine/tests/integration/issue_4459_decoy_gambit_unless_have_you_draw.rs
+++ b/crates/engine/tests/integration/issue_4459_decoy_gambit_unless_have_you_draw.rs
@@ -7,7 +7,7 @@ use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::actions::GameAction;
 use engine::types::game_state::CastPaymentMode;
 use engine::types::game_state::WaitingFor;
-use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -90,11 +90,7 @@ fn setup_at_unless_prompt() -> (engine::game::scenario::GameRunner, ObjectId, Ob
     let mut runner = scenario.build();
     add_mana(
         &mut runner,
-        &[
-            ManaType::Colorless,
-            ManaType::Colorless,
-            ManaType::Blue,
-        ],
+        &[ManaType::Colorless, ManaType::Colorless, ManaType::Blue],
     );
     cast_decoy_gambit_to_unless_prompt(&mut runner, gambit, creature);
     (runner, gambit, creature)

--- a/crates/engine/tests/integration/issue_4459_decoy_gambit_unless_have_you_draw.rs
+++ b/crates/engine/tests/integration/issue_4459_decoy_gambit_unless_have_you_draw.rs
@@ -1,0 +1,157 @@
+//! Regression for issue #4459: Decoy Gambit's unless-have-you-draw alternative
+//! must draw for the spell's controller and suppress the bounce when paid.
+//!
+//! https://github.com/phase-rs/phase/issues/4459
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::CastPaymentMode;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DECOY_GAMBIT_BOUNCE_ORACLE: &str =
+    "Return target creature to its owner's hand unless its controller has you draw a card.";
+
+fn add_mana(runner: &mut engine::game::scenario::GameRunner, mana: &[ManaType]) {
+    let dummy = ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn cast_decoy_gambit_to_unless_prompt(
+    runner: &mut engine::game::scenario::GameRunner,
+    gambit: ObjectId,
+    creature: ObjectId,
+) {
+    runner
+        .act(GameAction::CastSpell {
+            object_id: gambit,
+            card_id: runner.state().objects[&gambit].card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Decoy Gambit");
+
+    for _ in 0..24 {
+        match &runner.state().waiting_for {
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![engine::types::ability::TargetRef::Object(creature)],
+                    })
+                    .expect("target P1's creature");
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected pre-resolution prompt: {other:?}"),
+        }
+    }
+
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "Decoy Gambit must offer the creature controller an unless-payment prompt, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+fn setup_at_unless_prompt() -> (engine::game::scenario::GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_card_to_library_top(P0, "Library Top");
+
+    let gambit = scenario
+        .add_spell_to_hand_from_oracle(P0, "Decoy Gambit", true, DECOY_GAMBIT_BOUNCE_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 2,
+        })
+        .id();
+
+    let creature = scenario.add_creature(P1, "Test Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Blue,
+        ],
+    );
+    cast_decoy_gambit_to_unless_prompt(&mut runner, gambit, creature);
+    (runner, gambit, creature)
+}
+
+#[test]
+fn decoy_gambit_declined_unless_payment_bounces_targeted_creature() {
+    let (mut runner, _gambit, creature) = setup_at_unless_prompt();
+    let hand_before = runner.state().players[P1.0 as usize].hand.len();
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("decline draw alternative");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Hand,
+        "declining the unless cost must return the targeted creature to its owner's hand"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        0,
+        "declining the unless cost must not draw for the spell's controller"
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize].hand.len(),
+        hand_before + 1,
+        "declining the unless cost must put the creature in the controller's hand"
+    );
+}
+
+#[test]
+fn decoy_gambit_paid_unless_payment_draws_for_caster_and_spares_creature() {
+    let (mut runner, _gambit, creature) = setup_at_unless_prompt();
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("accept draw alternative");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "paying the unless cost must prevent the bounce"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        1,
+        "paying the unless cost must have the spell's controller draw a card"
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .values()
+            .any(|obj| obj.zone == Zone::Hand && obj.name == "Library Top"),
+        "the drawn card must come from the caster's library"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -377,6 +377,7 @@ mod issue_4269_nested_shambler_death_tokens;
 mod issue_4271_birthing_ritual_cmc_filter;
 mod issue_4272_birthing_ritual_etb_triggers;
 mod issue_4420_lava_blister_unless_deal_damage;
+mod issue_4459_decoy_gambit_unless_have_you_draw;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary

Decoy Gambit (`…unless its controller has you draw a card.`) bounced creatures unconditionally because the unless extractor only recognized deal-damage and generic they-pay shapes, not the have-you-draw alternative.

This adds parser binding for `unless its controller has you draw a card` → `EffectCost(Draw → OriginalController)`, runtime support in `handle_unless_payment` for `AbilityCost::EffectCost(Draw)` (mirroring the existing deal-damage path), and GameRunner integration coverage for pay vs decline.

## Test plan

- [x] `decoy_gambit_unless_have_you_draw_a_card` — bounce unless-have-draw binding
- [x] `condition_unless_accepts_representative_cards` — Decoy Gambit bounce line regression
- [x] `unless_have_you_draw_cost_resolves_for_original_controller` — unless-payment draw unit test
- [x] `decoy_gambit_declined_unless_payment_bounces_targeted_creature` — decline path integration
- [x] `decoy_gambit_paid_unless_payment_draws_for_caster_and_spares_creature` — pay path integration
- [x] Existing unless-have-deal-damage tests unchanged

Closes #4459
