### PR TITLE
feat: Cosmic Cube + Hawkeye, Young Avenger (MSH)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -49485,4 +49485,104 @@ mod tests {
              (PaymentContext::Spell); got {spell_res:?}"
         );
     }
+
+    /// MSH-F Sub-Plan A2 — runtime enforcement of the *dynamic* mana-value
+    /// ceiling at the finalize seam. Cosmic Cube is the FIRST card to route a
+    /// `CastPermissionConstraint::ManaValue { value: Ref(Aggregate{Max, Power,
+    /// attacking creatures you control}) }` through
+    /// [`cast_permission_constraint_allows_cast`]; every pre-existing dynamic
+    /// ceiling resolves to a computed `Fixed`, so the
+    /// `resolve_quantity(Aggregate) -> comparator.evaluate` composition at this
+    /// seam had zero direct coverage. This drives the seam directly (no
+    /// card-data, no harness).
+    ///
+    /// CR 202.3: mana value is the comparison subject. CR 601.2e: cast legality
+    /// is re-checked at finalization once the resulting mana value is known.
+    ///
+    /// Non-vacuous + discriminating: the board carries a NON-attacking power-7
+    /// creature the caster controls. The ceiling is the greatest power among
+    /// *attacking* creatures (max(2, 3) = 3), so `Some(4)` must be rejected — if
+    /// the `Attacking` predicate were dropped (or the comparator inverted), the
+    /// ceiling would read 7 and `Some(4)` would wrongly be accepted.
+    #[test]
+    fn cosmic_cube_dynamic_mv_ceiling_enforced_at_finalize() {
+        fn add_creature(state: &mut GameState, card: u64, name: &str, power: i32) -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(card),
+                PlayerId(0),
+                name.to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(power);
+            obj.toughness = Some(power);
+            id
+        }
+
+        let mut state = setup_game_at_main_phase();
+
+        // Two attacking creatures you control, power 2 and 3 → ceiling = max = 3.
+        let atk_lo = add_creature(&mut state, 7001, "Attacker Lo", 2);
+        let atk_hi = add_creature(&mut state, 7002, "Attacker Hi", 3);
+        // Non-attacking power-7 creature you control: the discriminating control.
+        // It must NOT raise the ceiling.
+        let _bench = add_creature(&mut state, 7003, "Bench Bruiser", 7);
+
+        // Only the two attackers are declared in combat (bench is not).
+        state.combat = Some(crate::game::combat::CombatState {
+            attackers: vec![
+                crate::game::combat::AttackerInfo::attacking_player(atk_lo, PlayerId(1)),
+                crate::game::combat::AttackerInfo::attacking_player(atk_hi, PlayerId(1)),
+            ],
+            ..Default::default()
+        });
+
+        // The spell being finalized on the stack, controlled by the caster (P0).
+        let spell = create_object(
+            &mut state,
+            CardId(7004),
+            PlayerId(0),
+            "Cast From Among Them".to_string(),
+            Zone::Stack,
+        );
+
+        // c = ManaValue { LE, Ref(Aggregate{Max, Power, attacking creatures you control}) }
+        let constraint = Some(CastPermissionConstraint::ManaValue {
+            comparator: Comparator::LE,
+            value: QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::Power,
+                    filter: TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Creature],
+                        controller: Some(ControllerRef::You),
+                        properties: vec![FilterProp::Attacking { defender: None }],
+                    }),
+                },
+            },
+        });
+
+        let obj = state.objects.get(&spell).unwrap();
+
+        // 3 <= 3 → accept: the ceiling is the attackers' max power (3).
+        assert!(
+            cast_permission_constraint_allows_cast(&state, obj, &constraint, Some(3)),
+            "resulting MV 3 must be accepted: greatest attacking power is 3"
+        );
+        // 4 > 3 → reject. Proves the non-attacking power-7 creature did NOT lift
+        // the ceiling (would be 7 and accept if the Attacking filter leaked).
+        assert!(
+            !cast_permission_constraint_allows_cast(&state, obj, &constraint, Some(4)),
+            "resulting MV 4 must be rejected: non-attacking power-7 creature must \
+             NOT raise the dynamic ceiling"
+        );
+        // Offer-time check (resulting MV unknown yet) stays permissive — the
+        // ceiling is enforced at finalize once the MV is concrete.
+        assert!(
+            cast_permission_constraint_allows_cast(&state, obj, &constraint, None),
+            "offer-time check (resulting MV unknown) must be permissive"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/add_target_replacement.rs
+++ b/crates/engine/src/game/effects/add_target_replacement.rs
@@ -108,14 +108,16 @@ fn stamp_for_as_long_as_controlled_gate(
 }
 
 /// CR 107.3a + CR 601.2b: Freeze the announced value of X into a "deals that
-/// much damage plus X" replacement at activation time. The parser emits
-/// `DamageModification::Plus { value: 0 }` as a placeholder (the `u32`-typed
-/// modification cannot carry a symbolic X); here the announced X (held on the
-/// activating ability as `chosen_x`) replaces the placeholder so the replacement
-/// applies the locked-in value for the rest of the turn (Taii Wakeen's second
-/// ability). The `chosen_x.is_some()` guard ensures a genuine literal "plus 0"
-/// (no X in the cost) is never clobbered. (CR 107.3a: an activated ability's X
-/// equals its announced value while on the stack and beyond.)
+/// much damage plus X" replacement at activation time. The parser emits the
+/// bare-"plus x" form (no "where X is" binding) as
+/// `DamageModification::Plus { value: QuantityExpr::Fixed { value: 0 } }`
+/// placeholder; here the announced X (held on the activating ability as
+/// `chosen_x`) replaces the placeholder so the replacement applies the
+/// locked-in value for the rest of the turn (Taii Wakeen's second ability). The
+/// `Fixed { value: 0 }` guard ensures a genuine literal "plus 0" (no X) or a
+/// where-bound dynamic offset (`Ref`, e.g. Hawkeye) is never clobbered. (CR
+/// 107.3a: an activated ability's X equals its announced value while on the
+/// stack and beyond.)
 fn freeze_damage_modification_x(
     replacement: &mut ReplacementDefinition,
     ability: &ResolvedAbility,
@@ -123,8 +125,13 @@ fn freeze_damage_modification_x(
     if let (Some(crate::types::ability::DamageModification::Plus { value }), Some(chosen_x)) =
         (replacement.damage_modification.as_mut(), ability.chosen_x)
     {
-        if *value == 0 {
-            *value = chosen_x;
+        if matches!(
+            value,
+            crate::types::ability::QuantityExpr::Fixed { value: 0 }
+        ) {
+            *value = crate::types::ability::QuantityExpr::Fixed {
+                value: chosen_x as i32,
+            };
         }
     }
 }
@@ -536,7 +543,9 @@ mod tests {
         // of truth.
         let mut state = GameState::new_two_player(42);
         let replacement = ReplacementDefinition::new(ReplacementEvent::DamageDone)
-            .damage_modification(DamageModification::Plus { value: 1 })
+            .damage_modification(DamageModification::Plus {
+                value: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+            })
             .damage_source_filter(TargetFilter::Typed(
                 crate::types::ability::TypedFilter::default()
                     .controller(crate::types::ability::ControllerRef::You),
@@ -604,7 +613,9 @@ mod tests {
         );
 
         let replacement = ReplacementDefinition::new(ReplacementEvent::DamageDone)
-            .damage_modification(DamageModification::Plus { value: 1 })
+            .damage_modification(DamageModification::Plus {
+                value: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+            })
             .damage_source_filter(TargetFilter::Typed(
                 TypedFilter::default().controller(ControllerRef::You),
             ));

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -971,7 +971,40 @@ fn damage_done_applier(
             let new_amount = match modification {
                 DamageModification::Double => amount.saturating_mul(2),
                 DamageModification::Triple => amount.saturating_mul(3),
-                DamageModification::Plus { value } => amount.saturating_add(value),
+                // CR 614.1a + CR 120 + CR 107.1b: additive damage modification.
+                // The added magnitude is a game quantity resolved each time the
+                // replacement applies, clamped >= 0 (CR 107.1b). A `Fixed` value
+                // (Torbran, Artist's Talent, Rankle and Torbran, I Call for
+                // Slaughter) needs no source object; a `Ref` (Hawkeye's "~'s
+                // power") reads the object-hosted source's live characteristics
+                // via `rid.source`. The controller authority mirrors
+                // `damage_modification_for_rid`'s discriminator (CR 109.4):
+                // object-hosted replacements derive it from the host's zone,
+                // pending-registry replacements (ObjectId(0) sentinel) carry it
+                // on the definition. `damage_modification_for_rid` returns an
+                // owned clone, so this immutable `resolve_quantity` read does
+                // not conflict with the `&mut state` applier (mirrors the
+                // `SetToSourcePower` arm).
+                DamageModification::Plus { value } => {
+                    let controller = if rid.source == ObjectId(0) {
+                        state
+                            .pending_damage_replacements
+                            .get(rid.index)
+                            .and_then(|r| r.source_controller)
+                            .unwrap_or(PlayerId(0))
+                    } else {
+                        state
+                            .objects
+                            .get(&rid.source)
+                            .map(replacement_source_player)
+                            .unwrap_or(PlayerId(0))
+                    };
+                    let added = crate::game::quantity::resolve_quantity(
+                        state, &value, controller, rid.source,
+                    )
+                    .max(0) as u32;
+                    amount.saturating_add(added)
+                }
                 // CR 615.1 + CR 614.1a: Saturating subtract. `Minus { value: u32::MAX }`
                 // is the continuous prevent-all sentinel — yields 0 for any amount and
                 // is not consumed (continuous, not shield-style).
@@ -7232,8 +7265,11 @@ mod tests {
 
         let furnace_of_rath = ReplacementDefinition::new(ReplacementEvent::DamageDone)
             .damage_modification(DamageModification::Double);
-        let torbran = ReplacementDefinition::new(ReplacementEvent::DamageDone)
-            .damage_modification(DamageModification::Plus { value: 2 });
+        let torbran = ReplacementDefinition::new(ReplacementEvent::DamageDone).damage_modification(
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 },
+            },
+        );
 
         let mut state = GameState::new_two_player(42);
         let mut src1 = GameObject::new(
@@ -9692,9 +9728,131 @@ mod tests {
         }
     }
 
+    /// MSH-F Sub-Plan B (B2): the additive damage offset reads the replacement
+    /// source's LIVE power through the full `replace_event` pipeline. Hawkeye
+    /// (the source) power 2 + a 3-damage noncombat source you control →
+    /// opponent takes 5; raising Hawkeye's power to 4 makes the next event add 4
+    /// (proves a live re-read, not a snapshot). Combat damage and damage to your
+    /// own permanent are NOT amplified (NoncombatOnly + opponent target filter).
+    /// Revert-fail: with the parser/type lift reverted the offset is frozen to
+    /// `Fixed(0)`, so the opponent would take 3 on both events.
+    #[test]
+    fn damage_applier_plus_dynamic_source_power_is_live() {
+        use crate::types::ability::{
+            ControllerRef, ObjectScope, QuantityExpr, QuantityRef, TypedFilter,
+        };
+        use crate::types::card_type::CoreType;
+
+        // Hawkeye-shaped replacement: +X where X is the source's (Hawkeye's)
+        // current power; only noncombat damage to an opponent / their permanents.
+        let repl = ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .damage_modification(DamageModification::Plus {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Source,
+                    },
+                },
+            })
+            .combat_scope(CombatDamageScope::NoncombatOnly)
+            .damage_source_filter(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            ))
+            .damage_target_filter(DamageTargetFilter::PlayerOrPermanentsControlledBy {
+                player: DamageTargetPlayerScope::Opponent,
+            });
+
+        // Hawkeye = ObjectId(10), controlled by P0, power 2.
+        let mut state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
+        state.objects.get_mut(&ObjectId(10)).unwrap().power = Some(2);
+
+        // A noncombat damage source P0 controls (ObjectId(50)).
+        let mut src = GameObject::new(
+            ObjectId(50),
+            CardId(2),
+            PlayerId(0),
+            "Ping".to_string(),
+            Zone::Battlefield,
+        );
+        src.power = Some(1);
+        state.objects.insert(ObjectId(50), src);
+        state.battlefield.push_back(ObjectId(50));
+
+        let noncombat_to_opp = || ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 3,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+
+        let mut events = Vec::new();
+        // Power 2 → 3 + 2 = 5.
+        match replace_event(&mut state, noncombat_to_opp(), &mut events) {
+            ReplacementResult::Execute(ProposedEvent::Damage { amount, .. }) => {
+                assert_eq!(amount, 5, "3 + live Hawkeye power(2)")
+            }
+            other => panic!("expected modified damage, got {other:?}"),
+        }
+
+        // Raise Hawkeye's power to 4 → the next event re-reads it live: 3 + 4 = 7.
+        state.objects.get_mut(&ObjectId(10)).unwrap().power = Some(4);
+        match replace_event(&mut state, noncombat_to_opp(), &mut events) {
+            ReplacementResult::Execute(ProposedEvent::Damage { amount, .. }) => {
+                assert_eq!(amount, 7, "live re-read: 3 + Hawkeye power(4)")
+            }
+            other => panic!("expected modified damage, got {other:?}"),
+        }
+
+        // NEGATIVE: combat damage is not amplified (NoncombatOnly scope).
+        let combat = ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 3,
+            is_combat: true,
+            applied: HashSet::new(),
+        };
+        match replace_event(&mut state, combat, &mut events) {
+            ReplacementResult::Execute(ProposedEvent::Damage { amount, .. }) => {
+                assert_eq!(amount, 3, "combat damage must not be amplified")
+            }
+            other => panic!("expected unmodified combat damage, got {other:?}"),
+        }
+
+        // NEGATIVE: noncombat damage to YOUR OWN permanent is not amplified
+        // (target filter is opponent-only).
+        let mut own = GameObject::new(
+            ObjectId(60),
+            CardId(3),
+            PlayerId(0),
+            "Own Creature".to_string(),
+            Zone::Battlefield,
+        );
+        own.card_types.core_types.push(CoreType::Creature);
+        state.objects.insert(ObjectId(60), own);
+        state.battlefield.push_back(ObjectId(60));
+        let to_own = ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Object(ObjectId(60)),
+            amount: 3,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+        match replace_event(&mut state, to_own, &mut events) {
+            ReplacementResult::Execute(ProposedEvent::Damage { amount, .. }) => {
+                assert_eq!(
+                    amount, 3,
+                    "damage to your own permanent must not be amplified"
+                )
+            }
+            other => panic!("expected unmodified self-damage, got {other:?}"),
+        }
+    }
+
     #[test]
     fn damage_applier_plus() {
-        let repl = damage_repl(DamageModification::Plus { value: 2 });
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 2 },
+        });
         let mut state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
         let mut events = Vec::new();
         let rid = ReplacementId {
@@ -9885,11 +10043,12 @@ mod tests {
 
     #[test]
     fn damage_target_filter_opponent_blocks_self() {
-        let repl = damage_repl(DamageModification::Plus { value: 2 }).damage_target_filter(
-            DamageTargetFilter::PlayerOrPermanentsControlledBy {
-                player: DamageTargetPlayerScope::Opponent,
-            },
-        );
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 2 },
+        })
+        .damage_target_filter(DamageTargetFilter::PlayerOrPermanentsControlledBy {
+            player: DamageTargetPlayerScope::Opponent,
+        });
         // Replacement on P0's object
         let state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
 
@@ -9908,11 +10067,12 @@ mod tests {
 
     #[test]
     fn damage_target_filter_opponent_allows_opponent() {
-        let repl = damage_repl(DamageModification::Plus { value: 2 }).damage_target_filter(
-            DamageTargetFilter::PlayerOrPermanentsControlledBy {
-                player: DamageTargetPlayerScope::Opponent,
-            },
-        );
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 2 },
+        })
+        .damage_target_filter(DamageTargetFilter::PlayerOrPermanentsControlledBy {
+            player: DamageTargetPlayerScope::Opponent,
+        });
         let state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
 
         // Damage targets P1 (opponent) — should match
