### PR TITLE
fix(parser): hoist "if it's an opponent's turn" intervening-if condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -640,6 +640,18 @@ fn parse_turn_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
         map(tag("it's not your turn"), |_| StaticCondition::Not {
             condition: Box::new(StaticCondition::DuringYourTurn),
         }),
+        // CR 102.1 + CR 102.2: there is always exactly one active player, so
+        // "it's an opponent's turn" is exactly "it's not your turn" — the active
+        // player is any non-controller. Maps to the same Not(DuringYourTurn).
+        map(
+            alt((
+                tag("it's an opponent's turn"),
+                tag("it is an opponent's turn"),
+            )),
+            |_| StaticCondition::Not {
+                condition: Box::new(StaticCondition::DuringYourTurn),
+            },
+        ),
         parse_day_night_condition,
     ))
     .parse(input)
@@ -6991,6 +7003,25 @@ mod tests {
         let (rest, c) = parse_condition("if it's your turn, do").unwrap();
         assert_eq!(rest, ", do");
         assert_eq!(c, StaticCondition::DuringYourTurn);
+    }
+
+    #[test]
+    fn test_parse_condition_opponents_turn() {
+        // CR 102.1 + CR 102.2: there is always exactly one active player, so
+        // "it's an opponent's turn" is exactly "it's not your turn" — the active
+        // player is any non-controller. Represented as `Not(DuringYourTurn)`,
+        // mirroring the existing "it's not your turn" arm.
+        let expected = StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        };
+        for input in [
+            "if it's an opponent's turn, do",
+            "if it is an opponent's turn, do",
+        ] {
+            let (rest, c) = parse_condition(input).unwrap();
+            assert_eq!(rest, ", do", "remainder for {input:?}");
+            assert_eq!(c, expected, "condition for {input:?}");
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -643,11 +643,17 @@ fn parse_turn_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
         // CR 102.1 + CR 102.2: there is always exactly one active player, so
         // "it's an opponent's turn" is exactly "it's not your turn" — the active
         // player is any non-controller. Maps to the same Not(DuringYourTurn).
+        // Both apostrophe forms are accepted at each position (U+0027 straight
+        // and U+2019 curly — Scryfall English oracle text uses the curly form).
+        // The surface permutations are composed from two small `alt`s rather than
+        // enumerated as full strings (compose combinators, don't enumerate).
         map(
-            alt((
-                tag("it's an opponent's turn"),
-                tag("it is an opponent's turn"),
-            )),
+            (
+                alt((tag("it's"), tag("it\u{2019}s"), tag("it is"))),
+                tag(" an opponent"),
+                alt((tag("'s"), tag("\u{2019}s"))),
+                tag(" turn"),
+            ),
             |_| StaticCondition::Not {
                 condition: Box::new(StaticCondition::DuringYourTurn),
             },
@@ -7010,13 +7016,19 @@ mod tests {
         // CR 102.1 + CR 102.2: there is always exactly one active player, so
         // "it's an opponent's turn" is exactly "it's not your turn" — the active
         // player is any non-controller. Represented as `Not(DuringYourTurn)`,
-        // mirroring the existing "it's not your turn" arm.
+        // mirroring the existing "it's not your turn" arm. Both apostrophe forms
+        // (U+0027 straight, U+2019 curly — Scryfall uses the curly form) parse at
+        // each position, so the contraction/possessive permutations all hold.
         let expected = StaticCondition::Not {
             condition: Box::new(StaticCondition::DuringYourTurn),
         };
         for input in [
             "if it's an opponent's turn, do",
             "if it is an opponent's turn, do",
+            "if it\u{2019}s an opponent\u{2019}s turn, do",
+            "if it's an opponent\u{2019}s turn, do",
+            "if it\u{2019}s an opponent's turn, do",
+            "if it is an opponent\u{2019}s turn, do",
         ] {
             let (rest, c) = parse_condition(input).unwrap();
             assert_eq!(rest, ", do", "remainder for {input:?}");

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14915,6 +14915,34 @@ mod tests {
         }
     }
 
+    /// Discordant Spirit: "if it's an opponent's turn" must hoist as the
+    /// intervening-if condition. CR 102.1 + CR 102.2: a turn is never vacant, so
+    /// "an opponent's turn" is "the active player is any non-controller" —
+    /// `Not(DuringPlayersTurn { Controller })`, equivalent to "it's not your
+    /// turn". Without this the condition was silently dropped and the counter
+    /// would be placed on the controller's own end step too.
+    #[test]
+    fn trigger_intervening_if_opponents_turn_discordant_spirit() {
+        let def = parse_trigger_line(
+            "At the beginning of each end step, if it's an opponent's turn, put a +1/+1 counter on this creature for each 1 damage dealt to you this turn.",
+            "Discordant Spirit",
+        );
+        match &def.condition {
+            Some(TriggerCondition::Not { condition }) => {
+                assert!(
+                    matches!(
+                        condition.as_ref(),
+                        TriggerCondition::DuringPlayersTurn {
+                            player: PlayerFilter::Controller,
+                        }
+                    ),
+                    "expected Not(DuringPlayersTurn {{ Controller }}), got {condition:?}"
+                );
+            }
+            other => panic!("expected Not(DuringPlayersTurn), got {other:?}"),
+        }
+    }
+
     #[test]
     fn trigger_intervening_if_spell_from_hand_this_turn_attaches_condition() {
         let def = parse_trigger_line(


### PR DESCRIPTION
## Summary

Adds a parser arm so the intervening-if condition **"if it's an opponent's turn"**
is recognized and hoisted onto a trigger's `condition`, instead of being silently
dropped. This is a general parser building block covering the **class** of cards
that gate a triggered ability on the active player being an opponent — mirroring
the existing `"it's not your turn"` arm.

## The bug

**Discordant Spirit** reads:

> At the beginning of each end step, if it's an opponent's turn, put a +1/+1
> counter on this creature for each 1 damage dealt to you this turn.

The released parse dropped the intervening-if entirely (`"condition": null`), so the
counter would be placed on **every** end step — including the controller's own turn,
where the ability should do nothing. The condition was unparsed because
`parse_turn_conditions` had no arm for the "an opponent's turn" phrasing.

## The fix

Add an `alt` arm in `parse_turn_conditions` (`parser/oracle_nom/condition.rs`)
mapping both apostrophe forms to `StaticCondition::Not { DuringYourTurn }`:

- `"it's an opponent's turn"`
- `"it is an opponent's turn"`

**CR 102.1 + CR 102.2:** each turn has exactly one active player, so "it's an
opponent's turn" is logically identical to "it's not your turn" — the active player
is any non-controller. Representing it as `Not(DuringYourTurn)` reuses the existing
negation pathway rather than introducing a new condition variant.

No trigger-bridge changes were needed: `static_condition_to_trigger_condition`
(`parser/oracle_trigger.rs`) already lowers `Not(DuringYourTurn)` →
`Not(DuringPlayersTurn { player: Controller })`. The intervening-if now hoists
correctly through the existing path.

## Building block, not one card

The condition arm handles **any** card with an "it's an opponent's turn"
intervening-if, not just Discordant Spirit, which is simply the motivating example.

## Scope note (intentional)

Discordant Spirit's separate `for each 1 damage dealt to you this turn` dynamic
count is a **pre-existing, independent parser gap** — `parse_damage_dealt_this_turn_ref`
(`parser/oracle_nom/quantity.rs`) only has `"...to your opponents"` and
`"...to target opponent"` arms, with no `"...to you"` (controller-targeted) arm, so
the count degrades to `Fixed 1`. That fix additionally requires runtime resolution
of `DamageDealtThisTurn` targeted at the controller, which is a larger blast radius.
It is **deliberately out of scope** here to keep this change surgical and low-risk.

## Tests

- `test_parse_condition_opponents_turn` — both apostrophe forms parse with the
  correct remainder.
- `trigger_intervening_if_opponents_turn_discordant_spirit` — the full trigger line
  hoists `Not(DuringPlayersTurn { Controller })`.
- 343 condition + 825 trigger parser tests pass; `cargo fmt --all` clean;
  `scripts/check-parser-combinators.sh` passes (exit 0).

