### PR TITLE
fix(parser+engine): Visions of Ruin flashback commander cost reduction (closes #4467)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4,8 +4,8 @@ use crate::types::ability::{
     ContinuousModification, CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection,
     Duration, Effect, FilterProp, GameRestriction, ModalSelectionCondition, ObjectScope,
     PlayerFilter, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
-    RestrictionExpiry, RestrictionPlayerScope, StaticDefinition, TapCreaturesRequirement,
-    TargetFilter, TargetRef,
+    RestrictionExpiry, RestrictionPlayerScope, StaticCondition, StaticDefinition,
+    TapCreaturesRequirement, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -14876,9 +14876,9 @@ mod tests {
                 }),
             })
             .affected(TargetFilter::SelfRef)
-            .condition(Some(StaticCondition::CastingAsVariant {
+            .condition(StaticCondition::CastingAsVariant {
                 variant: CastingVariant::Flashback,
-            }));
+            });
             def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
             obj.static_definitions.push(def);
         }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4860,14 +4860,8 @@ pub(super) fn apply_target_dependent_cost_modifiers(
             *mana_cost = super::restrictions::add_mana_cost(mana_cost, &strive_cost);
         }
     }
-    let mut collected = collect_self_spell_cost_modifiers(
-        state,
-        player,
-        object_id,
-        Some(ability),
-        true,
-        None,
-    );
+    let mut collected =
+        collect_self_spell_cost_modifiers(state, player, object_id, Some(ability), true, None);
     collected.extend(collect_battlefield_cost_modifiers(
         state,
         player,
@@ -5054,14 +5048,8 @@ pub(super) fn apply_self_spell_cost_modifiers_with_selected_targets(
     ability: &ResolvedAbility,
     mana_cost: &mut ManaCost,
 ) {
-    let collected = collect_self_spell_cost_modifiers(
-        state,
-        caster,
-        spell_id,
-        Some(ability),
-        true,
-        None,
-    );
+    let collected =
+        collect_self_spell_cost_modifiers(state, caster, spell_id, Some(ability), true, None);
     apply_cost_modifications_in_order(mana_cost, &collected);
 }
 
@@ -5085,13 +5073,9 @@ fn self_spell_cost_condition_matches(
         StaticCondition::Or { conditions } => conditions.iter().any(|cond| {
             self_spell_cost_condition_matches(state, cond, caster, spell_id, casting_variant)
         }),
-        StaticCondition::Not { condition } => !self_spell_cost_condition_matches(
-            state,
-            condition,
-            caster,
-            spell_id,
-            casting_variant,
-        ),
+        StaticCondition::Not { condition } => {
+            !self_spell_cost_condition_matches(state, condition, caster, spell_id, casting_variant)
+        }
         StaticCondition::CastingAsVariant { variant } => casting_variant == Some(*variant),
         _ => super::layers::evaluate_condition(state, condition, caster, spell_id),
     }
@@ -5171,13 +5155,7 @@ fn collect_self_spell_cost_modifiers(
 
         // CR 604.1: Evaluate any trailing condition ("if you control a Wizard").
         if let Some(ref cond) = def.condition {
-            if !self_spell_cost_condition_matches(
-                state,
-                cond,
-                caster,
-                spell_id,
-                casting_variant,
-            ) {
+            if !self_spell_cost_condition_matches(state, cond, caster, spell_id, casting_variant) {
                 continue;
             }
         }
@@ -14813,7 +14791,7 @@ mod tests {
 
     #[test]
     fn visions_of_ruin_flashback_commander_mv_reduces_flashback_cost() {
-        use crate::types::ability::{AggregateFunction, ObjectProperty, QuantityRef};
+        use crate::types::ability::{AggregateFunction, Effect, ObjectProperty, QuantityExpr, QuantityRef};
         use crate::types::keywords::{FlashbackCost, Keyword};
         use crate::types::statics::StaticMode;
 
@@ -14849,10 +14827,21 @@ mod tests {
                 shards: vec![ManaCostShard::Red],
                 generic: 3,
             };
-            obj.keywords.push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::Cost {
-                shards: vec![ManaCostShard::Red, ManaCostShard::Red],
-                generic: 8,
-            })));
+            obj.keywords
+                .push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::Cost {
+                    shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+                    generic: 8,
+                })));
+            obj.base_keywords = obj.keywords.clone();
+            let ability = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            );
+            Arc::make_mut(&mut obj.abilities).push(ability.clone());
+            Arc::make_mut(&mut obj.base_abilities).push(ability);
             let mut def = StaticDefinition::new(StaticMode::ModifyCost {
                 mode: CostModifyMode::Reduce,
                 amount: ManaCost::generic(1),

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4684,7 +4684,13 @@ fn prepare_spell_cast_with_variant_override_inner(
 
     // CR 601.2f: Apply every cost modifier (self-spell statics, battlefield statics,
     // affinity, one-shot reductions, cost floor) in CR-correct order.
-    apply_all_cost_modifiers(state, player, object_id, &mut mana_cost);
+    apply_all_cost_modifiers(
+        state,
+        player,
+        object_id,
+        &mut mana_cost,
+        Some(casting_variant),
+    );
 
     // CR 702.96b-c: When casting with Overload, transform the spell's ability
     // tree so every target-bearing effect is promoted to its all-matching
@@ -4772,6 +4778,7 @@ fn apply_non_floor_cost_modifiers(
     player: PlayerId,
     object_id: ObjectId,
     mana_cost: &mut ManaCost,
+    casting_variant: Option<CastingVariant>,
 ) {
     // CR 601.2f: A spell cast via a `PlayFromExile` grant may carry a printed
     // cost increase ("Each spell cast this way costs {N} more to cast." —
@@ -4787,7 +4794,8 @@ fn apply_non_floor_cost_modifiers(
     // CR 601.2f: collect self-spell statics ("This spell costs
     // {N} less ...") and battlefield statics together so all increases apply
     // before any reductions across both passes.
-    let mut collected = collect_self_spell_cost_modifiers(state, player, object_id, None, false);
+    let mut collected =
+        collect_self_spell_cost_modifiers(state, player, object_id, None, false, casting_variant);
     collected.extend(collect_battlefield_cost_modifiers(
         state, player, object_id, None, false,
     ));
@@ -4810,8 +4818,9 @@ pub(super) fn apply_all_cost_modifiers(
     player: PlayerId,
     object_id: ObjectId,
     mana_cost: &mut ManaCost,
+    casting_variant: Option<CastingVariant>,
 ) {
-    apply_non_floor_cost_modifiers(state, player, object_id, mana_cost);
+    apply_non_floor_cost_modifiers(state, player, object_id, mana_cost, casting_variant);
     // CR 601.2b + CR 601.2f: Cost-floor statics (Trinisphere class) — LAST, after
     // every additive/subtractive modifier so the floor sees the final mana
     // component. While the cost still contains `{X}`, X has mana value 0
@@ -4851,8 +4860,14 @@ pub(super) fn apply_target_dependent_cost_modifiers(
             *mana_cost = super::restrictions::add_mana_cost(mana_cost, &strive_cost);
         }
     }
-    let mut collected =
-        collect_self_spell_cost_modifiers(state, player, object_id, Some(ability), true);
+    let mut collected = collect_self_spell_cost_modifiers(
+        state,
+        player,
+        object_id,
+        Some(ability),
+        true,
+        None,
+    );
     collected.extend(collect_battlefield_cost_modifiers(
         state,
         player,
@@ -4881,7 +4896,7 @@ pub(super) fn concrete_cost_for_x(
 ) -> ManaCost {
     let mut cost = base.clone();
     cost.concretize_x(x);
-    apply_non_floor_cost_modifiers(state, player, object_id, &mut cost);
+    apply_non_floor_cost_modifiers(state, player, object_id, &mut cost, None);
     apply_target_dependent_cost_modifiers(state, player, object_id, ability, &mut cost);
     apply_cost_floor(state, player, object_id, &mut cost);
     apply_cost_floor_with_selected_targets(state, player, object_id, ability, &mut cost);
@@ -4986,7 +5001,7 @@ pub(super) fn apply_cost_modifiers_to_base(
             }
         }
     }
-    apply_all_cost_modifiers(state, player, object_id, &mut mana_cost);
+    apply_all_cost_modifiers(state, player, object_id, &mut mana_cost, None);
     Some(mana_cost)
 }
 
@@ -5027,7 +5042,7 @@ fn apply_self_spell_cost_modifiers(
     spell_id: ObjectId,
     mana_cost: &mut ManaCost,
 ) {
-    let collected = collect_self_spell_cost_modifiers(state, caster, spell_id, None, false);
+    let collected = collect_self_spell_cost_modifiers(state, caster, spell_id, None, false, None);
     apply_cost_modifications_in_order(mana_cost, &collected);
 }
 
@@ -5039,7 +5054,14 @@ pub(super) fn apply_self_spell_cost_modifiers_with_selected_targets(
     ability: &ResolvedAbility,
     mana_cost: &mut ManaCost,
 ) {
-    let collected = collect_self_spell_cost_modifiers(state, caster, spell_id, Some(ability), true);
+    let collected = collect_self_spell_cost_modifiers(
+        state,
+        caster,
+        spell_id,
+        Some(ability),
+        true,
+        None,
+    );
     apply_cost_modifications_in_order(mana_cost, &collected);
 }
 
@@ -5049,12 +5071,39 @@ struct CostModification {
     multiplier: u32,
 }
 
+fn self_spell_cost_condition_matches(
+    state: &GameState,
+    condition: &StaticCondition,
+    caster: PlayerId,
+    spell_id: ObjectId,
+    casting_variant: Option<CastingVariant>,
+) -> bool {
+    match condition {
+        StaticCondition::And { conditions } => conditions.iter().all(|cond| {
+            self_spell_cost_condition_matches(state, cond, caster, spell_id, casting_variant)
+        }),
+        StaticCondition::Or { conditions } => conditions.iter().any(|cond| {
+            self_spell_cost_condition_matches(state, cond, caster, spell_id, casting_variant)
+        }),
+        StaticCondition::Not { condition } => !self_spell_cost_condition_matches(
+            state,
+            condition,
+            caster,
+            spell_id,
+            casting_variant,
+        ),
+        StaticCondition::CastingAsVariant { variant } => casting_variant == Some(*variant),
+        _ => super::layers::evaluate_condition(state, condition, caster, spell_id),
+    }
+}
+
 fn collect_self_spell_cost_modifiers(
     state: &GameState,
     caster: PlayerId,
     spell_id: ObjectId,
     selected_ability: Option<&ResolvedAbility>,
     target_sensitive_only: bool,
+    casting_variant: Option<CastingVariant>,
 ) -> Vec<CostModification> {
     let Some(spell_obj) = state.objects.get(&spell_id) else {
         return Vec::new();
@@ -5122,7 +5171,13 @@ fn collect_self_spell_cost_modifiers(
 
         // CR 604.1: Evaluate any trailing condition ("if you control a Wizard").
         if let Some(ref cond) = def.condition {
-            if !super::layers::evaluate_condition(state, cond, caster, spell_id) {
+            if !self_spell_cost_condition_matches(
+                state,
+                cond,
+                caster,
+                spell_id,
+                casting_variant,
+            ) {
                 continue;
             }
         }
@@ -14757,6 +14812,89 @@ mod tests {
     }
 
     #[test]
+    fn visions_of_ruin_flashback_commander_mv_reduces_flashback_cost() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty, QuantityRef};
+        use crate::types::keywords::{FlashbackCost, Keyword};
+        use crate::types::statics::StaticMode;
+
+        let mut state = setup_game_at_main_phase();
+        let commander = create_object(
+            &mut state,
+            CardId(8801),
+            PlayerId(0),
+            "Krenko, Mob Boss".to_string(),
+            Zone::Command,
+        );
+        {
+            let obj = state.objects.get_mut(&commander).unwrap();
+            obj.is_commander = true;
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+                generic: 2,
+            };
+        }
+
+        let spell = create_object(
+            &mut state,
+            CardId(8802),
+            PlayerId(0),
+            "Visions of Ruin".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 3,
+            };
+            obj.keywords.push(Keyword::Flashback(FlashbackCost::Mana(ManaCost::Cost {
+                shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+                generic: 8,
+            })));
+            let mut def = StaticDefinition::new(StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                amount: ManaCost::generic(1),
+                spell_filter: None,
+                dynamic_count: Some(QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::ManaValue,
+                    filter: TargetFilter::Typed(
+                        TypedFilter::default()
+                            .with_type(TypeFilter::Creature)
+                            .properties(vec![
+                                FilterProp::IsCommander,
+                                FilterProp::Owned {
+                                    controller: ControllerRef::You,
+                                },
+                                FilterProp::InAnyZone {
+                                    zones: vec![Zone::Battlefield, Zone::Command],
+                                },
+                            ]),
+                    ),
+                }),
+            })
+            .affected(TargetFilter::SelfRef)
+            .condition(Some(StaticCondition::CastingAsVariant {
+                variant: CastingVariant::Flashback,
+            }));
+            def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
+            obj.static_definitions.push(def);
+        }
+
+        let prepared = prepare_spell_cast(&state, PlayerId(0), spell).unwrap();
+        assert_eq!(prepared.casting_variant, CastingVariant::Flashback);
+        match prepared.mana_cost {
+            ManaCost::Cost { generic, shards } => {
+                assert_eq!(generic, 4, "8 generic flashback minus commander MV 4");
+                assert_eq!(shards, vec![ManaCostShard::Red, ManaCostShard::Red]);
+            }
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn grant_next_spell_without_paying_casts_for_free() {
         use super::super::engine::apply_as_current;
         use crate::types::ability::{EffectKind, ResolvedAbility};
@@ -20840,6 +20978,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -20864,6 +21003,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -20922,6 +21062,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -20961,6 +21102,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -21001,6 +21143,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -21040,6 +21183,7 @@ mod tests {
             PlayerId(0),
             obj_id,
             &mut mana_cost,
+            None,
         );
         assert_eq!(
             mana_cost,
@@ -45254,7 +45398,7 @@ mod tests {
         );
 
         let mut cost = state.objects[&spell].mana_cost.clone();
-        apply_all_cost_modifiers(&state, PlayerId(0), spell, &mut cost);
+        apply_all_cost_modifiers(&state, PlayerId(0), spell, &mut cost, None);
 
         assert_eq!(
             cost,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14791,7 +14791,9 @@ mod tests {
 
     #[test]
     fn visions_of_ruin_flashback_commander_mv_reduces_flashback_cost() {
-        use crate::types::ability::{AggregateFunction, Effect, ObjectProperty, QuantityExpr, QuantityRef};
+        use crate::types::ability::{
+            AggregateFunction, Effect, ObjectProperty, QuantityExpr, QuantityRef,
+        };
         use crate::types::keywords::{FlashbackCost, Keyword};
         use crate::types::statics::StaticMode;
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -6571,6 +6571,7 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::SourceInZone { .. } => ("SourceInZone", Handled),
         StaticCondition::EnchantedIsFaceDown => ("EnchantedIsFaceDown", Handled),
         StaticCondition::AdditionalCostPaid => ("AdditionalCostPaid", Handled),
+        StaticCondition::CastingAsVariant { .. } => ("CastingAsVariant", Handled),
     }
 }
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3534,6 +3534,7 @@ fn fmt_static_condition(cond: &StaticCondition) -> String {
         SC::SourceInZone { zone } => format!("source is in {}", fmt_zone(zone)),
         SC::EnchantedIsFaceDown => "enchanted creature is face-down".into(),
         SC::AdditionalCostPaid => "additional cost was paid".into(),
+        SC::CastingAsVariant { variant } => format!("casting as {variant:?}"),
         SC::None => "none".into(),
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -791,6 +791,7 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::EnchantedIsFaceDown
         | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
         | StaticCondition::None => false,
     }
 }
@@ -917,6 +918,7 @@ fn entered_object_perturbs_static_condition(
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::EnchantedIsFaceDown
         | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
         | StaticCondition::None => false,
     }
 }
@@ -1304,6 +1306,9 @@ fn evaluate_condition_with_context(
             .filter(|pc| pc.object_id == source_id)
             .map(|pc| pc.ability.context.additional_cost_paid)
             .unwrap_or(false),
+        // CR 702.34a: Cast-time variant gates are evaluated in
+        // `collect_self_spell_cost_modifiers`, not the layer pipeline.
+        StaticCondition::CastingAsVariant { .. } => false,
         StaticCondition::None => true,
         // CR 309.7: True when the controller has completed at least one dungeon.
         StaticCondition::CompletedADungeon => state

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -557,6 +557,7 @@ pub(crate) fn static_condition_uses_unspent_mana(condition: &StaticCondition) ->
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::EnchantedIsFaceDown
         | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
         | StaticCondition::None => false,
     }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -44,10 +44,9 @@ use super::oracle_classifier::{
     is_compound_turn_limit, is_defiler_cost_pattern, is_enters_tapped_cant_untap_compound,
     is_enters_with_counter_replacement_line, is_enters_with_counter_trigger,
     is_flashback_equal_mana_cost, is_granted_static_line, is_instead_replacement_line,
-    split_flashback_trailing_self_spell_cost_reduction,
     is_opening_hand_begin_game, is_pay_life_as_colored_mana_pattern, is_replacement_pattern,
     is_spells_alternative_cost_pattern, is_static_pattern, is_vehicle_tier_line, lower_starts_with,
-    should_defer_spell_to_effect,
+    should_defer_spell_to_effect, split_flashback_trailing_self_spell_cost_reduction,
 };
 use super::oracle_condition::parse_restriction_condition;
 use super::oracle_cost::{parse_oracle_cost, try_parse_cost_reduction};
@@ -3511,13 +3510,33 @@ pub(crate) fn parse_oracle_ir(
         // otherwise route it to the spell-effect catch-all and produce
         // `Unimplemented`. Intercept it here, before the spell catch-all, and
         // delegate to `parse_keyword_from_oracle`'s em-dash dispatcher.
-        if lower_starts_with(&lower, "flashback") && line.contains('\u{2014}') {
-            // Strip trailing punctuation so the em-dash dispatcher sees a clean
-            // cost string. Reminder text was already removed by `strip_reminder_text`
-            // upstream, but the trailing period from "Pay 3 life." remains.
-            let lower_clean = lower.trim_end_matches('.').trim();
-            if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
-                result.extracted_keywords.push(kw);
+        //
+        // Visions of Ruin also prints a period-separated compound line:
+        // "Flashback {8}{R}{R}. This spell costs {X} less to cast this way, …".
+        // `is_keyword_cost_line` matches that line at Priority 9 but
+        // `parse_keyword_from_oracle` fails on the full text, so split the
+        // trailing self-spell reduction before the spell catch-all.
+        if lower_starts_with(&lower, "flashback") {
+            if line.contains('\u{2014}') {
+                // Strip trailing punctuation so the em-dash dispatcher sees a clean
+                // cost string. Reminder text was already removed by `strip_reminder_text`
+                // upstream, but the trailing period from "Pay 3 life." remains.
+                let lower_clean = lower.trim_end_matches('.').trim();
+                if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
+                    result.extracted_keywords.push(kw);
+                    i += 1;
+                    continue;
+                }
+            } else if let Some((flashback_part, reduction_part)) =
+                split_flashback_trailing_self_spell_cost_reduction(&line, &lower)
+            {
+                let flashback_lower = flashback_part.to_lowercase();
+                if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
+                    result.extracted_keywords.push(kw);
+                }
+                if let Some(def) = parse_static_line(reduction_part) {
+                    result.statics.push(def);
+                }
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -82,7 +82,8 @@ use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
     parse_cast_spells_alternative_cost_multi, parse_chosen_creature_type_static_prefix,
     parse_collect_evidence_alt_cost, parse_every_creature_type_static_prefix,
-    parse_spells_alternative_cost, parse_static_line, parse_static_line_multi,
+    parse_spells_alternative_cost, parse_flashback_trailing_self_spell_cost_reduction,
+    parse_static_line, parse_static_line_multi,
     try_parse_graveyard_keyword_grant_clause, try_parse_graveyard_keyword_grant_static,
     GraveyardGrantedKeywordKind,
 };
@@ -3113,7 +3114,7 @@ pub(crate) fn parse_oracle_ir(
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
                     result.extracted_keywords.push(kw);
                 }
-                if let Some(def) = parse_static_line(reduction_part) {
+                if let Some(def) = parse_flashback_trailing_self_spell_cost_reduction(reduction_part) {
                     result.statics.push(def);
                 }
                 i += 1;
@@ -3801,7 +3802,7 @@ pub(crate) fn parse_oracle_ir(
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
                     result.extracted_keywords.push(kw);
                 }
-                if let Some(def) = parse_static_line(reduction_part) {
+                if let Some(def) = parse_flashback_trailing_self_spell_cost_reduction(reduction_part) {
                     result.statics.push(def);
                 }
                 i += 1;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -44,6 +44,7 @@ use super::oracle_classifier::{
     is_compound_turn_limit, is_defiler_cost_pattern, is_enters_tapped_cant_untap_compound,
     is_enters_with_counter_replacement_line, is_enters_with_counter_trigger,
     is_flashback_equal_mana_cost, is_granted_static_line, is_instead_replacement_line,
+    split_flashback_trailing_self_spell_cost_reduction,
     is_opening_hand_begin_game, is_pay_life_as_colored_mana_pattern, is_replacement_pattern,
     is_spells_alternative_cost_pattern, is_static_pattern, is_vehicle_tier_line, lower_starts_with,
     should_defer_spell_to_effect,
@@ -3784,6 +3785,21 @@ pub(crate) fn parse_oracle_ir(
         // Priority 13: Keyword cost lines — extract keyword if parseable, then skip.
         // MTGJSON provides keyword names (e.g. "Morph") but not parameterized forms.
         // The Oracle text has the full form (e.g. "Morph {2}{B}{G}{U}") which we extract here.
+        if lower_starts_with(&lower, "flashback") {
+            if let Some((flashback_part, reduction_part)) =
+                split_flashback_trailing_self_spell_cost_reduction(&line, &lower)
+            {
+                let flashback_lower = flashback_part.to_lowercase();
+                if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
+                    result.extracted_keywords.push(kw);
+                }
+                if let Some(def) = parse_static_line(reduction_part) {
+                    result.statics.push(def);
+                }
+                i += 1;
+                continue;
+            }
+        }
         if is_keyword_cost_line(&lower) {
             if let Some(kw) = parse_keyword_from_oracle(&lower) {
                 result.extracted_keywords.push(kw);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3094,6 +3094,33 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
+        // CR 702.34a: Flashback em-dash / compound self-spell cost-reduction lines.
+        // Must run before Priority 7 static patterns: "This spell costs {X} less
+        // to cast this way" matches `is_static_pattern` and would swallow the
+        // flashback keyword on Visions of Ruin class cards.
+        if lower_starts_with(&lower, "flashback") {
+            if line.contains('\u{2014}') {
+                let lower_clean = lower.trim_end_matches('.').trim();
+                if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
+                    result.extracted_keywords.push(kw);
+                    i += 1;
+                    continue;
+                }
+            } else if let Some((flashback_part, reduction_part)) =
+                split_flashback_trailing_self_spell_cost_reduction(&line, &lower)
+            {
+                let flashback_lower = flashback_part.to_lowercase();
+                if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
+                    result.extracted_keywords.push(kw);
+                }
+                if let Some(def) = parse_static_line(reduction_part) {
+                    result.statics.push(def);
+                }
+                i += 1;
+                continue;
+            }
+        }
+
         // Priority 7: Static/continuous patterns
         // CR 611.2a + CR 611.3a: On permanents, "creatures you control get +1/+1"
         // is a static ability (CR 611.3a). On instants/sorceries, lines with an
@@ -3503,45 +3530,6 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        // CR 702.34a: Flashback em-dash form — "Flashback—{cost}", "Flashback—Tap N
-        // creatures...", or compound "Flashback—{mana}, Pay N life." The comma in
-        // compound costs prevents `extract_keyword_line` (priority 1b) from
-        // recognising the line as a keyword-only line, and Priority 9 would
-        // otherwise route it to the spell-effect catch-all and produce
-        // `Unimplemented`. Intercept it here, before the spell catch-all, and
-        // delegate to `parse_keyword_from_oracle`'s em-dash dispatcher.
-        //
-        // Visions of Ruin also prints a period-separated compound line:
-        // "Flashback {8}{R}{R}. This spell costs {X} less to cast this way, …".
-        // `is_keyword_cost_line` matches that line at Priority 9 but
-        // `parse_keyword_from_oracle` fails on the full text, so split the
-        // trailing self-spell reduction before the spell catch-all.
-        if lower_starts_with(&lower, "flashback") {
-            if line.contains('\u{2014}') {
-                // Strip trailing punctuation so the em-dash dispatcher sees a clean
-                // cost string. Reminder text was already removed by `strip_reminder_text`
-                // upstream, but the trailing period from "Pay 3 life." remains.
-                let lower_clean = lower.trim_end_matches('.').trim();
-                if let Some(kw) = parse_keyword_from_oracle(lower_clean) {
-                    result.extracted_keywords.push(kw);
-                    i += 1;
-                    continue;
-                }
-            } else if let Some((flashback_part, reduction_part)) =
-                split_flashback_trailing_self_spell_cost_reduction(&line, &lower)
-            {
-                let flashback_lower = flashback_part.to_lowercase();
-                if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
-                    result.extracted_keywords.push(kw);
-                }
-                if let Some(def) = parse_static_line(reduction_part) {
-                    result.statics.push(def);
-                }
-                i += 1;
-                continue;
-            }
-        }
-
         // CR 702.27a: Buyback em-dash form — "Buyback—Sacrifice a land." (Constant
         // Mists) etc. MTGJSON omits the Buyback keyword when the cost is non-mana,
         // so `extract_keyword_line` bails and the line would otherwise fall through
@@ -3631,10 +3619,7 @@ pub(crate) fn parse_oracle_ir(
                     || ends_with_quoted_activated_ability(&prepared_line.effect_text)
                     || is_self_exile_cleanup_line(&next_prepared.effect_text, card_name)
                     || is_standalone_spell_keyword_action_line(&prepared_line.effect_text)
-                    || lower_starts_with(
-                        &next_prepared.effect_text.to_lowercase(),
-                        "flashback",
-                    )
+                    || lower_starts_with(&next_prepared.effect_text.to_lowercase(), "flashback")
                     || !is_spell_resolution_instruction_line(
                         &next_prepared,
                         card_name,

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3631,6 +3631,10 @@ pub(crate) fn parse_oracle_ir(
                     || ends_with_quoted_activated_ability(&prepared_line.effect_text)
                     || is_self_exile_cleanup_line(&next_prepared.effect_text, card_name)
                     || is_standalone_spell_keyword_action_line(&prepared_line.effect_text)
+                    || lower_starts_with(
+                        &next_prepared.effect_text.to_lowercase(),
+                        "flashback",
+                    )
                     || !is_spell_resolution_instruction_line(
                         &next_prepared,
                         card_name,

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -82,10 +82,9 @@ use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
     parse_cast_spells_alternative_cost_multi, parse_chosen_creature_type_static_prefix,
     parse_collect_evidence_alt_cost, parse_every_creature_type_static_prefix,
-    parse_spells_alternative_cost, parse_flashback_trailing_self_spell_cost_reduction,
-    parse_static_line, parse_static_line_multi,
-    try_parse_graveyard_keyword_grant_clause, try_parse_graveyard_keyword_grant_static,
-    GraveyardGrantedKeywordKind,
+    parse_flashback_trailing_self_spell_cost_reduction, parse_spells_alternative_cost,
+    parse_static_line, parse_static_line_multi, try_parse_graveyard_keyword_grant_clause,
+    try_parse_graveyard_keyword_grant_static, GraveyardGrantedKeywordKind,
 };
 use super::oracle_trigger::{lower_trigger_ir, parse_trigger_lines_at_index};
 use super::oracle_util::{
@@ -3114,7 +3113,9 @@ pub(crate) fn parse_oracle_ir(
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
                     result.extracted_keywords.push(kw);
                 }
-                if let Some(def) = parse_flashback_trailing_self_spell_cost_reduction(reduction_part) {
+                if let Some(def) =
+                    parse_flashback_trailing_self_spell_cost_reduction(reduction_part)
+                {
                     result.statics.push(def);
                 }
                 i += 1;
@@ -3802,7 +3803,9 @@ pub(crate) fn parse_oracle_ir(
                 if let Some(kw) = parse_keyword_from_oracle(&flashback_lower) {
                     result.extracted_keywords.push(kw);
                 }
-                if let Some(def) = parse_flashback_trailing_self_spell_cost_reduction(reduction_part) {
+                if let Some(def) =
+                    parse_flashback_trailing_self_spell_cost_reduction(reduction_part)
+                {
                     result.statics.push(def);
                 }
                 i += 1;

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -48,6 +48,26 @@ pub(crate) fn is_flashback_equal_mana_cost(lower: &str) -> bool {
         && scan_contains(lower, "mana cost")
 }
 
+/// CR 702.34a + CR 601.2f: Split a compound flashback line that also carries a
+/// self-spell cost reduction (Visions of Ruin: "Flashback {8}{R}{R}. This spell
+/// costs {X} less to cast this way, …").
+pub(crate) fn split_flashback_trailing_self_spell_cost_reduction<'a>(
+    line: &'a str,
+    lower: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    for marker in [". this spell costs ", ". this card costs "] {
+        let Some(idx) = lower.find(marker) else {
+            continue;
+        };
+        let flashback_part = line[..idx].trim();
+        let reduction_part = line[idx + 1..].trim();
+        if lower_starts_with(lower, "flashback") {
+            return Some((flashback_part, reduction_part));
+        }
+    }
+    None
+}
+
 pub(crate) fn is_defiler_cost_pattern(lower: &str) -> bool {
     lower_starts_with(lower, "as an additional cost to cast ")
         && !scan_contains(lower, "this spell")
@@ -855,6 +875,16 @@ mod tests {
     fn unquoted_cant_block_static_unchanged() {
         // No quotes → fast path → classification unchanged.
         assert!(is_static_pattern("creatures you control can't block"));
+    }
+
+    #[test]
+    fn split_flashback_trailing_self_spell_cost_reduction_splits_visions_line() {
+        let line = "Flashback {8}{R}{R}. This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.";
+        let lower = line.to_lowercase();
+        let (flashback, reduction) =
+            split_flashback_trailing_self_spell_cost_reduction(line, &lower).unwrap();
+        assert_eq!(flashback, "Flashback {8}{R}{R}");
+        assert!(reduction.starts_with("This spell costs {X} less to cast this way"));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -884,7 +884,10 @@ mod tests {
         let (flashback, reduction) =
             split_flashback_trailing_self_spell_cost_reduction(line, &lower).unwrap();
         assert_eq!(flashback, "Flashback {8}{R}{R}");
-        assert!(reduction.starts_with("This spell costs {X} less to cast this way"));
+        assert_eq!(
+            reduction,
+            "This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone."
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -1,7 +1,8 @@
+use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
-use nom::bytes::complete::tag;
-use nom::combinator::{opt, verify};
+use nom::bytes::complete::{tag, take_until};
+use nom::combinator::{opt, value, verify};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -55,16 +56,31 @@ pub(crate) fn split_flashback_trailing_self_spell_cost_reduction<'a>(
     line: &'a str,
     lower: &'a str,
 ) -> Option<(&'a str, &'a str)> {
-    for marker in [". this spell costs ", ". this card costs "] {
-        let Some(idx) = lower.find(marker) else {
-            continue;
-        };
-        let flashback_part = line[..idx].trim();
-        let reduction_part = line[idx + 1..].trim();
-        if lower_starts_with(lower, "flashback") {
-            return Some((flashback_part, reduction_part));
-        }
+    const SPELL_MARKER: &str = ". this spell costs ";
+    const CARD_MARKER: &str = ". this card costs ";
+
+    if let Some(((), reduction_text)) = nom_on_lower(line, lower, |input| {
+        preceded(
+            tag("flashback"),
+            value((), (take_until(SPELL_MARKER), tag(". "))),
+        )
+        .parse(input)
+    }) {
+        let flashback_len = line.len() - ". ".len() - reduction_text.len();
+        return Some((line[..flashback_len].trim(), reduction_text.trim()));
     }
+
+    if let Some(((), reduction_text)) = nom_on_lower(line, lower, |input| {
+        preceded(
+            tag("flashback"),
+            value((), (take_until(CARD_MARKER), tag(". "))),
+        )
+        .parse(input)
+    }) {
+        let flashback_len = line.len() - ". ".len() - reduction_text.len();
+        return Some((line[..flashback_len].trim(), reduction_text.trim()));
+    }
+
     None
 }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3269,6 +3269,7 @@ pub(crate) fn static_condition_to_ability_condition(
         // target-relative tap condition (Zygon Infiltrator's copy duration), not
         // an effect-resolution gate — no `AbilityCondition` equivalent.
         | StaticCondition::IsTapped { .. }
+        | StaticCondition::CastingAsVariant { .. }
         | StaticCondition::None => None,
     }
 }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2543,7 +2543,7 @@ pub(crate) fn parse_static_line_inner(
         && (nom_primitives::scan_contains(tp.lower, "less")
             || nom_primitives::scan_contains(tp.lower, "more"))
     {
-        if let Some(def) = try_parse_cost_modification(&text, &lower) {
+        if let Some(def) = try_parse_cost_modification(&text, &lower, None) {
             return Some(def);
         }
     }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -173,7 +173,13 @@ pub fn parse_static_line(text: &str) -> Option<crate::types::ability::StaticDefi
 pub(crate) fn parse_flashback_trailing_self_spell_cost_reduction(
     text: &str,
 ) -> Option<crate::types::ability::StaticDefinition> {
-    let mut def = static_helpers::parse_flashback_trailing_self_spell_cost_reduction(text)?;
+    let text = crate::parser::oracle_util::strip_reminder_text(text);
+    let lower = text.to_lowercase();
+    let mut def = static_helpers::try_parse_cost_modification(
+        &text,
+        &lower,
+        Some(crate::types::game_state::CastingVariant::Flashback),
+    )?;
     shared::populate_active_zones_from_condition(&mut def);
     Some(def)
 }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -168,6 +168,16 @@ pub fn parse_static_line(text: &str) -> Option<crate::types::ability::StaticDefi
     Some(lower_static_ir(&ir))
 }
 
+/// CR 702.34a + CR 601.2f: Parse a self-spell cost modifier trailing a proven
+/// Flashback clause (Visions of Ruin class).
+pub(crate) fn parse_flashback_trailing_self_spell_cost_reduction(
+    text: &str,
+) -> Option<crate::types::ability::StaticDefinition> {
+    let mut def = static_helpers::parse_flashback_trailing_self_spell_cost_reduction(text)?;
+    shared::populate_active_zones_from_condition(&mut def);
+    Some(def)
+}
+
 /// IR production: parse a static line into `StaticIr` (pre-lowering).
 pub(crate) fn parse_static_line_ir(text: &str) -> Option<StaticIr> {
     let definition = parse_static_line_inner(text, InvertedAsLongAs::Allow)?;

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -312,8 +312,7 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         peel_leading_cost_modifier_condition(TextPair::new(text, lower));
     let text = cost_text.original;
     let lower = cost_text.lower;
-    let cast_this_way_variant = lower
-        .contains(" to cast this way")
+    let cast_this_way_variant = nom_primitives::scan_contains(lower, " to cast this way")
         .then_some(crate::types::game_state::CastingVariant::Flashback);
 
     let is_raise = nom_primitives::scan_contains(lower, "more to cast")

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -305,15 +305,31 @@ pub(crate) fn try_parse_impose_additional_cost(
     )
 }
 
+/// CR 702.34a + CR 601.2f: Parse the trailing self-spell cost modifier from a
+/// compound Flashback line whose leading clause was already proven Flashback.
+pub(crate) fn parse_flashback_trailing_self_spell_cost_reduction(
+    text: &str,
+) -> Option<StaticDefinition> {
+    let text = strip_reminder_text(text);
+    let lower = text.to_lowercase();
+    try_parse_cost_modification(
+        &text,
+        &lower,
+        Some(crate::types::game_state::CastingVariant::Flashback),
+    )
+}
+
 /// Dynamic "for each" counts are extracted when present.
-pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<StaticDefinition> {
+pub(crate) fn try_parse_cost_modification(
+    text: &str,
+    lower: &str,
+    casting_as_variant: Option<crate::types::game_state::CastingVariant>,
+) -> Option<StaticDefinition> {
     let original_text = text;
     let (cost_text, leading_condition) =
         peel_leading_cost_modifier_condition(TextPair::new(text, lower));
     let text = cost_text.original;
     let lower = cost_text.lower;
-    let cast_this_way_variant = nom_primitives::scan_contains(lower, "less to cast this way")
-        .then_some(crate::types::game_state::CastingVariant::Flashback);
 
     let is_raise = nom_primitives::scan_contains(lower, "more to cast")
         || nom_primitives::scan_contains(lower, "more to activate");
@@ -748,7 +764,10 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         definition.condition = Some(StaticCondition::DuringYourTurn);
     }
 
-    if let Some(variant) = cast_this_way_variant {
+    // CR 601.2f + CR 702.34a: Caller-proven casting variant (e.g. Flashback from
+    // the compound-line parser) gates self-spell cost modifiers — never inferred
+    // from generic "cast this way" wording alone.
+    if let Some(variant) = casting_as_variant {
         definition.condition = Some(match definition.condition.take() {
             Some(existing) => StaticCondition::And {
                 conditions: vec![existing, StaticCondition::CastingAsVariant { variant }],

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -312,6 +312,9 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         peel_leading_cost_modifier_condition(TextPair::new(text, lower));
     let text = cost_text.original;
     let lower = cost_text.lower;
+    let cast_this_way_variant = lower
+        .contains(" to cast this way")
+        .then_some(crate::types::game_state::CastingVariant::Flashback);
 
     let is_raise = nom_primitives::scan_contains(lower, "more to cast")
         || nom_primitives::scan_contains(lower, "more to activate");
@@ -744,6 +747,15 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
             .is_ok()
     {
         definition.condition = Some(StaticCondition::DuringYourTurn);
+    }
+
+    if let Some(variant) = cast_this_way_variant {
+        definition.condition = Some(match definition.condition.take() {
+            Some(existing) => StaticCondition::And {
+                conditions: vec![existing, StaticCondition::CastingAsVariant { variant }],
+            },
+            None => StaticCondition::CastingAsVariant { variant },
+        });
     }
 
     Some(definition)

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -312,7 +312,7 @@ pub(crate) fn try_parse_cost_modification(text: &str, lower: &str) -> Option<Sta
         peel_leading_cost_modifier_condition(TextPair::new(text, lower));
     let text = cost_text.original;
     let lower = cost_text.lower;
-    let cast_this_way_variant = nom_primitives::scan_contains(lower, " to cast this way")
+    let cast_this_way_variant = nom_primitives::scan_contains(lower, "less to cast this way")
         .then_some(crate::types::game_state::CastingVariant::Flashback);
 
     let is_raise = nom_primitives::scan_contains(lower, "more to cast")

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -305,20 +305,6 @@ pub(crate) fn try_parse_impose_additional_cost(
     )
 }
 
-/// CR 702.34a + CR 601.2f: Parse the trailing self-spell cost modifier from a
-/// compound Flashback line whose leading clause was already proven Flashback.
-pub(crate) fn parse_flashback_trailing_self_spell_cost_reduction(
-    text: &str,
-) -> Option<StaticDefinition> {
-    let text = strip_reminder_text(text);
-    let lower = text.to_lowercase();
-    try_parse_cost_modification(
-        &text,
-        &lower,
-        Some(crate::types::game_state::CastingVariant::Flashback),
-    )
-}
-
 /// Dynamic "for each" counts are extracted when present.
 pub(crate) fn try_parse_cost_modification(
     text: &str,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2449,7 +2449,7 @@ fn chandras_incinerator_self_cost_reduction_uses_noncombat_damage_to_opponents()
 
 #[test]
 fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
-    let def = parse_static_line(
+    let def = parse_flashback_trailing_self_spell_cost_reduction(
         "This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
     )
     .unwrap();
@@ -2477,6 +2477,18 @@ fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
         })
     ));
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+}
+
+#[test]
+fn cast_this_way_cost_reduction_without_flashback_context_has_no_variant_gate() {
+    let def = parse_static_line(
+        "This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
+    )
+    .unwrap();
+    assert!(!matches!(
+        def.condition,
+        Some(StaticCondition::CastingAsVariant { .. })
+    ));
 }
 
 /// CR 601.2f + CR 102.2/102.3: Heliod, the Warped Eclipse. "Spells you cast cost

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2447,6 +2447,34 @@ fn chandras_incinerator_self_cost_reduction_uses_noncombat_damage_to_opponents()
     );
 }
 
+#[test]
+fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
+    let def = parse_static_line(
+        "This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
+    )
+    .unwrap();
+
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        dynamic_count: Some(QuantityRef::Aggregate {
+            function: AggregateFunction::Max,
+            property: ObjectProperty::ManaValue,
+            ..
+        }),
+        ..
+    } = def.mode
+    else {
+        panic!("expected commander-MV dynamic ReduceCost, got {:?}", def.mode);
+    };
+    assert!(matches!(
+        def.condition,
+        Some(StaticCondition::CastingAsVariant {
+            variant: crate::types::game_state::CastingVariant::Flashback
+        })
+    ));
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+}
+
 /// CR 601.2f + CR 102.2/102.3: Heliod, the Warped Eclipse. "Spells you cast cost
 /// {1} less to cast for each card your opponents have drawn this turn." must lower
 /// to a `ModifyCost { mode: Reduce, dynamic_count: CardsDrawnThisTurn{Opponent{Sum}} }`.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2456,15 +2456,19 @@ fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
 
     let StaticMode::ModifyCost {
         mode: CostModifyMode::Reduce,
-        dynamic_count: Some(QuantityRef::Aggregate {
-            function: AggregateFunction::Max,
-            property: ObjectProperty::ManaValue,
-            ..
-        }),
+        dynamic_count:
+            Some(QuantityRef::Aggregate {
+                function: AggregateFunction::Max,
+                property: ObjectProperty::ManaValue,
+                ..
+            }),
         ..
     } = def.mode
     else {
-        panic!("expected commander-MV dynamic ReduceCost, got {:?}", def.mode);
+        panic!(
+            "expected commander-MV dynamic ReduceCost, got {:?}",
+            def.mode
+        );
     };
     assert!(matches!(
         def.condition,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3222,6 +3222,7 @@ pub(crate) fn static_condition_to_trigger_condition(
         // CR 702.166a: Bargain payment is a cost-determination predicate with no
         // intervening-if (`TriggerCondition`) equivalent.
         | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
         | StaticCondition::None => None,
 
         // CR 309.7: Dungeon completion bridges directly.

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4161,6 +4161,45 @@ mod tests {
         );
     }
 
+    /// CR 702.34a + CR 601.2f: Visions of Ruin — flashback cost plus commander-MV
+    /// "cast this way" reduction must parse without swallowing either clause.
+    #[test]
+    fn visions_of_ruin_flashback_commander_reduction_parses_without_swallow() {
+        let parsed = parse_named(
+            "Each opponent sacrifices an artifact. For each artifact sacrificed this way, you create a Treasure token.\n\
+             Flashback {8}{R}{R}. This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own on the battlefield or in the command zone.",
+            "Visions of Ruin",
+            &["Sorcery"],
+        );
+        assert!(
+            parsed
+                .extracted_keywords
+                .iter()
+                .any(|k| matches!(k, Keyword::Flashback(_))),
+            "expected Flashback keyword, got {:?}",
+            parsed.extracted_keywords
+        );
+        assert!(
+            parsed.statics.iter().any(|sd| {
+                matches!(sd.mode, StaticMode::ModifyCost { .. })
+                    && sd.condition.as_ref().is_some_and(|cond| matches!(
+                        cond,
+                        crate::types::ability::StaticCondition::CastingAsVariant { .. }
+                    ))
+            }),
+            "expected flashback-gated ReduceCost static, got {:?}",
+            parsed.statics
+        );
+        assert!(
+            parsed
+                .parse_warnings
+                .iter()
+                .all(|warning| !matches!(warning, OracleDiagnostic::SwallowedClause { .. })),
+            "Visions of Ruin must not swallow flashback cost-reduction clauses: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
     /// CR 508.1 + CR 118.9: Lethargy Trap — leading-if attacking-creature count
     /// gate on the {U} alternative casting cost must not report Condition_If.
     #[test]

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -2895,6 +2895,7 @@ mod tests {
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
     use crate::types::ability::{AbilityDefinition, Effect, OutsideGameSourcePool, TargetFilter};
     use crate::types::identifiers::TrackedSetId;
+    use crate::types::keywords::Keyword;
     use crate::types::mana::ManaCost;
     use crate::types::statics::StaticMode;
     use crate::types::zones::Zone;

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4183,10 +4183,12 @@ mod tests {
         assert!(
             parsed.statics.iter().any(|sd| {
                 matches!(sd.mode, StaticMode::ModifyCost { .. })
-                    && sd.condition.as_ref().is_some_and(|cond| matches!(
-                        cond,
-                        crate::types::ability::StaticCondition::CastingAsVariant { .. }
-                    ))
+                    && sd.condition.as_ref().is_some_and(|cond| {
+                        matches!(
+                            cond,
+                            crate::types::ability::StaticCondition::CastingAsVariant { .. }
+                        )
+                    })
             }),
             "expected flashback-gated ReduceCost static, got {:?}",
             parsed.statics

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5705,6 +5705,13 @@ pub enum StaticCondition {
     /// Hamlet Glutton's "This spell costs {2} less to cast if it's bargained." Evaluated
     /// against the in-flight cast's `additional_cost_paid` flag (`state.pending_cast`).
     AdditionalCostPaid,
+    /// CR 702.34a + CR 601.2f: True when the spell is being cast via the named
+    /// alternative-cast variant (e.g. flashback "cast this way" cost reduction on
+    /// Visions of Ruin). Evaluated only during self-spell `ModifyCost` collection,
+    /// not in the layer pipeline.
+    CastingAsVariant {
+        variant: crate::types::game_state::CastingVariant,
+    },
     None,
 }
 


### PR DESCRIPTION
## Summary

Visions of Ruin (`Flashback {8}{R}{R}. This spell costs {X} less to cast this way, where X is the greatest mana value of a commander you own…`) was keyword-only: the trailing commander-MV reduction was swallowed by the flashback keyword path.

- Split compound flashback + self-spell reduction lines in `oracle.rs`
- Parse `to cast this way` as `StaticCondition::CastingAsVariant::Flashback` on self-spell `ModifyCost` statics
- Evaluate that gate during `collect_self_spell_cost_modifiers` (not the layer pipeline)
- Greatest-commander-MV dynamic count reuses existing quantity parsing

## Test plan

- [x] `visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv` — static parser binding
- [x] `split_flashback_trailing_self_spell_cost_reduction_splits_visions_line` — line split
- [x] `visions_of_ruin_flashback_commander_reduction_parses_without_swallow` — full-card parse
- [x] `visions_of_ruin_flashback_commander_mv_reduces_flashback_cost` — flashback cast cost reduced by commander MV 4

Closes #4467
