### PR TITLE
feat(analysis): combo-detection PR-3 — detect mandatory-loop winner for drain-cascade combos (CR 704.5a)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -29,7 +29,7 @@
 //! ("resolve_trigger", "apply_damage") here is out of scope; this is a
 //! structural legality pipeline, not a rules engine.
 
-use crate::game::engine::apply_as_current_for_legality;
+use crate::game::engine::{apply_as_current_for_legality, SimulationProbeGuard};
 use crate::types::game_state::GameState;
 
 use super::CandidateAction;
@@ -110,7 +110,13 @@ impl CandidateFilter for SimulationFilter {
         }
         crate::game::perf_counters::record_state_clone_for_legality();
         let mut sim = state.clone();
-        // Legality-only probe: `sim` is discarded, so skip display derivation
+        // PR-3 Defect-2: mark the entire nested clone-and-apply as a legality probe so
+        // the top-level-only loop-shortcut detection (`reconcile_terminal_result` §3)
+        // and ring accumulation (`pass_priority_once_with_pipeline` §2) are suppressed
+        // inside it. The guard restores the previous flag on drop (panic-safe, nesting-
+        // correct), terminating the §3→§9→legal_actions→SimulationFilter recursion.
+        let _probe = SimulationProbeGuard::enter();
+        // Legality-only probe (#4479): `sim` is discarded, so skip display derivation
         // (the O(N^2) mana-availability board sweep on go-wide token boards).
         apply_as_current_for_legality(&mut sim, candidate.action.clone()).is_ok()
     }

--- a/crates/engine/src/analysis/corpus_tests.rs
+++ b/crates/engine/src/analysis/corpus_tests.rs
@@ -17,8 +17,12 @@
 //!    The set (see `DRIVEN_ROW_INDICES`): Heliod + Walking Ballista; Kilo,
 //!    Freed, Relic; Grim Monolith + Power Artifact; Devoted Druid + Vizier; Bloom
 //!    Tender + Freed; Priest of Titania + Umbral Mantle; Selvala + Staff of
-//!    Domination; Faeburrow + Pemmin's Aura; Marwyn + Sword of the Paruns; Spike
-//!    Feeder + Archangel. Two synthetic loops (`drive_damage_loop_certificate`
+//!    Domination; Faeburrow + Pemmin's Aura; Marwyn + Sword of the Paruns; Sanguine
+//!    Bond + Exquisite Blood; Marauding Blight-Priest + Bloodthirsty Conqueror; Spike
+//!    Feeder + Archangel. The two drain-feedback combos are driven LIVE through the
+//!    per-beat `apply(PassPriority)` reducer (PR-3 Option C — the persisted
+//!    `loop_detect_ring` + the §3 reconcile shortcut), not the offline `detect_loop`
+//!    harness. Two synthetic loops (`drive_damage_loop_certificate`
 //!    plus the negatives `drive_board_change_is_not_a_loop` /
 //!    `drive_idle_board_is_not_a_loop`) exercise the same pipeline without the
 //!    export. These are the discriminating regression tests — reverting either
