### PR TITLE
feat(engine): The Ruinous Wrecking Crew + Hawkeye, Master Marksman (MSH)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1484,6 +1484,9 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             }
         }
         QuantityRef::ConvokedCreatureCount => "creatures that convoked this spell".into(),
+        QuantityRef::TimesCostPaidThisResolution => {
+            "times the repeated optional cost was paid this resolution".into()
+        }
         QuantityRef::ManaSpentToCast { scope, metric } => {
             format!("mana spent to cast ({scope:?}, {metric:?})")
         }
@@ -5460,7 +5463,20 @@ fn is_modal_header_line(lower: &str) -> bool {
         "choose any number",
         "choose x.",
     ];
-    CHOOSE_PHRASES.iter().any(|p| lower.contains(p))
+    if CHOOSE_PHRASES.iter().any(|p| lower.contains(p)) {
+        return true;
+    }
+    // CR 700.2 + CR 107.3m: a dynamic modal header ("choose up to X —",
+    // "choose up to that many.") plus its bulleted modes is one logical unit;
+    // fold the bullets into the header so a parsed modal (1 parent + N
+    // children) is not miscounted as N+1 dropped Oracle lines. The cap is a
+    // resolution- or cast-time value (CR 107.3m for cast X), not a fixed word.
+    // A loose substring match here cannot false-green a card on its own — the
+    // load-bearing honesty gate is the Modal_DynamicMaxDropped swallow detector,
+    // and a non-modal "choose up to X <nouns>" selection clause has no bullets
+    // to fold (so folding leaves its line count unchanged).
+    const DYNAMIC_CHOOSE_HEADERS: &[&str] = &["choose up to x", "choose up to that many"];
+    DYNAMIC_CHOOSE_HEADERS.iter().any(|p| lower.contains(p))
 }
 
 /// Strip structural formatting prefixes from an Oracle line, returning the
@@ -6436,6 +6452,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ("AdditionalCostPaymentCountFor", Handled)
         }
         QuantityRef::ConvokedCreatureCount => ("ConvokedCreatureCount", Handled),
