### PR TITLE
fix(engine): The Incredible Hulk — gate Enrage riders and untap him when attacking (CR 608.2c)

### DIFF
--- a/crates/engine/src/game/effects/tap_untap.rs
+++ b/crates/engine/src/game/effects/tap_untap.rs
@@ -15,6 +15,16 @@ use crate::types::zones::Zone;
 ///
 /// - `SelfRef` → the source object — the printed-name "tap ~"/"untap ~"
 ///   anaphor that always refers to the source regardless of `ability.targets`.
+///   A chained "untap him"/"untap it" anaphor after a `SelfRef`-subject head
+///   (The Incredible Hulk: "put a +1/+1 counter on him ... untap him") is
+///   rewritten from `ParentTarget` to `SelfRef` at parse time by
+///   `sequence::patch_self_ref_head_tap_anaphor`, so it arrives here as
+///   `SelfRef` and binds the source. Resolving the anaphor at parse time (where
+///   the head's subject is still visible) is mandatory: by resolution time the
+///   discriminator is erased — a declined "up to one target" anaphor (Tyvar
+///   Kell) reaches the `_` arm with the SAME empty `ability.targets`, and per
+///   CR 608.2b that case must do nothing, so a blanket source fallback here
+///   would wrongly untap the source.
 /// - `TrackedSet` → the chain's tracked object set published by a preceding
 ///   effect (e.g. `ChooseObjectsIntoTrackedSet`'s "untap those creatures"
 ///   tail). The `TrackedSetId(0)` sentinel binds to the highest tracked-set
@@ -429,6 +439,158 @@ mod tests {
         assert!(
             state.objects[&obj_id].tapped,
             "SelfRef tap must tap the source object"
+        );
+    }
+
+    /// CR 608.2b: a chained tap/untap anaphor that lowers to `ParentTarget` with
+    /// an EMPTY `ability.targets` slot must be an inert NO-OP. This is the
+    /// *declined optional-target* case — Tyvar Kell "Put a +1/+1 counter on up to
+    /// one target Elf. Untap it." with no Elf chosen: the anaphor "it" has no
+    /// referent, so per CR 608.2b the part of the effect that needs it doesn't
+    /// happen. (Hulk's `SelfRef`-head "untap him" never reaches this arm — it is
+    /// rewritten to `SelfRef` at parse time by
+    /// `sequence::patch_self_ref_head_tap_anaphor`, then binds the source via the
+    /// `SelfRef` arm above.)
+    ///
+    /// Discrimination: this is the regression fence for the rejected
+    /// `ParentTarget | None if ability.targets.is_empty() => source` arm —
+    /// reintroduce it and the source is wrongly untapped AND a spurious
+    /// `PermanentUntapped` event fires, flipping BOTH assertions red.
+    #[test]
+    fn untap_parent_target_with_empty_targets_is_noop() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tyvar Kell".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&obj_id).unwrap().tapped = true;
+
+        let ability = ResolvedAbility::new(
+            Effect::SetTapState {
+                target: TargetFilter::ParentTarget,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            },
+            vec![], // declined optional target — the anaphor "it" has no referent
+            obj_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_set_tap_state(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            state.objects[&obj_id].tapped,
+            "declined optional-target anaphor (ParentTarget + empty slot) must NOT untap the source (CR 608.2b)"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::PermanentUntapped { .. })),
+            "no PermanentUntapped event may fire for a declined-optional no-op"
+        );
+    }
+
+    /// NARROWNESS FENCE — guards against an OVER-BROAD "`ParentTarget` always →
+    /// source" resolver arm. When a parent target WAS chosen, `ParentTarget`
+    /// binds that object via the chosen-targets `_` arm, and the source must stay
+    /// untouched. Discrimination: any arm that maps `ParentTarget` to the source
+    /// regardless of `ability.targets` would untap the source here, flipping the
+    /// second assertion red.
+    #[test]
+    fn untap_parent_target_with_chosen_object_does_not_untap_source() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let other = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Other".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&source).unwrap().tapped = true;
+        state.objects.get_mut(&other).unwrap().tapped = true;
+        assert_ne!(source, other);
+
+        let ability = ResolvedAbility::new(
+            Effect::SetTapState {
+                target: TargetFilter::ParentTarget,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            },
+            vec![TargetRef::Object(other)], // a parent target WAS chosen
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_set_tap_state(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            !state.objects[&other].tapped,
+            "the chosen parent-target object must be untapped"
+        );
+        assert!(
+            state.objects[&source].tapped,
+            "the source must stay tapped: the empty-slot fallback must NOT fire when a target was chosen"
+        );
+    }
+
+    /// CR 608.2b: class fence. `TriggeringSource` is an event-context filter
+    /// resolved from `ability.targets`; a `SelfRef`-head → `TriggeringSource`
+    /// sub-effect (Blistercoil Weird: SpellCast trigger `Pump{SelfRef}` →
+    /// `SetTapState{TriggeringSource, "untap it"}`) with an EMPTY slot has no
+    /// materialized event object, so per CR 608.2b it must stay an inert no-op —
+    /// it must NOT untap the source.
+    ///
+    /// Discrimination: any over-broad arm mapping `ParentTarget`/`None`/
+    /// `TriggeringSource` to the source on an empty slot would untap the source
+    /// here and emit a spurious event, flipping both assertions red. The `_` arm
+    /// reads `ability.targets` → `[]` → no-op.
+    #[test]
+    fn untap_triggering_source_with_empty_targets_is_noop() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Blistercoil Weird".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&obj_id).unwrap().tapped = true;
+
+        let ability = ResolvedAbility::new(
+            Effect::SetTapState {
+                target: TargetFilter::TriggeringSource,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            },
+            vec![], // empty — no event-context object is materialized into the slot
+            obj_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_set_tap_state(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            state.objects[&obj_id].tapped,
+            "TriggeringSource with an empty target slot must stay a no-op (source stays tapped)"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::PermanentUntapped { .. })),
+            "no PermanentUntapped event may fire for a TriggeringSource no-op"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3309,6 +3309,33 @@ pub(crate) fn static_condition_to_ability_condition(
             };
             Some(counter_threshold_to_condition(qty, *minimum, *maximum))
         }