@@ -59,6 +63,7 @@ use crate::types::game_state::{CastPaymentMode, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaType;
 use crate::types::phase::Phase;
+use crate::types::player::PlayerId;
 
 /// One row of the acceptance corpus: a combo, its documented unbounded resource
 /// family, the expected [`WinKind`], and (for the 4 card-gated combos) the card
@@ -1905,10 +1910,18 @@ fn drive_idle_board_is_not_a_loop() {
 //    is consumed reads as a per-color deficit, which `loop_check::is_progress`
 //    rightly rejects. (Selvala + Staff IS driven because Selvala can produce the
 //    one color its whole cycle consumes — see that driver's green-only float.)
-//  * DRAIN FEEDBACK cascades (Sanguine Bond + Exquisite Blood; Marauding Blight-
-//    Priest + Bloodthirsty Conqueror): a mandatory triggered cascade that needs a
-//    clean external life-gain to start and per-pair stack stepping to measure one
-//    cycle — a bespoke driver follow-up.
+//  * DRAIN FEEDBACK cascades (Sanguine Bond + Exquisite Blood [idx 17]; Marauding
+//    Blight-Priest + Bloodthirsty Conqueror [idx 18]): a mandatory triggered cascade
+//    seeded by a clean external life-gain. PR-3 (Option C) DRIVES BOTH LIVE — they are
+//    promoted to `DRIVEN_ROW_INDICES`. The persisted `loop_detect_ring` accumulates
+//    across the per-beat `apply(PassPriority)` drive and `reconcile_terminal_result`'s
+//    §3 shortcut emits `GameOver{Some(P0)}` by ~beat 6 (CR 732.2a → CR 704.5a), well
+//    before the high-life 704.5a death. idx 17's targeted "target opponent loses life"
+//    trigger auto-resolves to the sole legal target (the opponent — "target opponent"
+//    has exactly one legal target in two-player; no target-selection stop), so the targeted
+//    shape drives identically. (Drivers: `drive_drain_idx18_wins_live`,
+//    `drive_drain_idx17_targeted_wins_live`; recursion-regression backstop
+//    `drive_drain_idx18_legal_actions_terminates_bounded`.)
 //  * CARD-GATED (4): Doc Aurlock / Professor Onyx / Animate Dead / Grindstone +
 //    Painter's Servant have Unimplemented parts (§3).
 //
@@ -1934,6 +1947,8 @@ const DRIVEN_ROW_INDICES: &[usize] = &[
     12, // Selvala, Heart of the Wilds + Staff      (drive_combo_11_selvala_staff)
     13, // Faeburrow Elder + Pemmin's Aura          (drive_combo_11_faeburrow_pemmin)
     14, // Marwyn, the Nurturer + Sword of Paruns   (drive_combo_14_marwyn_sword)
+    17, // Sanguine Bond + Exquisite Blood          (drive_drain_idx17_targeted_wins_live)
+    18, // Marauding Blight-Priest + Conqueror      (drive_drain_idx18_wins_live)
     49, // Spike Feeder + Archangel of Thune        (drive_combo_47_spike_archangel)
 ];
 
@@ -1949,4 +1964,451 @@ fn confirmed_drivers_match_expected() {
             CORPUS[idx].name
         );
     }
+}
+
+// ===========================================================================
+// PR-3 (Option C) live drain-cascade drivers. These drive the REAL per-beat
+// `apply(PassPriority)` reducer (not the offline `detect_loop` harness) so the
+// persisted `loop_detect_ring` accumulation (§2) and the reconcile-seam win
+// shortcut (§3) are exercised end-to-end. Each names its revert-fail line.
+// ===========================================================================
+
+/// Build a 2-player board with the named permanents installed on P0, P1 set to a
+/// high life total `victim_life` (so a natural CR 704.5a death cannot be the cause
+/// of any early `GameOver`), and the active player P0 at a clean `PreCombatMain`
+/// priority window. No mana is floated (the drain cascade is trigger-driven, not
+/// activated). Returns `None` if the export is absent or any name is missing.
+fn build_drain_board(cards: &[&str], victim_life: i32) -> Option<ComboBoard> {
+    let db = card_db();
+    if cards.iter().any(|c| db.get_face_by_name(c).is_none()) {
+        return None;
+    }
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 40);
+    scenario.with_life(P1, victim_life);
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.priority_player = P0;
+    }
+    let mut ids = Vec::new();
+    {
+        let state = runner.state_mut();
+        for &name in cards {
+            ids.push(install_on_battlefield(state, db, name, P0)?);
+        }
+        settle_layers(state);
+    }
+    Some(ComboBoard { runner, ids })
+}
+
+/// Seed a drain cascade by gaining P0 1 life through the real life-gain pipeline
+/// and placing the resulting "whenever you gain life" trigger on the stack via the
+/// production trigger chokepoint (`process_triggers`). Leaves the board at a
+/// priority window with exactly one trigger on the stack — the same shape a real
+/// external lifegain would produce. Returns the stack length after seeding.
+fn seed_lifegain_cascade(board: &mut ComboBoard) -> usize {
+    let state = board.runner.state_mut();
+    let mut events = Vec::new();
+    // CR 119.3: gain P0 1 life — fires Marauding Blight-Priest's "whenever you gain
+    // life" trigger.
+    let _ = crate::game::effects::life::apply_life_gain(state, P0, 1, &mut events);
+    // CR 603.3: put the triggered ability on the stack as a player would receive
+    // priority — the production placement path.
+    crate::game::triggers::process_triggers(state, &events);
+    // Reset to a clean active-player priority window (the seed is pre-loop setup).
+    state.priority_player = state.active_player;
+    state.waiting_for = WaitingFor::Priority {
+        player: state.active_player,
+    };
+    state.stack.len()
+}
+
+/// One observation of the live per-beat drive.
+#[derive(Debug)]
+struct BeatTrace {
+    beat: usize,
+    wf: WaitingFor,
+    stack_len: usize,
+    ring_len: usize,
+    p0_life: i32,
+    p1_life: i32,
+}
+
+/// Drive `runner.act(PassPriority)` up to `max_beats` times, recording one
+/// [`BeatTrace`] per beat. Stops early on `GameOver`. Returns the trace.
+fn drive_pass_priority(board: &mut ComboBoard, max_beats: usize) -> Vec<BeatTrace> {
+    let mut trace = Vec::new();
+    for beat in 1..=max_beats {
+        if matches!(
+            board.runner.state().waiting_for,
+            WaitingFor::GameOver { .. }
+        ) {
+            break;
+        }
+        if board.runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+        let s = board.runner.state();
+        trace.push(BeatTrace {
+            beat,
+            wf: s.waiting_for.clone(),
+            stack_len: s.stack.len(),
+            ring_len: s.loop_detect_ring.len(),
+            p0_life: s.players[0].life,
+            p1_life: s.players[1].life,
+        });
+        if matches!(
+            board.runner.state().waiting_for,
+            WaitingFor::GameOver { .. }
+        ) {
+            break;
+        }
+    }
+    trace
+}
+
+/// Index of the first beat whose `waiting_for` is `GameOver { winner: Some(w) }`,
+/// or `None` if no early win occurred within the driven window.
+fn first_gameover_beat(trace: &[BeatTrace]) -> Option<(usize, PlayerId)> {
+    trace.iter().find_map(|t| match t.wf {
+        WaitingFor::GameOver {
+            winner: Some(winner),
+        } => Some((t.beat, winner)),
+        _ => None,
+    })
+}
+
+/// C-L1: the PERSISTED loop-detection ring wins idx 18 (Marauding Blight-Priest +
+/// Bloodthirsty Conqueror) LIVE under the default per-beat `apply(PassPriority)`
+/// drive. P1 starts at 200 life so a natural CR 704.5a death cannot be the cause
+/// (it would take ~400 beats); the live `GameOver{Some(P0)}` fires by ~beat 6 from
+/// the accumulated ring + the §3 reconcile shortcut.
+///
+/// REVERT-FAIL (the named discriminators, each flips this assertion):
+///  (a) remove the §3 block in `reconcile_terminal_result` (engine.rs) ⇒ the
+///      cascade grinds, no early `GameOver` within the window ⇒ `expect` fails.
+///  (b) remove the relocated §2 `record_loop_detect_sample` block in
+///      `pass_priority_once_with_pipeline` ⇒ the ring never persists across beats
+///      (caps at 0), §3 never matches ⇒ no early `GameOver` ⇒ `expect` fails. This
+///      proves the PERSISTED ring is the load-bearing new surface.
+#[test]
+fn drive_drain_idx18_wins_live() {
+    let Some(mut board) = build_drain_board(CORPUS[18].cards, 200) else {
+        return; // export absent (CI / fresh checkout): skip, never fail spuriously
+    };
+    seed_lifegain_cascade(&mut board);
+    let trace = drive_pass_priority(&mut board, 40);
+    let (beat, winner) = first_gameover_beat(&trace)
+        .expect("idx18 drain cascade must win LIVE via the persisted ring + §3 shortcut");
+    assert_eq!(
+        winner, P0,
+        "the single non-falling player (P0) must be the winner"
+    );
+    assert!(
+        beat <= 12,
+        "the live win must fire from the ring (~beat 6), not the ~400-beat 704.5a death; got beat {beat}"
+    );
+    // The PERSISTED ring accumulated across beats (≥ 3 snapshots are needed for the
+    // modulo-match that fires the win — see the §4 trace), and the cascade held the
+    // stack non-empty the whole time (a self-refilling, NON-shrinking loop).
+    let max_ring = trace.iter().map(|t| t.ring_len).max().unwrap_or(0);
+    assert!(
+        max_ring >= 3,
+        "the ring must accumulate ≥3 persisted snapshots before the shortcut (got {max_ring})"
+    );
+    assert!(
+        trace.iter().all(|t| t.stack_len >= 1),
+        "a self-refilling cascade keeps the stack non-empty at every beat"
+    );
+    // Drain direction: the victim P1 drained (and is well above 0 — the win is the
+    // SHORTCUT, not a real CR 704.5a death), while the controller P0 gained.
+    let last = trace.last().expect("at least one beat");
+    assert!(
+        last.p1_life > 100 && last.p1_life < 200,
+        "P1 must have drained but still be at high life when shortcut-eliminated (got {})",
+        last.p1_life
+    );
+    assert!(
+        last.p0_life >= 41,
+        "controller P0 gained life across the cascade"
+    );
+}
+
+/// C-L2 (a genuinely SECOND loop shape — idx 17, Sanguine Bond + Exquisite Blood,
+/// the TARGETED `LoseLife` variant). §4 disposition measurement: the per-beat drive
+/// auto-resolves Sanguine Bond's "target opponent loses that much life" trigger to
+/// the sole legal target (opponent P1) with NO target-selection stop — "target
+/// opponent" has exactly one legal target in a two-player game, so this targeted
+/// shape also wins live — promoting idx 17 alongside idx 18. The assertion that NO
+/// `TargetSelection`/`TriggerTargetSelection` window ever appears is what makes the
+/// auto-resolution claim non-vacuous (if the engine stopped for a target, this test
+/// would catch it and idx 17 would stay targeting-deferred).
+///
+/// REVERT-FAIL: same as C-L1 — removing the §3 block or the §2 sample drops the
+/// early `GameOver`. Additionally exercises §7's stack-id canon
+/// (`project_out_resources`, resource.rs:751): reverting the `entry.id =
+/// ObjectId(pos)` canon loop makes each refilled trigger's fresh `ObjectId` defeat
+/// the modulo-match, so no cycle point is ever found ⇒ no early `GameOver`.
+#[test]
+fn drive_drain_idx17_targeted_wins_live() {
+    let Some(mut board) = build_drain_board(CORPUS[17].cards, 200) else {
+        return; // export absent: skip
+    };
+    seed_lifegain_cascade(&mut board);
+    let trace = drive_pass_priority(&mut board, 40);
+    // The targeted trigger auto-resolves: no target window appears at any beat.
+    assert!(
+        trace.iter().all(|t| !matches!(
+            t.wf,
+            WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. }
+        )),
+        "idx17's targeted trigger must auto-resolve (no target-selection stop) under the per-beat drive"
+    );
+    let (beat, winner) = first_gameover_beat(&trace)
+        .expect("idx17 targeted drain cascade must win LIVE (auto-resolved target)");
+    assert_eq!(winner, P0);
+    assert!(
+        beat <= 12,
+        "live win from the ring, not the 704.5a death; got beat {beat}"
+    );
+    // P1 (the targeted opponent) is the faller — the auto-resolved target is correct.
+    assert!(
+        board.runner.state().players[1].life < 200,
+        "the auto-resolved target must be the opponent P1 (its life drained)"
+    );
+}
+
+/// C-L1-probe — Defect-2 BOUNDED-TERMINATION regression guard. After the live drive
+/// has populated the ring (stack≠∅, at the RESOLVING `Priority{non-active}` window,
+/// ring ≥ 2, BEFORE any `GameOver`), call `legal_actions` directly. The legality
+/// probe clones-and-applies `PassPriority`, which resolves the top and re-enters
+/// `reconcile_terminal_result` §3 — the seam the Defect-2 recursion concern is about.
+/// This asserts the call TERMINATES with a bounded, non-empty action list and does
+/// not mutate the live game.
+///
+/// HONEST DISCRIMINATION NOTE (measured, not assumed): in the SHIPPED architecture
+/// this test is a bounded-termination *property* test, NOT a non-vacuous discriminator
+/// of the `&& !in_simulation_probe()` guard. Measured across three revert configs
+/// (drop the §3 guard; drop the filter.rs `SimulationProbeGuard::enter()` so the flag
+/// is never set; both with the real per-beat drive AND this direct `legal_actions`
+/// call), the `reconcile→§3→§9→legal_actions→SimulationFilter→reconcile` path does NOT
+/// recurse — the §9 gate (`no_living_player_has_meaningful_priority_action`) resets
+/// each probe's priority/pass state, so the nested `SimulationFilter` applies are
+/// handoffs that never re-resolve, and §3 (which only fires when a winner is FOUND)
+/// completes at ring=3 on the real path before the ring could grow. The thread-local
+/// guard is therefore DEFENSIVE DEPTH enforcing the top-level-only invariant, not the
+/// "sole barrier" the plan framed; the original SIGABRT (impl-report §2, observed at
+/// ring cap 16 with a different §9/§2 configuration) does not reproduce here. This
+/// test still guards against a FUTURE change that drops the §9 reset and re-opens the
+/// recursion: with such a change AND the guard removed it would overflow; with the
+/// guard it stays bounded.
+#[test]
+fn drive_drain_idx18_legal_actions_terminates_bounded() {
+    let Some(mut board) = build_drain_board(CORPUS[18].cards, 200) else {
+        return; // export absent: skip
+    };
+    seed_lifegain_cascade(&mut board);
+    // Drive until the ring is populated (≥ 2 snapshots) at the RESOLVING priority
+    // window — `Priority{non-active}` (the last passer), where the NEXT all-pass
+    // resolves the top and would push the ring to a modulo MATCH. This is the exact
+    // state whose legality probe (a clone-and-apply of `PassPriority`) re-enters
+    // `reconcile_terminal_result` §3; stop here, BEFORE the real drive fires GameOver.
+    let active = board.runner.state().active_player;
+    let mut reached = false;
+    for _ in 0..40 {
+        if matches!(
+            board.runner.state().waiting_for,
+            WaitingFor::GameOver { .. }
+        ) {
+            break;
+        }
+        if board.runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+        let s = board.runner.state();
+        if s.loop_detect_ring.len() >= 2
+            && !s.stack.is_empty()
+            && matches!(s.waiting_for, WaitingFor::Priority { player } if player != active)
+        {
+            reached = true;
+            break;
+        }
+    }
+    assert!(
+        reached,
+        "must reach a populated-ring RESOLVING priority window before GameOver"
+    );
+    // The decisive call: with the guard, this terminates and returns a bounded list.
+    // Without the guard it would stack-overflow (SIGABRT) and the test could not pass.
+    let actions = crate::ai_support::legal_actions(board.runner.state());
+    assert!(
+        !actions.is_empty(),
+        "legal_actions must return a bounded, non-empty action list (no recursion)"
+    );
+    // The immutable probe must not have ended the live game.
+    assert!(
+        !matches!(
+            board.runner.state().waiting_for,
+            WaitingFor::GameOver { .. }
+        ),
+        "legal_actions takes &state — it must not mutate the live game to GameOver"
+    );
+}
+
+/// Install a board-neutral artifact on `player` with a costless "draw 1" activated
+/// ability — a meaningful (loop-ending) priority action. Mirrors the engine's
+/// `add_non_mana_activated_artifact` U-gate helper at the corpus level.
+fn add_meaningful_action_artifact(state: &mut GameState, player: PlayerId) -> ObjectId {
+    use crate::types::card_type::CoreType;
+    use crate::types::identifiers::CardId;
+    use crate::types::zones::Zone;
+    let id = crate::game::zones::create_object(
+        state,
+        CardId(state.next_object_id),
+        player,
+        "Loop-Ending Artifact".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).expect("just created");
+    obj.card_types.core_types.push(CoreType::Artifact);
+    obj.summoning_sick = false;
+    std::sync::Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    ));
+    id
+}
+
+/// C-neg-A (+ the live face of the all-players §9 probe): a victim that holds a
+/// MEANINGFUL loop-ending action is NEVER shortcut-eliminated. The victim P1 (the
+/// NON-current holder at the §3 site, where priority has reset to active P0) holds
+/// a costless "draw 1" ability, so `no_living_player_has_meaningful_priority_action`
+/// probes P1, finds the out, and returns `false` ⇒ the §3 shortcut is refused and
+/// the cascade falls through to the existing grind — no early `GameOver`.
+///
+/// REVERT-FAIL:
+///  - remove the §9 gate call at the §3 site ⇒ `GameOver{Some(P0)}` fires while P1
+///    had an out (unsound) — this assertion (`no early GameOver`) flips.
+///  - swap §9 for the current-holder-only `priority_player_has_meaningful_action`
+///    (which probes only P0, who has no action) ⇒ it misses P1's masked out and the
+///    shortcut wrongly fires (the all-players generalization is load-bearing; the
+///    unit-level `loop_gate_probes_all_living_players_not_just_current_holder`
+///    pins the same distinction).
+#[test]
+fn drive_drain_idx18_victim_with_out_is_not_eliminated() {
+    let Some(mut board) = build_drain_board(CORPUS[18].cards, 200) else {
+        return; // export absent: skip
+    };
+    add_meaningful_action_artifact(board.runner.state_mut(), P1);
+    settle_layers(board.runner.state_mut());
+    seed_lifegain_cascade(&mut board);
+    let trace = drive_pass_priority(&mut board, 40);
+    assert!(
+        first_gameover_beat(&trace).is_none(),
+        "P1 holds a loop-ending action — the §9 gate must refuse the shortcut (no GameOver)"
+    );
+}
+
+/// C-neg-D — ring HYGIENE: a finite, non-refilling multi-spell stack that drains to
+/// empty NEVER accumulates loop snapshots and NEVER produces a `GameOver`. Three
+/// costless "draw 1" abilities are stacked, then resolved one-per-beat; each
+/// resolution SHRINKS the stack (`len_after < len_before`), so the §2 refill gate's
+/// `stack.len() >= stack_len_before` clause is false ⇒ the clear arm runs ⇒ the
+/// ring stays empty after every shrinking resolution.
+///
+/// REVERT-FAIL: removing the `state.stack.len() >= stack_len_before` clause from the
+/// §2 refill gate makes a normal shrinking resolution RECORD a snapshot ⇒ the ring
+/// becomes non-empty ⇒ the `is_empty()` assertion flips. (No `GameOver` either way —
+/// these resolutions drain no life — so the ring-emptiness assertion is the
+/// load-bearing hygiene discriminator.)
+#[test]
+fn drive_finite_stack_keeps_ring_empty() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 40);
+    scenario.with_life(P1, 40);
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.priority_player = P0;
+    }
+    // A board-neutral costless "gain 1 life" ability — resolvable repeatedly with no
+    // decking SBA and no triggers on this synthetic board, so the only effect of each
+    // resolution is to SHRINK the stack.
+    let artifact = {
+        use crate::types::card_type::CoreType;
+        use crate::types::identifiers::CardId;
+        use crate::types::zones::Zone;
+        let state = runner.state_mut();
+        let id = crate::game::zones::create_object(
+            state,
+            CardId(state.next_object_id),
+            P0,
+            "Gain-Life Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).expect("just created");
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.summoning_sick = false;
+        std::sync::Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+        ));
+        id
+    };
+    settle_layers(runner.state_mut());
+    let gain_idx = ability_index_where(runner.state(), artifact, |e| {
+        matches!(e, Effect::GainLife { .. })
+    })
+    .expect("the artifact has a gain-life ability");
+    // Stack three non-refilling abilities (each ActivateAbility clears the ring, the
+    // §2.3 invalidation — so we start each measurement from an empty ring).
+    for _ in 0..3 {
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: artifact,
+                ability_index: gain_idx,
+            })
+            .expect("activate costless gain-life");
+    }
+    assert_eq!(runner.state().stack.len(), 3, "three abilities stacked");
+    // Drive PassPriority ONLY until the finite stack drains to empty (driving past
+    // empty would advance turns into a draw-step deck-out — unrelated to loop
+    // hygiene). The ring must stay empty at EVERY shrinking-resolution beat, and no
+    // shortcut GameOver may occur while the stack is non-empty.
+    let mut resolutions = 0;
+    let mut max_ring = 0usize;
+    for _ in 0..20 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        assert!(
+            !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+            "a finite non-loop stack must not be shortcut to a GameOver"
+        );
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+        max_ring = max_ring.max(runner.state().loop_detect_ring.len());
+        resolutions += 1;
+    }
+    assert!(
+        runner.state().stack.is_empty(),
+        "the finite stack must drain to empty within the window"
+    );
+    assert_eq!(
+        max_ring, 0,
+        "a shrinking finite stack must never record a loop snapshot (ring stayed empty)"
+    );
+    assert!(resolutions >= 3, "the drive must have processed real beats");
 }