+        QuantityRef::TimesCostPaidThisResolution => ("TimesCostPaidThisResolution", Handled),
         QuantityRef::ManaSpentToCast { .. } => ("ManaSpentToCast", Handled),
         QuantityRef::EventContextSourceCostX => ("EventContextSourceCostX", Handled),
         QuantityRef::ColorsInCommandersColorIdentity => {
@@ -11214,6 +11231,46 @@ mod tests {
                     \u{2022} Return target nonland permanent card from your graveyard to the battlefield.";
         // 1 modal header; both bullets fold into the header.
         assert_eq!(count_effective_oracle_lines(text), 1);
+    }
+
+    /// CR 700.2 + CR 107.3m: dynamic modal headers ("choose up to X —",
+    /// "choose up to that many.") must fold their bullets like any other modal
+    /// header, so a parsed modal (1 parent + N children) is not miscounted as
+    /// N+1 dropped Oracle lines. Revert discriminator: dropping the
+    /// `DYNAMIC_CHOOSE_HEADERS` arm in `is_modal_header_line` leaves the header
+    /// unrecognized — the Ruinous case returns 6 (not 2) and the "that many"
+    /// case returns 4 (not 1), failing these assertions.
+    #[test]
+    fn count_effective_oracle_lines_folds_dynamic_modal_headers() {
+        // Ruinous shape (em-dash "choose up to X —"): enters line + dynamic
+        // header + 4 bullets → 2 (enters line + folded header).
+        let ruinous = "The Ruinous Wrecking Crew enters with X +1/+1 counters on it.\n\
+                       When The Ruinous Wrecking Crew enters, choose up to X \u{2014}\n\
+                       \u{2022} Discard a card, then draw a card.\n\
+                       \u{2022} Target opponent loses 2 life.\n\
+                       \u{2022} Destroy target token.\n\
+                       \u{2022} Each player sacrifices a creature of their choice.";
+        assert_eq!(count_effective_oracle_lines(ruinous), 2);
+
+        // Hawkeye shape (period "choose up to that many."): dynamic header + 3
+        // bullets → 1 (folded header).
+        let that_many = "Choose up to that many.\n\
+                         \u{2022} Net \u{2014} Target creature can't block this turn.\n\
+                         \u{2022} Explosive \u{2014} Deals 2 damage to target player.\n\
+                         \u{2022} Boomerang \u{2014} Discard a card, then draw a card.";
+        assert_eq!(count_effective_oracle_lines(that_many), 1);
+
+        // Hostile (A1): a NON-modal "choose up to that many <nouns>" selection
+        // clause with 0 bullets is unchanged by the recognizer — there are no
+        // bullets to fold (Heroic Feast text, one paragraph).
+        let heroic_feast = "Choose up to that many target creatures you control. \
+                            Put a +1/+1 counter on each of them.";
+        assert_eq!(count_effective_oracle_lines(heroic_feast), 1);
+
+        // Regression guard: a FIXED "choose up to two —" header still folds its
+        // own 2 bullets (the existing word-cardinal path is unaffected).
+        let fixed = "Choose up to two \u{2014}\n\u{2022} Draw a card.\n\u{2022} You gain 2 life.";
+        assert_eq!(count_effective_oracle_lines(fixed), 1);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4039,6 +4039,10 @@ fn drive_repeated_optional_payment(
     payment_unit.repeat_for = None;
     payment_unit.sub_ability = None;
     payment_unit.optional = false;
+    // Strip any resolution-time condition from the per-iteration payment unit:
+    // the top-level ability's condition (if any) is evaluated once in the
+    // depth==0 prelude and must not re-gate each individual {1} payment.
+    payment_unit.condition = None;
 
     state.pending_repeated_optional_payment = Some(Box::new(PendingRepeatedOptionalPayment {
         payment_unit: Box::new(payment_unit),
@@ -4087,25 +4091,31 @@ pub(super) fn resolve_repeated_optional_payment_choice(
             state.optional_cost_payments_this_resolution = state
                 .optional_cost_payments_this_resolution
                 .saturating_add(1);
-        }
-        if remaining > 0 {
-            // CR 700.2d: offer the next "up to N" payment.
-            let player = payment_unit.controller;
-            let source_id = payment_unit.source_id;
-            let description = payment_unit.description.clone();
-            state.pending_repeated_optional_payment =
-                Some(Box::new(PendingRepeatedOptionalPayment {
-                    payment_unit,
-                    reflexive,
-                    remaining: remaining - 1,
-                }));
-            state.waiting_for = WaitingFor::OptionalEffectChoice {
-                player,
-                source_id,
-                description,
-                may_trigger_key: None,
-            };
-            return Ok(());
+            // CR 118.3 + CR 603.12a: only a payment that actually succeeded can
+            // lead to another "you may pay {1} [again]" offer. A failed payment
+            // — the player accepted but lacked the resources (CR 118.3) — does
+            // not satisfy the "if you do" rider, so the sequence ends here and
+            // the reflexive resolves once with the payments already made (it is
+            // not offered another payment opportunity).
+            if remaining > 0 {
+                // CR 700.2d: offer the next "up to N" payment.
+                let player = payment_unit.controller;
+                let source_id = payment_unit.source_id;
+                let description = payment_unit.description.clone();
+                state.pending_repeated_optional_payment =
+                    Some(Box::new(PendingRepeatedOptionalPayment {
+                        payment_unit,
+                        reflexive,
+                        remaining: remaining - 1,
+                    }));
+                state.waiting_for = WaitingFor::OptionalEffectChoice {
+                    player,
+                    source_id,
+                    description,
+                    may_trigger_key: None,
+                };
+                return Ok(());
+            }
         }
     }
     // CR 603.12a: a decline ends the repeated payment early; either way the

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -21,8 +21,8 @@ use crate::types::ability::{AttackScope, AttackSubject};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
     AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, GameState, LKISnapshot,
-    MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch, WaitingFor,
-    ZoneChangeRecord,
+    MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch,
+    PendingRepeatedOptionalPayment, WaitingFor, ZoneChangeRecord,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
@@ -3955,6 +3955,184 @@ fn has_member_driven_repeat_after_hydration(state: &GameState, ability: &Resolve
     has_member_driven_repeat(&ability_with_event_context_targets(state, ability))
 }
 
+/// CR 603.12a + CR 608.2c: True when this ability is a "you may pay {cost} up to
+/// N times. When you do, [reflexive]" process (Hawkeye, Master Marksman — "Trick
+/// Arrows"). Unlike a generic `repeat_for` loop (one up-front "you may" then N
+/// mandatory iterations), each payment is offered SEPARATELY and the reflexive
+/// triggers exactly once for one-or-more payments, sized by the payment count
+/// (CR 700.2d). Such an ability is driven by `drive_repeated_optional_payment`
+/// instead of the up-front optional gate + `repeated_full_chain` loop. Mirrors
+/// `has_kind_driven_repeat` / `has_member_driven_repeat`.
+///
+/// The cost is restricted to the SYNCHRONOUS mana class (see
+/// `is_synchronous_mana_pay_cost`): the driver pays each iteration in line and
+/// reads the failure flag immediately, so a cost that PAUSES (sets
+/// `WaitingFor::PayAmountChoice` for unannounced-X / pay-any-amount, or returns
+/// `PaymentOutcome::Paused` for interactive `Discard`/`Sacrifice`/replacement
+/// payments) cannot be driven here — it would mis-count K and clobber its own
+/// continuation. Any repeated-optional ability whose cost pauses falls through to
+/// the generic `repeat_for` path and stays honestly unimplemented (no false
+/// green) until the driver gains pause-resume plumbing.
+fn is_repeated_optional_payment(ability: &ResolvedAbility) -> bool {
+    ability.optional
+        && is_synchronous_mana_pay_cost(&ability.effect)
+        && matches!(ability.repeat_for, Some(QuantityExpr::Fixed { .. }))
+        && ability
+            .sub_ability
+            .as_ref()
+            .is_some_and(|sub| sub.condition == Some(AbilityCondition::WhenYouDo))
+}
+
+/// CR 118.1: A `PayCost` whose cost is a pure, fully-static mana cost — the only
+/// resolution-time payment class guaranteed synchronous (auto-tap + pool
+/// deduction returns Paid/Failed, never a `PayAmountChoice`/`Paused` pause).
+/// Excludes:
+/// - mana costs carrying an unannounced `{X}` (which prompt `PayAmountChoice`,
+///   pay.rs `cost_has_x` arm),
+/// - a per-object `scale` (resolution-only multiplier, not the repeated-optional
+///   shape),
+/// - every non-mana `AbilityCost` (Discard/Sacrifice/PayLife/PayEnergy/Composite/
+///   …) — these either branch interactively or pause.
+///
+/// A mana payment intercepted by a payment-replacement effect is the one residual
+/// pause vector; it is outside the current corpus and the predicate cannot see it
+/// at AST time. A future pause-resume driver would lift this.
+fn is_synchronous_mana_pay_cost(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::PayCost {
+            cost: AbilityCost::Mana { cost },
+            scale: None,
+            ..
+        } if !crate::game::casting_costs::cost_has_x(cost)
+    )
+}
+
+/// CR 603.12a: Fire the first per-iteration payment prompt for a
+/// repeated-optional-payment process and stash the continuation. Each
+/// subsequent prompt + the once-after-loop reflexive are driven by
+/// `resolve_repeated_optional_payment_choice` as the player answers each
+/// `DecideOptionalEffect`. Returns having set `WaitingFor::OptionalEffectChoice`
+/// (or, for an "up to 0 times" bound, a no-op resolution with K = 0).
+fn drive_repeated_optional_payment(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+) -> Result<(), EffectError> {
+    // CR 700.2d: the "up to N" payment budget.
+    let n = match &ability.repeat_for {
+        Some(QuantityExpr::Fixed { value }) => (*value).max(0),
+        _ => 0,
+    };
+    let Some(reflexive) = ability.sub_ability.as_ref() else {
+        return Ok(());
+    };
+    if n == 0 {
+        // CR 603.12a: with no payment opportunity, K stays 0 — the reflexive
+        // never triggers and the modal is never offered.
+        return Ok(());
+    }
+    // The PayCost-only unit prompted/paid each iteration: clear `repeat_for` and
+    // `sub_ability` so resolving it neither re-enters this driver nor
+    // re-resolves the reflexive, and clear `optional` (the prompt itself is the
+    // optionality — on accept the payment is performed unconditionally).
+    let mut payment_unit = ability.clone();
+    payment_unit.repeat_for = None;
+    payment_unit.sub_ability = None;
+    payment_unit.optional = false;
+
+    state.pending_repeated_optional_payment = Some(Box::new(PendingRepeatedOptionalPayment {
+        payment_unit: Box::new(payment_unit),
+        reflexive: Box::new((**reflexive).clone()),
+        remaining: (n - 1) as u32,
+    }));
+    state.waiting_for = WaitingFor::OptionalEffectChoice {
+        player: ability.controller,
+        source_id: ability.source_id,
+        description: ability.description.clone(),
+        may_trigger_key: None,
+    };
+    Ok(())
+}
+
+/// CR 603.12a + CR 608.2c: Resume a repeated-optional-payment process for one
+/// `DecideOptionalEffect`. On accept, pay the per-iteration cost (resolution-
+/// time mana payment is synchronous — auto-tap, never pauses) and count it
+/// toward K iff it succeeded; then offer the next payment if budget remains.
+/// On decline (or after the last payment), resolve the reflexive modal exactly
+/// once iff K >= 1. Called by `handle_optional_effect_choice`.
+pub(super) fn resolve_repeated_optional_payment_choice(
+    state: &mut GameState,
+    accept: bool,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Some(pending) = state.pending_repeated_optional_payment.take() else {
+        return Ok(());
+    };
+    let PendingRepeatedOptionalPayment {
+        payment_unit,
+        reflexive,
+        remaining,
+    } = *pending;
+
+    if accept {
+        // CR 608.2c: clear the resolution failure flag before THIS payment so a
+        // prior iteration's failure can't be misread as this payment's outcome
+        // (which would under-count K on a fail-then-succeed sweep).
+        state.cost_payment_failed_flag = false;
+        // CR 118.1: pay the cost. Depth >= 1 keeps the resolution-
+        // local K counter (cleared only by the depth==0 prelude) alive.
+        resolve_ability_chain(state, &payment_unit, events, 1)?;
+        // CR 603.12a: count only successful payments toward K.
+        if !state.cost_payment_failed_flag {
+            state.optional_cost_payments_this_resolution = state
+                .optional_cost_payments_this_resolution
+                .saturating_add(1);
+        }
+        if remaining > 0 {
+            // CR 700.2d: offer the next "up to N" payment.
+            let player = payment_unit.controller;
+            let source_id = payment_unit.source_id;
+            let description = payment_unit.description.clone();
+            state.pending_repeated_optional_payment =
+                Some(Box::new(PendingRepeatedOptionalPayment {
+                    payment_unit,
+                    reflexive,
+                    remaining: remaining - 1,
+                }));
+            state.waiting_for = WaitingFor::OptionalEffectChoice {
+                player,
+                source_id,
+                description,
+                may_trigger_key: None,
+            };
+            return Ok(());
+        }
+    }
+    // CR 603.12a: a decline ends the repeated payment early; either way the
+    // reflexive resolves exactly once iff at least one payment succeeded.
+    finish_repeated_optional_payment(state, &reflexive, events)
+}
+
+/// CR 603.12a: resolve the reflexive modal exactly once iff K >= 1. K == 0 ⇒ no
+/// "do" occurred ⇒ the modal is never offered. Resolved at depth >= 1 so the
+/// `depth == 0` prelude does not zero the K counter before
+/// `modal_choice_for_player` reads it as the dynamic modal cap (CR 700.2d).
+fn finish_repeated_optional_payment(
+    state: &mut GameState,
+    reflexive: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    if state.optional_cost_payments_this_resolution >= 1 {
+        // CR 608.2c: clear the per-iteration failure flag before the reflexive so
+        // a loop-terminating decline can't suppress it. (The WhenYouDo gate is
+        // flag-independent for the reflexive's `GenericEffect`, but clear
+        // defensively for the general class.)
+        state.cost_payment_failed_flag = false;
+        resolve_ability_chain(state, reflexive, events, 1)?;
+    }
+    Ok(())
+}
+
 /// CR 608.2c + CR 609.3: True when a counted repeat loop must wrap scoped
 /// and/or unless-pay instructions (Torment of Hailfire — "Repeat X times.
 /// Each opponent loses 3 life unless …"). The repeat count is the outermost
@@ -4641,6 +4819,13 @@ pub fn resolve_ability_chain(
         // the `engine.rs` apply() clear. (CR 706.2 + CR 706.4 + CR 603.12)
         state.last_effect_counts_by_player.clear();
         state.exiled_from_hand_this_resolution = 0;
+        // CR 603.12a: the repeated-optional-payment count is resolution-local.
+        // Reset it per top-level resolution so a prior Hawkeye/Frillback tap
+        // can't leak K into the next one. MUST be depth-0 only: the
+        // repeated-optional-payment driver resolves its reflexive modal at
+        // depth >= 1 so `modal_choice_for_player` reads the live K before this
+        // prelude can wipe it (CR 700.2d clamp).
+        state.optional_cost_payments_this_resolution = 0;
         // CR 608.2e: The clause-local equalization snapshot is resolution-
         // scoped. It is overwritten per `player_scope` link within a chain
         // (and survives the interactive `EffectZoneChoice` drain, which
@@ -5400,9 +5585,14 @@ fn resolve_chain_body(
     // accept another. Suppress the single up-front gate here; the `repeat_for`
     // loop below fires its own per-iteration `OptionalEffectChoice` for each
     // counter kind (see the `kind_driven` optional path in the loop).
+    // CR 603.12a: a repeated-optional-payment process (Hawkeye) offers its "you
+    // may" PER iteration via `drive_repeated_optional_payment`, not once up
+    // front — suppress the single gate here exactly as the kind/member-driven
+    // loops do.
     if ability.optional
         && !has_kind_driven_repeat(ability)
         && !has_member_driven_repeat_after_hydration(state, ability)
+        && !is_repeated_optional_payment(ability)
     {
         let description = ability.description.clone();
         let prompt_player = optional_prompt_player(state, ability);
@@ -5445,6 +5635,16 @@ fn resolve_chain_body(
             may_trigger_key,
         };
         return Ok(());
+    }
+
+    // CR 603.12a: a "you may pay {cost} up to N times. When you do, [reflexive]"
+    // process drives its own per-iteration payment loop + once-after-loop
+    // reflexive (Hawkeye, Master Marksman). The up-front gate is suppressed for
+    // this class above; resolve it through the dedicated driver here, before the
+    // generic `repeat_for` loop (which would re-resolve the reflexive per
+    // payment).
+    if is_repeated_optional_payment(ability) {
+        return drive_repeated_optional_payment(state, ability);
     }
 
     // CR 118.12 + CR 118.12a: "Effect unless [player] pays {cost}" —
@@ -8218,6 +8418,111 @@ mod tests {
         assert!(
             ability_or_branch_references_tracked_set(&ability),
             "repeat_for: TrackedSetSize must mark the ability as referencing the tracked set"
+        );
+    }
+
+    /// CR 118.1 + CR 603.12a: the repeated-optional-payment driver pays each
+    /// iteration in line and reads the failure flag immediately, so it must admit
+    /// ONLY a pure, static mana `PayCost` (Hawkeye's `{1}`). A PayCost whose cost
+    /// PAUSES — unannounced-`{X}` mana (`WaitingFor::PayAmountChoice`) or an
+    /// interactive `Discard` (`PaymentOutcome::Paused`) — or a per-object `scale`
+    /// must fall through to the generic `repeat_for` path and stay honestly
+    /// unimplemented; driving it would mis-count K and clobber the payment's own
+    /// continuation.
+    ///
+    /// Revert discriminator: widening `is_synchronous_mana_pay_cost` back to a
+    /// bare `matches!(effect, Effect::PayCost { .. })` makes the X-mana, Discard,
+    /// and scaled-mana fixtures satisfy the predicate ⇒ the `!...` assertions fail.
+    #[test]
+    fn repeated_optional_payment_admits_only_synchronous_mana_cost() {
+        use crate::types::ability::{CardSelectionMode, DiscardSelfScope};
+        use crate::types::mana::ManaCostShard;
+
+        fn repeated_optional_with_cost(
+            cost: AbilityCost,
+            scale: Option<QuantityExpr>,
+        ) -> ResolvedAbility {
+            let mut ability = ResolvedAbility::new(
+                Effect::PayCost {
+                    cost,
+                    scale,
+                    payer: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(1),
+                PlayerId(0),
+            );
+            ability.optional = true;
+            ability.repeat_for = Some(QuantityExpr::Fixed { value: 3 });
+            let mut reflexive = ResolvedAbility::new(
+                Effect::GenericEffect {
+                    static_abilities: vec![],
+                    duration: None,
+                    target: None,
+                },
+                vec![],
+                ObjectId(1),
+                PlayerId(0),
+            );
+            reflexive.condition = Some(AbilityCondition::WhenYouDo);
+            ability.sub_ability = Some(Box::new(reflexive));
+            ability
+        }
+
+        // Positive control: Hawkeye's `{1}` — pure static mana, synchronous.
+        let mana = repeated_optional_with_cost(
+            AbilityCost::Mana {
+                cost: ManaCost::generic(1),
+            },
+            None,
+        );
+        assert!(
+            is_repeated_optional_payment(&mana),
+            "pure {{1}} mana is the synchronous repeated-optional class"
+        );
+
+        // Negative: unannounced `{X}` mana pauses via `WaitingFor::PayAmountChoice`.
+        let x_mana = repeated_optional_with_cost(
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::X],
+                    generic: 0,
+                },
+            },
+            None,
+        );
+        assert!(
+            !is_repeated_optional_payment(&x_mana),
+            "{{X}} mana prompts PayAmountChoice — must NOT be driven"
+        );
+
+        // Negative: interactive Discard pauses via `PaymentOutcome::Paused` — the
+        // exact "you may discard a card up to N times" class the driver cannot run.
+        let discard = repeated_optional_with_cost(
+            AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: None,
+                selection: CardSelectionMode::default(),
+                self_scope: DiscardSelfScope::default(),
+            },
+            None,
+        );
+        assert!(
+            !is_repeated_optional_payment(&discard),
+            "interactive Discard pauses — must NOT be driven"
+        );
+
+        // Negative: a per-object `scale` is the resolution-only multiplier shape,
+        // not the repeated-optional shape.
+        let scaled = repeated_optional_with_cost(
+            AbilityCost::Mana {
+                cost: ManaCost::generic(1),
+            },
+            Some(QuantityExpr::Fixed { value: 2 }),
+        );
+        assert!(
+            !is_repeated_optional_payment(&scaled),
+            "scaled mana is not the synchronous repeated-optional class"
         );
     }
 

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -34,7 +34,13 @@ pub(super) fn handle_optional_effect_choice(
     state.cost_payment_failed_flag = false;
     set_active_priority(state);
 
-    if let Some(ability) = state.pending_optional_effect.take() {
+    // CR 603.12a: a repeated-optional-payment process (Hawkeye, Master Marksman)
+    // drives its own per-iteration payment + once-after-loop reflexive modal,
+    // distinct from the generic single up-front optional effect below.
+    if state.pending_repeated_optional_payment.is_some() {
+        effects::resolve_repeated_optional_payment_choice(state, accept, events)
+            .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?;
+    } else if let Some(ability) = state.pending_optional_effect.take() {
         let choice = if accept {
             AutoMayChoice::Accept
         } else {

--- a/crates/engine/src/game/marksman_tests.rs
+++ b/crates/engine/src/game/marksman_tests.rs
@@ -1,0 +1,423 @@
+//! Runtime + parser tests for the repeated-optional-payment + reflexive-modal
+//! driver (Hawkeye, Master Marksman — "Trick Arrows"). CR 603.12a / CR 700.2d.
+//!
+//! These drive the real production seams:
+//! - the parser (`parse_oracle_text`) for the modal AST (B4);
+//! - the production trigger-resolution function (`resolve_ability_chain` at
+//!   depth 0, exactly as the engine resolves a stack trigger) to reach the
+//!   per-iteration `WaitingFor::OptionalEffectChoice`;
+//! - the real action handler (`apply`) for every `DecideOptionalEffect` and
+//!   `SelectModes`, so the changed `WaitingFor`/`GameAction` route is exercised.
+
+#![cfg(test)]
+
+use crate::game::ability_utils::build_resolved_from_def;
+use crate::game::effects::resolve_ability_chain;
+use crate::game::scenario::GameScenario;
+use crate::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use crate::types::ability::{ModalChoice, QuantityExpr, QuantityRef, TargetRef};
+use crate::types::actions::GameAction;
+use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::mana::{ManaType, ManaUnit};
+use crate::types::player::PlayerId;
+use crate::types::triggers::TriggerMode;
+
+const HAWKEYE_ORACLE: &str = "First strike, reach\n\
+     Trick Arrows — Whenever Hawkeye becomes tapped, you may pay {1} up to three times. \
+     When you do, choose up to that many.\n\
+     • Net — Target creature can't block this turn.\n\
+     • Explosive — Hawkeye deals 2 damage to target player.\n\
+     • Boomerang — Discard a card, then draw a card.";
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+fn parse_hawkeye() -> ParsedAbilities {
+    parse_oracle_text(
+        HAWKEYE_ORACLE,
+        "Hawkeye, Master Marksman",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &[],
+    )
+}
+
+/// The reflexive sub-ability's modal (`when you do, choose up to that many`).
+fn hawkeye_reflexive_modal(parsed: &ParsedAbilities) -> ModalChoice {
+    let taps = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Taps)
+        .expect("Hawkeye has a Taps trigger");
+    let execute = taps.execute.as_ref().expect("Taps trigger has an execute");
+    let reflexive = execute
+        .sub_ability
+        .as_ref()
+        .expect("PayCost has a reflexive sub-ability");
+    reflexive
+        .modal
+        .clone()
+        .expect("reflexive sub carries a modal")
+}
+
+// ── B4 parser: the modal carries the resolution-local dynamic cap ────────
+
+/// Revert discriminator: dropping the `"choose up to that many"` parser arm (or
+/// the `ModalCountSpec::Dynamic { qty }` wiring) leaves the modal at the fixed
+/// `(1, 1)` default with `dynamic_max_choices == None`, failing every assertion.
+#[test]
+fn hawkeye_modal_parses_with_resolution_local_dynamic_cap() {
+    let parsed = parse_hawkeye();
+    let modal = hawkeye_reflexive_modal(&parsed);
+
+    assert_eq!(modal.min_choices, 0, "min is 0 — may choose no modes");
+    assert_eq!(modal.mode_count, 3, "Net / Explosive / Boomerang");
+    assert_eq!(
+        modal.dynamic_max_choices,
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::TimesCostPaidThisResolution
+        }),
+        "the cap binds to the resolution-local repeated-payment count"
+    );
+}
+
+// ── Runtime harness ─────────────────────────────────────────────────────
+
+/// Hawkeye on P0's battlefield with `mana` colorless mana in pool, the Taps
+/// trigger resolved through the production resolver (depth 0). Leaves the engine
+/// at the first per-iteration `WaitingFor::OptionalEffectChoice`.
+fn hawkeye_runtime(mana: usize, p0_hand: &[&str]) -> crate::game::scenario::GameRunner {
+    let mut scenario = GameScenario::new();
+    scenario.with_life(P1, 20);
+    if !p0_hand.is_empty() {
+        scenario.with_cards_in_hand(P0, p0_hand);
+    }
+    let hawkeye = scenario
+        .add_creature_from_oracle(P0, "Hawkeye, Master Marksman", 3, 3, HAWKEYE_ORACLE)
+        .id();
+    if mana > 0 {
+        scenario.with_mana_pool(
+            P0,
+            vec![
+                ManaUnit::new(
+                    ManaType::Colorless,
+                    crate::types::identifiers::ObjectId(9_999),
+                    false,
+                    vec![]
+                );
+                mana
+            ],
+        );
+    }
+    let mut runner = scenario.build();
+
+    // Resolve the Taps trigger exactly as the engine resolves a stack trigger:
+    // `resolve_ability_chain` at depth 0 (the production trigger-resolution
+    // path). This builds the per-iteration `OptionalEffectChoice` from the real
+    // parsed ability — no hand-built `WaitingFor`.
+    let parsed = parse_hawkeye();
+    let taps = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Taps)
+        .unwrap();
+    let execute = taps.execute.as_ref().unwrap();
+    let resolved = build_resolved_from_def(execute, hawkeye, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("trigger resolution");
+    let _ = hawkeye;
+    runner
+}
+
+fn decide(runner: &mut crate::game::scenario::GameRunner, accept: bool) {
+    runner
+        .act(GameAction::DecideOptionalEffect { accept })
+        .expect("DecideOptionalEffect accepted");
+}
+
+fn k_count(state: &GameState) -> u32 {
+    state.optional_cost_payments_this_resolution
+}
+
+fn modal_cap(state: &GameState) -> Option<(usize, usize)> {
+    match &state.waiting_for {
+        WaitingFor::AbilityModeChoice { modal, .. } => Some((modal.min_choices, modal.max_choices)),
+        _ => None,
+    }
+}
+
+// ── B-i / B-ii / B-iii: K accounting, dynamic cap, reflexive K-gate ─────
+
+/// Paying three times captures K = 3 and the reflexive is offered exactly once
+/// with a modal capped at `min(K, mode_count) == 3`, `min_choices == 0`.
+/// Revert discriminator: dropping the K increment in
+/// `resolve_repeated_optional_payment_choice` leaves K = 0 ⇒ cap 0; dropping
+/// the B4 dynamic-max wiring pins the cap at the fixed (1,1).
+#[test]
+fn pay_three_times_caps_modal_at_three_and_offers_reflexive_once() {
+    let mut runner = hawkeye_runtime(3, &[]);
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "first payment prompt is offered"
+    );
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+    // Still a payment prompt before the third accept (not yet the modal).
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+    ));
+    decide(&mut runner, true);
+
+    assert_eq!(k_count(runner.state()), 3, "three successful payments");
+    assert_eq!(
+        modal_cap(runner.state()),
+        Some((0, 3)),
+        "reflexive modal offered once, capped at min(K, 3) with min 0"
+    );
+    // CR 118.3a: the three {1} payments drained the mana pool.
+    let pool_left: usize = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.mana_pool.total())
+        .unwrap_or(0);
+    assert_eq!(pool_left, 0, "all three {{1}} payments were made");
+}
+
+/// Paying twice then declining ends the loop early at K = 2; the reflexive modal
+/// is offered once capped at 2. Revert discriminator: dropping the B4 dynamic
+/// cap pins it at (1,1); not stopping on decline would prompt a third payment.
+#[test]
+fn pay_twice_then_decline_caps_modal_at_two() {
+    let mut runner = hawkeye_runtime(3, &[]);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+    decide(&mut runner, false); // decline the third — stop early
+
+    assert_eq!(k_count(runner.state()), 2);
+    assert_eq!(modal_cap(runner.state()), Some((0, 2)));
+}
+
+/// CR 603.12a: declining every payment leaves K = 0 — the reflexive NEVER fires
+/// and the modal is never offered. Revert discriminator: removing the `K >= 1`
+/// guard in `finish_repeated_optional_payment` resolves the reflexive at K = 0,
+/// surfacing an `AbilityModeChoice` and failing this assertion.
+#[test]
+fn decline_immediately_skips_reflexive_at_k_zero() {
+    let mut runner = hawkeye_runtime(3, &[]);
+    decide(&mut runner, false);
+
+    assert_eq!(k_count(runner.state()), 0);
+    assert!(
+        modal_cap(runner.state()).is_none(),
+        "no modal is offered when K == 0: {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        runner.state().pending_repeated_optional_payment.is_none(),
+        "the repeated-payment continuation is cleared"
+    );
+}
+
+/// K counts only SUCCESSFUL payments: with funding for a single {1}, the first
+/// accept pays (K=1) and the second accept fails (insufficient mana, K stays 1).
+/// Revert discriminator: dropping the `if !cost_payment_failed_flag` guard counts
+/// the failed payment, yielding K=2 and a modal cap of 2 instead of 1.
+#[test]
+fn k_counts_only_successful_payments() {
+    let mut runner = hawkeye_runtime(1, &[]);
+    decide(&mut runner, true); // pays {1} — K = 1
+    decide(&mut runner, true); // no mana left — payment fails, K stays 1
+    decide(&mut runner, false); // stop
+
+    assert_eq!(
+        k_count(runner.state()),
+        1,
+        "only the funded payment counts toward K"
+    );
+    assert_eq!(modal_cap(runner.state()), Some((0, 1)));
+}
+
+// ── B-iv: a chosen mode resolves; reflexive resolves exactly once ───────
+
+/// Choosing the Boomerang mode once resolves it exactly once (discard a card,
+/// then draw a card — net hand size unchanged), and the resolution settles
+/// without offering a second modal. Drives `SelectModes` through `apply`.
+/// Revert discriminator: resolving the reflexive per payment (the old
+/// `repeated_full_chain` path) would offer the modal three times.
+#[test]
+fn boomerang_mode_resolves_once_through_apply() {
+    let mut runner = hawkeye_runtime(3, &["Mountain", "Forest"]);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+
+    // The reflexive modal is offered once. Boomerang is mode index 2.
+    assert_eq!(modal_cap(runner.state()), Some((0, 3)));
+    let hand_before = p0_hand_size(runner.state());
+
+    runner
+        .act(GameAction::SelectModes { indices: vec![2] })
+        .expect("SelectModes accepted");
+
+    // Boomerang = discard 1, then draw 1 → net hand size unchanged, and no
+    // second modal is offered (reflexive resolved exactly once).
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::AbilityModeChoice { .. }
+        ),
+        "no second modal after the single reflexive resolves"
+    );
+    assert_eq!(
+        p0_hand_size(runner.state()),
+        hand_before,
+        "Boomerang discards one then draws one (net 0)"
+    );
+}
+
+/// CR 700.2b + CR 120.3: choosing a TARGETED reflexive mode (Explosive — "Hawkeye
+/// deals 2 damage to target player") resolves exactly once with correct targeting
+/// after the K-payment sweep. Drives `SelectModes` then `ChooseTarget` through
+/// `apply`; closes the targeted-mode coverage gap (Boomerang is the no-target
+/// case). Revert discriminator: resolving the reflexive per payment (the old
+/// `repeated_full_chain` path) would deal 2 damage three times (P1 → 14) and/or
+/// re-offer the modal; the single post-loop reflexive deals exactly 2 (P1 → 18).
+#[test]
+fn explosive_targeted_mode_resolves_once_through_apply() {
+    let mut runner = hawkeye_runtime(3, &[]);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+
+    assert_eq!(modal_cap(runner.state()), Some((0, 3)));
+    assert_eq!(
+        p1_life(runner.state()),
+        20,
+        "no damage before the mode resolves"
+    );
+
+    // Explosive is mode index 1 (Net = 0, Explosive = 1, Boomerang = 2).
+    runner
+        .act(GameAction::SelectModes { indices: vec![1] })
+        .expect("SelectModes accepted");
+
+    // A targeted triggered mode surfaces a per-target prompt.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::TriggerTargetSelection { .. }
+        ),
+        "Explosive needs a target player, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Player(P1)),
+        })
+        .expect("ChooseTarget accepted");
+
+    // The reflexive Explosive ability is on the stack with its target bound;
+    // resolve it through the real priority/stack machinery.
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        p1_life(runner.state()),
+        18,
+        "Explosive deals exactly 2 damage once (not 2×K)"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::AbilityModeChoice { .. }
+        ),
+        "no second modal after the single reflexive resolves"
+    );
+}
+
+/// Fix 1 (HIGH) — CR 603.12a + CR 700.2d: at the per-iteration
+/// `OptionalEffectChoice` pause, K (`optional_cost_payments_this_resolution`) is
+/// already nonzero and the paired `pending_repeated_optional_payment` continuation
+/// is `Some`. That pause spans separate `apply()` calls and is a serde boundary
+/// (server crash/restart via `to_persisted`/`from_persisted`, single-player
+/// save/load, multiplayer host-resume). K must survive it — a roundtrip restoring
+/// K = 0 collapses the reflexive modal cap below the payments actually made,
+/// denying the player modes they paid for.
+///
+/// Non-vacuity (MEASURED): with the field at `#[serde(skip, default)]` the
+/// roundtrip restores K = 0, so resuming with a decline runs
+/// `finish_repeated_optional_payment` at K = 0 → the reflexive is SKIPPED and no
+/// modal is offered. Measured left/right under that revert: `restored.K` = `0`
+/// vs expected `2`, and the resumed cap = `None` vs expected `Some((0, 2))`.
+#[test]
+fn k_counter_survives_serde_roundtrip_mid_payment_loop() {
+    let mut runner = hawkeye_runtime(3, &[]);
+    decide(&mut runner, true);
+    decide(&mut runner, true);
+    // Paused at the third payment prompt: K = 2, continuation pending.
+    assert_eq!(k_count(runner.state()), 2);
+    assert!(runner.state().pending_repeated_optional_payment.is_some());
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+    ));
+
+    // Serialize across the pause (the persistence boundary) and restore.
+    let json = serde_json::to_string(runner.state()).expect("serialize paused state");
+    let restored: GameState = serde_json::from_str(&json).expect("deserialize paused state");
+    assert_eq!(
+        restored.optional_cost_payments_this_resolution, 2,
+        "K must survive the mid-payment-loop serde boundary"
+    );
+    assert!(
+        restored.pending_repeated_optional_payment.is_some(),
+        "the paired continuation also survives"
+    );
+    // K is eq-INCLUDED: a state differing only in K is no longer equal. Revert
+    // discriminator: removing K from `PartialEq` makes these compare equal, so an
+    // AI-search dedup or save-equality check would treat two different payment
+    // counts as identical.
+    let mut k_perturbed = restored.clone();
+    k_perturbed.optional_cost_payments_this_resolution = 99;
+    assert_ne!(
+        k_perturbed, restored,
+        "K participates in PartialEq (states differing only in K are unequal)"
+    );
+
+    // Resume from the RESTORED state and decline the third payment. The reflexive
+    // modal cap must reflect the two payments already made (CR 700.2d), proving K
+    // survived: a lost K would skip the reflexive entirely.
+    *runner.state_mut() = restored;
+    decide(&mut runner, false);
+    assert_eq!(
+        modal_cap(runner.state()),
+        Some((0, 2)),
+        "resumed reflexive cap = min(K = 2, mode_count = 3)"
+    );
+}
+
+fn p0_hand_size(state: &GameState) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.hand.len())
+        .unwrap_or(0)
+}
+
+fn p1_life(state: &GameState) -> i32 {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .map(|p| p.life)
+        .unwrap_or(0)
+}