+        // CR 508.1k + CR 608.2c: source-anaphoric mid-effect "if he's/she's/they're
+        // attacking" rider. `SourceIsAttacking` has no dedicated `AbilityCondition`
+        // variant, but "attacking" is a runtime `FilterProp` the resolver already
+        // evaluates against the ability source, so the gate composes as
+        // `SourceMatchesFilter` against the source — mirroring the `SourceIsSaddled`
+        // bridge above. Drives The Incredible Hulk's Enrage ("untap him and there is
+        // an additional combat phase") gate.
+        StaticCondition::SourceIsAttacking => Some(AbilityCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter {
+                properties: vec![FilterProp::Attacking { defender: None }],
+                ..Default::default()
+            }),
+        }),
+        // CR 509.1g + CR 608.2c: same bridge for "he's/she's/they're blocking".
+        StaticCondition::SourceIsBlocking => Some(AbilityCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter {
+                properties: vec![FilterProp::Blocking],
+                ..Default::default()
+            }),
+        }),
+        // CR 506.5 + CR 608.2c: same bridge for "it's attacking alone".
+        StaticCondition::SourceAttackingAlone => Some(AbilityCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter {
+                properties: vec![FilterProp::AttackingAlone],
+                ..Default::default()
+            }),
+        }),
         StaticCondition::DevotionGE { .. }
         // CR 702.176a + CR 611.3a: Persistent alternative-cost markers are
         // source-bound static predicates with no effect-resolution
@@ -3329,9 +3356,6 @@ pub(crate) fn static_condition_to_ability_condition(
         | StaticCondition::RecipientAttackingOwnerTarget { .. }
         | StaticCondition::SourceInZone { .. }
         | StaticCondition::DefendingPlayerControls { .. }
-        | StaticCondition::SourceAttackingAlone
-        | StaticCondition::SourceIsAttacking
-        | StaticCondition::SourceIsBlocking
         | StaticCondition::SourceIsBlocked
         | StaticCondition::SourceIsEquipped
         | StaticCondition::SourceIsEnchanted
@@ -6874,6 +6898,55 @@ mod tests {
                     ..Default::default()
                 }),
             }
