### PR TITLE
fix(parser): Incremental Growth multi-target +1/+1 counter chain (closes #4503)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11972,6 +11972,59 @@ fn try_parse_multi_target_counter_chain(
     })
 }
 
+/// CR 115.4 + CR 601.2c: Bare counter-chain continuations re-invoke
+/// `try_parse_put_counter` on `put {segment}`; when the segment still says
+/// "another target" / "other target" / "third target", belt-and-suspenders
+/// re-inject `FilterProp::Another` in case the type-phrase recovery path
+/// dropped it (Incremental Growth / Incremental Blight class).
+fn ensure_another_on_counter_target(effect: Effect, segment: &str) -> Effect {
+    let lower = segment.trim().to_lowercase();
+    let has_distinct_target = nom_on_lower(&lower, &lower, |i| {
+        value((), alt((
+            tag("another target"),
+            tag("other target"),
+            tag("third target"),
+            tag("another "),
+            tag("other "),
+        )))
+        .parse(i)
+    })
+    .is_some();
+    if !has_distinct_target {
+        return effect;
+    }
+    match effect {
+        Effect::PutCounter {
+            counter_type,
+            count,
+            target,
+        } => Effect::PutCounter {
+            counter_type,
+            count,
+            target: ensure_another_target_filter(target),
+        },
+        other => other,
+    }
+}
+
+fn ensure_another_target_filter(filter: TargetFilter) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(mut tf) => {
+            if !tf.properties.contains(&FilterProp::Another) {
+                tf.properties.push(FilterProp::Another);
+            }
+            TargetFilter::Typed(tf)
+        }
+        TargetFilter::Or { filters } => TargetFilter::Or {
+            filters: filters
+                .into_iter()
+                .map(ensure_another_target_filter)
+                .collect(),
+        },
+        other => other,
+    }
+}
+
 fn parse_bare_counter_continuation<'a>(
     text: &'a str,
     ctx: &mut ParseContext,
@@ -11982,6 +12035,7 @@ fn parse_bare_counter_continuation<'a>(
         counter::try_parse_put_counter(&reparsed_lower, &reparsed_text, ctx)?;
     let consumed = reparsed_text.len().checked_sub(remainder.len())?;
     let text_consumed = consumed.checked_sub("put ".len())?;
+    let effect = ensure_another_on_counter_target(effect, text);
     Some((effect, &text[text_consumed..], multi_target))
 }
 
@@ -24735,6 +24789,32 @@ mod tests {
         def.sub_ability.as_deref()
     }
 
+    fn assert_plus_counter_node(
+        def: &AbilityDefinition,
+        count: i32,
+        another: bool,
+    ) -> Option<&AbilityDefinition> {
+        match def.effect.as_ref() {
+            Effect::PutCounter {
+                counter_type,
+                count: QuantityExpr::Fixed { value },
+                target,
+            } => {
+                assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                assert_eq!(*value, count);
+                let tf = typed_leg(target).expect("counter target should be typed");
+                assert!(has_type(tf, TypeFilter::Creature));
+                assert_eq!(
+                    tf.properties.contains(&FilterProp::Another),
+                    another,
+                    "unexpected Another property on {tf:?}",
+                );
+            }
+            other => panic!("expected PutCounter, got {other:?}"),
+        }
+        def.sub_ability.as_deref()
+    }
+
     /// Issue #943: comma-separated counter placements with bare count-led
     /// continuations inherit the `put` verb and stay as ordered sub-abilities.
     #[test]
