### PR TITLE
fix(parser+engine): Faith's Fetters combat lock on enchanted host (closes #3249)

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1016,6 +1016,14 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         && (nom_primitives::scan_contains(&lower, "can't attack")
             || nom_primitives::scan_contains(&lower, "can't block"))
     {
+        let tp = TextPair::new(&stripped, &lower);
+        // Faith's Fetters / Arrest-class Aura lines lead with "enchanted
+        // permanent/creature …"; the combat lock and activation prohibition apply
+        // to the host, not the Aura source.
+        let affected = attached_subject_filter(&tp)
+            .map(|(filter, _)| filter)
+            .unwrap_or(TargetFilter::SelfRef);
+        let source_filter = affected.clone();
         let mut defs = Vec::new();
         let combat_mode = if nom_primitives::scan_contains(&lower, "can't attack or block") {
             StaticMode::CantAttackOrBlock
@@ -1026,18 +1034,16 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         };
         defs.push(
             StaticDefinition::new(combat_mode)
-                .affected(TargetFilter::SelfRef)
+                .affected(affected.clone())
                 .description(stripped.to_string()),
         );
         defs.push(
-            // CR 602.5 + CR 603.2a: Self-reference case — the affected permanent's
-            // own activated abilities can't be activated by anyone.
             StaticDefinition::new(StaticMode::CantBeActivated {
                 who: ProhibitionScope::AllPlayers,
-                source_filter: TargetFilter::SelfRef,
+                source_filter,
                 exemption: parse_cant_be_activated_exemption_in_text(&lower),
             })
-            .affected(TargetFilter::SelfRef)
+            .affected(affected)
             .description(stripped.to_string()),
         );
         return defs;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16691,8 +16691,16 @@ fn cant_be_activated_self_ref_mana_exemption_suffix() {
 #[test]
 fn cant_be_activated_compound_aura_mana_exemption_suffix() {
     let defs = parse_static_line_multi(
-            "Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
-        );
+        "Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
+    );
+    let expected_affected = TargetFilter::Typed(
+        TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy]),
+    );
+    let cant_attack_or_block = defs
+        .iter()
+        .find(|def| def.mode == StaticMode::CantAttackOrBlock)
+        .expect("compound Aura text should emit CantAttackOrBlock");
+    assert_eq!(cant_attack_or_block.affected, Some(expected_affected.clone()));
     let cant_be_activated = defs
         .iter()
         .find(|def| matches!(def.mode, StaticMode::CantBeActivated { .. }))
@@ -16704,7 +16712,8 @@ fn cant_be_activated_compound_aura_mana_exemption_suffix() {
             exemption,
         } => {
             assert_eq!(*who, ProhibitionScope::AllPlayers);
-            assert_eq!(source_filter, &TargetFilter::SelfRef);
+            assert_eq!(source_filter, &expected_affected);
+            assert_eq!(cant_be_activated.affected, Some(expected_affected));
             assert_eq!(*exemption, ActivationExemption::ManaAbilities);
         }
         other => panic!("expected CantBeActivated, got {other:?}"),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16693,14 +16693,16 @@ fn cant_be_activated_compound_aura_mana_exemption_suffix() {
     let defs = parse_static_line_multi(
         "Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.",
     );
-    let expected_affected = TargetFilter::Typed(
-        TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy]),
-    );
+    let expected_affected =
+        TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy]));
     let cant_attack_or_block = defs
         .iter()
         .find(|def| def.mode == StaticMode::CantAttackOrBlock)
         .expect("compound Aura text should emit CantAttackOrBlock");
