### PR TITLE
feat(pr-review): extract review-loop into policy-driven pr_review.py

### DIFF
--- a/.agents/pr-review-policy.toml
+++ b/.agents/pr-review-policy.toml
@@ -1,0 +1,58 @@
+# Repo-level PR review policy. Keep contributor names, reviewer identities,
+# standings, and personal exceptions out of this committed file.
+
+[defaults]
+tier = "T2"
+
+[domain]
+rules_domain = "mtg-cr"
+
+[hard_stops]
+patterns = [
+  ".agents/skills/**",
+  ".claude/skills/**",
+  ".claude/agents/**",
+  ".github/workflows/**",
+  "AGENTS.md",
+  "CLAUDE.md",
+  "GEMINI.md",
+  "docs/AI-CONTRIBUTOR.md",
+  "Cargo.toml",
+  "client/package.json",
+  "client/src-tauri/build.rs",
+  "crates/**/build.rs",
+]
+
+[generated]
+patterns = [
+  "client/public/card-data*.json",
+  "client/public/coverage-*.json",
+  "client/public/scryfall-*.json",
+  "client/public/changelog*.json",
+  "data/mtgjson/**",
+  "triage/**",
+]
+
+[path_classes.frontend]
+patterns = [
+  "client/**",
+  "lobby-worker/**",
+]
+
+[path_classes.engine]
+patterns = [
+  "crates/engine/**",
+  "crates/phase-ai/**",
+  "crates/phase-server/**",
+]
+
+[path_classes.skill]
+patterns = [
+  ".agents/skills/**",
+  ".claude/skills/**",
+]
+
+[path_classes.github]
+patterns = [
+  ".github/**",
+]

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -1,195 +1,91 @@
 ---
 name: pr-review-loop
-description: Use to run a continuous, hands-off review sweep over open contributor PRs in phase.rs — select unreviewed/updated PRs, dispatch an isolated agent to review each against the architecture/idiom/value lenses, post one verdict comment per PR, then poll for new PRs and real content commits until told to stop. Use when the user says "review PRs starting from N", "keep reviewing new PRs", "run the PR review loop", or asks to watch open PRs and leave a review on each. Read-only — it comments and never checks out or rewrites PRs (that is `pr-contribution-handler`). An opt-in authorized maintainer mode additionally delegates approve/label/enqueue to `pr-contribution-handler` when the runner genuinely has merge authority on the repo.
+description: Use to run a continuous review sweep over open contributor PRs in phase.rs. The skill is a thin orchestration layer over scripts/pr_review.py: discover candidates, detect stale reviews/follow-ups, dispatch review-impl for PRs that need judgment, and delegate authorized merge handling to pr-contribution-handler.
 ---
 
 # PR Review Loop
 
-Continuously review open contributor PRs and leave one verdict comment per PR, re-reviewing only when a PR's actual code changes, polling for new PRs on an interval until the user stops.
+Continuously review open contributor PRs, reprocessing only when GitHub state indicates new information: changed head, author follow-up, stale approval, stale request-changes, CI transition, queue drop, or a policy/hard-stop condition.
 
-This skill is the **orchestration loop**. It does not contain review lenses — each per-PR review is performed by a spawned agent running the **`review-impl`** skill. Keep that boundary: review criteria live in `review-impl`; this file owns only *which* PRs get reviewed, *when*, and *how the sweep paces itself*.
+This skill is intentionally small. Mutable policy and contributor-specific state do **not** live here.
 
-## Relationship to sibling skills
+## Sources Of Truth
 
-- **`review-impl`** — the per-PR findings checklist (correct seam · idiomatic code at that seam · does it provide value, plus surface-specific lenses). The spawned reviewer runs this. Do not duplicate its lenses here.
-- **`pr-contribution-handler`** — checks out and *fixes/enqueues* PRs end-to-end. The loop delegates to it in authorized mode; it is never reimplemented here.
+- **GitHub is authoritative** for PR head, author, reviews, comments, labels, CI, and merge-queue state.
+- **Repo policy** lives in `.agents/pr-review-policy.toml` and must contain only repo-level, non-personal rules: path classifiers, domain capabilities, labels, hard-stop path patterns, generated-file patterns, and default gates.
+- **Local review memory** lives outside the repo by default under `~/.local/state/pr-review/<owner>__<repo>/` unless `PR_REVIEW_STATE_DIR` or `--state-dir` is set. This directory contains:
+  - `review-events.jsonl` — canonical append-only local event log.
+  - `review-state.sqlite` — derived query index/cache.
+  - `review-summary.json` — generated token-minimal summary.
+- **No hardcoded names.** Contributor standings, frontend exceptions, reviewer identities, private overrides, and one-off maintainer policy belong in local/private state, never in this skill.
 
-**Two modes.** The sweep mechanics (candidate selection, dedup gate, pacing) are identical in both; they differ only in what happens after a verdict is reached:
-- **Read-only review (default):** post exactly one verdict comment per PR and move on — never check out, edit, or enqueue. This is the rest of this file.
-- **Authorized maintainer (opt-in — only when the runner genuinely has approve/enqueue authority on the repo):** after the verdict, additionally drive worthy PRs toward merge by delegating to `pr-contribution-handler` (approve / label / enqueue), and maintain the two persistent artifacts in *Persistent state (authorized mode)*. Everything the read-only mode does still applies; this is a superset.
+## Commands
 
-## Arguments
-
-| Arg | Meaning | Default |
-|-----|---------|---------|
-| `floor` | Lowest PR number to consider | lowest open PR |
-| `interval` | Poll wait when caught up | 15 minutes |
-| `defer_to` | Reviewer logins to defer to — skip any PR already carrying their comment/review | empty |
-
-Resolve once per invocation, then reuse:
+Use the CLI from the repo root:
 
 ```bash
-ACTING_LOGIN=$(gh api user --jq '.login')          # runner identity — NEVER hardcode a name
-REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')   # phase.rs repo, derived not literal
+python3 scripts/pr_review.py scan --repo phase-rs/phase --config .agents/pr-review-policy.toml
+python3 scripts/pr_review.py inspect <PR> --repo phase-rs/phase --mode full
+python3 scripts/pr_review.py recommend <PR> --repo phase-rs/phase
+python3 scripts/pr_review.py record --event-json -
+python3 scripts/pr_review.py compact
 ```
 
