### PR TITLE
fix(parser): UNSUPPORTED one-off: River of Tears

### DIFF
--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -3740,6 +3740,90 @@ mod tests {
         assert!(state.objects.get(&source).unwrap().tapped);
     }
 
+    /// CR 305.2a + CR 608.2c + CR 605.1a + CR 605.3b: River of Tears, built end-
+    /// to-end from its Oracle text via `parse_oracle_text`, swaps {U}→{B} at
+    /// resolution exactly when the controller has played a land this turn. This
+    /// exercises both branches of `apply_condition_instead_mana_swap` against the
+    /// *parsed* AST (parser + runtime integration proof).
+    #[test]
+    fn river_of_tears_mana_swaps_blue_to_black_after_land_played() {
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "{T}: Add {U}. If you played a land this turn, add {B} instead.",
+            "River of Tears",
+            &[],
+            &["Land".to_string()],
+            &[],
+        );
+        assert_eq!(parsed.abilities.len(), 1, "single mana ability");
+        let ability = parsed.abilities[0].clone();
+
+        let mut state = GameState::new_two_player(42);
+
+        // No land played this turn (lands_played_this_turn == 0): base {U}.
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "River of Tears".to_string(),
+            Zone::Battlefield,
+        );
+        Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability.clone());
+        assert_eq!(state.players[0].lands_played_this_turn, 0);
+
+        let mut events = Vec::new();
+        let waiting = activate_mana_ability(
+            &mut state,
+            source,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            waiting,
+            WaitingFor::Priority {
+                player: PlayerId(0)
+            }
+        );
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Blue), 1);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Black), 0);
+        assert_eq!(state.players[0].mana_pool.total(), 1);
+        assert!(state.objects.get(&source).unwrap().tapped);
+
+        // A land has now been played this turn: the {U}→{B} instead-swap fires.
+        state.players[0].mana_pool.clear();
+        state.players[0].lands_played_this_turn = 1;
+        let source2 = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "River of Tears".to_string(),
+            Zone::Battlefield,
+        );
+        Arc::make_mut(&mut state.objects.get_mut(&source2).unwrap().abilities)
+            .push(ability.clone());
+
+        let mut events2 = Vec::new();
+        activate_mana_ability(
+            &mut state,
+            source2,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events2,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .unwrap();
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Black), 1);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Blue), 0);
+        assert_eq!(state.players[0].mana_pool.total(), 1);
+        assert!(state.objects.get(&source2).unwrap().tapped);
+    }
+
     #[test]
     fn exhaust_mana_ability_only_once_is_enforced_and_emits_mana_event() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -19946,6 +19946,77 @@ Artifacts you control have \"{T}: Add {U}. Spend this mana only to cast a spell 
         }
     }
 
