### PR TITLE
fix(client): recover from unresponsive engine worker via request timeout

### DIFF
--- a/client/src/adapter/__tests__/engine-worker-client.test.ts
+++ b/client/src/adapter/__tests__/engine-worker-client.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EngineWorkerClient } from "../engine-worker-client";
+import { AdapterError, AdapterErrorCode } from "../types";
+
+/**
+ * Controllable stand-in for the engine Web Worker. Captures posted messages
+ * and lets a test decide whether (and when) to reply, so we can exercise the
+ * watchdog timeout that converts an infinite worker hang into a typed,
+ * recoverable ENGINE_UNRESPONSIVE rejection (instead of a silent freeze that
+ * leaves the dispatch mutex held forever).
+ */
+class MockWorker {
+  /** The most recently constructed instance, so a test can drive its replies. */
+  static last: MockWorker | undefined;
+
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  readonly posted: Array<Record<string, unknown>> = [];
+
+  constructor() {
+    MockWorker.last = this;
+  }
+
+  postMessage(msg: Record<string, unknown>): void {
+    this.posted.push(msg);
+  }
+
+  terminate(): void {}
+
+  /** Simulate a `result` reply for a previously-posted request id. */
+  replyResult(id: number, data: unknown): void {
+    this.onmessage?.({ data: { type: "result", id, data } } as MessageEvent);
+  }
+}
+
+function currentWorker(): MockWorker {
+  if (!MockWorker.last) throw new Error("no MockWorker constructed yet");
+  return MockWorker.last;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("Worker", MockWorker);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("EngineWorkerClient request timeout", () => {
+  it("rejects a gameplay round-trip with ENGINE_UNRESPONSIVE after the timeout", async () => {
+    vi.useFakeTimers();
+    const client = new EngineWorkerClient();
+
+    // The worker never replies — simulates a wedged engine call.
+    const promise = client.getState();
+    // Attach the rejection assertion before advancing timers so the eventual
+    // rejection is never seen as "unhandled".
+    const assertion = expect(promise).rejects.toBeInstanceOf(AdapterError);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+
+    await expect(promise).rejects.toMatchObject({
+      code: AdapterErrorCode.ENGINE_UNRESPONSIVE,
+      recoverable: true,
+    });
+  });
+
+  it("does not false-reject when the worker replies before the timeout, and clears the timer", async () => {
+    vi.useFakeTimers();
+    const client = new EngineWorkerClient();
+
+    const promise = client.getState();
+    const worker = currentWorker();
+    const reqId = worker.posted[0].id as number;
+
+    // Slow-but-completing reply at 30s — well within the 60s watchdog.
+    await vi.advanceTimersByTimeAsync(30_000);
+    worker.replyResult(reqId, { stack: [] });
+
+    await expect(promise).resolves.toEqual({ stack: [] });
+
+    // Pushing past the original deadline must not re-settle or throw: the
+    // settle path cleared the watchdog timer. A still-pending timer would
+    // fire here and reject an already-resolved promise (an unhandled
+    // rejection that fails the run).
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(promise).resolves.toEqual({ stack: [] });
+  });
+});

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -23,12 +23,41 @@ type EngineResponse =
   | { type: "result"; id: number; data: unknown }
   | { type: "error"; id: number; message: string; bracketViolation?: true };
 
+/**
+ * Watchdog timeout for gameplay round-trip calls. Generous on purpose: a
+ * legitimately slow call (e.g. a turn-21 four-player board) can take many
+ * seconds, and a false-positive timeout on a valid-but-slow call is worse
+ * than a longer wait. This does NOT speed anything up — it converts an
+ * otherwise-infinite worker hang into a 60s-then-recoverable error so the
+ * dispatch mutex is released and the user sees the recovery prompt instead
+ * of a silently dead UI. Tunable; only applied to gameplay round-trips, never
+ * to bulk/long setup calls (card-DB load, game init, batch resolve, restore).
+ */
+const ENGINE_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Watchdog timeout for AI search round-trips (getAiAction /
+ * getAiScoredCandidates / selectActionFromScores). Deliberately much larger
+ * than ENGINE_REQUEST_TIMEOUT_MS: AI search legitimately exceeds 60s on
+ * pathological boards (turn-40 squirrel / mana-token storms take hundreds of
+ * seconds in debug; release is ~10-50x faster but can still cross a minute),
+ * so the 60s gameplay window would false-positive and surface the engine-lost
+ * recovery modal mid-AI-turn on a perfectly healthy worker. 5 minutes gives
+ * generous headroom over realistic release AI times while still converting a
+ * true infinite hang into a recoverable error.
+ */
+const ENGINE_AI_TIMEOUT_MS = 300_000;
+
 export class EngineWorkerClient {
   private worker: Worker;
   private nextId = 0;
   private pending = new Map<
     number,
-    { resolve: (value: unknown) => void; reject: (reason: Error) => void }
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason: Error) => void;
+      timer?: ReturnType<typeof setTimeout>;
+    }
   >();
   private readyPromise: Promise<void>;
   private readyResolve!: () => void;