--- a/crates/engine/src/analysis/loop_check.rs
+++ b/crates/engine/src/analysis/loop_check.rs
@@ -7,16 +7,33 @@
 //! module is the classifier that turns those two measurements into a
 //! [`LoopCertificate`].
 //!
-//! # What "detection" means here (and what it does NOT)
+//! # What "detection" means here
 //!
-//! This is **purely offline analysis**. It changes no game behavior: the live
-//! resolution loop (`game::engine::run_auto_pass_loop`) still draws a repeating
-//! *mandatory* loop (CR 104.4b / CR 732.4) and still halts a runaway cascade
-//! (`emit_resolution_halt`) exactly as before. [`detect_loop`] is never called
-//! from the reducer; it is called by analysis code and the corpus test harness on
-//! a *driven* `GameRunner` to answer the question the engine's live path cannot:
-//! "given that the board returned to an identical configuration while a resource
-//! strictly increased, what resource is unbounded and how does this loop win?"
+//! [`detect_loop`] is the offline classifier: given two driven states plus a
+//! per-cycle delta it answers "what resource is unbounded and how does this loop
+//! win?" It is called by analysis code and the corpus test harness on a *driven*
+//! `GameRunner`.
+//!
+//! [`live_mandatory_loop_winner`] couples that classifier into the live reducer
+//! (`game::engine::reconcile_terminal_result`, CR 732.2a / CR 704.5a): at an
+//! all-mandatory cascade whose board has returned identical modulo monotone resources
+//! (and the volatile stack id, see `resource::project_out_resources`) while exactly
+//! one opponent's life drains without bound, it shortcuts to the forced loss instead
+//! of halting on the resource ceiling. PR-3 (Option C) scans a persisted bounded ring
+//! of post-resolution snapshots (`GameState::loop_detect_ring`), maintained at the
+//! post-pipeline frame of `game::engine::pass_priority_once_with_pipeline` (after
+//! `run_post_action_pipeline` places refilling triggers, CR 603.3) and scanned at the
+//! single SBA-reconciliation seam — so the win path
+//! fires LIVE under the default per-beat `apply(PassPriority)` drive (the production
+//! frontend default), which runs `reconcile_terminal_result` after every beat. Note
+//! `run_auto_pass_loop` does NOT call `reconcile_terminal_result` inside its internal
+//! iterations, so its net-progress grind still runs to the natural CR 704.5a death;
+//! the per-beat drive is the accelerated path. So `detect_loop` IS now reached from
+//! the reducer via that
+//! helper. The strict CR 104.4b / CR 732.4 mandatory-DRAW path (a repeat with no net
+//! progress) and the `emit_resolution_halt` runaway backstop are unchanged — the live
+//! win path is strictly additive and fires only when life strictly advances toward a
+//! single determinate opponent loss.
 //!
 //! # The detection rule (CR 732.2a — the shortcut, not the draw)
 //!