@@ -9931,11 +10091,12 @@ mod tests {
     #[test]
     fn damage_target_filter_opponent_allows_opponents_permanent() {
         use crate::types::card_type::CoreType;
-        let repl = damage_repl(DamageModification::Plus { value: 2 }).damage_target_filter(
-            DamageTargetFilter::PlayerOrPermanentsControlledBy {
-                player: DamageTargetPlayerScope::Opponent,
-            },
-        );
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 2 },
+        })
+        .damage_target_filter(DamageTargetFilter::PlayerOrPermanentsControlledBy {
+            player: DamageTargetPlayerScope::Opponent,
+        });
         let mut state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
 
         // Add opponent's creature
@@ -11016,11 +11177,12 @@ mod tests {
 
     #[test]
     fn damage_target_filter_opponent_only() {
-        let repl = damage_repl(DamageModification::Plus { value: 1 }).damage_target_filter(
-            DamageTargetFilter::Player {
-                player: DamageTargetPlayerScope::Opponent,
-            },
-        );
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 1 },
+        })
+        .damage_target_filter(DamageTargetFilter::Player {
+            player: DamageTargetPlayerScope::Opponent,
+        });
         let state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
 
         // Damage to opponent (P1) — should match
@@ -11078,11 +11240,12 @@ mod tests {
 
     #[test]
     fn damage_target_filter_controller_only() {
-        let repl = damage_repl(DamageModification::Plus { value: 1 }).damage_target_filter(
-            DamageTargetFilter::Player {
-                player: DamageTargetPlayerScope::Controller,
-            },
-        );
+        let repl = damage_repl(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 1 },
+        })
+        .damage_target_filter(DamageTargetFilter::Player {
+            player: DamageTargetPlayerScope::Controller,
+        });
         let state = test_state_with_damage_repl(ObjectId(10), PlayerId(0), vec![repl]);
         let registry = build_replacement_registry();
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -63,7 +63,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{anychar, multispace0, multispace1, space1};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, recognize, rest, value};
-use nom::multi::{many1, separated_list1};
+use nom::multi::{many1, many_till, separated_list1};
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
@@ -15851,6 +15851,17 @@ fn try_parse_cast_effect(lower: &str) -> Option<Effect> {
 }
 
 fn parse_cast_permission_constraint(lower: &str) -> Option<CastPermissionConstraint> {
+    // Two distinct grammar shapes carry a cast-permission mana-value ceiling:
+    // Beseech's post-value suffix ("...mana value is N or less") and the
+    // "with mana value <comparator> <quantity>" pre-value prefix used by Cosmic
+    // Cube. They cannot share a comparator combinator (suffix vs. prefix), so
+    // dispatch over two sub-combinators.
+    parse_beseech_mv_constraint(lower).or_else(|| parse_with_mana_value_constraint(lower))
+}
+
+/// Beseech-family constraint: `... if that spell's mana value is N or less`.
+/// Post-value suffix comparator (`or less`/`or greater`, else equality).
+fn parse_beseech_mv_constraint(lower: &str) -> Option<CastPermissionConstraint> {
     type E<'a> = OracleError<'a>;
     let (tail, _) = take_until::<_, _, E>("if that spell's mana value is ")
         .parse(lower)
@@ -15867,6 +15878,44 @@ fn parse_cast_permission_constraint(lower: &str) -> Option<CastPermissionConstra
     } else {
         Comparator::EQ
     };