--- a/crates/engine/src/game/marksman_tests.rs
+++ b/crates/engine/src/game/marksman_tests.rs
@@ -226,23 +226,42 @@ fn decline_immediately_skips_reflexive_at_k_zero() {
     );
 }
 
-/// K counts only SUCCESSFUL payments: with funding for a single {1}, the first
-/// accept pays (K=1) and the second accept fails (insufficient mana, K stays 1).
-/// Revert discriminator: dropping the `if !cost_payment_failed_flag` guard counts
-/// the failed payment, yielding K=2 and a modal cap of 2 instead of 1.
+/// K counts only SUCCESSFUL payments, AND a failed payment ENDS the repeated
+/// sequence. CR 118.3: a player can't pay a cost without the resources to pay it
+/// fully. CR 603.12a: the "you may pay {1} [again]" rider is satisfied only by a
+/// payment that actually happened. With funding for a single {1}, the first
+/// accept pays (K=1); the second accept fails for lack of mana, so the loop
+/// terminates immediately and the reflexive modal is offered exactly once, capped
+/// at K=1 — NO third payment prompt is offered.
+///
+/// Discriminators: (a) dropping the `if !cost_payment_failed_flag` K-guard counts
+/// the failed payment, yielding K=2 and a cap of 2; (b) the pre-fix behavior of
+/// offering another prompt after a failed payment (the `if remaining > 0` branch
+/// running regardless of `cost_payment_failed_flag`) leaves
+/// `pending_repeated_optional_payment` Some with no modal offered, failing the
+/// termination + cap assertions below.
 #[test]
