### PR TITLE
feat(engine): Alchemy perpetual P/T modifier (perpetually gets +N/+M)

### DIFF
--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -153,4 +153,45 @@ mod tests {
         assert_eq!(obj.power, Some(4));
         assert_eq!(obj.toughness, Some(1));
     }
+
+    #[test]
+    fn perpetual_modify_pt_adds_to_base_and_updates_live_pt() {
+        let mut state = GameState::new_two_player(7);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Heir to Dragonfire".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.base_power = Some(1);
+            obj.base_toughness = Some(1);
+        }
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::flush_layers(&mut state);
+
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: crate::types::ability::TargetFilter::Any,
+                modification: PerpetualModification::ModifyPowerToughness {
+                    power_delta: 3,
+                    toughness_delta: 3,
+                },
+            },
+            vec![TargetRef::Object(id)],
+            id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        super::resolve(&mut state, &ability, &mut events).unwrap();
+
+        crate::game::layers::flush_layers(&mut state);
+        let obj = state.objects.get(&id).unwrap();
+        assert_eq!(obj.base_power, Some(4));
+        assert_eq!(obj.base_toughness, Some(4));
+        assert_eq!(obj.power, Some(4));
+        assert_eq!(obj.toughness, Some(4));
+    }
 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1047,6 +1047,23 @@ impl GameObject {
                 self.base_power = Some(*power);
                 self.base_toughness = Some(*toughness);
             }
+            PerpetualModification::ModifyPowerToughness {
+                power_delta,
+                toughness_delta,
+            } => {
+                let base_power = self
+                    .base_power
+                    .or(self.power)
+                    .unwrap_or(0)
+                    .saturating_add(*power_delta);
+                let base_toughness = self
+                    .base_toughness
+                    .or(self.toughness)
+                    .unwrap_or(0)
+                    .saturating_add(*toughness_delta);
+                self.base_power = Some(base_power);
+                self.base_toughness = Some(base_toughness);
+            }
         }
         self.perpetual_mods.push(modification.clone());
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6110,6 +6110,12 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "[~/that X] perpetually gets +N/+M" — persistent
+    // base P/T modifier (Heir to Dragonfire, Tiana's Vehicle).
+    if let Some(effect) = try_parse_perpetual_modify_pt(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "draft a card from [X]'s spellbook [+ destination]".
     if let Some(effect) = try_parse_spellbook_draft(tp) {
         return parsed_clause(effect);
@@ -6302,6 +6308,82 @@ fn try_parse_perpetual_base_pt(tp: TextPair) -> Option<Effect> {
         modification: crate::types::ability::PerpetualModification::SetBasePowerToughness {
             power: power as i32,
             toughness: toughness as i32,
+        },
+    })
+}
+
+/// Digital-only Alchemy: parse the "perpetually gets +N/+M" modifier form —
+/// "[~ / this creature / …] perpetually gets +N/+M" or
+/// "that [type] perpetually gets +N/+M" → [`Effect::ApplyPerpetual`] with
+/// [`PerpetualModification::ModifyPowerToughness`].
+///
+/// Self-subjects resolve to the source; the anaphoric "that …" form binds to
+/// [`TargetFilter::ParentTarget`] (the trigger/event object, e.g. Tiana's
+/// crewed Vehicle). The clause tail must be fully consumed so compound riders
+/// on other perpetual forms fall through to `Unimplemented`.
+fn try_parse_perpetual_modify_pt(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    let lower = tp.lower;
+
+    // Anaphoric back-reference: "that Vehicle perpetually gets +1/+0".
+    if let Ok((after_that, _)) = tag::<_, _, OracleError<'_>>("that ").parse(lower) {
+        let (rest, _) = take_until::<_, _, OracleError<'_>>("perpetually ")
+            .parse(after_that)
+            .ok()?;
+        let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
+            .parse(rest)
+            .ok()?;
+        let (rest, _) = alt((
+            tag::<_, _, OracleError<'_>>("gets "),
+            tag::<_, _, OracleError<'_>>("get "),
+        ))
+        .parse(rest)
+        .ok()?;
+        let (rest, (power_delta, toughness_delta)) =
+            nom_primitives::parse_pt_modifier(rest).ok()?;
+        return tail_done(rest).then_some(Effect::ApplyPerpetual {
+            target: TargetFilter::ParentTarget,
+            modification: crate::types::ability::PerpetualModification::ModifyPowerToughness {
+                power_delta,
+                toughness_delta,
+            },
+        });
+    }
+
+    let after_subject = [
+        "~ ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this permanent ",
+        "this token ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
+        .parse(after_subject)
+        .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("gets "),
+        tag::<_, _, OracleError<'_>>("get "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, (power_delta, toughness_delta)) = nom_primitives::parse_pt_modifier(rest).ok()?;
+    tail_done(rest).then_some(Effect::ApplyPerpetual {
+        target: TargetFilter::Any,
+        modification: crate::types::ability::PerpetualModification::ModifyPowerToughness {
+            power_delta,
+            toughness_delta,
         },
     })
 }