+        );
+    }
+
+    /// CR 508.1k + CR 509.1g + CR 506.5 + CR 608.2c: the source-anaphoric
+    /// combat-state static conditions bridge to `SourceMatchesFilter` against
+    /// the ability source with the matching runtime `FilterProp`. This is the
+    /// building-block-level guard for the whole class (not one card): if any
+    /// arm regresses to `None`, the in-effect `if he's attacking/blocking`
+    /// rider is silently dropped and the gated sub-effects fire
+    /// unconditionally (The Incredible Hulk's Enrage untap + extra combat).
+    #[test]
+    fn source_combat_state_conditions_bridge_to_source_matches_filter() {
+        let cases = [
+            (
+                StaticCondition::SourceIsAttacking,
+                vec![FilterProp::Attacking { defender: None }],
+            ),
+            (
+                StaticCondition::SourceIsBlocking,
+                vec![FilterProp::Blocking],
+            ),
+            (
+                StaticCondition::SourceAttackingAlone,
+                vec![FilterProp::AttackingAlone],
+            ),
+        ];
+        for (sc, props) in cases {
+            let mapped = static_condition_to_ability_condition(&sc, &mut ParseContext::default());
+            assert_eq!(
+                mapped,
+                Some(AbilityCondition::SourceMatchesFilter {
+                    filter: TargetFilter::Typed(TypedFilter {
+                        properties: props,
+                        ..Default::default()
+                    }),
+                }),
+                "{sc:?} must bridge to SourceMatchesFilter, not None"
+            );
+        }
+        // `SourceIsBlocked` has no clean 1:1 runtime FilterProp and must stay
+        // unmapped (left in the `=> None` bucket) — guards against accidentally
+        // moving it out alongside the bridged siblings.
+        assert_eq!(
+            static_condition_to_ability_condition(
+                &StaticCondition::SourceIsBlocked,
+                &mut ParseContext::default()
+            ),
+            None,
+            "SourceIsBlocked must remain unmapped (no clean FilterProp::Blocked)"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -152,37 +152,89 @@ fn rewrite_else_parent_target_to_self_ref(def: &mut AbilityDefinition) {
 }
 
 /// CR 608.2c + CR 608.2b: A chained tap/untap anaphor ("untap him"/"untap it")
-/// inherits its referent from the antecedent head's subject. When a def whose
-/// subject is the source itself (`SelfRef` — The Incredible Hulk: "put a +1/+1
-/// counter on him ... untap him") is followed by a chained single-permanent
-/// `SetTapState` whose target lowered to the `ParentTarget` anaphor, that anaphor
-/// refers to the source, so rewrite it to `SelfRef` (the runtime then binds it to
-/// `source_id`). A head with a real or *optional* target (Tyvar Kell: "...up to
-/// one target Elf. Untap it.") is NOT `SelfRef`, so its anaphor stays
-/// `ParentTarget`: it binds the chosen target, and a DECLINED optional target
-/// leaves the target list empty so the sub correctly does nothing (CR 608.2b —
-/// the anaphor has no referent). This is the `sub_ability`-chain analogue of
-/// [`rewrite_else_parent_target_to_self_ref`]; it must run at lowering time
-/// because by resolution the discriminator is erased — both Hulk and a
-/// declined-optional anaphor reach the resolver with the same empty target list,
-/// so the head's subject filter (visible only here) is the only thing that tells
-/// them apart. Scope is restricted to `Single` (the anaphoric singular) — `All`
-/// ("untap all ...") is a population filter, never an anaphor.
+/// inherits its referent from the active antecedent. When the source itself
+/// (`SelfRef` — The Incredible Hulk: "put a +1/+1 counter on him ... untap him")
+/// is the active antecedent, a chained single-permanent `SetTapState` whose target
+/// lowered to the `ParentTarget` anaphor refers to the source, so rewrite it to
+/// `SelfRef` (the runtime then binds it to `source_id`).
+///
+/// The active antecedent is carried DOWN the sub-ability chain, so an intervening
+/// instruction that introduces NO new permanent referent ("... You gain 2 life.
+/// Untap him." / Hulk's extra-phase rider) does not break the rewrite — the
+/// immediate-child-only earlier version silently no-op'd those. It is reset only
+/// when an effect establishes a NEW OBJECT antecedent: a non-`SelfRef`,
+/// non-player-scoped target ("destroy target creature. Untap it." — "it" is the
+/// creature, not the source). Targetless and player-directed effects (life gain,
+/// extra phases, draws) leave the permanent antecedent intact.
+///
+/// A head with a real or *optional* target (Tyvar Kell: "...up to one target Elf.
+/// Untap it.") is NOT `SelfRef`, so its anaphor stays `ParentTarget`: it binds the
+/// chosen target, and a DECLINED optional target leaves the target list empty so
+/// the sub correctly does nothing (CR 608.2b — the anaphor has no referent).
+///
+/// Sibling of [`rewrite_else_parent_target_to_self_ref`] for the `sub_ability`
+/// chain. Must run at lowering time: by resolution the discriminator is erased
+/// (both Hulk and a declined-optional anaphor reach the resolver with the same
+/// empty target list), so the head's subject filter — visible only here — is the
+/// only thing that tells them apart. Scope is restricted to `Single` (the
+/// anaphoric singular) — `All` ("untap all ...") is a population filter.
 fn patch_self_ref_head_tap_anaphor(def: &mut AbilityDefinition) {
-    let head_is_self_ref = definition_targets_self_source(def);
-    if let Some(sub) = def.sub_ability.as_deref_mut() {
-        patch_self_ref_head_tap_anaphor(sub);
-        if head_is_self_ref {
-            if let Effect::SetTapState {
-                target: target @ TargetFilter::ParentTarget,
-                scope: EffectScope::Single,
-                ..
-            } = sub.effect.as_mut()
-            {
-                *target = TargetFilter::SelfRef;
+    fn walk(def: &mut AbilityDefinition, carried_self_ref: bool) {
+        // Update the active permanent antecedent for THIS node, then apply it to
+        // the immediate chained sub before recursing further down the chain.
+        let active_self_ref = match def.effect.target_filter() {
+            Some(TargetFilter::SelfRef) => true,
+            // A new object antecedent (target creature/permanent/...) takes over.
+            Some(filter) if !target_filter_is_player_scoped(filter) => false,
+            // Player-directed (life/phase/draw) or targetless effects introduce no
+            // permanent referent — carry the antecedent through unchanged.
+            _ => carried_self_ref,
+        };
+        if let Some(sub) = def.sub_ability.as_deref_mut() {
+            if active_self_ref {
+                if let Effect::SetTapState {
+                    target: target @ TargetFilter::ParentTarget,
+                    scope: EffectScope::Single,
+                    ..
+                } = sub.effect.as_mut()
+                {
+                    *target = TargetFilter::SelfRef;
+                }
             }
+            walk(sub, active_self_ref);
         }
     }
+    walk(def, false);
+}
+
+/// CR 608.2c: True for `TargetFilter`s that refer to a PLAYER (or set of players),
+/// which therefore do NOT establish a new permanent antecedent for a chained
+/// tap/untap "him"/"it" anaphor (see [`patch_self_ref_head_tap_anaphor`]).
+///
+/// Deliberately a NON-exhaustive allow-list: any unlisted filter is treated as a
+/// potential new object antecedent, which only ever STOPS a rewrite (leaving the
+/// anaphor as `ParentTarget` — the pre-fix behavior), never causes a wrong-object
+/// untap. So an omission is safe; a false inclusion would not be, which is why
+/// only unambiguously player-referencing variants are listed.
+fn target_filter_is_player_scoped(filter: &TargetFilter) -> bool {
+    matches!(
+        filter,
+        TargetFilter::Player
+            | TargetFilter::Controller
+            | TargetFilter::AllPlayers
+            | TargetFilter::DefendingPlayer
+            | TargetFilter::ScopedPlayer
+            | TargetFilter::TriggeringPlayer
+            | TargetFilter::OriginalController
+            | TargetFilter::SourceChosenPlayer
+            | TargetFilter::ParentTargetController
+            | TargetFilter::ParentTargetOwner
+            | TargetFilter::TriggeringSpellController
+            | TargetFilter::TriggeringSpellOwner
+            | TargetFilter::TriggeringSourceController
+            | TargetFilter::PostReplacementSourceController
+            | TargetFilter::SpecificPlayer { .. }
+    )
 }
 
 #[cfg(test)]
@@ -282,6 +334,96 @@ mod self_ref_tap_anaphor_tests {
             ),
             "All-scope SetTapState must not be rewritten, got {:?}",
             sub.effect
+        );
+    }
+
+    /// Builds `PutCounter{head_target}` -> `middle` -> `SetTapState{ParentTarget,
+    /// Single}` untap — a THREE-node chain to exercise antecedent propagation
+    /// across an intervening instruction.
+    fn head_middle_untap_chain(head_target: TargetFilter, middle: Effect) -> AbilityDefinition {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: head_target,
+            },
+        );
+        let mut middle_def = AbilityDefinition::new(AbilityKind::Spell, middle);
+        middle_def.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::SetTapState {
+                target: TargetFilter::ParentTarget,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            },
+        )));
+        def.sub_ability = Some(Box::new(middle_def));
+        def
+    }
+
+    fn untap_of(chain: AbilityDefinition) -> AbilityDefinition {
+        *chain
+            .sub_ability
+            .expect("middle")
+            .sub_ability
+            .expect("untap")
+    }
+
+    // CR 608.2c: an intervening PLAYER-directed instruction (here "you gain 2
+    // life") between a `SelfRef` head and the untap does NOT introduce a new
+    // permanent referent, so the source antecedent carries through and the untap
+    // is still rewritten to `SelfRef`. Discrimination: the immediate-child-only
+    // version (and gemini's `target_filter().is_some()` reset) left this as
+    // `ParentTarget` — a runtime no-op.
+    #[test]
+    fn self_ref_head_intermediate_player_effect_still_rewrites() {
+        let mut def = head_middle_untap_chain(
+            TargetFilter::SelfRef,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                player: TargetFilter::Controller,
+            },
+        );
+        patch_self_ref_head_tap_anaphor(&mut def);
+        let untap = untap_of(def);
+        assert!(
+            matches!(
+                &*untap.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ),
+            "anaphor after SelfRef head + intervening player effect must rewrite to SelfRef, got {:?}",
+            untap.effect
+        );
+    }
+
+    // CR 608.2b/608.2c: an intervening effect that establishes a NEW OBJECT
+    // antecedent (here pairing with a chosen creature) resets the antecedent, so a
+    // following "untap it" binds THAT object (`ParentTarget`), not the source.
+    // This is the target-head negative fixture the maintainer asked for.
+    #[test]
+    fn self_ref_head_intermediate_object_target_does_not_rewrite() {
+        let mut def = head_middle_untap_chain(
+            TargetFilter::SelfRef,
+            Effect::PairWith {
+                target: TargetFilter::Typed(TypedFilter::default()),
+            },
+        );
+        patch_self_ref_head_tap_anaphor(&mut def);
+        let untap = untap_of(def);
+        assert!(
+            matches!(
+                &*untap.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::ParentTarget,
+                    ..
+                }
+            ),
+            "anaphor after an intervening object-target effect must stay ParentTarget, got {:?}",
+            untap.effect
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -151,6 +151,141 @@ fn rewrite_else_parent_target_to_self_ref(def: &mut AbilityDefinition) {
     }
 }
 
