### PR TITLE
fix(parser+engine): Drag to the Underworld devotion cost reduction

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -21191,9 +21191,8 @@ mod tests {
     #[test]
     fn drag_to_the_underworld_devotion_cost_reduction_applies_from_hand() {
         use crate::types::ability::{DevotionColors, QuantityRef};
-        use crate::types::mana::ManaCostShard;
+        use crate::types::mana::{ManaColor, ManaCostShard};
         use crate::types::statics::StaticMode;
-        use crate::types::mana::ManaColor;
 
         let mut state = setup_game_at_main_phase();
         let parsed = crate::parser::oracle::parse_oracle_text(
@@ -21204,7 +21203,11 @@ mod tests {
             &[String::from("Instant")],
             &[],
         );
-        assert_eq!(parsed.statics.len(), 1, "expected one self-spell cost static");
+        assert_eq!(
+            parsed.statics.len(),
+            1,
+            "expected one self-spell cost static"
+        );
         assert!(
             matches!(
                 parsed.statics[0].mode,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -21270,7 +21270,7 @@ mod tests {
 
         match mana_cost {
             ManaCost::Cost { generic, shards } => {
-                assert_eq!(generic, 0, "devotion 3 must reduce {2} generic to {0}");
+                assert_eq!(generic, 0, "devotion 3 must reduce {{2}} generic to {{0}}");
                 assert_eq!(shards, vec![ManaCostShard::Black, ManaCostShard::Black]);
             }
             other => panic!("expected ManaCost::Cost, got {other:?}"),

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -21186,6 +21186,94 @@ mod tests {
         );
     }
 
+    /// CR 601.2f + CR 700.5: Drag to the Underworld — devotion where-X self-spell
+    /// cost reduction must apply from hand using parser-emitted statics.
+    #[test]
+    fn drag_to_the_underworld_devotion_cost_reduction_applies_from_hand() {
+        use crate::types::ability::{DevotionColors, QuantityRef};
+        use crate::types::mana::ManaCostShard;
+        use crate::types::statics::StaticMode;
+        use crate::types::mana::ManaColor;
+
+        let mut state = setup_game_at_main_phase();
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n\
+             Destroy target creature.",
+            "Drag to the Underworld",
+            &[],
+            &[String::from("Instant")],
+            &[],
+        );
+        assert_eq!(parsed.statics.len(), 1, "expected one self-spell cost static");
+        assert!(
+            matches!(
+                parsed.statics[0].mode,
+                StaticMode::ModifyCost {
+                    dynamic_count: Some(QuantityRef::Devotion {
+                        colors: DevotionColors::Fixed(ref colors),
+                    }),
+                    ..
+                } if *colors == vec![ManaColor::Black]
+            ),
+            "expected devotion-bound ModifyCost, got {:?}",
+            parsed.statics[0].mode
+        );
+
+        let spell_id = create_object(
+            &mut state,
+            CardId(994),
+            PlayerId(0),
+            "Drag to the Underworld".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+                generic: 2,
+            };
+            for static_def in parsed.statics {
+                obj.static_definitions.push(static_def.clone());
+                Arc::make_mut(&mut obj.base_static_definitions).push(static_def);
+            }
+            obj.abilities = Arc::new(parsed.abilities.clone());
+            obj.base_abilities = Arc::new(parsed.abilities);
+        }
+
+        for (i, black_pips) in [(995u64, 1), (996, 2)] {
+            let permanent = create_object(
+                &mut state,
+                CardId(i),
+                PlayerId(0),
+                format!("Devotion Permanent {i}"),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&permanent).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Black; black_pips as usize],
+                generic: 0,
+            };
+        }
+
+        let mut mana_cost = state.objects.get(&spell_id).unwrap().mana_cost.clone();
+        super::super::casting::apply_self_spell_cost_modifiers(
+            &state,
+            PlayerId(0),
+            spell_id,
+            &mut mana_cost,
+        );
+
+        match mana_cost {
+            ManaCost::Cost { generic, shards } => {
+                assert_eq!(generic, 0, "devotion 3 must reduce {2} generic to {0}");
+                assert_eq!(shards, vec![ManaCostShard::Black, ManaCostShard::Black]);
+            }
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
     /// CR 903.8 + CR 601.2f: A commander cast from the command zone still uses
     /// self-spell cost modifications printed on that card. Ghalta's "This
     /// spell costs {X} less..." must therefore function from Command as well

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -17824,6 +17824,53 @@ Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell 
     }
 
     #[test]
+    fn drag_to_the_underworld_devotion_cost_reduction_and_destroy_parse() {
+        use crate::types::ability::DevotionColors;
+
+        let r = parse(
+            "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n\
+             Destroy target creature.",
+            "Drag to the Underworld",
+            &[],
+            &["Instant"],
+            &[],
+        );
+
+        assert_eq!(r.statics.len(), 1);
+        let StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            amount: ManaCost::Cost { generic: 1, .. },
+            dynamic_count:
+                Some(QuantityRef::Devotion {
+                    colors: DevotionColors::Fixed(colors),
+                }),
+            ..
+        } = &r.statics[0].mode
+        else {
+            panic!(
+                "expected devotion-bound self-spell ReduceCost, got {:?}",
+                r.statics[0].mode
+            );
+        };
+        assert_eq!(*colors, vec![ManaColor::Black]);
+        assert!(matches!(r.statics[0].affected, Some(TargetFilter::SelfRef)));
+        assert_eq!(r.abilities.len(), 1);
+        assert!(
+            matches!(*r.abilities[0].effect, Effect::Destroy { .. }),
+            "destroy effect must be preserved, got {:?}",
+            r.abilities[0].effect
+        );
+        assert!(
+            r.parse_warnings
+                .iter()
+                .all(|warning| warning.to_string().split_whitespace().next()
+                    != Some("Swallow:DynamicQty")),
+            "unexpected DynamicQty warning: {:?}",
+            r.parse_warnings
+        );
+    }
+
+    #[test]
     fn spell_cost_reduction_for_creatures_that_attacked_stays_static() {
         let r = parse(
             "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -603,6 +603,14 @@ pub(crate) fn try_parse_cost_modification(
         }
     }
 
+    // CR 601.2f: {X}-flavored self-spell reductions must bind X to a quantity
+    // (devotion, object counts, etc.). Emitting ModifyCost with multiplier 1
+    // and no dynamic_count silently under-reduces by {1} (Drag to the Underworld
+    // class when the where-X clause fails to lower).
+    if amount_is_variable_x && dynamic_count.is_none() {
+        return None;
+    }
+
     let amount = if amount_is_variable_x {
         ManaCost::generic(1)
     } else {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2533,6 +2533,44 @@ fn heliod_warped_eclipse_cost_reduction_counts_opponents_draws() {
 }
 
 #[test]
+fn drag_to_the_underworld_self_cost_reduction_binds_devotion_to_black() {
+    use crate::types::ability::DevotionColors;
+    use crate::types::mana::ManaColor;
+
+    let def = parse_static_line(
+        "This spell costs {X} less to cast, where X is your devotion to black.",
+    )
+    .unwrap();
+
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount: ManaCost::Cost { generic: 1, .. },
+        dynamic_count:
+            Some(QuantityRef::Devotion {
+                colors: DevotionColors::Fixed(colors),
+            }),
+        ..
+    } = def.mode
+    else {
+        panic!("expected devotion-bound self-spell ReduceCost, got {:?}", def.mode);
+    };
+    assert_eq!(colors, vec![ManaColor::Black]);
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert_eq!(
+        def.active_zones,
+        crate::types::zones::self_spell_cost_mod_active_zones()
+    );
+}
+
+#[test]
+fn variable_x_self_cost_reduction_without_where_x_binding_is_rejected() {
+    assert!(
+        parse_static_line("This spell costs {X} less to cast.").is_none(),
+        "unbound {X} self-spell reduction must not lower to a silent {{1}} reducer"
+    );
+}
+
+#[test]
 fn ghalta_self_cost_reduction_is_active_from_command_zone() {
     let def = parse_static_line(
         "This spell costs {X} less to cast, where X is the total power of creatures you control.",

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2537,10 +2537,9 @@ fn drag_to_the_underworld_self_cost_reduction_binds_devotion_to_black() {
     use crate::types::ability::DevotionColors;
     use crate::types::mana::ManaColor;
 
-    let def = parse_static_line(
-        "This spell costs {X} less to cast, where X is your devotion to black.",
-    )
-    .unwrap();
+    let def =
+        parse_static_line("This spell costs {X} less to cast, where X is your devotion to black.")
+            .unwrap();
 
     let StaticMode::ModifyCost {
         mode: CostModifyMode::Reduce,
@@ -2552,7 +2551,10 @@ fn drag_to_the_underworld_self_cost_reduction_binds_devotion_to_black() {
         ..
     } = def.mode
     else {
-        panic!("expected devotion-bound self-spell ReduceCost, got {:?}", def.mode);
+        panic!(
+            "expected devotion-bound self-spell ReduceCost, got {:?}",
+            def.mode
+        );
     };
     assert_eq!(colors, vec![ManaColor::Black]);
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2568,7 +2568,7 @@ fn drag_to_the_underworld_self_cost_reduction_binds_devotion_to_black() {
 fn variable_x_self_cost_reduction_without_where_x_binding_is_rejected() {
     assert!(
         parse_static_line("This spell costs {X} less to cast.").is_none(),
-        "unbound {X} self-spell reduction must not lower to a silent {{1}} reducer"
+        "unbound {{X}} self-spell reduction must not lower to a silent {{1}} reducer"
     );
 }
 

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -26,7 +26,7 @@ use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, Comparator, ContinuousModification,
     CopyRetargetPermission, Effect, FilterProp, ModalSelectionConstraint, OpponentMayScope,
-    PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode,
+    PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode,
     StaticDefinition, TargetFilter, TriggerDefinition,
 };
 use crate::types::game_state::RetargetScope;
@@ -4172,12 +4172,16 @@ mod tests {
             "Drag to the Underworld",
             &["Instant"],
         );
-        assert_eq!(parsed.statics.len(), 1, "expected one self-spell cost static");
+        assert_eq!(
+            parsed.statics.len(),
+            1,
+            "expected one self-spell cost static"
+        );
         assert!(
             matches!(
                 parsed.statics[0].mode,
                 StaticMode::ModifyCost {
-                    dynamic_count: Some(QuantityRef::Devotion { .. }),
+                    dynamic_count: Some(crate::types::ability::QuantityRef::Devotion { .. }),
                     ..
                 }
             ),

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -26,8 +26,8 @@ use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, Comparator, ContinuousModification,
     CopyRetargetPermission, Effect, FilterProp, ModalSelectionConstraint, OpponentMayScope,
-    PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode,
-    StaticDefinition, TargetFilter, TriggerDefinition,
+    PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode, StaticDefinition,
+    TargetFilter, TriggerDefinition,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -26,8 +26,8 @@ use super::oracle_ir::diagnostic::{CascadeSlot, OracleDiagnostic};
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, Comparator, ContinuousModification,
     CopyRetargetPermission, Effect, FilterProp, ModalSelectionConstraint, OpponentMayScope,
-    PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode, StaticDefinition,
-    TargetFilter, TriggerDefinition,
+    PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode,
+    StaticDefinition, TargetFilter, TriggerDefinition,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
@@ -4158,6 +4158,39 @@ mod tests {
                 .iter()
                 .all(|warning| { !matches!(warning, OracleDiagnostic::SwallowedClause { .. }) }),
             "Progenitor's Icon must not trigger swallowed clause warnings: {:?}",
+            parsed.parse_warnings
+        );
+    }
+
+    /// CR 601.2f + CR 700.5: Drag to the Underworld — devotion where-X self-spell
+    /// cost reduction must parse alongside destroy without swallowing either clause.
+    #[test]
+    fn drag_to_the_underworld_devotion_cost_reduction_parses_without_swallow() {
+        let parsed = parse_named(
+            "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n\
+             Destroy target creature.",
+            "Drag to the Underworld",
+            &["Instant"],
+        );
+        assert_eq!(parsed.statics.len(), 1, "expected one self-spell cost static");
+        assert!(
+            matches!(
+                parsed.statics[0].mode,
+                StaticMode::ModifyCost {
+                    dynamic_count: Some(QuantityRef::Devotion { .. }),
+                    ..
+                }
+            ),
+            "expected devotion-bound ModifyCost, got {:?}",
+            parsed.statics[0].mode
+        );
+        assert_eq!(parsed.abilities.len(), 1);
+        assert!(
+            parsed
+                .parse_warnings
+                .iter()
+                .all(|warning| !matches!(warning, OracleDiagnostic::SwallowedClause { .. })),
+            "Drag to the Underworld must not swallow cost-reduction or destroy clauses: {:?}",
             parsed.parse_warnings
         );
     }


### PR DESCRIPTION
## Summary

Drag to the Underworld (`This spell costs {X} less to cast, where X is your devotion to black.`) must bind devotion into the self-spell cost-reduction static and apply that reduction at cast time.

- Reject unbound `{X}` self-spell cost reductions instead of emitting a silent `{1}` reducer when `dynamic_count` is missing
- Parser, swallow-check, and runtime casting tests for devotion where-X + destroy on the same card

## Test plan

- [x] `drag_to_the_underworld_self_cost_reduction_binds_devotion_to_black` — static line binds `QuantityRef::Devotion`
- [x] `variable_x_self_cost_reduction_without_where_x_binding_is_rejected` — fail-closed on unbound `{X}`
- [x] `drag_to_the_underworld_devotion_cost_reduction_and_destroy_parse` — full-card parse preserves static + destroy
- [x] `drag_to_the_underworld_devotion_cost_reduction_parses_without_swallow` — swallow check
- [x] `drag_to_the_underworld_devotion_cost_reduction_applies_from_hand` — runtime generic reduction from parser statics

Closes #4483
