### PR TITLE
fix(parser+engine): Wretched Banquet least-power destroy gate

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4,13 +4,15 @@ use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::char;
+use nom::character::complete::multispace0;
 use nom::combinator::{all_consuming, opt, peek, value};
-use nom::sequence::{preceded, terminated};
+use nom::sequence::{preceded, terminated, tuple};
 use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
 use super::super::oracle_nom::condition::{
-    inject_controller_you, parse_cast_using_teamwork_phrase, try_parse_spell_target_has_superlative,
+    inject_controller_you, parse_cast_using_teamwork_phrase,
+    parse_spell_target_superlative_suffix,
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
@@ -1890,20 +1892,30 @@ pub(super) fn strip_superlative_target_conditional(
     text: &str,
 ) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
-    let tp = TextPair::new(text, &lower);
-    let Some((before, after)) = tp.rsplit_around(" if it has the ") else {
-        return (None, text.to_string());
-    };
-    let suffix = after.original.trim_end_matches('.').trim();
-    let suffix_lower = after.lower.trim_end_matches('.').trim();
-    let Some(condition) = try_parse_spell_target_has_superlative(suffix_lower) else {
-        return (None, text.to_string());
-    };
-    let _ = suffix; // preserve original-case suffix for diagnostics if needed
-    (
-        Some(condition),
-        before.original.trim_end_matches('.').trim().to_string(),
-    )
+    let suffix_sep = " if ";
+    let mut best: Option<(usize, AbilityCondition)> = None;
+    for (idx, _) in lower.match_indices(suffix_sep) {
+        let suffix_orig = &text[idx + suffix_sep.len()..];
+        let suffix_lower = &lower[idx + suffix_sep.len()..];
+        if let Some((condition, rest)) = nom_on_lower(suffix_orig, suffix_lower, |input| {
+            terminated(
+                parse_spell_target_superlative_suffix,
+                tuple((opt(tag(".")), multispace0)),
+            )
+            .parse(input)
+        }) {
+            if rest.is_empty() {
+                best = Some((idx, condition));
+            }
+        }
+    }
+    if let Some((split_at, condition)) = best {
+        return (
+            Some(condition),
+            text[..split_at].trim_end_matches('.').trim().to_string(),
+        );
+    }
+    (None, text.to_string())
 }
 
 /// Parse the body of a leading mana-value conditional — "`<N>` or less/greater, [effect]" —