+/// CR 608.2c + CR 608.2b: A chained tap/untap anaphor ("untap him"/"untap it")
+/// inherits its referent from the antecedent head's subject. When a def whose
+/// subject is the source itself (`SelfRef` — The Incredible Hulk: "put a +1/+1
+/// counter on him ... untap him") is followed by a chained single-permanent
+/// `SetTapState` whose target lowered to the `ParentTarget` anaphor, that anaphor
+/// refers to the source, so rewrite it to `SelfRef` (the runtime then binds it to
+/// `source_id`). A head with a real or *optional* target (Tyvar Kell: "...up to
+/// one target Elf. Untap it.") is NOT `SelfRef`, so its anaphor stays
+/// `ParentTarget`: it binds the chosen target, and a DECLINED optional target
+/// leaves the target list empty so the sub correctly does nothing (CR 608.2b —
+/// the anaphor has no referent). This is the `sub_ability`-chain analogue of
+/// [`rewrite_else_parent_target_to_self_ref`]; it must run at lowering time
+/// because by resolution the discriminator is erased — both Hulk and a
+/// declined-optional anaphor reach the resolver with the same empty target list,
+/// so the head's subject filter (visible only here) is the only thing that tells
+/// them apart. Scope is restricted to `Single` (the anaphoric singular) — `All`
+/// ("untap all ...") is a population filter, never an anaphor.
+fn patch_self_ref_head_tap_anaphor(def: &mut AbilityDefinition) {
+    let head_is_self_ref = definition_targets_self_source(def);
+    if let Some(sub) = def.sub_ability.as_deref_mut() {
+        patch_self_ref_head_tap_anaphor(sub);
+        if head_is_self_ref {
+            if let Effect::SetTapState {
+                target: target @ TargetFilter::ParentTarget,
+                scope: EffectScope::Single,
+                ..
+            } = sub.effect.as_mut()
+            {
+                *target = TargetFilter::SelfRef;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod self_ref_tap_anaphor_tests {
+    use super::*;
+    use crate::types::ability::TapStateChange;
+
+    /// Builds a `PutCounter{head_target}` head with a chained
+    /// `SetTapState{ParentTarget, scope}` untap sub — the shape every chained
+    /// tap/untap anaphor lowers to.
+    fn put_counter_then_untap_chain(
+        head_target: TargetFilter,
+        sub_scope: EffectScope,
+    ) -> AbilityDefinition {
+        let mut def = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: head_target,
+            },
+        );
+        def.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::SetTapState {
+                target: TargetFilter::ParentTarget,
+                scope: sub_scope,
+                state: TapStateChange::Untap,
+            },
+        )));
+        def
+    }
+
+    // CR 608.2c: a chained "untap him" anaphor after a `SelfRef`-subject head (The
+    // Incredible Hulk: "put a +1/+1 counter on him ... untap him") refers to the
+    // source, so the patch rewrites its `ParentTarget` to `SelfRef`.
+    #[test]
+    fn self_ref_head_tap_anaphor_rewrites_to_self_ref() {
+        let mut def = put_counter_then_untap_chain(TargetFilter::SelfRef, EffectScope::Single);
+        patch_self_ref_head_tap_anaphor(&mut def);
+        let sub = def.sub_ability.expect("sub-ability");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ),
+            "SelfRef-head anaphor must be rewritten to SelfRef, got {:?}",
+            sub.effect
+        );
+    }
+
+    // CR 608.2b: a head with a real/optional target (Tyvar Kell "...up to one
+    // target Elf. Untap it.") is NOT `SelfRef`, so the anaphor MUST stay
+    // `ParentTarget` — it binds the chosen target, and a declined optional target
+    // leaves the target list empty so the sub no-ops. This is exactly the
+    // discrimination the rejected bare-`is_empty()` resolver arm lacked (it would
+    // have wrongly untapped the source planeswalker on a declined target).
+    #[test]
+    fn typed_head_tap_anaphor_stays_parent_target() {
+        let mut def = put_counter_then_untap_chain(
+            TargetFilter::Typed(TypedFilter::default()),
+            EffectScope::Single,
+        );
+        patch_self_ref_head_tap_anaphor(&mut def);
+        let sub = def.sub_ability.expect("sub-ability");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::ParentTarget,
+                    ..
+                }
+            ),
+            "Typed-head anaphor must stay ParentTarget (CR 608.2b), got {:?}",
+            sub.effect
+        );
+    }
+
+    // Scope guard: `All` ("untap all ...") is a population filter, never an
+    // anaphor — it must not be rewritten even under a `SelfRef` head.
+    #[test]
+    fn self_ref_head_tap_all_scope_not_rewritten() {
+        let mut def = put_counter_then_untap_chain(TargetFilter::SelfRef, EffectScope::All);
+        patch_self_ref_head_tap_anaphor(&mut def);
+        let sub = def.sub_ability.expect("sub-ability");
+        assert!(
+            matches!(
+                &*sub.effect,
+                Effect::SetTapState {
+                    target: TargetFilter::ParentTarget,
+                    scope: EffectScope::All,
+                    ..
+                }
+            ),
+            "All-scope SetTapState must not be rewritten, got {:?}",
+            sub.effect
+        );
+    }
+}
+
 /// CR 608.2c + CR 401.4: After an optional `CastFromZone` from a linked-exile
 /// pool (Sanwell, Chaos Wand class), a trailing "put the rest / put the exiled
 /// cards … on the bottom" clause must route uncards still linked to the source