-fn k_counts_only_successful_payments() {
+fn failed_payment_ends_sequence_and_offers_reflexive_once() {
     let mut runner = hawkeye_runtime(1, &[]);
     decide(&mut runner, true); // pays {1} — K = 1
-    decide(&mut runner, true); // no mana left — payment fails, K stays 1
-    decide(&mut runner, false); // stop
+    decide(&mut runner, true); // accept, but no mana left — payment FAILS → loop ends
 
     assert_eq!(
         k_count(runner.state()),
         1,
         "only the funded payment counts toward K"
     );
-    assert_eq!(modal_cap(runner.state()), Some((0, 1)));
+    assert!(
+        runner.state().pending_repeated_optional_payment.is_none(),
+        "a failed payment terminates the repeated-payment sequence — no further \
+         payment prompt is offered: {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        modal_cap(runner.state()),
+        Some((0, 1)),
+        "the reflexive modal is offered exactly once, capped at K=1"
+    );
 }
 
 // ── B-iv: a chosen mode resolves; reflexive resolves exactly once ───────

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -79,6 +79,9 @@ pub mod meld;
 // Tests for `meld` live in a sibling file (declared here, not in `meld.rs`,
 // so `meld.rs` stays implementation-only).
 #[cfg(test)]
+#[path = "marksman_tests.rs"]
+mod marksman_tests;
+#[cfg(test)]
 #[path = "meld_tests.rs"]
 mod meld_tests;
 pub mod merge;

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -407,6 +407,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::AdditionalCostPaymentCount
         | QuantityRef::AdditionalCostPaymentCountFor { .. }
         | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::TimesCostPaidThisResolution
         | QuantityRef::ManaSpentToCast { .. }
         | QuantityRef::ColorsInCommandersColorIdentity
         | QuantityRef::VoteCount { .. }
@@ -655,6 +656,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::AdditionalCostPaymentCount
         | QuantityRef::AdditionalCostPaymentCountFor { .. }
         | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::TimesCostPaidThisResolution
         | QuantityRef::ManaSpentToCast { .. }
         | QuantityRef::ColorsInCommandersColorIdentity
         | QuantityRef::VoteCount { .. }
@@ -838,6 +840,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::AdditionalCostPaymentCount
         | QuantityRef::AdditionalCostPaymentCountFor { .. }
         | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::TimesCostPaidThisResolution
         | QuantityRef::ManaSpentToCast { .. }
         | QuantityRef::ColorsInCommandersColorIdentity
         | QuantityRef::VoteCount { .. }
@@ -2887,6 +2890,15 @@ fn resolve_ref(
             .get(&ctx.self_object())
             .map(|obj| usize_to_i32_saturating(obj.convoked_creatures.len()))
             .unwrap_or(0),
+        // CR 603.12a: Number of times the controller paid the repeated optional
+        // cost during THIS resolution. Resolution-local transient on the
+        // GameState (cleared at the depth==0 prelude of resolve_ability_chain,
+        // incremented once per successful payment); never read from an object,
+        // never snapshotted. Sizes the reflexive "choose up to that many" modal
+        // cap (CR 700.2d clamps it to mode_count).
+        QuantityRef::TimesCostPaidThisResolution => {
+            u32_to_i32_saturating(state.optional_cost_payments_this_resolution)
+        }
         // CR 603.10a + CR 603.6e: Count attachments present on the leaving object
         // at zone-change time (look-back). Reads the `attachments` snapshot on
         // the `ZoneChanged` event in `current_trigger_event`, filtered by kind

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6583,6 +6583,7 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::AdditionalCostPaymentCount
         | QuantityRef::AdditionalCostPaymentCountFor { .. }
         | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::TimesCostPaidThisResolution
         | QuantityRef::ColorsInCommandersColorIdentity
         | QuantityRef::CommanderCastFromCommandZoneCount
         | QuantityRef::CommanderManaValue { .. }

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1,7 +1,7 @@
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::multispace0;
+use nom::character::complete::{alpha1, multispace0};
 use nom::combinator::{map, not, opt, success, value};
 use nom::multi::fold_many1;
 use nom::sequence::{delimited, preceded, terminated};
@@ -593,19 +593,15 @@ pub(crate) fn parse_modal_header_ast(text: &str) -> Option<ModalHeaderAst> {
             .unwrap_or(ModalCountSpec::Fixed { min: 1, max: 1 })
     };
 
-    // CR 700.2 + CR 107.3m: a `DynamicCostX` ("choose up to X —") header has
-    // min 0 (decline all modes) and a placeholder max of `usize::MAX` that
-    // `build_modal_choice` clamps to `mode_count`; the live cap is carried in
-    // `dynamic_max_choices` and resolved at runtime from the cast {X}.
+    // CR 700.2 + CR 107.3m / CR 603.12a: a `Dynamic { qty }` header ("choose up
+    // to X / up to that many") has min 0 (decline all modes) and a placeholder
+    // max of `usize::MAX` that `build_modal_choice` clamps to `mode_count`; the
+    // live cap is carried in `dynamic_max_choices` and resolved at runtime from
+    // `qty` (cast {X} for CostXPaid, or the resolution-local repeated-payment
+    // count for TimesCostPaidThisResolution).
     let (min_choices, max_choices, dynamic_max_choices) = match count_spec {
         ModalCountSpec::Fixed { min, max } => (min, max, None),
-        ModalCountSpec::DynamicCostX => (
-            0,
-            usize::MAX,
-            Some(QuantityExpr::Ref {
-                qty: QuantityRef::CostXPaid,
-            }),
-        ),
+        ModalCountSpec::Dynamic { qty } => (0, usize::MAX, Some(QuantityExpr::Ref { qty })),
     };
     let mut allow_repeat_modes = false;
     let mut constraints = Vec::new();
@@ -1655,13 +1651,27 @@ pub(super) fn extract_ability_word_reminder_body(raw: &str) -> Option<String> {
 }
 
 /// CR 700.2: The recognized shape of a modal header's count phrase. `Fixed`
-/// holds a statically-resolved `(min, max)` pair; `DynamicCostX` marks a
-/// "choose up to X —" header whose maximum resolves at runtime from the cast
-/// {X} (CR 107.3m) and is clamped to `mode_count` (CR 700.2d).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// holds a statically-resolved `(min, max)` pair; `Dynamic { qty }` marks a
+/// "choose up to X / up to that many" header whose maximum resolves at runtime
+/// from `qty` and is clamped to `mode_count` (CR 700.2d). `qty` is
+/// `CostXPaid` for the cast-{X} subclass (CR 107.3m, The Ruinous Wrecking Crew)
+/// and `TimesCostPaidThisResolution` for the repeated-optional-payment subclass
+/// (CR 603.12a, Hawkeye, Master Marksman). LOW-1: `Copy` is dropped because
+/// `QuantityRef` is not `Copy`.
+///
+/// Known coverage gap (empty in the current corpus): the
+/// `TimesCostPaidThisResolution` cap is emitted cost-agnostically here, but the
+/// runtime driver (`is_synchronous_mana_pay_cost`, effects/mod.rs) only handles a
+/// pure static-mana repeated cost. A future "choose up to that many." +
+/// `WhenYouDo` card whose repeated cost is non-mana / X-mana would parse a cap
+/// (so the `Modal_DynamicMaxDropped` swallow-detector stays silent ⇒ "supported")
+/// yet fall to the generic `repeat_for` path with the wrong cap — a false-green.
+/// Before such a card lands: cross-check the carrying ability's cost is
+/// synchronous mana in the coverage detector, or add driver pause-resume plumbing.
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ModalCountSpec {
     Fixed { min: usize, max: usize },
-    DynamicCostX,
+    Dynamic { qty: QuantityRef },
 }
 
 /// Scan for modal count override phrases at word boundaries using nom combinators.
@@ -1711,10 +1721,35 @@ fn scan_modal_count_override(text: &str) -> Option<ModalCountSpec> {
             // `dynamic_max_choices` is a follow-up; this PR's scope is the
             // cast-{X} subclass (The Ruinous Wrecking Crew).
             value(
-                ModalCountSpec::DynamicCostX,
+                ModalCountSpec::Dynamic {
+                    qty: QuantityRef::CostXPaid,
+                },
                 terminated(
                     tag::<_, _, OracleError<'_>>("choose up to x"),
                     not(preceded((opt(tag(",")), multispace0), tag("where"))),
+                ),
+            ),
+            // CR 603.12a + CR 700.2d: "choose up to that many." (Hawkeye, Master
+            // Marksman) caps the modal at the resolution-local count of repeated
+            // optional payments. MED-1: match the PERIOD/bare/bullet-terminated
+            // header form ONLY — the negative lookahead rejects a following
+            // em-dash (Tranquil Frillback's "choose up to that many —", whose
+            // reflexive condition is NOT WhenYouDo and so is not handled by the
+            // repeated-optional-payment driver) and a following noun phrase (the
+            // non-modal selection clauses "choose up to that many target
+            // creatures you control" / "...creatures tapped this way"). Only a
+            // clean termination (period / end / bullet) yields the dynamic cap,
+            // so an unhandled card is never silently false-greened.
+            value(
+                ModalCountSpec::Dynamic {
+                    qty: QuantityRef::TimesCostPaidThisResolution,
+                },
+                terminated(
+                    tag::<_, _, OracleError<'_>>("choose up to that many"),
+                    not(preceded(
+                        multispace0,
+                        alt((tag("\u{2014}"), tag("\u{2013}"), tag("-"), alpha1)),
+                    )),
                 ),
             ),
             // CR 700.2a / CR 700.2d: "choose up to N —" is a modal header where
@@ -1939,14 +1974,56 @@ mod tests {
         );
     }
 
-    // CR 700.2 + CR 107.3m: "choose up to X —" is a DynamicCostX header, not a
-    // numeric fixed cap. `parse_number` fails on bare "x" so it cannot shadow
+    // CR 700.2 + CR 107.3m: "choose up to X —" is a cast-{X} dynamic header, not
+    // a numeric fixed cap. `parse_number` fails on bare "x" so it cannot shadow
     // the numeric "choose up to N" arm.
     #[test]
     fn parse_modal_choose_count_up_to_x_is_dynamic() {
         assert_eq!(
             parse_modal_choose_count("choose up to x —"),
-            ModalCountSpec::DynamicCostX
+            ModalCountSpec::Dynamic {
+                qty: QuantityRef::CostXPaid
+            }
+        );
+    }
+
+    // CR 603.12a + CR 700.2d: "choose up to that many." (Hawkeye, period/bare
+    // form) is the repeated-optional-payment dynamic header. Revert
+    // discriminator: dropping the new `value()/tag()` arm makes this fall to the
+    // fixed `(1, 1)` default (`fixed(1, 1)`), failing the assertion.
+    #[test]
+    fn parse_modal_choose_count_up_to_that_many_period_is_dynamic() {
+        assert_eq!(
+            parse_modal_choose_count("choose up to that many"),
+            ModalCountSpec::Dynamic {
+                qty: QuantityRef::TimesCostPaidThisResolution
+            }
+        );
+        assert_eq!(
+            parse_modal_choose_count("choose up to that many."),
+            ModalCountSpec::Dynamic {
+                qty: QuantityRef::TimesCostPaidThisResolution
+            }
+        );
+    }
+
+    // MED-1 guard: the "that many" arm must NOT match the em-dash header
+    // (Tranquil Frillback, whose reflexive condition is not WhenYouDo and so is
+    // not handled by the repeated-optional-payment driver — matching it would
+    // false-green an unhandled card) nor the non-modal selection clauses
+    // ("choose up to that many target creatures you control"). These fall to the
+    // fixed default. Revert the negative lookahead → both wrongly become Dynamic.
+    #[test]
+    fn parse_modal_choose_count_up_to_that_many_em_dash_and_noun_are_not_dynamic() {
+        // Tranquil Frillback (em-dash continuation).
+        assert_eq!(
+            parse_modal_choose_count("choose up to that many \u{2014}"),
+            fixed(1, 1)
+        );
+        // Heroic Feast (non-modal selection clause).
+        assert_eq!(
+            parse_modal_choose_count("choose up to that many target creatures you control"),
+            fixed(1, 1)
         );
     }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -115,6 +115,7 @@ pub fn check_swallowed_clauses(
     detect_duration_next_turn(&cleaned, oracle_text, &ast_json, diagnostics);
     detect_optional_may_have(&cleaned, oracle_text, &ast_json, diagnostics);
     detect_apnap(&cleaned, oracle_text, &ast_json, diagnostics);
+    detect_modal_dynamic_max_dropped(&cleaned, oracle_text, &ast_json, diagnostics);
 }
 
 // ── Detector A: Replacement_Instead ─────────────────────────────────────
@@ -1544,6 +1545,71 @@ fn detect_dynamic_qty(
     });
 }
 