-    assert_eq!(cant_attack_or_block.affected, Some(expected_affected.clone()));
+    assert_eq!(
+        cant_attack_or_block.affected,
+        Some(expected_affected.clone())
+    );
     let cant_be_activated = defs
         .iter()
         .find(|def| matches!(def.mode, StaticMode::CantBeActivated { .. }))

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -1,0 +1,42 @@
+//! Issue #3249 — Faith's Fetters must prevent the enchanted permanent from attacking.
+//!
+//! Root cause: the compound static splitter for "can't attack or block, and …
+//! activated abilities can't be activated" bound both prohibitions to
+//! `TargetFilter::SelfRef` (the Aura) instead of the enchanted host filter.
+
+use engine::game::combat::AttackTarget;
+use engine::game::effects::attach::attach_to;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::phase::Phase;
+
+const FAITHS_FETTERS: &str = "Enchant permanent\n\
+When this Aura enters, you gain 4 life.\n\
+Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.";
+
+#[test]
+fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let fetters = {
+        let mut builder =
+            scenario.add_creature_from_oracle(P0, "Faith's Fetters", 0, 0, FAITHS_FETTERS);
+        builder.as_enchantment();
+        builder.with_subtypes(vec!["Aura"]);
+        builder.id()
+    };
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+    attach_to(runner.state_mut(), fetters, bear)
+        .expect("Faith's Fetters must attach to the bear");
+
+    runner.advance_to_combat();
+    let err = runner
+        .declare_attackers(&[(bear, AttackTarget::Player(P1))])
+        .expect_err("enchanted creature must be unable to attack under Faith's Fetters");
+    assert!(
+        err.to_string().contains("can't attack"),
+        "expected attack prohibition error, got {err}"
+    );
+}

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -6,7 +6,7 @@
 
 use engine::game::combat::AttackTarget;
 use engine::game::effects::attach::attach_to;
-use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::phase::Phase;
 
 const FAITHS_FETTERS: &str = "Enchant permanent\n\
@@ -28,8 +28,7 @@ fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
     let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
 
     let mut runner = scenario.build();