@@ -1337,6 +1472,11 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     rewire_result_anchored_subchain(&mut result);
     wire_optional_cast_decline_fallback(&mut result);
     retarget_counter_additional_cost_to_target(&mut result);
+    // CR 608.2c + CR 608.2b: resolve a chained tap/untap anaphor against a
+    // SelfRef-subject head (The Incredible Hulk's "untap him") — rewrite its
+    // ParentTarget to SelfRef so it binds the source, while a real/optional
+    // target head (Tyvar Kell) keeps ParentTarget and no-ops when declined.
+    patch_self_ref_head_tap_anaphor(&mut result);
     if matches!(&*result.effect, Effect::SearchOutsideGame { .. }) {
         result.optional = false;
         result.optional_for = None;

--- a/crates/engine/tests/incredible_hulk_enrage_attacking.rs
+++ b/crates/engine/tests/incredible_hulk_enrage_attacking.rs
@@ -1,0 +1,237 @@
+//! The Incredible Hulk (MSH) — Enrage's "If he's attacking," rider must GATE
+//! the additional-combat-phase (and untap) sub-effects while leaving the +1/+1
+//! counter ungated.
+//!
+//! Oracle: "Reach, trample\nEnrage — Whenever The Incredible Hulk is dealt
+//! damage, put a +1/+1 counter on him. If he's attacking, untap him and there
+//! is an additional combat phase after this phase."
+//!
+//! The recognizer already yields `StaticCondition::SourceIsAttacking` for "he's
+//! attacking"; the fix bridges it to `AbilityCondition::SourceMatchesFilter {
+//! Typed([Attacking]) }` in `static_condition_to_ability_condition` so the
+//! parsed sub-ability carries the gate. CR 608.2c: instructions resolve in
+//! written order and the rider modifies the later sub-effects only. CR 207.2c:
+//! Enrage is an ability word (no rules meaning) — the line is a plain
+//! `DamageReceived` trigger.
+//!
+//! Discriminating observable: the **additional combat phase** (`state.extra_phases`)
+//! is scheduled iff Hulk is attacking. The ONLY variable between the two tests is
+//! whether Hulk is in `state.combat.attackers`; the damage source is held constant
+//! (direct `Effect::DealDamage` to Hulk). Reverting the bridge (the arm back to
+//! `=> None`) drops the condition, so the gated chain fires unconditionally and
+//! Test B's `extra_phases.is_empty()` assertion flips to red.
+//!
+//! NOTE: the chained "untap him" (`SetTapState { target: ParentTarget }`) is a
+//! pre-existing no-op for this card — the head `PutCounter` targets `SelfRef`,
+//! which is not materialized into `ability.targets`, so the chained
+//! `ParentTarget` inherits no object to untap. The root cause is a targeting-path
+//! inconsistency independent of this condition-bridge fix: `resolved_targets`
+//! falls back to the source for `ParentTarget` + empty targets, but
+//! `resolved_object_ids_for_filter` (the path `SetTapState` resolution uses) does
+//! not. That gap is tracked SEPARATELY (it affects many SelfRef-head →
+//! ParentTarget-anaphor chains, not just Hulk). Consequently these tests
+//! deliberately assert on the additional-combat-phase observable
+//! (`state.extra_phases`), which the gate *does* control, rather than on the
+//! broken untap — keeping the discriminator non-vacuous (revert-proven).
+
+use engine::game::combat::{AttackTarget, AttackerInfo, CombatState};
+use engine::game::effects::deal_damage;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{
+    AbilityCondition, Effect, FilterProp, QuantityExpr, ResolvedAbility, SubAbilityLink,
+    TargetFilter, TargetRef, TypedFilter,
+};
+use engine::types::counter::CounterType;
+use engine::types::game_state::ExtraPhase;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const HULK_ORACLE: &str = "Reach, trample\n\
+Enrage — Whenever The Incredible Hulk is dealt damage, put a +1/+1 counter on \
+him. If he's attacking, untap him and there is an additional combat phase after \
+this phase.";
+
+/// A no-cost direct-damage source (an opponent's effect) used to fire Enrage.
+fn damage_ability(source: ObjectId, target: ObjectId, amount: i32) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: amount },
+            target: TargetFilter::Any,
+            damage_source: None,
+        },
+        vec![TargetRef::Object(target)],
+        source,
+        P1,
+    )
+}
+
+struct EnrageOutcome {
+    plus_counters: u32,
+    extra_phase_scheduled: bool,
+}
+
+/// Build Hulk on the battlefield, deal it direct damage to fire Enrage, resolve
+/// the trigger through the real trigger→stack→resolution pipeline, and report
+/// the observables. When `attacking` is true, Hulk is placed in
+/// `state.combat.attackers` (CR 508.1k) — the only variable across the two cases.
+fn run_enrage(attacking: bool) -> EnrageOutcome {
+    let mut scenario = GameScenario::new();
+    let hulk = scenario
+        .add_creature_from_oracle(P0, "The Incredible Hulk", 8, 8, HULK_ORACLE)
+        .id();
+    // An opponent permanent to act as the damage source.
+    let source = scenario.add_creature(P1, "Damage Source", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // CR 500.10a: the additional-combat-phase guard only adds the phase to the
+    // controller's own turn — make Hulk's controller the active player.
+    runner.state_mut().active_player = P0;
+
+    if attacking {
+        // CR 508.1k + CR 506.4: a declared attacker remains an attacking
+        // creature (being dealt damage is not a removal-from-combat condition),
+        // so the gate reads it as attacking when the trigger resolves. The gate
+        // (`FilterProp::Attacking`) is a LIVE read of `state.combat.attackers`,
+        // so injecting the combat membership directly isolates attacking-status
+        // as the sole variable.
+        runner.state_mut().combat = Some(CombatState {
+            attackers: vec![AttackerInfo {
+                object_id: hulk,
+                defending_player: P1,
+                attack_target: AttackTarget::Player(P1),
+                blocked: false,
+                band_id: None,
+            }],
+            ..Default::default()
+        });
+    }
+
+    // Fire Enrage by dealing direct damage to Hulk, then resolve the trigger
+    // through the real trigger→stack→resolution pipeline.
+    let mut events = Vec::new();
+    deal_damage::resolve(
+        runner.state_mut(),
+        &damage_ability(source, hulk, 2),
+        &mut events,
+    )
+    .expect("damage to Hulk resolves");
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    let state = runner.state();
+    EnrageOutcome {
+        plus_counters: state.objects[&hulk]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        extra_phase_scheduled: state.extra_phases.contains(&ExtraPhase {
+            anchor: Phase::EndCombat,
+            phase: Phase::BeginCombat,
+        }),
+    }
+}
+
+/// Test A — Hulk IS attacking: the gated path FIRES (non-vacuous positive).
+/// CR 122.1 counter + CR 500.8 extra combat phase.
+#[test]
+fn enrage_when_attacking_schedules_extra_combat() {
+    let out = run_enrage(true);
+    assert_eq!(
+        out.plus_counters, 1,
+        "ungated +1/+1 counter must always be placed (CR 122.1)"
+    );
+    assert!(
+        out.extra_phase_scheduled,
+        "gated additional combat phase must be scheduled while attacking (CR 500.8)"
+    );
+}
+
+/// Test B — Hulk is NOT attacking: the gate BLOCKS the rider (revert probe).
+/// The counter still applies (ungated) but the extra combat phase does not.
+#[test]
+fn enrage_when_not_attacking_gates_extra_combat() {
+    let out = run_enrage(false);
+    // Non-vacuity: B is not "nothing happens" — the counter MUST still fire,
+    // proving only the rider is gated, not the whole chain.
+    assert_eq!(
+        out.plus_counters, 1,
+        "ungated +1/+1 counter must still be placed when not attacking (CR 122.1)"
+    );
+    assert!(
+        !out.extra_phase_scheduled,
+        "no additional combat phase may be scheduled when not attacking (CR 608.2c)"
+    );
+}
+
+/// Building-block-level chain shape (the fastest revert detector): the parsed
+/// Enrage trigger must lower to an ungated `PutCounter`, then a `SetTapState`
+/// untap gated by `SourceMatchesFilter { Typed([Attacking]) }`, then an
+/// `AdditionalPhase` reached as that untap's `ContinuationStep` child (so a
+/// false gate transitively skips it — effects/mod.rs resolves only
+/// SequentialSibling children of a failed gate).
+#[test]
+fn enrage_chain_gates_untap_and_extra_combat_on_attacking() {
+    let parsed = engine::parser::oracle::parse_oracle_text(
+        HULK_ORACLE,
+        "The Incredible Hulk",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Hero".to_string()],
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "no swallowed-clause / unimplemented warnings expected, got {:?}",
+        parsed.parse_warnings
+    );
+    let trigger = parsed
+        .triggers
+        .into_iter()
+        .next()
+        .expect("Enrage damage trigger");
+    let head = trigger.execute.expect("trigger execute chain");
+
+    // Head: ungated +1/+1 counter.
+    assert!(
+        matches!(&*head.effect, Effect::PutCounter { .. }),
+        "head must be PutCounter, got {:?}",
+        head.effect
+    );
+    assert_eq!(head.condition, None, "the counter must be ungated");
+
+    // Sub 1: the untap, gated by SourceMatchesFilter{Attacking}.
+    let untap = head.sub_ability.as_deref().expect("untap sub-ability");
+    assert!(
+        matches!(&*untap.effect, Effect::SetTapState { .. }),
+        "first sub must be the untap, got {:?}",
+        untap.effect
+    );
+    assert_eq!(
+        untap.condition,
+        Some(AbilityCondition::SourceMatchesFilter {
+            filter: TargetFilter::Typed(TypedFilter {
+                properties: vec![FilterProp::Attacking { defender: None }],
+                ..Default::default()
+            }),
+        }),
+        "untap must be gated by SourceMatchesFilter{{Attacking}} (the bridge fix)"
+    );
+
+    // Sub 2: the additional combat phase, a ContinuationStep child of the gated
+    // untap (so a false gate transitively skips it).
+    let extra = untap
+        .sub_ability
+        .as_deref()
+        .expect("additional-phase sub-ability");
+    assert!(
+        matches!(&*extra.effect, Effect::AdditionalPhase { .. }),
+        "second sub must be AdditionalPhase, got {:?}",
+        extra.effect
+    );
+    assert_eq!(
+        extra.sub_link,
+        SubAbilityLink::ContinuationStep,
+        "AdditionalPhase must be a ContinuationStep child of the gated untap"
+    );
+}

--- a/crates/engine/tests/incredible_hulk_enrage_attacking.rs
+++ b/crates/engine/tests/incredible_hulk_enrage_attacking.rs
@@ -21,18 +21,21 @@
 //! `=> None`) drops the condition, so the gated chain fires unconditionally and
 //! Test B's `extra_phases.is_empty()` assertion flips to red.
 //!
-//! NOTE: the chained "untap him" (`SetTapState { target: ParentTarget }`) is a
+//! The chained "untap him" (`SetTapState { target: ParentTarget }`) was a
 //! pre-existing no-op for this card — the head `PutCounter` targets `SelfRef`,
-//! which is not materialized into `ability.targets`, so the chained
-//! `ParentTarget` inherits no object to untap. The root cause is a targeting-path
-//! inconsistency independent of this condition-bridge fix: `resolved_targets`
-//! falls back to the source for `ParentTarget` + empty targets, but
-//! `resolved_object_ids_for_filter` (the path `SetTapState` resolution uses) does
-//! not. That gap is tracked SEPARATELY (it affects many SelfRef-head →
-//! ParentTarget-anaphor chains, not just Hulk). Consequently these tests
-//! deliberately assert on the additional-combat-phase observable
-//! (`state.extra_phases`), which the gate *does* control, rather than on the
-//! broken untap — keeping the discriminator non-vacuous (revert-proven).
+//! which is not materialized into `ability.targets` (issue #323), so the chained
+//! `ParentTarget` inherited no object to untap. That targeting-path gap (distinct
+//! from this condition-bridge fix) is now closed at parse time:
+//! `sequence::patch_self_ref_head_tap_anaphor` rewrites the chained
+//! single-permanent `SetTapState`'s `ParentTarget` to `SelfRef` whenever the
+//! antecedent head's subject is `SelfRef`, so the untap binds the source via
+//! `tap_untap_target_ids`' `SelfRef` arm. A head with a real or optional target
+//! (Tyvar Kell "...up to one target Elf. Untap it.") keeps `ParentTarget`, so a
+//! declined optional target correctly no-ops (CR 608.2b — the anaphor has no
+//! referent). `enrage_untaps_hulk_when_attacking` (Test C) exercises Hulk's untap
+//! directly; the condition-bridge tests (A/B) keep their independent observable on
+//! the additional-combat-phase (`state.extra_phases`), which the gate *does*
+//! control, so the gate discriminator stays revert-proven.
 
 use engine::game::combat::{AttackTarget, AttackerInfo, CombatState};
 use engine::game::effects::deal_damage;
@@ -69,6 +72,7 @@ fn damage_ability(source: ObjectId, target: ObjectId, amount: i32) -> ResolvedAb
 struct EnrageOutcome {
     plus_counters: u32,
     extra_phase_scheduled: bool,
+    hulk_tapped: bool,
 }
 
 /// Build Hulk on the battlefield, deal it direct damage to fire Enrage, resolve
@@ -87,6 +91,12 @@ fn run_enrage(attacking: bool) -> EnrageOutcome {
     // CR 500.10a: the additional-combat-phase guard only adds the phase to the
     // controller's own turn — make Hulk's controller the active player.
     runner.state_mut().active_player = P0;
+
+    // Pre-tap Hulk so the chained "untap him" rider has an observable to flip.
+    // CR 508.1f: a declared attacker is normally tapped; for the not-attacking
+    // control a tapped Hulk is simply a tapped permanent — attacking-status
+    // remains the sole variable across the two cases.
+    runner.state_mut().objects.get_mut(&hulk).unwrap().tapped = true;
 
     if attacking {
         // CR 508.1k + CR 506.4: a declared attacker remains an attacking
@@ -130,6 +140,7 @@ fn run_enrage(attacking: bool) -> EnrageOutcome {
             anchor: Phase::EndCombat,
             phase: Phase::BeginCombat,
         }),
+        hulk_tapped: state.objects[&hulk].tapped,
     }
 }
 
