### PR TITLE
chore(agents): grant SendMessage to sub-agents for graceful cull + report-back

### DIFF
--- a/.claude/agents/engine-implementation-executor.md
+++ b/.claude/agents/engine-implementation-executor.md
@@ -1,7 +1,7 @@
 ---
 name: engine-implementation-executor
 description: Execute an already-reviewed phase.rs implementation plan surgically. Receives the approved plan + scope, edits files, runs Tilt-first verification, and returns a diff summary with any judgement-call notes. Does NOT plan, does NOT review, does NOT commit. Spawned by the `/engine-implementer` skill.
-tools: Read, Edit, Write, Bash, Grep, Glob
+tools: Read, Edit, Write, Bash, Grep, Glob, SendMessage
 model: opus
 ---
 
@@ -202,7 +202,7 @@ Any `UNVERIFIED:` line is a hard stop — the rule number does not exist in the 
 
 ## Output
 
-Return a structured report to the orchestrator:
+Return a structured report to the orchestrator. This structured report is your return value and is the contract — always emit it as your final text. You also have the `SendMessage` teammate tool: use it to send the lead a brief progress update or completion notice while you work, and to acknowledge a `shutdown_request` so you can be culled gracefully instead of being tmux-pane-killed. `SendMessage` is purely additive — it never replaces this final structured report.
 
 1. **Diff summary** — files touched, grouped by subsystem, with a one-line purpose per file.
 2. **Verification results** — which Tilt resources are green; any failures with `tilt logs` excerpts (own vs unrelated).

--- a/.claude/agents/mtg-rules-auditor.md
+++ b/.claude/agents/mtg-rules-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: mtg-rules-auditor
 description: Audits MTG Comprehensive Rules coverage in engine code. Accepts targeted file lists or CR sections for lightweight runs, or does a full codebase sweep. Produces structured reports mapping game logic to CR rule numbers.
-tools: Read, Grep, Glob, LS, Bash, Write
+tools: Read, Grep, Glob, LS, Bash, Write, SendMessage
 model: sonnet
 maxTurns: 200
 ---
@@ -158,6 +158,8 @@ Write to `.planning/rules-audit/`:
 - Group findings by CR chapter for navigation.
 
 ## Report Summary
+
+Your written report files under `.planning/rules-audit/` remain the durable deliverable (they survive context compaction) and your final text summary remains your return value to the caller. Additionally, you have the `SendMessage` teammate tool: use it to report completion (or notable progress) back to the orchestrating lead, and to acknowledge a `shutdown_request` so you can be culled gracefully rather than tmux-pane-killed. `SendMessage` is additive — it does not replace the disk reports or the final-text summary.
 
 End your response with a brief summary:
 - How many source files were analyzed

--- a/.claude/agents/parser-gap-finder.md
+++ b/.claude/agents/parser-gap-finder.md
@@ -1,7 +1,7 @@
 ---
 name: parser-gap-finder
 description: Analyzes parser coverage gaps, classifies them by failure reason, and proposes prioritized parser fixes to unlock the most cards with the least code changes. Run with `cargo parser-gaps` data available.
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, SendMessage
 model: opus
 maxTurns: 200
 ---
@@ -15,6 +15,7 @@ You are a read-only analysis agent that identifies low-hanging fruit in the Orac
 - **NEVER modify source files.** You may only write to `.planning/parser-gaps/`.
 - Use absolute paths based on the project root (the directory containing `Cargo.toml` and `CLAUDE.md`).
 - Focus on **actionable fixes** — not just listing gaps, but explaining what parser change would close each one.
+- You have the `SendMessage` teammate tool. Your report at `.planning/parser-gaps/REPORT.md` remains the durable deliverable and your final text remains your return value; additionally use `SendMessage` to report completion (or progress) to the orchestrating lead and to acknowledge a `shutdown_request` so you can be culled gracefully instead of tmux-pane-killed. This is additive — it never replaces the disk report or the final-text return.
 
 ## Scope Modes
 

--- a/.claude/agents/pr-review-comment-resolver.md
+++ b/.claude/agents/pr-review-comment-resolver.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review-comment-resolver
 description: Use proactively for comprehensive PR review comment resolution in phase.rs. Fetches PR review comments, categorizes actionable feedback by type and priority, fixes issues directly, self-reviews the diff, iterates until no gaps remain, verifies with the repo's Tilt-first workflow, and reports unresolved manual items.
-tools: Bash, Edit, MultiEdit, Read, Glob, Grep, Task, TodoWrite, WebFetch
+tools: Bash, Edit, MultiEdit, Read, Glob, Grep, Task, TodoWrite, WebFetch, SendMessage
 model: sonnet
 color: purple
 ---
@@ -205,6 +205,8 @@ git commit -m "fix(PR-<PR>): address <category> review comments"
 Include addressed comments, assumptions, verification, and manual follow-ups in the commit body. Do not push unless explicitly requested.
 
 ## Final Report