@@ -24747,7 +24827,22 @@ mod tests {
         let second = assert_minus_counter_node(&def, 1, false).expect("second counter node");
         let third = assert_minus_counter_node(second, 2, true).expect("third counter node");
         assert!(
-            assert_minus_counter_node(third, 3, false).is_none(),
+            assert_minus_counter_node(third, 3, true).is_none(),
+            "counter chain should contain exactly three nodes",
+        );
+    }
+
+    #[test]
+    fn incremental_growth_plus_counter_chain() {
+        let def = parse_effect_chain(
+            "Put a +1/+1 counter on target creature, two +1/+1 counters on another target creature, and three +1/+1 counters on a third target creature.",
+            AbilityKind::Spell,
+        );
+
+        let second = assert_plus_counter_node(&def, 1, false).expect("second counter node");
+        let third = assert_plus_counter_node(second, 2, true).expect("third counter node");
+        assert!(
+            assert_plus_counter_node(third, 3, true).is_none(),
             "counter chain should contain exactly three nodes",
         );
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11980,13 +11980,16 @@ fn try_parse_multi_target_counter_chain(
 fn ensure_another_on_counter_target(effect: Effect, segment: &str) -> Effect {
     let lower = segment.trim().to_lowercase();
     let has_distinct_target = nom_on_lower(&lower, &lower, |i| {
-        value((), alt((
-            tag("another target"),
-            tag("other target"),
-            tag("third target"),
-            tag("another "),
-            tag("other "),
-        )))
+        value(
+            (),
+            alt((
+                tag("another target"),
+                tag("other target"),
+                tag("third target"),
+                tag("another "),
+                tag("other "),
+            )),
+        )
         .parse(i)
     })
     .is_some();

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11986,8 +11986,6 @@ fn segment_requires_distinct_target(segment: &str) -> bool {
             )),
         )
         .parse(input)
-        .ok()
-        .map(|(_, _)| ())
     })
     .is_some()
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11972,23 +11972,33 @@ fn try_parse_multi_target_counter_chain(
     })
 }
 
