### PR TITLE
feat(engine): Omnath, Locus of All — eligibility, dynamic mana, and decline-to-hand

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6991,6 +6991,12 @@ fn production_override_for_option(
         | crate::types::ability::ManaProduction::ChoiceAmongExiledColors { .. }
         | crate::types::ability::ManaProduction::OpponentLandColors { .. }
         | crate::types::ability::ManaProduction::AnyTypeProduceableBy { .. }
+        // CR 106.1 + CR 202.2c: Omnath, Locus of All is a one-shot triggered mana
+        // effect, not an activatable mana source the cost payer taps, so this is
+        // unreachable for the only current printing. Grouped with the dynamic
+        // any-color producers: each produced unit picks a single color, so the
+        // chosen option maps to a SingleColor override.
+        | crate::types::ability::ManaProduction::AnyCombinationOfObjectColors { .. }
         | crate::types::ability::ManaProduction::AnyInCommandersColorIdentity { .. } => Some(
             crate::types::game_state::ProductionOverride::SingleColor(option.mana_type),
         ),

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1226,7 +1226,10 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
                 ObjectScope::EventTarget => "event target",
                 ObjectScope::CostPaidObject => "cost-paid object",
             };
-            format!("{color:?} mana symbols in {scope_str}'s mana cost")
+            match color {
+                Some(c) => format!("{c:?} mana symbols in {scope_str}'s mana cost"),
+                None => format!("colored mana symbols in {scope_str}'s mana cost"),
+            }
         }
         QuantityRef::SelfManaValue => "self mana value".into(),
         QuantityRef::Aggregate {
@@ -1710,6 +1713,13 @@ fn fmt_mana_production(mp: &ManaProduction) -> String {
                 fmt_target(filter),
                 fmt_quantity(count)
             )
+        }
+        ManaProduction::AnyCombinationOfObjectColors { count, scope } => {
+            let subject = match scope {
+                ObjectScope::Target => "target's",
+                _ => "object's",
+            };
+            format!("{} any combo of {subject} colors", fmt_quantity(count))
         }
         ManaProduction::TriggerEventManaType => "1 of the triggering mana's type".to_string(),
     }

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -370,6 +370,7 @@ fn snapshot_parent_dependent_quantities(
                 ManaProduction::Colorless { count }
                 | ManaProduction::AnyOneColor { count, .. }
                 | ManaProduction::AnyCombination { count, .. }
+                | ManaProduction::AnyCombinationOfObjectColors { count, .. }
                 | ManaProduction::ChosenColor { count, .. },
             ..
         } => {

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -4,7 +4,7 @@ use crate::game::{mana_payment, mana_sources};
 use crate::types::ability::ManaContribution;
 use crate::types::ability::{
     ChoiceValue, Effect, EffectError, EffectKind, LinkedExileScope, ManaProduction,
-    ManaSpendRestriction, ResolvedAbility,
+    ManaSpendRestriction, ObjectScope, ResolvedAbility, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -503,6 +503,24 @@ fn resolve_mana_types_impl(
             };
             vec![first; amount]
         }
+        // CR 106.1 + CR 106.5 + CR 202.2c: Omnath, Locus of All — "add three mana
+        // in any combination of its colors." The color set is the scoped object's
+        // colors (dynamic, mirroring AnyOneColorAmongPermanents), not a static
+        // option list. This is the no-override default path; the per-unit free
+        // choice is surfaced by `mana_choice_prompt` (ManaChoicePrompt::AnyCombination)
+        // when the object has more than one color. Without an override the colors
+        // are cycled, mirroring the static AnyCombination default. CR 106.5: a
+        // colorless / unbound object produces no mana.
+        ManaProduction::AnyCombinationOfObjectColors { count, scope } => {
+            let amount = resolve_count(count, state, ability, controller, source_id);
+            let color_options = object_colors_for_scope(state, ability, *scope);
+            if color_options.is_empty() {
+                return Vec::new();
+            }
+            (0..amount)
+                .map(|index| mana_color_to_type(&color_options[index % color_options.len()]))
+                .collect()
+        }
         // CR 106.7 + CR 106.1b: Reflecting Pool class — produce N mana of any
         // type (W/U/B/R/G/C) that a land matching `land_filter` could produce.
         // Without an explicit choice override (auto-tap during cost payment, or
@@ -631,6 +649,41 @@ fn resolve_mana_types_impl(
 /// present among permanents matching `filter`. Colorless permanents contribute
 /// nothing. Used by both the mana ability resolver and `mana_sources` so that
 /// cost-payment and direct activation see the same option set.
+/// CR 202.2c + CR 106.5: Colors of the object identified by `scope`, for an
+/// `AnyCombinationOfObjectColors` mana production (Omnath, Locus of All). Reads
+/// the object's current `color` (zone-independent — correct after the revealed
+/// card is put into hand, per CR 400.7j), returned in stable WUBRG order. Empty
+/// when the scope binds no object or the object is colorless (CR 106.5). Only
+/// `ObjectScope::Target` has a printing today; other scopes bind no object.
+pub(crate) fn object_colors_for_scope(
+    state: &GameState,
+    ability: Option<&ResolvedAbility>,
+    scope: ObjectScope,
+) -> Vec<ManaColor> {
+    let obj_id = match scope {
+        ObjectScope::Target => ability.and_then(|a| {
+            a.targets.iter().find_map(|t| match t {
+                TargetRef::Object(id) => Some(*id),
+                _ => None,
+            })
+        }),
+        _ => None,
+    };
+    let Some(obj) = obj_id.and_then(|id| state.objects.get(&id)) else {
+        return Vec::new();
+    };
+    [
+        ManaColor::White,
+        ManaColor::Blue,
+        ManaColor::Black,
+        ManaColor::Red,
+        ManaColor::Green,
+    ]
+    .into_iter()
+    .filter(|c| obj.color.contains(c))
+    .collect()
+}
+
 pub(crate) fn distinct_colors_among_permanents(
     state: &GameState,
     ability: Option<&ResolvedAbility>,
@@ -788,6 +841,65 @@ mod tests {
 
         assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 1);
         assert_eq!(state.players[0].mana_pool.total(), 1);
+    }
+
+    /// CR 106.1 + CR 106.5 + CR 202.2c: `AnyCombinationOfObjectColors` (Omnath,
+    /// Locus of All) draws its colors from the target object. A monocolored
+    /// target needs no prompt — `resolve` produces `count` mana of that color
+    /// directly; a colorless target produces no mana (CR 106.5). (The multicolor
+    /// prompt→produce flow is covered by the `omnath_tests` runtime suite.)
+    #[test]
+    fn any_combination_of_object_colors_uses_target_colors_and_empty_when_colorless() {
+        let mk_ability = |target: ObjectId| {
+            ResolvedAbility::new(
+                Effect::Mana {
+                    produced: ManaProduction::AnyCombinationOfObjectColors {
+                        count: QuantityExpr::Fixed { value: 3 },
+                        scope: crate::types::ability::ObjectScope::Target,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+                vec![TargetRef::Object(target)],
+                ObjectId(100),
+                PlayerId(0),
+            )
+        };
+
+        // Monocolored (Black) target → three black mana, no prompt.
+        let mut state = GameState::new_two_player(42);
+        let mono = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Hand,
+        );
+        state.objects.get_mut(&mono).unwrap().color = vec![ManaColor::Black];
+        let mut events = Vec::new();
+        resolve(&mut state, &mk_ability(mono), &mut events).unwrap();
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ChooseManaColor { .. }),
+            "a single-color object needs no prompt"
+        );
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Black), 3);
+        assert_eq!(state.players[0].mana_pool.total(), 3);
+
+        // CR 106.5: colorless target → no prompt, no mana.
+        let mut state2 = GameState::new_two_player(42);
+        let colorless = create_object(
+            &mut state2,
+            CardId(2),
+            PlayerId(0),
+            "CL".to_string(),
+            Zone::Hand,
+        );
+        state2.objects.get_mut(&colorless).unwrap().color = vec![];
+        let mut events2 = Vec::new();
+        resolve(&mut state2, &mk_ability(colorless), &mut events2).unwrap();
+        assert_eq!(state2.players[0].mana_pool.total(), 0);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1757,39 +1757,78 @@ pub(super) fn resolve_optional_effect_decision(
             }
         }
         AutoMayChoice::Decline => {
-            let decline_branch = ability.else_ability.as_ref().or_else(|| {
-                ability.sub_ability.as_ref().filter(|sub| {
-                    // CR 608.2c: a conditioned decline branch (IfYouDo /
-                    // Otherwise / composite) resolves on decline — authoritative
-                    // check.
-                    should_resolve_subability_on_optional_decline(sub)
-                        // CR 608.2c: a separate-sentence sibling is the next
-                        // printed instruction and resolves regardless of the
-                        // optional decision — BUT only when it is not a
-                        // reflexive trigger. CR 603.12: a reflexive ("When you
-                        // do, …") sub's "do" did not occur when the action was
-                        // declined, so it must NOT fire even though it is a
-                        // separate sentence (issue #3179: Swashbuckler
-                        // Extraordinaire's declined Treasure sacrifice must not
-                        // resolve the double-strike reflexive). CastFromZone's
-                        // graveyard-exile rider is not a printed follow-up to
-                        // execute on decline; it is permission metadata consumed
-                        // only if the graveyard spell is actually cast.
-                        || (sub.sub_link == SubAbilityLink::SequentialSibling
-                            && !sub_ability_is_reflexive(sub)
-                            && !(matches!(&ability.effect, Effect::CastFromZone { .. })
-                                && (cast_from_zone::is_graveyard_exile_rider_subability(sub)
-                                    // CR 614.1c + CR 122.1: the enters-with-counter
-                                    // rider is permission metadata (Osteomancer
-                                    // Adept, The Tomb of Aclazotz), not a printed
-                                    // follow-up to execute on decline.
-                                    || cast_from_zone::is_enters_with_counter_rider_subability(
-                                        sub,
-                                    ))))
-                })
+            let decline_branch = ability.else_ability.as_deref().or_else(|| {
+                let sub = ability.sub_ability.as_deref()?;
+                // CR 608.2c: a conditioned decline branch (IfYouDo /
+                // Otherwise / composite) resolves on decline — authoritative
+                // check.
+                let selected = should_resolve_subability_on_optional_decline(sub)
+                    // CR 608.2c: a separate-sentence sibling is the next
+                    // printed instruction and resolves regardless of the
+                    // optional decision — BUT only when it is not a
+                    // reflexive trigger. CR 603.12: a reflexive ("When you
+                    // do, …") sub's "do" did not occur when the action was
+                    // declined, so it must NOT fire even though it is a
+                    // separate sentence (issue #3179: Swashbuckler
+                    // Extraordinaire's declined Treasure sacrifice must not
+                    // resolve the double-strike reflexive). CastFromZone's
+                    // graveyard-exile rider is not a printed follow-up to
+                    // execute on decline; it is permission metadata consumed
+                    // only if the graveyard spell is actually cast.
+                    || (sub.sub_link == SubAbilityLink::SequentialSibling
+                        && !sub_ability_is_reflexive(sub)
+                        && !(matches!(&ability.effect, Effect::CastFromZone { .. })
+                            && (cast_from_zone::is_graveyard_exile_rider_subability(sub)
+                                // CR 614.1c + CR 122.1: the enters-with-counter
+                                // rider is permission metadata (Osteomancer
+                                // Adept, The Tomb of Aclazotz), not a printed
+                                // follow-up to execute on decline.
+                                || cast_from_zone::is_enters_with_counter_rider_subability(sub))));
+                if !selected {
+                    return None;
+                }
+                // CR 608.2c: An `IfYouDo` head with no `else_ability` gates its
+                // ENTIRE accept body ("if you do, A and B") on the optional
+                // decision. On decline, run ONLY the trailing
+                // `Not(OptionalEffectPerformed)` clause ("if you don't, C") —
+                // never the accept-only instructions chained under the head
+                // (Omnath, Locus of All: declining the reveal must put the card
+                // in hand without adding mana). For every other selected shape
+                // (direct `Not` head, `else_ability` head whose condition-false
+                // path runs the else, composite `And`/`Or` head re-evaluated
+                // post-decline, or a `SequentialSibling`) the head itself is the
+                // branch to resolve.
+                if sub
+                    .condition
+                    .as_ref()
+                    .is_some_and(|c| c.is_optional_effect_performed())
+                    && sub.else_ability.is_none()
+                {
+                    Some(nested_optional_decline_clause(sub).unwrap_or(sub))
+                } else {
+                    Some(sub)
+                }
             });
             if let Some(branch) = decline_branch {
-                let mut resolved = branch.as_ref().clone();
+                let mut resolved = branch.clone();
+                // CR 608.2c: inherit the parent's resolved object targets ONLY
+                // when the decline clause's effect actually anaphors the parent
+                // target (`ParentTarget`) — e.g. Omnath, Locus of All's "if you
+                // don't, put IT into your hand", where the looked-at card is the
+                // parent's target. Mirrors the sub-ability target threading the
+                // condition-false descent applies in `resolve_ability_chain`,
+                // required here because an extracted nested decline clause is
+                // resolved directly rather than reached through that descent. The
+                // `effect_refs_parent_target` guard keeps a decline clause that
+                // carries its OWN target filter (e.g. a Chaos-Wand cleanup that
+                // returns `ExiledBySource` cards) from being clobbered with the
+                // parent's targets.
+                if resolved.targets.is_empty()
+                    && !ability.targets.is_empty()
+                    && effect_refs_parent_target(&resolved.effect)
+                {
+                    resolved.targets = ability.targets.clone();
+                }
                 resolved.context = ability.context.clone();
                 // CR 608.2c: This optional effect was DECLINED — the decline
                 // branch's `Not{IfYouDo}` / `IfYouDo` gate must evaluate
@@ -1952,6 +1991,33 @@ fn inject_last_revealed_targets(
         .collect()
 }
 
+/// CR 608.2c: Locate the `Not(OptionalEffectPerformed)` decline clause anywhere
+/// in an `IfYouDo` head's accept-body sub-chain. A parent optional ability has a
+/// single `sub_ability` link, so the accept body ("If you do, A and B") and the
+/// decline continuation ("If you don't, C") form one linked chain: when the
+/// accept body has two or more instructions, the decline clause C is nested
+/// BELOW them rather than as the head's direct child (Omnath, Locus of All:
+/// "If you do, add mana AND put it into hand. If you don't, put it into hand").
+/// Walking the chain finds C at any depth. Returning the precise decline node
+/// lets the resolver run ONLY it on decline — never the accept-only instructions
+/// gated by "if you do" (CR 608.2c: follow the instructions in the order
+/// written). For the single-instruction Springheart Nantuko shape (C is the
+/// direct child) this returns that same direct child. Locator helper.
+fn nested_optional_decline_clause(ability: &ResolvedAbility) -> Option<&ResolvedAbility> {
+    let mut current = ability.sub_ability.as_deref();
+    while let Some(node) = current {
+        if node
+            .condition
+            .as_ref()
+            .is_some_and(AbilityCondition::is_not_optional_effect_performed)
+        {
+            return Some(node);
+        }
+        current = node.sub_ability.as_deref();
+    }
+    None
+}
+
 fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> bool {
     match ability.condition {
         Some(AbilityCondition::Not { ref condition })
@@ -1979,15 +2045,14 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
         Some(AbilityCondition::EffectOutcome {
             signal: EffectOutcomeSignal::OptionalEffectPerformed,
         }) => {
+            // CR 608.2c: The `Not(OptionalEffectPerformed)` decline clause may be
+            // the head's direct child (single-instruction accept body —
+            // Springheart Nantuko) or a deeper descendant (multi-instruction
+            // accept body — Omnath, Locus of All). `nested_optional_decline_clause`
+            // walks the chain to find it at any depth.
             ability.else_ability.is_some()
                 || (ability.player_scope.is_none()
-                    && ability.sub_ability.as_ref().is_some_and(|s| {
-                        matches!(
-                            &s.condition,
-                            Some(AbilityCondition::Not { condition })
-                                if condition.is_optional_effect_performed()
-                        )
-                    }))
+                    && nested_optional_decline_clause(ability).is_some())
         }
         // CR 608.2c + CR 608.2d: A composite `And`/`Or` condition that contains
         // a performed-gate is a valid decline branch — declining the
@@ -9643,6 +9708,150 @@ mod tests {
         assert_eq!(state.players[1].life, 18);
         // Controller drew a card
         assert_eq!(state.players[0].hand.len(), 1);
+    }
+
+    /// CR 608.2c: General building block for the Omnath, Locus of All decline
+    /// shape — "you may X. If you do, A and B. If you don't, put IT into hand."
+    /// The decline clause C is a `Not(OptionalEffectPerformed)` GRANDCHILD of the
+    /// `IfYouDo` head (the accept body A;B is a two-instruction chain, so C is
+    /// appended below them). On DECLINE only C must run; the accept-only
+    /// instructions A and B must NOT. C moves the PARENT'S target object to hand
+    /// via `ParentTarget` (exactly Omnath's "put it into your hand"), so this
+    /// fixture is discriminating for BOTH failure modes: a finder-only fix runs
+    /// the unconditioned B on decline (life changes), and a fix that resolves C
+    /// detached WITHOUT inheriting the parent's targets leaves `ParentTarget`
+    /// empty so the card never moves. Drives the real
+    /// `resolve_optional_effect_decision` routing function.
+    #[test]
+    fn optional_decline_runs_only_nested_decline_clause_not_accept_body() {
+        fn build_chain(card: ObjectId) -> ResolvedAbility {
+            // C: decline clause — move the parent's target object to hand, gated
+            // Not(IfYouDo). `ParentTarget` must resolve against the inherited
+            // parent target (the card), as Omnath's "if you don't, put it into
+            // your hand" does.
+            let decline = ResolvedAbility::new(
+                Effect::ChangeZone {
+                    origin: None,
+                    destination: Zone::Hand,
+                    target: TargetFilter::ParentTarget,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: vec![],
+                    face_down_profile: None,
+                },
+                vec![],
+                ObjectId(100),
+                PlayerId(0),
+            )
+            .condition(AbilityCondition::Not {
+                condition: Box::new(AbilityCondition::EffectOutcome {
+                    signal: EffectOutcomeSignal::OptionalEffectPerformed,
+                }),
+            });
+            // B: second accept-body instruction — unconditioned GainLife(+3).
+            let accept_b = ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(100),
+                PlayerId(0),
+            )
+            .sub_ability(decline);
+            // A: IfYouDo head — GainLife(+2), gated OptionalEffectPerformed.
+            let accept_a = ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(100),
+                PlayerId(0),
+            )
+            .condition(AbilityCondition::EffectOutcome {
+                signal: EffectOutcomeSignal::OptionalEffectPerformed,
+            })
+            .sub_ability(accept_b);
+            // Parent optional ability ("you may X") targeting the looked-at card;
+            // neutral GainLife(0) effect.
+            ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 0 },
+                    player: TargetFilter::Controller,
+                },
+                vec![TargetRef::Object(card)],
+                ObjectId(100),
+                PlayerId(0),
+            )
+            .sub_ability(accept_a)
+        }
+
+        fn fresh_state() -> (GameState, ObjectId) {
+            let mut state = GameState::new_two_player(42);
+            let card = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Card".to_string(),
+                Zone::Library,
+            );
+            (state, card)
+        }
+
+        // DECLINE: only C runs — the parent-target card moves to hand, life
+        // UNCHANGED (A and B skipped). Card-in-hand proves C resolved AND bound
+        // its `ParentTarget` to the inherited parent target; life-unchanged
+        // proves the accept-only instructions did not run.
+        {
+            let (mut state, card) = fresh_state();
+            let start_life = state.players[0].life;
+            let mut events = Vec::new();
+            resolve_optional_effect_decision(
+                &mut state,
+                build_chain(card),
+                AutoMayChoice::Decline,
+                &mut events,
+                0,
+            )
+            .expect("decline resolves");
+            assert!(
+                state.players[0].hand.contains(&card),
+                "decline runs C and binds ParentTarget (card moved to hand)"
+            );
+            assert_eq!(
+                state.players[0].life, start_life,
+                "decline must NOT run accept-only A/B (life unchanged)"
+            );
+        }
+
+        // ACCEPT: A and B run (life +5), C skipped (card stays in library).
+        {
+            let (mut state, card) = fresh_state();
+            let start_life = state.players[0].life;
+            let mut events = Vec::new();
+            resolve_optional_effect_decision(
+                &mut state,
+                build_chain(card),
+                AutoMayChoice::Accept,
+                &mut events,
+                0,
+            )
+            .expect("accept resolves");
+            assert_eq!(
+                state.players[0].life,
+                start_life + 5,
+                "accept runs A(+2) and B(+3)"
+            );
+            assert!(
+                !state.players[0].hand.contains(&card),
+                "accept skips decline clause C (card stays in library)"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -6471,6 +6471,31 @@ fn resolve_chain_body(
                 return Ok(());
             }
 
+            // CR 608.2c + CR 400.7j: When the parent effect wrote the
+            // last-revealed set (a look/reveal/dig) but carries no targets of its
+            // own, the gated sub references that revealed object both in its
+            // condition ("if it has three or more colored mana symbols in its
+            // mana cost") and in its effect ("add three mana in any combination
+            // of its colors") — Omnath, Locus of All. CR 400.7j: an effect can
+            // find an object it moved to a public zone, so the deep add-mana sub
+            // still finds the revealed card after it is put into hand. Inject the
+            // revealed ids as the parent's targets so BOTH the condition
+            // evaluation and the performed-true sub-resolution (which inherits
+            // the parent's targets via the early continuation/sibling paths) bind
+            // to the revealed object.
+            let injected_parent;
+            let ability: &ResolvedAbility = if effect_writes_last_revealed_ids(&ability.effect)
+                && !state.last_revealed_ids.is_empty()
+                && ability.targets.is_empty()
+            {
+                let mut clone = ability.clone();
+                clone.targets = inject_last_revealed_targets(state, ability, sub.as_ref());
+                injected_parent = clone;
+                &injected_parent
+            } else {
+                ability
+            };
+
             let condition_met = evaluate_condition(condition, state, ability);
             if !condition_met {
                 // CR 608.2c: Execute else branch if present ("Otherwise, [effect]")

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -6916,7 +6916,7 @@ mod tests {
             let qty = QuantityExpr::Ref {
                 qty: QuantityRef::ManaSymbolsInManaCost {
                     scope: crate::types::ability::ObjectScope::Recipient,
-                    color: ManaColor::White,
+                    color: Some(ManaColor::White),
                 },
             };
             obj.static_definitions.push(

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -710,6 +710,29 @@ pub(crate) fn mana_choice_prompt(
                 None
             }
         }
+        // CR 106.1 + CR 202.2c: Omnath, Locus of All — each of the produced mana
+        // is freely chosen among the scoped object's colors (dynamic, mirrors
+        // AnyCombination but with a runtime-resolved option set). Surface the
+        // AnyCombination prompt only when the object has more than one color; 0 or
+        // 1 color needs no prompt (CR 106.5 empty → no mana; single auto-picks).
+        ManaProduction::AnyCombinationOfObjectColors { scope, .. } => {
+            let options = super::effects::mana::object_colors_for_scope(state, ability, *scope)
+                .iter()
+                .map(mana_color_to_type)
+                .collect::<Vec<_>>();
+            if options.len() <= 1 {
+                return None;
+            }
+            let ability = ability?;
+            let count =
+                super::effects::mana::resolve_mana_types_for_ability(produced, state, ability)
+                    .len();
+            if count > 0 {
+                Some(ManaChoicePrompt::AnyCombination { count, options })
+            } else {
+                None
+            }
+        }
         _ => None,
     }
 }

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -684,6 +684,10 @@ pub fn display_land_mana_pips(
                     push(&mut pips, ManaPip::OneOfColors(colors));
                 }
             }
+            // CR 106.1 + CR 202.2c: Omnath, Locus of All — colors are read from a
+            // target object resolved at trigger-resolution time, not from this
+            // permanent's frame, so there is no static pip to display here.
+            ManaProduction::AnyCombinationOfObjectColors { .. } => {}
             // CR 603.7c + CR 106.3: Resolves only inside a TapsForMana
             // trigger; outside a trigger context there is no pre-resolution
             // pip to display, so contribute nothing.
@@ -1070,6 +1074,11 @@ fn profile_kind_from_production(
             }
         }
         ManaProduction::TriggerEventManaType => None,