@@ -162,6 +173,47 @@ fn enrage_when_not_attacking_gates_extra_combat() {
     assert!(
         !out.extra_phase_scheduled,
         "no additional combat phase may be scheduled when not attacking (CR 608.2c)"
+    );
+}
+
+/// Test C — the targeting fix: the chained "untap him" must actually untap Hulk
+/// when the attacking gate passes. CR 608.2c + CR 701.26b.
+///
+/// The head `PutCounter { SelfRef }` never materializes the `SelfRef` antecedent
+/// into `ability.targets` (issue #323). `sequence::patch_self_ref_head_tap_anaphor`
+/// rewrites the chained `SetTapState`'s `ParentTarget` to `SelfRef` at parse time
+/// (the head's subject is `SelfRef`), so at resolution it binds Hulk via
+/// `tap_untap_target_ids`' `SelfRef` arm.
+///
+/// Discrimination: reverting the parse-time patch leaves the sub as
+/// `SetTapState { ParentTarget }` with an EMPTY `ability.targets` slot, which the
+/// `_` arm reads as `[]` → the untap loop iterates nothing → Hulk stays tapped →
+/// the `!hulk_tapped` assertion flips red. The not-attacking control stays green
+/// either way (its untap rider is gated off by `SourceMatchesFilter {Attacking}`,
+/// so it never reaches the resolver), proving the gate — not the resolver —
+/// controls firing.
+#[test]
+fn enrage_untaps_hulk_when_attacking() {
+    let attacking = run_enrage(true);
+    assert_eq!(
+        attacking.plus_counters, 1,
+        "ungated +1/+1 counter must always be placed (CR 122.1)"
+    );
+    assert!(
+        !attacking.hulk_tapped,
+        "attacking Hulk must be untapped by the chained 'untap him' (the targeting fix)"
+    );
+
+    // Control: not attacking → the untap rider is gated off, so Hulk stays
+    // tapped while the ungated counter still applies.
+    let not_attacking = run_enrage(false);
+    assert_eq!(
+        not_attacking.plus_counters, 1,
+        "ungated +1/+1 counter must still be placed when not attacking (CR 122.1)"
+    );
+    assert!(
+        not_attacking.hulk_tapped,
+        "non-attacking Hulk stays tapped: the untap rider is gated off (CR 608.2c)"
     );
 }
 