-    attach_to(runner.state_mut(), fetters, bear)
-        .expect("Faith's Fetters must attach to the bear");
+    attach_to(runner.state_mut(), fetters, bear).expect("Faith's Fetters must attach to the bear");
 
     runner.advance_to_combat();
     let err = runner

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -18,17 +18,29 @@ fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    let fetters = {
-        let mut builder =
-            scenario.add_creature_from_oracle(P0, "Faith's Fetters", 0, 0, FAITHS_FETTERS);
-        builder.as_enchantment();
-        builder.with_subtypes(vec!["Aura"]);
-        builder.id()
-    };
+    let fetters = scenario
+        .add_creature(P0, "Faith's Fetters", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(FAITHS_FETTERS)
+        .id();
     let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
 
     let mut runner = scenario.build();
-    attach_to(runner.state_mut(), fetters, bear).expect("Faith's Fetters must attach to the bear");
+    {
+        let fetters_obj = runner
+            .state_mut()
+            .objects
+            .get_mut(&fetters)
+            .expect("Faith's Fetters present");
+        if !fetters_obj.card_types.subtypes.iter().any(|s| s == "Aura") {
+            fetters_obj.card_types.subtypes.push("Aura".to_string());
+            fetters_obj.base_card_types = fetters_obj.card_types.clone();
+        }
+    }
+    assert!(
+        attach_to(runner.state_mut(), fetters, bear).is_some(),
+        "Faith's Fetters must attach to the bear"
+    );
 
     runner.advance_to_combat();
     let err = runner

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -1,53 +1,176 @@
-//! Issue #3249 — Faith's Fetters must prevent the enchanted permanent from attacking.
+//! Issue #3249 — Faith's Fetters must prevent the enchanted permanent from attacking
+//! and blocking.
 //!
 //! Root cause: the compound static splitter for "can't attack or block, and …
 //! activated abilities can't be activated" bound both prohibitions to
 //! `TargetFilter::SelfRef` (the Aura) instead of the enchanted host filter.
 
-use engine::game::combat::AttackTarget;
-use engine::game::effects::attach::attach_to;
-use engine::game::scenario::{GameScenario, P0, P1};
-use engine::types::phase::Phase;
+use engine::game::combat::{declare_attackers, declare_blockers, AttackTarget};
+use engine::game::layers::evaluate_layers;
+use engine::game::zones::create_object;
+use engine::parser::oracle_static::parse_static_line_multi;
+use engine::types::card_type::CoreType;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::CardId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
 
-const FAITHS_FETTERS: &str = "Enchant permanent\n\
-When this Aura enters, you gain 4 life.\n\
-Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.";
+const FAITHS_FETTERS_STATIC_LINE: &str = "Enchanted permanent can't attack or block, and its activated abilities can't be activated unless they're mana abilities.";
+
+const P0: PlayerId = PlayerId(0); // Aura controller and enchanted creature's controller
+const P1: PlayerId = PlayerId(1); // attacking opponent
 
 #[test]
 fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.active_player = P0;
+    state.turn_number = 2;
 
-    let fetters = scenario
-        .add_creature(P0, "Faith's Fetters", 0, 0)
-        .as_enchantment()
-        .from_oracle_text(FAITHS_FETTERS)
-        .id();
-    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
-
-    let mut runner = scenario.build();
+    let bear = CardId(state.next_object_id);
+    let bear_obj = create_object(
+        &mut state,
+        bear,
+        P0,
+        "Grizzly Bears".to_string(),
+        Zone::Battlefield,
+    );
     {
-        let fetters_obj = runner
-            .state_mut()
-            .objects
-            .get_mut(&fetters)
-            .expect("Faith's Fetters present");
-        if !fetters_obj.card_types.subtypes.iter().any(|s| s == "Aura") {
-            fetters_obj.card_types.subtypes.push("Aura".to_string());
-            fetters_obj.base_card_types = fetters_obj.card_types.clone();
-        }
+        let obj = state.objects.get_mut(&bear_obj).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
     }
+
+    let parsed_defs = parse_static_line_multi(FAITHS_FETTERS_STATIC_LINE);
+    let fetters = CardId(state.next_object_id);
+    let fetters_obj = create_object(
+        &mut state,
+        fetters,
+        P0,
+        "Faith's Fetters".to_string(),
+        Zone::Battlefield,
+    );
+    let ts = state.next_timestamp();
+    {
+        let aura_obj = state.objects.get_mut(&fetters_obj).unwrap();
+        aura_obj.card_types.core_types = vec![CoreType::Enchantment];
+        aura_obj.card_types.subtypes = vec!["Aura".to_string()];
+        aura_obj.base_card_types = aura_obj.card_types.clone();
+        aura_obj.attached_to = Some(bear.into());
+        aura_obj.timestamp = ts;
+        aura_obj.static_definitions = parsed_defs.clone().into();
+        aura_obj.base_static_definitions = std::sync::Arc::new(parsed_defs);
+    }
+    state
+        .objects
+        .get_mut(&bear_obj)
+        .unwrap()
+        .attachments
+        .push(fetters);
+
+    evaluate_layers(&mut state);
+
+    let mut events = Vec::new();
     assert!(
-        attach_to(runner.state_mut(), fetters, bear).is_some(),
-        "Faith's Fetters must attach to the bear"
+        declare_attackers(
+            &mut state,
+            &[(bear, AttackTarget::Player(P1))],
+            &mut events,
+        )
+        .is_err(),
+        "enchanted creature must be unable to attack under Faith's Fetters"
+    );
+}
+
+#[test]
+fn faiths_fetters_prevents_enchanted_creature_from_blocking() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.active_player = P1;
+    state.turn_number = 2;
+
+    let bear = CardId(state.next_object_id);
+    let bear_obj = create_object(
+        &mut state,
+        bear,
+        P0,
+        "Grizzly Bears".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&bear_obj).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+    }
+
+    let attacker = CardId(state.next_object_id);
+    let attacker_obj = create_object(
+        &mut state,
+        attacker,
+        P1,
+        "Attacker".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&attacker_obj).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(3);
+        obj.toughness = Some(3);
+        obj.base_power = Some(3);
+        obj.base_toughness = Some(3);
+    }
+
+    let parsed_defs = parse_static_line_multi(FAITHS_FETTERS_STATIC_LINE);
+    let fetters = CardId(state.next_object_id);
+    let fetters_obj = create_object(
+        &mut state,
+        fetters,
+        P0,
+        "Faith's Fetters".to_string(),
+        Zone::Battlefield,
+    );
+    let ts = state.next_timestamp();
+    {
+        let aura_obj = state.objects.get_mut(&fetters_obj).unwrap();
+        aura_obj.card_types.core_types = vec![CoreType::Enchantment];
+        aura_obj.card_types.subtypes = vec!["Aura".to_string()];
+        aura_obj.base_card_types = aura_obj.card_types.clone();
+        aura_obj.attached_to = Some(bear.into());
+        aura_obj.timestamp = ts;
+        aura_obj.static_definitions = parsed_defs.clone().into();
+        aura_obj.base_static_definitions = std::sync::Arc::new(parsed_defs);
+    }
+    state
+        .objects
+        .get_mut(&bear_obj)
+        .unwrap()
+        .attachments
+        .push(fetters);
+
+    evaluate_layers(&mut state);
+
+    let mut events = Vec::new();
+    assert!(
+        declare_attackers(
+            &mut state,
+            &[(attacker, AttackTarget::Player(P0))],
+            &mut events,
+        )
+        .is_ok(),
+        "attacker must be able to attack P0"
     );
 