+        // CR 106.1 + CR 202.2c: Omnath, Locus of All — a one-shot triggered mana
+        // effect, never an activatable mana ability tapped during cost payment.
+        // No target-bound object exists in this profile context, so it surfaces
+        // no activatable profile (CR 106.5).
+        ManaProduction::AnyCombinationOfObjectColors { .. } => None,
         _ => {
             let types =
                 super::effects::mana::resolve_mana_types_for_ability(produced, state, resolved);
@@ -1735,6 +1744,11 @@ fn mana_options_from_production(
                 .map(mana_color_to_type)
                 .collect()
         }
+        // CR 106.1 + CR 202.2c: Omnath, Locus of All — colors come from a target
+        // object bound at trigger resolution, not available in this mana-source
+        // enumeration context (no target / no ability). Contributes no option set
+        // (CR 106.5), mirroring TriggerEventManaType.
+        ManaProduction::AnyCombinationOfObjectColors { .. } => Vec::new(),
         // CR 603.7c + CR 106.3: "add one mana of any type that land produced"
         // resolves only inside a triggered ability (TapsForMana). For the mana
         // source enumeration path (cost-payment auto-tap, direct activation),

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -85,6 +85,9 @@ mod marksman_tests;
 #[path = "meld_tests.rs"]
 mod meld_tests;
 pub mod merge;
+#[cfg(test)]
+#[path = "omnath_tests.rs"]
+mod omnath_tests;
 // Tests for `merge` live in a sibling file (declared here, not in `merge.rs`,
 // so `merge.rs` stays implementation-only).
 pub mod archenemy;

--- a/crates/engine/src/game/omnath_tests.rs
+++ b/crates/engine/src/game/omnath_tests.rs
@@ -291,21 +291,23 @@ fn eligible_declined_reveal_produces_no_mana() {
         mana_prompt(runner.state()).is_none(),
         "no mana prompt on decline"
     );
+    // CR 608.2c: the decline branch must resolve to completion, not leave the
+    // chain parked at the optional reveal (the original stuck-state regression).
+    assert!(
+        !is_optional_reveal_pause(runner.state()),
+        "decline must not leave the chain parked at the optional reveal"
+    );
 }
 