+    Some(CastPermissionConstraint::ManaValue { comparator, value })
+}
+
+/// Cosmic-Cube-family constraint: `... with mana value <comparator> <quantity> ...`.
+/// CR 202.3: mana value is the comparison subject. CR 601.2e: the ceiling gates
+/// cast legality (re-checked at finalization once the resulting MV is known).
+/// The comparator is a PRE-value prefix; the quantity may be a dynamic aggregate
+/// (e.g. "the greatest power among attacking creatures you control") whose
+/// combinator returns the trailing remainder ("... without paying its mana
+/// cost") for the caller to ignore — class-general, no card-specific delimiter.
+fn parse_with_mana_value_constraint(lower: &str) -> Option<CastPermissionConstraint> {
+    type E<'a> = OracleError<'a>;
+    // Skip any preamble up to the mana-value anchor, then consume the anchor.
+    let (after_anchor, _) = many_till(
+        anychar,
+        alt((tag::<_, _, E>("with mana value "), tag("of mana value "))),
+    )
+    .parse(lower)
+    .ok()?;
+    // Dedicated PREFIX comparator (longest-match first: LE/GE before LT/GT, EQ last).
+    let (after_comparator, comparator) = alt((
+        value(Comparator::LE, tag::<_, _, E>("less than or equal to ")),
+        value(Comparator::GE, tag("greater than or equal to ")),
+        value(Comparator::LT, tag("less than ")),
+        value(Comparator::GT, tag("greater than ")),
+        value(Comparator::EQ, tag("equal to ")),
+    ))
+    .parse(after_anchor)
+    .ok()?;
+    // Quantity: dynamic aggregate/ref first (remainder-returning), then fixed N / X.
+    let (_, value) = alt((
+        map(nom_quantity::parse_quantity_ref, |qty| QuantityExpr::Ref {
+            qty,
+        }),
+        nom_quantity::parse_quantity_expr_number,
+    ))
+    .parse(after_comparator)
+    .ok()?;
     Some(CastPermissionConstraint::ManaValue { comparator, value })
 }
 
