### PR TITLE
fix(parser): UNSUPPORTED one-off: Duggan, Private Detective

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -65,8 +65,9 @@ use super::oracle_keyword::{
 };
 use super::oracle_level::parse_level_blocks;
 use super::oracle_modal::{
-    extract_ability_word_reminder_body, lower_oracle_block, parse_oracle_block, strip_ability_word,
-    strip_ability_word_with_name, strip_flavor_word_with_name,
+    extract_ability_word_reminder_body, lower_oracle_block, parse_oracle_block,
+    split_short_label_prefix, strip_ability_word, strip_ability_word_with_name,
+    strip_flavor_word_with_name, FLAVOR_WORD_COST_LABEL_MAX_WORDS,
 };
 use super::oracle_replacement::{
     find_copy_verb_present, lower_replacement_ir, parse_replacement_line,
@@ -4057,6 +4058,12 @@ fn parse_activated_ability_definition(
     ctx: &mut ParseContext,
 ) -> (AbilityDefinition, String) {
     let (effect_text, constraints) = strip_activated_constraints(effect_text);
+    // CR 207.2c / CR 207.2d: drop a leading ability-/flavor-word label so the cost
+    // after the em-dash parses (covers 5–6-word Universes-Beyond flavor names that
+    // exceed the 4-word ability-word cap, e.g. "The Most Important Punch in History
+    // — {1}{G}, {T}"). No-op when the label was already stripped upstream
+    // (Priority-6b path) or absent.
+    let cost_text = strip_activated_cost_label(cost_text).unwrap_or(cost_text);
     let normalized_cost_text = normalize_self_refs_for_static(cost_text, card_name);
     let cost = parse_oracle_cost(&normalized_cost_text);
 
@@ -4596,16 +4603,16 @@ pub(super) fn find_activated_colon(line: &str) -> Option<usize> {
         return Some(colon_pos);
     }
 
-    // CR 207.2c + CR 602.1: an ability-word label may precede the activation
-    // cost ("Mental Organism — Pay 3 life: ~ connives" — M.O.D.O.K.). Ability
-    // words have no rules meaning, so strip the italic 1–4 word label and re-test
-    // the remaining cost prefix. `split_short_label_prefix` already guards against
-    // matching real cost text (it rejects prefixes containing `{` or `:`), so this
+    // CR 207.2c / CR 207.2d + CR 602.1: an ability-word (<=4 words) or flavor-word
+    // (Universes Beyond, any length) label may precede the activation cost
+    // ("Mental Organism — Pay 3 life: ~ connives" — M.O.D.O.K.; "I've Come Up with
+    // a New Recipe! — {1}{G}{U}, {T}: ..." — Ignis Scientia). Labels have no rules
+    // meaning, so strip the italic label and re-test the remaining cost prefix.
+    // `strip_activated_cost_label` re-validates via `cost_prefix_is_activated` and
+    // `split_short_label_prefix` rejects prefixes containing `{` or `:`, so this
     // never misclassifies an em-dash that lives inside the cost itself.
-    if let Some(after_word) = strip_ability_word(prefix) {
-        if cost_prefix_is_activated(&after_word) {
-            return Some(colon_pos);
-        }
+    if strip_activated_cost_label(prefix).is_some() {
+        return Some(colon_pos);
     }
 
     None
@@ -4636,6 +4643,23 @@ fn cost_prefix_is_activated(prefix: &str) -> bool {
     // Only lowercase when needed (skipped entirely if '{' was found above)
     let lower_prefix = trimmed.to_lowercase();
     cost_starters.iter().any(|s| lower_prefix.starts_with(s))
+}
+
+/// CR 207.2c / CR 207.2d: an ability word (<=4 words) or a flavor word (Universes
+/// Beyond, any length) may label an activated ability — e.g. "The Most Important
+/// Punch in History — {1}{G}, {T}: ..." (6 words, Duggan) or "I've Come Up with a
+/// New Recipe! — {1}{G}{U}, {T}: ..." (7 words, Ignis Scientia). Labels have no
+/// rules meaning, so strip the "<label> — " prefix before parsing the activation
+/// cost. Returns the cost remainder ONLY when it reads as a genuine activation
+/// cost (`cost_prefix_is_activated`); this guarantees a real em-dash-bearing cost
+/// is never mistaken for a label, and an un-labeled cost is reported via `None`
+/// (the caller keeps the original text untouched). `cost_prefix_is_activated` —
+/// not a word count — is the discriminator, so the label strip is uncapped
+/// (`FLAVOR_WORD_COST_LABEL_MAX_WORDS`); a longer flavor name can never widen the
+/// set of em-dash lines accepted, only the labels that reach the cost validator.
+fn strip_activated_cost_label(cost_text: &str) -> Option<&str> {
+    let (_label, rest) = split_short_label_prefix(cost_text, FLAVOR_WORD_COST_LABEL_MAX_WORDS)?;
+    cost_prefix_is_activated(rest).then_some(rest)
 }
 
 fn find_top_level_colon(line: &str) -> Option<usize> {
@@ -16695,6 +16719,285 @@ mod tests {
             text.starts_with("This spell costs"),
             "expected 'This spell costs...' got: {}",
             text
+        );
+    }
+
+    // -- Activated-ability flavor-word cost-label stripping (CR 207.2c / 207.2d) --
+
+    /// Returns whether an `AbilityCost` tree contains any `Unimplemented` leaf
+    /// (recursing through the `Composite` / `OneOf` aggregate variants).
+    fn cost_has_unimplemented(cost: &AbilityCost) -> bool {
+        match cost {
+            AbilityCost::Unimplemented { .. } => true,
+            AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+                costs.iter().any(cost_has_unimplemented)
+            }
+            _ => false,
+        }
+    }
+
+    /// Cluster 58 — Duggan, Private Detective (Universes Beyond, WHO). The
+    /// activated ability carries a CR 207.2d flavor-word label ("The Most
+    /// Important Punch in History", 6 words) before its `{1}{G}, {T}` cost.
+    /// Pre-fix the 6-word label exceeded the 4-word ability-word cap on the cost
+    /// path, so the cost parsed as `Composite([Unimplemented(...), Tap])` and the
+    /// whole card flagged UNSUPPORTED. Widening the activated-cost label strip to
+    /// the flavor-word cap (`strip_activated_cost_label`) lets the full kit parse
+    /// with zero Unimplemented nodes. Revert-discriminating: a reverted cap leaves
+    /// `AbilityCost::Unimplemented` in the Composite cost and fails below.
+    #[test]
+    fn duggan_private_detective_full_kit_parses() {
+        use crate::types::ability::{ObjectScope, PlayerScope};
+
+        let r = parse(
+            "Duggan's power and toughness are each equal to the number of cards in your hand.\n\
+             Whenever Duggan enters or attacks, investigate.\n\
+             The Most Important Punch in History \u{2014} {1}{G}, {T}: Duggan deals damage equal \
+             to twice its power to another target creature. Activate only once.",
+            "Duggan, Private Detective",
+            &[],
+            &["Creature"],
+            &["Human", "Detective"],
+        );
+
+        // Activated ability: cost is {1}{G} + {T}, no Unimplemented (regression guard).
+        assert_eq!(
+            r.abilities.len(),
+            1,
+            "Duggan has exactly one activated ability: {:?}",
+            r.abilities
+        );
+        let punch = &r.abilities[0];
+        assert_eq!(punch.kind, AbilityKind::Activated);
+        let cost = punch
+            .cost
+            .as_ref()
+            .expect("activated ability carries a cost");
+        match cost {
+            AbilityCost::Composite { costs } => {
+                assert_eq!(costs.len(), 2, "cost is {{1}}{{G}} then {{T}}: {costs:?}");
+                match &costs[0] {
+                    AbilityCost::Mana { cost } => {
+                        assert_eq!(cost.mana_value(), 2, "{{1}}{{G}} has mana value 2")
+                    }
+                    other => panic!("first cost component must be Mana, got {other:?}"),
+                }
+                assert_eq!(costs[1], AbilityCost::Tap, "second cost component is Tap");
+            }
+            other => panic!("expected Composite([Mana, Tap]) cost, got {other:?}"),
+        }
+        assert!(
+            !cost_has_unimplemented(cost),
+            "activated cost must contain no Unimplemented node: {cost:?}"
+        );
+
+        // Effect: deals damage equal to twice its (source) power to another creature.
+        match punch.effect.as_ref() {
+            Effect::DealDamage { amount, target, .. } => {
+                assert!(
+                    matches!(
+                        amount,
+                        QuantityExpr::Multiply { factor: 2, inner }
+                            if matches!(
+                                inner.as_ref(),
+                                QuantityExpr::Ref {
+                                    qty: QuantityRef::Power { scope: ObjectScope::Source }
+                                }
+                            )
+                    ),
+                    "amount must be 2 x source power, got {amount:?}"
+                );
+                assert!(
+                    matches!(target, TargetFilter::Typed(_)),
+                    "target is a typed 'another creature' filter, got {target:?}"
+                );
+            }
+            other => panic!("expected DealDamage effect, got {other:?}"),
+        }
+
+        // CR 602.5b: "Activate only once" → OnlyOnce restriction.
+        assert!(
+            punch
+                .activation_restrictions
+                .contains(&ActivationRestriction::OnlyOnce),
+            "Activate only once must yield OnlyOnce: {:?}",
+            punch.activation_restrictions
+        );
+
+        // CR 603.1: "Whenever Duggan enters or attacks, ..." parses as a triggered
+        // ability. The "attacks" branch is the attack-declaration trigger (CR 508.3a)
+        // and the "enters" branch is an enters-the-battlefield zone-change trigger
+        // (CR 603.6); the parser unifies them under the EntersOrAttacks mode.
+        assert_eq!(r.triggers.len(), 1, "one trigger: {:?}", r.triggers);
+        assert_eq!(r.triggers[0].mode, TriggerMode::EntersOrAttacks);
+        // CR 701.16a: the trigger's effect is Investigate ("Create a Clue token").
+        let investigate = r.triggers[0]
+            .execute
+            .as_ref()
+            .expect("the enters-or-attacks trigger carries an effect");
+        assert!(
+            matches!(investigate.effect.as_ref(), Effect::Investigate),
+            "trigger effect must be Investigate, got {:?}",
+            investigate.effect
+        );
+
+        // CR 208.2a: CDA P/T equal to your hand size (Maro path, unchanged).
+        let cda = r
+            .statics
+            .iter()
+            .find(|s| s.characteristic_defining)
+            .expect("Duggan must parse a characteristic-defining P/T static");
+        let hand = QuantityExpr::Ref {
+            qty: QuantityRef::HandSize {
+                player: PlayerScope::Controller,
+            },
+        };
+        assert_eq!(
+            cda.modifications,
+            vec![
+                ContinuousModification::SetDynamicPower {
+                    value: hand.clone()
+                },
+                ContinuousModification::SetDynamicToughness { value: hand },
+            ]
+        );
+
+        // No ability effect is Unimplemented (mirrors the Adamaro no-Unimplemented walk).
+        assert!(
+            !r.abilities
+                .iter()
+                .any(|a| matches!(a.effect.as_ref(), Effect::Unimplemented { .. })),
+            "no ability effect may be Unimplemented"
+        );
+    }
+
+    /// Cluster 58 same-class sibling — Ignis Scientia (Universes Beyond, FIN). Its
+    /// activated ability carries a CR 207.2d flavor-word label ("I've Come Up with
+    /// a New Recipe!", **7 words**) before its `{1}{G}{U}, {T}` cost. The 6-word
+    /// `FLAVOR_WORD_MAX_WORDS` heuristic that fixed Duggan is one word too short for
+    /// this sibling, so the cost-label path was given the uncapped
+    /// `FLAVOR_WORD_COST_LABEL_MAX_WORDS` (the `cost_prefix_is_activated` re-check is
+    /// the real guard). Pre-fix the cost parsed as
+    /// `Composite([Unimplemented("I've Come Up with a New Recipe! — {1}{G}{U}"),
+    /// Tap])` and the card flagged UNSUPPORTED. Revert-discriminating: re-imposing a
+    /// finite word cap below 7 restores the `Unimplemented` leaf and fails below.
+    #[test]
+    fn ignis_scientia_seven_word_flavor_cost_label_parses() {
+        let r = parse(
+            "When Ignis Scientia enters, look at the top six cards of your library. \
+             You may put a land card from among them onto the battlefield tapped. Put \
+             the rest on the bottom of your library in a random order.\n\
+             I've Come Up with a New Recipe! \u{2014} {1}{G}{U}, {T}: Exile target card \
+             from a graveyard. If a creature card was exiled this way, create a Food token.",
+            "Ignis Scientia",
+            &[],
+            &["Creature"],
+            &["Human", "Advisor"],
+        );
+
+        // Exactly one activated ability — the ETB clause is a trigger, not an ability.
+        assert_eq!(
+            r.abilities.len(),
+            1,
+            "Ignis has exactly one activated ability: {:?}",
+            r.abilities
+        );
+        let recipe = &r.abilities[0];
+        assert_eq!(recipe.kind, AbilityKind::Activated);
+        let cost = recipe
+            .cost
+            .as_ref()
+            .expect("activated ability carries a cost");
+        // The 7-word flavor label is stripped; cost is {1}{G}{U} + {T}, no Unimplemented.
+        match cost {
+            AbilityCost::Composite { costs } => {
+                assert_eq!(
+                    costs.len(),
+                    2,
+                    "cost is {{1}}{{G}}{{U}} then {{T}}: {costs:?}"
+                );
+                match &costs[0] {
+                    AbilityCost::Mana { cost } => {
+                        assert_eq!(cost.mana_value(), 3, "{{1}}{{G}}{{U}} has mana value 3")
+                    }
+                    other => panic!("first cost component must be Mana, got {other:?}"),
+                }
+                assert_eq!(costs[1], AbilityCost::Tap, "second cost component is Tap");
+            }
+            other => panic!("expected Composite([Mana, Tap]) cost, got {other:?}"),
+        }
+        assert!(
+            !cost_has_unimplemented(cost),
+            "7-word flavor-labeled cost must contain no Unimplemented node: {cost:?}"
+        );
+    }
+
+    /// Building-block test (not card-specific): a 6-word flavor-word label before
+    /// a mana+tap cost strips so the cost parses as `Composite([Mana, Tap])`. This
+    /// proves the flavor-word cap on the activated-cost path independent of Duggan.
+    #[test]
+    fn flavor_named_activated_ability_mana_cost_strips_label() {
+        let r = parse(
+            "One Two Three Four Five Six \u{2014} {1}{G}, {T}: ~ deals 3 damage to any target.",
+            "Test Flavor Cost",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(
+            r.abilities.len(),
+            1,
+            "one activated ability: {:?}",
+            r.abilities
+        );
+        let cost = r.abilities[0]
+            .cost
+            .as_ref()
+            .expect("activated ability carries a cost");
+        match cost {
+            AbilityCost::Composite { costs } => {
+                assert_eq!(costs.len(), 2, "{{1}}{{G}} then {{T}}: {costs:?}");
+                assert!(
+                    matches!(costs[0], AbilityCost::Mana { .. }),
+                    "first cost is Mana: {costs:?}"
+                );
+                assert_eq!(costs[1], AbilityCost::Tap);
+            }
+            other => panic!("expected Composite([Mana, Tap]), got {other:?}"),
+        }
+        assert!(
+            !cost_has_unimplemented(cost),
+            "flavor-named mana cost must not be Unimplemented: {cost:?}"
+        );
+    }
+
+    /// Detection widening: a 6-word flavor-word label before a verb-only cost
+    /// (no mana symbols) is still recognized as an activated ability. Pre-fix
+    /// `find_activated_colon` only re-tested the 4-word ability-word cap, so a
+    /// 5-6 word flavor label with a `Sacrifice`/`Pay` cost was not detected.
+    #[test]
+    fn flavor_named_activated_ability_verb_cost_detected() {
+        let r = parse(
+            "One Two Three Four Five Six \u{2014} Sacrifice a creature: Draw a card.",
+            "Test Flavor Verb Cost",
+            &[],
+            &["Creature"],
+            &[],
+        );
+        assert_eq!(
+            r.abilities.len(),
+            1,
+            "the flavor-labeled verb-cost line must parse as one activated ability: {:?}",
+            r.abilities
+        );
+        assert_eq!(r.abilities[0].kind, AbilityKind::Activated);
+        let cost = r.abilities[0]
+            .cost
+            .as_ref()
+            .expect("activated ability carries a cost");
+        assert!(
+            matches!(cost, AbilityCost::Sacrifice(_)),
+            "verb-only cost after the flavor label must parse as Sacrifice, got {cost:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1499,18 +1499,38 @@ pub(super) fn strip_ability_word_with_name(line: &str) -> Option<(String, String
     split_short_label_prefix(line, 4).map(|(name, rest)| (name.to_lowercase(), rest.to_string()))
 }
 
-/// CR 207.2c: flavor words (Universes Beyond) are italic ability-word prefixes
+/// CR 207.2d: flavor words (Universes Beyond) are italic ability-word prefixes
 /// with no rules meaning; unlike the in-game ability words enumerated by CR
 /// 207.2c (which are <=2 words), flavor-word names routinely run 5-6 words
 /// ("Woman Who Walked the Earth", "Deal with the Black Guardian"). At the 4-word
-/// cap these never strip, so the trigger body behind them never reaches the
-/// trigger parser. Only the Priority-6b trigger-dispatch path (oracle.rs:2837)
-/// uses this wider cap: its activated branch is gated on
+/// cap these never strip, so the body behind them never reaches the relevant
+/// sub-parser.
+///
+/// This heuristic cap governs the Priority-6b trigger-dispatch path (oracle.rs),
+/// where the post-strip remainder is re-validated structurally rather than by a
+/// length-independent guard: its activated branch is gated on
 /// `ability_word_to_condition` (known ability words, <=2 words) and its trigger
-/// branch re-validates via `has_trigger_prefix`, so an over-long strip that
-/// yields no trigger body is rejected and the original line falls through. All
-/// other consumers keep the 4-word `strip_ability_word*` cap.
-const FLAVOR_WORD_MAX_WORDS: usize = 6;
+/// branch re-validates via `has_trigger_prefix`. The 6-word ceiling bounds how
+/// far an em-dash sentence may be treated as a label on that path.
+///
+/// The activated-ability cost-label path uses the wider
+/// `FLAVOR_WORD_COST_LABEL_MAX_WORDS` instead — see that constant for why a word
+/// count is the wrong guard there.
+///
+/// All other consumers keep the 4-word `strip_ability_word*` cap.
+pub(super) const FLAVOR_WORD_MAX_WORDS: usize = 6;
+
+/// CR 207.2d: the activated-ability cost-label path
+/// (`oracle::strip_activated_cost_label`) re-validates the stripped remainder
+/// through `cost_prefix_is_activated`, a length-independent guard requiring mana
+/// symbols or a cost-starter verb. Because that guard — not the word count — is
+/// what distinguishes a genuine flavor-word cost label from an ordinary em-dash
+/// line, the word count is the wrong filter here: capping it merely drops valid
+/// labels whose names happen to be long. Universes Beyond flavor names run
+/// arbitrarily long ("I've Come Up with a New Recipe!", 7 words — Ignis
+/// Scientia; "The Most Important Punch in History", 6 words — Duggan), so this
+/// path is uncapped and leans entirely on `cost_prefix_is_activated`.
+pub(super) const FLAVOR_WORD_COST_LABEL_MAX_WORDS: usize = usize::MAX;
 
 pub(super) fn strip_flavor_word_with_name(line: &str) -> Option<(String, String)> {
     split_short_label_prefix(line, FLAVOR_WORD_MAX_WORDS)

--- a/crates/engine/tests/duggan_private_detective_punch.rs
+++ b/crates/engine/tests/duggan_private_detective_punch.rs
@@ -1,0 +1,100 @@
+//! Runtime proof for Duggan, Private Detective (cluster 58, Universes Beyond — WHO).
+//!
+//! Duggan's activated ability — "The Most Important Punch in History — {1}{G}, {T}:
+//! Duggan deals damage equal to twice its power to another target creature.
+//! Activate only once." — was UNSUPPORTED on upstream/main because the CR 207.2d
+//! flavor-word label ("The Most Important Punch in History", 6 words) exceeded the
+//! 4-word ability-word cap on the activated-cost path, so the cost parsed as
+//! `Composite([Unimplemented(...), Tap])`. Widening the cost-label strip to the
+//! flavor-word cap lets the cost parse, after which the rest of the card runs on
+//! existing primitives (Maro-style CDA, EntersOrAttacks trigger, OnlyOnce limit,
+//! `Multiply(2, Power{Source})` damage).
+//!
+//! This test drives the real activation pipeline: with a 4-card hand the CDA makes
+//! Duggan 4/4 (CR 208.2a), the once-per-game punch resolves dealing 2 x 4 = 8
+//! damage to the targeted opponent creature (CR 208.1), and the OnlyOnce counter
+//! records the single activation (CR 602.5b). Revert-proof: if the cost-label fix
+//! is reverted the cost is `Unimplemented`, the ability cannot be activated, and
+//! `activate(..).resolve()` panics before reaching the damage assertion.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const DUGGAN_ORACLE: &str =
+    "Duggan's power and toughness are each equal to the number of cards in \
+your hand.\nWhenever Duggan enters or attacks, investigate.\nThe Most Important Punch in History \
+\u{2014} {1}{G}, {T}: Duggan deals damage equal to twice its power to another target creature. \
+Activate only once.";
+
+#[test]
+fn duggan_punch_deals_twice_power_and_records_once_per_game() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0 hand: 4 cards → the CDA sets Duggan to 4/4 (CR 208.2a). Card identities
+    // are irrelevant; only the hand size feeds `HandSize { Controller }`.
+    scenario.with_cards_in_hand(P0, &["Memo A", "Memo B", "Memo C", "Memo D"]);
+    // Fund {1}{G} from the pool — the activation driver does not model source
+    // auto-tap, so two green mana cover the {G} pip and the {1} generic.
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    // Opponent creature with toughness 10 survives 8 damage, so `damage_marked`
+    // stays observable (SBA does not destroy it). Its own power (2) differs from
+    // the expected 8 so a wrong amount referent cannot coincidentally pass.
+    let target = scenario.add_vanilla(P1, 2, 10);
+    // Duggan base 0/0; the CDA overrides P/T to the controller's hand size.
+    let duggan = scenario
+        .add_creature_from_oracle(P0, "Duggan, Private Detective", 0, 0, DUGGAN_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // CDA proof: force a layer pass and confirm Duggan is 4/4 from the 4-card hand.
+    {
+        let st = runner.state_mut();
+        st.layers_dirty.mark_full();
+        evaluate_layers(st);
+    }
+    assert_eq!(
+        runner.state().objects[&duggan].power,
+        Some(4),
+        "CR 208.2a: Duggan's power equals your hand size (4 cards → 4)"
+    );
+    assert_eq!(
+        runner.state().objects[&duggan].toughness,
+        Some(4),
+        "CR 208.2a: Duggan's toughness equals your hand size (4 cards → 4)"
+    );
+
+    // Activate the once-per-game punch targeting the opponent creature. This only
+    // succeeds because the {1}{G}, {T} cost now parses (the fix under test).
+    let outcome = runner.activate(duggan, 0).target_object(target).resolve();
+
+    // CR 208.1 + Multiply(2, Power{Source}): 2 × 4 = 8 damage marked on the target.
+    assert_eq!(
+        outcome.state().objects[&target].damage_marked,
+        8,
+        "Duggan deals twice its power (2 × 4 = 8) to the targeted creature, \
+         not 0 (dropped referent) and not the target's own power (2)"
+    );
+
+    // CR 602.5b: "Activate only once" recorded the single per-game activation.
+    assert_eq!(
+        outcome
+            .state()
+            .activated_abilities_this_game
+            .get(&(duggan, 0))
+            .copied(),
+        Some(1),
+        "Activate only once must record exactly one per-game activation (CR 602.5b)"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED one-off: Duggan, Private Detective

## Cards corrected
- Duggan, Private Detective

## Fix
test

## Files changed
- a
- b

## CR references
- x
- y

## Verification
- `cargo fmt --all` — clean (exit 0, no files changed, nothing to commit)
- `check-parser-combinators.sh <upstream/main merge-base>` — clean (exit 0)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean (exit 0, no warnings; fix's own changed files are clippy-clean)
- `cargo test -p engine` — clean (exit 0, 0 failed; duggan_private_detective_punch integration test and duggan_private_detective_full_kit_parses regression guard both passed)
- `oracle-gen data --filter 'duggan, private detective'` — confirmed (exit 0, AST matches oracle text, no Unimplemented in activated cost)
Cards confirmed re-parsed correctly: duggan, private detective

🤖 Generated with [Claude Code](https://claude.com/claude-code)