-/// KNOWN GAP (stop-and-return): declining the optional reveal should still put
-/// the card into hand ("If you don't reveal it, put it into your hand"), but the
-/// decline branch is NOT reached today. The parser nests that Not(OptionalEffect-
-/// Performed) clause as a GRANDCHILD of the IfYouDo clause (the "If you do" body
-/// has two instructions — add mana AND put into hand — so the decline clause is
-/// appended after the in-hand move), and
-/// `should_resolve_subability_on_optional_decline` only inspects the IfYouDo
-/// sub's DIRECT child for a Not(IfYouDo) decline branch. Fixing this requires a
-/// decline-branch-selection change (or a parser sibling-linking change) in shared
-/// optional-effect infrastructure — out of scope for the GAP-1/GAP-2 plan, with
-/// broad blast radius. Tracked for a follow-up plan.
+/// CR 608.2c: declining the optional reveal still puts the card into hand ("If
+/// you don't reveal it, put it into your hand"). The `Not(OptionalEffectPerformed)`
+/// decline clause is nested as a GRANDCHILD of the IfYouDo head (the "If you do"
+/// body has two instructions — add mana AND put into hand — so the decline clause
+/// is chained after the in-hand move). `nested_optional_decline_clause` walks the
+/// head's sub-chain to find it, and the decline resolves ONLY that clause — not
+/// the accept-only add-mana instruction. DISCRIMINATING: reverting the resolver
+/// change leaves the card on top of the library (decline branch never reached).
 #[test]