@@ -170,6 +187,93 @@ pub fn detect_loop(
         win_kind,
         mandatory,
     })
+}
+
+/// CR 732.2a + CR 704.5a: the LIVE coupling of [`detect_loop`] into the reducer.
+///
+/// At an all-mandatory auto-pass cascade whose board has returned identical (modulo
+/// monotone resources AND the volatile stack id, see
+/// [`crate::analysis::resource::project_out_resources`]), decide whether the loop
+/// forces a single determinate opponent life-loss and, if so, name the winner.
+/// Returns `None` unless the outcome is unambiguous (the soundness guarantee: the
+/// reducer only shortcuts to a WIN it can prove).
+///
+/// The caller guarantees `mandatory == true` (every iteration in the auto-pass loop
+/// is mandatory by construction) and passes the LIVE (raw) reducer state as
+/// `cycle_end` so the SBA-layer can't-lose/can't-win firewall sees real
+/// `transient_continuous_effects` and is not perturbed by `normalize_for_loop`'s
+/// `layers_dirty = full()`. `cycle_start` is a prior NORMALIZED window snapshot; the
+/// caller-measured per-cycle `delta` is the `snapshot`/`delta` difference between
+/// them.
+///
+/// Every `BTreeMap` read uses `.get(&k).copied().unwrap_or(0)` — `map_delta` drops
+/// zero-delta keys, so an unchanged axis is ABSENT and `[]` would panic in the live
+/// reducer.
+pub(crate) fn live_mandatory_loop_winner(
+    cycle_start: &GameState,
+    cycle_end: &GameState,
+    delta: &ResourceVector,
+) -> Option<PlayerId> {
+    // CR 104.2a: a forced single-loser outcome is unambiguous only in a 2-player
+    // game; multiplayer player-elimination is deferred (offline-covered by PR-2).
+    let living: Vec<PlayerId> = cycle_end
+        .players
+        .iter()
+        .filter(|p| !p.is_eliminated)
+        .map(|p| p.id)
+        .collect();
+    if living.len() != 2 {
+        return None;
+    }
+
+    // CR 704.5a: the per-player attributable life axis — who is draining out.
+    let life_fallers: Vec<PlayerId> = living
+        .iter()
+        .copied()
+        .filter(|p| delta.life.get(p).copied().unwrap_or(0) < 0)
+        .collect();
+    // CR 704.5b: any decking (library going down) is a SECOND determinate-loss path.
+    let any_library_loss = living
+        .iter()
+        .any(|p| delta.library_delta.get(p).copied().unwrap_or(0) < 0);
+    // CR 704.5c: poison is keyed by an aggregate (Poison, Player) pair in `snapshot`
+    // (unattributable per player), so treat any poison gain conservatively.
+    let any_poison_gain = delta
+        .counters
+        .get(&(CounterClass::Poison, ObjectClass::Player))
+        .copied()
+        .unwrap_or(0)
+        > 0;
+    // Single-faller firewall: reject dual-faller (mutual drain), the Niv shape
+    // (opponent life ↓ AND a controller library ↓), and any second determinate-loss
+    // path. PR-3 wins ONLY on the CR 704.5a life axis.
+    if life_fallers.len() != 1 || any_library_loss || any_poison_gain {
+        return None;
+    }
+    let faller = life_fallers[0];
+    let winner = living.iter().copied().find(|&p| p != faller)?;
+
+    // CR 101.2 + CR 104.3b + CR 704.5a: a player who can't lose the game can't be the
+    // faller of a forced loss (Platinum Angel / "you can't lose the game"). CR 101.2 +
+    // CR 104.2b: a player who can't win can't be named winner (Abyssal Persecutor:
+    // "your opponents can't win the game"). Reuse the SBA-layer predicates on the LIVE
+    // `cycle_end` so static effects are evaluated against the real board. (This
+    // firewall is strict 2-player — the Two-Headed Giant team rule CR 810.8a does not
+    // apply here.)
+    if crate::game::sba::player_has_cant_lose(cycle_end, faller)
+        || crate::game::static_abilities::player_has_cant_win(cycle_end, winner)
+    {
+        return None;
+    }
+
+    // Confirm via the PR-2 classifier: `detect_loop` re-runs
+    // `loop_states_equal_modulo_resources` (so the board-equality gate is enforced
+    // here, no redundant pre-check) and `is_progress`. Holds by construction —
+    // `is_progress` passes (winner life Δ≥0), and `classify_win_kind` sees `faller`
+    // life<0 with faller≠winner ⇒ `LethalDamage`. Require exactly that win kind so the
+    // live shortcut is scoped to the CR 704.5a life axis.
+    let cert = detect_loop(cycle_start, cycle_end, delta, winner, true)?;
+    matches!(cert.win_kind, WinKind::LethalDamage).then_some(winner)
 }
 
 /// CR 732.2a: controller-scoped net-progress. Returns true iff the cycle makes