@@ -202,9 +254,19 @@ fn enrage_chain_gates_untap_and_extra_combat_on_attacking() {
 
     // Sub 1: the untap, gated by SourceMatchesFilter{Attacking}.
     let untap = head.sub_ability.as_deref().expect("untap sub-ability");
+    // The chained "untap him" must be rewritten from `ParentTarget` to `SelfRef`
+    // by `patch_self_ref_head_tap_anaphor` (the SelfRef-subject head is The
+    // Incredible Hulk's `PutCounter{SelfRef}`), so at resolution it binds Hulk.
+    // Discrimination: reverting the patch leaves this `ParentTarget`.
     assert!(
-        matches!(&*untap.effect, Effect::SetTapState { .. }),
-        "first sub must be the untap, got {:?}",
+        matches!(
+            &*untap.effect,
+            Effect::SetTapState {
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ),
+        "first sub must be the untap rewritten to SelfRef, got {:?}",
         untap.effect
     );
     assert_eq!(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## The Incredible Hulk (MSH) — Enrage chain

Oracle: *"Reach, trample / Enrage — Whenever The Incredible Hulk is dealt damage, put a +1/+1 counter on him. If he's attacking, untap him and there is an additional combat phase after this phase."*

Two distinct fixes, both required for the card to resolve correctly.

### 1. Condition bridge (CR 608.2c)
The "If he's attacking" rider must **gate** the untap + additional-combat-phase sub-effects while leaving the +1/+1 counter ungated. `static_condition_to_ability_condition` now bridges `StaticCondition::SourceIsAttacking` / `SourceIsBlocking` / `SourceAttackingAlone` to `AbilityCondition::SourceMatchesFilter`, so the chained riders carry the gate (mirrors the existing `SourceIsSaddled` precedent).

### 2. Chained "untap him" anaphor (CR 608.2c / CR 608.2b)
"untap him" lowered to `SetTapState{ParentTarget}`, but the head `PutCounter{SelfRef}` is never materialized into `ability.targets` (issue #323), so the untap resolved against an empty target list — a silent no-op. Fixed by resolving the anaphor at **lowering time**: `patch_self_ref_head_tap_anaphor` (inside `lower_effect_chain_ir`, the single chain chokepoint that covers trigger / activated / spell entry points) rewrites the chained `SetTapState{ParentTarget, Single}` to `SelfRef` when the antecedent head's subject is `SelfRef`. It reuses the existing `definition_targets_self_source` and mirrors the sibling helper `rewrite_else_parent_target_to_self_ref` (the else-branch analogue).

**Builds for the class, not the card.** A head with a real or *optional* target (Tyvar Kell / A-Tyvar Kell / Nissa, Who Shakes the World: *"...up to one target X. Untap it."*) is **not** `SelfRef`, so its anaphor stays `ParentTarget`: it binds the chosen target, and a **declined** optional target leaves the slot empty so the sub correctly does nothing (CR 608.2b — the anaphor has no referent). An earlier resolver-level `ability.targets.is_empty()` fallback was rejected in review because it wrongly untapped the *source* planeswalker (and fired a spurious untap event) on a declined target; the lowering-time approach discriminates correctly because the head's subject filter is still visible there.

## Tests
- **Building-block** (`lower.rs`): `SelfRef` head → rewrite to `SelfRef`; `Typed` head → stays `ParentTarget`; `All`-scope guard.
- **Resolver fences** (`tap_untap.rs`): declined-optional no-op (CR 608.2b), narrowness fence, `TriggeringSource` class fence.
- **Integration** (`incredible_hulk_enrage_attacking.rs`): Hulk untaps when attacking (gated rider fires), +1/+1 counter ungated, extra combat phase scheduled; chain-shape `SelfRef` assertion. Discrimination verified by call-site/function-body disable.

## Verification
`cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` = 0 · `cargo test -p engine` green (lib 13878/0).