@@ -23099,6 +23148,165 @@ mod tests {
     use super::*;
     use crate::parser::parse_oracle_text;
     use crate::types::ability::AttachmentKind;
+
+    // ── MSH-F Sub-Plan A: Cosmic Cube — dynamic mana-value cast permission ──
+
+    /// Recursively find the first `CastFromZone` effect's constraint in an
+    /// ability tree (effect → sub_ability → else_ability). Returns
+    /// `Some(constraint)` when a `CastFromZone` is present, `None` otherwise.
+    fn find_cast_from_zone_constraint(
+        ad: &AbilityDefinition,
+    ) -> Option<Option<CastPermissionConstraint>> {
+        if let Effect::CastFromZone { constraint, .. } = ad.effect.as_ref() {
+            return Some(constraint.clone());
+        }
+        ad.sub_ability
+            .as_deref()
+            .and_then(find_cast_from_zone_constraint)
+            .or_else(|| {
+                ad.else_ability
+                    .as_deref()
+                    .and_then(find_cast_from_zone_constraint)
+            })
+    }
+
+    /// A0: the aggregate quantity combinator (`parse_quantity_ref`, the
+    /// delegation target) consumes only `the greatest power among attacking
+    /// creatures you control` and RETURNS the trailing
+    /// `without paying its mana cost` remainder. The round-1 delegation target
+    /// (`parse_quantity_ref_with_context`) gates on a snapshot suffix and would
+    /// yield `None` on this trailing text. Revert-fail: switching to the gated
+    /// combinator makes `rest` non-empty rejection collapse the constraint.
+    #[test]
+    fn cosmic_cube_aggregate_quantity_returns_trailing_suffix() {
+        let (rest, qty) = nom_quantity::parse_quantity_ref(
+            "the greatest power among attacking creatures you control without paying its mana cost",
+        )
+        .expect("aggregate quantity must parse, leaving the trailing suffix");
+        assert_eq!(rest, " without paying its mana cost");
+        assert!(
+            matches!(
+                qty,
+                QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::Power,
+                    ..
+                }
+            ),
+            "expected Max-power aggregate, got {qty:?}"
+        );
+    }
+
+    /// A1 (direct seam): the new `with mana value <comparator> <quantity>`
+    /// branch produces a dynamic `ManaValue` constraint. Revert-fail: without
+    /// `parse_with_mana_value_constraint`, `parse_cast_permission_constraint`
+    /// only knows the Beseech suffix form and returns `None`.
+    #[test]
+    fn cosmic_cube_constraint_parses_dynamic_mana_value_ceiling() {
+        let constraint = parse_cast_permission_constraint(
+            "you may cast a spell from among them with mana value less than or equal to \
+             the greatest power among attacking creatures you control without paying its mana cost",
+        );
+        match constraint {
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::Aggregate {
+                                function: AggregateFunction::Max,
+                                property: ObjectProperty::Power,
+                                ..
+                            },
+                    },
+            }) => {}
+            other => panic!("expected dynamic ManaValue{{LE, Max-power aggregate}}, got {other:?}"),
+        }
+    }
+
+    /// A1 negative/fixed: the same prefix grammar accepts a fixed numeric
+    /// ceiling and a `greater than` comparator. Guards comparator ordering and
+    /// the `Fixed` fallback arm.
+    #[test]
+    fn with_mana_value_constraint_fixed_and_comparators() {
+        assert_eq!(
+            parse_cast_permission_constraint("with mana value less than or equal to 4"),
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 4 },
+            }),
+        );
+        assert_eq!(
+            parse_cast_permission_constraint("with mana value greater than or equal to 3"),
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 3 },
+            }),
+        );
+        // "less than" (strict) must NOT be shadowed by "less than or equal to".
+        assert_eq!(
+            parse_cast_permission_constraint("with mana value less than 5"),
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LT,
+                value: QuantityExpr::Fixed { value: 5 },
+            }),
+        );
+    }
+
+    /// A1 regression guard: the Beseech post-value suffix form is untouched by
+    /// the refactor (still dispatched by `parse_beseech_mv_constraint`).
+    #[test]
+    fn beseech_suffix_constraint_unchanged_after_refactor() {
+        assert_eq!(
+            parse_cast_permission_constraint("if that spell's mana value is 4 or less"),
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 4 },
+            }),
+        );
+    }
+
+    /// A1 (full line): Cosmic Cube's whole attack trigger lowers to a
+    /// `CastFromZone` whose `constraint` carries the dynamic ceiling. Revert-fail:
+    /// today the constraint serializes as `null` (verified in card-data.json).
+    #[test]
+    fn cosmic_cube_full_trigger_carries_dynamic_constraint() {
+        let parsed = parse_oracle_text(
+            "Ward {2}\nWhenever you attack, look at the top six cards of your library. \
+             You may cast a spell from among them with mana value less than or equal to \
+             the greatest power among attacking creatures you control without paying its \
+             mana cost. Put the rest on the bottom of your library in a random order.",
+            "Cosmic Cube",
+            &["Ward".to_string()],
+            &["Artifact".to_string()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find_map(|t| {
+                t.execute
+                    .as_deref()
+                    .and_then(find_cast_from_zone_constraint)
+            })
+            .expect("Cosmic Cube must lower to a CastFromZone effect");
+        match trigger {
+            Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::Aggregate {
+                                property: ObjectProperty::Power,
+                                ..
+                            },
+                    },
+            }) => {}
+            other => panic!(
+                "Cosmic Cube CastFromZone constraint must be the dynamic MV ceiling, got {other:?}"
+            ),
+        }
+    }
 
     /// CR 510.1a + CR 613.11: The Kingpin of Crime's attack ability — "Whenever you
     /// attack, you may pay 2 life. If you do, until end of turn, creatures you

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4,7 +4,7 @@ use crate::parser::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{char, multispace1};
-use nom::combinator::{all_consuming, eof, opt, peek, rest, value};
+use nom::combinator::{all_consuming, eof, map_opt, opt, peek, rest, value};
 use nom::multi::separated_list1;
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
@@ -4924,27 +4924,52 @@ fn scan_damage_modification(text: &str) -> Option<DamageModification> {
     {
         return Some(modification);
     }
-    // Fallback: "that much damage plus/minus N" (fixed) or "that much damage
-    // plus X" (variable). The X case yields a `Plus { value: 0 }` placeholder —
-    // `DamageModification::Plus` carries a `u32`, so X is frozen at activation in
-    // `add_target_replacement::resolve` (CR 107.3a). Composed from nom
-    // combinators rather than `strip_after` so dispatch stays structural.
+    // Fallback: "that much damage plus/minus N" (fixed), "that much damage plus
+    // X, where X is <quantity>" (dynamic — carried as `Plus { Ref(..) }`), or a
+    // bare "that much damage plus X" with no binding (yields the
+    // `Plus { Fixed { 0 } }` placeholder frozen at activation in
+    // `add_target_replacement::freeze_damage_modification_x`, CR 107.3a).
+    // Composed from nom combinators rather than `strip_after` so dispatch stays
+    // structural.
     nom_primitives::scan_at_word_boundaries(text, parse_that_much_damage_offset)
 }
 