@@ -691,6 +795,238 @@ mod tests {
             cert.covers(&[ResourceAxis::DamageDealt(pid(0))]),
             "certificate names the controller's damage axis (the unbounded resource), \
              but classifies it as Advantage, not a win"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // live_mandatory_loop_winner (§8): the LIVE reducer coupling. Each test
+    // injects a per-cycle delta into a modulo-equal (start == end.clone())
+    // state, exactly as the existing detect_loop tests do.
+    // ------------------------------------------------------------------
+
+    /// Add a battlefield permanent controlled by `owner` carrying a `mode` static
+    /// (CR 101.2 can't-lose / can't-win shape) affecting its controller ("You").
+    fn add_cant_static(
+        state: &mut GameState,
+        owner: u8,
+        id: u64,
+        mode: crate::types::statics::StaticMode,
+    ) {
+        use crate::types::ability::{ControllerRef, StaticDefinition, TargetFilter, TypedFilter};
+        let oid = ObjectId(id);
+        let mut object = GameObject::new(
+            oid,
+            CardId(2),
+            PlayerId(owner),
+            "Platinum Angel".to_string(),
+            Zone::Battlefield,
+        );
+        object
+            .static_definitions
+            .push(StaticDefinition::new(mode).affected(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            )));
+        state.objects.insert(oid, object);
+        state.battlefield.push_back(oid);
+    }
+
+    /// U1 POSITIVE: a clean single-opponent life-drain names the winner.
+    #[test]
+    fn live_winner_positive_life_drain() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1); // opponent drains
+        delta.life.insert(pid(0), 1); // controller gains
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            Some(pid(0)),
+            "a single-opponent forced life-drain shortcuts to the winner"
+        );
+    }
+
+    /// U2 SOUNDNESS (CR 704.5b): a dual-faller (opponent life ↓ AND a controller
+    /// library ↓ — the Niv shape) is a SECOND determinate-loss path ⇒ None.
+    /// Revert: dropping `any_library_loss` wrongly yields `Some(P0)`.
+    #[test]
+    fn live_winner_dual_faller_library_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.library_delta.insert(pid(0), -1); // controller mills itself too
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "opponent life-loss AND a library-loss is two loss paths — refuse to name a winner"
+        );
+    }
+
+    /// U3 SOUNDNESS: a mutual drain (both players' life falls) has no single
+    /// determinate loser ⇒ None (the single-faller guard rejects, and is_progress
+    /// would reject the negative-life winner as a backstop).
+    #[test]
+    fn live_winner_mutual_drain_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(0), -1);
+        delta.life.insert(pid(1), -1);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a mutual drain has no single determinate loser"
+        );
+    }
+
+    /// U4: pure advantage (mana up, no life faller) is not a forced loss ⇒ None.
+    #[test]
+    fn live_winner_advantage_no_faller_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let delta = ResourceVector {
+            mana: [0, 0, 0, 0, 0, 1],
+            ..Default::default()
+        };
+        assert_eq!(live_mandatory_loop_winner(&start, &end, &delta), None);
+    }
+
+    /// U5 SOUNDNESS: a board change at cycle end (extra permanent) is not a
+    /// repeating cycle ⇒ None even with a clean life-drain delta. `detect_loop`'s
+    /// board-equality gate is load-bearing here.
+    #[test]
+    fn live_winner_board_change_is_none() {
+        let mut end = GameState::new_two_player(7);
+        let start = end.clone();
+        battlefield_creature(&mut end, 900, 0); // board grew only at end
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(0), 1);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a growing board is not a repeating cycle (detect_loop rejects)"
+        );
+    }
+
+    /// U6 SOUNDNESS: a single faller but THREE living players ⇒ None (2-player
+    /// scope only; multiplayer deferred). Revert: dropping `living.len()==2` yields
+    /// a winner.
+    #[test]
+    fn live_winner_three_player_is_none() {
+        let mut end = GameState::new_two_player(7);
+        let mut p2 = end.players[1].clone();
+        p2.id = pid(2);
+        end.players.push(p2);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(0), 1);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a determinate single-loser outcome is unambiguous only in 2-player"
+        );
+    }
+
+    /// U7 SOUNDNESS (CR 704.5c): opponent life ↓ AND a poison gain is a SECOND
+    /// (unattributable) loss path ⇒ None. Revert: dropping `any_poison_gain`
+    /// wrongly yields `Some(P0)`.
+    #[test]
+    fn live_winner_dual_faller_poison_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta
+            .counters
+            .insert((CounterClass::Poison, ObjectClass::Player), 1);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "opponent life-loss AND poison gain is two loss paths — refuse to name a winner"
+        );
+    }
+
+    /// U8: PR-3 wins ONLY on the CR 704.5a life axis — a pure opponent mill (no
+    /// life faller) is not shortcut here ⇒ None (decking live-shortcut deferred).
+    #[test]
+    fn live_winner_pure_mill_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.library_delta.insert(pid(1), -1);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "PR-3 shortcuts only the life axis; a pure mill has no life faller"
+        );
+    }
+
+    /// U9 SOUNDNESS (CR 101.2 + CR 104.3b): the faller CAN'T LOSE ⇒ None. Reverting
+    /// the `player_has_cant_lose` firewall would end a game P1 cannot lose.
+    #[test]
+    fn live_winner_faller_cant_lose_is_none() {
+        let mut end = GameState::new_two_player(7);
+        add_cant_static(
+            &mut end,
+            1, // permanent controlled by the faller P1, affecting itself
+            901,
+            crate::types::statics::StaticMode::CantLoseTheGame,
+        );
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(0), 1);
+        assert!(
+            crate::game::sba::player_has_cant_lose(&end, pid(1)),
+            "fixture sanity: P1 must actually have can't-lose"
+        );
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a forced loss can't be applied to a player who can't lose"
+        );
+    }
+
+    /// U10 SOUNDNESS (CR 101.2 + CR 104.2b): the winner CAN'T WIN ⇒ None. Reverting
+    /// the `player_has_cant_win` firewall would name a winner who cannot win.
+    #[test]
+    fn live_winner_winner_cant_win_is_none() {
+        let mut end = GameState::new_two_player(7);
+        add_cant_static(
+            &mut end,
+            0, // permanent controlled by the winner P0, affecting itself
+            902,
+            crate::types::statics::StaticMode::CantWinTheGame,
+        );
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(0), 1);
+        assert!(
+            crate::game::static_abilities::player_has_cant_win(&end, pid(0)),
+            "fixture sanity: P0 must actually have can't-win"
+        );
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a player who can't win must not be named the loop winner"
+        );
+    }
+
+    /// U-draw: a net-zero cycle (every axis zero) has no life faller ⇒ None. The
+    /// modulo path can never hijack a true mandatory-draw (structural complement of
+    /// the strict CR 104.4b block, which runs first and returns).
+    #[test]
+    fn live_winner_net_zero_is_none() {
+        let end = GameState::new_two_player(7);
+        let start = end.clone();
+        let delta = ResourceVector::default();
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            None,
+            "a net-zero repeat is a draw, not a win — no life faller"
         );
     }
 }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -719,6 +719,38 @@ fn project_out_resources(state: &GameState) -> GameState {
     s.combat_phases_started_this_turn = 0;
     s.end_steps_started_this_turn = 0;
 
+    // CR 104.4b / CR 732.2a — MODULO LAYER ONLY. The strict `loop_states_equal` /
+    // `normalize_for_loop` are deliberately NOT changed; they never call this fn
+    // (`project_out_resources` is reached only via `loop_states_equal_modulo_resources`).
+    //
+    // A triggered/activated ability placed on the stack takes a FRESH
+    // `entry_id = ObjectId(next_object_id++)` every time it goes on the stack, and
+    // `StackEntry`/`GameState` `PartialEq` compare that id. A MANDATORY trigger
+    // cascade (e.g. Marauding Blight-Priest + Bloodthirsty Conqueror) holds one
+    // in-loop trigger on the stack at every priority window (the stack never empties
+    // between resolutions), so two same-phase cycle points differ ONLY in this
+    // volatile id and never compare modulo-equal — the loop is invisible to the
+    // modulo scan. Canonicalize the id to its stack POSITION (the modulo analogue of
+    // `normalize_for_loop` zeroing `next_object_id`) while PRESERVING
+    // source_id/controller/kind, so different triggers/spells from different sources
+    // at the same depth still compare UNEQUAL.
+    //
+    // What is STILL compared element-wise inside `kind` (and is therefore the real
+    // discriminator, left intentionally untouched): for a `TriggeredAbility` the
+    // `trigger_event` (`GameEvent::LifeChanged { player_id, amount }` for the drain
+    // class — no volatile id, constant amount per cycle), `subject_match_count`, and
+    // `die_result`, plus the boxed `ability` and `condition`. These are CONTENT, not
+    // bookkeeping: a residual difference in any of them only makes the two states
+    // compare UNEQUAL, which SUPPRESSES a match — fail-safe (never a false win). The
+    // same fail-safe direction holds for any state field that still references a raw
+    // stack id (`stack_paid_facts`, `pending_trigger_entry`, a `WaitingFor` carrying
+    // a stack-entry id): left AS-IS, a residual mismatch can only suppress a match.
+    // Canonicalizing the position id can therefore never MANUFACTURE a false positive
+    // (a wrongful win); it can only make a genuine repeat visible.
+    for (pos, entry) in s.stack.iter_mut().enumerate() {
+        entry.id = ObjectId(pos as u64);
+    }
+
     s
 }
 
@@ -1347,5 +1379,71 @@ mod tests {
             &state,
             &(ObjectId(9999), 0)
         ));
