### PR TITLE
feat(engine): Baron Helmut Zemo (MSH) — Boast aggregate-exile cost + copy/cast up to three (CR 702.142a)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1622,6 +1622,43 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             crate::game::casting_costs::tap_creature_power_contribution,
             |cards| GameAction::SelectCards { cards },
         ),
+        // CR 117.1 + CR 601.2b: Aggregate-threshold "exile any number" cost
+        // (Baron Helmut Zemo's Boast). The threshold is satisfied by ANY chosen
+        // subset whose summed `property` meets the comparator, so enumerate
+        // minimal-cover subsets (mirroring the Crew/Saddle aggregate-tap path)
+        // rather than a fixed-cardinality selection. `minimal_power_subset_candidates`
+        // is sum-based, so this arm handles the `Sum` aggregate (the only shape in
+        // the corpus); other aggregate functions fall through to the generic arm.
+        WaitingFor::PayCost {
+            player,
+            kind:
+                PayCostKind::ExileAggregate {
+                    function: crate::types::ability::AggregateFunction::Sum,
+                    property,
+                    comparator,
+                    value,
+                    ..
+                },
+            choices,
+            ..
+        } => {
+            let property = *property;
+            minimal_power_subset_candidates(
+                state,
+                *player,
+                choices,
+                |total| comparator.evaluate(total, *value),
+                move |state, id| {
+                    crate::game::quantity::aggregate_property_over(
+                        state,
+                        &[id],
+                        crate::types::ability::AggregateFunction::Sum,
+                        property,
+                    )
+                },
+                |cards| GameAction::SelectCards { cards },
+            )
+        }
         WaitingFor::PayCost {
             player,
             choices,

--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -1114,6 +1114,10 @@ fn fold_cost(acc: &mut NodeAcc, cost: &AbilityCost) {
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        // CR 118.3: an aggregate graveyard-exile cost (Baron Helmut Zemo's Boast)
+        // is a structural exile cost like CollectEvidence — it consumes/produces no
+        // resource axis the loop detector models.
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::PaySpeed { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Unattach

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11937,6 +11937,35 @@ pub(super) fn find_non_self_exile(
     }
 }
 
+/// CR 117.1 + CR 601.2b: Detect an `ExileWithAggregate` activation cost (Baron
+/// Helmut Zemo's Boast) requiring an interactive "exile any number reaching the
+/// aggregate threshold" selection. Returns a borrowed view of its parameters.
+/// Recurses into `Composite`.
+#[allow(clippy::type_complexity)]
+pub(super) fn find_exile_with_aggregate_cost(
+    cost: &AbilityCost,
+) -> Option<(
+    &TargetFilter,
+    crate::types::ability::AggregateFunction,
+    crate::types::ability::ObjectProperty,
+    crate::types::ability::Comparator,
+    i32,
+    Zone,
+)> {
+    match cost {
+        AbilityCost::ExileWithAggregate {
+            filter,
+            function,
+            property,
+            comparator,
+            value,
+            zone,
+        } => Some((filter, *function, *property, *comparator, *value, *zone)),
+        AbilityCost::Composite { costs } => costs.iter().find_map(find_exile_with_aggregate_cost),
+        _ => None,
+    }
+}
+
 /// CR 702.167a/b: Detect a craft materials cost requiring interactive object
 /// selection across the battlefield/graveyard union. Returns `(count,
 /// materials)`. Recurses into `Composite` (the synthesized craft cost is a
@@ -12975,6 +13004,58 @@ pub fn handle_activate_ability(
                 min_count: 0,
                 resume: CostResume::Spell {
                     spell: Box::new(pending_discard),
+                },
+            });
+        }
+
+        // CR 117.1 + CR 601.2b + CR 602.2b: Pre-check for an `ExileWithAggregate`
+        // cost (Baron Helmut Zemo's Boast — "Exile any number of black cards from
+        // your graveyard with fifteen or more black mana symbols among their mana
+        // costs"). The player chooses any subset of the eligible cards whose
+        // aggregate satisfies the threshold; the handler validates the threshold
+        // and (CR 608.2c) publishes the exiled cards as the tracked set the
+        // `CastCopyOfCard` effect consumes. The effect target is `TrackedSet`
+        // (resolution-time), not a declared target, so no target-selection
+        // detour is needed.
+        if let Some((filter, function, property, comparator, value, zone)) =
+            find_exile_with_aggregate_cost(cost)
+        {
+            let eligible = super::cost_payability::eligible_exile_with_aggregate_objects(
+                state, player, source_id, filter, zone,
+            );
+            // CR 118.3: payability was pre-checked above; re-derive the maximal
+            // aggregate (exile-all) here so an unsatisfiable threshold fails fast.
+            let total =
+                super::quantity::aggregate_property_over(state, &eligible, function, property);
+            if !comparator.evaluate(total, value) {
+                return Err(EngineError::ActionNotAllowed(
+                    "Not enough eligible cards to reach the exile threshold".into(),
+                ));
+            }
+            let mut pending_agg =
+                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+            pending_agg.activation_cost = Some(cost.clone());
+            pending_agg.activation_ability_index = Some(ability_index);
+            let max_count = eligible.len();
+            return Ok(WaitingFor::PayCost {
+                player,
+                kind: PayCostKind::ExileAggregate {
+                    zone,
+                    function,
+                    property,
+                    comparator,
+                    value,
+                    filter: filter.clone(),
+                },
+                choices: eligible,
+                count: max_count,
+                // CR 601.2b: "any number" reaching the threshold — the threshold
+                // (not a fixed cardinality) is enforced by the handler. A nonzero
+                // GE/Sum threshold can never be met by the empty set, so at least
+                // one card is required; `min_count: 1` is the loose lower bound.
+                min_count: 1,
+                resume: CostResume::Spell {
+                    spell: Box::new(pending_agg),
                 },
             });
         }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2162,7 +2162,7 @@ pub(crate) fn handle_exile_aggregate_for_cost(
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // CR 601.2b: the chosen cards must be distinct.
-    if chosen.iter().copied().collect::<HashSet<_>>().len() != chosen.len() {
+    if (0..chosen.len()).any(|i| chosen[i + 1..].contains(&chosen[i])) {
         return Err(EngineError::InvalidAction(
             "Selected cards must be unique".to_string(),
         ));

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2,11 +2,12 @@ use std::collections::HashSet;
 
 use crate::types::ability::{
     is_chosen_remove_counter_cost_count, AbilityCondition, AbilityCost, AbilityDefinition,
-    AbilityKind, AdditionalCost, AdditionalCostInstance, AdditionalCostOrigin, BeholdCostAction,
-    CastTimingPermission, CostPaidObjectSnapshot, CounterCostSelection, Effect, KickerVariant,
-    QuantityExpr, QuantityRef, ReplacementDefinition, ResolvedAbility, SacrificeCost,
-    SacrificeRequirement, SpellCastingOptionKind, StaticCondition, TapCreaturesAggregate,
-    TargetFilter, TypeFilter, TypedFilter, EXILE_COST_X,
+    AbilityKind, AdditionalCost, AdditionalCostInstance, AdditionalCostOrigin, AggregateFunction,
+    BeholdCostAction, CastTimingPermission, Comparator, CostPaidObjectSnapshot,
+    CounterCostSelection, Effect, KickerVariant, ObjectProperty, QuantityExpr, QuantityRef,
+    ReplacementDefinition, ResolvedAbility, SacrificeCost, SacrificeRequirement,
+    SpellCastingOptionKind, StaticCondition, TapCreaturesAggregate, TargetFilter, TypeFilter,
+    TypedFilter, EXILE_COST_X,
 };
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
@@ -2122,6 +2123,92 @@ fn finish_exile_selection_for_cost(
     for &id in chosen {
         super::zones::move_to_zone(state, id, Zone::Exile, events);
     }
+
+    finish_pending_cost_or_cast(state, player, pending, events)
+}
+
+/// CR 117.1 + CR 601.2b + CR 602.2b + CR 608.2c: Resolve an `ExileWithAggregate`
+/// activation cost (Baron Helmut Zemo's Boast). The player has chosen any number
+/// of eligible graveyard cards; validate uniqueness, legality, and still-in-zone
+/// membership, then enforce the aggregate threshold (CR 118.3 — a cost can't be
+/// paid without the necessary resources). Exile the chosen cards, publish them as
+/// a fresh tracked set, and bind the resolving ability's tracked-set sentinel to
+/// that CONCRETE id BEFORE the ability is pushed onto the stack.
+///
+/// CR 608.2c (robustness): the binding MUST be to the concrete id, not left as
+/// the `TrackedSetId(0)` sentinel. The cost is paid at ACTIVATION time, but the
+/// `CastCopyOfCard` effect resolves LATER, off the stack. Between the two,
+/// `state.chain_tracked_set_id` is reset to `None` at depth-0 resolution
+/// (`effects::resolve_ability_chain`) and intervening instant-speed effects may
+/// publish their own tracked sets, so the sentinel's "newest set" fallback
+/// (`resolve_tracked_set_sentinel` / `latest_tracked_set_id`) would resolve to
+/// the WRONG set. `state.tracked_object_sets` is append-only (never cleared or
+/// rekeyed), so the concrete id published here remains valid through resolution.
+/// The threshold guarantees the chosen set is non-empty (a ≥15 sum needs at
+/// least one card), so the published set is never empty.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_exile_aggregate_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    zone: Zone,
+    function: AggregateFunction,
+    property: ObjectProperty,
+    comparator: Comparator,
+    value: i32,
+    filter: &TargetFilter,
+    pending: PendingCast,
+    legal_cards: &[ObjectId],
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    // CR 601.2b: the chosen cards must be distinct.
+    if chosen.iter().copied().collect::<HashSet<_>>().len() != chosen.len() {
+        return Err(EngineError::InvalidAction(
+            "Selected cards must be unique".to_string(),
+        ));
+    }
+    for id in chosen {
+        if !legal_cards.contains(id) {
+            return Err(EngineError::InvalidAction(
+                "Selected card not eligible for the exile cost".to_string(),
+            ));
+        }
+    }
+    // CR 601.2b: re-validate each chosen card is still eligible (still in the
+    // source zone and still matches the filter) against the live state.
+    let still_eligible = super::cost_payability::eligible_exile_with_aggregate_objects(
+        state,
+        player,
+        pending.object_id,
+        filter,
+        zone,
+    );
+    for id in chosen {
+        if !still_eligible.contains(id) {
+            return Err(EngineError::InvalidAction(
+                "Selected card is no longer eligible to exile".to_string(),
+            ));
+        }
+    }
+    // CR 118.3: the chosen set must satisfy the advertised aggregate threshold.
+    let total = super::quantity::aggregate_property_over(state, chosen, function, property);
+    if !comparator.evaluate(total, value) {
+        return Err(EngineError::InvalidAction(format!(
+            "Chosen cards aggregate to {total}, which does not satisfy the exile cost threshold ({value})"
+        )));
+    }
+
+    for &id in chosen {
+        super::zones::move_to_zone(state, id, Zone::Exile, events);
+    }
+
+    // CR 608.2c: publish the exiled cards as a fresh tracked set and bind the
+    // resolving ability's `TrackedSetId(0)` sentinel to that concrete id before
+    // the ability reaches the stack (see the doc comment for the robustness
+    // rationale across the activation→resolution gap).
+    let set_id = super::effects::publish_fresh_tracked_set(state, chosen.to_vec());
+    let mut pending = pending;
+    pending.ability.bind_tracked_set_sentinel_recursive(set_id);
 
     finish_pending_cost_or_cast(state, player, pending, events)
 }

--- a/crates/engine/src/game/cipher.rs
+++ b/crates/engine/src/game/cipher.rs
@@ -249,6 +249,7 @@ fn recast_trigger(
         Effect::CastCopyOfCard {
             target: TargetFilter::None,
             cost: ManaCost::zero(),
+            count: None,
         },
         vec![TargetRef::Object(card_id)],
         creature_id,

--- a/crates/engine/src/game/cipher_tests.rs
+++ b/crates/engine/src/game/cipher_tests.rs
@@ -266,7 +266,7 @@ fn combat_damage_collects_optional_recast_trigger_for_encoded_card() {
     // trigger is not dropped for the exile card being an illegal target).
     assert_eq!(trig.ability.targets, vec![TargetRef::Object(card)]);
     match &trig.ability.effect {
-        Effect::CastCopyOfCard { target, cost } => {
+        Effect::CastCopyOfCard { target, cost, .. } => {
             assert_eq!(target, &TargetFilter::None);
             assert!(
                 cost.is_without_paying_mana(),

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -391,6 +391,25 @@ impl AbilityCost {
             AbilityCost::CollectEvidence { amount } => {
                 super::effects::collect_evidence::can_collect_evidence(state, player, *amount)
             }
+            // CR 118.3 + CR 601.2b: An "exile any number of [filter] with
+            // [aggregate] [cmp] N" cost is payable iff the aggregate over EVERY
+            // eligible object (the maximal chosen set) satisfies the comparator.
+            // For a `Sum`/`GE` threshold (Baron Helmut Zemo: ≥15 black symbols),
+            // "exile all" is the maximal value, so this is the correct ceiling.
+            AbilityCost::ExileWithAggregate {
+                filter,
+                function,
+                property,
+                comparator,
+                value,
+                zone,
+            } => {
+                let ids =
+                    eligible_exile_with_aggregate_objects(state, player, source, filter, *zone);
+                let total =
+                    super::quantity::aggregate_property_over(state, &ids, *function, *property);
+                comparator.evaluate(total, *value)
+            }
             // CR 601.2b: Tapping N creatures requires N untapped creatures
             // matching the filter. The source is excluded only when a {T} cost
             // is also present (handled by the Composite arm); otherwise the
@@ -702,6 +721,39 @@ pub(super) fn eligible_exile_cost_objects(
             && filter_ref.is_none_or(|f| matches_target_filter_in_owner_zone(state, id, f, &ctx))
     })
     .collect()
+}
+
+/// CR 117.1 + CR 601.2b: Objects eligible to be exiled for an
+/// `AbilityCost::ExileWithAggregate` — cards in `zone` matching `filter`,
+/// excluding the ability source. Single source of truth for both the payability
+/// ceiling (aggregate over ALL eligible) and the interactive payment prompt's
+/// `choices`. Uses the owner-zone matcher so `controller: You` / `InZone` /
+/// `Owned` predicates resolve against non-battlefield cards (CR 400.3: a card in
+/// a graveyard is owned by, and controlled relative to, its owner). The filter's
+/// `controller: You` binds to `player` via the source-controller override.
+pub(crate) fn eligible_exile_with_aggregate_objects(
+    state: &GameState,
+    player: PlayerId,
+    source: ObjectId,
+    filter: &TargetFilter,
+    zone: Zone,
+) -> Vec<ObjectId> {
+    let ctx = FilterContext::from_source_with_controller(source, player);
+    let zone_ids: Vec<ObjectId> = match (zone, state.players.get(player.0 as usize)) {
+        (Zone::Graveyard, Some(p)) => p.graveyard.iter().copied().collect(),
+        (Zone::Hand, Some(p)) => p.hand.iter().copied().collect(),
+        // Other zones (battlefield/exile) — scan the object table by zone.
+        _ => state
+            .objects
+            .values()
+            .filter(|o| o.zone == zone)
+            .map(|o| o.id)
+            .collect(),
+    };
+    zone_ids
+        .into_iter()
+        .filter(|&id| id != source && matches_target_filter_in_owner_zone(state, id, filter, &ctx))
+        .collect()
 }
 
 /// CR 702.167a/b: Objects eligible to be exiled as the materials of a craft

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -984,8 +984,13 @@ fn pay_ability_cost_inner(
         }
         // Other cost types require interactive resolution and are intercepted
         // before reaching pay_ability_cost, or are not yet auto-payable.
+        // CR 117.1 + CR 601.2b: `ExileWithAggregate` (Baron Helmut Zemo's Boast)
+        // is paid by the `WaitingFor::PayCost { kind: ExileAggregate }` detour
+        // before this resume runs; this arm is an idempotent no-op (mirrors the
+        // `CollectEvidence`/`ExileMaterials` interactive-cost arms).
         AbilityCost::Exile { .. }
         | AbilityCost::CollectEvidence { .. }
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::ReturnToHand { .. }
         | AbilityCost::Mill { .. }
@@ -1149,6 +1154,10 @@ fn supported_at_resolution(cost: &AbilityCost) -> bool {
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        // CR 117.1 + CR 601.2b: `ExileWithAggregate` is an activation-only cost
+        // (paid by the interactive `PayCost { ExileAggregate }` detour); it has
+        // no resolution-time payment path.
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }
@@ -1287,6 +1296,8 @@ fn can_pay_resolution(
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        // CR 117.1: `ExileWithAggregate` is paid at activation, not resolution.
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }
@@ -1356,6 +1367,16 @@ mod tests {
                 count: CostObjectCount::default(),
             },
             AbilityCost::CollectEvidence { .. } => AbilityCost::CollectEvidence { amount: 1 },
+            AbilityCost::ExileWithAggregate { .. } => AbilityCost::ExileWithAggregate {
+                filter: TargetFilter::Any,
+                function: crate::types::ability::AggregateFunction::Sum,
+                property: crate::types::ability::ObjectProperty::ManaSymbolCount(
+                    crate::types::mana::ManaColor::Black,
+                ),
+                comparator: crate::types::ability::Comparator::GE,
+                value: 1,
+                zone: Zone::Graveyard,
+            },
             AbilityCost::TapCreatures { .. } => AbilityCost::TapCreatures {
                 requirement: TapCreaturesRequirement::count(1),
                 filter: TargetFilter::Any,
@@ -1457,6 +1478,16 @@ mod tests {
                 count: CostObjectCount::default(),
             },
             AbilityCost::CollectEvidence { amount: 0 },
+            AbilityCost::ExileWithAggregate {
+                filter: TargetFilter::Any,
+                function: crate::types::ability::AggregateFunction::Sum,
+                property: crate::types::ability::ObjectProperty::ManaSymbolCount(
+                    crate::types::mana::ManaColor::Black,
+                ),
+                comparator: crate::types::ability::Comparator::GE,
+                value: 0,
+                zone: Zone::Graveyard,
+            },
             AbilityCost::TapCreatures {
                 requirement: TapCreaturesRequirement::count(0),
                 filter: TargetFilter::Any,

--- a/crates/engine/src/game/effects/cast_copy_of_card.rs
+++ b/crates/engine/src/game/effects/cast_copy_of_card.rs
@@ -17,8 +17,12 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (target_filter, cost) = match &ability.effect {
-        Effect::CastCopyOfCard { target, cost } => (target, cost),
+    let (target_filter, cost, count) = match &ability.effect {
+        Effect::CastCopyOfCard {
+            target,
+            cost,
+            count,
+        } => (target, cost, count),
         _ => return Err(EffectError::MissingParam("CastCopyOfCard".to_string())),
     };
 
@@ -47,18 +51,33 @@ pub fn resolve(
             .collect();
 
         if !source_ids.is_empty() {
-            let count = source_ids.len();
+            // CR 707.12a: "you may cast UP TO N of the copies" caps how many of
+            // the copies may be cast. `count: None` (the 13 existing cards) means
+            // every copy may be cast. The choice is always `up_to` (the player
+            // chooses individually whether to cast each copy), so the cap is the
+            // upper bound `min(N, available)`.
+            let cap = count
+                .as_ref()
+                .map(|expr| {
+                    crate::game::quantity::resolve_quantity_with_targets(state, expr, ability)
+                        .max(0) as usize
+                })
+                .unwrap_or(source_ids.len());
+            let choose = cap.min(source_ids.len());
             let mut resume = ability.clone();
             resume.effect = Effect::CastCopyOfCard {
                 target: TargetFilter::None,
                 cost: cost.clone(),
+                // The cap is consumed by this choice; the resumed cast of the
+                // chosen copies (explicit targets) must not re-apply it.
+                count: None,
             };
             resume.sub_ability = None;
             super::append_to_pending_continuation(state, Some(Box::new(resume)));
             state.waiting_for = WaitingFor::ChooseFromZoneChoice {
                 player: ability.controller,
                 cards: source_ids,
-                count,
+                count: choose,
                 up_to: true,
                 constraint: None,
                 source_id: ability.source_id,
@@ -86,6 +105,7 @@ pub fn resolve(
             resume.effect = Effect::CastCopyOfCard {
                 target: TargetFilter::None,
                 cost: cost.clone(),
+                count: None,
             };
             resume.sub_ability = None;
             if index + 1 < source_ids.len() {
@@ -281,6 +301,7 @@ mod tests {
             Effect::CastCopyOfCard {
                 target: TargetFilter::None,
                 cost: ManaCost::zero(),
+                count: None,
             },
             vec![TargetRef::Object(source_id)],
             ObjectId(99),
@@ -324,6 +345,7 @@ mod tests {
                     id: TrackedSetId(0),
                 },
                 cost: ManaCost::zero(),
+                count: None,
             },
             Vec::new(),
             ObjectId(99),
@@ -369,6 +391,7 @@ mod tests {
                     id: TrackedSetId(1),
                 },
                 cost: ManaCost::zero(),
+                count: None,
             },
             Vec::new(),
             ObjectId(99),
@@ -415,6 +438,7 @@ mod tests {
             Effect::CastCopyOfCard {
                 target: TargetFilter::None,
                 cost: ManaCost::zero(),
+                count: None,
             },
             vec![TargetRef::Object(source_id)],
             ObjectId(99),
@@ -460,6 +484,7 @@ mod tests {
             Effect::CastCopyOfCard {
                 target: TargetFilter::None,
                 cost: ManaCost::zero(),
+                count: None,
             },
             vec![TargetRef::Object(source_id)],
             ObjectId(99),

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2647,6 +2647,31 @@ fn apply_action(
                         &mut events,
                     )?
                 }
+                // CR 117.1 + CR 601.2b + CR 608.2c: Aggregate-threshold "exile
+                // any number" cost (Baron Helmut Zemo's Boast); the handler
+                // validates the threshold, exiles, publishes the tracked set, and
+                // binds the resolving ability's tracked-set sentinel to it.
+                PayCostKind::ExileAggregate {
+                    zone,
+                    function,
+                    property,
+                    comparator,
+                    value,
+                    filter,
+                } => engine_casting::handle_exile_aggregate_for_cost(
+                    state,
+                    *player,
+                    *zone,
+                    *function,
+                    *property,
+                    *comparator,
+                    *value,
+                    filter,
+                    *pending_cast.clone(),
+                    choices,
+                    &chosen,
+                    &mut events,
+                )?,
                 PayCostKind::RemoveCounter {
                     counter_type,
                     count: counter_count,
@@ -2745,6 +2770,7 @@ fn apply_action(
                 | PayCostKind::ExileFromZone { .. }
                 | PayCostKind::ExileMaterials { .. }
                 | PayCostKind::ExilePermanent { .. }
+                | PayCostKind::ExileAggregate { .. }
                 | PayCostKind::RemoveCounter { .. }
                 | PayCostKind::Behold { .. } => {
                     return Err(EngineError::InvalidAction(

--- a/crates/engine/src/game/engine_casting.rs
+++ b/crates/engine/src/game/engine_casting.rs
@@ -280,6 +280,37 @@ pub(super) fn handle_exile_for_cost(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub(super) fn handle_exile_aggregate_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    zone: crate::types::zones::Zone,
+    function: crate::types::ability::AggregateFunction,
+    property: crate::types::ability::ObjectProperty,
+    comparator: crate::types::ability::Comparator,
+    value: i32,
+    filter: &TargetFilter,
+    pending_cast: PendingCast,
+    legal_cards: &[ObjectId],
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    casting_costs::handle_exile_aggregate_for_cost(
+        state,
+        player,
+        zone,
+        function,
+        property,
+        comparator,
+        value,
+        filter,
+        pending_cast,
+        legal_cards,
+        chosen,
+        events,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(super) fn handle_exile_permanent_for_cost(
     state: &mut GameState,
     player: PlayerId,

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -1036,6 +1036,9 @@ pub(super) fn handle_unless_payment(
             | AbilityCost::Exile { .. }
             | AbilityCost::ExileMaterials { .. }
             | AbilityCost::CollectEvidence { .. }
+            // CR 118.12: `ExileWithAggregate` has no unless-payment dialog; an
+            // unpayable unless cost falls through to the effect (rules-correct).
+            | AbilityCost::ExileWithAggregate { .. }
             | AbilityCost::TapCreatures { .. }
             // CR 122.6 + CR 118.12: `RemoveCounter { target: Some(_) }`
             // (e.g., Chisei "a permanent you control") requires an

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -791,6 +791,7 @@ fn walk_cost(cost: &AbilityCost, out: &mut Vec<String>) {
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::PayEnergy { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1390,6 +1390,56 @@ fn divide_rounded(value: i32, divisor: u32, rounding: RoundingMode) -> i32 {
 /// matched set, so a trigger object that matches the filter predicate but lies
 /// outside the filter's zone is not wrongly decremented. The `Aggregate` resolver
 /// delegates here for its population, so count and aggregate share this exclusion.
+/// CR 202.3 + CR 107.4a/107.4e/202.1: Aggregate (`function`) a single
+/// `property` over a set of objects. The single summation authority shared by
+/// `QuantityRef::Aggregate`, `QuantityRef::TrackedSetAggregate`, the
+/// `AbilityCost::ExileWithAggregate` cost payability + payment, and (via those)
+/// the Collect Evidence family.
+///
+/// Per-object value reads the live object first — post-layer P/T (CR 613) and
+/// the printed mana cost / per-color symbol count (CR 202.1, stable across
+/// zones) — falling back to the LKI snapshot for off-battlefield P/T look-backs
+/// (CR 608.2h + CR 400.7). `ManaSymbolCount` never needs the LKI fallback: the
+/// live printed cost is authoritative and the LKI snapshot does not retain
+/// individual shards. Hybrid symbols contribute to each of their colors
+/// (CR 107.4e) via `count_cost_color_symbols`.
+pub(crate) fn aggregate_property_over(
+    state: &GameState,
+    ids: &[ObjectId],
+    function: AggregateFunction,
+    property: ObjectProperty,
+) -> i32 {
+    let extract = |id: ObjectId| -> Option<i32> {
+        let live = state.objects.get(&id).and_then(|obj| match property {
+            ObjectProperty::Power => obj.power,
+            ObjectProperty::Toughness => obj.toughness,
+            // CR 202.3e: include X when on the stack (cost_x_paid).
+            ObjectProperty::ManaValue => Some(u32_to_i32_saturating(
+                obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),
+            )),
+            // CR 107.4a + CR 107.4e + CR 202.1: colored mana symbols of `color`;
+            // hybrid symbols contribute to each of their colors.
+            ObjectProperty::ManaSymbolCount(color) => Some(u32_to_i32_saturating(
+                crate::game::devotion::count_cost_color_symbols(&obj.mana_cost, color),
+            )),
+        });
+        live.or_else(|| {
+            state.lki_cache.get(&id).and_then(|lki| match property {
+                ObjectProperty::Power => lki.power,
+                ObjectProperty::Toughness => lki.toughness,
+                ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
+                ObjectProperty::ManaSymbolCount(_) => None,
+            })
+        })
+    };
+    let values = ids.iter().filter_map(|&id| extract(id));
+    match function {
+        AggregateFunction::Max => values.max().unwrap_or(0),
+        AggregateFunction::Min => values.min().unwrap_or(0),
+        AggregateFunction::Sum => values.sum(),
+    }
+}
+
 pub(crate) fn object_count_matching_ids(
     state: &GameState,
     filter: &TargetFilter,
@@ -1807,41 +1857,13 @@ fn resolve_ref(
             property,
             filter,
         } => {
+            // CR 608.2h + CR 400.7: id population delegated to
+            // `object_count_matching_ids` (single source of truth for zone
+            // selection + the `OtherThanTriggerObject` exclusion); per-object
+            // aggregation delegated to `aggregate_property_over` (single
+            // summation authority, live-then-LKI per property).
             let ids = object_count_matching_ids(state, filter, &filter_ctx, source_id);
-            let extract = |id: ObjectId| -> Option<i32> {
-                let live = state.objects.get(&id).and_then(|obj| match property {
-                    ObjectProperty::Power => obj.power,
-                    ObjectProperty::Toughness => obj.toughness,
-                    // CR 202.3e: include X when on the stack (cost_x_paid).
-                    // Printed value is stable across zones, no LKI fallback needed.
-                    ObjectProperty::ManaValue => Some(u32_to_i32_saturating(
-                        obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),
-                    )),
-                    // CR 107.4a + CR 107.4e + CR 202.1: count colored mana symbols
-                    // of `color` in the object's printed cost; hybrid symbols
-                    // contribute to each of their colors. Always defined (0 when
-                    // the object has no mana cost), so no LKI fallback is needed.
-                    ObjectProperty::ManaSymbolCount(color) => Some(u32_to_i32_saturating(
-                        crate::game::devotion::count_cost_color_symbols(&obj.mana_cost, *color),
-                    )),
-                });
-                live.or_else(|| {
-                    state.lki_cache.get(&id).and_then(|lki| match property {
-                        ObjectProperty::Power => lki.power,
-                        ObjectProperty::Toughness => lki.toughness,
-                        ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
-                        // The live cost is authoritative for symbol counting; the
-                        // LKI snapshot does not retain individual shards.
-                        ObjectProperty::ManaSymbolCount(_) => None,
-                    })
-                })
-            };
-            let values = ids.iter().filter_map(|&id| extract(id));
-            match function {
-                AggregateFunction::Max => values.max().unwrap_or(0),
-                AggregateFunction::Min => values.min().unwrap_or(0),
-                AggregateFunction::Sum => values.sum(),
-            }
+            aggregate_property_over(state, &ids, *function, *property)
         }
         // CR 107.1 + CR 700.1: min/max across players of the count of
         // battlefield objects matching `filter` each player controls.
@@ -2199,34 +2221,9 @@ fn resolve_ref(
             let Some((_, ids)) = state.tracked_object_sets.iter().max_by_key(|(id, _)| id.0) else {
                 return 0;
             };
-            let extract = |id: ObjectId| -> Option<i32> {
-                let live = state.objects.get(&id).and_then(|obj| match property {
-                    ObjectProperty::Power => obj.power,
-                    ObjectProperty::Toughness => obj.toughness,
-                    // CR 202.3e: include X when on the stack (cost_x_paid).
-                    ObjectProperty::ManaValue => Some(u32_to_i32_saturating(
-                        obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid),
-                    )),
-                    // CR 107.4a + CR 202.1: colored mana symbols of `color`.
-                    ObjectProperty::ManaSymbolCount(color) => Some(u32_to_i32_saturating(
-                        crate::game::devotion::count_cost_color_symbols(&obj.mana_cost, *color),
-                    )),
-                });
-                live.or_else(|| {
-                    state.lki_cache.get(&id).and_then(|lki| match property {
-                        ObjectProperty::Power => lki.power,
-                        ObjectProperty::Toughness => lki.toughness,
-                        ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
-                        ObjectProperty::ManaSymbolCount(_) => None,
-                    })
-                })
-            };
-            let values = ids.iter().filter_map(|&id| extract(id));
-            match function {
-                AggregateFunction::Max => values.max().unwrap_or(0),
-                AggregateFunction::Min => values.min().unwrap_or(0),
-                AggregateFunction::Sum => values.sum(),
-            }
+            // Per-object aggregation delegated to the shared
+            // `aggregate_property_over` summation authority (live-then-LKI).
+            aggregate_property_over(state, ids, *function, *property)
         }
         // CR 400.7 + CR 608.2c: Read the per-resolution counter populated by
         // ChangeZoneAll when it exiles cards from a hand. Used by "draws a card
@@ -5188,6 +5185,73 @@ mod tests {
         // graveyard excluded); P1 sees only their own 2.
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), bf), 3);
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(1), opp), 2);
+    }
+
+    /// CR 107.4a + CR 107.4e + CR 202.1: `aggregate_property_over` is the single
+    /// summation authority shared by the `Aggregate`/`TrackedSetAggregate`
+    /// resolvers, the `ExileWithAggregate` cost payability, and its payment.
+    /// `Sum` of `ManaSymbolCount(Black)` counts each black symbol once and counts
+    /// a hybrid `{B/R}` as black (CR 107.4e: a hybrid symbol is all of its
+    /// colors). `{B}{B}` (2) + `{B/R}` (1) + `{1}{R}` (0) = 3 over the set.
+    ///
+    /// Revert probe: making `aggregate_property_over` return `0` (or counting
+    /// only monocolored `Black` shards, dropping the hybrid) flips the
+    /// assertions — the hybrid contribution (3 vs 2) and the nonzero total both
+    /// fail, proving the test is non-vacuous and discriminating.
+    #[test]
+    fn aggregate_property_over_sums_black_symbols_including_hybrid() {
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
+        use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
+        let mut state = GameState::new_two_player(7);
+        let make = |state: &mut GameState, cid: u64, shards: Vec<ManaCostShard>| -> ObjectId {
+            let id = create_object(
+                state,
+                CardId(cid),
+                PlayerId(0),
+                "C".to_string(),
+                Zone::Graveyard,
+            );
+            state.objects.get_mut(&id).unwrap().mana_cost = ManaCost::Cost { shards, generic: 1 };
+            id
+        };
+        let bb = make(
+            &mut state,
+            1,
+            vec![ManaCostShard::Black, ManaCostShard::Black],
+        );
+        let hybrid = make(&mut state, 2, vec![ManaCostShard::BlackRed]);
+        let red = make(&mut state, 3, vec![ManaCostShard::Red]);
+
+        // {B}{B}(2) + {B/R}(1) = 3 black symbols; the red-only card adds 0.
+        assert_eq!(
+            super::aggregate_property_over(
+                &state,
+                &[bb, hybrid, red],
+                AggregateFunction::Sum,
+                ObjectProperty::ManaSymbolCount(ManaColor::Black),
+            ),
+            3
+        );
+        // The hybrid alone contributes exactly one black symbol (CR 107.4e).
+        assert_eq!(
+            super::aggregate_property_over(
+                &state,
+                &[hybrid],
+                AggregateFunction::Sum,
+                ObjectProperty::ManaSymbolCount(ManaColor::Black),
+            ),
+            1
+        );
+        // Empty set sums to 0 (no panic on `values.sum()`).
+        assert_eq!(
+            super::aggregate_property_over(
+                &state,
+                &[],
+                AggregateFunction::Sum,
+                ObjectProperty::ManaSymbolCount(ManaColor::Black),
+            ),
+            0
+        );
     }
 
     /// CR 107.4a/107.4e/107.4f + CR 202.1: `ManaSymbolsInManaCost { color: None }`

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -502,6 +502,7 @@ fn replacement_cost_description(cost: &AbilityCost) -> String {
         | AbilityCost::Loyalty { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::PayEnergy { .. }

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -19,9 +19,10 @@ use super::oracle_util::parse_mana_symbols;
 use super::oracle_util::parse_number;
 use super::oracle_util::TextPair;
 use crate::types::ability::{
-    AbilityCost, BeholdCostAction, CostReduction, CounterCostSelection, FilterProp, PlayerScope,
-    QuantityExpr, QuantityRef, SacrificeCost, TapCreaturesRequirement, TargetFilter, TypedFilter,
-    EXILE_COST_X, REMOVE_COUNTER_COST_ALL, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X,
+    AbilityCost, AggregateFunction, BeholdCostAction, Comparator, ControllerRef, CostReduction,
+    CounterCostSelection, FilterProp, ObjectProperty, PlayerScope, QuantityExpr, QuantityRef,
+    SacrificeCost, TapCreaturesRequirement, TargetFilter, TypedFilter, EXILE_COST_X,
+    REMOVE_COUNTER_COST_ALL, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X,
 };
 use crate::types::counter::parse_counter_match;
 use crate::types::zones::Zone;
@@ -1031,6 +1032,15 @@ pub fn parse_single_cost(text: &str) -> AbilityCost {
         }
     }
 
+    // CR 117.1 + CR 601.2b + CR 107.4a/107.4e/202.1: "Exile any number of
+    // [color] cards from your graveyard with [N] or more/greater [color] mana
+    // symbols among their mana costs" — Baron Helmut Zemo's Boast cost. Must run
+    // before the EffectCost fallback, which would otherwise wrap the exile as a
+    // non-functional `ChangeZone` effect-cost.
+    if let Some(cost) = try_parse_exile_with_aggregate_cost(&lower) {
+        return cost;
+    }
+
     // CR 118.3: Fallback — try parsing the cost text as an effect. Many
     // activation costs are structurally identical to effects ("Put a -1/-1
     // counter on ~", "Return a land you control to its owner's hand") and
@@ -1288,6 +1298,73 @@ fn ensure_another_sacrifice_filter(filter: TargetFilter, phrase: &str) -> Target
         },
         other => other,
     }
+}
+
+/// CR 117.1 + CR 601.2b + CR 107.4a/107.4e/202.1: Parse Baron Helmut Zemo's
+/// Boast cost — "Exile any number of [color] cards from your graveyard with [N]
+/// or more [color] mana symbols among their mana costs" — into a standalone
+/// `AbilityCost::ExileWithAggregate` (the aggregate-threshold sibling of
+/// `CollectEvidence`). `lower` is the already-lowercased cost text.
+///
+/// Composed from nom combinators (no string-dispatch): each grammar axis (the
+/// any-number prefix, the filter color + card noun, the graveyard zone, the
+/// threshold number, the comparator words, the aggregated color + symbol noun) is
+/// a single `tag`/`alt`/`parse_color`/`parse_number` step. Hybrid symbols count
+/// for each of their colors at resolution time (CR 107.4e) via the
+/// `ObjectProperty::ManaSymbolCount` resolver.
+fn try_parse_exile_with_aggregate_cost(lower: &str) -> Option<AbilityCost> {
+    type E<'a> = super::oracle_nom::error::OracleError<'a>;
+    let (i, _) = tag::<_, _, E<'_>>("exile any number of ")
+        .parse(lower)
+        .ok()?;
+    // Filter: "[color] card(s)".
+    let (i, filter_color) = nom_primitives::parse_color(i).ok()?;
+    let (i, _) = alt((tag::<_, _, E<'_>>(" cards"), tag(" card")))
+        .parse(i)
+        .ok()?;
+    // Zone: "from your graveyard" — owned by you, in the graveyard.
+    let (i, _) = tag::<_, _, E<'_>>(" from your graveyard with ")
+        .parse(i)
+        .ok()?;
+    // Threshold: "[N] or more/greater".
+    let (i, n) = nom_primitives::parse_number(i).ok()?;
+    let (i, _) = alt((tag::<_, _, E<'_>>(" or more "), tag(" or greater ")))
+        .parse(i)
+        .ok()?;
+    // Aggregated property: "[color] mana symbols among their mana costs".
+    let (i, agg_color) = nom_primitives::parse_color(i).ok()?;
+    let (i, _) = alt((
+        tag::<_, _, E<'_>>(" mana symbols among their mana costs"),
+        tag(" mana symbols among their costs"),
+    ))
+    .parse(i)
+    .ok()?;
+    // The whole cost phrase must have been consumed — a trailing remainder means
+    // this is a different (unsupported) shape that must not silently match.
+    if !i.trim().is_empty() {
+        return None;
+    }
+
+    let filter = TargetFilter::Typed(
+        TypedFilter::card()
+            .controller(ControllerRef::You)
+            .properties(vec![
+                FilterProp::HasColor {
+                    color: filter_color,
+                },
+                FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                },
+            ]),
+    );
+    Some(AbilityCost::ExileWithAggregate {
+        filter,
+        function: AggregateFunction::Sum,
+        property: ObjectProperty::ManaSymbolCount(agg_color),
+        comparator: Comparator::GE,
+        value: n as i32,
+        zone: Zone::Graveyard,
+    })
 }
 
 /// CR 112.3: Parse self-exile cost patterns like "this card from your graveyard",

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7110,6 +7110,9 @@ fn apply_where_x_to_ability_cost(cost: &mut AbilityCost, where_x_expression: Opt
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        // CR 117.1: `ExileWithAggregate`'s threshold is a fixed `i32` and its
+        // filter is static — no where-X `QuantityExpr` amount to bind.
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -15722,6 +15722,56 @@ fn is_free_cast_exile_instead_rider(input: &str) -> bool {
     .is_ok()
 }
 
+/// CR 707.12 + CR 707.12a + CR 118.9: "Cast [up to N of] {the copies | those
+/// exiled cards} without paying their mana costs" — the cast half of the
+/// "Copy [those cards]. You may cast … the copies" idiom (Baron Helmut Zemo's
+/// Boast). Produces `Effect::CastCopyOfCard` directly, carrying the optional
+/// "up to N" cap as `count` (CR 707.12a: the controller may cast UP TO N of the
+/// copies). The redundant `CopySpell` from the preceding "Copy …" clause is
+/// dropped by `fold_cast_copy_of_card_defs`.
+///
+/// Scoped to the copies-specific anaphors ("the copies" / "those exiled cards")
+/// plus the free-cast rider, so the long-standing `CopySpell + CastFromZone`
+/// fold path (the 13 existing cast-a-copy cards) is left untouched.
+fn try_parse_cast_copies_with_count(lower: &str) -> Option<Effect> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("cast ").parse(lower).ok()?;
+    // CR 707.12a: optional "up to N of " / "N of " cap on how many copies to cast.
+    let (rest, count) = parse_cast_copies_count_prefix(rest);
+    // CR 707.12: the copies created by the preceding "Copy …" clause.
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("the copies"),
+        tag("those exiled cards"),
+    ))
+    .parse(rest)
+    .ok()?;
+    // CR 118.9: require the free-cast rider so this only matches the copy-cast
+    // idiom and never a paid cast.
+    if !scan_contains_phrase(rest, "without paying") {
+        return None;
+    }
+    Some(Effect::CastCopyOfCard {
+        target: tracked_set_filter(),
+        cost: ManaCost::zero(),
+        count,
+    })
+}
+
+/// Parse an optional "[up to ]N of " count prefix, returning the remainder and
+/// the captured `count` (`None` when no count prefix is present). Word and digit
+/// numbers are accepted (`nom_primitives::parse_number`: "three" → 3).
+fn parse_cast_copies_count_prefix(input: &str) -> (&str, Option<QuantityExpr>) {
+    let after_upto = opt(tag::<_, _, OracleError<'_>>("up to "))
+        .parse(input)
+        .map(|(r, _)| r)
+        .unwrap_or(input);
+    if let Ok((rest, n)) = nom_primitives::parse_number(after_upto) {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(" of ").parse(rest) {
+            return (rest, Some(QuantityExpr::Fixed { value: n as i32 }));
+        }
+    }
+    (input, None)
+}
+
 /// 1. Anaphoric — "cast it", "cast that spell", "cast those cards" — target is
 ///    `ParentTarget` (refers to the cards exiled / chosen by a prior effect).
 /// 2. Constrained — "cast a [type-phrase] [from <zone>] [with mana value <bound>]
@@ -16491,6 +16541,14 @@ fn parse_imperative_effect_inner(tp: TextPair, ctx: &mut ParseContext) -> Parsed
     // opens an interactive free-cast window, not a standing CastFromZone permission.
     // Keep this at the normal per-clause cast seam, before the generic cast parser.
     if let Some(effect) = try_parse_free_cast_from_zones(tp.lower) {
+        return parsed_clause(effect);
+    }
+
+    // CR 707.12 + CR 707.12a: "cast [up to N of] the copies / those exiled cards
+    // without paying their mana costs" — the cast half of the copy-then-cast
+    // idiom. Must run before the generic cast parser (which would drop the
+    // "up to N" cap and the copies anaphor onto a `CastFromZone { Any }`).
+    if let Some(effect) = try_parse_cast_copies_with_count(tp.lower) {
         return parsed_clause(effect);
     }
 
@@ -17268,6 +17326,8 @@ fn publishes_tracked_set_from_resolution(effect: &Effect) -> bool {
 /// `lower` must be the pre-lowered version of the text.
 fn contains_explicit_tracked_set_pronoun(lower: &str) -> bool {
     scan_contains_phrase(lower, "those cards")
+        || scan_contains_phrase(lower, "those exiled cards")
+        || scan_contains_phrase(lower, "the copies")
         || scan_contains_phrase(lower, "those permanents")
         || scan_contains_phrase(lower, "those creatures")
         || scan_contains_phrase(lower, "those tokens")
@@ -17400,7 +17460,49 @@ fn rewrite_filter_parent_to_tracked_set(filter: &mut TargetFilter) {
 fn fold_cast_copy_of_card_defs(defs: &mut Vec<AbilityDefinition>) {
     let mut index = 0;
     while index + 1 < defs.len() {
-        let copies_parent_card = matches!(
+        // "Copy [those exiled cards]" — the copy half. The anaphor binds either
+        // to `ParentTarget` (legacy "them"/"that card") or the tracked-set
+        // sentinel `TrackedSet(0)` ("those exiled cards"/"the copies", via
+        // `TRACKED_SET_PHRASES`).
+        let copies_card = matches!(
+            &*defs[index].effect,
+            Effect::CopySpell {
+                target: TargetFilter::ParentTarget
+                    | TargetFilter::TrackedSet {
+                        id: TrackedSetId(0)
+                    },
+                ..
+            }
+        );
+        if !copies_card {
+            index += 1;
+            continue;
+        }
+
+        // Case 1: the cast half is already a `CastCopyOfCard` (produced by
+        // `try_parse_cast_copies_with_count`, carrying the "up to N" count from
+        // CR 707.12a). The leading `CopySpell` is redundant — the engine's
+        // `CastCopyOfCard` both creates and casts the copies — so drop it and
+        // keep the count-bearing `CastCopyOfCard`. The `up_to` choice in the
+        // resolver carries the "you may cast" optionality, so the def-level
+        // `optional`/`repeat_for` are cleared to mirror the legacy fold.
+        if matches!(&*defs[index + 1].effect, Effect::CastCopyOfCard { .. }) {
+            defs[index + 1].optional = false;
+            defs[index + 1].repeat_for = None;
+            defs.remove(index);
+            continue;
+        }
+
+        // Case 2 (legacy): the cast half is a `CastFromZone { without_paying,
+        // Cast }`. Restricted to the legacy `ParentTarget` idiom on BOTH halves.
+        // A `TrackedSet(0)` copy paired with a `CastFromZone` is the "copy the
+        // exiled card. If you do, cast the copy" parent-sub idiom (Isochron
+        // Scepter / Spellbinder / Spellweaver Helix); fusing it would drop the
+        // conditional cast sub-ability and orphan the "if you do" clause. The
+        // `TrackedSet(0)` "those exiled cards"/"the copies" path always casts via
+        // a count-bearing `CastCopyOfCard` (Case 1), so Case 2 stays narrow —
+        // matching the pre-PR-4b fold and leaving those three cards untouched.
+        let copies_parent_target = matches!(
             &*defs[index].effect,
             Effect::CopySpell {
                 target: TargetFilter::ParentTarget,
@@ -17416,11 +17518,11 @@ fn fold_cast_copy_of_card_defs(defs: &mut Vec<AbilityDefinition>) {
                 ..
             }
         );
-
-        if copies_parent_card && casts_the_copy_without_paying {
+        if copies_parent_target && casts_the_copy_without_paying {
             *defs[index].effect = Effect::CastCopyOfCard {
                 target: tracked_set_filter(),
                 cost: ManaCost::zero(),
+                count: None,
             };
             defs[index].optional = false;
             defs[index].repeat_for = None;
@@ -40252,7 +40354,7 @@ mod tests {
             .sub_ability
             .as_deref()
             .expect("card-copy cast sub-ability");
-        let Effect::CastCopyOfCard { target, cost } = cast_copy.effect.as_ref() else {
+        let Effect::CastCopyOfCard { target, cost, .. } = cast_copy.effect.as_ref() else {
             panic!("expected CastCopyOfCard, got {:?}", cast_copy.effect);
         };
         assert_eq!(

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -847,6 +847,12 @@ pub fn parse_target_with_syntax<'a>(
         "those tokens",
         "those auras",
         "the revealed cards",
+        // CR 603.7 + CR 707.12: "those exiled cards" / "the copies" — the cards a
+        // prior clause (or, for Baron Helmut Zemo's Boast, the activation COST)
+        // exiled and published into the tracked set. Ordered before "those cards"
+        // so the longer "those exiled cards" anaphor is not shadowed.
+        "those exiled cards",
+        "the copies",
         "those cards",
         "those permanents",
         "those creatures",

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -5120,6 +5120,7 @@ this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
                 id: TrackedSetId(0),
             },
             cost: ManaCost::zero(),
+            count: None,
         };
         assert!(super::effect_has_internal_optionality(&effect));
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6529,6 +6529,29 @@ pub enum AbilityCost {
     CollectEvidence {
         amount: u32,
     },
+    /// CR 117.1 + CR 118.3 + CR 601.2b: Exile *any number* of cards matching
+    /// `filter` from `zone` as a cost, where the aggregate `function` of
+    /// `property` over the chosen cards must satisfy `comparator` against
+    /// `value`. Baron Helmut Zemo's Boast — "Exile any number of black cards
+    /// from your graveyard with fifteen or more black mana symbols among their
+    /// mana costs" — is `{ Sum, ManaSymbolCount(Black), GE, 15 }` over
+    /// `Typed(Card, You, [HasColor:Black, InZone:Graveyard])` from `Graveyard`.
+    ///
+    /// CR 601.2b/602.2b: "any number" is a count choice made as the ability is
+    /// activated; the chosen set is constrained only by the aggregate threshold,
+    /// not by a fixed cardinality. A standalone sibling of `CollectEvidence`
+    /// (CR 701.59a, the `Sum`/`ManaValue`/`GE` special case), NOT a
+    /// parameterization of `Exile` (which is a fixed-count exile with no
+    /// aggregate axis and ~132 call sites). CR 107.4a/107.4e/202.1: hybrid mana
+    /// symbols count for each of their colors via `ObjectProperty::ManaSymbolCount`.
+    ExileWithAggregate {
+        filter: TargetFilter,
+        function: AggregateFunction,
+        property: ObjectProperty,
+        comparator: Comparator,
+        value: i32,
+        zone: Zone,
+    },
     /// CR 601.2b: Tap creatures as an additional/activation cost. The
     /// `requirement` axis selects between a fixed count (Conspire's "tap two
     /// creatures") and an aggregate "any number with total power N or greater"
@@ -6724,6 +6747,10 @@ impl AbilityCost {
             | AbilityCost::Exile { .. }
             | AbilityCost::ExileMaterials { .. }
             | AbilityCost::CollectEvidence { .. }
+            // CR 117.1: `ExileWithAggregate` requires interactive object
+            // selection (the CR 601.2h cost-payment window), so the cheap gate
+            // cannot settle it — it must still simulate.
+            | AbilityCost::ExileWithAggregate { .. }
             | AbilityCost::TapCreatures { .. }
             | AbilityCost::RemoveCounter { .. }
             | AbilityCost::PayEnergy { .. }
@@ -6805,6 +6832,8 @@ impl AbilityCost {
             // CR 702.167a: Craft's materials component exiles other objects.
             AbilityCost::ExileMaterials { .. } => vec![CostCategory::ExilesCards],
             AbilityCost::CollectEvidence { .. } => vec![CostCategory::ExilesCards],
+            // CR 117.1: `ExileWithAggregate` exiles other cards from a zone.
+            AbilityCost::ExileWithAggregate { .. } => vec![CostCategory::ExilesCards],
             AbilityCost::TapCreatures { .. } => vec![CostCategory::TapsOtherCreatures],
             AbilityCost::RemoveCounter { .. } => vec![CostCategory::RemovesCounters],
             AbilityCost::PayEnergy { .. } => vec![CostCategory::PaysEnergy],
@@ -6903,6 +6932,9 @@ impl AbilityCost {
             // own exile is the separate `Exile { filter: SelfRef }` sub-cost.
             | AbilityCost::ExileMaterials { .. }
             | AbilityCost::CollectEvidence { .. }
+            // CR 117.1: `ExileWithAggregate` exiles OTHER cards (from the
+            // graveyard), never the source.
+            | AbilityCost::ExileWithAggregate { .. }
             | AbilityCost::TapCreatures { .. }
             | AbilityCost::RemoveCounter { .. }
             | AbilityCost::PayEnergy { .. }
@@ -8565,6 +8597,15 @@ pub enum Effect {
         /// Mizzix's Mastery and Cipher use `ManaCost::zero()`.
         #[serde(default)]
         cost: ManaCost,
+        /// CR 707.12a: Optional cap on how many of the copies the controller may
+        /// cast ("you may cast UP TO THREE of the copies"). `None` (the default,
+        /// preserving the 13 existing cards and their on-disk JSON) means every
+        /// copy may be cast; `Some(n)` caps the `WaitingFor::ChooseFromZoneChoice`
+        /// at `min(n, available)`. The choice is always `up_to` (CR 707.12a: the
+        /// player chooses individually whether to cast each copy), so this is an
+        /// upper bound, never a forced count.
+        #[serde(default)]
+        count: Option<QuantityExpr>,
     },
     /// CR 707.2 / CR 707.5: Create a token that's a copy of a permanent.
     /// Copies copiable characteristics (name, mana cost, color, types, P/T, abilities, keywords)
@@ -11205,6 +11246,36 @@ impl TargetFilter {
         }
     }
 
+    /// CR 608.2c: Rewrite the tracked-set sentinel (`TrackedSetId(0)`) inside
+    /// this filter to a CONCRETE tracked-set id. Recurses through `Or`/`And`/`Not`
+    /// composites. A non-sentinel `TrackedSet`/`TrackedSetFiltered` (already
+    /// bound to a real id) and every non-tracked-set filter are left untouched.
+    ///
+    /// Used when a *cost* publishes the "those exiled cards" set (Baron Helmut
+    /// Zemo's Boast): binding the sentinel to the concrete id at cost-payment
+    /// time makes the effect immune to the activation→resolution gap, during
+    /// which intervening instant-speed effects would otherwise clobber
+    /// `chain_tracked_set_id` and the latest-id heuristic.
+    pub fn rebind_tracked_set_sentinel(
+        &mut self,
+        concrete: crate::types::identifiers::TrackedSetId,
+    ) {
+        match self {
+            TargetFilter::TrackedSet { id } | TargetFilter::TrackedSetFiltered { id, .. }
+                if *id == crate::types::identifiers::TrackedSetId(0) =>
+            {
+                *id = concrete;
+            }
+            TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+                for f in filters {
+                    f.rebind_tracked_set_sentinel(concrete);
+                }
+            }
+            TargetFilter::Not { filter } => filter.rebind_tracked_set_sentinel(concrete),
+            _ => {}
+        }
+    }
+
     /// Extract the `InZone` zone from this filter's properties, if any.
     ///
     /// Recursively checks `Typed`, `Or`, `And`, and `Not` variants.
@@ -11327,6 +11398,25 @@ impl Effect {
     ///
     /// Exhaustive match — no wildcards — so the compiler forces an update when new
     /// Effect variants are added.
+    /// CR 608.2c: Bind a tracked-set sentinel (`TrackedSetId(0)`) inside this
+    /// effect's tracked-set target slot to a CONCRETE id. Scoped to the effects
+    /// that consume a *cost-published* tracked set (the copy/cast/move family —
+    /// Baron Helmut Zemo's "Copy those exiled cards. You may cast … the copies").
+    /// Other effects carry no cost-published tracked-set target, so they are
+    /// intentionally left untouched (documented no-op arm).
+    pub fn bind_tracked_set_sentinel(&mut self, concrete: crate::types::identifiers::TrackedSetId) {
+        match self {
+            Effect::CastCopyOfCard { target, .. }
+            | Effect::CastFromZone { target, .. }
+            | Effect::CopySpell { target, .. }
+            | Effect::ChangeZone { target, .. }
+            | Effect::GrantCastingPermission { target, .. } => {
+                target.rebind_tracked_set_sentinel(concrete);
+            }
+            _ => {}
+        }
+    }
+
     pub fn target_filter(&self) -> Option<&TargetFilter> {
         match self {
             // --- Effects with a `target: TargetFilter` field ---
@@ -17228,6 +17318,30 @@ impl ResolvedAbility {
                 .objects
                 .get(&self.source_id)
                 .is_some_and(|obj| obj.incarnation == captured),
+        }
+    }
+
+    /// CR 608.2c: Bind a tracked-set sentinel (`TrackedSetId(0)`) to a CONCRETE
+    /// tracked-set id across this ability's effect and every sub/else branch.
+    ///
+    /// Used when a *cost* (not an effect) publishes the "those exiled cards" set:
+    /// the set must survive the activation→resolution gap, during which
+    /// intervening instant-speed effects can publish their own tracked sets and
+    /// clobber `chain_tracked_set_id` / the latest-id heuristic (and `state.
+    /// chain_tracked_set_id` is reset to `None` at depth-0 resolution anyway).
+    /// Rewriting the sentinel to the concrete id in the resolving ability at
+    /// cost-payment time — before the ability is pushed onto the stack — makes
+    /// the binding immune to that gap (Baron Helmut Zemo's Boast).
+    pub fn bind_tracked_set_sentinel_recursive(
+        &mut self,
+        concrete: crate::types::identifiers::TrackedSetId,
+    ) {
+        self.effect.bind_tracked_set_sentinel(concrete);
+        if let Some(sub) = self.sub_ability.as_mut() {
+            sub.bind_tracked_set_sentinel_recursive(concrete);
+        }
+        if let Some(else_branch) = self.else_ability.as_mut() {
+            else_branch.bind_tracked_set_sentinel_recursive(concrete);
         }
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2685,6 +2685,25 @@ pub enum PayCostKind {
     Behold {
         action: BeholdCostAction,
     },
+    /// CR 117.1 + CR 601.2b + CR 602.2b: Interactive payment of an
+    /// `AbilityCost::ExileWithAggregate` — the player exiles *any number* of the
+    /// pre-filtered `WaitingFor::PayCost.choices` from `zone` such that the
+    /// aggregate `function` of `property` over the chosen set satisfies
+    /// `comparator` against `value`. Modeled on `PayCostKind::TapCreatures`
+    /// (aggregate-threshold payment, validated by the handler rather than a fixed
+    /// cardinality) combined with `ExileFromZone` (graveyard exile). The handler
+    /// (`handle_exile_aggregate_for_cost`) re-validates uniqueness, still-in-zone
+    /// membership, and the threshold, then publishes the exiled cards as a fresh
+    /// tracked set and binds the resolving ability's tracked-set sentinel to it
+    /// before the ability is pushed to the stack (CR 608.2c, Baron Helmut Zemo).
+    ExileAggregate {
+        zone: Zone,
+        function: crate::types::ability::AggregateFunction,
+        property: crate::types::ability::ObjectProperty,
+        comparator: crate::types::ability::Comparator,
+        value: i32,
+        filter: crate::types::ability::TargetFilter,
+    },
 }
 
 /// CR 601.2b + CR 605.3b: Resumption context after a PayCost choice completes.

--- a/crates/engine/tests/baron_helmut_zemo_boast.rs
+++ b/crates/engine/tests/baron_helmut_zemo_boast.rs
@@ -1,0 +1,491 @@
+//! Baron Helmut Zemo (MSH) — Boast: "Exile any number of black cards from your
+//! graveyard with fifteen or more black mana symbols among their mana costs:
+//! Copy those exiled cards. You may cast up to three of the copies without paying
+//! their mana costs."
+//!
+//! Drives the REAL pipeline (parser + `GameRunner::act` activation → interactive
+//! `PayCost { ExileAggregate }` → resolution → `ChooseFromZoneChoice`) through the
+//! four gaps: the aggregate-threshold exile cost (`AbilityCost::ExileWithAggregate`),
+//! the cost→effect tracked-set binding (CR 608.2c), the "up to three" copy cap
+//! (`Effect::CastCopyOfCard.count`), and the parser fold.
+//!
+//! MSH is release-gated and not in the local fixture, so the tests parse the real
+//! Oracle text. Each test documents the revert probe that flips its assertions.
+
+use std::sync::Arc;
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, Comparator, Effect,
+    ObjectProperty, QuantityExpr, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const ZEMO: &str = "Whenever you cast a black spell from your hand, Baron Helmut Zemo connives.\nBoast — Exile any number of black cards from your graveyard with fifteen or more black mana symbols among their mana costs: Copy those exiled cards. You may cast up to three of the copies without paying their mana costs. (Activate only if this creature attacked this turn and only once each turn.)";
+
+fn zemo_parse() -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(
+        ZEMO,
+        "Baron Helmut Zemo",
+        &["Boast".to_string(), "Connive".to_string()],
+        &["Creature".to_string()],
+        &[
+            "Human".to_string(),
+            "Noble".to_string(),
+            "Villain".to_string(),
+        ],
+    )
+}
+
+/// Create a black instant in `player`'s graveyard with `black_pips` black mana
+/// symbols and a real Spell ability so its copy is a castable spell.
+fn add_black_spell_to_gy(
+    state: &mut GameState,
+    player: PlayerId,
+    name: &str,
+    black_pips: usize,
+) -> ObjectId {
+    let cid = CardId(state.next_object_id);
+    let id = create_object(
+        state,
+        cid,
+        player,
+        name.to_string(),
+        engine::types::zones::Zone::Graveyard,
+    );
+    let cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Black; black_pips],
+        generic: 0,
+    };
+    let obj = state.objects.get_mut(&id).expect("created");
+    obj.card_types.core_types.push(CoreType::Instant);
+    obj.mana_cost = cost.clone();
+    obj.color = engine::game::printed_cards::derive_colors_from_mana_cost(&cost);
+    obj.abilities = Arc::new(vec![AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    )]);
+    id
+}
+
+/// Index of Zemo's Boast activated ability (the only `CastCopyOfCard` ability).
+fn boast_index(runner: &GameRunner, zemo: ObjectId) -> usize {
+    runner.state().objects[&zemo]
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::CastCopyOfCard { .. }))
+        .expect("Zemo must carry a CastCopyOfCard (Boast) activated ability")
+}
+
+/// Build a battlefield Zemo that has attacked this turn, with `gy` black graveyard
+/// spells, P0 holding priority on an empty stack in a main phase.
+fn setup(gy: &[usize]) -> (GameRunner, ObjectId, Vec<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let zemo = scenario
+        .add_creature_from_oracle(P0, "Baron Helmut Zemo", 3, 3, ZEMO)
+        .id();
+    let mut runner = scenario.build();
+    let gy_ids: Vec<ObjectId> = gy
+        .iter()
+        .enumerate()
+        .map(|(i, &pips)| add_black_spell_to_gy(runner.state_mut(), P0, &format!("Gy{i}"), pips))
+        .collect();
+    // CR 702.142a: Boast requires the source to have attacked this turn.
+    runner.state_mut().creatures_attacked_this_turn.insert(zemo);
+    runner.state_mut().turn_number = 3;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    (runner, zemo, gy_ids)
+}
+
+/// Pass priority (both players) until the wait is no longer a priority window
+/// (e.g. an interactive choice opens) or the stack drains.
+fn drain_priority(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return;
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gap A/B/C/D — parser AST (the load-bearing shape the runtime consumes).
+// ---------------------------------------------------------------------------
+
+/// Zemo's Boast must parse to the aggregate-threshold exile cost and the
+/// count-capped copy-and-cast effect, with ZERO parse warnings.
+///
+/// Revert probe: with the pre-change parser the cost is `EffectCost{ChangeZone}`,
+/// the effect is `CopySpell{Any}`+`CastFromZone{Any}`, `count` is dropped, and a
+/// `TargetFallback "those exiled cards"` warning fires — every assertion below
+/// flips.
+#[test]
+fn zemo_parses_to_exile_aggregate_cost_and_capped_cast_copy() {
+    let parsed = zemo_parse();
+    assert_eq!(
+        parsed.parse_warnings.len(),
+        0,
+        "expected zero parse warnings, got {:?}",
+        parsed.parse_warnings
+    );
+    let boast = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.effect.as_ref(), Effect::CastCopyOfCard { .. }))
+        .expect("Boast activated ability");
+
+    // Cost: aggregate-threshold exile.
+    match boast.cost.as_ref().expect("Boast has a cost") {
+        AbilityCost::ExileWithAggregate {
+            function,
+            property,
+            comparator,
+            value,
+            zone,
+            filter,
+        } => {
+            assert_eq!(*function, AggregateFunction::Sum);
+            assert_eq!(*property, ObjectProperty::ManaSymbolCount(ManaColor::Black));
+            assert_eq!(*comparator, Comparator::GE);
+            assert_eq!(*value, 15);
+            assert_eq!(*zone, engine::types::zones::Zone::Graveyard);
+            // Filter is black cards in your graveyard.
+            assert!(
+                matches!(filter, TargetFilter::Typed(_)),
+                "filter should be a typed black-graveyard-card filter, got {filter:?}"
+            );
+        }
+        other => panic!("expected ExileWithAggregate cost, got {other:?}"),
+    }
+
+    // Effect: copy the exiled set, cast up to three.
+    match boast.effect.as_ref() {
+        Effect::CastCopyOfCard { target, count, .. } => {
+            assert_eq!(
+                *target,
+                TargetFilter::TrackedSet {
+                    id: TrackedSetId(0)
+                }
+            );
+            assert_eq!(*count, Some(QuantityExpr::Fixed { value: 3 }));
+        }
+        other => panic!("expected CastCopyOfCard, got {other:?}"),
+    }
+    // The fold dropped the redundant CopySpell sub-ability.
+    assert!(
+        boast.sub_ability.is_none(),
+        "the CopySpell/CastFromZone pair must fold into a single CastCopyOfCard"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gap A — cost payability threshold (production path: ActivateAbility).
+// ---------------------------------------------------------------------------
+
+/// 15 black symbols (5 × {B}{B}{B}) → the Boast activation is payable and opens
+/// the `PayCost { ExileAggregate }` prompt over all five graveyard cards.
+///
+/// Revert probe: changing the parsed threshold `value` to 14 (or `comparator` to
+/// `GT`) makes the 14-symbol graveyard below payable, flipping the negative test.
+#[test]
+fn zemo_boast_payable_at_fifteen_symbols() {
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3]); // 15 black symbols
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("Boast is payable with 15 black symbols");
+    match &runner.state().waiting_for {
+        WaitingFor::PayCost { choices, .. } => {
+            assert_eq!(choices.len(), 5, "all five graveyard cards are eligible");
+            for id in &gy {
+                assert!(choices.contains(id));
+            }
+        }
+        other => panic!("expected PayCost(ExileAggregate), got {other:?}"),
+    }
+}
+
+/// 14 black symbols (4 × {B}{B}{B} + {B}{B}) → the Boast activation is NOT payable
+/// (CR 118.3): exiling EVERY eligible card still falls one symbol short of 15.
+///
+/// Revert probe: as above — dropping the threshold to 14 accepts this activation.
+#[test]
+fn zemo_boast_unpayable_at_fourteen_symbols() {
+    let (mut runner, zemo, _gy) = setup(&[3, 3, 3, 3, 2]); // 14 black symbols
+    let idx = boast_index(&runner, zemo);
+    let result = runner.act(GameAction::ActivateAbility {
+        source_id: zemo,
+        ability_index: idx,
+    });
+    assert!(
+        result.is_err(),
+        "Boast must be unpayable with only 14 black symbols, got {result:?}"
+    );
+    assert!(
+        runner.state().stack.is_empty(),
+        "a rejected activation must not put the ability on the stack"
+    );
+}
+
+/// With 15 symbols available, selecting a SUBSET that totals only 14 is rejected
+/// at payment time (CR 118.3 — the chosen set must meet the threshold).
+///
+/// Revert probe: dropping the handler's threshold re-check would accept the 14
+/// subset, flipping `is_err()`.
+#[test]
+fn zemo_boast_rejects_subset_below_threshold() {
+    // Six cards: five {B}{B}{B} (=15) plus one {B}{B} (so a 14-subset exists).
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3, 2]);
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("payable: 17 symbols available");
+    // Choose four {B}{B}{B} (12) + the {B}{B} (2) = 14 symbols — one short.
+    let subset = vec![gy[0], gy[1], gy[2], gy[3], gy[5]];
+    let result = runner.act(GameAction::SelectCards { cards: subset });
+    assert!(
+        result.is_err(),
+        "a 14-symbol subset must be rejected (threshold is 15), got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gap D — "up to three" cap on the cast choice (production path).
+// ---------------------------------------------------------------------------
+
+/// Exiling five black spells (≥15) opens a `ChooseFromZoneChoice` capped at THREE
+/// of the five copies, and the choice is `up_to` (CR 707.12a — may cast fewer).
+///
+/// Revert probe: reverting `count` to `None` (or removing the resolver cap) makes
+/// the choice offer all FIVE copies — `count == 5` instead of `3`.
+#[test]
+fn zemo_boast_caps_cast_choice_at_three() {
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3]); // 15 symbols, 5 cards
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("payable");
+    // Pay the cost by exiling all five graveyard cards.
+    runner
+        .act(GameAction::SelectCards { cards: gy.clone() })
+        .expect("cost paid by exiling all five");
+    // Resolve the Boast ability off the stack → opens the copy-cast choice.
+    drain_priority(&mut runner);
+    match &runner.state().waiting_for {
+        WaitingFor::ChooseFromZoneChoice {
+            cards,
+            count,
+            up_to,
+            ..
+        } => {
+            assert_eq!(
+                *count, 3,
+                "the 'up to three' cap limits the cast choice to 3"
+            );
+            assert!(
+                *up_to,
+                "CR 707.12a: each copy is cast at the player's option"
+            );
+            assert_eq!(cards.len(), 5, "all five copies are offered as candidates");
+        }
+        other => panic!("expected ChooseFromZoneChoice, got {other:?}"),
+    }
+    // Selecting four copies is rejected (cap is three).
+    let four: Vec<ObjectId> = {
+        let WaitingFor::ChooseFromZoneChoice { cards, .. } = &runner.state().waiting_for else {
+            unreachable!()
+        };
+        cards.iter().take(4).copied().collect()
+    };
+    assert!(
+        runner.act(GameAction::SelectCards { cards: four }).is_err(),
+        "selecting four copies must be rejected — the cap is three"
+    );
+}
+
+/// Casting exactly three of the copies puts three spell copies on the stack, each
+/// cast without paying its mana cost (CR 118.9).
+#[test]
+fn zemo_boast_casts_three_copies_for_free() {
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3]);
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("payable");
+    runner
+        .act(GameAction::SelectCards { cards: gy.clone() })
+        .expect("cost paid");
+    drain_priority(&mut runner);
+    let chosen: Vec<ObjectId> = {
+        let WaitingFor::ChooseFromZoneChoice { cards, .. } = &runner.state().waiting_for else {
+            panic!("expected ChooseFromZoneChoice");
+        };
+        cards.iter().take(3).copied().collect()
+    };
+    runner
+        .act(GameAction::SelectCards { cards: chosen })
+        .expect("cast three copies");
+    drain_priority(&mut runner);
+    // The three copies were cast as spell copies (CR 707.12) — each is a fresh
+    // object distinct from the five exiled sources.
+    let copy_count = runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.is_copy)
+        .count();
+    assert_eq!(
+        copy_count, 3,
+        "exactly three copies must be created and cast (the 'up to three' cap)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gap C — cost→effect tracked-set binding survives the activation→resolution gap.
+// ---------------------------------------------------------------------------
+
+/// The cost-exiled cards are published as a tracked set and bound to the effect's
+/// `CastCopyOfCard` BEFORE the ability is pushed to the stack. Even when an
+/// UNRELATED tracked set is published between activation and resolution, the
+/// copy-cast choice must offer exactly the cost-exiled cards — not the intervening
+/// set.
+///
+/// Revert probe: replacing the concrete-id rewrite with the sentinel/"latest set"
+/// path (`bind_tracked_set_sentinel_recursive` removed) makes the choice resolve
+/// against the intervening tracked set instead — `cards` would be the decoy ids.
+#[test]
+fn zemo_boast_binds_cost_exiled_set_across_intervening_set() {
+    let (mut runner, zemo, gy) = setup(&[3, 3, 3, 3, 3]);
+    let idx = boast_index(&runner, zemo);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: zemo,
+            ability_index: idx,
+        })
+        .expect("payable");
+    runner
+        .act(GameAction::SelectCards { cards: gy.clone() })
+        .expect("cost paid; tracked set published + bound");
+
+    // Simulate an intervening instant-speed effect publishing its OWN, newer
+    // tracked set between activation and resolution. The sentinel/"latest" path
+    // would bind to THIS decoy; the concrete-id rewrite must ignore it.
+    let decoy_a = create_object(
+        runner.state_mut(),
+        CardId(9001),
+        P1,
+        "Decoy A".to_string(),
+        engine::types::zones::Zone::Exile,
+    );
+    let decoy_b = create_object(
+        runner.state_mut(),
+        CardId(9002),
+        P1,
+        "Decoy B".to_string(),
+        engine::types::zones::Zone::Exile,
+    );
+    let next_id = runner.state().next_tracked_set_id;
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(TrackedSetId(next_id), vec![decoy_a, decoy_b]);
+    runner.state_mut().next_tracked_set_id = next_id + 1;
+    runner.state_mut().chain_tracked_set_id = Some(TrackedSetId(next_id));
+
+    // Resolve the Boast ability → the copy-cast choice.
+    drain_priority(&mut runner);
+    match &runner.state().waiting_for {
+        WaitingFor::ChooseFromZoneChoice { cards, .. } => {
+            let set: std::collections::HashSet<_> = cards.iter().copied().collect();
+            let expected: std::collections::HashSet<_> = gy.iter().copied().collect();
+            assert_eq!(
+                set, expected,
+                "the copy-cast choice must offer the COST-exiled cards, not the intervening decoy set"
+            );
+            assert!(
+                !cards.contains(&decoy_a) && !cards.contains(&decoy_b),
+                "the intervening tracked set must not leak into the bound effect"
+            );
+        }
+        other => panic!("expected ChooseFromZoneChoice, got {other:?}"),
+    }
+}
+
+/// Regression guard for the `fold_cast_copy_of_card_defs` broadening (PR-4b/Zemo).
+/// Extending the fold's copy-half match to `CopySpell { TrackedSet(0) }` (for
+/// Zemo's "Copy those exiled cards") must NOT fuse the legacy "copy the exiled
+/// card. If you do, cast the copy" parent-sub idiom, whose copy half is also
+/// `TrackedSet(0)`. Fusing it dropped the conditional cast sub-ability and
+/// orphaned the "If you do" clause (a swallowed `Condition_If`), regressing
+/// Isochron Scepter / Spellbinder / Spellweaver Helix.
+///
+/// Discrimination: broaden Case 2 of `fold_cast_copy_of_card_defs` back to accept
+/// a `TrackedSet(0)` copy half and each of these flips to a swallowed clause.
+#[test]
+fn copy_then_conditional_cast_idiom_not_fused_away() {
+    let cards = [
+        (
+            "Isochron Scepter",
+            "Imprint — When this artifact enters, you may exile an instant card with mana value 2 or less from your hand.\n{2}, {T}: You may copy the exiled card. If you do, you may cast the copy without paying its mana cost.",
+            vec!["Artifact".to_string()],
+            Vec::<String>::new(),
+        ),
+        (
+            "Spellbinder",
+            "Imprint — When this Equipment enters, you may exile an instant card from your hand.\nWhenever equipped creature deals combat damage to a player, you may copy the exiled card. If you do, you may cast the copy without paying its mana cost.\nEquip {4}",
+            vec!["Artifact".to_string()],
+            Vec::<String>::new(),
+        ),
+        (
+            "Spellweaver Helix",
+            "Imprint — When this artifact enters, you may exile two target sorcery cards from a single graveyard.\nWhenever a player casts a card, if it has the same name as one of the cards exiled with this artifact, you may copy the other. If you do, you may cast the copy without paying its mana cost.",
+            vec!["Artifact".to_string()],
+            Vec::<String>::new(),
+        ),
+    ];
+    for (name, oracle, types, subs) in &cards {
+        let parsed = parse_oracle_text(oracle, name, &[], types, subs);
+        let swallowed: Vec<_> = parsed
+            .parse_warnings
+            .iter()
+            .filter(|w| format!("{w:?}").contains("Swallow"))
+            .collect();
+        assert!(
+            swallowed.is_empty(),
+            "{name}: the copy-then-conditional-cast idiom must not orphan its 'If you do' clause, got {swallowed:?}"
+        );
+    }
+}

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -381,6 +381,9 @@ fn rewrite_bound_x_in_ability_cost(cost: &mut AbilityCost, binding: &QuantityExp
         // CR 702.167a/b: Craft materials carry no X-bound quantity.
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
+        // CR 117.1: `ExileWithAggregate`'s threshold is a fixed `i32` (like
+        // `CollectEvidence`'s amount) — no X-bound `QuantityExpr` to rewrite.
+        | AbilityCost::ExileWithAggregate { .. }
         | AbilityCost::TapCreatures { .. }
         | AbilityCost::RemoveCounter { .. }
         | AbilityCost::ReturnToHand { .. }

--- a/crates/phase-ai/src/policies/payment_selection.rs
+++ b/crates/phase-ai/src/policies/payment_selection.rs
@@ -279,9 +279,16 @@ fn payment_cost(
         PayCostKind::RemoveCounter { .. } => permanent_value(state, obj_id) * 0.5,
         PayCostKind::TapCreatures { .. } => permanent_value(state, obj_id) * 0.35,
         // CR 117.1 + CR 601.2b: "exile any number" aggregate-threshold cost
-        // (Baron Helmut Zemo's Boast) — always exiles from the graveyard, so it
-        // values like the graveyard `ExileFromZone` / `ExileMaterials` cases.
-        PayCostKind::ExileAggregate { .. } => 0.1 + card_value(state, obj_id) * 0.2,
+        // (Baron Helmut Zemo's Boast). `AbilityCost::ExileWithAggregate` is a
+        // zone-parameterized building block, so value the chosen card by its
+        // source `zone` — mirroring `ExileFromManaZone` — rather than assuming
+        // graveyard fuel: a hand/battlefield aggregate exile spends real cards.
+        PayCostKind::ExileAggregate { zone, .. } => match zone {
+            Zone::Battlefield => permanent_value(state, obj_id),
+            Zone::Hand => card_value(state, obj_id) * 1.2,
+            Zone::Graveyard => 0.1 + card_value(state, obj_id) * 0.2,
+            _ => card_value(state, obj_id) * 0.5,
+        },
         PayCostKind::Behold { .. } => card_value(state, obj_id) * 0.1,
         PayCostKind::Sacrifice => sacrifice_cost(state, obj_id, penalties),
     }
@@ -583,6 +590,47 @@ mod tests {
         let creature_score = score_for(&state, waiting_for(vec![blank, creature]), vec![creature]);
 
         assert!(blank_score > creature_score);
+    }
+
+    // The aggregate-exile cost (`PayCostKind::ExileAggregate`) is zone-parameterized,
+    // so its payment must be valued by the source `zone`: a graveyard exile is cheap
+    // fuel (0.1 + card_value*0.2) while a hand exile spends a real card
+    // (card_value*1.2). The AI must therefore prefer paying a graveyard aggregate
+    // over an otherwise-identical hand one.
+    //
+    // Discrimination: the pre-fix arm valued every `ExileAggregate` as graveyard,
+    // making these two scores equal — so `assert!(graveyard > hand)` flips red.
+    #[test]
+    fn exile_aggregate_cost_values_by_source_zone() {
+        use engine::types::ability::{AggregateFunction, Comparator, ObjectProperty, TargetFilter};
+        use engine::types::mana::ManaColor;
+
+        let mut state = GameState::new_two_player(42);
+        let hand_card = make_creature(&mut state, "Hand Card", Zone::Hand, 5);
+        let gy_card = make_creature(&mut state, "Graveyard Card", Zone::Graveyard, 5);
+        let agg = |zone, choices| WaitingFor::PayCost {
+            player: AI,
+            kind: PayCostKind::ExileAggregate {
+                zone,
+                function: AggregateFunction::Sum,
+                property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                comparator: Comparator::GE,
+                value: 15,
+                filter: TargetFilter::Any,
+            },
+            choices,
+            count: 1,
+            min_count: 1,
+            resume: CostResume::Spell { spell: pending() },
+        };
+
+        let hand_score = score_for(&state, agg(Zone::Hand, vec![hand_card]), vec![hand_card]);
+        let gy_score = score_for(&state, agg(Zone::Graveyard, vec![gy_card]), vec![gy_card]);
+
+        assert!(
+            gy_score > hand_score,
+            "graveyard aggregate exile must be cheaper (preferred) than hand: gy={gy_score} hand={hand_score}"
+        );
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/payment_selection.rs
+++ b/crates/phase-ai/src/policies/payment_selection.rs
@@ -278,6 +278,10 @@ fn payment_cost(
         },
         PayCostKind::RemoveCounter { .. } => permanent_value(state, obj_id) * 0.5,
         PayCostKind::TapCreatures { .. } => permanent_value(state, obj_id) * 0.35,
+        // CR 117.1 + CR 601.2b: "exile any number" aggregate-threshold cost
+        // (Baron Helmut Zemo's Boast) — always exiles from the graveyard, so it
+        // values like the graveyard `ExileFromZone` / `ExileMaterials` cases.
+        PayCostKind::ExileAggregate { .. } => 0.1 + card_value(state, obj_id) * 0.2,
         PayCostKind::Behold { .. } => card_value(state, obj_id) * 0.1,
         PayCostKind::Sacrifice => sacrifice_cost(state, obj_id, penalties),
     }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Baron Helmut Zemo (MSH) — Boast

Oracle: *"Whenever you cast a black spell from your hand, Baron Helmut Zemo connives. / Boast — Exile any number of black cards from your graveyard with fifteen or more black mana symbols among their mana costs: Copy those exiled cards. You may cast up to three of the copies without paying their mana costs."*

The Connive trigger already parsed correctly. This PR implements the **Boast** ability — a cost + effect that needed four gaps closed, all as parameterized building blocks (no card-specific string matching).

### New `AbilityCost::ExileWithAggregate`
A standalone aggregate-exile cost sibling (modeled on `CollectEvidence`, **not** an `Exile` parameterization — avoids churning ~132 call sites). Zemo = `Sum` of `ManaSymbolCount(Black) >= 15` over black graveyard cards (hybrid pips count per color, **CR 107.4e**). Interactive payment via new `PayCostKind::ExileAggregate` (payability = exile-all max for `Sum`/`GE`; the choice handler validates the ≥15 threshold + AI legal-action producer). **CR 117.1 / 118.3 / 601.2b / 601.2h.** The shared `aggregate_property_over` summation is the single authority (`Aggregate` + `TrackedSetAggregate` resolvers delegate to it).

### "Copy those exiled cards" — cost-published tracked set surviving activation→resolution
The cost-paid exile publishes a fresh tracked set whose **concrete id** is bound into the effect chain's `TrackedSet(0)` sentinel **before** the ability is pushed to the stack. This is required because the `chain_tracked_set_id`/latest-id sentinel path is reset at depth-0 resolution and would not survive an intervening tracked set published between activation and resolution. **CR 603.7.** (A revert probe confirms: removing the concrete-id rewrite makes the effect bind a decoy set, proving the rewrite is load-bearing.)

### "Cast up to three of the copies"
`Effect::CastCopyOfCard` gains `count: Option<QuantityExpr>` (`#[serde(default)]` = up-to-all, preserving the 13 existing cards + on-disk JSON). Zemo caps at `min(3, N)` via the existing `up_to` `ChooseFromZoneChoice` (you may cast fewer/zero; uncast copies cease to exist). **CR 707.12 / 707.12a / 707.10a.**

### Final parse
cost `ExileWithAggregate{Sum, ManaSymbolCount(Black), GE, 15, Typed(Card,You,[HasColor:Black,InZone:Graveyard]), Graveyard}`; effect `CastCopyOfCard{TrackedSet(0), zero, Some(Fixed 3)}`; **zero parse_warnings**.

## Tests
`crates/engine/tests/baron_helmut_zemo_boast.rs` (7 integration) + `aggregate_property_over` unit. Revert probes confirm each fix is load-bearing: the ≥15 threshold (15 payable / 14 unpayable / 14-subset rejected), the tracked-set concrete-id binding (vs a decoy set), and the cast cap (`min(3,N)` vs all). Parser is nom-combinator only; every new variant goes through an exhaustive no-wildcard match (including the `fold_cost` drift gate).

## Verification
`cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` = 0 · `cargo test -p engine` 13982 passed / 0 failed · all 21 CR annotations grep-verified.