-/// CR 614.1a + CR 107.3a: "that much damage plus N" / "plus X" / "minus N".
-/// The "plus X" arm emits `Plus { value: 0 }` as a placeholder frozen at
-/// activation (X cannot live in the `u32`-typed `DamageModification`).
+/// CR 614.1a + CR 107.3a: "that much damage plus N" / "plus X, where X is
+/// <quantity>" / "plus X" / "minus N". A bound `where X is <quantity>` form
+/// carries the live game quantity as `Plus { Ref(..) }`; a bare "plus x" with
+/// no binding still emits the `Plus { Fixed { 0 } }` placeholder frozen at
+/// activation.
 fn parse_that_much_damage_offset(
     input: &str,
 ) -> nom::IResult<&str, DamageModification, OracleError<'_>> {
     let (rest, _) = tag("that much damage ").parse(input)?;
     alt((
-        // "plus X" — variable offset, frozen at install. Tried before the
-        // numeric arm so the literal "x" token is not consumed by parse_number.
-        value(DamageModification::Plus { value: 0 }, tag("plus x")),
+        // CR 614.1a + CR 107.3a: dynamic additive offset — "plus X, where X is
+        // <quantity>" (Hawkeye, Young Avenger: "...plus X, where X is ~'s
+        // power"). Placed BEFORE the bare-"plus x" freeze arm so the
+        // where-binding is not shadowed. `parse_cda_quantity` strips a trailing
+        // '.' internally, so "~'s power." parses; it returns
+        // `Option<QuantityExpr>`, composed via `map_opt`.
+        map_opt(
+            preceded(tag("plus x, where x is "), nom::combinator::rest),
+            |q: &str| {
+                crate::parser::oracle_quantity::parse_cda_quantity(q)
+                    .map(|value| DamageModification::Plus { value })
+            },
+        ),
+        // "plus X" with no binding — variable offset frozen at install. Tried
+        // before the numeric arm so the literal "x" token is not consumed by
+        // parse_number.
+        value(
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 },
+            },
+            tag("plus x"),
+        ),
         nom::combinator::map(preceded(tag("plus "), nom_primitives::parse_number), |n| {
-            DamageModification::Plus { value: n }
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: n as i32 },
+            }
         }),
         nom::combinator::map(preceded(tag("minus "), nom_primitives::parse_number), |n| {
             DamageModification::Minus { value: n }
@@ -11821,7 +11846,9 @@ mod tests {
         ).unwrap();
         assert_eq!(
             def.damage_modification,
-            Some(DamageModification::Plus { value: 2 })
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            })
         );
         assert_eq!(
             def.damage_target_filter,
@@ -11848,7 +11875,9 @@ mod tests {
         ).unwrap();
         assert_eq!(
             def.damage_modification,
-            Some(DamageModification::Plus { value: 2 })
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            })
         );
         assert_eq!(def.combat_scope, Some(CombatDamageScope::NoncombatOnly));
         assert_eq!(
@@ -11863,6 +11892,106 @@ mod tests {
             }
             other => panic!("Expected Typed filter, got {other:?}"),
         }