+    }
+
+    /// Build a `TriggeredAbility` stack entry from `source`/`controller` with the
+    /// given volatile `entry_id` (fresh each cycle in the live reducer).
+    fn trigger_entry(
+        entry_id: u64,
+        source: u64,
+        controller: u8,
+    ) -> crate::types::game_state::StackEntry {
+        use crate::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+        use crate::types::game_state::{StackEntry, StackEntryKind};
+        let src = ObjectId(source);
+        StackEntry {
+            id: ObjectId(entry_id),
+            source_id: src,
+            controller: PlayerId(controller),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: src,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                    vec![],
+                    src,
+                    PlayerId(controller),
+                )),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+            },
+        }
+    }
+
+    /// U-stack ([BLOCKER 0]): the modulo comparator must treat two cascade cycle
+    /// points whose stacks hold the SAME triggered ability from the SAME source but
+    /// a DIFFERENT (fresh) entry id as equal — otherwise a mandatory trigger cascade
+    /// is invisible to the modulo scan and PR-3 is dead code. The control pair (a
+    /// DIFFERENT source) must still compare UNEQUAL (the canon zeroes only the
+    /// bookkeeping id, never the content).
+    ///
+    /// Revert proof: removing the `entry.id = ObjectId(pos)` loop in
+    /// `project_out_resources` flips the first assertion to `false`.
+    #[test]
+    fn modulo_equal_ignores_volatile_stack_entry_id() {
+        let mut a = GameState::new_two_player(7);
+        a.stack.push_back(trigger_entry(10, 500, 0));
+        let mut b = a.clone();
+        b.stack.clear();
+        b.stack.push_back(trigger_entry(11, 500, 0)); // same source, fresh id
+        assert!(
+            loop_states_equal_modulo_resources(&a, &b),
+            "same triggered ability from the same source must compare equal modulo its fresh id"
+        );
+
+        // CONTROL: a different source_id is a genuinely different stack point.
+        let mut c = a.clone();
+        c.stack.clear();
+        c.stack.push_back(trigger_entry(10, 501, 0));
+        assert!(
+            !loop_states_equal_modulo_resources(&a, &c),
+            "a trigger from a DIFFERENT source must NOT be equated (content is preserved)"
+        );
     }
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -216,6 +216,42 @@ pub(super) fn apply_action_boundary_with_stack_limit(
     Ok(result)
 }
 
+thread_local! {
+    /// PR-3 (Option C): set while inside a legality/search simulation probe
+    /// (`ai_support::SimulationFilter`'s clone-and-apply). Loop-shortcut detection
+    /// (`reconcile_terminal_result` §3) and ring accumulation
+    /// (`pass_priority_once_with_pipeline` §2) are TOP-LEVEL-ONLY — a hypothetical
+    /// single-action probe is NOT a real CR 732.2a play sequence, so it must neither
+    /// shortcut nor accumulate. Engine game logic is single-threaded (no rayon /
+    /// par_iter / std::thread::spawn in the apply or legal_actions path), `apply()` is
+    /// fully synchronous (no `.await` between set and restore), and the tokio server
+    /// runs each apply synchronously within one task on one thread, so the RAII
+    /// set/restore is balanced on a single thread within one call. Mirrors the in-engine
+    /// thread-local idiom (`perf_counters.rs`, `layers.rs`, `quantity.rs`).
+    static IN_SIMULATION_PROBE: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// True while inside a `SimulationFilter` legality probe. Read by §2 and §3.
+pub(crate) fn in_simulation_probe() -> bool {
+    IN_SIMULATION_PROBE.with(|f| f.get())
+}
+
+/// RAII guard: sets the probe flag, restores the PREVIOUS value on drop (panic-safe,
+/// nesting-correct — a probe that itself enumerates legal actions keeps the flag set).
+#[must_use]
+pub(crate) struct SimulationProbeGuard(bool);
+impl SimulationProbeGuard {
+    pub(crate) fn enter() -> Self {
+        SimulationProbeGuard(IN_SIMULATION_PROBE.with(|f| f.replace(true)))
+    }
+}
+impl Drop for SimulationProbeGuard {
+    fn drop(&mut self) {
+        IN_SIMULATION_PROBE.with(|f| f.set(self.0));
+    }
+}
+
 fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
     // Safety net (fixes #962): If a player-loss SBA would eliminate a player,
     // run SBAs now. CR 704.3 normally checks SBAs when a player would receive
@@ -236,6 +272,56 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
     if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
         match_flow::handle_game_over_transition(state);
         result.waiting_for = state.waiting_for.clone();
+    }
+
+    // CR 732.2a + CR 704.5a: shortcut a NET-PROGRESS mandatory cascade to its
+    // determinate single-opponent loss. Runs AFTER the CR 704 state-based actions
+    // above (CR 704.3 ordering), so a player ALREADY at 0 life loses via the real
+    // 704.5a SBA first and this never preempts or double-fires a legitimate win — it
+    // only fires when the game would otherwise grind on (high victim life, or mid-drain
+    // before 0). The `!GameOver` guard makes it idempotent across the :196/:200 calls.
+    if !matches!(state.waiting_for, WaitingFor::GameOver { .. })
+        && matches!(state.waiting_for, WaitingFor::Priority { .. }) // a player would get priority (CR 704.3)
+        && !state.stack.is_empty()
+        && !state.loop_detect_ring.is_empty()
+        // PR-3 Defect-2: loop-shortcut detection is TOP-LEVEL-ONLY. Inside a
+        // `SimulationFilter` legality probe the flag is set, so §3 is skipped. This
+        // enforces the invariant that a hypothetical single-action probe never runs
+        // game-ending shortcut logic, and guards the
+        // reconcile→§3→§9→legal_actions→SimulationFilter→reconcile path against
+        // unbounded re-entry. (In the current architecture the §9 gate's pass-state
+        // reset already makes those nested probes handoffs that do not re-resolve, so
+        // the path is bounded even without this conjunct — see the impl report's
+        // Defect-2 measurement — but the guard keeps the top-level-only invariant
+        // explicit and robust to future §9/§2 changes.)
+        && !in_simulation_probe()
+    {
+        // Clone the Arc handles (cheap refcount bumps) to release the borrow on the
+        // ring before the GameOver mutation below.
+        let priors: Vec<std::sync::Arc<GameState>> =
+            state.loop_detect_ring.iter().cloned().collect();
+        let cur = crate::analysis::resource::ResourceVector::snapshot(state);
+        if let Some(winner) = priors.iter().find_map(|prior| {
+            let delta = crate::analysis::resource::ResourceVector::delta(
+                &crate::analysis::resource::ResourceVector::snapshot(prior),
+                &cur,
+            );
+            crate::analysis::loop_check::live_mandatory_loop_winner(prior, state, &delta)
+        }) {
+            // CR 732.5: shortcut ONLY a loop NO living player can break. The gate runs
+            // ONCE after find_map (not per prior). At the per-beat drive this is the
+            // entire soundness firewall.
+            if no_living_player_has_meaningful_priority_action(state) {
+                result.events.push(GameEvent::GameOver {
+                    winner: Some(winner),
+                });
+                state.waiting_for = WaitingFor::GameOver {
+                    winner: Some(winner),
+                };
+                result.waiting_for = state.waiting_for.clone();
+                match_flow::handle_game_over_transition(state);
+            }
+        }
     }
 }
 
