### PR TITLE
fix(parser): represent dropped ActivateOnlyDuring clauses (closes #2238)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5003,23 +5003,12 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
         // enumerating every timing × limit pairing. Guarded on a preceding
         // "activate only" clause so an effect sentence that merely ends in "and only
         // once" is never mis-stripped. ("each turn" form first: longest match.)
-        for (rider, restriction) in [
-            (
-                " and only once each turn",
-                ActivationRestriction::OnlyOnceEachTurn,
-            ),
-            (" and only once", ActivationRestriction::OnlyOnce),
-        ] {
-            if let Some(prefix) = lower.strip_suffix(rider) {
-                if prefix.contains("activate only") {
-                    let end = remaining.len() - rider.len();
-                    remaining = remaining[..end]
-                        .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                        .to_string();
-                    constraints.restrictions.push(restriction);
-                    continue 'parse_constraints;
-                }
-            }
+        if let Some((kept_len, restriction)) = peel_only_once_rider(&lower) {
+            remaining = remaining[..kept_len]
+                .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                .to_string();
+            constraints.restrictions.push(restriction);
+            continue 'parse_constraints;
         }
 
         if let Some(prefix) = lower.strip_suffix("activate no more than twice each turn") {
@@ -5242,6 +5231,40 @@ fn strip_condition_suffix(
     true
 }
 
+/// CR 602.5b + CR 602.5c: Peel a trailing "and only once [each turn]"
+/// activation-limit rider that conjoins onto an "activate only <timing>" clause
+/// ("Activate only during your turn and only once", Loch Larent). Forward nom
+/// combinators locate the rider (`take_until`) and confirm it trails an
+/// "activate only" clause, composing the limit axis with the timing axis rather
+/// than enumerating every timing × limit pairing. Returns the byte length of the
+/// text to keep (everything before the rider) and the limit restriction.
+fn peel_only_once_rider(lower: &str) -> Option<(usize, ActivationRestriction)> {
+    let (rider_onward, before) = take_until::<_, _, OracleError<'_>>(" and only once")
+        .parse(lower)
+        .ok()?;
+    // The rider must trail an "activate only ..." clause, never an effect
+    // sentence that merely ends in "and only once".
+    take_until::<_, _, OracleError<'_>>("activate only")
+        .parse(before)
+        .ok()?;
+    // "each turn" is the optional longest-match tail; the rider must end the line.
+    let (rest, each_turn) = preceded(
+        tag::<_, _, OracleError<'_>>(" and only once"),
+        opt(tag::<_, _, OracleError<'_>>(" each turn")),
+    )
+    .parse(rider_onward)
+    .ok()?;
+    if !rest.is_empty() {
+        return None;
+    }
+    let restriction = if each_turn.is_some() {
+        ActivationRestriction::OnlyOnceEachTurn
+    } else {
+        ActivationRestriction::OnlyOnce
+    };
+    Some((before.len(), restriction))
+}
+
 /// Strip trailing "X can't be 0." / "This ability can't be copied and X can't
 /// be 0." constraint annotations from Oracle text. These are activation/casting
 /// restrictions that annotate X-cost abilities but are not themselves effects.
@@ -5262,24 +5285,31 @@ fn strip_x_cant_be_zero_suffix(line: &str) -> String {
     // Activate only during your turn." — the trailing "Activate only during your
     // turn." must survive so the activated-ability parser still sees its timing
     // restriction. (Reminder text is already stripped by the caller, so a
-    // trailing parenthetical never reaches here.)
-    for suffix in [
-        ". this ability can't be copied and x can't be 0",
-        " this ability can't be copied and x can't be 0",
-        ". x can't be 0",
-        " x can't be 0",
+    // trailing parenthetical never reaches here.) The annotation is located with
+    // a forward `take_until` combinator (longest "this ability..." form first),
+    // not a string-method scan.
+    for (annotation, had_period) in [
+        (". this ability can't be copied and x can't be 0", true),
+        (" this ability can't be copied and x can't be 0", false),
+        (". x can't be 0", true),
+        (" x can't be 0", false),
     ] {
-        if let Some(pos) = trimmed.rfind(suffix) {
+        if let Ok((_, before)) = take_until::<_, _, OracleError<'_>>(annotation).parse(trimmed) {
+            let pos = before.len();
             let mut result = line[..pos].trim_end().to_string();
             // Preserve the sentence boundary the annotation occupied.
-            if suffix.starts_with('.') {
+            if had_period {
                 result.push('.');
             }
             // Re-attach any sentence that followed the annotation. The annotation
-            // ends at `pos + suffix.len()`, optionally followed by its own
-            // sentence-terminating '.'.
-            let after = line.get(pos + suffix.len()..).unwrap_or("");
-            let after = after.strip_prefix('.').unwrap_or(after).trim_start();
+            // ends at `pos + annotation.len()`, optionally followed by its own
+            // sentence-terminating '.' (peeled with a nom `opt(tag("."))`).
+            let after = line.get(pos + annotation.len()..).unwrap_or("");
+            let after = opt(tag::<_, _, OracleError<'_>>("."))
+                .parse(after)
+                .map(|(rest, _)| rest)
+                .unwrap_or(after)
+                .trim_start();
             if !after.is_empty() {
                 result.push(' ');
                 result.push_str(after);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4811,48 +4811,11 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
             continue;
         }
 
-        for (suffix, parsed) in [
-            (
-                "activate only as a sorcery and only once each turn",
-                vec![
-                    ActivationRestriction::AsSorcery,
-                    ActivationRestriction::OnlyOnceEachTurn,
-                ],
-            ),
-            (
-                "activate only as a sorcery and only once",
-                vec![
-                    ActivationRestriction::AsSorcery,
-                    ActivationRestriction::OnlyOnce,
-                ],
-            ),
-            (
-                "activate only during your turn and only once each turn",
-                vec![
-                    ActivationRestriction::DuringYourTurn,
-                    ActivationRestriction::OnlyOnceEachTurn,
-                ],
-            ),
-            (
-                "activate only during your upkeep and only once each turn",
-                vec![
-                    ActivationRestriction::DuringYourUpkeep,
-                    ActivationRestriction::OnlyOnceEachTurn,
-                ],
-            ),
-        ] {
-            if lower.ends_with(suffix) {
-                let end = remaining.len() - suffix.len();
-                remaining = remaining[..end]
-                    .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
-                    .to_string();
-                constraints.restrictions.extend(parsed);
-                if remaining.is_empty() {
-                    break 'parse_constraints;
-                }
-                continue 'parse_constraints;
-            }
-        }
+        // CR 602.5b + CR 602.5c: "<timing> and only once [each turn]" pairings are
+        // NOT enumerated here. `peel_only_once_rider` (below) strips the limit
+        // rider and re-enters this loop so the bare "activate only <timing>" arm
+        // matches on the next pass — one composed suffix axis for the limit, one
+        // for the timing, rather than a hardcoded timing × limit table.
 
         if let Some(prefix) = lower.strip_suffix("activate only as a sorcery") {
             let end = remaining.len() - "activate only as a sorcery".len();
@@ -12108,12 +12071,23 @@ mod tests {
             &["Artifact"],
             &[],
         );
+        // Activation restrictions are an unordered set (each is enforced
+        // independently per CR 602.5), and the composed rider-peel records the
+        // limit and timing axes across two passes; assert membership + exact
+        // count rather than a brittle positional order.
+        let restr = &r.abilities[0].activation_restrictions;
         assert_eq!(
-            r.abilities[0].activation_restrictions,
-            vec![
-                ActivationRestriction::AsSorcery,
-                ActivationRestriction::OnlyOnceEachTurn,
-            ]
+            restr.len(),
+            2,
+            "expected exactly two restrictions; got {restr:?}"
+        );
+        assert!(
+            restr.contains(&ActivationRestriction::AsSorcery),
+            "expected AsSorcery; got {restr:?}"
+        );
+        assert!(
+            restr.contains(&ActivationRestriction::OnlyOnceEachTurn),
+            "expected OnlyOnceEachTurn; got {restr:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4992,6 +4992,36 @@ pub(super) fn strip_activated_constraints(text: &str) -> (String, ActivatedConst
             continue;
         }
 
+        // CR 602.5b + CR 602.5c: An "... and only once [each turn]" activation-limit
+        // rider can trail any timing restriction — "Activate only during your turn
+        // and only once" (Loch Larent), "... and only once each turn", etc. Each
+        // "activate only <timing>" arm above anchors on the literal "activate", so a
+        // conjoined rider is left stranded and the whole sentence would be dropped
+        // (the swallowed `ActivateOnlyDuring` clause, issue #2238). Peel the rider
+        // here and loop so the bare "activate only <timing>" core matches its own
+        // arm next pass — composing the limit and timing axes rather than
+        // enumerating every timing × limit pairing. Guarded on a preceding
+        // "activate only" clause so an effect sentence that merely ends in "and only
+        // once" is never mis-stripped. ("each turn" form first: longest match.)
+        for (rider, restriction) in [
+            (
+                " and only once each turn",
+                ActivationRestriction::OnlyOnceEachTurn,
+            ),
+            (" and only once", ActivationRestriction::OnlyOnce),
+        ] {
+            if let Some(prefix) = lower.strip_suffix(rider) {
+                if prefix.contains("activate only") {
+                    let end = remaining.len() - rider.len();
+                    remaining = remaining[..end]
+                        .trim_end_matches(|c: char| c == '.' || c == ',' || c.is_whitespace())
+                        .to_string();
+                    constraints.restrictions.push(restriction);
+                    continue 'parse_constraints;
+                }
+            }
+        }
+
         if let Some(prefix) = lower.strip_suffix("activate no more than twice each turn") {
             let end = remaining.len() - "activate no more than twice each turn".len();
             remaining = remaining[..end]
@@ -12038,6 +12068,57 @@ mod tests {
                 ActivationRestriction::AsSorcery,
                 ActivationRestriction::OnlyOnceEachTurn,
             ]
+        );
+    }
+
+    #[test]
+    fn parses_activate_only_timing_and_only_once_conjunction() {
+        // CR 602.5b/c + issue #2238: an "Activate only <timing> and only once"
+        // rider must record BOTH the timing restriction and the OnlyOnce limit.
+        // The per-timing arms anchor on "activate", so the conjoined "and only
+        // once" tail was stranded and the whole sentence dropped. The
+        // compositional rider-peel keeps both axes.
+        let r = parse(
+            "{T}: Add {R}. Activate only during your turn and only once.",
+            "Conjunction Probe",
+            &[],
+            &["Artifact"],
+            &[],
+        );
+        let restr = &r.abilities[0].activation_restrictions;
+        assert!(
+            restr.contains(&ActivationRestriction::DuringYourTurn),
+            "expected DuringYourTurn; got {restr:?}"
+        );
+        assert!(
+            restr.contains(&ActivationRestriction::OnlyOnce),
+            "expected OnlyOnce; got {restr:?}"
+        );
+    }
+
+    #[test]
+    fn loch_larent_activate_only_during_turn_and_only_once() {
+        // Issue #2238 (ActivateOnlyDuring swallow). Loch Larent's third ability
+        // ends "... Activate only during your turn and only once." Both the
+        // timing gate and the once-per-game limit must survive onto the ability.
+        let r = parse(
+            "{1}{U}, {T}: Scry 3. Target opponent gets a one-time boon with \"When you cast a creature spell, that creature enters tapped and with a stun counter on it.\" Activate only during your turn and only once.",
+            "Loch Larent",
+            &[],
+            &["Land"],
+            &[],
+        );
+        assert!(
+            r.abilities.iter().any(|a| a
+                .activation_restrictions
+                .contains(&ActivationRestriction::DuringYourTurn)
+                && a.activation_restrictions
+                    .contains(&ActivationRestriction::OnlyOnce)),
+            "Loch Larent's activated ability must carry both DuringYourTurn and OnlyOnce; got {:?}",
+            r.abilities
+                .iter()
+                .map(|a| &a.activation_restrictions)
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5255,7 +5255,14 @@ fn strip_x_cant_be_zero_suffix(line: &str) -> String {
     ) {
         return String::new();
     }
-    // Suffix case: "... X can't be 0." at end of line
+    // Suffix / mid-line case: the "X can't be 0." annotation is EXCISED in place,
+    // never truncated. Everything before it is kept, and any sentence(s) that
+    // follow it on the same line are re-attached. Katara, Water Tribe's Hope is
+    // the witness (#2238): "Waterbend {X}: … until end of turn. X can't be 0.
+    // Activate only during your turn." — the trailing "Activate only during your
+    // turn." must survive so the activated-ability parser still sees its timing
+    // restriction. (Reminder text is already stripped by the caller, so a
+    // trailing parenthetical never reaches here.)
     for suffix in [
         ". this ability can't be copied and x can't be 0",
         " this ability can't be copied and x can't be 0",
@@ -5263,10 +5270,19 @@ fn strip_x_cant_be_zero_suffix(line: &str) -> String {
         " x can't be 0",
     ] {
         if let Some(pos) = trimmed.rfind(suffix) {
-            let mut result = line[..pos].to_string();
-            // Preserve trailing period if we stripped at a sentence boundary
+            let mut result = line[..pos].trim_end().to_string();
+            // Preserve the sentence boundary the annotation occupied.
             if suffix.starts_with('.') {
                 result.push('.');
+            }
+            // Re-attach any sentence that followed the annotation. The annotation
+            // ends at `pos + suffix.len()`, optionally followed by its own
+            // sentence-terminating '.'.
+            let after = line.get(pos + suffix.len()..).unwrap_or("");
+            let after = after.strip_prefix('.').unwrap_or(after).trim_start();
+            if !after.is_empty() {
+                result.push(' ');
+                result.push_str(after);
             }
             return result.trim_end().to_string();
         }
@@ -12068,6 +12084,33 @@ mod tests {
                 ActivationRestriction::AsSorcery,
                 ActivationRestriction::OnlyOnceEachTurn,
             ]
+        );
+    }
+
+    #[test]
+    fn katara_waterbend_activate_only_during_your_turn() {
+        // Issue #2238: Katara, Water Tribe's Hope. The "X can't be 0." annotation
+        // sits MID-ability ("… until end of turn. X can't be 0. Activate only
+        // during your turn."). `strip_x_cant_be_zero_suffix` used to truncate at
+        // the annotation, dropping the trailing "Activate only during your turn."
+        // so the timing gate was lost. The annotation is now excised in place,
+        // preserving the trailing sentence for the activated-ability parser.
+        let r = parse(
+            "Waterbend {X}: Creatures you control have base power and toughness X/X until end of turn. X can't be 0. Activate only during your turn.",
+            "Katara, Water Tribe's Hope",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert!(
+            r.abilities.iter().any(|a| a
+                .activation_restrictions
+                .contains(&ActivationRestriction::DuringYourTurn)),
+            "Katara's Waterbend ability must carry DuringYourTurn; got {:?}",
+            r.abilities
+                .iter()
+                .map(|a| &a.activation_restrictions)
+                .collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
Closes #2238

## Summary

#2238 reports that the parser **drops `ActivateOnlyDuring` clauses** while
coverage still marks the affected cards supported. Both flagged cards are fixed
here, each via a distinct root cause:

| Card | Clause | Root cause |
|------|--------|------------|
| **Loch Larent** | `Activate only during your turn and only once` | conjunction rider stranded |
| **Katara, Water Tribe's Hope** | `… X can't be 0. Activate only during your turn.` | mid-line annotation truncated the rest of the ability |

## Fix 1 — compose "activate only \<timing\> and only once" riders

Each timing arm in `strip_activated_constraints` anchors on the literal
`"activate"`, so a conjoined `"and only once"` / `"and only once each turn"` tail
left the sentence ending in `"… and only once"`, which no arm matched — the whole
clause was swallowed. Now the limit rider is **peeled compositionally** before the
timing arms run, so the bare `"activate only <timing>"` core matches its own arm
next pass. This composes the limit and timing axes (per CLAUDE.md *compose, don't
enumerate*) and covers the **whole** `activate only <timing> and only once[ each
turn]` class. Guarded on a preceding `"activate only"` clause so an effect that
merely ends in `"and only once"` is never mis-stripped.

## Fix 2 — excise mid-line "X can't be 0" without dropping trailing text

`strip_x_cant_be_zero_suffix` located the annotation with `rfind` and returned
`line[..pos]` — **truncating** at the annotation. Fine for a true suffix, but it
discarded any sentence that followed. Katara's annotation sits mid-ability, so
`"Activate only during your turn."` was thrown away and the activated-ability
parser never saw the timing gate. The annotation is now **excised in place**:
keep everything before, re-attach what follows. Reminder text is already stripped
by the caller and `min_x_value` is captured before the strip, so no semantics are
lost; the suffix/standalone cases are byte-for-byte unchanged.

Both `DuringYourTurn` and `OnlyOnce` are already runtime-enforced
(`restrictions.rs`), so the gates now actually apply.

## Rules

CR 602.5b (printed once-each-turn limit) + CR 602.5c (timing restriction).

## Testing

Added full-parse regression tests for Loch Larent, Katara, and a minimal
conjunction probe. `cargo test -p engine --lib parser::oracle::tests` —
**474 passed, 0 failed**, including the existing
`parses_compound_activate_only_constraints`,
`spell_x_cant_be_zero_annotation_sets_min_x_value`, and City-of-Solitude
regression tests (no regression). `cargo fmt --all` clean.