+    /// CR 305.1 + CR 305.2a + CR 608.2c + CR 605.1a: River of Tears — a
+    /// conditional dual-color mana land whose `{T}` ability adds {U}, but adds
+    /// {B} *instead* if the controller has played a land this turn. The
+    /// simple-past "you played a land this turn" condition must lower to a
+    /// `ConditionInstead` mana swap with ZERO Unimplemented nodes.
+    #[test]
+    fn river_of_tears_conditional_mana_swap_fully_supported() {
+        use crate::types::ability::{AbilityCondition, AbilityCost, PlayerScope, QuantityRef};
+        use crate::types::mana::ManaColor;
+
+        let r = parse_oracle_text(
+            "{T}: Add {U}. If you played a land this turn, add {B} instead.",
+            "River of Tears",
+            &[],
+            &["Land".to_string()],
+            &[],
+        );
+        assert_eq!(r.abilities.len(), 1, "single {{T}} mana ability: {r:#?}");
+        let ability = &r.abilities[0];
+        assert!(
+            !has_unimplemented(ability),
+            "no Unimplemented nodes anywhere in the ability: {ability:#?}"
+        );
+        assert_eq!(ability.cost, Some(AbilityCost::Tap));
+
+        // Root produces {U}.
+        let Effect::Mana { produced, .. } = &*ability.effect else {
+            panic!("expected root Effect::Mana, got {:?}", ability.effect);
+        };
+        assert!(
+            matches!(produced, ManaProduction::Fixed { colors, .. } if colors == &[ManaColor::Blue]),
+            "root must add {{U}}, got {produced:?}"
+        );
+
+        // Sub-ability: ConditionInstead{ LandsPlayedThisTurn >= 1 } producing {B}.
+        let sub = ability
+            .sub_ability
+            .as_ref()
+            .expect("conditional-instead sub-ability must be attached");
+        let Some(AbilityCondition::ConditionInstead { inner }) = sub.condition.as_ref() else {
+            panic!("expected ConditionInstead on sub, got {:?}", sub.condition);
+        };
+        assert!(
+            matches!(
+                inner.as_ref(),
+                AbilityCondition::QuantityCheck {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::LandsPlayedThisTurn {
+                            player: PlayerScope::Controller,
+                            from_zones: None,
+                        },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 1 },
+                }
+            ),
+            "expected LandsPlayedThisTurn{{Controller, None}} >= 1, got {inner:?}"
+        );
+        let Effect::Mana {
+            produced, target, ..
+        } = &*sub.effect
+        else {
+            panic!("expected sub Effect::Mana, got {:?}", sub.effect);
+        };
+        assert_eq!(target, &None, "mana swap sub-ability is untargeted");
+        assert!(
+            matches!(produced, ManaProduction::Fixed { colors, .. } if colors == &[ManaColor::Black]),
+            "instead branch must add {{B}}, got {produced:?}"
+        );
+    }
+
     #[test]
     fn leading_conditional_instead_composes_self_replacement() {
         use crate::types::ability::{AbilityCondition, QuantityRef};

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -3729,24 +3729,35 @@ fn parse_youve_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
         parse_youve_life_history_condition,
         parse_youve_combat_history_condition,
         parse_youve_player_action_history_condition,
-        // CR 305.2a + CR 603.4: "you've played a land [this turn]" — land-play
-        // history condition. Backs intervening-if predicates like Spider-Man
-        // 2099's "if you've played a land or cast a spell this turn from
-        // anywhere other than your hand".
-        // The " this turn" suffix is optional so the combinator also serves as
-        // the LHS of `parse_condition_disjunction` when "played a land" is
-        // followed by " or" rather than " this turn".
-        map((tag("played a land"), opt(tag(" this turn"))), |_| {
-            make_quantity_ge(
-                QuantityRef::LandsPlayedThisTurn {
-                    player: PlayerScope::Controller,
-                    from_zones: None,
-                },
-                1,
-            )
-        }),
+        // CR 305.1 + CR 305.2a: "you've played a land [this turn]" — present-
+        // perfect land-play history. Shares `parse_played_a_land_this_turn_body`
+        // with the simple-past / "you have" dispatcher. Backs intervening-if
+        // predicates like Spider-Man 2099's "if you've played a land or cast a
+        // spell this turn from anywhere other than your hand"; the optional
+        // " this turn" suffix keeps it usable as the disjunction LHS.
+        parse_played_a_land_this_turn_body,
     ))
     .parse(rest)
+}
+
+/// CR 305.1 (playing a land is a special action) + CR 305.2a (count of lands a
+/// player has already played this turn): "[…]played a land [this turn]" body.
+/// "played" is identical across simple-past and present-perfect, so one body
+/// serves every subject prefix. The " this turn" suffix is optional so the
+/// combinator can also serve as the LHS of `parse_condition_disjunction`
+/// ("played a land or cast …"). `from_zones: None` selects the scalar
+/// `Player::lands_played_this_turn` counter (no zone-origin restriction).
+fn parse_played_a_land_this_turn_body(input: &str) -> OracleResult<'_, StaticCondition> {
+    map((tag("played a land"), opt(tag(" this turn"))), |_| {
+        make_quantity_ge(
+            QuantityRef::LandsPlayedThisTurn {
+                player: PlayerScope::Controller,
+                from_zones: None,
+            },
+            1,
+        )
+    })
+    .parse(input)
 }
 
 fn parse_youve_played_land_or_cast_spell_this_turn(
@@ -3912,6 +3923,7 @@ fn parse_event_state_conditions(input: &str) -> OracleResult<'_, StaticCondition
         parse_combat_history_condition,
         parse_no_attacked_this_turn,
         parse_player_action_this_turn,
+        parse_played_a_land_this_turn,
         parse_spell_history_condition,
         parse_counter_history_condition,
         parse_board_state_condition,
@@ -4399,10 +4411,36 @@ fn parse_player_action_this_turn_body(input: &str) -> OracleResult<'_, StaticCon
     .parse(input)
 }
 
+/// Ordering is load-bearing: `preceded(alt(...))` does NOT backtrack into the
+/// alt once the body fails, so the non-contracted "you have " MUST precede the
+/// bare "you " — otherwise "you have surveilled…" consumes "you ", leaves
+/// "have surveilled…", the body fails, and there is no retry. Longest/most-
+/// specific prefixes first. (`"you've "` cannot be confused with `"you "`
+/// because the apostrophe follows `you` directly, but it is ordered first for
+/// consistency.)
 fn parse_player_action_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     preceded(
-        alt((tag("you "), tag("you've "), tag("you have "))),
+        alt((tag("you've "), tag("you have "), tag("you "))),
         parse_player_action_this_turn_body,
+    )
+    .parse(input)
+}
+
+/// CR 305.1 + CR 305.2a: "you[ have] played a land this turn" — the simple-past
+/// surface form printed on River of Tears (whose mana ability swaps {U}→{B}
+/// once the controller has played a land), plus the non-contracted "you have"
+/// sibling. The present-perfect "you've played a land this turn" is owned by
+/// `parse_youve_this_turn`; all three share `parse_played_a_land_this_turn_body`.
+///
+/// Ordering is load-bearing: `preceded(alt(...))` does NOT backtrack into the
+/// alt once the body fails, so "you have " MUST precede "you " — otherwise
+/// "you have played…" consumes "you ", leaves "have played…", the body fails,
+/// and there is no retry. (`parse_player_action_this_turn` uses the same
+/// longest-prefix-first ordering for the same reason.)
+fn parse_played_a_land_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
+    preceded(
+        alt((tag("you have "), tag("you "))),
+        parse_played_a_land_this_turn_body,
     )
     .parse(input)
 }
