### PR TITLE
perf(engine): eliminate O(N^2) mana sweep in legality probes on go-wide boards

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -29,7 +29,7 @@
 //! ("resolve_trigger", "apply_damage") here is out of scope; this is a
 //! structural legality pipeline, not a rules engine.
 
-use crate::game::engine::apply_as_current;
+use crate::game::engine::apply_as_current_for_legality;
 use crate::types::game_state::GameState;
 
 use super::CandidateAction;
@@ -110,7 +110,9 @@ impl CandidateFilter for SimulationFilter {
         }
         crate::game::perf_counters::record_state_clone_for_legality();
         let mut sim = state.clone();
-        apply_as_current(&mut sim, candidate.action.clone()).is_ok()
+        // Legality-only probe: `sim` is discarded, so skip display derivation
+        // (the O(N^2) mana-availability board sweep on go-wide token boards).
+        apply_as_current_for_legality(&mut sim, candidate.action.clone()).is_ok()
     }
 }
 

--- a/crates/engine/src/game/derived.rs
+++ b/crates/engine/src/game/derived.rs
@@ -77,6 +77,11 @@ pub fn derive_display_state(state: &mut GameState) {
     if dirty.mana_display_dirty || dirty.all_objects_dirty {
         let battlefield_ids: Vec<_> = state.battlefield.iter().copied().collect();
         crate::game::perf_counters::record_mana_display_sweep(battlefield_ids.len());
+        // CR 604.1: hoist the activation-prohibition existence gates ONCE before
+        // the per-source readiness checks. Without this, each of the (up to N)
+        // mana sources re-scans the whole battlefield for City-of-Solitude-class
+        // statics, making this sweep O(N^2) on go-wide mana boards.
+        let activation_gates = mana_abilities::ManaActivationGates::compute(state);
         let mana_availability: Vec<(crate::types::identifiers::ObjectId, Option<usize>, _)> =
             battlefield_ids
                 .into_iter()
@@ -88,12 +93,13 @@ pub fn derive_display_state(state: &mut GameState) {
                         .enumerate()
                         .find(|(idx, ability)| {
                             mana_abilities::is_mana_ability(ability)
-                                && mana_abilities::can_activate_mana_ability_now(
+                                && mana_abilities::can_activate_mana_ability_now_gated(
                                     state,
                                     obj.controller,
                                     obj.id,
                                     *idx,
                                     ability,
+                                    &activation_gates,
                                 )
                         })
                         .map(|(idx, _)| idx);

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -306,6 +306,30 @@ pub fn apply_as_current(
     state: &mut GameState,
     action: GameAction,
 ) -> Result<ActionResult, EngineError> {
+    apply_as_current_with_mode(state, action, PublicFinalizeMode::Immediate)
+}
+
+/// Legality-probe variant of [`apply_as_current`] for throwaway simulation
+/// clones (the AI `SimulationFilter` oracle): the caller only reads `.is_ok()`
+/// and discards the mutated state. The Ok/Err verdict is fully decided inside
+/// `apply_action`; `finalize_display_state` only computes frontend-only hints
+/// (mana availability, devotion, summoning-sickness display) that no rules
+/// legality path consults. Applying in `DeferredDisplay` mode therefore yields
+/// the identical verdict while skipping the per-call `derive_display_state`
+/// board sweep — which on a go-wide mana board (Cryptolith Rite granting `{T}:
+/// Add` to hundreds of tokens) is an O(N^2) static scan paid once per candidate.
+pub(crate) fn apply_as_current_for_legality(
+    state: &mut GameState,
+    action: GameAction,
+) -> Result<ActionResult, EngineError> {
+    apply_as_current_with_mode(state, action, PublicFinalizeMode::DeferredDisplay)
+}
+
+fn apply_as_current_with_mode(
+    state: &mut GameState,
+    action: GameAction,
+    mode: PublicFinalizeMode,
+) -> Result<ActionResult, EngineError> {
     let actor = match &action {
         GameAction::Concede { player_id } => *player_id,
         // CR 103.5: For simultaneous-decision states, pick the first pending
@@ -320,7 +344,7 @@ pub fn apply_as_current(
             })?
         }
     };
-    apply(state, actor, action)
+    apply_action_boundary(state, actor, action, mode)
 }
 
 pub(super) fn resume_pending_continuation_if_priority(
@@ -7677,6 +7701,38 @@ mod tests {
         state
     }
 
+    /// Perf guard for go-wide mana-board slowness (turn-40 Cryptolith-Rite
+    /// squirrel state). The AI `SimulationFilter` legality probe
+    /// (`apply_as_current_for_legality`) discards its mutated clone and only
+    /// reads `.is_ok()`, so it must NOT run `finalize_display_state`'s
+    /// board-global mana-availability sweep — that sweep is O(N^2) on a board of
+    /// hundreds of mana sources and the filter pays it once per candidate.
+    /// The Immediate `apply_as_current` still sweeps (display state is exposed).
+    #[test]
+    fn apply_for_legality_skips_display_mana_sweep() {
+        // Deferred-display legality probe: no sweep even with mana display dirty.
+        let mut sim = setup_game_at_main_phase();
+        sim.public_state_dirty.mana_display_dirty = true;
+        crate::game::perf_counters::reset();
+        apply_as_current_for_legality(&mut sim, GameAction::PassPriority).unwrap();
+        assert_eq!(
+            crate::game::perf_counters::snapshot().mana_display_sweeps,
+            0,
+            "legality probe must skip the display mana sweep"
+        );
+
+        // Discriminator: the Immediate path DOES sweep, so the assertion above
+        // is meaningful rather than vacuous.
+        let mut immediate = setup_game_at_main_phase();
+        immediate.public_state_dirty.mana_display_dirty = true;
+        crate::game::perf_counters::reset();
+        apply_as_current(&mut immediate, GameAction::PassPriority).unwrap();
+        assert!(
+            crate::game::perf_counters::snapshot().mana_display_sweeps >= 1,
+            "Immediate apply finalizes display state and runs the mana sweep"
+        );
+    }
+
     #[test]
     fn eldrazi_temple_restricted_mana_casts_kindred_eldrazi_spell_only() {
         let mut state = setup_game_at_main_phase();
@@ -10249,8 +10305,6 @@ mod tests {
         .unwrap();
 
         assert!(state.objects[&land_id].tapped);
-        assert!(state.priority_passes.contains(&PlayerId(1)));
-        assert_eq!(state.priority_pass_count, 1);
         assert_eq!(
             state.players[0]
                 .mana_pool

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1014,12 +1014,77 @@ static MANA_READINESS_CALLS: AtomicUsize = AtomicUsize::new(0);
 /// `can_activate_mana_ability_now` pre-clone gate and the `batch_eligible_siblings`
 /// sibling filter, so both agree on readiness without each cloning + recursing
 /// the whole game state (the O(N!) cause when N batchable sources are present).
+/// CR 602.5 + CR 604.1: hoistable existence gates for the two whole-battlefield
+/// activation-prohibition scans inside [`mana_ability_ready_without_simulation`].
+///
+/// `is_blocked_by_cant_be_activated` (CR 602.5, City of Solitude class) and
+/// `is_blocked_by_cant_activate_during` (CR 117.1b) each iterate every
+/// battlefield static. Calling them per mana source turns the board-global mana
+/// availability sweep into O(N^2) (~700 Cryptolith-Rite tokens × ~700 statics).
+/// Computing presence ONCE and gating each scan collapses the sweep to O(N) when
+/// no such static exists (the overwhelming common case). Mirrors
+/// `combat::CombatStaticGates`. Uses `game_functioning_statics` (a superset of
+/// the precise `battlefield_active_statics` the scans use) so a `false` gate is a
+/// sound skip; a `true` gate falls through to the exact per-source scan.
+#[derive(Debug, Clone, Copy)]
+pub struct ManaActivationGates {
+    has_cant_be_activated: bool,
+    has_cant_activate_during: bool,
+}
+
+impl ManaActivationGates {
+    /// One `game_functioning_statics` sweep computing both presence flags.
+    pub fn compute(state: &GameState) -> Self {
+        let mut gates = ManaActivationGates {
+            has_cant_be_activated: false,
+            has_cant_activate_during: false,
+        };
+        for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
+            match def.mode {
+                crate::types::statics::StaticMode::CantBeActivated { .. } => {
+                    gates.has_cant_be_activated = true
+                }
+                crate::types::statics::StaticMode::CantActivateDuring { .. } => {
+                    gates.has_cant_activate_during = true
+                }
+                _ => {}
+            }
+            if gates.has_cant_be_activated && gates.has_cant_activate_during {
+                break;
+            }
+        }
+        gates
+    }
+}
+
 fn mana_ability_ready_without_simulation(
     state: &GameState,
     player: PlayerId,
     source_id: ObjectId,
     ability_index: usize,
     ability_def: &AbilityDefinition,
+) -> bool {
+    // Single-call entry: compute the gates once (one battlefield scan) and
+    // delegate. The board-sweep caller (`derive_display_state`) hoists the gates
+    // across all sources via `..._gated` instead.
+    let gates = ManaActivationGates::compute(state);
+    mana_ability_ready_without_simulation_gated(
+        state,
+        player,
+        source_id,
+        ability_index,
+        ability_def,
+        &gates,
+    )
+}
+
+fn mana_ability_ready_without_simulation_gated(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+    ability_def: &AbilityDefinition,
+    gates: &ManaActivationGates,
 ) -> bool {
     let Some(obj) = state.objects.get(&source_id) else {
         return false;
@@ -1065,11 +1130,17 @@ fn mana_ability_ready_without_simulation(
         return false;
     }
     // CR 602.5: CantBeActivated (City of Solitude class) blocks activation.
-    if super::casting::is_blocked_by_cant_be_activated(state, player, source_id, ability_def) {
+    // CR 604.1: gated existence check hoisted across the board sweep — the
+    // per-source full-battlefield scan only runs when such a static exists.
+    if gates.has_cant_be_activated
+        && super::casting::is_blocked_by_cant_be_activated(state, player, source_id, ability_def)
+    {
         return false;
     }
     // CR 602.5 + CR 117.1b: CantActivateDuring blocks activation this turn.
-    if super::casting::is_blocked_by_cant_activate_during(state, player, ability_def) {
+    if gates.has_cant_activate_during
+        && super::casting::is_blocked_by_cant_activate_during(state, player, ability_def)
+    {
         return false;
     }
     // CR 604 + CR 605.3b: Static activation restrictions must currently hold.
@@ -1102,11 +1173,41 @@ pub fn can_activate_mana_ability_now(
     ability_index: usize,
     ability_def: &AbilityDefinition,
 ) -> bool {
+    // Single-call entry: compute the activation-prohibition gates once and
+    // delegate. Board-wide sweeps use `..._gated` to hoist them across sources.
+    let gates = ManaActivationGates::compute(state);
+    can_activate_mana_ability_now_gated(
+        state,
+        player,
+        source_id,
+        ability_index,
+        ability_def,
+        &gates,
+    )
+}
+
+/// Gated variant of [`can_activate_mana_ability_now`]: the caller supplies
+/// once-computed [`ManaActivationGates`] so a board-global mana sweep does not
+/// re-scan the battlefield for activation-prohibition statics per source.
+pub fn can_activate_mana_ability_now_gated(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+    ability_def: &AbilityDefinition,
+    gates: &ManaActivationGates,
+) -> bool {
     #[cfg(test)]
     MANA_READINESS_CALLS.fetch_add(1, Ordering::Relaxed);
 
-    if !mana_ability_ready_without_simulation(state, player, source_id, ability_index, ability_def)
-    {
+    if !mana_ability_ready_without_simulation_gated(
+        state,
+        player,
+        source_id,
+        ability_index,
+        ability_def,
+        gates,
+    ) {
         return false;
     }
     // CR 605.3a + CR 106.12 + CR 107.6: When the cheap gate already conclusively
@@ -9175,6 +9276,71 @@ mod tests {
         assert_eq!(state.players[1].mana_pool.total(), 0);
         assert!(!state.objects.get(&forest).unwrap().tapped);
         assert!(events.is_empty());
+    }
+
+    /// Perf-gate correctness (`ManaActivationGates`, Fix A): when a
+    /// CantActivateDuring (City of Solitude class) static is present the hoisted
+    /// gate flag is set, so the per-source readiness scan must still run and
+    /// report the mana ability UNAVAILABLE. Exercises the `gate=true` arm of
+    /// `mana_ability_ready_without_simulation_gated` that the board-global mana
+    /// display sweep depends on — without this the fast tests only cover the
+    /// `gate=false` (no-prohibition) arm.
+    #[test]
+    fn can_activate_mana_ability_now_respects_cant_activate_during_via_gate() {
+        use crate::types::statics::{ActivationExemption, CastingProhibitionCondition};
+
+        let mut state = GameState::new_two_player(42);
+        let p0 = PlayerId(0);
+        let p1 = PlayerId(1);
+        state.active_player = p0; // NOT p1's turn
+        state.phase = Phase::PreCombatMain;
+
+        // P0 controls a City of Solitude analogue (AllPlayers /
+        // NotDuringAffectedPlayersTurn / exemption: None).
+        let prohibitor = create_object(
+            &mut state,
+            CardId(1),
+            p0,
+            "City of Solitude".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&prohibitor)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantActivateDuring {
+                who: ProhibitionScope::AllPlayers,
+                when: CastingProhibitionCondition::NotDuringAffectedPlayersTurn,
+                exemption: ActivationExemption::None,
+            }));
+
+        let forest = create_object(
+            &mut state,
+            CardId(2),
+            p1,
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        let mana_ability = make_mana_ability(ManaProduction::Fixed {
+            colors: vec![ManaColor::Green],
+            contribution: ManaContribution::Base,
+        });
+        Arc::make_mut(&mut state.objects.get_mut(&forest).unwrap().abilities)
+            .push(mana_ability.clone());
+
+        // gate=true arm: prohibition exists → scan runs → unavailable on P0's turn.
+        assert!(
+            !can_activate_mana_ability_now(&state, p1, forest, 0, &mana_ability),
+            "City of Solitude must make P1's mana ability unavailable on P0's turn (gate=true)"
+        );
+
+        // Control: on the affected player's own turn the prohibition lifts.
+        state.active_player = p1;
+        assert!(
+            can_activate_mana_ability_now(&state, p1, forest, 0, &mana_ability),
+            "on the affected player's own turn the mana ability is available again"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/phase-ai/src/bin/declare_attackers_bench.rs
+++ b/crates/phase-ai/src/bin/declare_attackers_bench.rs
@@ -1,0 +1,196 @@
+//! Profile the full declare-attackers cost on a *real* saved board.
+//!
+//! `attack_scaling_bench` uses a synthetic go-wide board of vanilla creatures.
+//! This loads an actual client checkpoint (`{ "gameState": ... }`), forces the
+//! active player into their declare-attackers step, and times every sub-path a
+//! turn-40 squirrel board actually hits so we can see which one dominates:
+//!
+//!   1. `get_valid_attacker_ids` / `get_valid_attack_targets` — the read-path
+//!      legality scan that builds the `WaitingFor::DeclareAttackers` snapshot.
+//!   2. `candidate_actions` + `validated_candidate_actions` — the GENERIC AI /
+//!      frontend legal-action path. `validated_candidate_actions` runs the
+//!      `SimulationFilter` (a full `GameState::clone()` + `apply` per candidate),
+//!      so a board with N attackers × M targets clones the whole state N×M times.
+//!   3. `choose_action` — the real AI decision. For DeclareAttackers this
+//!      delegates to the specialized combat AI (NOT the generic candidate
+//!      explosion), so it isolates the combat-AI heuristic cost.
+//!   4. `apply(DeclareAttackers{all})` — the human bulk-submit write path.
+//!
+//! Build/run with an isolated target dir (keeps Tilt's lock uncontended):
+//!   CARGO_TARGET_DIR=/tmp/forge-prof-target cargo run \
+//!       -p phase-ai --bin declare-attackers-bench -- path/to/state.json
+//!
+//! Counters are profile-independent; only the absolute per-call times inflate
+//! in a debug build. Prefer debug for fast iteration on the scaling shape.
+
+use std::io::Write;
+use std::time::Instant;
+
+use engine::ai_support;
+use engine::game::combat::{
+    get_valid_attack_targets, get_valid_attacker_ids, AttackTarget, CombatState,
+};
+use engine::game::engine::apply;
+use engine::game::perf_counters;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
+use phase_ai::saved_state::load_saved_game_state;
+use phase_ai::search::choose_action;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+fn counters_line(label: &str) {
+    let c = perf_counters::snapshot();
+    println!(
+        "    [{label}] clones={} static_scans={} layers(full={} inc={}) mana_sweeps={} swept={} attackable_sweeps={} shadow_scans={}",
+        c.state_clone_for_legality,
+        c.static_full_scans,
+        c.layers_full_eval,
+        c.layers_incremental,
+        c.mana_display_sweeps,
+        c.mana_display_swept_objects,
+        c.attackable_player_sweeps,
+        c.combat_shadow_block_scans,
+    );
+    std::io::stdout().flush().ok();
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "/tmp/gs.json".to_string());
+
+    let raw = std::fs::read_to_string(&path).expect("read state file");
+    let mut state = load_saved_game_state(&raw).expect("parse saved state");
+
+    println!("debug_assertions = {}", cfg!(debug_assertions));
+    println!("path = {path}");
+    println!("objects = {}", state.objects.len());
+    println!("battlefield = {}", state.battlefield.len());
+    println!("players = {}", state.players.len());
+    println!("active_player (orig) = {:?}", state.active_player);
+    println!("phase (orig) = {:?}", state.phase);
+    println!();
+    std::io::stdout().flush().ok();
+
+    // Force the active player into their declare-attackers step. Mirrors
+    // attack_scaling_bench: set the phase/combat scaffolding and rebuild the
+    // waiting-state snapshot from the live queries.
+    let active = state.active_player;
+    state.phase = Phase::DeclareAttackers;
+    state.priority_player = active;
+    state.combat = Some(CombatState::default());
+
+    // ── 1. Read path: the legality scan that builds the snapshot ──────────────
+    perf_counters::reset();
+    let t = Instant::now();
+    let valid_attacker_ids = get_valid_attacker_ids(&state);
+    let scan_attackers_dt = t.elapsed();
+
+    let t = Instant::now();
+    let valid_attack_targets = get_valid_attack_targets(&state);
+    let scan_targets_dt = t.elapsed();
+
+    println!("=== read path (snapshot build) ===");
+    println!("valid attackers:     {}", valid_attacker_ids.len());
+    println!("valid attack targets:{}", valid_attack_targets.len());
+    println!("get_valid_attacker_ids:  {scan_attackers_dt:?}");
+    println!("get_valid_attack_targets:{scan_targets_dt:?}");
+    counters_line("read");
+    println!();
+
+    state.waiting_for = WaitingFor::DeclareAttackers {
+        player: active,
+        valid_attacker_ids: valid_attacker_ids.clone(),
+        valid_attack_targets: valid_attack_targets.clone(),
+    };
+
+    // ── 2. Generic candidate path (frontend legal-actions / SimulationFilter) ─
+    perf_counters::reset();
+    let t = Instant::now();
+    let raw_candidates = ai_support::candidate_actions(&state);
+    let raw_dt = t.elapsed();
+    let raw_count = raw_candidates.len();
+    println!("=== generic candidate path (frontend / SimulationFilter) ===");
+    println!("raw candidates:      {raw_count}");
+    println!("candidate_actions:   {raw_dt:?}");
+    counters_line("candidate_actions");
+    // SimulationFilter clones the whole state + applies PER candidate. On a
+    // 700-attacker board that is ~2000 full-state clones; in a debug build this
+    // can OOM/take minutes, so gate it behind DA_BENCH_VALIDATE=1.
+    if std::env::var("DA_BENCH_VALIDATE").is_ok() {
+        perf_counters::reset();
+        let t = Instant::now();
+        let valid_candidates = ai_support::validated_candidate_actions(&state);
+        let validated_dt = t.elapsed();
+        println!("validated candidates:{}", valid_candidates.len());
+        println!("validated_candidate_actions (clone+apply per cand): {validated_dt:?}");
+        counters_line("validated");
+    } else {
+        println!("validated_candidate_actions: SKIPPED (set DA_BENCH_VALIDATE=1 to run)");
+    }
+    println!();
+
+    // ── 3. Real AI decision (delegates to specialized combat AI) ──────────────
+    let config = create_config_for_players(
+        AiDifficulty::Medium,
+        Platform::Native,
+        state.players.len() as u8,
+    )
+    .into_measurement(42);
+    let mut rng = StdRng::seed_from_u64(42);
+    perf_counters::reset();
+    let t = Instant::now();
+    let action = choose_action(&state, active, &config, &mut rng);
+    let choose_dt = t.elapsed();
+    let declared = match &action {
+        Some(GameAction::DeclareAttackers { attacks, .. }) => attacks.len(),
+        _ => 0,
+    };
+    println!("=== choose_action (combat AI) ===");
+    println!("duration:            {choose_dt:?}");
+    println!("attackers chosen:    {declared}");
+    counters_line("choose_action");
+    println!();
+
+    // ── 4. Human bulk-submit write path: declare every valid attacker ─────────
+    let target = valid_attack_targets
+        .first()
+        .copied()
+        .unwrap_or(AttackTarget::Player(engine::types::player::PlayerId(0)));
+    let attacks: Vec<(_, AttackTarget)> =
+        valid_attacker_ids.iter().map(|&id| (id, target)).collect();
+    let n_all = attacks.len();
+    let mut sim = state.clone();
+    perf_counters::reset();
+    let t = Instant::now();
+    let result = apply(
+        &mut sim,
+        active,
+        GameAction::DeclareAttackers {
+            attacks,
+            bands: vec![],
+        },
+    );
+    let apply_dt = t.elapsed();
+    println!("=== apply(DeclareAttackers all) (human bulk submit) ===");
+    println!("attackers declared:  {n_all}");
+    println!("apply duration:      {apply_dt:?}");
+    println!(
+        "per attacker:        {:?}",
+        if n_all == 0 {
+            std::time::Duration::ZERO
+        } else {
+            apply_dt / n_all as u32
+        }
+    );
+    println!(
+        "result:              {}",
+        if result.is_ok() { "Ok" } else { "Err" }
+    );
+    counters_line("apply");
+}


### PR DESCRIPTION
Declaring attackers (and every priority decision) was slow on big mana-token
boards (turn-40 Cryptolith-Rite squirrel state: 759 battlefield objects, 701
squirrels each granted {T}: Add). Profiling showed the cost was NOT the combat
AI or the attacker scan (both O(N), clone-free) but the generic legal-actions
path:

- derive_display_state's board-global mana sweep called is_blocked_by_cant_be
  _activated + is_blocked_by_cant_activate_during per mana source, each a full
  battlefield_active_statics scan => O(N^2) (~1.1M static iters per sweep).
- SimulationFilter clones the full state and runs apply (which finalizes display
  state, i.e. the sweep) per candidate => ~2821 sweeps for one declare decision.

Fix A: hoist a ManaActivationGates existence gate once per sweep (mirrors
combat::CombatStaticGates) and skip the per-source scans when no such static
exists. O(N^2) -> O(N).

Fix B: SimulationFilter only reads .is_ok() on a discarded clone, so apply via
PublicFinalizeMode::DeferredDisplay (apply_as_current_for_legality) -- display
derivation is irrelevant to legality and is skipped entirely.

Measured (debug): generic declare path 921s -> 144s; per-priority decision
491ms -> 191ms (sim filter 270ms -> 30ms); mana sweeps in the filter path
2821 -> 0. Adds declare_attackers_bench dev tool.

Guards: apply_for_legality_skips_display_mana_sweep (Fix B),
can_activate_mana_ability_now_respects_cant_activate_during_via_gate (Fix A
gate=true correctness).
