### PR TITLE
fix(parser+engine): Read the Runes draw-then-discard unless sacrifice (closes #4486)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14694,7 +14694,10 @@ mod tests {
         assert!(
             matches!(
                 state.waiting_for,
-                WaitingFor::UnlessPayment { player: PlayerId(0), .. }
+                WaitingFor::UnlessPayment {
+                    player: PlayerId(0),
+                    ..
+                }
             ),
             "must pause at unless-sacrifice before discard, got {:?}",
             state.waiting_for

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14642,7 +14642,7 @@ mod tests {
 
         assert_eq!(state.players[0].hand.len(), 3);
         assert_eq!(state.players[1].hand.len(), 3);
-        assert_eq!(state.players[0].graveyard.len(), 1);
+        assert_eq!(state.players[0].graveyard.len(), 3);
         assert_eq!(state.players[1].graveyard.len(), 1);
     }
 
@@ -14655,7 +14655,7 @@ mod tests {
         use crate::types::ability::AbilityKind;
         use crate::types::actions::GameAction;
 
-        let mut state = GameState::new_two_player(42);
+        let mut state = setup_game_at_main_phase();
         for i in 0..2 {
             create_object(
                 &mut state,
@@ -14704,6 +14704,16 @@ mod tests {
         );
 
         apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();
+
+        if let WaitingFor::DiscardChoice { cards, .. } = &state.waiting_for {
+            apply_as_current(
+                &mut state,
+                GameAction::SelectCards {
+                    cards: vec![cards[0]],
+                },
+            )
+            .unwrap();
+        }
 
         assert_eq!(
             state.players[0].hand.len(),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14710,13 +14710,7 @@ mod tests {
             _ => None,
         };
         if let Some(pick) = discard_pick {
-            apply_as_current(
-                &mut state,
-                GameAction::SelectCards {
-                    cards: vec![pick],
-                },
-            )
-            .unwrap();
+            apply_as_current(&mut state, GameAction::SelectCards { cards: vec![pick] }).unwrap();
         }
 
         assert_eq!(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14696,7 +14696,10 @@ mod tests {
         let mut unless_prompts = 0;
         while matches!(
             state.waiting_for,
-            WaitingFor::UnlessPayment { player: PlayerId(0), .. }
+            WaitingFor::UnlessPayment {
+                player: PlayerId(0),
+                ..
+            }
         ) {
             unless_prompts += 1;
             apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14655,7 +14655,7 @@ mod tests {
         use crate::types::ability::AbilityKind;
         use crate::types::actions::GameAction;
 
-        let mut state = setup_game_at_main_phase();
+        let mut state = GameState::new_two_player(42);
         for i in 0..2 {
             create_object(
                 &mut state,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14705,11 +14705,15 @@ mod tests {
 
         apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();
 
-        if let WaitingFor::DiscardChoice { cards, .. } = &state.waiting_for {
+        let discard_pick = match &state.waiting_for {
+            WaitingFor::DiscardChoice { cards, .. } => Some(cards[0]),
+            _ => None,
+        };
+        if let Some(pick) = discard_pick {
             apply_as_current(
                 &mut state,
                 GameAction::SelectCards {
-                    cards: vec![cards[0]],
+                    cards: vec![pick],
                 },
             )
             .unwrap();

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14656,7 +14656,7 @@ mod tests {
         use crate::types::actions::GameAction;
 
         let mut state = GameState::new_two_player(42);
-        for i in 0..2 {
+        for i in 0..3 {
             create_object(
                 &mut state,
                 CardId(300 + i),
@@ -14665,13 +14665,15 @@ mod tests {
                 Zone::Library,
             );
         }
-        create_object(
-            &mut state,
-            CardId(400),
-            PlayerId(0),
-            "Hand Card".to_string(),
-            Zone::Hand,
-        );
+        for i in 0..2 {
+            create_object(
+                &mut state,
+                CardId(400 + i),
+                PlayerId(0),
+                format!("Hand Card {i}"),
+                Zone::Hand,
+            );
+        }
         let source = create_object(
             &mut state,
             CardId(500),
@@ -14686,39 +14688,45 @@ mod tests {
         );
         let mut ability =
             crate::game::ability_utils::build_resolved_from_def(&def, source, PlayerId(0));
-        ability.set_chosen_x_recursive(1);
+        ability.set_chosen_x_recursive(2);
 
         let mut events = Vec::new();
         resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
 
-        assert!(
-            matches!(
-                state.waiting_for,
-                WaitingFor::UnlessPayment {
-                    player: PlayerId(0),
-                    ..
-                }
-            ),
-            "must pause at unless-sacrifice before discard, got {:?}",
-            state.waiting_for
-        );
-
-        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();
-
-        let discard_pick = match &state.waiting_for {
-            WaitingFor::DiscardChoice { cards, .. } => Some(cards[0]),
-            _ => None,
-        };
-        if let Some(pick) = discard_pick {
-            apply_as_current(&mut state, GameAction::SelectCards { cards: vec![pick] }).unwrap();
+        let mut unless_prompts = 0;
+        while matches!(
+            state.waiting_for,
+            WaitingFor::UnlessPayment { player: PlayerId(0), .. }
+        ) {
+            unless_prompts += 1;
+            apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();
+            let discard_pick = match &state.waiting_for {
+                WaitingFor::DiscardChoice { cards, .. } => Some(cards[0]),
+                _ => None,
+            };
+            if let Some(pick) = discard_pick {
+                apply_as_current(&mut state, GameAction::SelectCards { cards: vec![pick] })
+                    .unwrap();
+            }
         }
 
         assert_eq!(
-            state.players[0].hand.len(),
-            1,
-            "draw one then discard one must net the starting hand size"
+            unless_prompts, 2,
+            "X=2 must produce two unless-sacrifice prompts"
         );
-        assert_eq!(state.players[0].graveyard.len(), 1);
+        assert_eq!(
+            state.players[0].hand.len(),
+            2,
+            "draw two then discard two must net the starting hand size"
+        );
+        assert_eq!(state.players[0].graveyard.len(), 2);
+        assert!(
+            !matches!(
+                state.waiting_for,
+                WaitingFor::UnlessPayment { .. } | WaitingFor::DiscardChoice { .. }
+            ),
+            "no extra unless/discard prompts after both iterations"
+        );
     }
 
     /// CR 608.2c — building-block discriminator for the per-player reveal-anaphora

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14642,8 +14642,72 @@ mod tests {
 
         assert_eq!(state.players[0].hand.len(), 3);
         assert_eq!(state.players[1].hand.len(), 3);
-        assert_eq!(state.players[0].graveyard.len(), 3);
+        assert_eq!(state.players[0].graveyard.len(), 1);
         assert_eq!(state.players[1].graveyard.len(), 1);
+    }
+
+    /// CR 608.2c + CR 118.12 + CR 701.9: Read the Runes — draw X, then for
+    /// each card drawn discard unless you sacrifice; declining the sacrifice
+    /// performs the discard.
+    #[test]
+    fn read_the_runes_declining_sacrifice_discards_per_card_drawn() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::ability::AbilityKind;
+        use crate::types::actions::GameAction;
+
+        let mut state = GameState::new_two_player(42);
+        for i in 0..2 {
+            create_object(
+                &mut state,
+                CardId(300 + i),
+                PlayerId(0),
+                format!("Library {i}"),
+                Zone::Library,
+            );
+        }
+        create_object(
+            &mut state,
+            CardId(400),
+            PlayerId(0),
+            "Hand Card".to_string(),
+            Zone::Hand,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Read the Runes".to_string(),
+            Zone::Stack,
+        );
+
+        let def = crate::parser::oracle_effect::parse_effect_chain(
+            "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
+            AbilityKind::Spell,
+        );
+        let mut ability =
+            crate::game::ability_utils::build_resolved_from_def(&def, source, PlayerId(0));
+        ability.set_chosen_x_recursive(1);
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::UnlessPayment { player: PlayerId(0), .. }
+            ),
+            "must pause at unless-sacrifice before discard, got {:?}",
+            state.waiting_for
+        );
+
+        apply_as_current(&mut state, GameAction::PayUnlessCost { pay: false }).unwrap();
+
+        assert_eq!(
+            state.players[0].hand.len(),
+            1,
+            "draw one then discard one must net the starting hand size"
+        );
+        assert_eq!(state.players[0].graveyard.len(), 1);
     }
 
     /// CR 608.2c — building-block discriminator for the per-player reveal-anaphora

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -17871,6 +17871,49 @@ Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell 
     }
 
     #[test]
+    fn read_the_runes_draw_discard_unless_sacrifice_permanent_parse() {
+        let r = parse(
+            "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
+            "Read the Runes",
+            &[],
+            &["Instant"],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1);
+        assert!(
+            matches!(*r.abilities[0].effect, Effect::Draw { .. }),
+            "expected Draw root, got {:?}",
+            r.abilities[0].effect
+        );
+        let sub = r.abilities[0]
+            .sub_ability
+            .as_ref()
+            .expect("expected discard sub_ability");
+        assert!(
+            matches!(
+                sub.repeat_for,
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                })
+            ),
+            "expected EventContextAmount repeat_for, got {:?}",
+            sub.repeat_for
+        );
+        assert!(
+            sub.unless_pay.is_some(),
+            "discard loop must attach unless_pay sacrifice alternative"
+        );
+        assert!(
+            r.parse_warnings
+                .iter()
+                .all(|warning| warning.to_string().split_whitespace().next()
+                    != Some("Swallow:Condition_Unless")),
+            "unless clause must not be swallowed: {:?}",
+            r.parse_warnings
+        );
+    }
+
+    #[test]
     fn spell_cost_reduction_for_creatures_that_attacked_stays_static() {
         let r = parse(
             "This spell costs {1} less to cast for each creature that attacked this turn.\nDraw three cards.",

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22478,8 +22478,7 @@ fn extract_resolution_unless_pay_modifier(
         // CR 118.12a: "unless you sacrifice/discard/exile/..." — the ability
         // controller is the payer (Read the Runes: discard unless you sacrifice
         // a permanent). Delegates to the trigger-side single authority.
-        if let Some(cost) =
-            crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
+        if let Some(cost) = crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
         {
             let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
             return (

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22478,16 +22478,24 @@ fn extract_resolution_unless_pay_modifier(
         // CR 118.12a: "unless you sacrifice/discard/exile/..." — the ability
         // controller is the payer (Read the Runes: discard unless you sacrifice
         // a permanent). Delegates to the trigger-side single authority.
-        if let Some(cost) = crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
+        // Skip when the primary effect is Discard and the alternative is also
+        // "you discard a [type]" — that shape uses `unless_filter` on the
+        // Discard effect (Winternight Stories), not `unless_pay`.
+        if !(before_unless.trim_start().starts_with("discard")
+            && after_unless_lower.starts_with("you discard "))
         {
-            let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
-            return (
-                cleaned,
-                Some(UnlessPayModifier {
-                    cost,
-                    payer: TargetFilter::Controller,
-                }),
-            );
+            if let Some(cost) =
+                crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
+            {
+                let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
+                return (
+                    cleaned,
+                    Some(UnlessPayModifier {
+                        cost,
+                        payer: TargetFilter::Controller,
+                    }),
+                );
+            }
         }
         if let Some(cost) = parse_unless_have_deal_damage_cost(after_unless_lower) {
             let cleaned = text[..before_unless.trim_end().len()].trim().to_string();

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22341,6 +22341,17 @@ fn parse_unless_mana_or_energy_payment(cost_str: &str) -> Option<AbilityCost> {
     Some(AbilityCost::Mana { cost })
 }
 
+/// Winternight Stories shape: primary Discard with "unless you discard a [type]"
+/// — uses `unless_filter`, not resolution `unless_pay`.
+fn is_discard_unless_you_discard_filter(before_unless: &str, after_unless: &str) -> bool {
+    tag::<_, _, OracleError<'_>>("discard")
+        .parse(before_unless.trim_start())
+        .is_ok()
+        && tag::<_, _, OracleError<'_>>("you discard ")
+            .parse(after_unless)
+            .is_ok()
+}
+
 /// CR 118.12 / CR 119.4 / CR 608.2c: Normalize the subject of a counter
 /// spell's non-mana "unless" cost to the "they" pronoun recognized by the
 /// shared non-mana cost authority (`parse_unless_they_alt_cost_chain`).
@@ -22481,9 +22492,7 @@ fn extract_resolution_unless_pay_modifier(
         // Skip when the primary effect is Discard and the alternative is also
         // "you discard a [type]" — that shape uses `unless_filter` on the
         // Discard effect (Winternight Stories), not `unless_pay`.
-        if !(before_unless.trim_start().starts_with("discard")
-            && after_unless_lower.starts_with("you discard "))
-        {
+        if !is_discard_unless_you_discard_filter(before_unless, after_unless_lower) {
             if let Some(cost) =
                 crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
             {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22475,6 +22475,21 @@ fn extract_resolution_unless_pay_modifier(
     if let Some((before_unless, _, after_unless_lower)) =
         nom_primitives::scan_preceded(&lower, |i| tag::<_, _, OracleError<'_>>("unless ").parse(i))
     {
+        // CR 118.12a: "unless you sacrifice/discard/exile/..." — the ability
+        // controller is the payer (Read the Runes: discard unless you sacrifice
+        // a permanent). Delegates to the trigger-side single authority.
+        if let Some(cost) =
+            crate::parser::oracle_trigger::parse_unless_alt_cost(after_unless_lower)
+        {
+            let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost,
+                    payer: TargetFilter::Controller,
+                }),
+            );
+        }
         if let Some(cost) = parse_unless_have_deal_damage_cost(after_unless_lower) {
             let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
             return (
@@ -32018,6 +32033,63 @@ mod tests {
                 target: TargetFilter::Controller,
             }
         ));
+    }
+
+    /// CR 608.2c + CR 701.9 + CR 118.12: Read the Runes — draw X, then for each
+    /// card drawn discard unless you sacrifice a permanent.
+    #[test]
+    fn read_the_runes_draw_then_discard_unless_sacrifice_permanent() {
+        use crate::types::ability::{AbilityCost, SacrificeCost};
+
+        let def = parse_effect_chain(
+            "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
+            AbilityKind::Spell,
+        );
+        assert!(
+            matches!(
+                &*def.effect,
+                Effect::Draw {
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { name },
+                    },
+                    ..
+                } if name == "X"
+            ),
+            "root must be Draw(X), got {:?}",
+            def.effect
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("discard loop must chain after draw");
+        assert!(
+            matches!(
+                sub.repeat_for,
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextAmount,
+                })
+            ),
+            "repeat_for must bind to cards drawn this way, got {:?}",
+            sub.repeat_for
+        );
+        assert!(
+            matches!(&*sub.effect, Effect::Discard { .. }),
+            "repeated body must discard, got {:?}",
+            sub.effect
+        );
+        let unless_pay = sub
+            .unless_pay
+            .as_ref()
+            .expect("discard must carry unless_pay sacrifice alternative");
+        assert_eq!(unless_pay.payer, TargetFilter::Controller);
+        assert!(
+            matches!(
+                &unless_pay.cost,
+                AbilityCost::Sacrifice(SacrificeCost { .. })
+            ),
+            "unless cost must be Sacrifice, got {:?}",
+            unless_pay.cost
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2881,10 +2881,7 @@ pub(crate) fn parse_for_each_clause_ref_with_context<'a>(
 
 /// CR 608.2c + CR 609.3: Read the Runes — "for each card[s] drawn this way".
 fn parse_for_each_card_drawn_this_way(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = alt((
-        tag::<_, _, OracleError<'_>>("card drawn this way"),
-        tag("cards drawn this way"),
-    ))
+    let (rest, _) = alt((tag("card drawn this way"), tag("cards drawn this way")))
     .parse(input)?;
     Ok((rest, QuantityRef::EventContextAmount))
 }
@@ -2895,6 +2892,7 @@ fn parse_for_each_clause_ref_with_they_controller(
 ) -> OracleResult<'_, QuantityRef> {
     alt((
         parse_for_each_card_drawn_this_way,
+        alt((
         parse_for_each_one_life_changed,
         parse_for_each_opponents_life_change,
         parse_counter_added_this_turn_for_each,
@@ -2936,6 +2934,7 @@ fn parse_for_each_clause_ref_with_they_controller(
         // from the graveyard-only "died" arm above.
         parse_for_each_creature_left_battlefield_this_turn,
         parse_entered_this_turn_ref,
+        )),
     ))
     .or(alt((
         |input| parse_for_each_combat_creature_controlled(input, they_controller.clone()),

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2881,8 +2881,7 @@ pub(crate) fn parse_for_each_clause_ref_with_context<'a>(
 
 /// CR 608.2c + CR 609.3: Read the Runes — "for each card[s] drawn this way".
 fn parse_for_each_card_drawn_this_way(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = alt((tag("card drawn this way"), tag("cards drawn this way")))
-    .parse(input)?;
+    let (rest, _) = alt((tag("card drawn this way"), tag("cards drawn this way"))).parse(input)?;
     Ok((rest, QuantityRef::EventContextAmount))
 }
 
@@ -2893,47 +2892,47 @@ fn parse_for_each_clause_ref_with_they_controller(
     alt((
         parse_for_each_card_drawn_this_way,
         alt((
-        parse_for_each_one_life_changed,
-        parse_for_each_opponents_life_change,
-        parse_counter_added_this_turn_for_each,
-        parse_color_of_object_for_each,
-        parse_object_colors_for_each,
-        parse_object_name_word_count_for_each,
-        parse_object_typeline_component_count_for_each,
-        parse_mana_symbols_in_object_mana_cost_for_each,
-        parse_distinct_card_types_in_zone,
-        parse_foretold_cards_owned_in_exile,
-        parse_zone_card_count,
-        parse_for_each_attached_to_source,
-        // CR 201.2: "for each differently named <type>" — distinct-by-name
-        // iteration. Must precede generic type-filter arm.
-        parse_for_each_differently_named,
-        // CR 201.2 + CR 603.4: "for each different <power|mana value> among <type>"
-        // — distinct-by-quality count (Golden Ratio, Lunar Insight, Sudden
-        // Insight). Must precede the generic type-filter arm so the "different
-        // <quality>" adjective prefix is consumed before the bare type word.
-        parse_distinct_quality_among_objects,
-        // CR 700.8: "creature in your party" must precede the generic
-        // "<type> you control" arm — same reason as in
-        // `parse_number_of_inner`.
-        parse_creature_in_party_for_each,
-        parse_player_counter_ref_tail,
-        // CR 700.4: "creature that died this turn" / "creature that
-        // died under your control this turn" — event-based count of dies-events
-        // tracked in `state.zone_changes_this_turn`. Must precede
-        // `parse_for_each_controlled_type` since the leading "creature" token
-        // would otherwise commit the simple `<type> you control` arm.
-        parse_for_each_subtype_died_this_turn,
-        parse_for_each_creature_died_this_turn,
-        // CR 701.21a: "[type] you['ve] sacrificed this turn" — event-based count
-        // of sacrifice events. Must precede `parse_for_each_controlled_type` so the
-        // leading type token does not commit to the generic `<type> you control` arm.
-        parse_for_each_sacrificed_this_turn,
-        // CR 400.7 + CR 603.10a: "creature that left the battlefield under your
-        // control this turn" — destination-agnostic zone-change count, distinct
-        // from the graveyard-only "died" arm above.
-        parse_for_each_creature_left_battlefield_this_turn,
-        parse_entered_this_turn_ref,
+            parse_for_each_one_life_changed,
+            parse_for_each_opponents_life_change,
+            parse_counter_added_this_turn_for_each,
+            parse_color_of_object_for_each,
+            parse_object_colors_for_each,
+            parse_object_name_word_count_for_each,
+            parse_object_typeline_component_count_for_each,
+            parse_mana_symbols_in_object_mana_cost_for_each,
+            parse_distinct_card_types_in_zone,
+            parse_foretold_cards_owned_in_exile,
+            parse_zone_card_count,
+            parse_for_each_attached_to_source,
+            // CR 201.2: "for each differently named <type>" — distinct-by-name
+            // iteration. Must precede generic type-filter arm.
+            parse_for_each_differently_named,
+            // CR 201.2 + CR 603.4: "for each different <power|mana value> among <type>"
+            // — distinct-by-quality count (Golden Ratio, Lunar Insight, Sudden
+            // Insight). Must precede the generic type-filter arm so the "different
+            // <quality>" adjective prefix is consumed before the bare type word.
+            parse_distinct_quality_among_objects,
+            // CR 700.8: "creature in your party" must precede the generic
+            // "<type> you control" arm — same reason as in
+            // `parse_number_of_inner`.
+            parse_creature_in_party_for_each,
+            parse_player_counter_ref_tail,
+            // CR 700.4: "creature that died this turn" / "creature that
+            // died under your control this turn" — event-based count of dies-events
+            // tracked in `state.zone_changes_this_turn`. Must precede
+            // `parse_for_each_controlled_type` since the leading "creature" token
+            // would otherwise commit the simple `<type> you control` arm.
+            parse_for_each_subtype_died_this_turn,
+            parse_for_each_creature_died_this_turn,
+            // CR 701.21a: "[type] you['ve] sacrificed this turn" — event-based count
+            // of sacrifice events. Must precede `parse_for_each_controlled_type` so the
+            // leading type token does not commit to the generic `<type> you control` arm.
+            parse_for_each_sacrificed_this_turn,
+            // CR 400.7 + CR 603.10a: "creature that left the battlefield under your
+            // control this turn" — destination-agnostic zone-change count, distinct
+            // from the graveyard-only "died" arm above.
+            parse_for_each_creature_left_battlefield_this_turn,
+            parse_entered_this_turn_ref,
         )),
     ))
     .or(alt((

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2879,11 +2879,22 @@ pub(crate) fn parse_for_each_clause_ref_with_context<'a>(
     parse_for_each_clause_ref_with_they_controller(input, they_controller)
 }
 
+/// CR 608.2c + CR 609.3: Read the Runes — "for each card[s] drawn this way".
+fn parse_for_each_card_drawn_this_way(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("card drawn this way"),
+        tag("cards drawn this way"),
+    ))
+    .parse(input)?;
+    Ok((rest, QuantityRef::EventContextAmount))
+}
+
 fn parse_for_each_clause_ref_with_they_controller(
     input: &str,
     they_controller: ControllerRef,
 ) -> OracleResult<'_, QuantityRef> {
     alt((
+        parse_for_each_card_drawn_this_way,
         parse_for_each_one_life_changed,
         parse_for_each_opponents_life_change,
         parse_counter_added_this_turn_for_each,
@@ -6389,6 +6400,13 @@ mod tests {
             },
             _ => panic!("expected ObjectCount"),
         }
+        assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn test_parse_for_each_card_drawn_this_way() {
+        let (rest, q) = parse_for_each_clause_ref("card drawn this way").unwrap();
+        assert_eq!(q, QuantityRef::EventContextAmount);
         assert_eq!(rest, "");
     }
 

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -6572,7 +6572,7 @@ mod tests {
     /// binds repeat count to the parent draw via `EventContextAmount`.
     #[test]
     fn card_drawn_this_way_uses_event_context_amount() {
-        let (rest, qty) = parse_for_each_clause_ref("card drawn this way").unwrap();
+        let (rest, qty) = nom_quantity::parse_for_each_clause_ref("card drawn this way").unwrap();
         assert!(rest.is_empty());
         assert_eq!(qty, QuantityRef::EventContextAmount);
     }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2666,6 +2666,16 @@ fn parse_for_each_clause_with_they_controller(
         if try_parse_counters_removed_this_way(&lower) {
             return Some(QuantityRef::PreviousEffectAmount);
         }
+        // CR 608.2c + CR 609.3: "card[s] drawn this way" — the count of cards
+        // just drawn by the immediately preceding draw instruction in the same
+        // resolution (Read the Runes). `EventContextAmount` reads the draw
+        // count stamped on `last_effect_count` by the parent Draw effect.
+        if matches!(
+            lower.as_str(),
+            "card drawn this way" | "cards drawn this way"
+        ) {
+            return Some(QuantityRef::EventContextAmount);
+        }
         // CR 608.2c + CR 400.7: "nontoken creature you controlled that was
         // destroyed this way" — tracked set members matching the filter prefix.
         // Use terminated(take_until(suffix), tag(suffix)) to split the clause
@@ -6566,6 +6576,14 @@ mod tests {
             },
             other => panic!("expected FilteredTrackedSetSize, got {other:?}"),
         }
+    }
+
+    /// CR 608.2c + CR 609.3: Read the Runes — "for each card drawn this way"
+    /// binds repeat count to the parent draw via `EventContextAmount`.
+    #[test]
+    fn card_drawn_this_way_uses_event_context_amount() {
+        let qty = parse_for_each_clause("card drawn this way").expect("must parse");
+        assert_eq!(qty, QuantityRef::EventContextAmount);
     }
 
     /// CR 608.2c + CR 701.9a: "nonland card discarded this way" (Seasoned

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2670,10 +2670,13 @@ fn parse_for_each_clause_with_they_controller(
         // just drawn by the immediately preceding draw instruction in the same
         // resolution (Read the Runes). `EventContextAmount` reads the draw
         // count stamped on `last_effect_count` by the parent Draw effect.
-        if matches!(
-            lower.as_str(),
-            "card drawn this way" | "cards drawn this way"
-        ) {
+        if all_consuming(alt((
+            tag::<_, _, OracleError<'_>>("card drawn this way"),
+            tag("cards drawn this way"),
+        )))
+        .parse(lower.as_str())
+        .is_ok()
+        {
             return Some(QuantityRef::EventContextAmount);
         }
         // CR 608.2c + CR 400.7: "nontoken creature you controlled that was

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -2666,19 +2666,6 @@ fn parse_for_each_clause_with_they_controller(
         if try_parse_counters_removed_this_way(&lower) {
             return Some(QuantityRef::PreviousEffectAmount);
         }
-        // CR 608.2c + CR 609.3: "card[s] drawn this way" — the count of cards
-        // just drawn by the immediately preceding draw instruction in the same
-        // resolution (Read the Runes). `EventContextAmount` reads the draw
-        // count stamped on `last_effect_count` by the parent Draw effect.
-        if all_consuming(alt((
-            tag::<_, _, OracleError<'_>>("card drawn this way"),
-            tag("cards drawn this way"),
-        )))
-        .parse(lower.as_str())
-        .is_ok()
-        {
-            return Some(QuantityRef::EventContextAmount);
-        }
         // CR 608.2c + CR 400.7: "nontoken creature you controlled that was
         // destroyed this way" — tracked set members matching the filter prefix.
         // Use terminated(take_until(suffix), tag(suffix)) to split the clause
@@ -6585,7 +6572,8 @@ mod tests {
     /// binds repeat count to the parent draw via `EventContextAmount`.
     #[test]
     fn card_drawn_this_way_uses_event_context_amount() {
-        let qty = parse_for_each_clause("card drawn this way").expect("must parse");
+        let (rest, qty) = parse_for_each_clause_ref("card drawn this way").unwrap();
+        assert!(rest.is_empty());
         assert_eq!(qty, QuantityRef::EventContextAmount);
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2064,7 +2064,7 @@ fn parse_unless_discard_cost(discard_tail: &str) -> Option<AbilityCost> {
 /// This is a known sub-fidelity gap (Balduvian Horde class). Post the
 /// 2026-05-09 fold, the `random: bool` field on `AbilityCost::Discard` is
 /// the natural home for this; wiring it into the runtime is future work.
-fn parse_unless_alt_cost(after_unless: &str) -> Option<AbilityCost> {
+pub(crate) fn parse_unless_alt_cost(after_unless: &str) -> Option<AbilityCost> {
     // CR 118.12 + CR 202.1: "you pay its mana cost" / "you pay ~'s mana cost" —
     // the unless cost is the ability source's OWN printed mana cost, which is
     // dynamic: it depends on the permanent the granting Aura is attached to

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4278,6 +4278,11 @@ mod tests {
                 &["Instant"][..],
             ),
             (
+                "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.",
+                "Read the Runes",
+                &["Instant"][..],
+            ),
+            (
                 "At the beginning of your upkeep, for each player, this enchantment deals 1 damage to that player unless they pay {B} or {3}.",
                 "Lim-Dul's Hex",
                 &["Enchantment"][..],


### PR DESCRIPTION
## Summary

- Route **"unless you sacrifice …"** resolution-time clauses through the existing trigger-side `parse_unless_alt_cost` authority with payer `Controller` (fixes Read the Runes and similar controller-payer unless shapes).
- Parse **"for each card drawn this way"** as `QuantityRef::EventContextAmount` so the discard loop repeats once per card actually drawn.
- Add parser, swallow, oracle pipeline, quantity, and engine runtime tests for Read the Runes.

Closes #4486

## Test plan

- [x] `read_the_runes_draw_then_discard_unless_sacrifice_permanent` (effect chain AST)
- [x] `read_the_runes_draw_discard_unless_sacrifice_permanent_parse` (full `parse_oracle_text`)
- [x] Swallow check: Read the Runes must not emit `Condition_Unless`
- [x] `card_drawn_this_way_uses_event_context_amount`
- [x] `read_the_runes_declining_sacrifice_discards_per_card_drawn` (engine runtime)