-#[ignore = "decline-to-hand: nested Not(IfYouDo) decline branch not reached; shared decline-routing follow-up"]
 fn eligible_declined_reveal_puts_card_to_hand() {
     let (mut runner, top) = omnath_runtime(
         vec![

--- a/crates/engine/src/game/omnath_tests.rs
+++ b/crates/engine/src/game/omnath_tests.rs
@@ -1,0 +1,325 @@
+//! Runtime tests for Omnath, Locus of All's precombat-main trigger.
+//!
+//! These drive the real production seams:
+//! - the parser (`parse_oracle_text`) for the trigger AST (GAP-1 eligibility
+//!   condition + GAP-2 dynamic-color mana production);
+//! - the production trigger-resolution function (`resolve_ability_chain` at
+//!   depth 0, exactly as the engine resolves a stack trigger), which exercises
+//!   the GAP-1 sub-condition binding (last-revealed → parent targets, STEP 4);
+//! - the real action handler (`apply`) for the optional-reveal decision and the
+//!   `ChooseManaColor` mana-combination prompt (GAP-2 runtime resolver, STEP 6).
+//!
+//! CR 608.2c / CR 608.2d / CR 400.7j / CR 106.1 / CR 106.5 / CR 202.2c.
+
+#![cfg(test)]
+
+use crate::game::ability_utils::build_resolved_from_def;
+use crate::game::effects::resolve_ability_chain;
+use crate::game::scenario::{GameRunner, GameScenario};
+use crate::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use crate::types::actions::GameAction;
+use crate::types::game_state::{GameState, ManaChoice, ManaChoicePrompt, WaitingFor};
+use crate::types::identifiers::ObjectId;
+use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType};
+use crate::types::player::PlayerId;
+use crate::types::triggers::TriggerMode;
+
+const OMNATH_ORACLE: &str = "If you would lose unspent mana, that mana becomes black instead.\n\
+    At the beginning of your first main phase, look at the top card of your library. \
+    You may reveal that card if it has three or more colored mana symbols in its mana cost. \
+    If you do, add three mana in any combination of its colors and put it into your hand. \
+    If you don't reveal it, put it into your hand.";
+
+const P0: PlayerId = PlayerId(0);
+
+fn parse_omnath() -> ParsedAbilities {
+    parse_oracle_text(
+        OMNATH_ORACLE,
+        "Omnath, Locus of All",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &[],
+    )
+}
+
+/// Omnath on P0's battlefield with a single top-of-library card carrying the
+/// given mana-cost shards and colors. The precombat-main trigger is resolved
+/// through the production resolver at depth 0 (no hand-built `WaitingFor`).
+fn omnath_runtime(shards: Vec<ManaCostShard>, colors: Vec<ManaColor>) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let omnath = scenario
+        .add_creature_from_oracle(P0, "Omnath, Locus of All", 4, 4, OMNATH_ORACLE)
+        .id();
+    let top = scenario.add_card_to_library_top(P0, "Top Card");
+    {
+        let obj = scenario.state.objects.get_mut(&top).unwrap();
+        obj.mana_cost = ManaCost::Cost { shards, generic: 1 };
+        obj.color = colors;
+    }
+    let mut runner = scenario.build();
+
+    let parsed = parse_omnath();
+    let phase = parsed
+        .triggers
+        .iter()
+        .find(|t| t.mode == TriggerMode::Phase)
+        .expect("Omnath has a precombat-main Phase trigger");
+    let execute = phase
+        .execute
+        .as_ref()
+        .expect("Phase trigger has an execute");
+    let resolved = build_resolved_from_def(execute, omnath, P0);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("trigger resolution");
+    (runner, top)
+}
+
+fn top_in_hand(state: &GameState, top: ObjectId) -> bool {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.hand.contains(&top))
+        .unwrap_or(false)
+}
+
+fn pool_total(state: &GameState) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.mana_pool.total())
+        .unwrap_or(0)
+}
+
+fn pool_color(state: &GameState, color: ManaType) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .map(|p| p.mana_pool.count_color(color))
+        .unwrap_or(0)
+}
+
+fn is_optional_reveal_pause(state: &GameState) -> bool {
+    matches!(state.waiting_for, WaitingFor::OptionalEffectChoice { .. })
+}
+
+fn mana_prompt(state: &GameState) -> Option<ManaChoicePrompt> {
+    match &state.waiting_for {
+        WaitingFor::ChooseManaColor { choice, .. } => Some(choice.clone()),
+        _ => None,
+    }
+}
+
+// ── GAP-1: ineligible top card never parks at an illegal optional reveal ──────
+
+/// CR 608.2d: Kitchen-Finks-shaped top card ({1}{G/W}{G/W} → 2 colored mana
+/// symbols) fails the "three or more colored mana symbols" eligibility check, so
+/// the optional reveal is NEVER offered, no mana is produced, and the card goes
+/// to hand. DISCRIMINATING: reverting the GAP-1 parser condition (STEP 3) drops
+/// the `QuantityCheck` gate, so the optional reveal would be offered for the
+/// ineligible card — `is_optional_reveal_pause` would be true and the engine
+/// would park (the reported bug).
+#[test]
+fn ineligible_two_symbol_top_card_no_reveal_no_mana() {
+    let (runner, top) = omnath_runtime(
+        vec![ManaCostShard::GreenWhite, ManaCostShard::GreenWhite],
+        vec![ManaColor::Green, ManaColor::White],
+    );
+    assert!(
+        !is_optional_reveal_pause(runner.state()),
+        "ineligible (2-symbol) top card must not offer the optional reveal: {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        mana_prompt(runner.state()).is_none(),
+        "no mana prompt for an ineligible card"
+    );
+    assert_eq!(pool_total(runner.state()), 0, "no mana produced");
+    assert!(
+        top_in_hand(runner.state(), top),
+        "the card is put into hand"
+    );
+}
+
+/// CR 608.2d: a zero-colored-symbol top card (Plains-shaped) is likewise
+/// ineligible — same no-reveal / no-mana / to-hand outcome.
+#[test]
+fn ineligible_zero_symbol_top_card_no_reveal_no_mana() {
+    let (runner, top) = omnath_runtime(vec![], vec![]);
+    assert!(
+        !is_optional_reveal_pause(runner.state()),
+        "ineligible (0-symbol) top card must not offer the optional reveal: {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(pool_total(runner.state()), 0);
+    assert!(top_in_hand(runner.state(), top));
+}
+
+// ── GAP-2: eligible multicolor card offers exactly its colors ────────────────
+
+/// CR 106.1 + CR 202.2c + CR 400.7j: an eligible 3-distinct-color top card
+/// ({B}{U}{G}) offers the optional reveal; accepting surfaces a
+/// `ManaChoicePrompt::AnyCombination` whose option set is EXACTLY the revealed
+/// card's colors {B,U,G} — not all five, not Omnath's colors. Choosing produces
+/// three mana of the chosen colors and the card is put into hand.
+///
+/// DISCRIMINATING for the STEP 4 deep binding: the add-mana sub reads its colors
+/// from the revealed object via `ObjectScope::Target`. Reverting the "carry the
+/// injected targets into the performed-true sub-resolution" half of STEP 4 leaves
+/// the sub with no target, so `object_colors_for_scope` returns empty → CR 106.5
+/// produces no mana (or no prompt), failing the option-set / pool assertions.
+#[test]
+fn eligible_multicolor_offers_exact_card_colors_and_produces_mana() {
+    let (mut runner, top) = omnath_runtime(
+        vec![
+            ManaCostShard::Black,
+            ManaCostShard::Blue,
+            ManaCostShard::Green,
+        ],
+        vec![ManaColor::Black, ManaColor::Blue, ManaColor::Green],
+    );
+    assert!(
+        is_optional_reveal_pause(runner.state()),
+        "eligible top card offers the optional reveal, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept the reveal");
+
+    let prompt = mana_prompt(runner.state()).unwrap_or_else(|| {
+        panic!(
+            "expected a mana prompt, got {:?}",
+            runner.state().waiting_for
+        )
+    });
+    let ManaChoicePrompt::AnyCombination { count, options } = prompt else {
+        panic!("expected AnyCombination prompt, got {prompt:?}");
+    };
+    assert_eq!(count, 3, "three mana to distribute");
+    assert_eq!(options.len(), 3, "exactly three color options: {options:?}");
+    for c in [ManaType::Black, ManaType::Blue, ManaType::Green] {
+        assert!(
+            options.contains(&c),
+            "option set must include {c:?}: {options:?}"
+        );
+    }
+    for c in [ManaType::White, ManaType::Red, ManaType::Colorless] {
+        assert!(
+            !options.contains(&c),
+            "option set must NOT include {c:?} (only the card's colors): {options:?}"
+        );
+    }
+
+    runner
+        .act(GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Black, ManaType::Blue, ManaType::Green]),
+            count: 1,
+        })
+        .expect("choose the three colors");
+
+    assert_eq!(pool_total(runner.state()), 3, "three mana produced");
+    assert_eq!(pool_color(runner.state(), ManaType::Black), 1);
+    assert_eq!(pool_color(runner.state(), ManaType::Blue), 1);
+    assert_eq!(pool_color(runner.state(), ManaType::Green), 1);
+    assert!(
+        top_in_hand(runner.state(), top),
+        "the card is put into hand"
+    );
+}
+
+/// CR 106.1 + CR 106.5: a monocolored eligible top card ({B}{B}{B}) needs no
+/// color prompt — accepting produces three black mana directly and the card goes
+/// to hand.
+#[test]
+fn eligible_monocolor_produces_three_black_without_prompt() {
+    let (mut runner, top) = omnath_runtime(
+        vec![
+            ManaCostShard::Black,
+            ManaCostShard::Black,
+            ManaCostShard::Black,
+        ],
+        vec![ManaColor::Black],
+    );
+    assert!(is_optional_reveal_pause(runner.state()));
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept the reveal");
+
+    assert!(
+        mana_prompt(runner.state()).is_none(),
+        "a single-color object needs no prompt, got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(pool_total(runner.state()), 3);
+    assert_eq!(pool_color(runner.state(), ManaType::Black), 3);
+    assert!(top_in_hand(runner.state(), top));
+}
+
+/// CR 608.2c: declining the optional reveal on an eligible card produces NO mana.
+/// The reveal is offered (eligible) and then declined; the "If you do, add three
+/// mana …" rider must not fire. DISCRIMINATING for the GAP-2 gate: producing mana
+/// here would mean the add-mana sub ran without the optional reveal being
+/// performed.
+#[test]
+fn eligible_declined_reveal_produces_no_mana() {
+    let (mut runner, _top) = omnath_runtime(
+        vec![
+            ManaCostShard::Black,
+            ManaCostShard::Blue,
+            ManaCostShard::Green,
+        ],
+        vec![ManaColor::Black, ManaColor::Blue, ManaColor::Green],
+    );
+    assert!(
+        is_optional_reveal_pause(runner.state()),
+        "eligible card offers the optional reveal"
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("decline the reveal");
+
+    assert_eq!(pool_total(runner.state()), 0, "no mana when declined");
+    assert!(
+        mana_prompt(runner.state()).is_none(),
+        "no mana prompt on decline"
+    );
+}
+
+/// KNOWN GAP (stop-and-return): declining the optional reveal should still put
+/// the card into hand ("If you don't reveal it, put it into your hand"), but the
+/// decline branch is NOT reached today. The parser nests that Not(OptionalEffect-
+/// Performed) clause as a GRANDCHILD of the IfYouDo clause (the "If you do" body
+/// has two instructions — add mana AND put into hand — so the decline clause is
+/// appended after the in-hand move), and
+/// `should_resolve_subability_on_optional_decline` only inspects the IfYouDo
+/// sub's DIRECT child for a Not(IfYouDo) decline branch. Fixing this requires a
+/// decline-branch-selection change (or a parser sibling-linking change) in shared
+/// optional-effect infrastructure — out of scope for the GAP-1/GAP-2 plan, with
+/// broad blast radius. Tracked for a follow-up plan.
+#[test]
+#[ignore = "decline-to-hand: nested Not(IfYouDo) decline branch not reached; shared decline-routing follow-up"]
+fn eligible_declined_reveal_puts_card_to_hand() {
+    let (mut runner, top) = omnath_runtime(
+        vec![
+            ManaCostShard::Black,
+            ManaCostShard::Blue,
+            ManaCostShard::Green,
+        ],
+        vec![ManaColor::Black, ManaColor::Blue, ManaColor::Green],
+    );
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("decline the reveal");
+    assert!(
+        top_in_hand(runner.state(), top),
+        "the card still goes to hand"
+    );
+}

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3680,10 +3680,15 @@ fn resolve_object_typeline_component_count(
         .unwrap_or(0)
 }
 
+// CR 107.4 + CR 202.1: Count colored mana symbols in an object's mana cost.
+// `Some(c)` counts symbols contributing to color `c`. `None` counts each colored
+// shard once regardless of color — CR 107.4a/107.4e/107.4f: a hybrid or Phyrexian
+// symbol is a single colored mana symbol even though it is all of its component
+// colors, so `{G/W}{G/W}` counts as 2 (not 4).
 fn resolve_mana_symbols_in_mana_cost(
     state: &GameState,
     scope: ObjectScope,
-    color: ManaColor,
+    color: Option<ManaColor>,
     ctx: QuantityContext,
     targets: &[TargetRef],
 ) -> i32 {
@@ -3692,7 +3697,10 @@ fn resolve_mana_symbols_in_mana_cost(
             ManaCost::Cost { shards, .. } => usize_to_i32_saturating(
                 shards
                     .iter()
-                    .filter(|shard| shard.contributes_to(color))
+                    .filter(|shard| match color {
+                        Some(c) => shard.contributes_to(c),
+                        None => ManaColor::ALL.iter().any(|c| shard.contributes_to(*c)),
+                    })
                     .count(),
             ),
             ManaCost::NoCost | ManaCost::SelfManaCost | ManaCost::SelfManaValue => 0,
@@ -5180,6 +5188,74 @@ mod tests {
         // graveyard excluded); P1 sees only their own 2.
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), bf), 3);
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(1), opp), 2);
+    }
+
+    /// CR 107.4a/107.4e/107.4f + CR 202.1: `ManaSymbolsInManaCost { color: None }`
+    /// counts each COLORED mana symbol once regardless of color. A hybrid symbol
+    /// is a single colored symbol even though it is all of its component colors,
+    /// so `{1}{G/W}{G/W}` (Kitchen Finks) counts as 2 — NOT 4 (which a sum-of-all-
+    /// five-colors would yield). Generic mana is uncolored and never counts.
+    /// `color: Some(c)` retains the per-color count.
+    #[test]
+    fn mana_symbols_in_mana_cost_none_counts_each_colored_symbol_once() {
+        use crate::types::ability::ObjectScope;
+        let mut state = GameState::new_two_player(42);
+        let mk = |state: &mut GameState, cid, shards: Vec<ManaCostShard>, generic| {
+            let id = create_object(state, cid, PlayerId(0), "C".to_string(), Zone::Battlefield);
+            state.objects.get_mut(&id).unwrap().mana_cost = ManaCost::Cost { shards, generic };
+            id
+        };
+        // {1}{G/W}{G/W} → 2 colored symbols (each hybrid is ONE symbol, CR 107.4e).
+        let gw = mk(
+            &mut state,
+            CardId(1),
+            vec![ManaCostShard::GreenWhite, ManaCostShard::GreenWhite],
+            1,
+        );
+        // {U}{R}{W} → 3 distinct colored symbols.
+        let urw = mk(
+            &mut state,
+            CardId(2),
+            vec![
+                ManaCostShard::Blue,
+                ManaCostShard::Red,
+                ManaCostShard::White,
+            ],
+            0,
+        );
+        // {B}{B}{B} → 3 (repeated color still counts each symbol).
+        let bbb = mk(
+            &mut state,
+            CardId(3),
+            vec![
+                ManaCostShard::Black,
+                ManaCostShard::Black,
+                ManaCostShard::Black,
+            ],
+            0,
+        );
+
+        let qty = QuantityExpr::Ref {
+            qty: QuantityRef::ManaSymbolsInManaCost {
+                scope: ObjectScope::Source,
+                color: None,
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), gw), 2);
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), urw), 3);
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), bbb), 3);
+
+        // CR 202.1: per-color count still works. Black counts only black symbols;
+        // a hybrid {G/W} contributes to neither.
+        let qty_black = QuantityExpr::Ref {
+            qty: QuantityRef::ManaSymbolsInManaCost {
+                scope: ObjectScope::Source,
+                color: Some(ManaColor::Black),
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &qty_black, PlayerId(0), bbb), 3);
+        assert_eq!(resolve_quantity(&state, &qty_black, PlayerId(0), urw), 0);
+        assert_eq!(resolve_quantity(&state, &qty_black, PlayerId(0), gw), 0);
     }
 
     /// CR 404.2 + CR 109.4: graveyard-scope chroma must scope its population by

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2178,6 +2178,34 @@ fn parse_triggering_spell_targets_filter_ability_condition(text: &str) -> Option
     }
 }
 