+    }
+
+    /// MSH-F Sub-Plan B (B1): Hawkeye, Young Avenger — the dynamic additive
+    /// offset "plus X, where X is ~'s power" lowers to
+    /// `Plus { Ref(Power { Source }) }`, NOT the over-frozen `Plus { Fixed(0) }`
+    /// the bare-"plus x" arm produces (verified in card-data.json today).
+    /// Revert-fail: removing the new `map_opt(... parse_cda_quantity ...)` arm
+    /// makes the freeze arm win and the assertion flips to `Fixed { 0 }`. The
+    /// trailing '.' on "~'s power." is tolerated by `parse_cda_quantity`.
+    #[test]
+    fn damage_hawkeye_plus_dynamic_source_power() {
+        let def = parse_replacement_line(
+            "If a source you control would deal noncombat damage to an opponent or a permanent an opponent controls, instead it deals that much damage plus X, where X is Hawkeye's power.",
+            "Hawkeye, Young Avenger",
+        )
+        .unwrap();
+        assert_eq!(
+            def.damage_modification,
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: crate::types::ability::ObjectScope::Source
+                    }
+                }
+            }),
+            "Hawkeye's '+X where X is ~'s power' must carry a live source-power Ref, not Fixed(0)"
+        );
+        assert_eq!(def.combat_scope, Some(CombatDamageScope::NoncombatOnly));
+        assert_eq!(
+            def.damage_target_filter,
+            Some(damage_target_opponent_or_permanents())
+        );
+        match def.damage_source_filter.unwrap() {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(tf.properties.is_empty());
+            }
+            other => panic!("Expected Typed source filter, got {other:?}"),
+        }
+    }
+
+    /// B1 negative: a bare "plus x" with NO `where X is` binding still freezes
+    /// to the `Plus { Fixed(0) }` placeholder (Taii Wakeen class), and a literal
+    /// "plus 2" still carries `Fixed(2)` — the new dynamic arm does not shadow
+    /// either.
+    #[test]
+    fn damage_offset_bare_x_and_literal_unaffected_by_dynamic_arm() {
+        assert_eq!(
+            scan_damage_modification("it deals that much damage plus x instead"),
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 }
+            }),
+        );
+        assert_eq!(
+            scan_damage_modification("it deals that much damage plus 2 instead"),
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            }),
+        );
+        assert_eq!(
+            scan_damage_modification("it deals that much damage minus 1 instead"),
+            Some(DamageModification::Minus { value: 1 }),
+        );
+    }
+
+    /// B3: serde back-compat for the `Plus.value` field-type lift. Pre-lift
+    /// card-data.json / snapshots stored a bare integer (`"value": 2`); the
+    /// `QuantityExpr` custom Deserialize loads it as `Fixed`. Proves the lift
+    /// does not break existing serialized data (no wire bump).
+    #[test]
+    fn damage_modification_plus_legacy_int_deserializes_to_fixed() {
+        let two: DamageModification = serde_json::from_str(r#"{"type":"Plus","value":2}"#).unwrap();
+        assert_eq!(
+            two,
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            }
+        );
+        // Hawkeye's live record stores the frozen placeholder as a bare 0.
+        let zero: DamageModification =
+            serde_json::from_str(r#"{"type":"Plus","value":0}"#).unwrap();
+        assert_eq!(
+            zero,
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 }
+            }
+        );
+        // New canonical tagged form also loads.
+        let tagged: DamageModification =
+            serde_json::from_str(r#"{"type":"Plus","value":{"type":"Fixed","value":3}}"#).unwrap();
+        assert_eq!(
+            tagged,
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 3 }
+            }
+        );
+        // A non-integer scalar value is rejected (no silent coercion).
+        assert!(
+            serde_json::from_str::<DamageModification>(r#"{"type":"Plus","value":"x"}"#).is_err()
+        );
     }
 
     #[test]
