### PR TITLE
fix(parser): Bounty of the Hunt cleanup counter removal (#4382)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3570,7 +3570,7 @@ pub(super) fn strip_temporal_suffix(text: &str) -> (&str, Option<DelayedTriggerC
                 player: crate::types::player::PlayerId(0),
             },
         ),
-        // CR 514.1 + CR 603.7a: "at the beginning of the next cleanup step"
+        // CR 514.3a + CR 603.7a: "at the beginning of the next cleanup step"
         // (Bounty of the Hunt and the class of temporary-counter effects).
         (
             " at the beginning of the next cleanup step",
@@ -3680,6 +3680,7 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                 },
                 tag("at end of combat, "),
             ),
+            // CR 514.3a + CR 603.7a: "at the beginning of the next cleanup step, "
             value(
                 DelayedTriggerCondition::AtNextPhase {
                     phase: Phase::Cleanup,

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3570,6 +3570,14 @@ pub(super) fn strip_temporal_suffix(text: &str) -> (&str, Option<DelayedTriggerC
                 player: crate::types::player::PlayerId(0),
             },
         ),
+        // CR 514.1 + CR 603.7a: "at the beginning of the next cleanup step"
+        // (Bounty of the Hunt and the class of temporary-counter effects).
+        (
+            " at the beginning of the next cleanup step",
+            DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::Cleanup,
+            },
+        ),
     ] {
         if lower.ends_with(suffix) {
             let end = text.len() - suffix.len();
@@ -3671,6 +3679,12 @@ pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerC
                     phase: Phase::EndCombat,
                 },
                 tag("at end of combat, "),
+            ),
+            value(
+                DelayedTriggerCondition::AtNextPhase {
+                    phase: Phase::Cleanup,
+                },
+                tag("at the beginning of the next cleanup step, "),
             ),
         ))
         .parse(i)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36127,6 +36127,53 @@ mod tests {
         );
     }
 
+    #[test]
+    fn strip_temporal_suffix_next_cleanup_step() {
+        let (text, cond) = strip_temporal_suffix(
+            "remove a +1/+1 counter from that creature at the beginning of the next cleanup step",
+        );
+        assert_eq!(text, "remove a +1/+1 counter from that creature");
+        assert_eq!(
+            cond,
+            Some(DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::Cleanup,
+            })
+        );
+    }
+
+    #[test]
+    fn bounty_of_the_hunt_schedules_cleanup_counter_removal() {
+        use crate::types::ability::AbilityKind;
+
+        let def = parse_effect_chain(
+            "Distribute three +1/+1 counters among one, two, or three target creatures. For each +1/+1 counter you put on a creature this way, remove a +1/+1 counter from that creature at the beginning of the next cleanup step.",
+            AbilityKind::Spell,
+        );
+        let sub = def
+            .sub_ability
+            .as_ref()
+            .expect("cleanup removal sub-ability");
+        match &*sub.effect {
+            Effect::CreateDelayedTrigger {
+                condition,
+                effect,
+                ..
+            } => {
+                assert_eq!(
+                    *condition,
+                    DelayedTriggerCondition::AtNextPhase {
+                        phase: Phase::Cleanup,
+                    }
+                );
+                match &*effect.effect {
+                    Effect::RemoveCounter { .. } => {}
+                    other => panic!("expected RemoveCounter, got {other:?}"),
+                }
+            }
+            other => panic!("expected CreateDelayedTrigger sub-ability, got {other:?}"),
+        }
+    }
+
     /// CR 603.7a: #638 Arcane Denial — "the next turn's upkeep" is the
     /// natural-language equivalent of "the next upkeep" and must produce the
     /// same `AtNextPhase { Upkeep }` delayed trigger. Covers the ~15-card

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36155,9 +36155,7 @@ mod tests {
             .expect("cleanup removal sub-ability");
         match &*sub.effect {
             Effect::CreateDelayedTrigger {
-                condition,
-                effect,
-                ..
+                condition, effect, ..
             } => {
                 assert_eq!(
                     *condition,


### PR DESCRIPTION
## Summary
- Parse "at the beginning of the next cleanup step" as a delayed-trigger temporal suffix/prefix
- Bounty of the Hunt now schedules counter removal on the next cleanup step instead of immediately after distribution

Fixes #4382

## Test plan
- [x] `cargo test -p engine bounty_of_the_hunt`
- [x] `cargo test -p engine strip_temporal_suffix_next_cleanup`