@@ -5758,6 +5770,35 @@ mod tests {
                 qty: QuantityRef::Aggregate {
                     function: AggregateFunction::Min,
                     property: ObjectProperty::Power,
+                    filter: TargetFilter::Typed(TypedFilter::creature()),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn strip_superlative_target_conditional_plural_subject() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
+
+        let (condition, body) = strip_superlative_target_conditional(
+            "Destroy those creatures if they have the greatest toughness among creatures.",
+        );
+        assert_eq!(body, "Destroy those creatures");
+        let Some(AbilityCondition::QuantityCheck {
+            comparator,
+            rhs,
+            ..
+        }) = condition
+        else {
+            panic!("expected QuantityCheck, got {condition:?}");
+        };
+        assert_eq!(comparator, Comparator::GE);
+        assert_eq!(
+            rhs,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Max,
+                    property: ObjectProperty::Toughness,
                     filter: TargetFilter::Typed(TypedFilter::creature()),
                 }
             }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -11,6 +11,7 @@ use nom::Parser;
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
 use super::super::oracle_nom::condition::{
     inject_controller_you, parse_cast_using_teamwork_phrase,
+    try_parse_spell_target_has_superlative,
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
@@ -1882,6 +1883,26 @@ pub(super) fn strip_mana_value_conditional(text: &str) -> (Option<AbilityConditi
     }
 
     (None, text.to_string())
+}
+
+/// CR 608.2c: Strip trailing "if it has the [least|greatest] <property> among
+/// <filter>" from a targeted spell effect (Wretched Banquet class).
+pub(super) fn strip_superlative_target_conditional(text: &str) -> (Option<AbilityCondition>, String) {
+    let lower = text.to_lowercase();
+    let tp = TextPair::new(text, &lower);
+    let Some((before, after)) = tp.rsplit_around(" if it has the ") else {
+        return (None, text.to_string());
+    };
+    let suffix = after.original.trim_end_matches('.').trim();
+    let suffix_lower = after.lower.trim_end_matches('.').trim();
+    let Some(condition) = try_parse_spell_target_has_superlative(suffix_lower) else {
+        return (None, text.to_string());
+    };
+    let _ = suffix; // preserve original-case suffix for diagnostics if needed
+    (
+        Some(condition),
+        before.original.trim_end_matches('.').trim().to_string(),
+    )
 }
 
 /// Parse the body of a leading mana-value conditional — "`<N>` or less/greater, [effect]" —
@@ -5702,6 +5723,43 @@ mod tests {
             Some(AbilityCondition::Not {
                 condition: Box::new(AbilityCondition::effect_performed())
             })
+        );
+    }
+
+    #[test]
+    fn strip_superlative_target_conditional_least_power() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
+
+        let (condition, body) = strip_superlative_target_conditional(
+            "Destroy target creature if it has the least power among creatures.",
+        );
+        assert_eq!(body, "Destroy target creature");
+        let Some(AbilityCondition::QuantityCheck {
+            lhs,
+            comparator,
+            rhs,
+        }) = condition
+        else {
+            panic!("expected QuantityCheck, got {condition:?}");
+        };
+        assert_eq!(comparator, Comparator::LE);
+        assert_eq!(
+            lhs,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Target,
+                }
+            }
+        );
+        assert_eq!(
+            rhs,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: AggregateFunction::Min,
+                    property: ObjectProperty::Power,
+                    filter: TargetFilter::Typed(TypedFilter::creature()),
+                }
+            }
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -10,8 +10,7 @@ use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
 use super::super::oracle_nom::condition::{
-    inject_controller_you, parse_cast_using_teamwork_phrase,
-    try_parse_spell_target_has_superlative,
+    inject_controller_you, parse_cast_using_teamwork_phrase, try_parse_spell_target_has_superlative,
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
@@ -1887,7 +1886,9 @@ pub(super) fn strip_mana_value_conditional(text: &str) -> (Option<AbilityConditi
 
 /// CR 608.2c: Strip trailing "if it has the [least|greatest] <property> among
 /// <filter>" from a targeted spell effect (Wretched Banquet class).
-pub(super) fn strip_superlative_target_conditional(text: &str) -> (Option<AbilityCondition>, String) {
+pub(super) fn strip_superlative_target_conditional(
+    text: &str,
+) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
     let Some((before, after)) = tp.rsplit_around(" if it has the ") else {

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -5783,7 +5783,9 @@ mod tests {
             "Destroy those creatures if they have the greatest toughness among creatures.",
         );
         assert_eq!(body, "Destroy those creatures");
-        let Some(AbilityCondition::QuantityCheck { comparator, rhs, .. }) = condition
+        let Some(AbilityCondition::QuantityCheck {
+            comparator, rhs, ..
+        }) = condition
         else {
             panic!("expected QuantityCheck, got {condition:?}");
         };

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -6,13 +6,12 @@ use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
 use nom::combinator::{all_consuming, opt, peek, value};
-use nom::sequence::{preceded, terminated, tuple};
+use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
 use super::super::oracle_nom::condition::{
-    inject_controller_you, parse_cast_using_teamwork_phrase,
-    parse_spell_target_superlative_suffix,
+    inject_controller_you, parse_cast_using_teamwork_phrase, parse_spell_target_superlative_suffix,
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
@@ -1900,7 +1899,7 @@ pub(super) fn strip_superlative_target_conditional(
         if let Some((condition, rest)) = nom_on_lower(suffix_orig, suffix_lower, |input| {
             terminated(
                 parse_spell_target_superlative_suffix,
-                tuple((opt(tag(".")), multispace0)),
+                (opt(tag(".")), multispace0),
             )
             .parse(input)
         }) {
@@ -5784,11 +5783,7 @@ mod tests {
             "Destroy those creatures if they have the greatest toughness among creatures.",
         );
         assert_eq!(body, "Destroy those creatures");
-        let Some(AbilityCondition::QuantityCheck {
-            comparator,
-            rhs,
-            ..
-        }) = condition
+        let Some(AbilityCondition::QuantityCheck { comparator, rhs, .. }) = condition
         else {
             panic!("expected QuantityCheck, got {condition:?}");
         };

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19943,11 +19943,15 @@ pub(crate) fn parse_effect_chain_ir(
         let (counter_cond, text) = strip_counter_conditional(&text);
         // CR 202.3 + CR 608.2c: Mana value threshold condition — same priority as counter_cond.
         let (mv_cond, text) = strip_mana_value_conditional(&text);
+        // CR 608.2c: Spell-target superlative gate — "if it has the least/greatest
+        // <property> among <filter>" (Wretched Banquet class).
+        let (superlative_target_cond, text) = strip_superlative_target_conditional(&text);
         let (target_supertype_cond, text) = strip_target_supertype_conditional(&text);
         let (cast_from_zone, text) = if condition.is_none()
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
         {
             strip_cast_from_zone_conditional(&text)
@@ -19958,6 +19962,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
         {
@@ -19969,6 +19974,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
             && card_type_cond.is_none()
@@ -19983,6 +19989,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
             && card_type_cond.is_none()
@@ -19997,6 +20004,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
             && card_type_cond.is_none()
@@ -20012,6 +20020,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
             && card_type_cond.is_none()
@@ -20030,6 +20039,7 @@ pub(crate) fn parse_effect_chain_ir(
             && if_you_do.is_none()
             && counter_cond.is_none()
             && mv_cond.is_none()
+            && superlative_target_cond.is_none()
             && target_supertype_cond.is_none()
             && cast_from_zone.is_none()
             && card_type_cond.is_none()
@@ -20045,6 +20055,7 @@ pub(crate) fn parse_effect_chain_ir(
         let condition = condition
             .or(counter_cond)
             .or(mv_cond)
+            .or(superlative_target_cond)
             .or(target_supertype_cond)
             .or(if_you_do)
             .or(cast_from_zone)
@@ -51276,6 +51287,118 @@ mod tests {
             }
             other => panic!("expected TargetMatchesFilter condition, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn wretched_banquet_least_power_condition() {
+        let def = parse_effect_chain(
+            "Destroy target creature if it has the least power among creatures.",
+            AbilityKind::Spell,
+        );
+        match def.condition {
+            Some(AbilityCondition::QuantityCheck {
+                lhs,
+                comparator,
+                rhs,
+            }) => {
+                assert_eq!(comparator, Comparator::LE);
+                assert_eq!(
+                    lhs,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::Target,
+                        }
+                    }
+                );
+                assert_eq!(
+                    rhs,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Aggregate {
+                            function: AggregateFunction::Min,
+                            property: ObjectProperty::Power,
+                            filter: TargetFilter::Typed(TypedFilter::creature()),
+                        }
+                    }
+                );
+            }
+            other => panic!("expected QuantityCheck least-power gate, got: {other:?}"),
+        }
+        assert!(
+            matches!(*def.effect, Effect::Destroy { .. }),
+            "expected Destroy effect, got {:?}",
+            def.effect
+        );
+    }
+
+    #[test]
+    fn wretched_banquet_least_power_evaluates_per_target() {
+        use crate::game::effects::evaluate_condition;
+        use crate::game::zones;
+        use crate::types::ability::{ResolvedAbility, TargetRef};
+        use crate::types::card_type::CoreType;
+        use crate::types::game_state::GameState;
+        use crate::types::identifiers::{CardId, ObjectId};
+        use crate::types::player::PlayerId;
+        use crate::types::zones::Zone;
+
+        let def = parse_effect_chain(
+            "Destroy target creature if it has the least power among creatures.",
+            AbilityKind::Spell,
+        );
+        let cond = def.condition.expect("expected least-power condition");
+
+        let mut state = GameState::new_two_player(42);
+        let weak = zones::create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "1/1".to_string(),
+            Zone::Battlefield,
+        );
+        let mid = zones::create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "2/2".to_string(),
+            Zone::Battlefield,
+        );
+        let strong = zones::create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "3/3".to_string(),
+            Zone::Battlefield,
+        );
+        for (id, power) in [(weak, 1), (mid, 2), (strong, 3)] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.power = Some(power);
+            obj.toughness = Some(power);
+        }
+
+        let ability_for = |target| {
+            ResolvedAbility::new(
+                Effect::Destroy {
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                },
+                vec![TargetRef::Object(target)],
+                ObjectId(100),
+                PlayerId(0),
+            )
+        };
+
+        assert!(
+            evaluate_condition(&cond, &state, &ability_for(weak)),
+            "1/1 tied for least power must pass"
+        );
+        assert!(
+            !evaluate_condition(&cond, &state, &ability_for(mid)),
+            "2/2 is not least power"
+        );
+        assert!(
+            !evaluate_condition(&cond, &state, &ability_for(strong)),
+            "3/3 is not least power"
+        );
     }
 
     // --- "The owner of target X" parser tests ---

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -51380,6 +51380,7 @@ mod tests {
             ResolvedAbility::new(
                 Effect::Destroy {
                     target: TargetFilter::Typed(TypedFilter::creature()),
+                    cant_regenerate: false,
                 },
                 vec![TargetRef::Object(target)],
                 ObjectId(100),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2214,7 +2214,7 @@ pub(crate) fn parse_spell_target_has_superlative(
     let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest)?;
     let (filter, remainder) = parse_type_phrase(rest);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
-        return Err(oracle_err(rest));
+        return Err(oracle_err(remainder));
     }
     let lhs_qty = match property {
         ObjectProperty::Power => QuantityRef::Power {
@@ -2226,13 +2226,13 @@ pub(crate) fn parse_spell_target_has_superlative(
         ObjectProperty::ManaValue => QuantityRef::ObjectManaValue {
             scope: ObjectScope::Target,
         },
-        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(rest)),
+        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(remainder)),
     };
     // "Has the least/greatest" allows ties — use LE/GE, not strict LT/GT.
     let comparator = match aggregate {
         AggregateFunction::Min => Comparator::LE,
         AggregateFunction::Max => Comparator::GE,
-        AggregateFunction::Sum => return Err(oracle_err(rest)),
+        AggregateFunction::Sum => return Err(oracle_err(remainder)),
     };
     Ok((
         rest,

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2205,7 +2205,9 @@ fn build_superlative_comparison(
 /// (Wretched Banquet body). Uses `ObjectScope::Target` on the LHS and a
 /// population aggregate without `OtherThanTriggerObject` — distinct from the
 /// trigger-anchored `build_superlative_comparison` form.
-pub(crate) fn parse_spell_target_has_superlative(input: &str) -> OracleResult<'_, AbilityCondition> {
+pub(crate) fn parse_spell_target_has_superlative(
+    input: &str,
+) -> OracleResult<'_, AbilityCondition> {
     let (rest, aggregate) = parse_superlative_adjective(input)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
     let (rest, property) = parse_property_keyword(rest)?;
@@ -2261,11 +2263,6 @@ pub(crate) fn parse_spell_target_superlative_suffix(
         parse_spell_target_has_superlative,
     )
     .parse(input)
-}
-
-/// Option wrapper for call sites that probe without error propagation.
-pub(crate) fn try_parse_spell_target_has_superlative(input: &str) -> Option<AbilityCondition> {
-    super::bridge::nom_parse_lower(input, parse_spell_target_has_superlative)
 }
 
 /// Attach `FilterProp::OtherThanTriggerObject` to a `TargetFilter`'s property

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2064,7 +2064,7 @@ fn parse_subject_has_superlative_form(input: &str) -> OracleResult<'_, StaticCon
 }
 
 /// Parse a superlative adjective into its corresponding `AggregateFunction`.
-fn parse_superlative_adjective(input: &str) -> OracleResult<'_, AggregateFunction> {
+pub(crate) fn parse_superlative_adjective(input: &str) -> OracleResult<'_, AggregateFunction> {
     alt((
         value(AggregateFunction::Max, tag("greatest")),
         value(AggregateFunction::Max, tag("highest")),
@@ -2075,7 +2075,7 @@ fn parse_superlative_adjective(input: &str) -> OracleResult<'_, AggregateFunctio
 }
 
 /// Property keyword parser — used by both LHS and RHS of the comparison.
-fn parse_property_keyword(input: &str) -> OracleResult<'_, ObjectProperty> {
+pub(crate) fn parse_property_keyword(input: &str) -> OracleResult<'_, ObjectProperty> {
     alt((
         value(ObjectProperty::Power, tag("power")),
         value(ObjectProperty::Toughness, tag("toughness")),
@@ -2199,6 +2199,50 @@ fn build_superlative_comparison(
             },
         },
     }
+}
+
+/// CR 608.2c: Spell-target gate "if it has the [least|greatest] <property> among
+/// <filter>" (Wretched Banquet). Uses `ObjectScope::Target` on the LHS and a
+/// population aggregate without `OtherThanTriggerObject` — distinct from the
+/// trigger-anchored `build_superlative_comparison` form.
+pub(crate) fn try_parse_spell_target_has_superlative(input: &str) -> Option<AbilityCondition> {
+    let (rest, aggregate) = parse_superlative_adjective(input).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest).ok()?;
+    let (rest, property) = parse_property_keyword(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest).ok()?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+        return None;
+    }
+    let lhs_qty = match property {
+        ObjectProperty::Power => QuantityRef::Power {
+            scope: ObjectScope::Target,
+        },
+        ObjectProperty::Toughness => QuantityRef::Toughness {
+            scope: ObjectScope::Target,
+        },
+        ObjectProperty::ManaValue => QuantityRef::ObjectManaValue {
+            scope: ObjectScope::Target,
+        },
+        ObjectProperty::ManaSymbolCount(_) => return None,
+    };
+    // "Has the least/greatest" allows ties — use LE/GE, not strict LT/GT.
+    let comparator = match aggregate {
+        AggregateFunction::Min => Comparator::LE,
+        AggregateFunction::Max => Comparator::GE,
+        AggregateFunction::Sum => return None,
+    };
+    Some(AbilityCondition::QuantityCheck {
+        lhs: QuantityExpr::Ref { qty: lhs_qty },
+        comparator,
+        rhs: QuantityExpr::Ref {
+            qty: QuantityRef::Aggregate {
+                function: aggregate,
+                property,
+                filter,
+            },
+        },
+    })
 }
 
 /// Attach `FilterProp::OtherThanTriggerObject` to a `TargetFilter`'s property

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2213,9 +2213,11 @@ pub(crate) fn parse_spell_target_has_superlative(
     let (rest, property) = parse_property_keyword(rest)?;
     let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest)?;
     let (filter, remainder) = parse_type_phrase(rest);
-    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+    if matches!(filter, TargetFilter::Any) {
         return Err(oracle_err(remainder));
     }
+    let consumed = rest.len() - remainder.len();
+    let rest = &rest[consumed..];
     let lhs_qty = match property {
         ObjectProperty::Power => QuantityRef::Power {
             scope: ObjectScope::Target,
@@ -2226,16 +2228,16 @@ pub(crate) fn parse_spell_target_has_superlative(
         ObjectProperty::ManaValue => QuantityRef::ObjectManaValue {
             scope: ObjectScope::Target,
         },
-        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(remainder)),
+        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(rest)),
     };
     // "Has the least/greatest" allows ties — use LE/GE, not strict LT/GT.
     let comparator = match aggregate {
         AggregateFunction::Min => Comparator::LE,
         AggregateFunction::Max => Comparator::GE,
-        AggregateFunction::Sum => return Err(oracle_err(remainder)),
+        AggregateFunction::Sum => return Err(oracle_err(rest)),
     };
     Ok((
-        rest,
+        remainder,
         AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref { qty: lhs_qty },
             comparator,

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2201,18 +2201,18 @@ fn build_superlative_comparison(
     }
 }
 
-/// CR 608.2c: Spell-target gate "if it has the [least|greatest] <property> among
-/// <filter>" (Wretched Banquet). Uses `ObjectScope::Target` on the LHS and a
+/// CR 608.2c: Spell-target gate "[least|greatest] <property> among <filter>"
+/// (Wretched Banquet body). Uses `ObjectScope::Target` on the LHS and a
 /// population aggregate without `OtherThanTriggerObject` — distinct from the
 /// trigger-anchored `build_superlative_comparison` form.
-pub(crate) fn try_parse_spell_target_has_superlative(input: &str) -> Option<AbilityCondition> {
-    let (rest, aggregate) = parse_superlative_adjective(input).ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest).ok()?;
-    let (rest, property) = parse_property_keyword(rest).ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest).ok()?;
+pub(crate) fn parse_spell_target_has_superlative(input: &str) -> OracleResult<'_, AbilityCondition> {
+    let (rest, aggregate) = parse_superlative_adjective(input)?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" ").parse(rest)?;
+    let (rest, property) = parse_property_keyword(rest)?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" among ").parse(rest)?;
     let (filter, remainder) = parse_type_phrase(rest);
     if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
-        return None;
+        return Err(oracle_err(rest));
     }
     let lhs_qty = match property {
         ObjectProperty::Power => QuantityRef::Power {
@@ -2224,25 +2224,48 @@ pub(crate) fn try_parse_spell_target_has_superlative(input: &str) -> Option<Abil
         ObjectProperty::ManaValue => QuantityRef::ObjectManaValue {
             scope: ObjectScope::Target,
         },
-        ObjectProperty::ManaSymbolCount(_) => return None,
+        ObjectProperty::ManaSymbolCount(_) => return Err(oracle_err(rest)),
     };
     // "Has the least/greatest" allows ties — use LE/GE, not strict LT/GT.
     let comparator = match aggregate {
         AggregateFunction::Min => Comparator::LE,
         AggregateFunction::Max => Comparator::GE,
-        AggregateFunction::Sum => return None,
+        AggregateFunction::Sum => return Err(oracle_err(rest)),
     };
-    Some(AbilityCondition::QuantityCheck {
-        lhs: QuantityExpr::Ref { qty: lhs_qty },
-        comparator,
-        rhs: QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: aggregate,
-                property,
-                filter,
+    Ok((
+        rest,
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref { qty: lhs_qty },
+            comparator,
+            rhs: QuantityExpr::Ref {
+                qty: QuantityRef::Aggregate {
+                    function: aggregate,
+                    property,
+                    filter,
+                },
             },
         },
-    })
+    ))
+}
+
+/// Suffix connector for spell-target superlative gates: "it has the …" /
+/// "they have the …" (CR 608.2c).
+pub(crate) fn parse_spell_target_superlative_suffix(
+    input: &str,
+) -> OracleResult<'_, AbilityCondition> {
+    preceded(
+        alt((
+            tag::<_, _, OracleError<'_>>("it has the "),
+            tag("they have the "),
+        )),
+        parse_spell_target_has_superlative,
+    )
+    .parse(input)
+}
+
+/// Option wrapper for call sites that probe without error propagation.
+pub(crate) fn try_parse_spell_target_has_superlative(input: &str) -> Option<AbilityCondition> {
+    super::bridge::nom_parse_lower(input, parse_spell_target_has_superlative)
 }
 
 /// Attach `FilterProp::OtherThanTriggerObject` to a `TargetFilter`'s property

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4173,10 +4173,9 @@ mod tests {
         );
         assert_eq!(parsed.abilities.len(), 1, "expected one spell ability");
         match &parsed.abilities[0].condition {
-            Some(crate::types::ability::AbilityCondition::QuantityCheck {
-                comparator,
-                ..
-            }) => assert_eq!(*comparator, crate::types::ability::Comparator::LE),
+            Some(crate::types::ability::AbilityCondition::QuantityCheck { comparator, .. }) => {
+                assert_eq!(*comparator, crate::types::ability::Comparator::LE)
+            }
             other => panic!("expected QuantityCheck least-power gate, got: {other:?}"),
         }
         assert!(

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4162,6 +4162,33 @@ mod tests {
         );
     }
 