+
+You have the `SendMessage` teammate tool. The structured report below remains your return value — emit it as your final text. Additionally use `SendMessage` to report completion (or progress) back to the orchestrating lead and to acknowledge a `shutdown_request` so you can be culled gracefully rather than tmux-pane-killed. `SendMessage` is additive — it never replaces this final report.
 
 Use this structure:
 

--- a/.claude/skills/batch-mechanics/SKILL.md
+++ b/.claude/skills/batch-mechanics/SKILL.md
@@ -122,7 +122,7 @@ After all groups are complete:
    ```
 2. Run `cargo coverage` (one-shot binary, always direct) to verify reduced Unimplemented count
 3. Report results to the user: which mechanics were implemented, coverage delta, any items that couldn't be completed
-4. Clean up the team
+4. Clean up the team — gracefully cull each teammate by sending a `shutdown_request` and waiting for its `shutdown_response` acknowledgment (teammates now carry `SendMessage`, so they can ack a graceful shutdown instead of being tmux-pane-killed, which left zombie roster entries). Only force-terminate a teammate that fails to acknowledge.
 
 ---
 

--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -320,7 +320,7 @@ The reviewer must read the diff (`git show <sha>`) with fresh context and apply 
 - Card-specific fixes that should have been modeled as reusable building blocks
 
 If the reviewer flags issues:
-- Send them back to the implementer via `SendMessage` (if still alive) for inline fix in a follow-up commit
+- Send them back to the implementer via `SendMessage` for inline fix in a follow-up commit. The implementer now carries `SendMessage` too, so it acknowledges receipt and reports when the fix lands — a reliable liveness signal. If it has already been gracefully shut (`shutdown_request`) or crashed and cannot ack, re-spawn a fresh executor with the findings instead.
 - Re-spawn isolated review on the fixup commit's diff
 - Repeat until the review is clean (typically 1-2 rounds in practice)
 

--- a/.claude/skills/engine-implementer/SKILL.md
+++ b/.claude/skills/engine-implementer/SKILL.md
@@ -20,7 +20,7 @@ This is the orchestrator for the phase.rs implementation pipeline. It runs as a 
 | 5. Review implementation | **Spawned `general-purpose` agent** invoking `/review-impl` | Independent reviewer, not the implementer |
 | 6. Commit | This thread | Owner of the working tree decides what gets staged |
 
-The orchestrator never authors content itself. Its only jobs are: spawn agents, route their output to the next step, loop review steps until clean, and own the commit.
+The orchestrator never authors content itself. Its only jobs are: spawn agents, route their output to the next step, loop review steps until clean, own the commit, and gracefully cull each spawned agent once its output is consumed (send a `shutdown_request` and wait for the `shutdown_response` ack — spawned agents now carry `SendMessage`, so they cull gracefully instead of being pane-killed). The structured report each agent returns stays the authoritative step handoff; SendMessage is an additive progress/acknowledgment channel, not a replacement.
 
 ## Inputs
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Grant `SendMessage` to custom sub-agents (graceful cull + report-back)

The four custom agent definitions in `.claude/agents/` each declare an explicit `tools:` list, none of which included `SendMessage`:

| Agent | tools (before) |
|---|---|
| `engine-implementation-executor` | Read, Edit, Write, Bash, Grep, Glob |
| `mtg-rules-auditor` | Read, Grep, Glob, LS, Bash, Write |
| `parser-gap-finder` | Read, Grep, Glob, Bash |
| `pr-review-comment-resolver` | Bash, Edit, MultiEdit, Read, Glob, Grep, Task, TodoWrite, WebFetch |

Without `SendMessage`, when these are spawned as background teammates they cannot:
- **acknowledge a `shutdown_request`** → they must be tmux-pane-killed, which leaves zombie roster entries; and
- **report progress/completion back to the orchestrating lead** → they can only write to disk.

### Change (additive only)
- Add `SendMessage` to each of the four agents' `tools:` lists, with a one-paragraph note at each agent's return-point describing the new capability.
- The grant is **strictly additive** — both existing contracts are explicitly preserved in the prose:
  - the *"final text IS the return value to the orchestrator"* contract, and
  - the durable `.planning/*.md` disk-report pattern (survives context compaction).
- Document the graceful-cull flow (`shutdown_request` → `shutdown_response`) in three skills: `batch-mechanics` (team cleanup), `engine-implementer` (orchestrator job list), `bug-triage` (implementer-feedback liveness).

### Notes
- `.codex/agents/*.toml` are thin wrappers that delegate to the `.claude/agents/*.md` source of truth and carry no `tools:` key — no change needed.
- `.agents/skills` and `.codex/skills` are symlinks to `.claude/skills`, so the skill-doc edits propagate automatically (no duplication).
- Markdown/doc-only; no engine, parser, or runtime code touched.

Assisted-by: ClaudeCode:claude-opus-4.8