+/// CR 608.2d + CR 107.4 + CR 202.1: Recognize "it has N or more colored mana
+/// symbols in its mana cost" (Omnath, Locus of All — "You may reveal that card
+/// if it has three or more colored mana symbols in its mana cost") into a
+/// quantity-comparison condition on the target object. `color: None` counts each
+/// colored mana symbol once regardless of color (CR 107.4a/107.4e/107.4f). The
+/// comparator is a typed axis (GE here); "or fewer"/"exactly" variants are future
+/// arms and must not be baked into the condition variant.
+fn parse_colored_mana_symbol_count_target_condition(text: &str) -> Option<AbilityCondition> {
+    let mut parser = all_consuming(preceded(
+        tag::<_, _, OracleError<'_>>("it has "),
+        terminated(
+            nom_primitives::parse_number,
+            tag(" or more colored mana symbols in its mana cost"),
+        ),
+    ));
+    let (_, n) = parser.parse(text).ok()?;
+    Some(AbilityCondition::QuantityCheck {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::ManaSymbolsInManaCost {
+                scope: ObjectScope::Target,
+                color: None,
+            },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: n as i32 },
+    })
+}
+
 pub(super) fn strip_suffix_conditional(
     text: &str,
     ctx: &mut ParseContext,
@@ -2188,6 +2216,13 @@ pub(super) fn strip_suffix_conditional(
     };
 
     let condition_text = lower[if_pos + " if ".len()..].trim_end_matches('.').trim();
+    // CR 608.2d: "it has " is in NON_REHOMEABLE_CONDITION_PREFIXES, so this
+    // source-referential mana-symbol eligibility check must be recognized BEFORE
+    // the rehomeable bail or it would never run. effect_prefix/effect_text are
+    // not computed yet, so return the stripped effect text directly.
+    if let Some(cond) = parse_colored_mana_symbol_count_target_condition(condition_text) {
+        return (Some(cond), text[..if_pos].trim().to_string());
+    }
     if !condition_text_is_rehomeable(condition_text) {
         return (None, text.to_string());
     }
@@ -5165,6 +5200,50 @@ mod tests {
         );
         assert_eq!(text, "Counter target spell");
         assert!(matches!(cond, Some(AbilityCondition::QuantityCheck { .. })));
+    }
+
+    /// CR 608.2d + CR 107.4 + CR 202.1: Omnath, Locus of All — "you may reveal
+    /// that card if it has three or more colored mana symbols in its mana cost"
+    /// re-homes the eligibility check as a `QuantityCheck` (GE) over the target's
+    /// colored-mana-symbol count (`color: None`), and the optional-reveal effect
+    /// text is stripped. The recognizer must run BEFORE the rehomeable bail since
+    /// "it has " is in NON_REHOMEABLE_CONDITION_PREFIXES.
+    #[test]
+    fn parse_colored_mana_symbol_count_condition_rehomes_eligibility() {
+        let cond = parse_colored_mana_symbol_count_target_condition(
+            "it has three or more colored mana symbols in its mana cost",
+        )
+        .expect("should parse the colored-mana-symbol eligibility condition");
+        assert_eq!(
+            cond,
+            AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ManaSymbolsInManaCost {
+                        scope: ObjectScope::Target,
+                        color: None,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            }
+        );
+
+        let (cond, text) = strip_suffix_conditional(
+            "You may reveal that card if it has three or more colored mana symbols in its mana cost",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(text, "You may reveal that card");
+        assert!(matches!(
+            cond,
+            Some(AbilityCondition::QuantityCheck {
+                comparator: Comparator::GE,
+                ..
+            })
+        ));
+
+        // Negative: a different number still parses (typed comparator/count axis),
+        // and an unrelated "it has" predicate does not falsely match.
+        assert!(parse_colored_mana_symbol_count_target_condition("it has flying").is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -11,7 +11,7 @@ use crate::parser::oracle_nom::error::OracleResult;
 use crate::parser::oracle_nom::primitives as nom_primitives;
 use crate::types::ability::{
     AbilityKind, AbilityTag, Comparator, Effect, LinkedExileScope, ManaContribution,
-    ManaProduction, ManaSpendRestriction, QuantityExpr, QuantityRef,
+    ManaProduction, ManaSpendRestriction, ObjectScope, QuantityExpr, QuantityRef,
 };
 use crate::types::keywords::KeywordKind;
 use crate::types::mana::{
@@ -140,6 +140,24 @@ fn strip_mana_subject_prefix(text: &str) -> Option<(TargetFilter, &str)> {
         )
         .parse(i)
     })
+}
+
+/// CR 202.2c: Recognize the dynamic-color tail of an "any combination of …"
+/// mana clause that refers to a scoped object's colors ("its colors" / "that
+/// card's colors" — Omnath, Locus of All). Maps to `ObjectScope::Target` so the
+/// runtime resolver surveys the bound object's colors at resolution time. Unlike
+/// the static `parse_mana_color_set` path, the color set here is computed
+/// dynamically (CR 106.1 + CR 106.5).
+fn parse_object_colors_scope(text: &str) -> Option<ObjectScope> {
+    let lower = text.trim().trim_end_matches('.').to_lowercase();
+    let mut parser = all_consuming(value(
+        ObjectScope::Target,
+        alt((
+            tag::<_, _, OracleError<'_>>("its colors"),
+            tag("that card's colors"),
+        )),
+    ));
+    parser.parse(lower.as_str()).ok().map(|(_, scope)| scope)
 }
 
 pub(super) fn try_parse_add_mana_effect(text: &str) -> Option<Effect> {
@@ -574,6 +592,19 @@ pub(super) fn try_parse_add_mana_effect(text: &str) -> Option<Effect> {
             value((), tag("mana in any combination of ")).parse(i)
         }) {
             let color_set_text = after_combo.trim();
+            // CR 106.1 + CR 202.2c: "...of its colors" / "...of that card's colors"
+            // produces mana freely chosen among a scoped object's colors, resolved
+            // dynamically at resolution time (Omnath, Locus of All). Dispatch this
+            // dynamic-color branch BEFORE the static brace-only color-set path.
+            if let Some(scope) = parse_object_colors_scope(color_set_text) {
+                return Some(Effect::Mana {
+                    produced: ManaProduction::AnyCombinationOfObjectColors { count, scope },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: where_x_target,
+                });
+            }
             if let Some(color_options) = parse_mana_color_set(color_set_text) {
                 return Some(Effect::Mana {
                     produced: ManaProduction::AnyCombination {
@@ -2565,6 +2596,42 @@ mod tests {
             }) => Some(options),
             _ => None,
         }
+    }
+
+    /// CR 106.1 + CR 202.2c: Omnath, Locus of All — "add three mana in any
+    /// combination of its colors" lowers to the dynamic-color
+    /// `AnyCombinationOfObjectColors { scope: Target }`, NOT the static
+    /// `AnyCombination`. The "its colors" dispatch must beat the brace-only
+    /// `parse_mana_color_set` path. "that card's colors" is the sibling phrasing.
+    #[test]
+    fn add_mana_in_any_combination_of_its_colors_is_dynamic() {
+        for oracle in [
+            "Add three mana in any combination of its colors",
+            "Add three mana in any combination of that card's colors",
+        ] {
+            let effect = try_parse_add_mana_effect(oracle)
+                .unwrap_or_else(|| panic!("{oracle:?} must parse as a mana effect"));
+            let Effect::Mana { produced, .. } = effect else {
+                panic!("expected Effect::Mana for {oracle:?}");
+            };
+            let ManaProduction::AnyCombinationOfObjectColors { count, scope } = produced else {
+                panic!("expected AnyCombinationOfObjectColors for {oracle:?}, got {produced:?}");
+            };
+            assert_eq!(count, QuantityExpr::Fixed { value: 3 });
+            assert_eq!(scope, ObjectScope::Target);
+        }
+
+        // The static brace form is unchanged (not captured by the dynamic branch).
+        let effect =
+            try_parse_add_mana_effect("Add three mana in any combination of {W}, {U}, or {B}")
+                .expect("static color-set form must still parse");
+        let Effect::Mana { produced, .. } = effect else {
+            panic!("expected Effect::Mana");
+        };
+        assert!(
+            matches!(produced, ManaProduction::AnyCombination { .. }),
+            "brace color-set must stay static AnyCombination, got {produced:?}"
+        );
     }
 
     /// CR 603.7c + CR 106.3: Roxanne, Starfall Savant — the mana-echo anaphor

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18210,6 +18210,12 @@ fn mana_production_with_count(
         ManaProduction::OpponentLandColors { .. } => {
             Some(ManaProduction::OpponentLandColors { count })
         }
+        ManaProduction::AnyCombinationOfObjectColors { scope, .. } => {
+            Some(ManaProduction::AnyCombinationOfObjectColors {
+                count,
+                scope: *scope,
+            })
+        }
         ManaProduction::AnyTypeProduceableBy { land_filter, .. } => {
             Some(ManaProduction::AnyTypeProduceableBy {
                 count,

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3359,7 +3359,13 @@ fn parse_mana_symbols_in_object_mana_cost_for_each(input: &str) -> OracleResult<
     let (rest, _) = tag(" in ").parse(rest)?;
     let (rest, scope) = parse_object_possessive_scope(rest)?;
     let (rest, _) = tag(" mana cost").parse(rest)?;
-    Ok((rest, QuantityRef::ManaSymbolsInManaCost { scope, color }))
+    Ok((
+        rest,
+        QuantityRef::ManaSymbolsInManaCost {
+            scope,
+            color: Some(color),
+        },
+    ))
 }
 
 /// CR 105.1 + CR 601.2f: "for each color[s] of <object>" — scoped object-color
@@ -5365,7 +5371,7 @@ mod tests {
             q,
             QuantityRef::ManaSymbolsInManaCost {
                 scope: crate::types::ability::ObjectScope::Recipient,
-                color: ManaColor::White,
+                color: Some(ManaColor::White),
             }
         );
         assert_eq!(rest, "");

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -11106,7 +11106,7 @@ fn static_for_each_mana_symbol_in_its_mana_cost_emits_recipient_symbol_count() {
         &QuantityExpr::Ref {
             qty: QuantityRef::ManaSymbolsInManaCost {
                 scope: ObjectScope::Recipient,
-                color: ManaColor::White,
+                color: Some(ManaColor::White),
             },
         }
     );
@@ -11116,7 +11116,7 @@ fn static_for_each_mana_symbol_in_its_mana_cost_emits_recipient_symbol_count() {
             value: QuantityExpr::Ref {
                 qty: QuantityRef::ManaSymbolsInManaCost {
                     scope: ObjectScope::Recipient,
-                    color: ManaColor::White,
+                    color: Some(ManaColor::White),
                 }
             }
         }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -1313,6 +1313,20 @@ pub enum ManaProduction {
         #[serde(default = "default_quantity_one")]
         count: QuantityExpr,
     },
+    /// CR 106.1 + CR 106.5 + CR 202.2c: Produce `count` mana, each freely chosen
+    /// among the colors of an object identified by `scope` (Omnath, Locus of All:
+    /// "add three mana in any combination of its colors"). Unlike the static
+    /// `AnyCombination` (whose `color_options` are fixed at parse time), the color
+    /// set here is computed dynamically at resolution time from the scoped object's
+    /// colors (CR 202.2c). Its analog is the dynamic-color family
+    /// (`AnyOneColorAmongPermanents` / `DistinctColorsAmongPermanents`), not the
+    /// static `AnyCombination`. If the object has no colors, CR 106.5 applies and
+    /// no mana is produced.
+    AnyCombinationOfObjectColors {
+        #[serde(default = "default_quantity_one")]
+        count: QuantityExpr,
+        scope: ObjectScope,
+    },
     /// CR 106.7 + CR 106.1b: Produce N mana of any **type** (W/U/B/R/G/C) that a
     /// land matching `land_filter` could produce. Differs from
     /// `OpponentLandColors` in that the choice axis is the full type set
@@ -1463,6 +1477,11 @@ impl<'de> serde::Deserialize<'de> for ManaProduction {
                         #[serde(default = "default_quantity_one")]
                         count: QuantityExpr,
                     },
+                    AnyCombinationOfObjectColors {
+                        #[serde(default = "default_quantity_one")]
+                        count: QuantityExpr,
+                        scope: ObjectScope,
+                    },
                     AnyTypeProduceableBy {
                         #[serde(default = "default_quantity_one")]
                         count: QuantityExpr,
@@ -1538,6 +1557,9 @@ impl<'de> serde::Deserialize<'de> for ManaProduction {
                     },
                     ManaProductionHelper::OpponentLandColors { count } => {
                         ManaProduction::OpponentLandColors { count }
+                    }
+                    ManaProductionHelper::AnyCombinationOfObjectColors { count, scope } => {
+                        ManaProduction::AnyCombinationOfObjectColors { count, scope }
                     }
                     ManaProductionHelper::AnyTypeProduceableBy { count, land_filter } => {
                         ManaProduction::AnyTypeProduceableBy { count, land_filter }
@@ -4110,9 +4132,16 @@ pub enum QuantityRef {
     /// `ManaCostShard::contributes_to`. `Recipient` preserves per-affected
     /// layer boosts such as "gets +1/+1 for each white mana symbol in its mana
     /// cost" by binding to the object currently receiving the effect.
+    ///
+    /// `color: Some(c)` counts symbols contributing to color `c`. `color: None`
+    /// counts each colored mana symbol once regardless of color — per
+    /// CR 107.4a/107.4e/107.4f a hybrid or Phyrexian symbol is a single colored
+    /// symbol even though it is all of its component colors, so e.g.
+    /// `{G/W}{G/W}` counts as 2. Used by "three or more colored mana symbols in
+    /// its mana cost" eligibility checks (Omnath, Locus of All).
     ManaSymbolsInManaCost {
         scope: ObjectScope,
-        color: ManaColor,
+        color: Option<ManaColor>,
     },
     /// CR 202.3: The mana value of the source object — i.e. the object passed
     /// as `source` to `resolve_quantity`. For an alt-cost cast (CR 118.9) this
@@ -18964,6 +18993,61 @@ mod tests {
         let json = serde_json::to_string(&effect).unwrap();
         let deserialized: Effect = serde_json::from_str(&json).unwrap();
         assert_eq!(effect, deserialized);
+    }
+
+    /// CR 107.4 + CR 202.1: `ManaSymbolsInManaCost.color` is now
+    /// `Option<ManaColor>`. `None` (count each colored symbol once) and
+    /// `Some(color)` (per-color count) both round-trip. serde renders
+    /// `Some(White)` as the bare `"color":"White"`, identical to the pre-change
+    /// non-optional form, so legacy payloads deserialize to `Some(White)`.
+    #[test]
+    fn mana_symbols_in_mana_cost_optional_color_serde_roundtrip() {
+        let none_ref = QuantityRef::ManaSymbolsInManaCost {
+            scope: ObjectScope::Target,
+            color: None,
+        };
+        let json = serde_json::to_string(&none_ref).unwrap();
+        assert_eq!(
+            serde_json::from_str::<QuantityRef>(&json).unwrap(),
+            none_ref
+        );
+
+        let some_ref = QuantityRef::ManaSymbolsInManaCost {
+            scope: ObjectScope::Recipient,
+            color: Some(ManaColor::White),
+        };
+        let json = serde_json::to_string(&some_ref).unwrap();
+        assert!(json.contains("\"color\":\"White\""), "{json}");
+        assert_eq!(
+            serde_json::from_str::<QuantityRef>(&json).unwrap(),
+            some_ref
+        );
+    }
+
+    /// CR 106.1 + CR 202.2c: the dynamic-color `AnyCombinationOfObjectColors`
+    /// mana production round-trips through the custom `ManaProduction` (de)serializer.
+    #[test]
+    fn any_combination_of_object_colors_serde_roundtrip() {
+        let mp = ManaProduction::AnyCombinationOfObjectColors {
+            count: QuantityExpr::Fixed { value: 3 },
+            scope: ObjectScope::Target,
+        };
+        let json = serde_json::to_string(&mp).unwrap();
+        let back: ManaProduction = serde_json::from_str(&json).unwrap();
+        assert_eq!(mp, back);
+
+        // count defaults to one when omitted (default_quantity_one).
+        let defaulted: ManaProduction = serde_json::from_str(
+            r#"{"type":"AnyCombinationOfObjectColors","scope":{"type":"Target"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            defaulted,
+            ManaProduction::AnyCombinationOfObjectColors {
+                count: default_quantity_one(),
+                scope: ObjectScope::Target,
+            }
+        );
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -306,6 +306,7 @@ fn rewrite_bound_x_in_mana_production(
         ManaProduction::Colorless { count }
         | ManaProduction::AnyOneColor { count, .. }
         | ManaProduction::AnyCombination { count, .. }
+        | ManaProduction::AnyCombinationOfObjectColors { count, .. }
         | ManaProduction::ChosenColor { count, .. }
         | ManaProduction::OpponentLandColors { count }
         | ManaProduction::AnyTypeProduceableBy { count, .. }

--- a/crates/phase-ai/src/mana_colors.rs
+++ b/crates/phase-ai/src/mana_colors.rs
@@ -84,6 +84,9 @@ pub(crate) fn collect_mana_production_colors(
         | ManaProduction::AnyInCommandersColorIdentity { .. }
         | ManaProduction::DistinctColorsAmongPermanents { .. }
         | ManaProduction::AnyOneColorAmongPermanents { .. }
+        // CR 202.2c: Omnath, Locus of All — colors come from a target object
+        // resolved at trigger time, not known from the card alone.
+        | ManaProduction::AnyCombinationOfObjectColors { .. }
         | ManaProduction::TriggerEventManaType => {}
     }
 }

--- a/crates/phase-ai/src/policies/land_animation.rs
+++ b/crates/phase-ai/src/policies/land_animation.rs
@@ -204,6 +204,10 @@ fn colors_produced_by_land(land: &game_object::GameObject) -> Vec<engine::types:
                         colors.push(*c);
                     }
                 }
+                // CR 202.2c: Omnath, Locus of All — colors come from a target
+                // object resolved at trigger time, not statically predictable
+                // for land-animation color preview. Contribute nothing.
+                ManaProduction::AnyCombinationOfObjectColors { .. } => {}
                 _ => {}
             }
         }


### PR DESCRIPTION
Two commits completing Omnath, Locus of All's precombat-main trigger end-to-end.

**c65c8d297 — GAP-1 + GAP-2 (eligibility + dynamic mana)**
Parse the previously-dropped "if it has three or more colored mana symbols in its mana cost" eligibility condition (CR 107.4e/f hybrid-safe, counting each colored shard once) and attach it to the optional reveal, so ineligible top cards (e.g. a Plains) no longer park the game on an impossible reveal — the player-reported stuck state. Implement "add three mana in any combination of its colors" as ManaProduction::AnyCombinationOfObjectColors drawing colors from the revealed card, with an interactive ChooseManaColor prompt that auto-resolves when monocolored.

**30a376f8f — decline-to-hand routing (CR 608.2c)**
When a multi-instruction "if you do" body is paired with a separate "if you don't" clause, the Not(OptionalEffectPerformed) decline clause nests as a grandchild of the IfYouDo head; the depth-1 selector never reached it. nested_optional_decline_clause walks the chain to find it at any depth and resolves ONLY that clause on decline (never the accept-only instructions), with parent-target inheritance guarded by effect_refs_parent_target so the anaphoric "put it into your hand" binds the looked-at card. Completes declining the reveal.

Reviewed via isolated /review-impl (CLEAN); runtime card tests drive parse → resolve_ability_chain → apply; decline/optional regression sweep green (248/0).