### PR TITLE
fix(changelog): wrap custom Discord emoji as <:name:id> for bot posts

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -135,9 +135,11 @@ Config (same contract as `fetch-changelog.ts`, no hardcoded secrets/ids):
 `DISCORD_BOT_TOKEN` (gate), `ANNOUNCEMENTS_CHANNEL_ID` (target channel — NOT
 `DISCORD_CHANNEL_ID`, which is the bug-reports channel), optional
 `DISCORD_GUILD_ID` (for the `discordUrl` write-back), optional
-`CHANGELOG_HEADER_EMOJI` (the post's leading emoji; a guild-scoped custom emoji
-must be the `<:name:id>` form — a bare `:name:` posts as literal text —
-defaults to `🎴`).
+`CHANGELOG_HEADER_EMOJI` (the post's leading emoji; defaults to `🎴`). A custom
+guild emoji is stored **bracket-free** as `name:id` (e.g. `phase:1500234…`) —
+the script wraps it as `<:name:id>` for the API, since a bare `:name:` only
+resolves in the Discord client (not over REST) and the `<`/`>` brackets would
+break `source .env`. A literal Unicode emoji (no colon) is used verbatim.
 
 Commit `changelog.json`, `changelog-meta.json`, and (when the post ran)
 `scripts/changelog/state.json`. The preview snapshot updates on the next push to

--- a/scripts/post-changelog.ts
+++ b/scripts/post-changelog.ts
@@ -53,12 +53,15 @@ const STATE_PATH = path.join(ROOT, "scripts/changelog/state.json");
 
 // The header line the in-app body omits but the Discord post leads with — the
 // inverse of cleanBody()'s HEADER_RE filter in fetch-changelog.ts. The leading
-// emoji is env-configurable because a custom Discord emoji is a guild-scoped id
-// (`<:phase:1234…>`) — same no-hardcoded-ids rule as DISCORD_GUILD_ID — and
-// falls back to a plain emoji so a token-less or other-guild run still reads
-// sensibly. Bots must send custom emoji as `<:name:id>`; a bare `:name:`
-// shortcode posts as literal text.
-const HEADER_EMOJI = Bun.env.CHANGELOG_HEADER_EMOJI ?? "🎴";
+// emoji is env-configurable (same no-hardcoded-ids rule as DISCORD_GUILD_ID),
+// falling back to plain `🎴` so a token-less or other-guild run still reads
+// sensibly. A custom guild emoji is stored bracket-free as `name:id` — bots
+// must send it to the API as `<:name:id>` (a bare `:name:` only resolves in the
+// Discord client composer, not over REST), but the `<`/`>` would break
+// `set -a; source .env` (shell redirects), so we keep them out of .env and wrap
+// here. A literal Unicode emoji (no colon) is used verbatim.
+const rawEmoji = Bun.env.CHANGELOG_HEADER_EMOJI?.trim();
+const HEADER_EMOJI = rawEmoji ? (rawEmoji.includes(":") ? `<:${rawEmoji}>` : rawEmoji) : "🎴";
 const HEADER = `${HEADER_EMOJI} What's New in phase.rs`;
 // Discord rejects messages longer than 2000 characters.
 const DISCORD_MAX = 2000;


### PR DESCRIPTION
A bot posting via the REST API must send a custom guild emoji as the
explicit <:name:id> markup; a bare :name: shortcode only resolves in the
Discord client composer and posts as literal text.

Store the emoji bracket-free as name:id in .env (the < and > would break
'set -a; source .env' in gen-card-data.sh, where they are shell redirects)
and wrap it as <:name:id> in post-changelog.ts. A literal Unicode emoji
(no colon) is used verbatim; unset falls back to the plain card emoji.