+// ── Detector M: Modal_DynamicMaxDropped ─────────────────────────────────
+
+/// CR 700.2 + CR 700.2d: a "choose up to X / up to that many" MODAL header
+/// whose dynamic cap was not captured (a `"modal":{` node exists but its
+/// `dynamic_max_choices` is None) silently mis-sizes the modal — the player
+/// would be locked to the fixed `mode_count` cap instead of the dynamic
+/// "up to X" / "up to that many" cap. Surface it so coverage stays honest.
+///
+/// The `"modal":{` gate excludes non-modal "choose up to X <nouns>" selection
+/// clauses (Heroic Feast: "choose up to that many target creatures you
+/// control"; Temporal Firestorm: "choose up to X creatures ... where X is ..."):
+/// those parse to a quantified target/selection, not a modal node, so no
+/// `"modal":{` appears and this detector stays silent on them.
+///
+/// Keys on serialized-field presence:
+/// - `modal` (`AbilityDefinitionRepr`, ability.rs:13381) is omitted when None
+///   via `skip_serializing_if`, so `"modal":{` is an exact proxy for "a modal
+///   node was parsed" (there is no `"modal":null` form to confuse it).
+/// - `dynamic_max_choices` (ability.rs:12925) carries
+///   `#[serde(default, skip_serializing_if = "Option::is_none")]`, so it is
+///   omitted when None; ABSENCE of `"dynamic_max_choices":{` means the dynamic
+///   cap was dropped (there is no `:null` form to test).
+///
+/// CONSERVATIVE-RED LIMITATION (deliberate, never false-green): the three gates
+/// are independent whole-text / whole-AST scans, not a per-node association. A
+/// single card carrying BOTH (a) an UNRELATED fixed modal node (gate 2) AND (b)
+/// a SEPARATE non-modal "choose up to X <nouns>" selection clause elsewhere in
+/// its text (gate 1) would fire even though its fixed modal's cap was never
+/// meant to be dynamic. This errs toward RED — it understates coverage, never
+/// over-states it — so a card so flagged stays honestly unsupported rather than
+/// being marked green without a working dynamic cap. No such card exists in the
+/// current corpus (the modal-bearing dynamic-header cards — Hawkeye, Tranquil
+/// Frillback, Bumi, Riku — each have the header ON the modal itself). Tightening
+/// to a per-node "the header terminates the modal node, not a noun phrase"
+/// association would duplicate the parser's `oracle_modal` negative-lookahead in
+/// audit code and risk regressing the measured Frillback/Hawkeye discrimination;
+/// it is intentionally NOT done while the false-RED set is empty.
+fn detect_modal_dynamic_max_dropped(
+    cleaned: &str,
+    original: &str,
+    ast_json: &str,
+    diagnostics: &mut Vec<OracleDiagnostic>,
+) {
+    // (1) Oracle carries a dynamic modal header (the "choose " lead is intrinsic
+    //     to both markers).
+    let has_dynamic_header = cleaned.contains("choose up to that many") // allow-noncombinator: swallow detector marker scan on classified text
+        || cleaned.contains("choose up to x"); // allow-noncombinator: swallow detector marker scan on classified text
+    if !has_dynamic_header {
+        return;
+    }
+    // (2) A modal node was parsed (excludes non-modal selection clauses).
+    if !json_has_any(ast_json, &["\"modal\":{"]) {
+        return;
+    }
+    // (3) ...but it carries no dynamic cap — the "up to X / that many" was lost.
+    if json_has_any(ast_json, &["\"dynamic_max_choices\":{"]) {
+        return;
+    }
+    diagnostics.push(OracleDiagnostic::SwallowedClause {
+        detector: "Modal_DynamicMaxDropped".into(),
+        description: truncate(original, 140).into(),
+        line_index: 0,
+    });
+}
+
 /// CR 701.38: True when every dynamic-quantity marker in `cleaned` belongs to a
 /// Council's-dilemma vote tally — "[equal to [twice|N times] ]the number of
 /// <choice> votes". Such tallies are realized by the Vote resolver's per-vote