-This skill is phase.rs-bound (it assumes Comprehensive Rules, the `review-impl` lenses, and that rtk corrupts `gh pr diff`). Do not point it at an arbitrary repo.
-
-## Source of truth
-
-**GitHub is the ledger.** Per-PR dedup is reconstructed each sweep from the acting login's own comment timestamps — in read-only mode there is no external state file. (Authorized mode adds two local cache/log files, see *Persistent state* below; they are an optional cache only, and GitHub still wins on any conflict.) This is durable and crash-idempotent: if the orchestrator dies after a comment posts, the next sweep sees the comment and dedups correctly. Two different people can run this loop without colliding, because each keys on *their own* login's comments.
-
-A running tally carried in the wakeup prompt is an *optional cache* to skip re-deriving timestamps. It is never authoritative — when cache and GitHub disagree, GitHub wins.
-
-## One sweep
-
-### 1. Select candidates
-
-List open PRs `>= floor`, ascending, excluding **(a)** any authored by `ACTING_LOGIN` (don't review your own work) — fold the author filter into the `jq` so the emitted number list is already clean:
+Import legacy state once:
 
 ```bash
-gh pr list --repo "$REPO" --state open --limit 100 \
-  --json number,author \
-  --jq ".[] | select(.number >= $floor and .author.login != \"$ACTING_LOGIN\") | .number" | sort -n
+python3 scripts/pr_review.py import \
+  --tracker /Users/matt/dev/forge.rs-pr-tracker.tsv \
+  --quality /Users/matt/dev/forge.rs-contributor-quality.md
+python3 scripts/pr_review.py compact
 ```
 
-Then exclude **(b)** any PR already carrying a comment or review by a login in `defer_to` — defer to that reviewer rather than piling on. Per candidate `$n`:
+## Sweep Protocol
 
-```bash
-skip=""
-for who in $defer_to; do
-  c=$(gh pr view "$n" --repo "$REPO" --json comments --jq "[.comments[] | select(.author.login==\"$who\")] | length")
-  r=$(gh pr view "$n" --repo "$REPO" --json reviews  --jq "[.reviews[]  | select(.author.login==\"$who\")] | length")
-  { [ "$c" != "0" ] || [ "$r" != "0" ]; } && { skip="$who"; break; }
-done
-[ -n "$skip" ] && continue   # a defer_to reviewer is already engaged
-```
+1. Resolve the acting identity from GitHub. Do not review PRs authored by the acting login.
+2. Run `scan`. Treat its result as a triage packet, not a final approval gate.
+3. For each candidate:
+   - `hard_stop` / `request_changes` — surface the precise blocker; do not enqueue.
+   - `defer` — record the deferral event; do not approve, label, enqueue, or merge.
+   - `hold_ci` — record a non-terminal hold and wait for exact-head CI to finish.
+   - `dequeue_stale_for_handler` / `update_branch_for_handler` / `approve_ready_for_handler` — advisory only; delegate execution to `pr-contribution-handler` in authorized mode.
+   - `review` — fetch an `inspect --mode full` packet, then run `review-impl` against the current head and GitHub API/local diff evidence.
+4. Record every material outcome with `record`; regenerate summaries with `compact` when useful.
 
-### 2. Per-PR dedup gate — the loop's efficiency core
+## Review Freshness
 
-For each surviving candidate, decide review / re-review / skip. Query each field with its **own** `gh pr view --json X --jq` call — combining fields into one blob and piping through a shell var triggers jq control-char parse errors.
+Approval freshness is attached to a head, not to a PR number. A post-approval force-push, same-head newer blocking maintainer activity, author follow-up after review, or queue drop must re-surface the PR. A terminal local event never overrides newer GitHub activity.
 
-*(Authorized mode only — zero-cost skip:* before the GitHub-derived gate below, consult the tracker (*Persistent state*). If its newest row for `$n` has `head_sha == current head` **and** a *terminal* verdict, skip without any further `gh` calls. On a non-terminal verdict, a mismatched/absent head, or any doubt, fall through to the GitHub-derived gate — GitHub wins.)
+The CLI models freshness using:
 
-The "ledger" is *all* of the acting login's prior activity on the PR — a plain comment (what this loop posts) **or** a formal review (a human runner may have left one). Take the max timestamp across both; one extra cheap call avoids redundantly re-reviewing a PR whose only prior verdict was a formal review:
+- current `headRefOid`;
+- latest maintainer comment/review and the commit SHA attached to formal reviews;
+- author follow-ups;
+- substantive vs merge-only commits;
+- review decision;
+- CI status;
+- labels and merge-queue membership.
 
-```bash
-lc=$(gh pr view "$n" --repo "$REPO" --json comments \
-  --jq "[.comments[] | select(.author.login==\"$ACTING_LOGIN\") | .createdAt] | max // empty")
-lr=$(gh pr view "$n" --repo "$REPO" --json reviews \
-  --jq "[.reviews[]  | select(.author.login==\"$ACTING_LOGIN\") | .submittedAt] | max // empty")
-last=$(printf '%s\n%s\n' "$lc" "$lr" | grep -v '^$' | sort | tail -n1)   # ISO-8601 sorts lexically
-```
+## Review Bar
 
-- **No prior activity (`last` empty)** → first review. Go to step 3.
-- **Prior activity exists** → check for an *actual code commit* after it. An actual code commit is a **non-merge** commit (a merge/rebase-from-main commit has ≥2 parents and does not change the PR's own content):
+The bar is still owned by `review-impl` and `pr-contribution-handler`:
 
-```bash
-gh api "repos/$REPO/pulls/$n/commits" --paginate \
-  --jq ".[] | select(.commit.committer.date > \"$last\") | select((.parents|length)==1) | .sha"
-```
+- correct architectural seam;
+- idiomatic implementation at that seam;
+- maintainability and building-block reuse;
+- value proportional to blast radius;
+- discriminating tests that would fail on revert;
+- rules/CR evidence when the repo policy enables the MTG Comprehensive Rules domain;
+- no unresolved blocking feedback.
 
-  - **No actual code commit after `last`** → **skip. Do not post a comment.** Prior verdict stands. (Merge-from-main and other rebase noise advance the tip's date without changing content — they are not a reason to re-review.)
-  - **One or more actual code commits after `last`** → re-review (step 3, re-review protocol).
+The CLI may recommend that a PR is ready for handler execution only when its structured gates say so, but the recommendation is advisory. Queue readiness is never satisfied from cache; the executor must live-check GitHub.
 
-**Trivial fix-up shortcut:** if a re-review is triggered on an already-approved PR by a small commit that exactly addresses a prior finding, verify the hunks yourself via the API diff (below) and post a short confirmation instead of spawning an agent.
+## Authorized Mode
 
-> Commit messages describe intermediate states, not the net diff, and a PR title may not match its diff. When in doubt, diff the head tree against `origin/main` rather than trusting messages.
+When the user explicitly authorizes maintainer actions, the loop may pass clean PRs to `pr-contribution-handler`. That skill owns assignee locks, checkout/worktree handling, fixups, formal approval, labels, update-branch, enqueue, dequeue, and live GraphQL verification.
 
-### 3. Dispatch a reviewer
+Do not perform GitHub mutations from this skill except ordinary review/comment actions explicitly required by the current sweep.
 
-**Cheap pre-gate first — value & direction, before any deep-review spend (large/speculative feature PRs only).** A wrong-*direction* PR should cost a paragraph, not an agent. Before classifying a tier or dispatching a reviewer on a PR that introduces a **new subsystem / high file count / a feature with no prior maintainer buy-in**, answer two questions from the PR description + file list + ~30 seconds of judgment — no diff trace, no agent:
-- **Direction fit:** is this a thing the project wants, or does it build a *parallel* path to infrastructure that already exists? Re-implementing an engine/subsystem the repo already owns (e.g. a second state-mutation layer beside `engine::apply`, a bespoke game-runner beside `phase-ai/duel_suite`) is wrong-by-construction regardless of code quality — a correctness review just confirms what the direction already disqualifies. If the direction is unwanted, **decline/close with a respectful redirect** to the wanted shape; do **not** spend a deep-review agent proving a bypass on a PR you'd decline anyway.
-- **Visual evidence (heavily-frontend PRs):** a large frontend PR with **no screenshot or screen recording** does not proceed to deep FE review — request visual evidence first. Its absence is itself a weak signal the author didn't validate their own running build (the recurring failure mode: broken image loading / unpolished UX that only surfaces on hands-on checkout, which a screenshot would have pre-empted). Frontend value is visual; it must be shown, not just diffed.
+## Drift Rule
 
-Only PRs that clear this pre-gate (or aren't large speculative features) proceed to tier classification below. Record the pre-gate decline in the tracker/quality log like any other verdict.
-
-**The bar is invariant; only the investigation depth scales.** Every PR, at every tier, must be validated against the same non-negotiable three lenses (owned by `review-impl` / `pr-contribution-handler`):
-1. the change is at the **right architectural seam**;
-2. the code is **idiomatic and follows repo patterns/standards AT that seam**;
-3. the PR provides real **value** (and, for a fix, carries a discriminating test that fails on revert).
-
-The tier does **not** change this bar — it changes **how much investigation you spend to become confident in it**. A small, isolated diff is *cheaper to be confident about*, not held to a lower standard. **If you cannot confidently clear all three lenses at a lower tier, that is not a pass — it is an escalation trigger.** Spend the least investigation that yields genuine confidence in the three lenses; never trade the bar for speed. Classify from the **diffstat + touched paths + contributor standing** (all cheap, no deep read):
-
-- **Tier 0 — inline, no agent.** Trivial diffs (≲30 lines), test-only / doc-only, or a commit that exactly addresses a prior finding. You still confirm all three lenses — it's just fast on a tiny surface. Verify the hunks via the API diff, post a short verdict. (The trivial-fix-up shortcut from step 2.)
-- **Tier 1 — light agent (e.g. sonnet, no worktree).** Small, single-surface, low-blast-radius changes (parser-only, one isolated card, a contained bugfix) from a contributor whose quality-log standing is `trusted`. The agent confirms the **same three lenses** against the read-only diff; "light" means **less machinery** (no worktree, no surface-specific deep-dives that don't apply to this diff) — **not a lower standard**. If the three lenses can't be confidently cleared from the diff alone, it escalates.
-- **Tier 2 — full `review-impl`, opus agent in worktree isolation.** Required when the diff touches a **shared/hot seam** (targeting, casting/priority, layer system, combat, mana, stack), introduces **new engine machinery** (a new enum variant or public surface), is **large / multi-file**, is **AI/policy** (escalated rigor — decision-space/bail/cache-key/determinism), or comes from a contributor whose standing is `watch`/`probation` or who is **first-time** (no log entry). Runs the full `review-impl` lenses + an adversarial second pass.
-
-**Route conservatively:** the default is Tier 2; drop to Tier 1/0 only when the diff is *demonstrably* small, isolated, and from a trusted contributor. Any whiff of a shared seam, new machinery, or value-uncertainty escalates. The classifier exists to avoid wasting *deep investigation* on trivia — never to skip *scrutiny* on risky code, and never to let a PR through without actually confirming seam, idiom, and value.
-
-The dispatched reviewer (Tier 1 cheap agent, or Tier 2 opus in worktree isolation):
-
-1. Fetches the ground-truth diff via the **GitHub API**, never `gh pr diff` (rtk corrupts it into fabricated content):
-   ```bash
-   gh api "repos/$REPO/pulls/$n.diff" -H "Accept: application/vnd.github.v3.diff"
-   ```
-2. Tier 2: runs the **`review-impl`** skill (three lenses + surface-specific lenses). Tier 1: applies just the three core lenses inline.
-3. Applies the orchestration discipline below.
-4. Posts **exactly one** comment via `gh pr comment "$n" --repo "$REPO" --body ...` containing an explicit verdict line, e.g. `VERDICT: approve` / `VERDICT: request-changes` / `VERDICT: approve with comments`. Use a plain comment, **not** a formal `gh pr review --approve/--request-changes` — a non-maintainer bot identity stacking formal review states is noisy and can interfere with required-review/merge-queue gates. (Override only if the user asks for formal reviews, e.g. authorized maintainer mode.)
-
-Bound concurrency: on a large first-run backlog, dispatch sequentially or in a small parallel batch rather than spawning an agent per PR all at once.
-
-### Orchestration discipline (every review, first or re-)
-
-These are loop-level checks that sit *around* the `review-impl` lenses — stated as principles, applied to whatever PR is in hand:
-
-- **Already fixed on `origin/main`?** A branch predating a just-landed fix will duplicate it. Recommend rebase + drop the dup — but keep any *superior test* the PR adds (resolve a duplicate into net coverage gain rather than a flat reject).
-- **PR content vs dirty-tree drift.** Diff against `origin/main` to separate the PR's real changes from concurrent working-tree noise. Watch for corrupted generated files, accidental binaries, submodule gitlink artifacts (mode 160000), and CI-unsafe hunks (e.g. a hardcoded frozen-allowlist count that matches neither base nor concurrent tree).
-- **Fix vs detector-suppression.** A "coverage exemption" commit is a genuine fix only if the supported-count goes *up*; if supported stays down while the swallow count drops, it's suppression, not a fix.
-- **Reachability + discriminating test.** A fix must be reachable in production, and its test must actually exercise the failure path — not an empty, doc-only, or pin-only test, and not a fixture so degenerate it takes a different internal branch than real input.
-- **Added behavior must not over-fire at a shared sink.** A fix that adds an effect at a sink shared by other paths can mis-fire for unrelated cards — verify the trigger condition is scoped correctly.
-
-### Re-review protocol (when an actual code commit landed after my last comment)
-
-1. Read the prior comment; mark each prior finding **ADDRESSED / PARTIAL / NOT**.
-2. **Re-examine whether the prior finding was itself correct.** Trace the *actual* parser/AST or code path on base and HEAD — do not re-reason from a static read of the dispatch order. A prior "this drops cards" finding can be a false positive that only a real trace refutes.
-3. When a test was rebased off the fix it originally shipped with (fix landed separately, PR is now test-only), **run the test against current `origin/main`** to confirm it is green on the landed seam alone — and keep it if it covers a subtlety the landed fix's own test missed.
-
-### 4. Pace or stop
-
-- **Caught up** (every candidate reviewed or skipped) → schedule the next sweep after `interval`, carrying this skill's loop prompt forward (optionally with the non-authoritative tally cache). Use the interval arg; never a literal duration.
-- **User says stop / pause** → end the loop by **omitting** the next wakeup. Do not schedule a placeholder tick. (`resume` re-invokes the skill.)
-
-## Authorized maintainer mode (opt-in)
-
-Only when the runner has real approve/enqueue authority. The sweep, dedup, and tiered review above are unchanged; this adds what happens *after* the verdict:
-
-- **`VERDICT: approve` and it clears the bar** → hand the PR to **`pr-contribution-handler`** to bring-current / fix-narrow / verify, then **repush-guard → approve → label → enqueue**:
-  - **Repush guard (mandatory):** capture `EXPECT=headRefOid`, add `@me` as assignee, re-read the head, **ABORT if it moved**. A sticky `reviewDecision=APPROVED` survives a contributor force-push, so the only freshness signal is current head vs the head you reviewed.
-  - **Label** one of the repo's valid labels; **enqueue** (squash-only: `gh pr merge <N> --auto --squash` — the response `! The merge strategy for main is set by the merge queue` is the EXPECTED success message, not an error); confirm `isInMergeQueue=true`. `mergeStateStatus=BLOCKED` is the *normal* resting state of a queued PR and `autoMergeRequest` reads `null` even when queued — queue membership is the affirmative signal.
-  - **Serial-merge treadmill:** every PR that merges advances `main`, flipping every armed-but-not-`CLEAN` PR behind it to `BEHIND`, and a `BEHIND` armed PR does **not** auto-re-enter the queue. Bring it current with `gh api repos/$REPO/pulls/<N>/update-branch -X PUT`; CI re-greens and the armed auto-merge re-enters it. Expect to repeat this on the trailing PRs until the batch drains.
-- **`VERDICT: request-changes`** → post the precise blocker (and the exact fix when it's a one-liner); record it. Narrow mechanical fixes (shared-`main.rs` test-registration conflicts, a one-line lint) are fine to land yourself; **wrong-seam / overbroad / unpolished is a BLOCK** — hand back.
-
-CI green is necessary, not sufficient: `cancelled` ≠ `failed` (read the latest `completed/success`); a `BEHIND` PR's red can be a stale-base artifact main already fixed (verify the named test against a completed `origin/main` run); a test asserting *wrong* behavior is a false green.
-
-## Persistent state (authorized mode only): tracker + quality log
-
-Read-only mode keeps no state — GitHub is the ledger. Authorized mode adds two local files (outside the repo, never committed):
-
-**PR tracker — in-flight state, pruned on merge.** Append-only TSV, newest row per PR authoritative; an *optional cache* over GitHub (GitHub wins on conflict) for enqueue bookkeeping + a zero-cost skip. Columns: `timestamp  pr  author  tier  verdict  label  enqueued  head_sha  notes`. `head_sha` = the head you assessed (high-water mark). **Verdict vocabulary** — *terminal* (skip at same head): `ENQUEUED · MERGED · CLOSED · CHANGES_REQUESTED · STILL-BLOCKED-same · SUPERSEDE-pending-close · DEFER-FE` (the last = a frontend PR left to the maintainer's own domain; skip at same head, no action); *non-terminal* (re-surface next pass even at same head): `…-pending-CI · …-needs-review · PARTIALLY-RESOLVED-judgment · CONFLICT-RESOLVED-awaiting-CI`. Append (never edit); record current head each time; `STILL-BLOCKED-same` for a new-but-non-fixing head; **prune all rows for a PR when it merges** (awk on the first `^[0-9]{4}$` field).
-
-**Contributor-quality log — lifetime signal, never pruned, keyed BY CONTRIBUTOR.** A separate file precisely because the tracker is pruned on merge and this is *not reconstructible from GitHub* once PRs merge. The shape is chosen so a single lookup sets a PR's review tier — **one section per login**, not a flat chronological log (which would force scanning the whole file to assess one contributor):
-
-```markdown
-### <login> — standing: trusted | watch | probation   (updated <YYYY-MM-DD>)
-<one-line rolling assessment: current trend + why>
-signals: <running tally, e.g. clippy-not-run ×3 · ast-shape-only ×2>
-- <YYYY-MM-DD> #<pr> — <observation + concrete evidence>
-- <YYYY-MM-DD> #<pr> — <…>   (positives recorded too — the point is the trend)
-```
-
-- **`standing` is the actionable field and the ONE mutable line** — update it in place each time you reassess; everything below it is **append-only** (never edit or delete a past observation). Standing is the file's contract with the loop:
-  - `trusted` → eligible for **Tier 0/1** review.
-  - `watch` / `probation` → **Tier 2 minimum**, regardless of diff size.
-  - no section yet (**first-time contributor**) → **Tier 2** by default; create the section after the first review.
-- **Signal vocabulary** (one is a yellow flag; a recurring pattern moves standing toward `watch`/`probation`): `fmt-not-run` / `clippy-not-run` (lint red on submit); `ast-shape-only` (tests assert AST shape, no runtime `apply()` discrimination); **`tests-protect-wrong-behavior`** (after a rules flag, author adds tests asserting the *violating* behavior — a false green, the most insidious); `parsed-but-not-consumed` (new AST field no handler reads); `allow-noncombinator-escape-hatch` (substring dispatch on new parser surface); `revert-churn` (revert-of-revert instead of a clean rebase; net diff deletes others' merged work); `rebase-not-fix` (new head is only `Merge branch main`). Record **positives** (clean enum parameterization, genuine fail-on-revert tests, single-round responsiveness) — standing moves both directions.
-- **Escalate the stance, not just the standing:** when defects recur, the hand-back should become directive ("this needs the full `engine-implementer` cycle, not another patch") rather than another round of the same nit.
-
-This closes the loop: the quality log feeds the tier classifier (`standing` → tier floor), and each review's outcome feeds the quality log (signals + standing update). The bar (three lenses) is unchanged for everyone — standing only decides *how much investigation* a contributor's next PR warrants by default.
-
-## Tooling gotchas
-
-- `gh pr diff` is rtk-corrupted — always fetch diffs via `gh api .../pulls/N.diff`.
-- jq "Invalid string: control characters" → query each field with its own `gh pr view --json X --jq` call; never pipe a combined multi-field blob through a shell var.
-- `gh pr view --jq` rejects extra `--arg`; put a value in a shell var and string-interpolate it into the filter.
-- Reviewers run in worktree isolation and only ever *read* the PR + *comment* — they must never touch the dirty main working tree or other agents' worktrees.
+`.agents/skills/pr-review-loop/SKILL.md` is the canonical Codex-facing copy. Keep `.claude/skills/pr-review-loop/SKILL.md` byte-for-byte synchronized.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ client/src/wasm/*.wasm.d.ts
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 .claude/projects/
+.pr-review/
 
 # Build output
 client/dist/

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -1,0 +1,797 @@
+#!/usr/bin/env python3
+"""Portable PR review intelligence helper.
+
+This tool keeps durable review memory as an append-only JSONL event log and
+maintains a derived SQLite index for cheap queries. It is advisory: GitHub
+mutations stay in the maintainer handling skills.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import fnmatch
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_POLICY = REPO_ROOT / ".agents/pr-review-policy.toml"
+
+
+@dataclass(frozen=True)
+class Policy:
+    raw: dict[str, Any]
+
+    @property
+    def hard_stop_patterns(self) -> list[str]:
+        return list(self.raw.get("hard_stops", {}).get("patterns", []))
+
+    @property
+    def generated_patterns(self) -> list[str]:
+        return list(self.raw.get("generated", {}).get("patterns", []))
+
+    @property
+    def path_classes(self) -> dict[str, list[str]]:
+        classes = self.raw.get("path_classes", {})
+        return {name: list(value.get("patterns", [])) for name, value in classes.items()}
+
+    @property
+    def rules_domain(self) -> str | None:
+        value = self.raw.get("domain", {}).get("rules_domain")
+        return str(value) if value else None
+
+    @property
+    def default_tier(self) -> str:
+        return str(self.raw.get("defaults", {}).get("tier", "T2"))
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def repo_slug(repo: str | None) -> str:
+    return (repo or "default").replace("/", "__")
+
+
+def default_state_dir(repo: str | None) -> Path:
+    if os.environ.get("PR_REVIEW_STATE_DIR"):
+        return Path(os.environ["PR_REVIEW_STATE_DIR"]).expanduser()
+    return Path.home() / ".local/state/pr-review" / repo_slug(repo)
+
+
+def load_policy(path: Path) -> Policy:
+    if not path.exists():
+        return Policy({})
+    with path.open("rb") as file:
+        return Policy(tomllib.load(file))
+
+
+def json_dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def text_hash(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def excerpt(value: str | None, limit: int = 500) -> str:
+    if not value:
+        return ""
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1] + "…"
+
+
+def event_id(event: dict[str, Any]) -> str:
+    clean = {key: value for key, value in event.items() if key != "event_id"}
+    return hashlib.sha256(json_dumps(clean).encode("utf-8")).hexdigest()
+
+
+def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(event)
+    normalized.setdefault("timestamp", now_iso())
+    normalized.setdefault("event_type", "observation")
+    normalized.setdefault("schema_version", 1)
+    normalized["event_id"] = normalized.get("event_id") or event_id(normalized)
+    return normalized
+
+
+def run_json(command: list[str]) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return json.loads(result.stdout or "null")
+
+
+def run_text(command: list[str]) -> str:
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def gh_user() -> str:
+    return str(run_json(["gh", "api", "user"])["login"])
+
+
+def ensure_state(state_dir: Path) -> sqlite3.Connection:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(state_dir / "review-state.sqlite")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events (
+            event_id TEXT PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            pr INTEGER,
+            head_sha TEXT,
+            author TEXT,
+            timestamp TEXT NOT NULL,
+            payload_json TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS leases (
+            pr INTEGER NOT NULL,
+            head_sha TEXT NOT NULL,
+            acting_login TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            acquired_at TEXT NOT NULL,
+            PRIMARY KEY (pr, head_sha, acting_login)
+        )
+        """
+    )
+    return conn
+
+
+def append_event(state_dir: Path, event: dict[str, Any]) -> bool:
+    normalized = normalize_event(event)
+    conn = ensure_state(state_dir)
+    inserted = False
+    with conn:
+        cursor = conn.execute(
+            """
+            INSERT OR IGNORE INTO events
+              (event_id, event_type, pr, head_sha, author, timestamp, payload_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                normalized["event_id"],
+                normalized["event_type"],
+                normalized.get("pr"),
+                normalized.get("head_sha"),
+                normalized.get("author"),
+                normalized["timestamp"],
+                json_dumps(normalized),
+            ),
+        )
+        inserted = cursor.rowcount == 1
+    if inserted:
+        with (state_dir / "review-events.jsonl").open("a", encoding="utf-8") as file:
+            file.write(json_dumps(normalized) + "\n")
+    conn.close()
+    return inserted
+
+
+def rebuild_index(state_dir: Path) -> None:
+    conn = ensure_state(state_dir)
+    with conn:
+        conn.execute("DELETE FROM events")
+        event_log = state_dir / "review-events.jsonl"
+        if event_log.exists():
+            for line in event_log.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                event = normalize_event(json.loads(line))
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO events
+                      (event_id, event_type, pr, head_sha, author, timestamp, payload_json)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event["event_id"],
+                        event["event_type"],
+                        event.get("pr"),
+                        event.get("head_sha"),
+                        event.get("author"),
+                        event["timestamp"],
+                        json_dumps(event),
+                    ),
+                )
+    conn.close()
+
+
+def all_events(state_dir: Path) -> list[dict[str, Any]]:
+    conn = ensure_state(state_dir)
+    rows = conn.execute(
+        "SELECT payload_json FROM events ORDER BY timestamp, event_id"
+    ).fetchall()
+    conn.close()
+    return [json.loads(row[0]) for row in rows]
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def classify_files(files: list[str], policy: Policy) -> dict[str, Any]:
+    hard_stops = [path for path in files if matches_any(path, policy.hard_stop_patterns)]
+    generated = [path for path in files if matches_any(path, policy.generated_patterns)]
+    classes: dict[str, list[str]] = {}
+    for name, patterns in policy.path_classes.items():
+        matched = [path for path in files if matches_any(path, patterns)]
+        if matched:
+            classes[name] = matched
+
+    if hard_stops:
+        surface = "hard_stop"
+        gate = "hard_stop"
+    elif classes and set(classes) == {"frontend"}:
+        surface = "frontend"
+        gate = "policy"
+    elif "frontend" in classes and len(classes) > 1:
+        surface = "mixed"
+        gate = "policy"
+    elif "engine" in classes:
+        surface = "backend"
+        gate = "review"
+    else:
+        surface = "unknown"
+        gate = "review"
+
+    return {
+        "surface": surface,
+        "gate": gate,
+        "hard_stop_paths": hard_stops,
+        "generated_paths": generated,
+        "path_classes": classes,
+    }
+
+
+def status_summary(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    pending = []
+    failures = []
+    successes = []
+    for check in checks:
+        name = check.get("name", "<unknown>")
+        status = check.get("status")
+        conclusion = (check.get("conclusion") or "").upper()
+        if status != "COMPLETED":
+            pending.append(name)
+        elif conclusion not in {"SUCCESS", "SKIPPED", "NEUTRAL"}:
+            failures.append(name)
+        else:
+            successes.append(name)
+    if failures:
+        state = "failed"
+    elif pending:
+        state = "pending"
+    elif successes:
+        state = "green"
+    else:
+        state = "unknown"
+    return {"state": state, "pending": pending, "failures": failures, "successes": successes}
+
+
+def pr_files_from_view(pr: dict[str, Any]) -> list[str]:
+    return [item["path"] for item in pr.get("files", []) if item.get("path")]
+
+
+def latest_review_commit(pr: dict[str, Any], acting_login: str) -> str | None:
+    reviews = [
+        review
+        for review in pr.get("reviews", [])
+        if review.get("author", {}).get("login") == acting_login
+    ]
+    if not reviews:
+        return None
+    reviews.sort(key=lambda review: review.get("submittedAt") or "")
+    commit = reviews[-1].get("commit") or {}
+    return commit.get("oid") or None
+
+
+def compact_pr_view(pr: dict[str, Any], acting_login: str) -> dict[str, Any]:
+    author_login = pr.get("author", {}).get("login")
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "state": pr.get("state"),
+        "isDraft": pr.get("isDraft"),
+        "url": pr.get("url"),
+        "author_login": author_login,
+        "self_authored": author_login == acting_login,
+        "headRefName": pr.get("headRefName"),
+        "headRefOid": pr.get("headRefOid"),
+        "baseRefName": pr.get("baseRefName"),
+        "mergeStateStatus": pr.get("mergeStateStatus"),
+        "reviewDecision": pr.get("reviewDecision"),
+        "isInMergeQueue": pr.get("isInMergeQueue"),
+        "mergeQueueEntry": pr.get("mergeQueueEntry"),
+        "labels": [label.get("name") for label in pr.get("labels", [])],
+        "assignees": [assignee.get("login") for assignee in pr.get("assignees", [])],
+        "body_hash": text_hash(pr.get("body")),
+        "body_excerpt": excerpt(pr.get("body"), 800),
+        "comments": [
+            {
+                "author": comment.get("author", {}).get("login"),
+                "createdAt": comment.get("createdAt"),
+                "body_hash": text_hash(comment.get("body")),
+                "body_excerpt": excerpt(comment.get("body"), 300),
+            }
+            for comment in pr.get("comments", [])
+        ],
+        "reviews": [
+            {
+                "author": review.get("author", {}).get("login"),
+                "state": review.get("state"),
+                "submittedAt": review.get("submittedAt"),
+                "commit": (review.get("commit") or {}).get("oid"),
+                "body_hash": text_hash(review.get("body")),
+                "body_excerpt": excerpt(review.get("body"), 300),
+            }
+            for review in pr.get("reviews", [])
+        ],
+    }
+
+
+def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
+    pr = packet["pr"]
+    head = pr.get("headRefOid")
+    checks = packet.get("ci", {})
+    classification = packet.get("classification", {})
+    latest_commit = packet.get("latest_maintainer_review_commit")
+    review_decision = pr.get("reviewDecision")
+    queue = bool(pr.get("isInMergeQueue"))
+
+    if pr.get("state") == "MERGED":
+        action = "merged_prune"
+        reason = "merged"
+    elif pr.get("state") == "CLOSED":
+        action = "skip"
+        reason = "closed"
+    elif pr.get("self_authored"):
+        action = "skip"
+        reason = "self_authored"
+    elif classification.get("hard_stop_paths"):
+        action = "request_changes"
+        reason = "hard_stop"
+    elif latest_commit and latest_commit != head and review_decision == "APPROVED":
+        action = "dequeue_stale_for_handler" if queue else "hold_ci"
+        reason = "stale_approval"
+    elif queue and review_decision == "APPROVED":
+        action = "queued"
+        reason = "already_in_merge_queue"
+    elif checks.get("state") == "failed":
+        action = "request_changes"
+        reason = "ci_failed"
+    elif checks.get("state") in {"pending", "unknown"}:
+        action = "hold_ci"
+        reason = "ci_not_green"
+    elif classification.get("surface") == "frontend":
+        action = "defer"
+        reason = "frontend_policy"
+    elif review_decision == "CHANGES_REQUESTED":
+        action = "review"
+        reason = "changes_requested"
+    else:
+        action = "review"
+        reason = "needs_review"
+
+    return {
+        "pr": pr.get("number"),
+        "head_sha": head,
+        "advisory_action": action,
+        "reason": reason,
+        "requires_live_verification": action.endswith("_for_handler"),
+        "policy_trace": packet.get("policy_trace", []),
+    }
+
+
+def make_packet(pr: dict[str, Any], policy: Policy, acting_login: str, mode: str) -> dict[str, Any]:
+    files = pr_files_from_view(pr)
+    classification = classify_files(files, policy)
+    checks = status_summary(pr.get("statusCheckRollup", []))
+    compact_pr = compact_pr_view(pr, acting_login)
+    packet = {
+        "schema_version": 1,
+        "completeness": "complete" if mode == "full" else "triage",
+        "acting_login": acting_login,
+        "pr": compact_pr,
+        "files": files,
+        "classification": classification,
+        "ci": checks,
+        "latest_maintainer_review_commit": latest_review_commit(pr, acting_login),
+        "domain": {"rules_domain": policy.rules_domain},
+        "policy_trace": policy_trace(classification),
+    }
+    packet["recommendation"] = recommend_from_packet(packet)
+    return packet
+
+
+def policy_trace(classification: dict[str, Any]) -> list[str]:
+    trace = ["hard_stop", "safety_queue_freshness", "private_override", "standing", "path_policy", "default"]
+    if classification.get("hard_stop_paths"):
+        trace.append("matched:hard_stop")
+    if classification.get("surface") == "frontend":
+        trace.append("matched:frontend")
+    if classification.get("surface") == "mixed":
+        trace.append("matched:mixed")
+    return trace
+
+
+def gh_pr_view(repo: str, pr_number: int) -> dict[str, Any]:
+    fields = (
+        "number,title,body,state,isDraft,url,author,headRefName,headRefOid,"
+        "baseRefName,mergeStateStatus,reviewDecision,labels,assignees,"
+        "statusCheckRollup,latestReviews,reviews,comments,files"
+    )
+    pr = run_json(["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", fields])
+    pr.update(gh_queue_state(repo, pr_number))
+    return pr
+
+
+def gh_queue_state(repo: str, pr_number: int) -> dict[str, Any]:
+    owner, name = repo.split("/", 1)
+    query = (
+        "query($owner:String!,$repo:String!,$number:Int!){"
+        "repository(owner:$owner,name:$repo){"
+        "pullRequest(number:$number){"
+        "isInMergeQueue mergeQueueEntry{position state}"
+        "}}}"
+    )
+    try:
+        result = run_json(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"owner={owner}",
+                "-f",
+                f"repo={name}",
+                "-F",
+                f"number={pr_number}",
+                "-f",
+                f"query={query}",
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return {"isInMergeQueue": None, "mergeQueueEntry": None}
+    pull = result.get("data", {}).get("repository", {}).get("pullRequest", {})
+    return {
+        "isInMergeQueue": pull.get("isInMergeQueue"),
+        "mergeQueueEntry": pull.get("mergeQueueEntry"),
+    }
+
+
+def command_scan(args: argparse.Namespace) -> int:
+    policy = load_policy(args.config)
+    acting_login = args.acting_login or gh_user()
+    prs = run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            args.repo,
+            "--state",
+            "open",
+            "--limit",
+            str(args.limit),
+            "--json",
+            "number,title,author,headRefOid,isDraft,mergeStateStatus,reviewDecision,labels,statusCheckRollup,files",
+        ]
+    )
+    candidates = []
+    for pr in prs:
+        pr.update(gh_queue_state(args.repo, int(pr["number"])))
+        packet = make_packet(pr, policy, acting_login, "light")
+        candidates.append(
+            {
+                "pr": pr.get("number"),
+                "title": pr.get("title"),
+                "head_sha": pr.get("headRefOid"),
+                "author_login": packet["pr"].get("author_login"),
+                "self_authored": packet["pr"].get("self_authored"),
+                "surface": packet["classification"]["surface"],
+                "gate": packet["classification"]["gate"],
+                "hard_stop_paths": packet["classification"]["hard_stop_paths"],
+                "ci": packet["ci"]["state"],
+                "review_decision": pr.get("reviewDecision"),
+                "is_in_merge_queue": packet["pr"].get("isInMergeQueue"),
+                "merge_queue_entry": packet["pr"].get("mergeQueueEntry"),
+                "advisory_action": packet["recommendation"]["advisory_action"],
+                "reason": packet["recommendation"]["reason"],
+                "policy_trace": packet["policy_trace"],
+            }
+        )
+    print(json_dumps({"acting_login": acting_login, "completeness": "triage", "candidates": candidates}))
+    return 0
+
+
+def command_inspect(args: argparse.Namespace) -> int:
+    policy = load_policy(args.config)
+    acting_login = args.acting_login or gh_user()
+    pr = gh_pr_view(args.repo, args.pr)
+    packet = make_packet(pr, policy, acting_login, args.mode)
+    print(json_dumps(packet))
+    return 0
+
+
+def command_recommend(args: argparse.Namespace) -> int:
+    policy = load_policy(args.config)
+    acting_login = args.acting_login or gh_user()
+    pr = gh_pr_view(args.repo, args.pr)
+    packet = make_packet(pr, policy, acting_login, "full")
+    recommendation = packet["recommendation"]
+    if packet["completeness"] != "complete" and recommendation["advisory_action"].endswith("_for_handler"):
+        recommendation = {
+            "pr": args.pr,
+            "head_sha": pr.get("headRefOid"),
+            "advisory_action": "hold_ci",
+            "reason": "insufficient_data",
+            "requires_live_verification": False,
+            "policy_trace": packet.get("policy_trace", []),
+        }
+    print(json_dumps(recommendation))
+    return 0
+
+
+def read_event_arg(value: str) -> dict[str, Any]:
+    if value == "-":
+        return json.loads(sys.stdin.read())
+    return json.loads(Path(value).read_text(encoding="utf-8"))
+
+
+def command_record(args: argparse.Namespace) -> int:
+    event = read_event_arg(args.event_json)
+    state_dir = args.state_dir
+    inserted = append_event(state_dir, event)
+    print(json_dumps({"inserted": inserted, "event_id": normalize_event(event)["event_id"]}))
+    return 0
+
+
+def tsv_import_events(path: Path) -> list[dict[str, Any]]:
+    events = []
+    with path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file, delimiter="\t")
+        for line_number, row in enumerate(reader, start=2):
+            pr_raw = row.get("pr") or ""
+            if not pr_raw.isdigit():
+                continue
+            events.append(
+                {
+                    "event_type": "tracker_row",
+                    "timestamp": row.get("timestamp") or now_iso(),
+                    "pr": int(pr_raw),
+                    "author": row.get("author") or None,
+                    "head_sha": row.get("head_sha") or None,
+                    "source": {"file": str(path), "line": line_number},
+                    "tracker": row,
+                }
+            )
+    return events
+
+
+def quality_import_events(path: Path) -> list[dict[str, Any]]:
+    events = []
+    current_login: str | None = None
+    current_lines: list[str] = []
+    start_line = 0
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines, start=1):
+        if line.startswith("### "):
+            if current_login:
+                events.append(quality_entry(path, start_line, current_login, current_lines))
+            heading = line[4:].strip()
+            current_login = heading.split("—", 1)[0].strip().split()[0]
+            current_lines = [line]
+            start_line = index
+        elif current_login:
+            current_lines.append(line)
+    if current_login:
+        events.append(quality_entry(path, start_line, current_login, current_lines))
+    return events
+
+
+def quality_entry(path: Path, line_number: int, login: str, lines: list[str]) -> dict[str, Any]:
+    body = "\n".join(lines).strip()
+    signals = []
+    for token in [
+        "runtime-test-gap",
+        "false-green",
+        "fmt/clippy-slip",
+        "wrong-seam",
+        "rebase-not-fix",
+        "scope-contamination",
+        "build-for-card",
+        "stale-approval",
+    ]:
+        if token in body:
+            signals.append(token)
+    return {
+        "event_type": "quality_entry",
+        "timestamp": now_iso(),
+        "author": login,
+        "source": {"file": str(path), "line": line_number},
+        "confidence": "low",
+        "quality": {
+            "login": login,
+            "signals": signals,
+            "summary": body[:1200],
+        },
+    }
+
+
+def command_import(args: argparse.Namespace) -> int:
+    count = 0
+    if args.tracker:
+        for event in tsv_import_events(args.tracker):
+            count += 1 if append_event(args.state_dir, event) else 0
+    if args.quality:
+        for event in quality_import_events(args.quality):
+            count += 1 if append_event(args.state_dir, event) else 0
+    print(json_dumps({"inserted": count, "state_dir": str(args.state_dir)}))
+    return 0
+
+
+def command_rebuild_index(args: argparse.Namespace) -> int:
+    rebuild_index(args.state_dir)
+    print(json_dumps({"rebuilt": True, "state_dir": str(args.state_dir)}))
+    return 0
+
+
+def command_check_skill_sync(args: argparse.Namespace) -> int:
+    canonical = args.canonical
+    mirror = args.mirror
+    canonical_bytes = canonical.read_bytes()
+    mirror_bytes = mirror.read_bytes()
+    synced = canonical_bytes == mirror_bytes
+    print(json_dumps({"synced": synced, "canonical": str(canonical), "mirror": str(mirror)}))
+    return 0 if synced else 1
+
+
+def command_compact(args: argparse.Namespace) -> int:
+    rebuild_index(args.state_dir)
+    events = all_events(args.state_dir)
+    prs: dict[str, dict[str, Any]] = {}
+    contributors: dict[str, dict[str, Any]] = {}
+    for event in events:
+        pr = event.get("pr")
+        author = event.get("author")
+        if pr is not None:
+            key = str(pr)
+            prs[key] = {
+                "pr": pr,
+                "head_sha": event.get("head_sha") or prs.get(key, {}).get("head_sha"),
+                "latest_event": event.get("event_type"),
+                "latest_timestamp": event.get("timestamp"),
+                "verdict": event.get("tracker", {}).get("verdict") or prs.get(key, {}).get("verdict"),
+            }
+        if author:
+            entry = contributors.setdefault(
+                author,
+                {"login": author, "events": 0, "signals": {}, "latest_timestamp": None},
+            )
+            entry["events"] += 1
+            entry["latest_timestamp"] = event.get("timestamp")
+            for signal in event.get("quality", {}).get("signals", []):
+                entry["signals"][signal] = entry["signals"].get(signal, 0) + 1
+    summary = {
+        "generated_at": now_iso(),
+        "prs": sorted(prs.values(), key=lambda item: item["pr"]),
+        "contributors": sorted(contributors.values(), key=lambda item: item["login"].lower()),
+    }
+    output = args.state_dir / "review-summary.json"
+    output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json_dumps({"summary": str(output), "prs": len(prs), "contributors": len(contributors)}))
+    return 0
+
+
+def existing_path(value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.exists():
+        raise argparse.ArgumentTypeError(f"{path} does not exist")
+    return path
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", default="phase-rs/phase")
+    parser.add_argument("--config", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--state-dir", type=Path, default=None)
+    parser.add_argument("--acting-login", default=None)
+
+
+def finalize_state_dir(args: argparse.Namespace) -> None:
+    if getattr(args, "state_dir", None) is None:
+        args.state_dir = default_state_dir(getattr(args, "repo", None))
+    args.state_dir = args.state_dir.expanduser()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    scan = sub.add_parser("scan")
+    add_common(scan)
+    scan.add_argument("--limit", type=int, default=100)
+    scan.set_defaults(func=command_scan)
+
+    inspect = sub.add_parser("inspect")
+    add_common(inspect)
+    inspect.add_argument("pr", type=int)
+    inspect.add_argument("--mode", choices=["light", "full"], default="light")
+    inspect.set_defaults(func=command_inspect)
+
+    recommend = sub.add_parser("recommend")
+    add_common(recommend)
+    recommend.add_argument("pr", type=int)
+    recommend.set_defaults(func=command_recommend)
+
+    record = sub.add_parser("record")
+    record.add_argument("--state-dir", type=Path, default=None)
+    record.add_argument("--event-json", required=True)
+    record.set_defaults(func=command_record)
+
+    import_cmd = sub.add_parser("import")
+    import_cmd.add_argument("--state-dir", type=Path, default=None)
+    import_cmd.add_argument("--tracker", type=existing_path)
+    import_cmd.add_argument("--quality", type=existing_path)
+    import_cmd.set_defaults(func=command_import)
+
+    compact = sub.add_parser("compact")
+    compact.add_argument("--state-dir", type=Path, default=None)
+    compact.set_defaults(func=command_compact)
+
+    rebuild = sub.add_parser("rebuild-index")
+    rebuild.add_argument("--state-dir", type=Path, default=None)
+    rebuild.set_defaults(func=command_rebuild_index)
+
+    skill_sync = sub.add_parser("check-skill-sync")
+    skill_sync.add_argument(
+        "--canonical",
+        type=Path,
+        default=REPO_ROOT / ".agents/skills/pr-review-loop/SKILL.md",
+    )
+    skill_sync.add_argument(
+        "--mirror",
+        type=Path,
+        default=REPO_ROOT / ".claude/skills/pr-review-loop/SKILL.md",
+    )
+    skill_sync.set_defaults(func=command_check_skill_sync)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    finalize_state_dir(args)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import pr_review
+
+
+class PrReviewTests(unittest.TestCase):
+    def test_event_record_is_idempotent_and_compacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            state_dir = Path(temp)
+            event = {
+                "event_type": "tracker_row",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "pr": 4495,
+                "author": "contributor",
+                "head_sha": "abc123",
+                "tracker": {"verdict": "HELD-stale-approval-superseded"},
+            }
+
+            self.assertTrue(pr_review.append_event(state_dir, event))
+            self.assertFalse(pr_review.append_event(state_dir, event))
+
+            args = type("Args", (), {"state_dir": state_dir})()
+            pr_review.command_compact(args)
+
+            summary = json.loads((state_dir / "review-summary.json").read_text())
+            self.assertEqual(summary["prs"][0]["pr"], 4495)
+            self.assertEqual(summary["prs"][0]["verdict"], "HELD-stale-approval-superseded")
+            self.assertEqual(summary["contributors"][0]["login"], "contributor")
+
+    def test_hard_stop_takes_precedence(self) -> None:
+        policy = pr_review.Policy(
+            {
+                "hard_stops": {"patterns": [".claude/skills/**"]},
+                "path_classes": {"frontend": {"patterns": ["client/**"]}},
+            }
+        )
+
+        classification = pr_review.classify_files(
+            [".claude/skills/pr-review-loop/SKILL.md", "client/src/App.tsx"],
+            policy,
+        )
+
+        self.assertEqual(classification["surface"], "hard_stop")
+        self.assertEqual(classification["gate"], "hard_stop")
+        self.assertEqual(
+            classification["hard_stop_paths"],
+            [".claude/skills/pr-review-loop/SKILL.md"],
+        )
+
+    def test_stale_approval_recommends_dequeue_when_queued(self) -> None:
+        packet = {
+            "pr": {
+                "number": 4495,
+                "headRefOid": "new-head",
+                "reviewDecision": "APPROVED",
+                "isInMergeQueue": True,
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "old-head",
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "dequeue_stale_for_handler")
+        self.assertEqual(recommendation["reason"], "stale_approval")
+
+    def test_frontend_policy_defers_only_when_no_harder_blocker(self) -> None:
+        packet = {
+            "pr": {
+                "number": 4405,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "reviewDecision": "",
+                "isInMergeQueue": False,
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "frontend"},
+            "latest_maintainer_review_commit": None,
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "defer")
+        self.assertEqual(recommendation["reason"], "frontend_policy")
+
+    def test_merged_pr_recommends_prune(self) -> None:
+        packet = {
+            "pr": {
+                "number": 4495,
+                "state": "MERGED",
+                "headRefOid": "head",
+                "reviewDecision": "APPROVED",
+                "isInMergeQueue": False,
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "head",
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "merged_prune")
+        self.assertEqual(recommendation["reason"], "merged")
+
+    def test_quality_import_extracts_bounded_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "quality.md"
+            path.write_text(
+                "### author-one — standing: watch\n"
+                "signals: false-green x1 · runtime-test-gap x1\n"
+                "long body\n"
+                "### author-two — standing: trusted\n"
+                "clean recovery\n",
+                encoding="utf-8",
+            )
+
+            events = pr_review.quality_import_events(path)
+
+            self.assertEqual([event["author"] for event in events], ["author-one", "author-two"])
+            self.assertIn("false-green", events[0]["quality"]["signals"])
+            self.assertIn("runtime-test-gap", events[0]["quality"]["signals"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace the procedural logic embedded in the pr-review-loop SKILL with a
tested Python tool (scripts/pr_review.py) backed by a committed, name-free
repo policy (.agents/pr-review-policy.toml). The skill becomes a thin
orchestration layer; GitHub is authoritative for PR state and local review
memory lives outside the repo.

- pr_review.py: scan/recommend with merge-queue awareness (queued action,
  isInMergeQueue/mergeQueueEntry surfacing via gh_queue_state)
- pr_review_tests.py: unit coverage for classify_files and recommend_from_packet
- gitignore .pr-review/ output dir