@@ -14064,8 +14193,10 @@ mod tests {
     fn that_much_damage_plus_x_is_zero_placeholder() {
         assert_eq!(
             scan_damage_modification("it deals that much damage plus x instead"),
-            Some(DamageModification::Plus { value: 0 }),
-            "'plus X' must parse to the Plus(0) placeholder frozen at activation"
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 }
+            }),
+            "'plus X' must parse to the Plus(Fixed(0)) placeholder frozen at activation"
         );
     }
 
@@ -14074,7 +14205,9 @@ mod tests {
     fn that_much_damage_plus_literal_carries_value() {
         assert_eq!(
             scan_damage_modification("it deals that much damage plus 2 instead"),
-            Some(DamageModification::Plus { value: 2 })
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            })
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -33087,7 +33087,9 @@ mod tests {
         };
         assert_eq!(
             replacement.damage_modification,
-            Some(DamageModification::Plus { value: 0 }),
+            Some(DamageModification::Plus {
+                value: crate::types::ability::QuantityExpr::Fixed { value: 0 }
+            }),
             "the 'plus X' placeholder is frozen at activation, not parse time"
         );
         assert_eq!(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -15896,8 +15896,12 @@ pub enum DamageModification {
     Double,
     /// amount * 3 (e.g. Fiery Emancipation)
     Triple,
-    /// amount + value (e.g. Torbran, +2)
-    Plus { value: u32 },
+    /// CR 614.1a + CR 120: amount + value, where the added magnitude is a
+    /// `QuantityExpr` resolved against the replacement source at application
+    /// time. `Fixed { value }` covers static offsets (Torbran +2, Artist's
+    /// Talent +2); a `Ref` carries a live game quantity ("...plus X, where X is
+    /// ~'s power" — Hawkeye, Young Avenger).
+    Plus { value: QuantityExpr },
     /// amount.saturating_sub(value) (e.g. Benevolent Unicorn, -1).
     /// CR 615.1 + CR 614.1a: Continuous prevention statics ("prevent that damage")
     /// emit `Minus { value: u32::MAX }` — saturating-subtraction yields 0 for any

--- a/crates/engine/tests/i_call_for_slaughter.rs
+++ b/crates/engine/tests/i_call_for_slaughter.rs
@@ -22,8 +22,8 @@ use engine::game::effects::add_target_replacement;
 use engine::game::replacement::{replace_event, ReplacementResult};
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    ControllerRef, DamageModification, Duration, Effect, ReplacementDefinition, ResolvedAbility,
-    TargetFilter, TargetRef, TypedFilter,
+    ControllerRef, DamageModification, Duration, Effect, QuantityExpr, ReplacementDefinition,
+    ResolvedAbility, TargetFilter, TargetRef, TypedFilter,
 };
 use engine::types::game_state::GameState;
 use engine::types::identifiers::{CardId, ObjectId};
@@ -35,7 +35,9 @@ use engine::types::zones::Zone;
 /// The replacement the parser emits for the scheme's "plus 1" clause.
 fn slaughter_replacement() -> ReplacementDefinition {
     ReplacementDefinition::new(ReplacementEvent::DamageDone)
-        .damage_modification(DamageModification::Plus { value: 1 })
+        .damage_modification(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 1 },
+        })
         .damage_source_filter(TargetFilter::Typed(
             TypedFilter::default().controller(ControllerRef::You),
         ))

--- a/crates/engine/tests/rankle_and_torbran.rs
+++ b/crates/engine/tests/rankle_and_torbran.rs
@@ -23,7 +23,7 @@ use engine::game::replacement::{replace_event, ReplacementResult};
 use engine::game::zones::create_object;
 use engine::types::ability::{
     DamageModification, DamageTargetFilter, DamageTargetPlayerScope, Duration, Effect,
-    ReplacementDefinition, ResolvedAbility, TargetFilter, TargetRef,
+    QuantityExpr, ReplacementDefinition, ResolvedAbility, TargetFilter, TargetRef,
 };
 use engine::types::game_state::GameState;
 use engine::types::identifiers::{CardId, ObjectId};
@@ -35,7 +35,9 @@ use engine::types::zones::Zone;
 /// The replacement the parser emits for Rankle and Torbran's third mode.
 fn torbran_replacement() -> ReplacementDefinition {
     ReplacementDefinition::new(ReplacementEvent::DamageDone)
-        .damage_modification(DamageModification::Plus { value: 2 })
+        .damage_modification(DamageModification::Plus {
+            value: QuantityExpr::Fixed { value: 2 },
+        })
         .damage_target_filter(DamageTargetFilter::Player {
             player: DamageTargetPlayerScope::Any,
         })

--- a/crates/engine/tests/taii_wakeen.rs
+++ b/crates/engine/tests/taii_wakeen.rs
@@ -230,7 +230,7 @@ mod a2_runtime {
     use engine::game::replacement::{replace_event, ReplacementResult};
     use engine::game::zones::create_object;
     use engine::types::ability::{
-        CombatDamageScope, ControllerRef, DamageModification, Duration, Effect,
+        CombatDamageScope, ControllerRef, DamageModification, Duration, Effect, QuantityExpr,
         ReplacementDefinition, ResolvedAbility, TargetFilter, TargetRef, TypedFilter,
     };
     use engine::types::game_state::GameState;
@@ -245,7 +245,9 @@ mod a2_runtime {
     /// time via `chosen_x`.
     fn a2_replacement() -> ReplacementDefinition {
         ReplacementDefinition::new(ReplacementEvent::DamageDone)
-            .damage_modification(DamageModification::Plus { value: 0 })
+            .damage_modification(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 },
+            })
             .combat_scope(CombatDamageScope::NoncombatOnly)
             .damage_source_filter(TargetFilter::Typed(
                 TypedFilter::default().controller(ControllerRef::You),
@@ -311,7 +313,9 @@ mod a2_runtime {
         );
         assert_eq!(
             pending.damage_modification,
-            Some(DamageModification::Plus { value: 2 }),
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            }),
             "announced X=2 must be frozen into the Plus value (CR 107.3a)"
         );
 
@@ -352,7 +356,9 @@ mod a2_runtime {
         install_a2(&mut state, 0);
         assert_eq!(
             state.pending_damage_replacements[0].damage_modification,
-            Some(DamageModification::Plus { value: 0 }),
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 0 }
+            }),
             "X=0 freezes to Plus 0"
         );
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## MSH cluster F — Cosmic Cube + Hawkeye, Young Avenger

Two Marvel's Spider-Man (MSH) cards, each a reusable building block rather than a one-off.

### Cosmic Cube — dynamic mana-value ceiling on cast-from-library
- New parser path `parse_with_mana_value_constraint` lifts the cast-permission ceiling from a fixed integer to a dynamic `QuantityExpr` (`Ref(Aggregate{Max, Power})`), delegating to the remainder-returning `nom_quantity::parse_quantity_ref` so the trailing clause is preserved.
- Cosmic Cube is the **first** card to route a dynamic (`Ref`) ceiling through `cast_permission_constraint_allows_cast`; all prior cards used `Fixed`. Covered by a focused finalize-seam unit test (`cosmic_cube_dynamic_mv_ceiling_enforced_at_finalize`) proving the ceiling is enforced at cast finalization, not just at parse.

### Hawkeye, Young Avenger — dynamic damage-amplification replacement
- `DamageModification::Plus { value }` lifted from `u32` to `QuantityExpr`, so the damage bonus can scale off a dynamic source (here, source power) instead of a constant.
- Legacy integer JSON still deserializes to `Fixed` (back-compat test `damage_modification_plus_legacy_int_deserializes_to_fixed`).

### Verification
- Targeted unit tests: cosmic_cube (4/0), plus_dynamic_source_power (2/0), plus_legacy (1/0) — all pass.
- Full engine lib suite: **13812 passed / 0 failed** against current `main` (v0.8.0) — no regression.
- clippy clean; integration suite 8/0.

### Post-merge follow-ups (non-blocking)
- Regenerate `data/engine-inventory.json` to reflect the `DamageModification::Plus` field-type change (`u32` → `QuantityExpr`).
- Run `cargo coverage` / `cargo semantic-audit` to refresh MSH coverage snapshot.

Assisted-by: ClaudeCode:claude-opus-4.8