@@ -53,6 +82,7 @@ export class EngineWorkerClient {
           const entry = this.pending.get(msg.id);
           if (entry) {
             this.pending.delete(msg.id);
+            if (entry.timer) clearTimeout(entry.timer);
             entry.resolve(msg.data);
           }
           break;
@@ -61,6 +91,7 @@ export class EngineWorkerClient {
           const entry = this.pending.get(msg.id);
           if (entry) {
             this.pending.delete(msg.id);
+            if (entry.timer) clearTimeout(entry.timer);
             // Bracket violation is a typed rejection so the caller can match
             // by code rather than by string substring on the error message.
             const err = msg.bracketViolation
@@ -78,18 +109,46 @@ export class EngineWorkerClient {
       const msg = e.message ?? "Worker error";
       debugLog(`Engine worker error: ${msg} (${this.pending.size} pending requests rejected)`);
       for (const [, entry] of this.pending) {
+        if (entry.timer) clearTimeout(entry.timer);
         entry.reject(new Error(msg));
       }
       this.pending.clear();
     };
   }
 
-  private request<T>(message: Record<string, unknown>): Promise<T> {
+  /**
+   * Post a typed message to the worker and resolve when it replies.
+   *
+   * `timeoutMs` arms a watchdog: if the worker never replies within the
+   * window, the pending entry is deleted and the promise rejects with
+   * `ENGINE_UNRESPONSIVE`. This is applied ONLY to gameplay round-trips (see
+   * call sites below) — never to bulk/long setup calls (card-DB load, game
+   * init, batch resolve, restore), where a long but legitimate runtime is
+   * expected. A late worker reply after the timeout is a safe no-op: the
+   * pending entry is already gone, so the `if (entry)` guard in `onmessage`
+   * discards it.
+   */
+  private request<T>(message: Record<string, unknown>, timeoutMs?: number): Promise<T> {
     const id = this.nextId++;
     return new Promise<T>((resolve, reject) => {
+      const timer =
+        timeoutMs !== undefined
+          ? setTimeout(() => {
+              if (this.pending.delete(id)) {
+                reject(
+                  new AdapterError(
+                    AdapterErrorCode.ENGINE_UNRESPONSIVE,
+                    `Engine worker did not respond within ${timeoutMs}ms (${String(message.type)})`,
+                    true,
+                  ),
+                );
+              }
+            }, timeoutMs)
+          : undefined;
       this.pending.set(id, {
         resolve: resolve as (value: unknown) => void,
         reject,
+        timer,
       });
       this.worker.postMessage({ ...message, id });
     });
@@ -140,39 +199,69 @@ export class EngineWorkerClient {
     });
   }
 
+  // ── Gameplay round-trips ──────────────────────────────────────────────
+  // Each of these is a per-action engine call that the UI awaits before it can
+  // continue (and that holds the dispatch mutex). They carry the watchdog
+  // timeout so a wedged worker rejects with ENGINE_UNRESPONSIVE instead of
+  // hanging forever. Human round-trips use ENGINE_REQUEST_TIMEOUT_MS (60s);
+  // the AI-search getters (getAiAction / getAiScoredCandidates /
+  // selectActionFromScores) use the far longer ENGINE_AI_TIMEOUT_MS because a
+  // healthy search can legitimately exceed a minute on pathological boards.
+  // Bulk/long setup calls (card-DB load, game init, deck compatibility, batch
+  // resolve, restore/resume, export, bracket estimate) deliberately omit the
+  // timeout — their runtime is legitimately long.
+
   async submitAction(actor: number, action: GameAction): Promise<SubmitResult> {
-    return this.request<SubmitResult>({ type: "submitAction", actor, action });
+    return this.request<SubmitResult>(
+      { type: "submitAction", actor, action },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
   }
 
   async getState(): Promise<GameState> {
-    return this.request<GameState>({ type: "getState" });
+    return this.request<GameState>({ type: "getState" }, ENGINE_REQUEST_TIMEOUT_MS);
   }
 
   async getFilteredState(viewerId: number): Promise<GameState> {
-    return this.request<GameState>({ type: "getFilteredState", viewerId });
+    return this.request<GameState>(
+      { type: "getFilteredState", viewerId },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
   }
 
   async getLegalActions(): Promise<LegalActionsResult> {
-    return this.request<LegalActionsResult>({ type: "getLegalActions" });
+    return this.request<LegalActionsResult>(
+      { type: "getLegalActions" },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
   }
 
   async getLegalActionsForViewer(viewerId: number): Promise<LegalActionsResult> {
-    return this.request<LegalActionsResult>({ type: "getLegalActionsForViewer", viewerId });
+    return this.request<LegalActionsResult>(
+      { type: "getLegalActionsForViewer", viewerId },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
   }
 
   async getViewerSnapshot(viewerId: number): Promise<ViewerSnapshot> {
-    return this.request<ViewerSnapshot>({ type: "getViewerSnapshot", viewerId });
+    return this.request<ViewerSnapshot>(
+      { type: "getViewerSnapshot", viewerId },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
   }
 
   async getAiAction(
     difficulty: string,
     playerId: number,
   ): Promise<GameAction | null> {
-    return this.request<GameAction | null>({
-      type: "getAiAction",
-      difficulty,
-      playerId,
-    });
+    return this.request<GameAction | null>(
+      {
+        type: "getAiAction",
+        difficulty,
+        playerId,
+      },
+      ENGINE_AI_TIMEOUT_MS,
+    );
   }
 
   async getAiScoredCandidates(
@@ -180,12 +269,15 @@ export class EngineWorkerClient {
     playerId: number,
     seed: number,
   ): Promise<[GameAction, number][]> {
-    return this.request<[GameAction, number][]>({
-      type: "getAiScoredCandidates",
-      difficulty,
-      playerId,
-      seed,
-    });
+    return this.request<[GameAction, number][]>(
+      {
+        type: "getAiScoredCandidates",
+        difficulty,
+        playerId,
+        seed,
+      },
+      ENGINE_AI_TIMEOUT_MS,
+    );
   }
 
   async selectActionFromScores(
@@ -193,12 +285,15 @@ export class EngineWorkerClient {
     difficulty: string,
     seed: number,
   ): Promise<GameAction | null> {
-    return this.request<GameAction | null>({
-      type: "selectActionFromScores",
-      scoresJson,
-      difficulty,
-      seed,
-    });
+    return this.request<GameAction | null>(
+      {
+        type: "selectActionFromScores",
+        scoresJson,
+        difficulty,
+        seed,
+      },
+      ENGINE_AI_TIMEOUT_MS,
+    );
   }
 
   async exportState(): Promise<string> {
@@ -228,6 +323,11 @@ export class EngineWorkerClient {
     await this.request<null>({ type: "setMultiplayerMode", enabled });
   }
 
+  // Fast multiplayer-host seat-projection round-trips (pure state transforms,
+  // no AI search or animation). Intentionally left without the gameplay
+  // watchdog: they don't hold the dispatch mutex and a wedge here surfaces
+  // through the host's own connection/recovery path rather than the per-action
+  // recovery prompt.
   async applySeatMutation(stateJson: string, mutationJson: string): Promise<unknown> {
     return this.request<unknown>({
       type: "applySeatMutation",
@@ -248,6 +348,13 @@ export class EngineWorkerClient {
     aiSeats: { playerId: number; difficulty: string }[],
     maxResolutions: number = 0,
   ): Promise<BatchResolveResult> {
+    // Intentionally no watchdog timeout: a batch resolve can be legitimately
+    // very long (a multi-thousand-item storm draining one chunk at a time),
+    // and a false timeout mid-drain is worse than a long wait. Residual risk:
+    // if the worker wedges *inside* resolveAll itself the promise never settles
+    // and the "Resolving…" overlay sticks. Accepted as a lower-severity UX
+    // bug than false-positiving a healthy long drain — revisit only if a
+    // bounded per-chunk timeout proves safe.
     return this.request<BatchResolveResult>({
       type: "resolveAll",
       requester,
@@ -278,6 +385,7 @@ export class EngineWorkerClient {
 
   dispose(): void {
     for (const [, entry] of this.pending) {
+      if (entry.timer) clearTimeout(entry.timer);
       entry.reject(new Error("Worker disposed"));
     }
     this.pending.clear();

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2217,6 +2217,17 @@ export const AdapterErrorCode = {
    * offer a pre-filled bug report.
    */
   ENGINE_PANIC: "ENGINE_PANIC",
+  /**
+   * A gameplay round-trip to the engine Web Worker never returned within the
+   * timeout window (see `ENGINE_REQUEST_TIMEOUT_MS` in engine-worker-client).
+   * Without this, a wedged worker call hangs forever and leaves the dispatch
+   * mutex held, silently dropping every subsequent click. Classified as
+   * recoverable (mirrors STATE_LOST): the recovery layer surfaces the Layer 3
+   * reload prompt via `notifyEngineLost` rather than freezing the UI. A late
+   * worker reply that arrives after the timeout is a safe no-op (the pending
+   * entry has already been deleted by id).
+   */
+  ENGINE_UNRESPONSIVE: "ENGINE_UNRESPONSIVE",
   WASM_ERROR: "WASM_ERROR",
   INVALID_ACTION: "INVALID_ACTION",
   BRACKET_ESTIMATION_UNSUPPORTED: "bracket-estimation/unsupported",

--- a/client/src/game/__tests__/dispatchTimeout.test.ts
+++ b/client/src/game/__tests__/dispatchTimeout.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EngineAdapter, GameAction, GameState, LegalActionsResult, SubmitResult } from "../../adapter/types";
+import { AdapterError, AdapterErrorCode } from "../../adapter/types";
+import { useGameStore } from "../../stores/gameStore";
+import { dispatchAction } from "../dispatch";
+
+// Spy on the recovery escalation so we can assert the dispatch.ts branch that
+// fires `notifyEngineLost` on ENGINE_UNRESPONSIVE actually runs. Without this
+// the test could not distinguish "recovery surfaced" from "error merely
+// rethrown" — both reset the mutex, so the mutex assertion alone is not
+// discriminating for the dispatch.ts hunk under review.
+const notifyEngineLost = vi.fn();
+vi.mock("../engineRecovery", () => ({
+  notifyEngineLost: (...args: unknown[]) => notifyEngineLost(...args),
+  // Unreachable on the ENGINE_UNRESPONSIVE path (we early-return before any
+  // rehydrate), but dispatch.ts imports them, so they must exist.
+  attemptStateRehydrate: vi.fn(async () => false),
+  isEnginePanic: () => false,
+  routePanic: vi.fn(async () => {}),
+}));
+
+/** Minimal stack-empty state — enough for dispatch's pre-call bookkeeping. */
+const emptyState = {
+  stack: [],
+  waiting_for: null,
+  players: [],
+} as unknown as GameState;
+
+/**
+ * Regression for the silent-freeze bug: when a gameplay worker round-trip
+ * wedges, `submitAction` rejects with ENGINE_UNRESPONSIVE (the watchdog
+ * timeout). That rejection must (a) drive `processAction` to escalate via
+ * `notifyEngineLost` so the user sees the Layer 3 recovery prompt, and
+ * (b) propagate through `dispatchAction`'s finally, which resets the
+ * module-level `isAnimating` mutex. If the mutex stayed held, every later
+ * click would be silently queued/dropped and the UI would look dead.
+ */
+describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    notifyEngineLost.mockClear();
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notifyEngineLost.mockClear();
+  });
+
+  it("surfaces recovery and releases the dispatch mutex so a later dispatch is not silently dropped", async () => {
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockRejectedValue(
+        new AdapterError(AdapterErrorCode.ENGINE_UNRESPONSIVE, "worker did not respond", true),
+      );
+
+    useGameStore.setState({
+      adapter: { submitAction } as unknown as EngineAdapter,
+      gameState: emptyState,
+      gameMode: "ai",
+    });
+
+    const actionA = { type: "PassPriority", data: {} } as unknown as GameAction;
+    const actionB = { type: "ConcedeGame", data: {} } as unknown as GameAction;
+
+    // First dispatch hits the wedged worker and rejects.
+    await expect(dispatchAction(actionA, 0)).rejects.toMatchObject({
+      code: AdapterErrorCode.ENGINE_UNRESPONSIVE,
+    });
+
+    // Discriminating for the dispatch.ts hunk: the ENGINE_UNRESPONSIVE branch
+    // must have escalated to the Layer 3 recovery prompt. Remove that branch
+    // and the error is merely rethrown — this assertion then fails even though
+    // the mutex still resets.
+    expect(notifyEngineLost).toHaveBeenCalledWith("submitAction-timeout");
+
+    // The mutex must be free: a second, distinct dispatch reaches submitAction
+    // again rather than being queued behind a stuck `isAnimating`. (A held
+    // mutex would queue actionB without ever calling submitAction.)
+    await expect(dispatchAction(actionB, 0)).rejects.toMatchObject({
+      code: AdapterErrorCode.ENGINE_UNRESPONSIVE,
+    });
+
+    expect(submitAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fire recovery on a normal successful dispatch", async () => {
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockResolvedValue({ events: [], log_entries: [] } as unknown as SubmitResult);
+    const getState = vi
+      .fn<EngineAdapter["getState"]>()
+      .mockResolvedValue(emptyState);
+    const getLegalActions = vi
+      .fn<EngineAdapter["getLegalActions"]>()
+      .mockResolvedValue({ actions: [], autoPassRecommended: false } as unknown as LegalActionsResult);
+
+    useGameStore.setState({
+      adapter: { submitAction, getState, getLegalActions } as unknown as EngineAdapter,
+      gameState: emptyState,
+      gameMode: "ai",
+    });
+
+    const action = { type: "PassPriority", data: {} } as unknown as GameAction;
+
+    await expect(dispatchAction(action, 0)).resolves.toBeUndefined();
+
+    // The healthy path must never surface the engine-lost recovery prompt.
+    expect(notifyEngineLost).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -98,6 +98,19 @@ function isStateLost(err: unknown): boolean {
   return err instanceof AdapterError && err.code === AdapterErrorCode.STATE_LOST;
 }
 
+/**
+ * True when a gameplay round-trip to the engine worker timed out (the worker
+ * wedged and never replied — see `ENGINE_REQUEST_TIMEOUT_MS`). Unlike
+ * STATE_LOST this is NOT rehydratable in place: the worker itself is
+ * unresponsive, so retrying or restoring through it would hang again. Surface
+ * the Layer 3 reload prompt and let the error propagate so the dispatch mutex
+ * is released (the alternative is an infinite freeze with a silently-held mutex
+ * that drops every later click).
+ */
+function isEngineUnresponsive(err: unknown): boolean {
+  return err instanceof AdapterError && err.code === AdapterErrorCode.ENGINE_UNRESPONSIVE;
+}
+
 async function processAction(action: GameAction, actor: number): Promise<void> {
   const { adapter, gameState } = useGameStore.getState();
   if (!adapter || !gameState) {
@@ -146,6 +159,13 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
       await routePanic("submitAction-panic", err.panic);
       throw err;
     }
+    // Worker wedged on submitAction: surface recovery and rethrow so the
+    // dispatch mutex is released. Do NOT rehydrate — the worker is the thing
+    // that's hung, so restoreState through it would hang too.
+    if (isEngineUnresponsive(err)) {
+      notifyEngineLost("submitAction-timeout");
+      throw err;
+    }
     if (!isStateLost(err)) throw err;
     debugLog(`processAction: STATE_LOST on ${action.type}; attempting rehydrate`, "warn");
     const recovered = await attemptStateRehydrate();
@@ -187,6 +207,10 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   } catch (err) {
     if (isEnginePanic(err)) {
       await routePanic("getState-panic", err.panic);
+      throw err;
+    }
+    if (isEngineUnresponsive(err)) {
+      notifyEngineLost("getState-timeout");
       throw err;
     }
     if (!isStateLost(err)) throw err;
@@ -298,6 +322,10 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
       notifyEngineLost("getLegalActions-panic", err.panic);
       throw err;
     }
+    if (isEngineUnresponsive(err)) {
+      notifyEngineLost("getLegalActions-timeout");
+      throw err;
+    }
     if (!isStateLost(err)) throw err;
     const recovered = await attemptStateRehydrate();
     if (!recovered) {
@@ -379,11 +407,12 @@ async function processQueue(): Promise<void> {
       // de-duped but the log becomes noisy and we waste cycles on doomed
       // rehydrates. User is about to reload; nothing in this queue is
       // going to succeed.
-      if (isStateLost(err) || isEnginePanic(err)) {
-        // Drain on ENGINE_PANIC too: each queued action would otherwise hit
-        // its own catch + (no-op) recovery + re-throw, doubling the noise
-        // for an unrecoverable failure. The first item already fired
-        // notifyEngineLost with the captured panic.
+      if (isStateLost(err) || isEnginePanic(err) || isEngineUnresponsive(err)) {
+        // Drain on ENGINE_PANIC / ENGINE_UNRESPONSIVE too: each queued action
+        // would otherwise hit its own catch + (no-op) recovery + re-throw,
+        // doubling the noise for an unrecoverable failure. The first item
+        // already fired notifyEngineLost (captured panic, or the timeout
+        // recovery prompt) — a wedged worker won't service the rest either.
         while (pendingQueue.length > 0) {
           const stale = pendingQueue.shift()!;
           stale.reject(err);


### PR DESCRIPTION
Engine Web Worker round-trips had no timeout, so an engine that never
answers (e.g. an Omnath optional reveal that never resolves) left the
dispatch mutex held and silently froze the UI with dead modal buttons.

Arm a timeout on each request: gameplay round-trips reject with a
recoverable AdapterError(ENGINE_UNRESPONSIVE) after 60s, AI getters
after 300s, bulk/setup calls remain untimed. dispatch.ts surfaces the
recoverable error via notifyEngineLost and resets isAnimating so the
client can recover instead of deadlocking.
