### PR TITLE
fix(parser): UNSUPPORTED one-off: River Song

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -149,6 +149,10 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             // CR 121.6: CantDraw carries `who` (controller vs all_players) —
             // runtime enforcement is in game/effects/draw.rs::allowed_draw_count.
             | StaticMode::CantDraw { .. }
+            // CR 121.1 / CR 613.11: DrawFromBottom carries `who` — top-vs-bottom
+            // selection is enforced in
+            // game/effects/draw.rs::select_cards_to_draw.
+            | StaticMode::DrawFromBottom { .. }
             // CR 614.1b + CR 614.10: SkipStep carries the `Phase` discriminant
             // (Draw, Untap, Upkeep, etc.). Runtime enforcement is in
             // turns.rs::should_skip_step_static(). Coverage support is via
@@ -7804,6 +7808,7 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             }
             StaticMode::MayChooseNotToUntap => effective_lower.contains("may choose not to untap"),
             StaticMode::CantDraw { .. } => effective_lower.contains("can't draw"),
+            StaticMode::DrawFromBottom { .. } => effective_lower.contains("from the bottom of"),
             StaticMode::PerTurnDrawLimit { .. } => effective_lower.contains("can't draw more than"),
             StaticMode::DoubleTriggers { .. } => {
                 effective_lower.contains("triggers an additional time")

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -143,16 +143,11 @@ pub(crate) fn resolve_connive_effect(
             else {
                 return;
             };
-            let Some(player) = state.players.iter().find(|p| p.id == player_id) else {
-                return;
-            };
-
-            let cards_to_draw: Vec<_> = player
-                .library
-                .iter()
-                .take(draw_count as usize)
-                .copied()
-                .collect();
+            // CR 121.1 + CR 613.11: route card selection through the single
+            // `select_cards_to_draw` authority so a `DrawFromBottom` static is
+            // honored on the connive draw too.
+            let cards_to_draw =
+                super::draw::select_cards_to_draw(state, player_id, draw_count as usize);
 
             if draw_count > 0 && cards_to_draw.len() < draw_count as usize {
                 if let Some(p) = state.players.iter_mut().find(|p| p.id == player_id) {

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -47,6 +47,51 @@ pub(crate) fn allowed_draw_count(
     allowed
 }
 
+/// CR 121.1 + CR 613.11: True when an active `DrawFromBottom` static redirects
+/// `player_id`'s draws to the bottom of their library. Mirrors the
+/// `battlefield_active_statics` scan in [`allowed_draw_count`].
+pub(crate) fn draws_from_bottom(
+    state: &GameState,
+    player_id: crate::types::player::PlayerId,
+) -> bool {
+    // CR 702.26b + CR 604.1: `battlefield_active_statics` owns the phased-out /
+    // command-zone / condition gate.
+    for (source_obj, def) in crate::game::functioning_abilities::battlefield_active_statics(state) {
+        if let StaticMode::DrawFromBottom { ref who } = def.mode {
+            if prohibition_scope_matches_player(who, player_id, source_obj.id, state) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// CR 121.1 + CR 121.2 + CR 613.11: SINGLE AUTHORITY for which library cards a
+/// draw pulls. Every draw-delivery path (spell/ability resolution, the
+/// turn-based draw step, connive, gift) MUST call this for card selection so a
+/// `DrawFromBottom` static is honored uniformly.
+///
+/// Returns up to `count` object ids, pulled from the BOTTOM (CR 121.2: cards are
+/// drawn one at a time, each taking the then-current bottommost card →
+/// `.rev().take(n)`) when an active `DrawFromBottom` matches the player,
+/// otherwise from the TOP (CR 121.1, `library[0]`). Partial draws
+/// (`count > library.len()`) return all available ids; an empty library returns
+/// an empty vec — empty-library SBA handling (CR 704.5b) stays at the call site.
+pub(crate) fn select_cards_to_draw(
+    state: &GameState,
+    player_id: crate::types::player::PlayerId,
+    count: usize,
+) -> Vec<crate::types::identifiers::ObjectId> {
+    let Some(player) = state.players.iter().find(|p| p.id == player_id) else {
+        return Vec::new();
+    };
+    if draws_from_bottom(state, player_id) {
+        player.library.iter().rev().take(count).copied().collect()
+    } else {
+        player.library.iter().take(count).copied().collect()
+    }
+}
+
 /// CR 121.1: Draw a card — put the top card of library into hand.
 ///
 /// CR 601.2c + CR 115.1: When the parsed `Effect::Draw { target }` is a
@@ -185,16 +230,9 @@ pub fn apply_draw_after_replacement(
     };
 
     let allowed_count = allowed_draw_count(state, player_id, count);
-    let Some(player) = state.players.iter().find(|p| p.id == player_id) else {
-        return;
-    };
-
-    let cards_to_draw: Vec<_> = player
-        .library
-        .iter()
-        .take(allowed_count as usize)
-        .copied()
-        .collect();
+    // CR 121.1 + CR 613.11: card selection routes through the single
+    // `select_cards_to_draw` authority so a `DrawFromBottom` static is honored.
+    let cards_to_draw = select_cards_to_draw(state, player_id, allowed_count as usize);
 
     // CR 704.5b: If library has fewer cards than requested, mark the player.
     // CR 121.4: Partial draws are legal — draw what's available.
@@ -871,6 +909,129 @@ mod tests {
         assert!(
             state.pending_miracle_offers.is_empty(),
             "non-first-drawn miracle card must not queue an offer"
+        );
+    }
+
+    /// Seed a player's library in deterministic top→bottom order. `create_object`
+    /// appends (push_back), and `library[0]` is the top, so the first name is the
+    /// top card and the last name is the bottom card.
+    fn seed_library(state: &mut GameState, player: PlayerId, names: &[&str]) -> Vec<ObjectId> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                create_object(
+                    state,
+                    CardId(1000 + i as u64),
+                    player,
+                    name.to_string(),
+                    Zone::Library,
+                )
+            })
+            .collect()
+    }
+
+    fn push_draw_from_bottom(state: &mut GameState, controller: PlayerId, who: ProhibitionScope) {
+        let source = create_object(
+            state,
+            CardId(9000),
+            controller,
+            "River Song".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::DrawFromBottom { who }));
+    }
+
+    /// CR 121.1: with no `DrawFromBottom` static, `select_cards_to_draw` pulls
+    /// from the TOP (`library[0]`) in order; `count > len` returns all available.
+    #[test]
+    fn select_pulls_from_top_without_static() {
+        let mut state = GameState::new_two_player(42);
+        let lib = seed_library(&mut state, PlayerId(0), &["top", "mid", "bottom"]);
+
+        assert!(!draws_from_bottom(&state, PlayerId(0)));
+        assert_eq!(select_cards_to_draw(&state, PlayerId(0), 1), vec![lib[0]]);
+        assert_eq!(
+            select_cards_to_draw(&state, PlayerId(0), 2),
+            vec![lib[0], lib[1]]
+        );
+        // count > len → all available, no panic.
+        assert_eq!(select_cards_to_draw(&state, PlayerId(0), 99), lib);
+    }
+
+    /// CR 121.1 + CR 121.2: with a controller-scoped `DrawFromBottom` static,
+    /// selection pulls from the BOTTOM one at a time (bottommost first, then
+    /// next-from-bottom). Empty library returns an empty vec.
+    #[test]
+    fn select_pulls_from_bottom_with_controller_static() {
+        let mut state = GameState::new_two_player(42);
+        let lib = seed_library(&mut state, PlayerId(0), &["top", "mid", "bottom"]);
+        push_draw_from_bottom(&mut state, PlayerId(0), ProhibitionScope::Controller);
+
+        assert!(draws_from_bottom(&state, PlayerId(0)));
+        // lib = [top, mid, bottom]; bottom is the last element.
+        assert_eq!(select_cards_to_draw(&state, PlayerId(0), 1), vec![lib[2]]);
+        assert_eq!(
+            select_cards_to_draw(&state, PlayerId(0), 2),
+            vec![lib[2], lib[1]]
+        );
+
+        state.players[0].library.clear();
+        assert!(select_cards_to_draw(&state, PlayerId(0), 1).is_empty());
+    }
+
+    /// CR 613.11: `DrawFromBottom { Opponents }` redirects an opponent's draws
+    /// but NOT the source-controller's — scope correctness across both players.
+    #[test]
+    fn select_scope_opponents_only() {
+        let mut state = GameState::new_two_player(42);
+        let p0_lib = seed_library(&mut state, PlayerId(0), &["p0top", "p0bottom"]);
+        let p1_lib = seed_library(&mut state, PlayerId(1), &["p1top", "p1bottom"]);
+        // Source controlled by P0, scoping its OPPONENTS (P1).
+        push_draw_from_bottom(&mut state, PlayerId(0), ProhibitionScope::Opponents);
+
+        // P1 (the opponent) draws from the bottom.
+        assert!(draws_from_bottom(&state, PlayerId(1)));
+        assert_eq!(
+            select_cards_to_draw(&state, PlayerId(1), 1),
+            vec![p1_lib[1]]
+        );
+        // P0 (the controller) is unaffected — top.
+        assert!(!draws_from_bottom(&state, PlayerId(0)));
+        assert_eq!(
+            select_cards_to_draw(&state, PlayerId(0), 1),
+            vec![p0_lib[0]]
+        );
+    }
+
+    /// CR 121.1 + CR 121.2 + CR 613.11: the spell/ability draw path
+    /// (`apply_draw_after_replacement`) honors `DrawFromBottom` — a draw-2 pulls
+    /// the bottommost then next-from-bottom, leaving the top card in the library.
+    #[test]
+    fn spell_draw_pulls_bottom_under_static() {
+        let mut state = GameState::new_two_player(42);
+        let lib = seed_library(&mut state, PlayerId(0), &["top", "mid", "bottom"]);
+        push_draw_from_bottom(&mut state, PlayerId(0), ProhibitionScope::Controller);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &make_ability(2), &mut events).unwrap();
+
+        assert!(
+            state.players[0].hand.contains(&lib[2]),
+            "bottom card must be drawn first"
+        );
+        assert!(
+            state.players[0].hand.contains(&lib[1]),
+            "next-from-bottom must be drawn second"
+        );
+        assert!(
+            state.players[0].library.contains(&lib[0]),
+            "top card must remain in the library"
         );
     }
 }

--- a/crates/engine/src/game/effects/gift_delivery.rs
+++ b/crates/engine/src/game/effects/gift_delivery.rs
@@ -111,16 +111,10 @@ fn deliver_card_draw(
             else {
                 return;
             };
-            let Some(player) = state.players.iter().find(|p| p.id == player_id) else {
-                return;
-            };
-
-            let cards_to_draw: Vec<_> = player
-                .library
-                .iter()
-                .take(count as usize)
-                .copied()
-                .collect();
+            // CR 121.1 + CR 613.11: route card selection through the single
+            // `select_cards_to_draw` authority so a `DrawFromBottom` static is
+            // honored on the gift draw too.
+            let cards_to_draw = super::draw::select_cards_to_draw(state, player_id, count as usize);
 
             for obj_id in cards_to_draw {
                 zones::move_to_zone(state, obj_id, Zone::Hand, events);

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -103,6 +103,10 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     registry.insert(StaticMode::MustBlock, handle_rule_mod);
     // Note: CantDraw is a data-carrying variant — runtime enforcement is in
     // game/effects/draw.rs. Coverage support is via is_data_carrying_static().
+    // Note: DrawFromBottom (CR 121.1/613.11) is a data-carrying variant — its
+    // top-vs-bottom selection is enforced in
+    // game/effects/draw.rs::select_cards_to_draw, which all four draw-delivery
+    // paths consult. Coverage support is via is_data_carrying_static().
     // Note: DoubleTriggers (CR 603.2d) is a data-carrying variant — runtime
     // enforcement is in triggers.rs::apply_trigger_doubling. Coverage support
     // is via is_data_carrying_static().

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1384,12 +1384,14 @@ fn execute_draw_for(
             };
             let allowed = crate::game::effects::draw::allowed_draw_count(state, player_id, count);
 
-            let cards_to_draw: Vec<_> = state
-                .players
-                .iter()
-                .find(|p| p.id == player_id)
-                .map(|p| p.library.iter().take(allowed as usize).copied().collect())
-                .unwrap_or_default();
+            // CR 121.1 + CR 613.11: route card selection through the single
+            // `select_cards_to_draw` authority so a `DrawFromBottom` static is
+            // honored on the turn-based draw step too.
+            let cards_to_draw = crate::game::effects::draw::select_cards_to_draw(
+                state,
+                player_id,
+                allowed as usize,
+            );
 
             // CR 704.5b: Attempting to draw from an empty library causes a game loss.
             if allowed > 0 && cards_to_draw.len() < allowed as usize {

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -613,6 +613,21 @@ fn is_static_compound_pattern(lower: &str) -> bool {
     if scan_contains(lower, "face a villainous choice") && scan_contains(lower, "additional time") {
         return true;
     }
+    // CR 121.1 / CR 613.11: "[subject] draw(s) cards from the bottom of [your|
+    // their] library rather than/instead of the top." — River Song's draw-source
+    // redirection static (Meet in Reverse). The body verb is "draw", so none of
+    // the generic static keywords (get/have/can't) anchor it; without this gate
+    // the (ability-word-prefixed) line never reaches Priority 7 and falls to the
+    // spell catch-all as Unimplemented. The "from the bottom of" + "library" +
+    // top-reference combination is the diagnostic; extraction is delegated to
+    // `parse_draw_from_bottom`, which lowers it to `StaticMode::DrawFromBottom`.
+    if scan_contains(lower, "from the bottom of")
+        && scan_contains(lower, "library")
+        && (scan_contains(lower, "rather than the top")
+            || scan_contains(lower, "instead of the top"))
+    {
+        return true;
+    }
     false
 }
 

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2226,6 +2226,13 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // --- CR 121.1 / CR 613.11: Draw-source redirection ("draw cards from the
+    // bottom of your library rather than the top") — River Song, "Meet in
+    // Reverse". ---
+    if let Some(def) = parse_draw_from_bottom(tp.lower, &text) {
+        return Some(def);
+    }
+
     // --- "~ doesn't untap during your untap step [as long as / if condition]" ---
     // CR 502.3: Effects can keep permanents from untapping during the untap step.
     if nom_primitives::scan_contains(tp.lower, "doesn't untap during")

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1332,9 +1332,17 @@ pub(crate) fn parse_draw_from_bottom(tp: &str, text: &str) -> Option<StaticDefin
 
     // Subject axis → `ProhibitionScope` via the shared building block.
     let (who, predicate) = strip_casting_prohibition_subject(tp)?;
-    // Verb axis: "draw"/"draws" (predicate is already lowercase).
-    let rest = nom_tag_lower(predicate, predicate, "draw cards from the bottom of ")
-        .or_else(|| nom_tag_lower(predicate, predicate, "draws cards from the bottom of "))?;
+    // Verb axis ("draw"/"draws") × quantity axis ("cards"/"a card") — composed, not permuted.
+    // Covers "draw a card", "draw cards", "draws a card", "draws cards".
+    let (rest, _) = alt((tag::<_, _, VE<'_>>("draw "), tag("draws ")))
+        .parse(predicate)
+        .ok()?;
+    let (rest, _) = alt((tag::<_, _, VE<'_>>("cards"), tag("a card")))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, VE<'_>>(" from the bottom of ")
+        .parse(rest)
+        .ok()?;
     // Possessive axis composed (not permuted).
     let (rest, _) = alt((tag::<_, _, VE<'_>>("your "), tag("their ")))
         .parse(rest)

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1322,6 +1322,38 @@ pub(crate) fn parse_cant_draw_cards(tp: &str, text: &str) -> Option<StaticDefini
     Some(StaticDefinition::new(StaticMode::CantDraw { who }).description(text.to_string()))
 }
 
+/// CR 121.1 + CR 613.11: Parse a draw-source redirection static from Oracle
+/// text: "[Subject] draw(s) cards from the bottom of [your|their] library
+/// rather than/instead of the top." → `DrawFromBottom { who }`.
+/// E.g., River Song ("Meet in Reverse"): "You draw cards from the bottom of
+/// your library rather than the top."
+pub(crate) fn parse_draw_from_bottom(tp: &str, text: &str) -> Option<StaticDefinition> {
+    type VE<'a> = OracleError<'a>;
+
+    // Subject axis → `ProhibitionScope` via the shared building block.
+    let (who, predicate) = strip_casting_prohibition_subject(tp)?;
+    // Verb axis: "draw"/"draws" (predicate is already lowercase).
+    let rest = nom_tag_lower(predicate, predicate, "draw cards from the bottom of ")
+        .or_else(|| nom_tag_lower(predicate, predicate, "draws cards from the bottom of "))?;
+    // Possessive axis composed (not permuted).
+    let (rest, _) = alt((tag::<_, _, VE<'_>>("your "), tag("their ")))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, VE<'_>>("library ").parse(rest).ok()?;
+    // Connector axis composed (not permuted).
+    let (rest, _) = alt((tag::<_, _, VE<'_>>("rather than"), tag("instead of")))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, VE<'_>>(" the top").parse(rest).ok()?;
+    // STRICT: reject a silently-dropped trailing clause — the redirect must be
+    // the whole sentence, not a fragment with an unparsed remainder.
+    let tail = rest.trim();
+    if !matches!(tail, "" | ".") {
+        return None;
+    }
+    Some(StaticDefinition::new(StaticMode::DrawFromBottom { who }).description(text.to_string()))
+}
+
 /// Parse the subject of "[type] cards in [zones] can't enter the battlefield".
 /// CR 604.3: Extracts the card type filter and zone restrictions into a TypedFilter.
 pub(crate) fn parse_cant_enter_battlefield_subject(tp: &TextPair) -> TargetFilter {
@@ -2587,6 +2619,74 @@ mod filtered_spend_any_type_tests {
         assert!(
             try_parse_filtered_spend_any_type_to_cast(text, &lower).is_none(),
             "an unrecognised spell class must stay an honest defer"
+        );
+    }
+}
+
+#[cfg(test)]
+mod draw_from_bottom_tests {
+    use super::*;
+
+    /// CR 121.1 + CR 613.11: River Song's exact "Meet in Reverse" line (after
+    /// ability-word stripping) lowers to `DrawFromBottom { Controller }`.
+    #[test]
+    fn parses_controller_draw_from_bottom() {
+        let text = "You draw cards from the bottom of your library rather than the top.";
+        let lower = text.to_ascii_lowercase();
+        let def = parse_draw_from_bottom(&lower, text)
+            .expect("River Song's draw-redirect line must lower to a static");
+        assert_eq!(
+            def.mode,
+            StaticMode::DrawFromBottom {
+                who: ProhibitionScope::Controller
+            }
+        );
+    }
+
+    /// The subject axis composes with the shared `strip_casting_prohibition_subject`
+    /// building block — "each opponent" scopes to `Opponents`, and "instead of"
+    /// is an accepted connector variant. Covers the class, not just River Song.
+    #[test]
+    fn parses_opponents_scope_and_instead_of_connector() {
+        let text = "Each opponent draws cards from the bottom of their library instead of the top.";
+        let lower = text.to_ascii_lowercase();
+        let def = parse_draw_from_bottom(&lower, text)
+            .expect("opponent-scoped draw-redirect must lower to a static");
+        assert_eq!(
+            def.mode,
+            StaticMode::DrawFromBottom {
+                who: ProhibitionScope::Opponents
+            }
+        );
+    }
+
+    /// The static dispatch chain (`parse_static_line_multi`) must route the
+    /// stripped body to `parse_draw_from_bottom` — guards against a future
+    /// dispatch-registration regression.
+    #[test]
+    fn static_line_multi_routes_to_draw_from_bottom() {
+        let defs = crate::parser::oracle_static::parse_static_line_multi(
+            "You draw cards from the bottom of your library rather than the top.",
+        );
+        assert_eq!(
+            defs.iter().map(|d| &d.mode).collect::<Vec<_>>(),
+            vec![&StaticMode::DrawFromBottom {
+                who: ProhibitionScope::Controller
+            }],
+            "static dispatch must lower to a single DrawFromBottom(controller)"
+        );
+    }
+
+    /// STRICT: a trailing clause must NOT be silently dropped — the redirect has
+    /// to be the whole sentence, else the line stays an honest defer.
+    #[test]
+    fn declines_trailing_clause() {
+        let text =
+            "You draw cards from the bottom of your library rather than the top and you lose 1 life.";
+        let lower = text.to_ascii_lowercase();
+        assert!(
+            parse_draw_from_bottom(&lower, text).is_none(),
+            "a silently-dropped trailing clause must NOT parse"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20652,3 +20652,73 @@ fn static_nonlegendary_creatures_enchanted_player_controls_base_pt_and_lose_type
         def.modifications
     );
 }
+
+/// CR 121.1 + CR 613.11: River Song regression. The "Meet in Reverse" line must
+/// lower to exactly one `DrawFromBottom { Controller }` static (NOT a spell
+/// catch-all `Effect::Unimplemented`), and the "Spoilers" trigger must remain a
+/// `PlayerPerformedAction` over [Scry, Surveil, SearchedLibrary].
+#[test]
+fn river_song_full_card_parses_without_unimplemented() {
+    use crate::types::events::PlayerActionKind;
+    use crate::types::triggers::TriggerMode;
+
+    let oracle = "Meet in Reverse \u{2014} You draw cards from the bottom of your library rather than the top.\n\
+        Spoilers \u{2014} Whenever an opponent scries, surveils, or searches their library, put a +1/+1 counter on River Song. Then River Song deals damage to that player equal to its power.";
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "River Song",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Time".to_string(), "Lord".to_string()],
+    );
+
+    // (i) No spell catch-all Unimplemented leaked into the abilities.
+    assert!(
+        !parsed
+            .abilities
+            .iter()
+            .any(|a| matches!(*a.effect, Effect::Unimplemented { .. })),
+        "River Song must parse with 0 Unimplemented abilities, got {:?}",
+        parsed.abilities
+    );
+
+    // (ii) Exactly one DrawFromBottom { Controller } static.
+    let bottom: Vec<_> = parsed
+        .statics
+        .iter()
+        .filter(|d| {
+            d.mode
+                == StaticMode::DrawFromBottom {
+                    who: ProhibitionScope::Controller,
+                }
+        })
+        .collect();
+    assert_eq!(
+        bottom.len(),
+        1,
+        "expected exactly one DrawFromBottom(controller) static, got statics {:?}",
+        parsed.statics
+    );
+
+    // (iii) The Spoilers trigger shape is intact.
+    let spoilers = parsed
+        .triggers
+        .iter()
+        .find(|t| t.player_actions.is_some())
+        .expect("Spoilers must remain a player-action trigger");
+    assert_eq!(spoilers.mode, TriggerMode::PlayerPerformedAction);
+    let actions = spoilers
+        .player_actions
+        .as_ref()
+        .expect("player_actions present");
+    for expected in [
+        PlayerActionKind::Scry,
+        PlayerActionKind::Surveil,
+        PlayerActionKind::SearchedLibrary,
+    ] {
+        assert!(
+            actions.contains(&expected),
+            "Spoilers must fire on {expected:?}; got {actions:?}"
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20722,3 +20722,36 @@ fn river_song_full_card_parses_without_unimplemented() {
         );
     }
 }
+
+/// CR 121.1 + CR 613.11: Singular-form coverage for `DrawFromBottom`.
+/// "You draw a card from the bottom of your library rather than the top."
+/// must parse identically to the plural River Song wording.
+#[test]
+fn draw_from_bottom_singular_controller() {
+    let def =
+        parse_static_line("You draw a card from the bottom of your library rather than the top.")
+            .expect("singular controller form must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::DrawFromBottom {
+            who: ProhibitionScope::Controller,
+        }
+    );
+}
+
+/// CR 121.1 + CR 613.11: Singular-form coverage for `DrawFromBottom` with
+/// opponent subject and "instead of" connector.
+/// "Each opponent draws a card from the bottom of their library instead of the top."
+#[test]
+fn draw_from_bottom_singular_opponents() {
+    let def = parse_static_line(
+        "Each opponent draws a card from the bottom of their library instead of the top.",
+    )
+    .expect("singular opponent form must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::DrawFromBottom {
+            who: ProhibitionScope::Opponents,
+        }
+    );
+}

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -971,6 +971,15 @@ pub enum StaticMode {
     CantDraw {
         who: ProhibitionScope,
     },
+    /// CR 121.1 + CR 613.11: Rule-modifying continuous effect — affected players
+    /// draw cards from the BOTTOM of their library rather than the top (River
+    /// Song, "Meet in Reverse"). Data-carrying / non-registry; the top-vs-bottom
+    /// decision is enforced by `game/effects/draw.rs::select_cards_to_draw`,
+    /// which EVERY draw-delivery path consults. `who` scopes the affected
+    /// players via `ProhibitionScope` (River Song = `Controller`).
+    DrawFromBottom {
+        who: ProhibitionScope,
+    },
     /// CR 603.2d: "If [cause], a triggered ability of a permanent you control
     /// triggers an additional time." Panharmonicon, Isshin Two Heavens as One,
     /// and the class of trigger-doublers. The `cause` predicate narrows which
@@ -1807,6 +1816,7 @@ impl Hash for StaticMode {
             | StaticMode::CantPayCost { .. }
             | StaticMode::DefilerCostReduction { .. }
             | StaticMode::CantDraw { .. }
+            | StaticMode::DrawFromBottom { .. }
             | StaticMode::PerTurnCastLimit { .. }
             | StaticMode::PerTurnDrawLimit { .. }
             | StaticMode::MaximumHandSize { .. }
@@ -1872,6 +1882,7 @@ impl StaticMode {
             | StaticMode::MustBlock
             | StaticMode::MustBlockAttacker { .. }
             | StaticMode::CantDraw { .. }
+            | StaticMode::DrawFromBottom { .. }
             | StaticMode::DoubleTriggers { .. }
             | StaticMode::IgnoreHexproof
             | StaticMode::ExtraBlockers { .. }
@@ -2040,6 +2051,7 @@ impl fmt::Display for StaticMode {
                 write!(f, "MustBlockAttacker({attacker:?})")
             }
             StaticMode::CantDraw { who } => write!(f, "CantDraw({who})"),
+            StaticMode::DrawFromBottom { who } => write!(f, "DrawFromBottom({who})"),
             StaticMode::DoubleTriggers { cause } => write!(f, "DoubleTriggers({cause})"),
             StaticMode::IgnoreHexproof => write!(f, "IgnoreHexproof"),
             StaticMode::GraveyardCastPermission {
@@ -2689,6 +2701,14 @@ impl FromStr for StaticMode {
                 {
                     if let Ok(who) = ProhibitionScope::from_str(inner) {
                         return Ok(StaticMode::CantDraw { who });
+                    }
+                    return Ok(StaticMode::Other(other.to_string()));
+                } else if let Some(inner) = other
+                    .strip_prefix("DrawFromBottom(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    if let Ok(who) = ProhibitionScope::from_str(inner) {
+                        return Ok(StaticMode::DrawFromBottom { who });
                     }
                     return Ok(StaticMode::Other(other.to_string()));
                 } else if let Some(inner) = other


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED one-off: River Song

## Cards corrected
- River Song

## Fix
Implemented Cluster 53 (River Song, one-off UNSUPPORTED). Added StaticMode::DrawFromBottom { who: ProhibitionScope } with full round-trip (Hash/as_keyword/Display/FromStr), a nom-combinator parser parse_draw_from_bottom + dispatch registration, a single runtime card-selection authority select_cards_to_draw/draws_from_bottom in draw.rs, and rerouted ALL FOUR draw-delivery closures (draw.rs spell path, turns.rs draw step, connive.rs, gift_delivery.rs) through it so the bottom-redirect is honored on every draw path. Coverage classification + supported-text and a registry note were added. DEVIATION FROM PLAN: the plan incorrectly assumed the ability-word line reaches the B7 static dispatch; it is gated by is_static_pattern (oracle.rs:3153), which did not recognize the draw-redirect shape, so the line stayed Unimplemented. A failing regression test surfaced this; I extended oracle_classifier.rs::is_static_compound_pattern with a scan_contains diagnostic ("from the bottom of" + "library" + top-reference) to route the line to Priority 7. Verification: cargo fmt clean; cargo clippy -p engine --all-targets 0 warnings; full cargo test -p engine green (116 result lines, 0 failed); parser diff gate clean (only Iterator::find/slice::contains in tests, no string dispatch in production parser); end-to-end oracle-gen shows River Song with abilities:[] (0 Unimplemented), static_abilities:[DrawFromBottom{Controller}], and Spoilers trigger [Scry,Surveil,SearchedLibrary] intact. select_cards_to_draw returns byte-identical results to the prior library.iter().take(n) when no DrawFromBottom static is active, so existing draw behavior is unchanged. No commit made. Restored one incidental oracle-subtypes.json regeneration artifact from the oracle-gen run. All CR numbers (121.1, 121.2, 613.11, 704.5b) grep-verified against docs/MagicCompRules.txt.

## Files changed
- crates/engine/src/types/statics.rs
- crates/engine/src/parser/oracle_static/restriction.rs
- crates/engine/src/parser/oracle_static/dispatch.rs
- crates/engine/src/parser/oracle_classifier.rs
- crates/engine/src/game/effects/draw.rs
- crates/engine/src/game/turns.rs
- crates/engine/src/game/effects/connive.rs
- crates/engine/src/game/effects/gift_delivery.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/game/static_abilities.rs
- crates/engine/src/parser/oracle_static/tests.rs

## CR references
- CR 121.1 (docs/MagicCompRules.txt:1140 - a player draws by putting the TOP card of their library into hand; the default this static overrides)
- CR 121.2 (docs/MagicCompRules.txt:1142 - cards drawn one at a time; each bottom-draw takes the then-current bottommost card, so .rev().take(n) yields the correct order)
- CR 613.11 (docs/MagicCompRules.txt:3046 - continuous effects that affect game RULES rather than objects; River Song's draw redirect is this kind, same as MaximumHandSize)
- CR 704.5b (docs/MagicCompRules.txt:5466 - drawing from an empty library loses the game; empty-library SBA handling stays at the call site, referenced in select_cards_to_draw doc)

## Verification
- `cargo fmt --all` — pass (no changes, nothing to commit)
- `./scripts/check-parser-combinators.sh <merge-base f65d7557>` — pass (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — pass (exit 0, clean; no pre-existing errors surfaced in engine scope)
- `cargo test -p engine` — pass (exit 0, all tests passed, 0 failed)
- `oracle-gen data --filter "river song"` — pass (River Song parses correctly)
Cards confirmed re-parsed correctly: River Song

🤖 Generated with [Claude Code](https://claude.com/claude-code)
