### PR TITLE
fix(parser): Blademane Baku for-each bare counter removed (closes #4472)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -49897,7 +49897,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "known: prefix-form 'For each [unrecognized clause], <body>' fails to thread subject onto Pump target — body Pump retains target=Any sentinel because parse_for_each_clause doesn't recognize 'counter removed' and the strip_for_each_prefix bail-out short-circuits subject threading. Tracked as a follow-up."]
     fn for_each_prefix_pump_threads_self_ref_target() {
         // Blademane Baku: "For each counter removed, this creature gets +2/+0
         // until end of turn" — prefix-form for-each. The Pump's target should

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -49905,6 +49905,13 @@ mod tests {
             "For each counter removed, this creature gets +2/+0 until end of turn",
             AbilityKind::Spell,
         );
+        assert_eq!(
+            def.repeat_for,
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::PreviousEffectAmount,
+            }),
+            "repeat_for should scale by counters removed in the activation cost"
+        );
         match &*def.effect {
             Effect::Pump { target, .. } => {
                 assert_eq!(

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2554,6 +2554,18 @@ fn parse_for_each_clause_with_they_controller(
         }
     }
 
+    // CR 106.1 + CR 122.1: bare "counter[s] removed" (Blademane Baku) — an
+    // activated ability whose cost removed counters scales the effect without
+    // an explicit "this way". Dispatches to `PreviousEffectAmount`, same runtime
+    // channel as "counter removed this way" (Coalition Relic class).
+    let lower = clause.to_ascii_lowercase();
+    if all_consuming(parse_counters_removed_phrase)
+        .parse(lower.as_str())
+        .is_ok()
+    {
+        return Some(QuantityRef::PreviousEffectAmount);
+    }
+
     // CR 406.6 + CR 607.1 + CR 614.1c: "[type phrase] card(s) exiled with it/~"
     // -- a count of the linked-exile set (cards exiled with this source, e.g.
     // via Delve) restricted to a type phrase. Murktide Regent's ETB counter
@@ -3459,6 +3471,14 @@ mod tests {
         // Storage Counter cycle (Saprazzan Cove etc.) — same shape, different
         // counter type. Must produce the same dispatch.
         let qty = parse_for_each_clause("storage counter removed this way").unwrap();
+        assert_eq!(qty, QuantityRef::PreviousEffectAmount);
+    }
+
+    #[test]
+    fn for_each_bare_counter_removed_is_previous_effect_amount() {
+        // Blademane Baku: "For each counter removed, this creature gets +2/+0
+        // until end of turn" — no "this way" suffix on the activated tail.
+        let qty = parse_for_each_clause("counter removed").unwrap();
         assert_eq!(qty, QuantityRef::PreviousEffectAmount);
     }
 

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2554,7 +2554,7 @@ fn parse_for_each_clause_with_they_controller(
         }
     }
 
-    // CR 106.1 + CR 122.1: bare "counter[s] removed" (Blademane Baku) — an
+    // CR 608.2c + CR 122.1: bare "counter[s] removed" (Blademane Baku) — an
     // activated ability whose cost removed counters scales the effect without
     // an explicit "this way". Dispatches to `PreviousEffectAmount`, same runtime
     // channel as "counter removed this way" (Coalition Relic class).


### PR DESCRIPTION
## Summary

- Recognize bare `counter[s] removed` in `parse_for_each_clause` (Blademane Baku activated tail).
- Un-ignore `for_each_prefix_pump_threads_self_ref_target` — Pump now gets `SelfRef` + `repeat_for`.

## Test plan

- [x] `for_each_bare_counter_removed_is_previous_effect_amount`
- [x] `for_each_prefix_pump_threads_self_ref_target`
- [x] Parser combinator gate

Closes #4472