@@ -2940,6 +3006,150 @@ mod tests {
         def.sub_ability
             .as_deref()
             .and_then(find_search_outside_game)
+    }
+
+    // ── Modal_DynamicMaxDropped (Sub-plan A) ────────────────────────────
+
+    /// Core gate (positive): a `"modal":{` node with no `"dynamic_max_choices":{`
+    /// and a dynamic header marker fires the detector. Revert discriminator:
+    /// removing the `diagnostics.push` in `detect_modal_dynamic_max_dropped`
+    /// (or gate (1)/(2)/(3)) drops the diagnostic and fails this assertion.
+    #[test]
+    fn modal_dynamic_max_dropped_fires_on_modal_without_dynamic_cap() {
+        let ast_json =
+            r#"{"abilities":[{"modal":{"min_choices":1,"max_choices":1,"mode_count":3}}]}"#;
+        let mut diags = Vec::new();
+        super::detect_modal_dynamic_max_dropped(
+            "when you do, choose up to that many",
+            "When you do, choose up to that many.",
+            ast_json,
+            &mut diags,
+        );
+        assert!(
+            diags.iter().any(|d| matches!(
+                d,
+                OracleDiagnostic::SwallowedClause { detector, .. }
+                    if detector == "Modal_DynamicMaxDropped"
+            )),
+            "detector must fire when a modal node lacks a dynamic cap: {diags:?}"
+        );
+    }
+
+    /// Negative (a) — Ruinous shape: a modal node that DOES carry
+    /// `"dynamic_max_choices":{` is silent (the cap was captured). Proves the
+    /// detector keys on the AST cap, not the phrase. Revert gate (3) → fires.
+    #[test]
+    fn modal_dynamic_max_dropped_silent_when_dynamic_cap_present() {
+        let ast_json = r#"{"abilities":[{"modal":{"min_choices":0,"max_choices":3,"mode_count":3,"dynamic_max_choices":{"type":"Ref","qty":"CostXPaid"}}}]}"#;
+        let mut diags = Vec::new();
+        super::detect_modal_dynamic_max_dropped(
+            "choose up to x",
+            "Choose up to X —",
+            ast_json,
+            &mut diags,
+        );
+        assert!(
+            diags.is_empty(),
+            "must stay silent when dynamic_max_choices is present: {diags:?}"
+        );
+    }
+
+    /// Negative (b) — A1 fix: a NON-modal "choose up to X <nouns>" selection
+    /// clause has no `"modal":{` node, so the detector is silent even though
+    /// the dynamic header marker is present. Revert gate (2) → false-fires on
+    /// Heroic Feast / Temporal Firestorm.
+    #[test]
+    fn modal_dynamic_max_dropped_silent_without_modal_node() {
+        let ast_json = r#"{"abilities":[{"effect":{"type":"PutCounter","count":{"type":"Ref","qty":"CostXPaid"}}}]}"#;
+        let mut diags = Vec::new();
+        super::detect_modal_dynamic_max_dropped(
+            "choose up to that many target creatures you control",
+            "Choose up to that many target creatures you control.",
+            ast_json,
+            &mut diags,
+        );
+        assert!(
+            diags.is_empty(),
+            "must stay silent without a modal node (A1 gate): {diags:?}"
+        );
+    }
+
+    /// Registration + real-pipeline positive: a "choose up to X, where X is ..."
+    /// modal keeps the fixed-default cap (the existing "where" guard blocks the
+    /// cast-{X} arm), so the real parser yields a modal node WITHOUT
+    /// `dynamic_max_choices`. Driven end-to-end through `parse_oracle_text` →
+    /// `check_swallowed_clauses`, so it discriminates the detector registration.
+    /// This "where X is" shape is unaffected by Sub-plan B's "that many" arm,
+    /// keeping the test stable across both commits. Revert the registration line
+    /// in `check_swallowed_clauses` → no diagnostic → fails.
+    #[test]
+    fn modal_dynamic_max_dropped_registered_via_real_parse() {
+        let parsed = parse_named(
+            "Choose up to X, where X is the number of cards in your hand \u{2014}\n\
+             \u{2022} You gain 2 life.\n\
+             \u{2022} Draw a card.",
+            "Synthetic Dropped Cap Modal",
+            &["Sorcery"],
+        );
+        assert!(
+            has_swallowed_detector(&parsed, "Modal_DynamicMaxDropped"),
+            "real parse of a dropped-cap modal must surface the detector: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
+    /// Real-pipeline negative — The Ruinous Wrecking Crew: its modal carries
+    /// `dynamic_max_choices: Some(CostXPaid)` on the base, so the detector is
+    /// silent and the line-counter fold (A-1) greens it. Stable across B.
+    #[test]
+    fn modal_dynamic_max_dropped_silent_on_ruinous() {
+        let parsed = parse_named(
+            "The Ruinous Wrecking Crew enters with X +1/+1 counters on it.\n\
+             When The Ruinous Wrecking Crew enters, choose up to X \u{2014}\n\
+             \u{2022} Discard a card, then draw a card.\n\
+             \u{2022} Target opponent loses 2 life.\n\
+             \u{2022} Destroy target token.\n\
+             \u{2022} Each player sacrifices a creature of their choice.",
+            "The Ruinous Wrecking Crew",
+            &["Creature"],
+        );
+        assert!(
+            !has_swallowed_detector(&parsed, "Modal_DynamicMaxDropped"),
+            "Ruinous carries a dynamic cap and must stay silent: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
+    /// Real-pipeline negative — Heroic Feast / Temporal Firestorm: a non-modal
+    /// "choose up to X/that many <nouns>" selection clause has no modal node, so
+    /// the detector stays silent (A1 gate on real parses). Guards no-regression.
+    #[test]
+    fn modal_dynamic_max_dropped_silent_on_non_modal_selection_clauses() {
+        let heroic = parse_named(
+            "When this enchantment enters, create a Food token.\n\
+             Whenever you gain life, choose up to that many target creatures you control. \
+             Put a +1/+1 counter on each of them.",
+            "Heroic Feast",
+            &["Enchantment"],
+        );
+        assert!(
+            !has_swallowed_detector(&heroic, "Modal_DynamicMaxDropped"),
+            "Heroic Feast is a non-modal selection clause and must stay silent: {:?}",
+            heroic.parse_warnings
+        );
+
+        let firestorm = parse_named(
+            "Choose up to X creatures and/or planeswalkers you control, where X is the number \
+             of times this spell was kicked. Those permanents phase out.\n\
+             Temporal Firestorm deals 5 damage to each creature and each planeswalker.",
+            "Temporal Firestorm",
+            &["Sorcery"],
+        );
+        assert!(
+            !has_swallowed_detector(&firestorm, "Modal_DynamicMaxDropped"),
+            "Temporal Firestorm is a non-modal selection clause and must stay silent: {:?}",
+            firestorm.parse_warnings
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4517,6 +4517,16 @@ pub enum QuantityRef {
     /// spell that became the source permanent. Reads `GameObject::convoked_creatures`;
     /// ETB replacement contexts resolve against the entering object.
     ConvokedCreatureCount,
+    /// CR 603.12a: Number of times the controller paid the repeated optional
+    /// cost during THIS ability's resolution ("you may pay {C} up to N times").
+    /// Resolution-local and transient: read from
+    /// `GameState::optional_cost_payments_this_resolution`, which is cleared at
+    /// the `depth == 0` prelude of `resolve_ability_chain` and incremented once
+    /// per successful payment. Distinct from the cast-time `CostXPaid` /
+    /// `KickerCount` / `AdditionalCostPaymentCount` tallies, which are read from
+    /// the source spell/object at announcement (CR 601.2 / 702.33 / 702.51).
+    /// Used to size a reflexive "choose up to that many" modal (CR 700.2d).
+    TimesCostPaidThisResolution,
     /// CR 106.3 + CR 601.2h: Mana spent to cast a spell, parameterized by
     /// which cast object is being measured and which spent-mana metric is
     /// needed. Covers total amount, distinct colors, and source-qualified

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -980,6 +980,30 @@ pub struct PendingRepeatIteration {
     pub total_iterations: usize,
 }
 
+/// CR 603.12a + CR 608.2c: A "you may pay {cost} up to N times. When you do,
+/// [reflexive]" process paused for one of its per-iteration optional-payment
+/// decisions (Hawkeye, Master Marksman — "Trick Arrows"). Unlike a generic
+/// `repeat_for` loop, each iteration's "you may" is offered SEPARATELY, the
+/// number of successful payments (K, accumulated in
+/// `GameState::optional_cost_payments_this_resolution`) sizes the reflexive
+/// modal (CR 700.2d), and the reflexive triggers EXACTLY ONCE for K >= 1
+/// (CR 603.12a) — never per payment. The resolution-time mana payment is
+/// synchronous (auto-tap, never pauses), so the only async boundaries are the
+/// per-iteration `OptionalEffectChoice` and the final `AbilityModeChoice`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingRepeatedOptionalPayment {
+    /// The PayCost-only unit prompted (and, on accept, paid) this iteration —
+    /// `repeat_for`/`sub_ability` cleared so resolving it neither re-enters the
+    /// driver nor re-resolves the reflexive.
+    pub payment_unit: Box<crate::types::ability::ResolvedAbility>,
+    /// The reflexive sub-ability (the modal) resolved exactly once after the
+    /// loop, iff at least one payment succeeded (CR 603.12a).
+    pub reflexive: Box<crate::types::ability::ResolvedAbility>,
+    /// Number of further per-iteration payment prompts after the one currently
+    /// outstanding (the "up to N" budget minus the iterations already offered).
+    pub remaining: u32,
+}
+
 /// CR 705.1 + CR 614.1a: Discriminates which multi-flip resolver paused for a
 /// Krark's Thumb keep-1 choice, carrying the loop position needed to re-enter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -6473,6 +6497,15 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_repeat_iteration: Option<PendingRepeatIteration>,
 
+    /// CR 603.12a + CR 608.2c: A repeated-optional-payment process (Hawkeye,
+    /// Master Marksman — "you may pay {1} up to three times. When you do, choose
+    /// up to that many.") paused for one of its per-iteration payment decisions.
+    /// Carries the PayCost-only unit, the reflexive modal to resolve once after
+    /// the loop, and the remaining payment budget. Driven by
+    /// `resolve_repeated_optional_payment_choice` on each `DecideOptionalEffect`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_repeated_optional_payment: Option<Box<PendingRepeatedOptionalPayment>>,
+
     /// CR 614.12b + CR 614.1c + CR 614.13: Pending multi-target `ChangeZone`
     /// iteration loop paused mid-flight because one of the moving objects
     /// triggered a per-permanent replacement choice. Drained by
@@ -6796,6 +6829,35 @@ pub struct GameState {
     /// resolution starts at 0.
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub exiled_from_hand_this_resolution: u32,
+
+    /// CR 603.12a: Number of times the controller has paid a repeated optional
+    /// cost ("you may pay {C} up to N times") during the CURRENT ability
+    /// resolution. Read by `QuantityRef::TimesCostPaidThisResolution` to size a
+    /// reflexive "choose up to that many" modal (Hawkeye, Master Marksman /
+    /// Tranquil Frillback class). Incremented once per successful payment by the
+    /// repeated-optional-payment driver in `resolve_chain_body`, and cleared at
+    /// the `depth == 0` prelude of `resolve_ability_chain` so each top-level
+    /// resolution starts at 0.
+    ///
+    /// This counter is nonzero AT the per-iteration `WaitingFor::OptionalEffectChoice`
+    /// pause: `resolve_repeated_optional_payment_choice` increments K and THEN
+    /// sets `waiting_for` and returns, so each `DecideOptionalEffect` is a
+    /// SEPARATE `apply()` call with K already nonzero. That pause is a serde
+    /// boundary — the persistence layer (`to_persisted`/`from_persisted`,
+    /// single-player save/load, multiplayer host-resume) can serialize the state
+    /// between two payment prompts. Because the paired continuation
+    /// `pending_repeated_optional_payment` is serialized-when-`Some` and
+    /// eq-included precisely to survive that pause, K must survive it too — a
+    /// roundtrip restoring K=0 would collapse the reflexive modal cap (CR 700.2d)
+    /// below the payments actually made, denying the player modes they paid for.
+    ///
+    /// Therefore K mirrors `exiled_from_hand_this_resolution` EXACTLY (the
+    /// resolution-local u32 counter observable at a pause), NOT `static_gate_truth`
+    /// (which is genuinely derived and recomputable via `refresh_static_gate_truth`):
+    /// `#[serde(default, skip_serializing_if = "is_zero_u32")]` (serialized
+    /// only when nonzero, so a roundtrip is faithful) and INCLUDED in `PartialEq`.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub optional_cost_payments_this_resolution: u32,
 
     /// CR 725: The current monarch, if any. At the beginning of the monarch's end step,
     /// the monarch draws a card. When a creature deals combat damage to the monarch,
@@ -7610,6 +7672,7 @@ impl GameState {
             public_revealed_cards: HashSet::new(),
             pending_continuation: None,
             pending_repeat_iteration: None,
+            pending_repeated_optional_payment: None,
             pending_change_zone_iteration: None,
             devour_eligible_snapshot: None,
             merged_card_component_route: None,
@@ -7651,6 +7714,7 @@ impl GameState {
             last_effect_counts_by_player: HashMap::new(),
             clause_minimum_snapshot: None,
             exiled_from_hand_this_resolution: 0,
+            optional_cost_payments_this_resolution: 0,
             monarch: None,
             city_blessing: HashSet::new(),
             epic_effects: Vec::new(),
@@ -8108,6 +8172,7 @@ impl PartialEq for GameState {
             && self.public_revealed_cards == other.public_revealed_cards
             && self.pending_continuation == other.pending_continuation
             && self.pending_repeat_iteration == other.pending_repeat_iteration
+            && self.pending_repeated_optional_payment == other.pending_repeated_optional_payment
             && self.pending_change_zone_iteration == other.pending_change_zone_iteration
             // `devour_eligible_snapshot` is INTENTIONALLY excluded from PartialEq.
             // It is a TRANSIENT mid-resolution carrier (CR 614.12a/13a): `Some`
@@ -8151,6 +8216,13 @@ impl PartialEq for GameState {
             && self.pending_optional_trigger_match_count
                 == other.pending_optional_trigger_match_count
             && self.exiled_from_hand_this_resolution == other.exiled_from_hand_this_resolution
+            // CR 603.12a: K is nonzero AT the per-iteration `OptionalEffectChoice`
+            // pause (a serde boundary across separate `apply()` calls). It is
+            // serialized-when-nonzero and eq-included — mirroring
+            // `exiled_from_hand_this_resolution` — so a save/restore mid-payment-loop
+            // preserves the reflexive modal cap (CR 700.2d).
+            && self.optional_cost_payments_this_resolution
+                == other.optional_cost_payments_this_resolution
             && self.lki_cache == other.lki_cache
             && self.city_blessing == other.city_blessing
             && self.planar_deck == other.planar_deck


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## MSH set rollout — batch E

Implements two more previously-unsupported Marvel's Spider-Man (MSH) cards: **The Ruinous Wrecking Crew** and **Hawkeye, Master Marksman**.

### The Ruinous Wrecking Crew — coverage-audit fix
A dynamic "choose up to X / that many" modal header was being miscounted as multiple Oracle lines by the coverage auditor, hiding the card's true support state. This folds the dynamic-cap modal header in the oracle-line counter so the count is honest, and adds a **swallow detector** that keeps a modal whose dynamic cap was dropped **conservatively unsupported (RED)** rather than letting it slip through as a false-green. Errs toward under-claiming support, never over-claiming.

### Hawkeye, Master Marksman — new feature: repeated optional cost payment
> "You may pay {1}. If you do, you may pay {1} again. (Repeat … up to three times.) … choose up to that many …"

The number of times the optional cost is paid becomes the **dynamic cap on a reflexive modal choice**. New building blocks:

- **`QuantityRef::TimesCostPaidThisResolution`** (CR 603.12a) — sizes the reflexive modal (CR 700.2d) from the count of successful payments this resolution.
- **A dedicated repeated-optional-payment driver** — counts successful payments and resolves the reflexive ability once iff `K ≥ 1`. Gated to **synchronous-mana costs only** via `is_synchronous_mana_pay_cost`; pausing/asynchronous costs fall through to the generic payment path (no behavior change for them).
- **Serde durability:** the times-paid counter (`optional_cost_payments_this_resolution`) is nonzero at the mid-loop `OptionalEffectChoice` pause — a serde boundary. It is serialized-when-nonzero and equality-included (mirroring `exiled_from_hand_this_resolution`), so save/restore mid-loop preserves the modal cap (CR 700.2d) instead of collapsing it.

These are **class-level building blocks**, not card-specific shims: `TimesCostPaidThisResolution` + the repeated-optional-payment driver cover any "pay a cost up to N times, then act that many times" card.

### Verification
- `cargo build -p engine` clean; `cargo clippy -p engine --lib --tests -- -D warnings` clean.
- Discriminating MSH-E tests (`game::marksman_tests`, `modal_dynamic_max_dropped`, `count_effective_oracle_lines_folds`): **15 passed / 0 failed**. Non-vacuity measured by serde-roundtrip discrimination (K=0 vs K=2) and by reverting the swallow detector (the dropped-cap modal flips false-green).
- Full `engine` suite: **13857 passed / 0 failed**, 6 ignored.
- All CR annotations (603.12a, 700.2d, 118.1, 118.3a) grep-verified against the Comprehensive Rules.

Cherry-picked cleanly onto current `main`.