@@ -432,6 +518,13 @@ fn pass_priority_once_with_pipeline(
     state.pending_activations.clear();
 
     let stack_was_empty = state.stack.is_empty();
+    // PR-3 (Option C) Defect-1: capture the pre-pipeline stack frame for the §2
+    // loop-shortcut window maintenance below. `stack_top_before` is the resolving
+    // entry's id; a real resolution this beat replaces the top with a different id
+    // (every refilled trigger gets a fresh monotonic ObjectId), whereas a bare
+    // priority handoff leaves it unchanged.
+    let stack_len_before = state.stack.len();
+    let stack_top_before = state.stack.last().map(|e| e.id);
     // CR 117.4 + CR 723.5/723.8: pass the *seat* that holds priority, not
     // `priority_player` — under turn-control the latter is the authorized
     // submitter (the controller), which would mis-count consecutive passes and
@@ -465,6 +558,45 @@ fn pass_priority_once_with_pipeline(
         skip_triggers,
     )?;
     sync_waiting_for(state, &wf);
+
+    // PR-3 (Option C) CR 732.2a loop-shortcut window accumulation — relocated here
+    // (PR3 Defect-1 fix). The refilling trigger is placed by
+    // `run_post_action_pipeline` (CR 603.3 / CR 704.3: triggered abilities waiting to
+    // go on the stack are put there the next time a player would receive priority),
+    // which runs above — AFTER the resolution seam in `handle_priority_pass_with_limit`.
+    // Sampling here is the only frame where a self-refilling cascade is already
+    // non-shrinking (the refilled trigger is on the stack).
+    //
+    // RESOLUTION-OCCURRED GATE. `resolved_this_beat` is true iff there WAS a top entry
+    // at function entry and it is no longer the top — i.e. a stack entry was actually
+    // resolved/consumed this beat. A bare priority handoff (the active player passes,
+    // priority moves on, stack untouched) leaves the top unchanged ⇒
+    // `resolved_this_beat == false` ⇒ the ring is LEFT INTACT so accumulation survives
+    // across the handoff beats that separate resolutions under the per-beat drive. A
+    // naive `len >= before` gate would false-positive on those handoffs; a strict
+    // clear-on-handoff would destroy the accumulation — both are wrong. This gate
+    // samples only on a real resolution and touches the ring only then.
+    let resolved_this_beat =
+        stack_top_before.is_some() && state.stack.last().map(|e| e.id) != stack_top_before;
+    if resolved_this_beat && !in_simulation_probe() {
+        // REFILL gate: a self-refilling MANDATORY cascade holds the stack non-empty and
+        // non-shrinking across the resolution, settling at a non-interactive priority
+        // window reset to the active player (the canonical modulo-comparison point —
+        // `project_out_resources` compares phase/priority exactly). A normal multi-spell
+        // stack SHRINKS; an interactive effect opens a non-Priority window; a finite
+        // chain drains to empty — all three fall to the clear arm.
+        if !state.stack.is_empty()
+            && state.stack.len() >= stack_len_before
+            && matches!(wf, WaitingFor::Priority { player } if player == state.active_player)
+        {
+            state.record_loop_detect_sample();
+        } else {
+            state.loop_detect_ring.clear();
+        }
+    }
+    // No else-branch: a bare handoff or an empty-stack pass-to-advance-phase does NOT
+    // touch the ring (leave-intact), so accumulation survives the inter-resolution beats.
+
     Ok(wf)
 }
 
@@ -482,6 +614,28 @@ fn priority_player_has_meaningful_action(state: &GameState) -> bool {
     // — it drops only the unused spell-cost object-walk and grouped-map build.
     let actions = crate::ai_support::flat_priority_actions(&probe);
     crate::ai_support::has_meaningful_priority_action(&probe, &actions)
+}
+
+/// CR 732.5: no player can be forced to keep looping if ANY of them could take an
+/// action that ends the loop. The cap-path [`priority_player_has_meaningful_action`]
+/// checks only the CURRENT priority holder; the loop-shortcut WIN designates a
+/// LOSER, so its gate must be stronger — the would-be loop-breaker (a victim whose
+/// priority is auto-passed by a stale `UntilStackEmpty`/`UntilEndOfTurn` session,
+/// which `priority_auto_pass_decision` Passes WITHOUT a meaningful check) need NOT
+/// hold priority at the modulo-match iteration. Probe EVERY living player as the
+/// priority holder (`legal_actions`/`has_meaningful_priority_action` key off
+/// `waiting_for`). Conservative: if anyone has a meaningful action this returns
+/// `false` and the cascade falls through to the existing halt (priority preserved) —
+/// fail-safe toward the status quo, never a wrong win.
+fn no_living_player_has_meaningful_priority_action(state: &GameState) -> bool {
+    state.players.iter().filter(|p| !p.is_eliminated).all(|p| {
+        let mut probe = state.clone();
+        probe.auto_pass.clear();
+        probe.priority_player = p.id;
+        probe.waiting_for = WaitingFor::Priority { player: p.id };
+        let actions = crate::ai_support::legal_actions(&probe);
+        !crate::ai_support::has_meaningful_priority_action(&probe, &actions)
+    })
 }
 
 fn finish_completed_or_interrupted_until_stack_empty_sessions(state: &mut GameState) -> bool {
@@ -1152,6 +1306,34 @@ mod auto_pass_decision_tests {
             }
         ));
     }
+
+    /// U-gate (CR 732.5): the loop-shortcut gate must probe EVERY living player,
+    /// not just the current priority holder. Here the NON-priority player P1 holds a
+    /// meaningful (non-mana activated) ability while the current holder P0 has none.
+    ///
+    /// - `no_living_player_has_meaningful_priority_action` returns `false` (P1's
+    ///   action blocks the shortcut) — correct.
+    /// - `priority_player_has_meaningful_action` (current holder P0 only) returns
+    ///   `false`, so a gate built on its negation (`!current_only`) would wrongly be
+    ///   `true` and clear the loop. That contrast proves the all-players
+    ///   generalization is load-bearing (the session-masked victim need not hold
+    ///   priority at the modulo-match iteration).
+    #[test]
+    fn loop_gate_probes_all_living_players_not_just_current_holder() {
+        let mut state = priority_state();
+        // P1 (NOT the current priority holder) has a meaningful action.
+        add_non_mana_activated_artifact(&mut state, PlayerId(1));
+
+        assert!(
+            !no_living_player_has_meaningful_priority_action(&state),
+            "P1 has a loop-ending action, so the all-players gate must refuse to clear"
+        );
+        assert!(
+            !priority_player_has_meaningful_action(&state),
+            "the current-holder-only check sees nothing for P0 — its negation would \
+             wrongly clear, proving the all-players probe is load-bearing"
+        );
+    }
 }
 
 /// Auto-pass loop: when a player has an auto-pass flag and receives priority,
@@ -1271,6 +1453,22 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) {
                                 match_flow::handle_game_over_transition(state);
                                 return;
                             }
+
+                            // PR-3 (Option C): the NET-PROGRESS mandatory-loop WIN
+                            // shortcut is NOT duplicated here. `run_auto_pass_loop`
+                            // resolves via `pass_priority_once_with_pipeline` (:1339),
+                            // whose §2 maintenance accumulates the persisted
+                            // `loop_detect_ring` across these internal iterations, but
+                            // `reconcile_terminal_result` (the §3 win site) is NOT called
+                            // inside this loop — only at :200 AFTER it returns. So the §3
+                            // shortcut does NOT accelerate this auto-pass grind: this loop
+                            // runs its own net-progress drive to the natural CR 704.5a
+                            // death (or the strict CR 104.4b DRAW block above) on its own.
+                            // The accelerated path is the per-beat repeated
+                            // `apply(PassPriority)` drive (the production frontend
+                            // default), where §3 runs after every beat. Keeping a second
+                            // win site here would create two divergent detectors.
+
                             // CR 104.4b: a sliding window of the most recent
                             // MAX_LOOP_WINDOW distinct states. A fill-once-and-stop
                             // buffer never records the cycle of a loop whose
@@ -1645,6 +1843,19 @@ fn apply_action(
             waiting_for: state.waiting_for.clone(),
             log_entries: vec![],
         });