+/// True when a bare counter-chain segment qualifies its *target* as distinct
+/// (`another target`, `other target`, ordinal `third target`) — not when `another`
+/// modifies the counter quantity (`another +1/+1 counter on target creature`).
+fn segment_requires_distinct_target(segment: &str) -> bool {
+    nom_primitives::scan_at_word_boundaries(segment.trim(), |input| {
+        preceded(
+            opt(nom_primitives::parse_article),
+            alt((
+                tag::<_, _, OracleError<'_>>("another target"),
+                tag::<_, _, OracleError<'_>>("other target"),
+                tag::<_, _, OracleError<'_>>("third target"),
+            )),
+        )
+        .parse(input)
+        .ok()
+        .map(|(_, _)| ())
+    })
+    .is_some()
+}
+
 /// CR 115.4 + CR 601.2c: Bare counter-chain continuations re-invoke
 /// `try_parse_put_counter` on `put {segment}`; when the segment still says
 /// "another target" / "other target" / "third target", belt-and-suspenders
 /// re-inject `FilterProp::Another` in case the type-phrase recovery path
 /// dropped it (Incremental Growth / Incremental Blight class).
 fn ensure_another_on_counter_target(effect: Effect, segment: &str) -> Effect {
-    let lower = segment.trim().to_lowercase();
-    let has_distinct_target = [
-        "another target",
-        "other target",
-        "third target",
-        "another ",
-        "other ",
-    ]
-    .iter()
-    .any(|phrase| nom_primitives::scan_contains(&lower, phrase));
-    if !has_distinct_target {
+    if !segment_requires_distinct_target(segment) {
         return effect;
     }
     match effect {
@@ -24842,6 +24852,22 @@ mod tests {
         assert!(
             assert_plus_counter_node(third, 3, true).is_none(),
             "counter chain should contain exactly three nodes",
+        );
+    }
+
+    /// `another` modifying the counter quantity must not force `FilterProp::Another`
+    /// on the target — only target-qualified ordinals (`another target`, etc.) do.
+    #[test]
+    fn counter_chain_another_counter_quantity_does_not_require_distinct_target() {
+        let def = parse_effect_chain(
+            "Put a +1/+1 counter on target creature, another +1/+1 counter on target creature",
+            AbilityKind::Spell,
+        );
+
+        let second = assert_plus_counter_node(&def, 1, false).expect("second counter node");
+        assert!(
+            assert_plus_counter_node(second, 1, false).is_none(),
+            "counter chain should contain exactly two nodes",
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11979,20 +11979,15 @@ fn try_parse_multi_target_counter_chain(
 /// dropped it (Incremental Growth / Incremental Blight class).
 fn ensure_another_on_counter_target(effect: Effect, segment: &str) -> Effect {
     let lower = segment.trim().to_lowercase();
-    let has_distinct_target = nom_on_lower(&lower, &lower, |i| {
-        value(
-            (),
-            alt((
-                tag("another target"),
-                tag("other target"),
-                tag("third target"),
-                tag("another "),
-                tag("other "),
-            )),
-        )
-        .parse(i)
-    })
-    .is_some();
+    let has_distinct_target = [
+        "another target",
+        "other target",
+        "third target",
+        "another ",
+        "other ",
+    ]
+    .iter()
+    .any(|phrase| nom_primitives::scan_contains(&lower, phrase));
     if !has_distinct_target {
         return effect;
     }

--- a/crates/engine/tests/integration/issue_4503_incremental_growth.rs
+++ b/crates/engine/tests/integration/issue_4503_incremental_growth.rs
@@ -1,0 +1,86 @@
+//! Incremental Growth — multi-target +1/+1 counter chain.
+//!
+//! https://github.com/phase-rs/phase/issues/4503
+
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::ability::{
+    AbilityDefinition, Effect, FilterProp, QuantityExpr, TargetFilter, TypeFilter,
+};
+use engine::types::counter::CounterType;
+
+const INCREMENTAL_GROWTH_ORACLE: &str = "Put a +1/+1 counter on target creature, two +1/+1 \
+counters on another target creature, and three +1/+1 counters on a third target creature.";
+
+fn parse_incremental_growth() -> ParsedAbilities {
+    parse_oracle_text(
+        INCREMENTAL_GROWTH_ORACLE,
+        "Incremental Growth",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    )
+}
+
+fn typed_creature(filter: &TargetFilter) -> Option<&engine::types::ability::TypedFilter> {
+    match filter {
+        TargetFilter::Typed(tf) => Some(tf),
+        TargetFilter::And { filters } => filters.iter().find_map(typed_creature),
+        _ => None,
+    }
+}
+
+fn assert_plus_counter_node(
+    def: &AbilityDefinition,
+    count: i32,
+    another: bool,
+) -> Option<&AbilityDefinition> {
+    match def.effect.as_ref() {
+        Effect::PutCounter {
+            counter_type,
+            count: QuantityExpr::Fixed { value },
+            target,
+        } => {
+            assert_eq!(*counter_type, CounterType::Plus1Plus1);
+            assert_eq!(*value, count);
+            let tf = typed_creature(target).expect("counter target should be typed creature");
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature)),);
+            assert_eq!(
+                tf.properties.contains(&FilterProp::Another),
+                another,
+                "unexpected Another property on {tf:?}",
+            );
+        }
+        other => panic!("expected PutCounter, got {other:?}"),
+    }
+    def.sub_ability.as_deref()
+}
+
+#[test]
+fn incremental_growth_spell_parses_three_leg_put_counter_chain() {
+    let parsed = parse_incremental_growth();
+    let def = parsed
+        .abilities
+        .first()
+        .expect("Incremental Growth should parse to a spell ability");
+
+    let second = assert_plus_counter_node(def, 1, false).expect("second counter node");
+    let third = assert_plus_counter_node(second, 2, true).expect("third counter node");
+    assert!(
+        assert_plus_counter_node(third, 3, true).is_none(),
+        "counter chain should contain exactly three nodes",
+    );
+}
+
+#[test]
+fn incremental_growth_parsed_has_no_unimplemented_leaks() {
+    let parsed = parse_incremental_growth();
+    let def = parsed.abilities.first().expect("spell ability");
+    assert!(
+        !matches!(def.effect.as_ref(), Effect::Unimplemented { .. }),
+        "primary effect leaked Unimplemented: {:?}",
+        def.effect
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -386,6 +386,7 @@ mod issue_4379_convoke_cancel_untap;
 mod issue_4384_airbend_stack_spell;
 mod issue_4420_lava_blister_unless_deal_damage;
 mod issue_4459_decoy_gambit_unless_have_you_draw;
+mod issue_4503_incremental_growth;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary

- Re-inject `FilterProp::Another` in `parse_bare_counter_continuation` when a comma-separated counter segment still says "another target" / "other target", so multi-target chains (Incremental Growth / Incremental Blight class) enforce distinct targets on leg 2.
- Add `incremental_growth_plus_counter_chain` parser unit test (+1/+1) alongside the existing Issue #943 Incremental Blight shape test.
- Add integration coverage for Incremental Growth via `parse_oracle_text`.

## Test plan

- [x] `multi_target_counter_chain_incremental_blight_shape`
- [x] `incremental_growth_plus_counter_chain`
- [x] `incremental_growth_spell_parses_three_leg_put_counter_chain`
- [x] `incremental_growth_parsed_has_no_unimplemented_leaks`

Closes #4503
