### PR TITLE
fix(parser): recover dynamic "gets +N/+M for each" after a leading keyword (Glamdring)

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -4,7 +4,6 @@
 use super::prelude::*;
 #[allow(unused_imports)]
 use super::support::*;
-use crate::parser::oracle_util::split_around;
 
 /// Try to parse "[Subtype] creatures you control get/have ..." patterns.
 /// `text` is the original-case text starting at the subtype word.
@@ -791,13 +790,22 @@ pub(crate) fn parse_continuous_gets_has(
         let pt_lower = pt_text.to_lowercase();
         // CR 613.4c: the "gets +N/+M" verb may sit AFTER a leading keyword clause
         // ("equipped creature has first strike and gets +1/+0 for each ...",
-        // Glamdring), not only at the head of the clause. Locate it at any word
-        // boundary via `split_around` so the dynamic P/T is still extracted; the
+        // Glamdring), not only at the head of the clause. Scan word boundaries for
+        // the verb with `nom_tag_lower` (the multi-position phrase-scan idiom, cf.
+        // `scan_timing_restrictions`) so the dynamic P/T is still extracted; the
         // leading keyword is recovered separately via `extract_keyword_clause`.
-        let pt_source = split_around(&pt_lower, "gets ")
-            .or_else(|| split_around(&pt_lower, "get "))
-            .map(|(_, after)| after)
-            .unwrap_or(&pt_lower);
+        let mut pt_scan: &str = &pt_lower;
+        let pt_source = loop {
+            if let Some(rest) = nom_tag_lower(pt_scan, pt_scan, "gets ")
+                .or_else(|| nom_tag_lower(pt_scan, pt_scan, "get "))
+            {
+                break rest;
+            }
+            match pt_scan.find(' ') {
+                Some(idx) => pt_scan = pt_scan[idx + 1..].trim_start(),
+                None => break pt_lower.as_str(),
+            }
+        };
 
         if let Some((p, t)) = parse_pt_mod(pt_source) {
             if let Some(quantity) =

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -4,6 +4,7 @@
 use super::prelude::*;
 #[allow(unused_imports)]
 use super::support::*;
+use crate::parser::oracle_util::split_around;
 
 /// Try to parse "[Subtype] creatures you control get/have ..." patterns.
 /// `text` is the original-case text starting at the subtype word.
@@ -788,8 +789,14 @@ pub(crate) fn parse_continuous_gets_has(
         let for_each_clause = strip_trailing_keyword_clause(raw_for_each);
 
         let pt_lower = pt_text.to_lowercase();
-        let pt_source = nom_tag_lower(&pt_lower, &pt_lower, "gets ")
-            .or_else(|| nom_tag_lower(&pt_lower, &pt_lower, "get "))
+        // CR 613.4c: the "gets +N/+M" verb may sit AFTER a leading keyword clause
+        // ("equipped creature has first strike and gets +1/+0 for each ...",
+        // Glamdring), not only at the head of the clause. Locate it at any word
+        // boundary via `split_around` so the dynamic P/T is still extracted; the
+        // leading keyword is recovered separately via `extract_keyword_clause`.
+        let pt_source = split_around(&pt_lower, "gets ")
+            .or_else(|| split_around(&pt_lower, "get "))
+            .map(|(_, after)| after)
             .unwrap_or(&pt_lower);
 
         if let Some((p, t)) = parse_pt_mod(pt_source) {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -9856,6 +9856,104 @@ fn static_parse_for_each_attached_to_self_kellan() {
     }
 }
 
+/// Helper: the dynamic-power `QuantityExpr` from a static line's first
+/// `AddDynamicPower` modification, plus whether `keyword` was granted.
+fn dyn_power_and_keyword(
+    line: &str,
+    keyword: &Keyword,
+) -> (crate::types::ability::QuantityExpr, bool) {
+    let def = parse_static_line(line).unwrap_or_else(|| panic!("static must parse: {line}"));
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let power = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("expected AddDynamicPower in: {line}"));
+    let has_kw = def
+        .modifications
+        .iter()
+        .any(|m| matches!(m, ContinuousModification::AddKeyword { keyword: k } if k == keyword));
+    (power, has_kw)
+}
+
+#[test]
+fn static_gets_for_each_survives_leading_keyword_clause() {
+    // Issue #4364 (Glamdring): "Equipped creature has first strike and gets
+    // +1/+0 for each instant and sorcery card in your graveyard." The leading
+    // "has first strike and" used to strand the "gets +N/+M" verb (the P/T
+    // extractor only stripped "gets " at the head of the clause), collapsing the
+    // dynamic boost to a flat +1/+0. The verb is now located at any word
+    // boundary, so BOTH the dynamic P/T and the leading keyword survive.
+    let assert_graveyard_is = |power: &crate::types::ability::QuantityExpr| match power {
+        QuantityExpr::Ref {
+            qty:
+                QuantityRef::ZoneCardCount {
+                    zone,
+                    card_types,
+                    scope,
+                    ..
+                },
+        } => {
+            assert_eq!(*zone, ZoneRef::Graveyard);
+            assert_eq!(*scope, CountScope::Controller);
+            assert!(
+                card_types.contains(&TypeFilter::Instant)
+                    && card_types.contains(&TypeFilter::Sorcery),
+                "expected instant+sorcery card types, got {card_types:?}"
+            );
+        }
+        other => panic!("expected ZoneCardCount Ref, got {other:?}"),
+    };
+
+    // Keyword-first (the bug witness) and the reordered control must agree.
+    let (kw_first, has_fs1) = dyn_power_and_keyword(
+        "Equipped creature has first strike and gets +1/+0 for each instant and sorcery card in your graveyard.",
+        &Keyword::FirstStrike,
+    );
+    let (gets_first, has_fs2) = dyn_power_and_keyword(
+        "Equipped creature gets +1/+0 for each instant and sorcery card in your graveyard and has first strike.",
+        &Keyword::FirstStrike,
+    );
+    assert_graveyard_is(&kw_first);
+    assert_graveyard_is(&gets_first);
+    assert!(
+        has_fs1,
+        "leading-keyword form must still grant first strike"
+    );
+    assert!(
+        has_fs2,
+        "trailing-keyword form must still grant first strike"
+    );
+    assert_eq!(
+        kw_first, gets_first,
+        "clause order must not change the boost"
+    );
+}
+
+#[test]
+fn static_gets_for_each_leading_keyword_class_generic() {
+    // Build-the-class check: "has <keyword> and gets +N/+M for each <filter>"
+    // must work for any keyword/filter, not just Glamdring.
+    let (power, has_trample) = dyn_power_and_keyword(
+        "Equipped creature has trample and gets +2/+2 for each Mountain you control.",
+        &Keyword::Trample,
+    );
+    assert!(has_trample, "leading keyword (trample) must survive");
+    assert!(
+        matches!(
+            power,
+            QuantityExpr::Multiply { factor: 2, .. }
+                | QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { .. }
+                }
+        ),
+        "expected a per-Mountain dynamic boost, got {power:?}"
+    );
+}
+
 #[test]
 fn static_parse_for_each_clause_other_creature() {
     // Verify parse_for_each_clause handles "other creature you control"


### PR DESCRIPTION
Closes #4364.

## Problem
Glamdring's "Equipped creature has first strike and gets +1/+0 for each instant
and sorcery card in your graveyard" gave a flat +1/+0 — the per-card scaling was
dropped.

## Cause
`parse_continuous_gets_has` extracted the P/T by stripping `"gets "` only at the
HEAD of the pre-`"for each"` clause. A leading `"has <keyword> and"` stranded the
verb, so the for-each branch bailed to the non-dynamic fallback.

## Fix
Locate the `"gets "`/`"get "` verb at any word boundary via `split_around`, so the
dynamic P/T is extracted regardless of clause order. The leading keyword is already
recovered separately via `extract_keyword_clause`. No new variants — reuses the
existing `AddDynamicPower` + `ZoneCardCount`/`ObjectCount` primitives.

## Tests
Build-the-class coverage: keyword-first vs reordered-control equality (proves order
no longer matters) + a generic "has trample and gets +2/+2 for each Mountain" case.
All 1477 static/anthem tests pass; parser-combinator gate and clippy clean.