@@ -7472,6 +7510,56 @@ mod tests {
         assert!(!zones.contains(&Zone::Hand));
         assert!(zones.contains(&Zone::Exile));
         assert!(zones.contains(&Zone::Graveyard));
+    }
+
+    /// Helper: assert a condition is `LandsPlayedThisTurn{Controller, None} >= 1`.
+    /// CR 305.1 + CR 305.2a — the scalar `lands_played_this_turn` counter shape
+    /// shared by River of Tears's simple-past form and the present-perfect form.
+    fn assert_played_a_land_ge1(condition: &StaticCondition) {
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::LandsPlayedThisTurn {
+                            player: PlayerScope::Controller,
+                            from_zones: None,
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        } = condition
+        else {
+            panic!("expected LandsPlayedThisTurn{{Controller, None}} >= 1, got {condition:?}");
+        };
+    }
+
+    /// CR 305.1 + CR 305.2a: River of Tears's printed simple-past surface form
+    /// "you played a land this turn" must parse to the scalar land-play count.
+    #[test]
+    fn parse_inner_condition_simple_past_played_a_land_this_turn() {
+        let (rest, condition) = parse_inner_condition("you played a land this turn").unwrap();
+        assert_eq!(rest, "");
+        assert_played_a_land_ge1(&condition);
+    }
+
+    /// CR 305.1 + CR 305.2a: non-contracted "you have played a land this turn"
+    /// sibling — exercises the longer-prefix-first `alt` ordering (must not be
+    /// mis-consumed by the bare "you " arm).
+    #[test]
+    fn parse_inner_condition_non_contracted_played_a_land_this_turn() {
+        let (rest, condition) = parse_inner_condition("you have played a land this turn").unwrap();
+        assert_eq!(rest, "");
+        assert_played_a_land_ge1(&condition);
+    }
+
+    /// Regression guard: the present-perfect "you've played a land this turn"
+    /// (Spider-Man 2099 path) still parses to the same shape after the
+    /// `parse_played_a_land_this_turn_body` extraction (behavior-preserving).
+    #[test]
+    fn parse_inner_condition_present_perfect_played_a_land_this_turn() {
+        let (rest, condition) = parse_inner_condition("you've played a land this turn").unwrap();
+        assert_eq!(rest, "");
+        assert_played_a_land_ge1(&condition);
     }
 
     #[test]
@@ -11253,6 +11341,40 @@ mod tests {
                 rhs: QuantityExpr::Fixed { value: 1 },
             }
         );
+    }
+
+    /// Regression: the non-contracted "you have <action> this turn" surface
+    /// form must parse for every player-action variant. Before the longest-
+    /// prefix-first reorder of `parse_player_action_this_turn`, the bare
+    /// "you " alt arm consumed "you ", left "have surveilled…", and the body
+    /// failed with no backtrack into the alt.
+    #[test]
+    fn you_have_player_action_this_turn_parses_for_all_variants() {
+        for (text, action) in [
+            ("you have surveilled this turn", PlayerActionKind::Surveil),
+            ("you have scried this turn", PlayerActionKind::Scry),
+            (
+                "you have collected evidence this turn",
+                PlayerActionKind::CollectEvidence,
+            ),
+        ] {
+            let (rest, c) = parse_inner_condition(text).unwrap();
+            assert_eq!(rest, "", "unparsed remainder for {text:?}");
+            assert_eq!(
+                c,
+                StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::PlayerActionsThisTurn {
+                            player: PlayerScope::Controller,
+                            action,
+                        },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 1 },
+                },
+                "wrong condition for {text:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED one-off: River of Tears

## Cards corrected
- River of Tears

## Fix
test

## Files changed
- a

## CR references
- b

## Verification
- `cargo fmt --all` — pass
- `check-parser-combinators.sh <upstream/main merge-base 45bc3e325>` — pass
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass
- `oracle-gen data --filter "river of tears"` — pass
Cards confirmed re-parsed correctly: River of Tears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