@@ -51102,6 +51184,35 @@ mod tests {
                 modification: PerpetualModification::SetBasePowerToughness {
                     power: 2,
                     toughness: 2,
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn perpetual_parser_maps_modify_pt() {
+        use crate::types::ability::PerpetualModification;
+        let e = parse_effect("~ perpetually gets +3/+3.");
+        assert!(matches!(
+            e,
+            Effect::ApplyPerpetual {
+                modification: PerpetualModification::ModifyPowerToughness {
+                    power_delta: 3,
+                    toughness_delta: 3,
+                },
+                ..
+            }
+        ));
+
+        let e = parse_effect("that vehicle perpetually gets +1/+0.");
+        assert!(matches!(
+            e,
+            Effect::ApplyPerpetual {
+                target: TargetFilter::ParentTarget,
+                modification: PerpetualModification::ModifyPowerToughness {
+                    power_delta: 1,
+                    toughness_delta: 0,
                 },
                 ..
             }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7779,6 +7779,12 @@ pub enum PerpetualModification {
     /// the card's persistent base power and toughness (High Fae Prankster,
     /// Three Tree Battalion, Blood Age Muster).
     SetBasePowerToughness { power: i32, toughness: i32 },
+    /// "[object] perpetually gets +N/+M" — permanently modifies base power and
+    /// toughness by the given deltas (Heir to Dragonfire, Tiana's Vehicle).
+    ModifyPowerToughness {
+        power_delta: i32,
+        toughness_delta: i32,
+    },
 }
 
 /// CR 701.20e + CR 608.2c: Discriminates where `Effect::Dig` reads its


### PR DESCRIPTION
Fixes #4524.

## Summary

Adds the Alchemy **perpetual P/T modifier** form — "[object] perpetually gets +N/+M" — as PerpetualModification::ModifyPowerToughness, parser arm, and resolver delta on persistent ase_power/ase_toughness with layer flush.

Cards: **Heir to Dragonfire** (~ perpetually gets +3/+3), **Tiana, Angelic Mechanic** (that Vehicle perpetually gets +1/+0).

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

> Focused parser + resolver increment on the existing `ApplyPerpetual` / `perpetual_mods` infrastructure from #4104; too small for the full pipeline.

## CR references

None (digital-only Alchemy mechanic, consistent with `Intensify` / `Conjure`).

## Verification

- Parser unit tests: self-subject `~ perpetually gets +3/+3` and anaphoric `that vehicle perpetually gets +1/+0` → `ModifyPowerToughness`.
- Resolver regression: +3/+3 on 1/1 base updates `base_*` and live P/T after `flush_layers`.
- CI covers `cargo fmt`, clippy, parser gate, and engine tests.