### PR TITLE
fix(parser): Morkrut Necropod sacrifice another creature FilterProp::Another (closes #4513)

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -12085,6 +12085,25 @@ mod tests {
             obj.base_power = Some(3);
             obj.base_toughness = Some(3);
         }
+        // A second other creature so the mandatory sacrifice does not
+        // auto-resolve when `FilterProp::Another` leaves exactly one eligible
+        // permanent (see sacrifice.rs mandatory-all fast path).
+        let grizzly_bears = create_object(
+            &mut state,
+            CardId(21),
+            PlayerId(0),
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grizzly_bears).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.power = Some(2);
+            obj.toughness = Some(2);
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+        }
         let library_cards: Vec<_> = (0..3)
             .map(|i| {
                 create_object(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1312,19 +1312,18 @@ pub(super) fn parse_targeted_action_ast(
         // with `FilterProp::Another`; `parse_count_expr`'s "another " arm would
         // mis-read that qualifier as an implicit count of 1 and strip it.
         let lower_rest = rest.trim_start().to_lowercase();
-        let (count, after_count) = if lower_rest.starts_with("another ")
-            || lower_rest.starts_with("other ")
-        {
-            (
-                crate::types::ability::QuantityExpr::Fixed { value: 1 },
-                rest.trim_start(),
-            )
-        } else {
-            super::super::oracle_util::parse_count_expr(rest).unwrap_or((
-                crate::types::ability::QuantityExpr::Fixed { value: 1 },
-                rest,
-            ))
-        };
+        let (count, after_count) =
+            if lower_rest.starts_with("another ") || lower_rest.starts_with("other ") {
+                (
+                    crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                    rest.trim_start(),
+                )
+            } else {
+                super::super::oracle_util::parse_count_expr(rest).unwrap_or((
+                    crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                    rest,
+                ))
+            };
         let (target_text, _) = super::strip_optional_target_prefix(after_count.trim_start());
         // Strip the "of their choice" / "of your choice" confirmation suffix —
         // CR 701.16b makes player choice the default, so the phrase is a no-op

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -44,8 +44,8 @@ use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase,
-    resolve_pronoun_target, TargetSyntax,
+    ensure_another_prefix_in_filter, parse_target, parse_target_with_ctx,
+    parse_target_with_syntax, parse_type_phrase, resolve_pronoun_target, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
@@ -1214,6 +1214,7 @@ pub(super) fn parse_one_or_more_sacrifice(
         strip_article(filter_text.trim_start()).trim_end_matches('.'),
     ));
     let (mut target, remainder) = parse_type_phrase(target_text.trim());
+    ensure_another_prefix_in_filter(target_text.trim(), &mut target);
     if !remainder.trim().is_empty() || matches!(target, TargetFilter::Any) {
         return None;
     }
@@ -1237,6 +1238,7 @@ pub(super) fn parse_all_sacrifice<'a>(
     let lower = text.to_lowercase();
     let ((), rest) = nom_on_lower(text, &lower, |input| value((), tag("all ")).parse(input))?;
     let (mut target, rem) = parse_target_with_ctx(rest.trim_start(), ctx);
+    ensure_another_prefix_in_filter(rest.trim_start(), &mut target);
     if matches!(target, TargetFilter::Any) {
         return None;
     }
@@ -1351,7 +1353,8 @@ pub(super) fn parse_targeted_action_ast(
         } else if ctx.subject.is_some() && is_bare_object_pronoun(target_text.trim()) {
             resolve_it_pronoun(ctx)
         } else {
-            let (target, _rem) = parse_target_with_ctx(&target_text, ctx);
+            let (mut target, _rem) = parse_target_with_ctx(&target_text, ctx);
+            ensure_another_prefix_in_filter(&target_text, &mut target);
             #[cfg(debug_assertions)]
             assert_no_compound_remainder(_rem, text);
             target
@@ -11759,6 +11762,40 @@ mod tests {
             },
             other => panic!("expected Effect::Sacrifice, got {other:?}"),
         }
+    }
+
+    /// CR 115.10a + CR 701.16a: Morkrut Necropod — "sacrifice another creature
+    /// or land" must scope the creature disjunct with `FilterProp::Another`.
+    #[test]
+    fn parse_sacrifice_another_creature_or_land_carries_another() {
+        let text = "sacrifice another creature or land";
+        let lower = text.to_lowercase();
+        let mut ctx = ParseContext {
+            actor: Some(ControllerRef::You),
+            ..Default::default()
+        };
+        let result =
+            parse_targeted_action_ast(text, &lower, &mut ctx).expect("sacrifice should parse");
+        let Effect::Sacrifice { target, .. } = lower_targeted_action_ast(result) else {
+            panic!("expected Sacrifice");
+        };
+        let TargetFilter::Or { filters } = target else {
+            panic!("expected Or sacrifice target, got {target:?}");
+        };
+        let creature_tf = filters.iter().find_map(|f| {
+            let TargetFilter::Typed(tf) = f else {
+                return None;
+            };
+            tf.type_filters.contains(&TypeFilter::Creature).then_some(tf)
+        });
+        let land_tf = filters.iter().find_map(|f| {
+            let TargetFilter::Typed(tf) = f else {
+                return None;
+            };
+            tf.type_filters.contains(&TypeFilter::Land).then_some(tf)
+        });
+        assert!(creature_tf.expect("creature leg").properties.contains(&FilterProp::Another));
+        assert!(!land_tf.expect("land leg").properties.contains(&FilterProp::Another));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1313,22 +1313,21 @@ pub(super) fn parse_targeted_action_ast(
         // mis-read that qualifier as an implicit count of 1 and strip it.
         let rest_trimmed = rest.trim_start();
         let lower_rest = rest_trimmed.to_lowercase();
-        let (count, after_count) =
-            if nom_on_lower(rest_trimmed, &lower_rest, |input| {
-                value((), alt((tag("another "), tag("other ")))).parse(input)
-            })
-            .is_some()
-            {
-                (
-                    crate::types::ability::QuantityExpr::Fixed { value: 1 },
-                    rest_trimmed,
-                )
-            } else {
-                super::super::oracle_util::parse_count_expr(rest).unwrap_or((
-                    crate::types::ability::QuantityExpr::Fixed { value: 1 },
-                    rest,
-                ))
-            };
+        let (count, after_count) = if nom_on_lower(rest_trimmed, &lower_rest, |input| {
+            value((), alt((tag("another "), tag("other ")))).parse(input)
+        })
+        .is_some()
+        {
+            (
+                crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                rest_trimmed,
+            )
+        } else {
+            super::super::oracle_util::parse_count_expr(rest).unwrap_or((
+                crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                rest,
+            ))
+        };
         let (target_text, _) = super::strip_optional_target_prefix(after_count.trim_start());
         // Strip the "of their choice" / "of your choice" confirmation suffix —
         // CR 701.16b makes player choice the default, so the phrase is a no-op

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1311,12 +1311,17 @@ pub(super) fn parse_targeted_action_ast(
         // CR 115.10a + CR 121.1: "sacrifice another creature" scopes the filter
         // with `FilterProp::Another`; `parse_count_expr`'s "another " arm would
         // mis-read that qualifier as an implicit count of 1 and strip it.
-        let lower_rest = rest.trim_start().to_lowercase();
+        let rest_trimmed = rest.trim_start();
+        let lower_rest = rest_trimmed.to_lowercase();
         let (count, after_count) =
-            if lower_rest.starts_with("another ") || lower_rest.starts_with("other ") {
+            if nom_on_lower(rest_trimmed, &lower_rest, |input| {
+                value((), alt((tag("another "), tag("other ")))).parse(input)
+            })
+            .is_some()
+            {
                 (
                     crate::types::ability::QuantityExpr::Fixed { value: 1 },
-                    rest.trim_start(),
+                    rest_trimmed,
                 )
             } else {
                 super::super::oracle_util::parse_count_expr(rest).unwrap_or((

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -44,8 +44,8 @@ use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    ensure_another_prefix_in_filter, parse_target, parse_target_with_ctx,
-    parse_target_with_syntax, parse_type_phrase, resolve_pronoun_target, TargetSyntax,
+    ensure_another_prefix_in_filter, parse_target, parse_target_with_ctx, parse_target_with_syntax,
+    parse_type_phrase, resolve_pronoun_target, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
@@ -1308,10 +1308,23 @@ pub(super) fn parse_targeted_action_ast(
                 min_count,
             });
         }
-        let (count, after_count) = super::super::oracle_util::parse_count_expr(rest).unwrap_or((
-            crate::types::ability::QuantityExpr::Fixed { value: 1 },
-            rest,
-        ));
+        // CR 115.10a + CR 121.1: "sacrifice another creature" scopes the filter
+        // with `FilterProp::Another`; `parse_count_expr`'s "another " arm would
+        // mis-read that qualifier as an implicit count of 1 and strip it.
+        let lower_rest = rest.trim_start().to_lowercase();
+        let (count, after_count) = if lower_rest.starts_with("another ")
+            || lower_rest.starts_with("other ")
+        {
+            (
+                crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                rest.trim_start(),
+            )
+        } else {
+            super::super::oracle_util::parse_count_expr(rest).unwrap_or((
+                crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                rest,
+            ))
+        };
         let (target_text, _) = super::strip_optional_target_prefix(after_count.trim_start());
         // Strip the "of their choice" / "of your choice" confirmation suffix —
         // CR 701.16b makes player choice the default, so the phrase is a no-op
@@ -11786,7 +11799,9 @@ mod tests {
             let TargetFilter::Typed(tf) = f else {
                 return None;
             };
-            tf.type_filters.contains(&TypeFilter::Creature).then_some(tf)
+            tf.type_filters
+                .contains(&TypeFilter::Creature)
+                .then_some(tf)
         });
         let land_tf = filters.iter().find_map(|f| {
             let TargetFilter::Typed(tf) = f else {
@@ -11794,8 +11809,14 @@ mod tests {
             };
             tf.type_filters.contains(&TypeFilter::Land).then_some(tf)
         });
-        assert!(creature_tf.expect("creature leg").properties.contains(&FilterProp::Another));
-        assert!(!land_tf.expect("land leg").properties.contains(&FilterProp::Another));
+        assert!(creature_tf
+            .expect("creature leg")
+            .properties
+            .contains(&FilterProp::Another));
+        assert!(!land_tf
+            .expect("land leg")
+            .properties
+            .contains(&FilterProp::Another));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3064,6 +3064,15 @@ fn distribute_shared_properties(filter: TargetFilter, shared_props: &[FilterProp
     match filter {
         TargetFilter::Typed(mut typed) => {
             for prop in shared_props {
+                if matches!(prop, FilterProp::Another)
+                    && typed.type_filters.contains(&TypeFilter::Land)
+                    && !typed
+                        .type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
+                {
+                    continue;
+                }
                 if !typed
                     .properties
                     .iter()

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3040,23 +3040,18 @@ pub(crate) fn ensure_another_prefix_in_filter(text: &str, filter: &mut TargetFil
 }
 
 fn inject_another_on_creature_legs(filter: &mut TargetFilter) {
-    match filter {
-        TargetFilter::Typed(tf) => {
-            if tf
-                .type_filters
-                .iter()
-                .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
-                && !tf.properties.contains(&FilterProp::Another)
-            {
-                tf.properties.push(FilterProp::Another);
-            }
+    if let TargetFilter::Typed(tf) = filter
+        && tf
+            .type_filters
+            .iter()
+            .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
+        && !tf.properties.contains(&FilterProp::Another)
+    {
+        tf.properties.push(FilterProp::Another);
+    } else if let TargetFilter::Or { filters } | TargetFilter::And { filters } = filter {
+        for f in filters {
+            inject_another_on_creature_legs(f);
         }
-        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
-            for f in filters {
-                inject_another_on_creature_legs(f);
-            }
-        }
-        _ => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3039,19 +3039,25 @@ pub(crate) fn ensure_another_prefix_in_filter(text: &str, filter: &mut TargetFil
     inject_another_on_creature_legs(filter);
 }
 
+#[allow(clippy::collapsible_match)]
 fn inject_another_on_creature_legs(filter: &mut TargetFilter) {
-    if let TargetFilter::Typed(tf) = filter
-        && tf
-            .type_filters
-            .iter()
-            .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
-        && !tf.properties.contains(&FilterProp::Another)
-    {
-        tf.properties.push(FilterProp::Another);
-    } else if let TargetFilter::Or { filters } | TargetFilter::And { filters } = filter {
-        for f in filters {
-            inject_another_on_creature_legs(f);
+    match filter {
+        TargetFilter::Typed(tf) => {
+            if tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
+                && !tf.properties.contains(&FilterProp::Another)
+            {
+                tf.properties.push(FilterProp::Another);
+            }
         }
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for f in filters {
+                inject_another_on_creature_legs(f);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3032,8 +3032,13 @@ fn stack_spell_filter(mut typed: TypedFilter) -> TargetFilter {
 /// leading "another"/"other" qualifier but the lowered filter omitted it
 /// (cluster 33 — Morkrut Necropod, Incremental Growth class).
 pub(crate) fn ensure_another_prefix_in_filter(text: &str, filter: &mut TargetFilter) {
-    let trimmed = text.trim_start().to_lowercase();
-    if !(trimmed.starts_with("another ") || trimmed.starts_with("other ")) {
+    let trimmed = text.trim_start();
+    let lower = trimmed.to_lowercase();
+    if nom_on_lower(trimmed, &lower, |input| {
+        value((), alt((tag("another "), tag("other ")))).parse(input)
+    })
+    .is_none()
+    {
         return;
     }
     inject_another_on_creature_legs(filter);

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -3028,6 +3028,38 @@ fn stack_spell_filter(mut typed: TypedFilter) -> TargetFilter {
     }
 }
 
+/// CR 115.10a: Re-inject `FilterProp::Another` when the source phrase carried a
+/// leading "another"/"other" qualifier but the lowered filter omitted it
+/// (cluster 33 — Morkrut Necropod, Incremental Growth class).
+pub(crate) fn ensure_another_prefix_in_filter(text: &str, filter: &mut TargetFilter) {
+    let trimmed = text.trim_start().to_lowercase();
+    if !(trimmed.starts_with("another ") || trimmed.starts_with("other ")) {
+        return;
+    }
+    inject_another_on_creature_legs(filter);
+}
+
+fn inject_another_on_creature_legs(filter: &mut TargetFilter) {
+    match filter {
+        TargetFilter::Typed(tf) => {
+            if tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Creature | TypeFilter::Permanent))
+                && !tf.properties.contains(&FilterProp::Another)
+            {
+                tf.properties.push(FilterProp::Another);
+            }
+        }
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for f in filters {
+                inject_another_on_creature_legs(f);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn distribute_shared_properties(filter: TargetFilter, shared_props: &[FilterProp]) -> TargetFilter {
     match filter {
         TargetFilter::Typed(mut typed) => {
@@ -12514,6 +12546,62 @@ mod tests {
         } else {
             panic!("Expected Typed filter, got {filter:?}");
         }
+    }
+
+    /// CR 115.10a + CR 701.16a: Morkrut Necropod — "sacrifice another creature
+    /// or land" must carry `FilterProp::Another` on the creature disjunct only.
+    #[test]
+    fn parse_type_phrase_another_creature_or_land() {
+        let (filter, rest) = parse_type_phrase("another creature or land");
+        assert!(rest.trim().is_empty(), "remainder: '{rest}'");
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or filter, got {filter:?}");
+        };
+        assert_eq!(filters.len(), 2);
+        let creature = filters.iter().find(|f| {
+            matches!(
+                f,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.contains(&TypeFilter::Creature)
+            )
+        });
+        let land = filters.iter().find(|f| {
+            matches!(
+                f,
+                TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Land)
+            )
+        });
+        let creature = creature.expect("missing creature leg");
+        let land = land.expect("missing land leg");
+        let TargetFilter::Typed(creature_tf) = creature else {
+            unreachable!()
+        };
+        let TargetFilter::Typed(land_tf) = land else {
+            unreachable!()
+        };
+        assert!(
+            creature_tf.properties.contains(&FilterProp::Another),
+            "creature leg must carry Another, got {:?}",
+            creature_tf.properties
+        );
+        assert!(
+            !land_tf.properties.contains(&FilterProp::Another),
+            "land leg must not carry Another, got {:?}",
+            land_tf.properties
+        );
+    }
+
+    #[test]
+    fn ensure_another_prefix_in_filter_reinjects_on_creature_or_land() {
+        let (mut filter, _) = parse_type_phrase("creature or land");
+        ensure_another_prefix_in_filter("another creature or land", &mut filter);
+        let TargetFilter::Or { filters } = filter else {
+            panic!("expected Or, got {filter:?}");
+        };
+        let TargetFilter::Typed(creature_tf) = &filters[0] else {
+            panic!("expected creature leg");
+        };
+        assert!(creature_tf.properties.contains(&FilterProp::Another));
     }
 
     /// CR 700.9 + CR 109.4: "modified creatures you control other than ~"

--- a/crates/engine/tests/integration/issue_4513_morkrut_necropod_sacrifice_another.rs
+++ b/crates/engine/tests/integration/issue_4513_morkrut_necropod_sacrifice_another.rs
@@ -1,0 +1,49 @@
+//! Regression for issue #4513: Morkrut Necropod sacrifice-another filter.
+//!
+//! Oracle: "Whenever this creature attacks or blocks, sacrifice another
+//! creature or land."
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, FilterProp, TargetFilter, TypeFilter};
+use engine::types::triggers::TriggerMode;
+
+const MORKRUT_NECROPOD_ORACLE: &str =
+    "Menace\nWhenever this creature attacks or blocks, sacrifice another creature or land.";
+
+#[test]
+fn morkrut_necropod_attacks_or_blocks_sacrifice_another_creature_or_land() {
+    let parsed = parse_oracle_text(
+        MORKRUT_NECROPOD_ORACLE,
+        "Morkrut Necropod",
+        &[],
+        &["Creature".to_string()],
+        &["Slug".to_string(), "Horror".to_string()],
+    );
+    assert_eq!(parsed.triggers.len(), 1);
+    let trigger = &parsed.triggers[0];
+    assert_eq!(trigger.mode, TriggerMode::AttacksOrBlocks);
+
+    let execute = trigger.execute.as_ref().expect("trigger execute");
+    let Effect::Sacrifice { target, .. } = &*execute.effect else {
+        panic!("expected Sacrifice, got {:?}", execute.effect);
+    };
+    let TargetFilter::Or { filters } = target else {
+        panic!("expected Or sacrifice filter, got {target:?}");
+    };
+    let creature_tf = filters.iter().find_map(|f| {
+        let TargetFilter::Typed(tf) = f else {
+            return None;
+        };
+        tf.type_filters.contains(&TypeFilter::Creature).then_some(tf)
+    });
+    let land_tf = filters.iter().find_map(|f| {
+        let TargetFilter::Typed(tf) = f else {
+            return None;
+        };
+        tf.type_filters.contains(&TypeFilter::Land).then_some(tf)
+    });
+    let creature_tf = creature_tf.expect("missing creature leg");
+    let land_tf = land_tf.expect("missing land leg");
+    assert!(creature_tf.properties.contains(&FilterProp::Another));
+    assert!(!land_tf.properties.contains(&FilterProp::Another));
+}

--- a/crates/engine/tests/integration/issue_4513_morkrut_necropod_sacrifice_another.rs
+++ b/crates/engine/tests/integration/issue_4513_morkrut_necropod_sacrifice_another.rs
@@ -34,7 +34,9 @@ fn morkrut_necropod_attacks_or_blocks_sacrifice_another_creature_or_land() {
         let TargetFilter::Typed(tf) = f else {
             return None;
         };
-        tf.type_filters.contains(&TypeFilter::Creature).then_some(tf)
+        tf.type_filters
+            .contains(&TypeFilter::Creature)
+            .then_some(tf)
     });
     let land_tf = filters.iter().find_map(|f| {
         let TargetFilter::Typed(tf) = f else {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -387,6 +387,7 @@ mod issue_4384_airbend_stack_spell;
 mod issue_4420_lava_blister_unless_deal_damage;
 mod issue_4459_decoy_gambit_unless_have_you_draw;
 mod issue_4503_incremental_growth;
+mod issue_4513_morkrut_necropod_sacrifice_another;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary

- Add `ensure_another_prefix_in_filter` in `oracle_target.rs` to re-inject `FilterProp::Another` on creature legs after "another"/"other" is consumed.
- Wire the helper into sacrifice imperative parsing (`oracle_effect/imperative.rs`).
- Add parser + integration tests for Morkrut Necropod's "sacrifice another creature or land" trigger.

## Test plan

- [x] `parse_type_phrase_another_creature_or_land`
- [x] `parse_sacrifice_another_creature_or_land_carries_another`
- [x] `morkrut_necropod_attacks_or_blocks_sacrifice_another_creature_or_land` (integration)

Closes #4513