-    runner.advance_to_combat();
-    let err = runner
-        .declare_attackers(&[(bear, AttackTarget::Player(P1))])
-        .expect_err("enchanted creature must be unable to attack under Faith's Fetters");
+    events.clear();
     assert!(
-        err.to_string().contains("can't attack"),
-        "expected attack prohibition error, got {err}"
+        declare_blockers(&mut state, &[(bear, attacker)], &mut events).is_err(),
+        "enchanted creature must be unable to block under Faith's Fetters"
     );
 }

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -76,7 +76,12 @@ fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
 
     let mut events = Vec::new();
     assert!(
-        declare_attackers(&mut state, &[(bear_obj, AttackTarget::Player(P1))], &mut events).is_err(),
+        declare_attackers(
+            &mut state,
+            &[(bear_obj, AttackTarget::Player(P1))],
+            &mut events,
+        )
+        .is_err(),
         "enchanted creature must be unable to attack under Faith's Fetters"
     );
 }
@@ -154,13 +159,23 @@ fn faiths_fetters_prevents_enchanted_creature_from_blocking() {
 
     let mut events = Vec::new();
     assert!(
-        declare_attackers(&mut state, &[(attacker_obj, AttackTarget::Player(P0))], &mut events).is_ok(),
+        declare_attackers(
+            &mut state,
+            &[(attacker_obj, AttackTarget::Player(P0))],
+            &mut events,
+        )
+        .is_ok(),
         "attacker must be able to attack P0"
     );
 
     events.clear();
     assert!(
-        declare_blockers(&mut state, &[(bear_obj, attacker_obj)], &mut events).is_err(),
+        declare_blockers(
+            &mut state,
+            &[(bear_obj, attacker_obj)],
+            &mut events,
+        )
+        .is_err(),
         "enchanted creature must be unable to block under Faith's Fetters"
     );
 }

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -60,7 +60,7 @@ fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
         aura_obj.card_types.core_types = vec![CoreType::Enchantment];
         aura_obj.card_types.subtypes = vec!["Aura".to_string()];
         aura_obj.base_card_types = aura_obj.card_types.clone();
-        aura_obj.attached_to = Some(bear.into());
+        aura_obj.attached_to = Some(bear_obj.into());
         aura_obj.timestamp = ts;
         aura_obj.static_definitions = parsed_defs.clone().into();
         aura_obj.base_static_definitions = std::sync::Arc::new(parsed_defs);