+    /// CR 608.2c: Wretched Banquet — least-power destroy gate must parse without
+    /// swallowing the intervening-if clause.
+    #[test]
+    fn wretched_banquet_least_power_destroy_parses_without_swallow() {
+        let parsed = parse_named(
+            "Destroy target creature if it has the least power among creatures.",
+            "Wretched Banquet",
+            &["Sorcery"],
+        );
+        assert_eq!(parsed.abilities.len(), 1, "expected one spell ability");
+        match &parsed.abilities[0].condition {
+            Some(crate::types::ability::AbilityCondition::QuantityCheck {
+                comparator,
+                ..
+            }) => assert_eq!(*comparator, crate::types::ability::Comparator::LE),
+            other => panic!("expected QuantityCheck least-power gate, got: {other:?}"),
+        }
+        assert!(
+            parsed
+                .parse_warnings
+                .iter()
+                .all(|warning| !matches!(warning, OracleDiagnostic::SwallowedClause { .. })),
+            "Wretched Banquet must not swallow the least-power gate: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
     /// CR 702.34a + CR 601.2f: Visions of Ruin — flashback cost plus commander-MV
     /// "cast this way" reduction must parse without swallowing either clause.
     #[test]


### PR DESCRIPTION
## Summary

Wretched Banquet (`Destroy target creature if it has the least power among creatures.`) lost its intervening-if superlative gate during spell-effect parsing.

- Add `try_parse_spell_target_has_superlative` for spell-target `if it has the least/greatest <property> among <filter>` (distinct from trigger-anchored `build_superlative_comparison`)
- Add `strip_superlative_target_conditional` and wire it into the effect-chain condition stripper after mana-value stripping
- Parser, swallow-check, and runtime `evaluate_condition` tests

## Test plan

- [x] `strip_superlative_target_conditional_least_power` — stripper unit test
- [x] `wretched_banquet_least_power_condition` — effect-chain parser binding
- [x] `wretched_banquet_least_power_evaluates_per_target` — runtime gate per target power
- [x] `wretched_banquet_least_power_destroy_parses_without_swallow` — full-card parse

Closes #4476