+    }
+
+    // PR-3 (Option C): CR 732.2a loop-detection ring invalidation. Any deliberate
+    // non-pass action (cast / activate / play-land) breaks a self-refilling mandatory
+    // cascade, so the accumulated detection window is stale and must be dropped.
+    // Placed AFTER every preference early-return (CancelAutoPass / SetPhaseStops /
+    // ReorderHand / Debug / Grant- & RevokeDebugPermission) so a no-op preference
+    // toggle never reaches here; PassPriority is the only action that CONTINUES a
+    // cascade and so must NOT clear. `run_auto_pass_loop` and `resolve_all_fast_forward`
+    // call the resolution seam directly (not via `apply_action`), so this clear does
+    // not fire during their internal iterations — the ring accumulates correctly there.
+    if !matches!(action, GameAction::PassPriority) {
+        state.loop_detect_ring.clear();
     }
 
     // Any deliberate player action (not auto-pass-related or a simple pass) cancels their auto-pass.

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -305,7 +305,11 @@ fn ascend_status(state: &GameState, player: PlayerId) -> AscendStatus {
 /// for entries pinned to this player via `SpecificPlayer { id }` whose
 /// modifications grant `StaticMode::CantLoseTheGame`. The battlefield scan
 /// handles the permanent-source path (Platinum Angel and friends).
-fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
+///
+/// `pub(crate)` so the live loop-shortcut firewall
+/// (`analysis::loop_check::live_mandatory_loop_winner`, CR 101.2) can reuse the same
+/// SBA-layer predicate rather than re-deriving the can't-lose check.
+pub(crate) fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
     let from_permanent = state.battlefield.iter().any(|&id| {
         let obj = match state.objects.get(&id) {
             Some(o) => o,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5761,6 +5761,28 @@ pub struct GameState {
     /// must not break AI-search dedup on semantically-identical positions.
     #[serde(skip)]
     pub static_source_index: StaticSourceIndex,
+    /// CR 732.2a loop-shortcut detection ring (PR-3). A bounded FIFO of recent
+    /// post-resolution NORMALIZED board snapshots, captured at the post-pipeline frame
+    /// of `game::engine::pass_priority_once_with_pipeline` (after
+    /// `run_post_action_pipeline` places refilling triggers, CR 603.3) and scanned at
+    /// the SBA-reconciliation seam (`game::engine::reconcile_terminal_result`). A
+    /// self-refilling MANDATORY cascade drives the engine one resolution per `apply()`
+    /// with no call-local window (the per-beat single-apply drive), so the window that
+    /// detects the loop MUST persist across `apply()` calls — hence on `GameState`.
+    ///
+    /// TRANSIENT DERIVED STATE — `#[serde(skip, default)]`. It is never serialized: it
+    /// is rebuilt deterministically from play and is a pure optimization over the
+    /// existing CR 704.5a SBA (which already ends every realistic-life drain), so
+    /// losing it across a save/load/MP-snapshot boundary only defers the shortcut by a
+    /// few resolutions — never changes a winner. Snapshots are `Arc`-shared so the
+    /// frequent `GameState::clone` (AI search, §9 probes) pays O(ring.len()) refcount
+    /// bumps, not deep copies. INTENTIONALLY omitted from `impl PartialEq for GameState`
+    /// (derived state, like `static_source_index`/`static_gate_truth` — both
+    /// `#[serde(skip)]` AND eq-excluded; NOT `public_state_dirty`/`state_revision`/
+    /// `layers_dirty`, which are `serde(skip)` but ARE compared in `eq`) so AI-search
+    /// dedup on semantically-identical positions is unaffected.
+    #[serde(skip, default)]
+    pub loop_detect_ring: std::collections::VecDeque<std::sync::Arc<GameState>>,
     pub next_timestamp: u64,
     #[serde(skip, default = "PublicStateDirty::all_dirty")]
     pub public_state_dirty: PublicStateDirty,
@@ -7471,6 +7493,7 @@ impl GameState {
             static_gate_truth: im::HashMap::new(),
             trigger_index: TriggerIndex::default(),
             static_source_index: StaticSourceIndex::default(),
+            loop_detect_ring: std::collections::VecDeque::new(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
             state_revision: 0,
@@ -7854,9 +7877,35 @@ impl GameState {
         clone.next_pip_id = 0;
         clone.layers_dirty = LayersDirty::full();
         clone.public_state_dirty = PublicStateDirty::all_dirty();
+        // PR-3 (Option C): snapshots stored in `loop_detect_ring` are produced BY this
+        // method, so without clearing here each stored snapshot would carry a clone of
+        // the live ring → recursive/quadratic growth. Cleared ⇒ every stored snapshot
+        // has clone depth 1. Does not affect any comparison (the ring is eq-excluded).
+        clone.loop_detect_ring.clear();
         clone
     }
+
+    /// PR-3 (Option C): push one NORMALIZED post-resolution snapshot onto the
+    /// CR 732.2a loop-detection ring, evicting the oldest at `LOOP_DETECT_RING_CAP`.
+    /// The snapshot is `normalize_for_loop`d (its own ring cleared, see above) and
+    /// `Arc`-shared so storage is O(1) per element. Called only from the post-pipeline
+    /// frame behind the refill gate (`game::engine::pass_priority_once_with_pipeline`,
+    /// after `run_post_action_pipeline` places refilling triggers).
+    pub(crate) fn record_loop_detect_sample(&mut self) {
+        if self.loop_detect_ring.len() == LOOP_DETECT_RING_CAP {
+            self.loop_detect_ring.pop_front();
+        }
+        let snapshot = std::sync::Arc::new(self.normalize_for_loop());
+        self.loop_detect_ring.push_back(snapshot);
+    }
 }
+
+/// PR-3 (Option C): max retained CR 732.2a loop-detection snapshots. A determinate
+/// drain has period ≤ 2; 16 covers ≥ 8 cycles and any loop whose repeating phase
+/// begins within a 16-resolution preamble. A longer-period/longer-preamble loop
+/// simply falls back to the natural CR 704.5a SBA death (fail-safe — never a wrong
+/// win). Kept small because the live `GameState` carries it through every clone.
+const LOOP_DETECT_RING_CAP: usize = 16;
 
 /// CR 104.4b confirmation between two states that have BOTH already been
 /// `normalize_for_loop`d. Reuses `PartialEq` for the ~95 non-object fields and


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Combo-detector series

This is **PR-3** of the staged, offline-first infinite-combo / loop detector (Engine A). The series goal is to incrementally build combo/loop detection toward **shortcutting mandatory, game-ending loops** — recognizing that a repeating modulo game state with no meaningful out must resolve to a deterministic winner, rather than grinding hundreds of beats to the CR 704.5a life-loss death.

| Pos | PR | State | Delivers |
|-----|----|----|----------|
| PR-0 | #4092 | MERGED | `ResourceVector` + `loop_states_equal_modulo_resources` (modulo-resource loop equality / reuse fingerprint); additive, no behavior change. |
| PR-1 | #4097 | MERGED | Analysis sim harness around `GameRunner::act` that feeds/consumes `ResourceVector`. |
| PR-2 | #4119 | MERGED | Net-progress detector (`analysis/loop_check.rs` `detect_loop` → `LoopCertificate`) + corpus harness driving Priest+Umbral & Marwyn+Sword loop certificates. |
| **PR-3** | **this PR** | open | A **live mandatory-loop winner shortcut** (`reconcile_terminal_result` + `live_mandatory_loop_winner`): detects a repeating modulo state and emits `GameOver` immediately, ahead of the existing `emit_resolution_halt` runaway backstop. |

Predecessors:
- **PR-1** — #4097 — https://github.com/phase-rs/phase/pull/4097 — analysis sim harness feeding `ResourceVector`.
- **PR-2** — #4119 — https://github.com/phase-rs/phase/pull/4119 — net-progress detector + loop-certificate corpus harness (immediate predecessor; this PR builds on its detector output).

(Foundation: **PR-0** — #4092 — https://github.com/phase-rs/phase/pull/4092 — `ResourceVector` + modulo-resource loop equality.)

## Summary
Adds a live mandatory-loop winner shortcut for drain-cascade combos. When priority passes in a cycle with a non-empty stack and the loop-detect ring shows a repeating modulo game state, `reconcile_terminal_result` identifies the single non-falling living player and emits `GameOver{winner}` immediately — instead of grinding hundreds of beats to the CR 704.5a life-loss death.

## What it does
- **Detection (§2/§3):** ring accumulation in `pass_priority_once_with_pipeline` + a modulo-match shortcut in `reconcile_terminal_result`. `loop_detect_ring` is `#[serde(skip)]` + eq-excluded (zero wire surface); reuses the existing `GameOver` event (no new variant, no inventory regen).
- **Soundness firewalls (§8/§9):** `no_living_player_has_meaningful_priority_action` probes *all* living players (not just the current holder); `live_mandatory_loop_winner` returns `None` for mutual-drain / can't-lose / net-zero / multi-faller boards. A player with a meaningful out is never shortcut (CR 104).
- **Defensive probe guard:** a thread-local guard keeps legality probes from running game-ending shortcut logic. Composes with #4479's `apply_as_current_for_legality` perf path (perf'd legality apply run *under* the guard).
- **Corpus promotions:** Sanguine Bond + Exquisite Blood (idx 17, "target opponent loses that much life" — auto-resolves to the sole legal target) and Marauding Blight-Priest + Bloodthirsty Conqueror (idx 18) promoted to `DRIVEN_ROW_INDICES`, each backed by a non-vacuous live `apply(PassPriority)` test observing `GameOver` at beat 6.

## Verification
- `cargo build -p engine` clean; `cargo clippy -p engine --lib --tests -- -D warnings` clean.
- Live hard-gate tests pass: `drive_drain_idx18_wins_live`, `drive_drain_idx17_targeted_wins_live`, bounded-termination, victim-with-out-not-eliminated.
- Full `analysis::` suite 96/0. Non-vacuity measured by source revert (disabling the §2 ring sample or the §3 shortcut drops the early `GameOver`).
- All CR annotations grep-verified against the Comprehensive Rules.

Rebased onto current `main`; the single conflict (with #4479's legality-probe perf refactor) was resolved by composing both changes and re-verified green.