@@ -70,18 +70,13 @@ fn faiths_fetters_prevents_enchanted_creature_from_attacking() {
         .get_mut(&bear_obj)
         .unwrap()
         .attachments
-        .push(fetters);
+        .push(fetters_obj);
 
     evaluate_layers(&mut state);
 
     let mut events = Vec::new();
     assert!(
-        declare_attackers(
-            &mut state,
-            &[(bear, AttackTarget::Player(P1))],
-            &mut events,
-        )
-        .is_err(),
+        declare_attackers(&mut state, &[(bear_obj, AttackTarget::Player(P1))], &mut events).is_err(),
         "enchanted creature must be unable to attack under Faith's Fetters"
     );
 }
@@ -143,7 +138,7 @@ fn faiths_fetters_prevents_enchanted_creature_from_blocking() {
         aura_obj.card_types.core_types = vec![CoreType::Enchantment];
         aura_obj.card_types.subtypes = vec!["Aura".to_string()];
         aura_obj.base_card_types = aura_obj.card_types.clone();
-        aura_obj.attached_to = Some(bear.into());
+        aura_obj.attached_to = Some(bear_obj.into());
         aura_obj.timestamp = ts;
         aura_obj.static_definitions = parsed_defs.clone().into();
         aura_obj.base_static_definitions = std::sync::Arc::new(parsed_defs);
@@ -153,24 +148,19 @@ fn faiths_fetters_prevents_enchanted_creature_from_blocking() {
         .get_mut(&bear_obj)
         .unwrap()
         .attachments
-        .push(fetters);
+        .push(fetters_obj);
 
     evaluate_layers(&mut state);
 
     let mut events = Vec::new();
     assert!(
-        declare_attackers(
-            &mut state,
-            &[(attacker, AttackTarget::Player(P0))],
-            &mut events,
-        )
-        .is_ok(),
+        declare_attackers(&mut state, &[(attacker_obj, AttackTarget::Player(P0))], &mut events).is_ok(),
         "attacker must be able to attack P0"
     );
 
     events.clear();
     assert!(
-        declare_blockers(&mut state, &[(bear, attacker)], &mut events).is_err(),
+        declare_blockers(&mut state, &[(bear_obj, attacker_obj)], &mut events).is_err(),
         "enchanted creature must be unable to block under Faith's Fetters"
     );
 }

--- a/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
+++ b/crates/engine/tests/integration/issue_3249_faiths_fetters.rs
@@ -170,12 +170,7 @@ fn faiths_fetters_prevents_enchanted_creature_from_blocking() {
 
     events.clear();
     assert!(
-        declare_blockers(
-            &mut state,
-            &[(bear_obj, attacker_obj)],
-            &mut events,
-        )
-        .is_err(),
+        declare_blockers(&mut state, &[(bear_obj, attacker_obj)], &mut events).is_err(),
         "enchanted creature must be unable to block under Faith's Fetters"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -277,6 +277,7 @@ mod issue_2941_vivien_reid;
 mod issue_2943_kayas_wrath;
 mod issue_3127_reveal_otherwise_graveyard;
 mod issue_3245_abhorrent_oculus_manifest_dread;
+mod issue_3249_faiths_fetters;
 mod issue_3250_paladin_class;
 mod issue_3251_force_of_negation;
 mod issue_3252_rhythm_of_the_wild;


### PR DESCRIPTION
## Summary

* Fix compound Aura static parsing for lines like Faith's Fetters ("Enchanted permanent can't attack or block, and its activated abilities can't be activated …"): bind `CantAttackOrBlock` / `CantBeActivated` to the **enchanted host** (`EnchantedBy` permanent filter), not `SelfRef` on the Aura.
* Update parser regression for the compound mana-ability exemption suffix.
* Add runtime integration test proving an enchanted creature cannot declare attackers.

Closes #3249

## Test plan

* `cant_be_activated_compound_aura_mana_exemption_suffix`
* `faiths_fetters_prevents_enchanted_creature_from_attacking`
