### PR TITLE
fix(parser): UNSUPPORTED one-off: Everything Comes to Dust

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -621,6 +621,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::Another
         | FilterProp::OtherThanTriggerObject
         | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
         | FilterProp::PowerGTSource
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -559,6 +559,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             FilterProp::Tapped => parts.push("tapped".into()),
             FilterProp::IsSaddled => parts.push("saddled".into()),
             FilterProp::SaddledSource => parts.push("saddled the source".into()),
+            FilterProp::ConvokedSource => parts.push("convoked the source".into()),
             FilterProp::ProtectorMatches { .. } => parts.push("protector matches".into()),
             FilterProp::Untapped => parts.push("untapped".into()),
             FilterProp::HasHasteOrControlledSinceTurnBegan => {

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -161,6 +161,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -371,6 +372,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -2863,6 +2865,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
@@ -3250,6 +3253,13 @@ fn matches_filter_prop(
             .objects
             .get(&source.id)
             .is_some_and(|src| src.saddled_by.contains(&object_id)),
+        // CR 702.51c: a creature tapped to pay the source spell's convoke cost
+        // (recorded in the source's `convoked_creatures`). Source-relative,
+        // mirroring `SaddledSource`.
+        FilterProp::ConvokedSource => state
+            .objects
+            .get(&source.id)
+            .is_some_and(|src| src.convoked_creatures.contains(&object_id)),
         // CR 310.8a: "each battle they protect" — protector is an opponent of
         // the source controller (Joyful Stormsculptor class).
         FilterProp::ProtectorMatches { controller } => {
@@ -4203,6 +4213,7 @@ fn zone_change_record_matches_property(
         FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -44,8 +44,8 @@ use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase,
-    resolve_pronoun_target, TargetSyntax,
+    parse_mass_type_union, parse_target, parse_target_with_ctx, parse_target_with_syntax,
+    parse_type_phrase, resolve_pronoun_target, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, parse_count_expr, parse_mana_symbols,
@@ -6291,6 +6291,29 @@ pub(super) fn parse_library_player_suffix<'a>(
     None
 }
 
+/// CR 112.1: A spell is a card on the stack. `scope_target_spell_phrase` lowers
+/// a "spell"/"spells" head noun to a `StackSpell` leg, so detecting a `StackSpell`
+/// (or an explicit `InZone(Stack)`) in the PARSED filter is how the "exile all
+/// spells" wipe knows to constrain its population to the stack. Recurses through
+/// `Or`/`And`/`Not`. Checks the parsed structure, never the raw text — a "spell"
+/// buried in a relative clause ("a creature that convoked this spell") must not
+/// trigger the constraint, and "cards" (also `TypeFilter::Card`, e.g. "exile all
+/// cards from target player's library", Jace) must NOT be treated as a spell.
+fn filter_targets_stack(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::StackSpell | TargetFilter::StackAbility { .. } => true,
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InZone { zone: Zone::Stack })),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(filter_targets_stack)
+        }
+        TargetFilter::Not { filter } => filter_targets_stack(filter),
+        _ => false,
+    }
+}
+
 pub(super) fn parse_exile_ast(
     text: &str,
     lower: &str,
@@ -6394,11 +6417,21 @@ pub(super) fn parse_exile_ast(
         value((), alt((tag("exile all "), tag("exile each ")))).parse(input)
     }) {
         let rest_lower = &lower[lower.len() - rest.len()..];
-        let (parsed_target, _rem) = parse_target(rest);
+        // CR 205.2a + CR 205.3a + CR 608.2c: parse the full target as a
+        // multi-type union so "exile all A except <X>, all B, and all C" lowers to
+        // one `ChangeZoneAll { Or[…] }` instead of fragmenting the trailing
+        // "all B"/"all C" legs into verb-less sub-abilities (Everything Comes to
+        // Dust). Union legs span card types (205.2a) and subtypes (205.3a).
+        let (parsed_target, _rem) = parse_mass_type_union(rest, ctx);
         #[cfg(debug_assertions)]
         assert_no_compound_remainder(_rem, text);
-        // CR 701.5a: "exile all spells" must constrain to the stack.
-        let target = if nom_primitives::scan_contains(rest_lower, "spell") {
+        // CR 109.2b + CR 701.13a: "exile all spells" must scope to the stack, but
+        // the bare word "spell" can appear deep inside a relative clause ("a
+        // creature that convoked this spell", Everything Comes to Dust) where it
+        // must NOT force a stack constraint. The parser is the detector: only
+        // constrain when the PARSED filter actually references a stack object,
+        // never a substring scan over the raw text.
+        let target = if filter_targets_stack(&parsed_target) {
             super::constrain_filter_to_stack(parsed_target)
         } else {
             parsed_target

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -879,6 +879,16 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         .is_some();
                         let bare_becomes_continuation =
                             bare_becomes_remainder && !antecedent_is_become;
+                        // CR 205.2a + CR 205.3a + CR 608.2c: "exile all A, all B,
+                        // and all C" — a bare "and" before a "[all|each] <type>"
+                        // union leg is a union delimiter, not a clause boundary
+                        // (Everything Comes to Dust; covers the non-"except" union
+                        // form too). The legs span both card types (205.2a:
+                        // creature/artifact/enchantment) and subtypes (205.3a).
+                        let mass_exile_union_continuation = continues_mass_exile_union(
+                            &before_lower,
+                            &remainder_trimmed.to_ascii_lowercase(),
+                        );
                         let suppress = (nom_primitives::scan_contains(&before_lower, "from among")
                         && !sacrifice_rest_remainder)
                         || is_inside_temporal_prefix(&before_lower)
@@ -895,6 +905,7 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                         || continuous_modifier_conjunct
                         || roll_die_modifier_continuation
                         || bare_becomes_continuation
+                        || mass_exile_union_continuation
                         || inside_prefix_comma_and_continuation;
                         if !suppress && starts_bare_and_clause(remainder_trimmed) {
                             push_clause_chunk(&mut chunks, before_and, Some(ClauseBoundary::Comma));
@@ -1008,6 +1019,38 @@ fn parse_search_exile_name_suffix(input: &str) -> Result<(&str, ()), nom::Err<Or
     Ok((rest, ()))
 }
 
+/// CR 205.2a + CR 205.3a + CR 608.2c: true when the clause-so-far is an "exile
+/// all/each …" mass effect and `next_lower` (the text right after a comma or a
+/// bare "and") is another "[all|each] <type>" union leg — where `<type>` spans
+/// both card types (205.2a) and subtypes (205.3a). Such a separator is a within-effect
+/// union delimiter — not a clause boundary — so the whole multi-type union
+/// reaches `parse_exile_ast` (→ `parse_mass_type_union`) as one chunk rather than
+/// fragmenting "all artifacts" / "all enchantments" into verb-less sub_abilities
+/// (Everything Comes to Dust). Combinator-only; no string-method dispatch.
+fn continues_mass_exile_union(current_lower: &str, next_lower: &str) -> bool {
+    type E<'a> = OracleError<'a>;
+    if alt((tag::<_, _, E>("exile all "), tag("exile each ")))
+        .parse(current_lower.trim_start())
+        .is_err()
+    {
+        return false;
+    }
+    // The comma path leaves a leading conjunction ("and …" / "or …") on `next`.
+    let seg = alt((
+        tag::<_, _, E>("and/or "),
+        tag::<_, _, E>("and "),
+        tag::<_, _, E>("or "),
+    ))
+    .parse(next_lower.trim_start())
+    .map(|(rest, _)| rest)
+    .unwrap_or_else(|_| next_lower.trim_start())
+    .trim_start();
+    match alt((tag::<_, _, E>("all "), tag::<_, _, E>("each "))).parse(seg) {
+        Ok((rest, _)) => crate::parser::oracle_target::starts_with_type_word(rest.trim_start()),
+        Err(_) => false,
+    }
+}
+
 fn split_comma_clause_boundary(current: &str, remainder: &str) -> Option<(ClauseBoundary, usize)> {
     let current_lower = current.trim().to_ascii_lowercase();
     let trimmed = remainder.trim_start();
@@ -1015,6 +1058,14 @@ fn split_comma_clause_boundary(current: &str, remainder: &str) -> Option<(Clause
     let trimmed_lower = trimmed.to_ascii_lowercase();
 
     if starts_prefix_clause(&current_lower) {
+        return None;
+    }
+
+    // CR 205.2a + CR 205.3a + CR 608.2c: keep an "exile all/each A, all B, and
+    // all C" union intact — a comma before a "[all|each] <type>" continuation is
+    // a union delimiter, not a clause boundary (Everything Comes to Dust). Legs
+    // span card types (205.2a) and subtypes (205.3a).
+    if continues_mass_exile_union(&current_lower, &trimmed_lower) {
         return None;
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1611,6 +1611,68 @@ pub fn parse_type_phrase(text: &str) -> (TargetFilter, &str) {
     parse_type_phrase_with_ctx(text, &mut ParseContext::default())
 }
 
+/// CR 608.2c: separator byte length for a mass-target union continuation
+/// ("…, all artifacts, and all enchantments"). Longest-match-first over the
+/// comma / "and" / "or" connectors. Returns `None` when `lower` does not start
+/// with a union separator.
+fn match_mass_union_separator(lower: &str) -> Option<usize> {
+    alt((
+        tag::<_, _, OracleError<'_>>(", and/or "),
+        tag(", and "),
+        tag(", or "),
+        tag(", "),
+        tag(" and/or "),
+        tag(" and "),
+        tag(" or "),
+    ))
+    .parse(lower)
+    .ok()
+    .map(|(rest, _)| lower.len() - rest.len())
+}
+
+/// CR 205.2a + CR 205.3a + CR 608.2c: Parse a mass target as a comma/"and"-separated
+/// union of "[all|each] <type-phrase>" legs — where each leg's type word spans both
+/// card types (205.2a: creature/artifact/enchantment) and subtypes (205.3a) — e.g.
+/// "creatures except those that share a
+/// creature type with a creature that convoked this spell, all artifacts, and
+/// all enchantments" (Everything Comes to Dust). Each leg is parsed by the full
+/// `parse_target_with_ctx` grammar (type words, relative clauses, the
+/// "except those" exclusion suffix, and spell-target stack scoping) and the legs
+/// are combined with `merge_or_filters`.
+///
+/// A single-leg input returns exactly what `parse_target_with_ctx` returns, so
+/// every existing `exile all <type>` card is unchanged — the loop only fires on a
+/// repeated-`all`/`each` continuation, which the base grammar's early type-union
+/// (`starts_with_or_article_type_segment` rejects a leading "all") deliberately
+/// stops at.
+pub(crate) fn parse_mass_type_union<'a>(
+    text: &'a str,
+    ctx: &mut ParseContext,
+) -> (TargetFilter, &'a str) {
+    let (mut acc, mut rest) = parse_target_with_ctx(text, ctx);
+    loop {
+        let lower = rest.to_lowercase();
+        let Some(sep_len) = match_mass_union_separator(&lower) else {
+            break;
+        };
+        let after_sep = &rest[sep_len..];
+        let after_sep_lower = after_sep.to_lowercase();
+        // Optional repeated "all "/"each " pluralizer the early union does not fold.
+        let plural_len = alt((tag::<_, _, OracleError<'_>>("all "), tag("each ")))
+            .parse(after_sep_lower.as_str())
+            .map(|(r, _)| after_sep_lower.len() - r.len())
+            .unwrap_or(0);
+        let leg_text = &after_sep[plural_len..];
+        if !starts_with_type_word(&leg_text.to_lowercase()) {
+            break;
+        }
+        let (leg, next) = parse_target_with_ctx(leg_text, ctx);
+        acc = merge_or_filters(acc, leg);
+        rest = next;
+    }
+    (acc, rest)
+}
+
 /// Context-aware variant of `parse_type_phrase`. Enables relative-player scope
 /// resolution via `ctx.relative_player_scope`.
 pub fn parse_type_phrase_with_ctx<'a>(
@@ -2304,6 +2366,53 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += consumed;
     }
 
+    // CR 608.2c: "<type> except those that <relative-clause>" / "other than those
+    // that <relative-clause>" — an exclusion suffix. The inner relative clause is
+    // parsed by the same `parse_that_clause_suffix` grammar and the leg matches the
+    // *complement* of the whole clause. `parse_that_clause_suffix` returns its
+    // predicates AND-combined (a conjunctive clause, e.g. "that are attacking and
+    // tapped"), so the complement is the De Morgan dual
+    // Not(X AND Y) = Not(X) OR Not(Y). A single predicate negates directly; a
+    // multi-predicate conjunction folds to a single `AnyOf{[Not(X), Not(Y)]}`
+    // (disjunction of negations) — never per-prop `Not(X) AND Not(Y)`, which would
+    // exclude every object matching X *or* Y rather than only those matching both.
+    // A clause whose disjunction is already a single prop (e.g. "enchanted or
+    // equipped" → `HasAnyAttachmentOf`) stays one prop and its `Not` De Morgans
+    // correctly at runtime. Covers "all creatures except those that share a
+    // creature type with a creature that convoked this spell" (Everything Comes to
+    // Dust) and the general class ("except those that attacked this turn").
+    {
+        let rem = lower[pos..].trim_start();
+        let ws = lower[pos..].len() - rem.len();
+        if let Ok((after_those, _)) = alt((
+            tag::<_, _, OracleError<'_>>("except those "),
+            tag("other than those "),
+        ))
+        .parse(rem)
+        {
+            let prefix_len = rem.len() - after_those.len();
+            if let Some((excl_props, consumed)) = parse_that_clause_suffix(after_those, Some(ctx)) {
+                let negated: Vec<FilterProp> = excl_props
+                    .into_iter()
+                    .map(|prop| FilterProp::Not {
+                        prop: Box::new(prop),
+                    })
+                    .collect();
+                match negated.len() {
+                    0 => {}
+                    1 => properties.push(
+                        negated
+                            .into_iter()
+                            .next()
+                            .expect("len checked to be exactly 1"),
+                    ),
+                    _ => properties.push(FilterProp::AnyOf { props: negated }),
+                }
+                pos += ws + prefix_len + consumed;
+            }
+        }
+    }
+
     // CR 109.4: "that <player> control(s)" relative clause supplying the object
     // controller — e.g. "permanents you own that your opponents control"
     // (Zedruu). Placed after `parse_that_clause_suffix` so the quality/combat/
@@ -2961,9 +3070,25 @@ fn scope_target_spell_phrase(filter: TargetFilter, phrase: &str) -> TargetFilter
 }
 
 fn target_phrase_mentions_spell_word(phrase: &str) -> bool {
-    phrase
+    // CR 109.2 + CR 109.2b: the word "spell" makes a head descriptor mean a spell
+    // on the stack, but "this spell" / "that spell" is an anaphoric self-reference
+    // to the source object inside a relative clause — NOT the target's head
+    // descriptor — so it must not trigger spell-target stack scoping (otherwise "a
+    // creature that convoked this spell", Everything Comes to Dust, whose head is
+    // the battlefield permanent "a creature" per CR 109.2, would be wrongly
+    // rewritten to a stack spell). Any other occurrence ("instant and sorcery
+    // spells", "another spell") is a real head-descriptor type noun.
+    let mut previous: Option<&str> = None;
+    for word in phrase
         .split(|ch: char| ch.is_ascii_whitespace() || matches!(ch, ',' | ';' | '(' | ')'))
-        .any(|word| matches!(word, "spell" | "spells"))
+        .filter(|word| !word.is_empty())
+    {
+        if matches!(word, "spell" | "spells") && !matches!(previous, Some("this") | Some("that")) {
+            return true;
+        }
+        previous = Some(word);
+    }
+    false
 }
 
 fn target_phrase_uses_spell_suffix(phrase: &str) -> bool {
@@ -5366,6 +5491,12 @@ pub(crate) fn parse_that_clause_suffix<'a>(
         // ability source. Calamity, Galloping Inferno. Longest match first.
         ("saddled it this turn", FilterProp::SaddledSource),
         ("saddled it", FilterProp::SaddledSource),
+        // CR 702.51c: "that convoked this spell" / "that convoked it" — the
+        // creature was tapped to pay the source spell's convoke cost (recorded in
+        // the source's `convoked_creatures`). "it"/"this spell" refer to the
+        // source. Everything Comes to Dust. Longest match first.
+        ("convoked this spell", FilterProp::ConvokedSource),
+        ("convoked it", FilterProp::ConvokedSource),
     ];
 
     for (phrase, prop) in VERB_PHRASES {
@@ -10605,6 +10736,124 @@ mod tests {
                     .contains(&TypeFilter::Non(Box::new(TypeFilter::Artifact))));
             }
             other => panic!("Expected Typed, got {:?}", other),
+        }
+    }
+
+    // ── Cluster 59: convoke-relative filter + "except those" exclusion + mass union ──
+
+    #[test]
+    fn creature_that_convoked_this_spell_is_convoked_source() {
+        // CR 702.51c: "a creature that convoked this spell" → creature +
+        // ConvokedSource. The "this spell" self-reference must NOT scope the
+        // result to the stack (the spell-suffix guard).
+        let (f, rest) = parse_target("a creature that convoked this spell");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::ConvokedSource])
+            ),
+            "must stay a battlefield creature filter, not a stack spell"
+        );
+        assert_eq!(rest.trim(), "");
+    }
+
+    #[test]
+    fn convoked_it_alias_is_convoked_source() {
+        let (f, _) = parse_target("a creature that convoked it");
+        assert_eq!(
+            f,
+            TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::ConvokedSource])
+            )
+        );
+    }
+
+    #[test]
+    fn except_those_sharing_type_with_convoker_negates() {
+        // CR 608.2c: "creatures except those that share a creature type with a
+        // creature that convoked this spell" → creature + Not(SharesQuality).
+        let (f, _) = parse_type_phrase(
+            "creatures except those that share a creature type with a creature that convoked this spell",
+        );
+        let expected_ref = TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::ConvokedSource]),
+        );
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Not {
+                prop: Box::new(FilterProp::SharesQuality {
+                    quality: SharedQuality::CreatureType,
+                    reference: Some(Box::new(expected_ref)),
+                    relation: SharedQualityRelation::Shares,
+                }),
+            }]))
+        );
+    }
+
+    #[test]
+    fn except_those_multi_predicate_folds_to_disjunction_of_negations() {
+        // CR 608.2c De Morgan: "except those that <X> and <Y>" excludes only
+        // objects matching the FULL conjunction X AND Y, so the complement kept by
+        // the leg is the disjunction Not(X) OR Not(Y) — a single `AnyOf`, NEVER
+        // per-prop `Not(X) AND Not(Y)` (which would exclude objects matching X *or*
+        // Y, far too many). Exercised with a clause that `parse_that_clause_suffix`
+        // returns as two props ([Not(AttackedThisTurn), Not(EnteredThisTurn)]).
+        let (f, _) =
+            parse_type_phrase("creatures except those that didn't attack or enter this turn");
+        // The two negated-verb predicates negate (double `Not`) and fold into one
+        // `AnyOf` — the structural signature that distinguishes the De Morgan-correct
+        // disjunction from the broken per-prop conjunction.
+        let expected_props = vec![FilterProp::AnyOf {
+            props: vec![
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::Not {
+                        prop: Box::new(FilterProp::AttackedThisTurn),
+                    }),
+                },
+                FilterProp::Not {
+                    prop: Box::new(FilterProp::Not {
+                        prop: Box::new(FilterProp::EnteredThisTurn),
+                    }),
+                },
+            ],
+        }];
+        assert_eq!(
+            f,
+            TargetFilter::Typed(TypedFilter::creature().properties(expected_props)),
+            "multi-predicate exclusion must fold to AnyOf of negations, not per-prop Not"
+        );
+    }
+
+    #[test]
+    fn mass_type_union_repeated_all() {
+        // CR 205.2a: "creatures, all artifacts, and all enchantments" →
+        // Or[creature, artifact, enchantment] (repeated-`all` continuation over
+        // card types).
+        let mut ctx = ParseContext::default();
+        let (f, rest) =
+            parse_mass_type_union("creatures, all artifacts, and all enchantments", &mut ctx);
+        assert_eq!(
+            f,
+            TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::creature()),
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Enchantment)),
+                ],
+            }
+        );
+        assert_eq!(rest.trim(), "");
+    }
+
+    #[test]
+    fn mass_type_union_single_leg_matches_parse_target() {
+        // Regression: inputs without a repeated-`all` continuation must equal the
+        // bare `parse_target` result (the loop must not fire on within-leg unions).
+        let mut ctx = ParseContext::default();
+        for phrase in ["artifacts", "artifacts and creatures", "other spells"] {
+            let (f, _) = parse_mass_type_union(phrase, &mut ctx);
+            let (baseline, _) = parse_target(phrase);
+            assert_eq!(f, baseline, "mass union changed bare parse for {phrase:?}");
         }
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2647,6 +2647,13 @@ pub enum FilterProp {
     /// of `BlockingSource`; used by "choose a creature that saddled it this turn"
     /// (Calamity, Galloping Inferno).
     SaddledSource,
+    /// CR 702.51c: Matches a creature that convoked the filter source — i.e. was
+    /// tapped to pay the source spell's convoke cost, recorded in the source
+    /// object's `convoked_creatures`. Source-relative, mirroring `SaddledSource`
+    /// / `BlockingSource`. Membership analogue of
+    /// `QuantityRef::ConvokedCreatureCount` (both read `convoked_creatures`).
+    /// Used by "a creature that convoked this spell" (Everything Comes to Dust).
+    ConvokedSource,
     /// CR 310.8a + CR 310.8e: Matches battles whose protector satisfies
     /// `controller` relative to the ability source ("each battle they protect").
     ProtectorMatches {

--- a/crates/engine/tests/everything_comes_to_dust_convoke_exile.rs
+++ b/crates/engine/tests/everything_comes_to_dust_convoke_exile.rs
@@ -1,0 +1,114 @@
+//! Runtime proof for Cluster 59 — Everything Comes to Dust (WHO).
+//!
+//! "Convoke. Exile all creatures except those that share a creature type with a
+//! creature that convoked this spell, all artifacts, and all enchantments."
+//!
+//! Proves the parsed `ChangeZoneAll { Exile, Or[...] }` resolves correctly:
+//! - leg 1 (CR 702.51c + CR 205.3m): creatures EXCEPT those sharing a creature
+//!   type with a convoker survive; every other creature is exiled.
+//! - legs 2/3 (CR 701.13a): all artifacts and all enchantments are exiled.
+//! - lands, and the convoker's tribe, survive.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ORACLE: &str = "Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature's color.)\nExile all creatures except those that share a creature type with a creature that convoked this spell, all artifacts, and all enchantments.";
+
+#[test]
+fn convoke_exception_protects_convoker_tribe() {
+    let mut scenario = GameScenario::new_n_player(2, 5959);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // goblin_a convokes the spell; goblin_b shares its creature type.
+    let goblin_a = scenario
+        .add_creature(P0, "Goblin A", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let goblin_b = scenario
+        .add_creature(P1, "Goblin B", 2, 2)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    // A creature that shares NO type with a Goblin.
+    let bird = scenario
+        .add_creature(P1, "Sparrow", 1, 1)
+        .with_subtypes(vec!["Bird"])
+        .id();
+    let artifact = scenario.add_creature(P1, "Relic", 0, 0).as_artifact().id();
+    let enchantment = scenario
+        .add_creature(P1, "Aura Thing", 0, 0)
+        .as_enchantment()
+        .id();
+    let land = scenario.add_basic_land(P1, ManaColor::Green);
+
+    // Override the printed {7}{W}{W}{W} with {1} so a single convoked creature
+    // pays the whole cost — the effect's resolution is what's under test.
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Everything Comes to Dust", false, ORACLE)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    let mut runner = scenario.build();
+    // CR 205.3m: the live game seeds `all_creature_types` from the card DB; the
+    // scenario harness leaves it empty, so register the types under test (a
+    // subtype is only counted toward `SharedQuality::CreatureType` if it is a
+    // known creature type).
+    runner.state_mut().all_creature_types = vec!["Goblin".into(), "Bird".into()];
+    // Pay the {1} via convoke → stamps the spell's convoked_creatures = [goblin_a].
+    runner.cast(spell).convoke_with(&[goblin_a]).resolve();
+    runner.advance_until_stack_empty();
+
+    let zone_of = |id| runner.state().objects[&id].zone;
+
+    // CR 702.51c + CR 205.3m: convoker and its tribe share a creature type → survive.
+    assert_eq!(zone_of(goblin_a), Zone::Battlefield, "convoker survives");
+    assert_eq!(
+        zone_of(goblin_b),
+        Zone::Battlefield,
+        "shares Goblin with convoker → survives"
+    );
+    // CR 701.13a: every other arm of the union is exiled.
+    assert_eq!(zone_of(bird), Zone::Exile, "non-sharing creature exiled");
+    assert_eq!(zone_of(artifact), Zone::Exile, "artifact exiled");
+    assert_eq!(zone_of(enchantment), Zone::Exile, "enchantment exiled");
+    assert_eq!(zone_of(land), Zone::Battlefield, "land untouched");
+}
+
+#[test]
+fn no_convoke_exiles_every_creature() {
+    let mut scenario = GameScenario::new_n_player(2, 5960);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let goblin = scenario
+        .add_creature(P0, "Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let bird = scenario
+        .add_creature(P1, "Sparrow", 1, 1)
+        .with_subtypes(vec!["Bird"])
+        .id();
+    let artifact = scenario.add_creature(P1, "Relic", 0, 0).as_artifact().id();
+    let enchantment = scenario
+        .add_creature(P1, "Aura Thing", 0, 0)
+        .as_enchantment()
+        .id();
+    let land = scenario.add_basic_land(P1, ManaColor::Green);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Everything Comes to Dust", false, ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    // No convoke → convoked_creatures is empty → the exception protects nobody.
+    runner.cast(spell).resolve();
+    runner.advance_until_stack_empty();
+
+    let zone_of = |id| runner.state().objects[&id].zone;
+    assert_eq!(zone_of(goblin), Zone::Exile, "no convoker → goblin exiled");
+    assert_eq!(zone_of(bird), Zone::Exile);
+    assert_eq!(zone_of(artifact), Zone::Exile);
+    assert_eq!(zone_of(enchantment), Zone::Exile);
+    assert_eq!(zone_of(land), Zone::Battlefield, "land untouched");
+}


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED one-off: Everything Comes to Dust

## Cards corrected
- Everything Comes to Dust

## Fix
Fully implemented Cluster 59 — "Everything Comes to Dust" (WHO) — rules-correct per CR, with end-to-end runtime proof. The card was a silent misparse (dropped exception clause + spurious InZone(Stack) + two Unimplemented sub-abilities); it now parses to a single ChangeZoneAll{Exile, Or[creature-except-convoker-tribe, artifact, enchantment]} with zero Unimplemented.

WHAT I BUILT
1. New leaf variant FilterProp::ConvokedSource (CR 702.51c) — the convoke-payoff membership predicate, the structural twin of FilterProp::SaddledSource. Wired across ALL layers: types/ability.rs (variant + doc), game/filter.rs (eval arm reading src.convoked_creatures, plus the 4 exhaustive classification groups: object-population, entered-perturbs, spell-record-snapshot, zone-change-record), ai_support/filter.rs (POISON group), game/coverage.rs (human-readable string). Reads the already-stamped GameObject::convoked_creatures (same source of truth as the shipped QuantityRef::ConvokedCreatureCount).
2. Parser (oracle_target.rs): VERB_PHRASES entries "convoked this spell"/"convoked it"→ConvokedSource; a general "except those that <clause>" / "other than those that <clause>" exclusion suffix in parse_type_phrase_with_ctx that negates each predicate via FilterProp::Not (delegates to the existing parse_that_clause_suffix grammar); parse_mass_type_union + match_mass_union_separator combinators for repeated-"all/each <type>" unions; and a guard in target_phrase_mentions_spell_word so a "this spell"/"that spell" self-reference (CR 109.2/109.2b) inside a relative clause no longer mis-scopes the target to the stack.
3. Clause splitter (oracle_effect/sequence.rs): new continues_mass_exile_union combinator-guard wired into BOTH the comma path (split_comma_clause_boundary) and the bare-"and" path so "exile all A except <X>, all B, and all C" stays ONE clause instead of fragmenting "all artifacts"/"all enchantments" into verb-less Unimplemented sub-abilities. (The plan assumed parse_exile_ast received the full sentence; in reality the splitter pre-split it — this guard closes that gap.)
4. Handler (oracle_effect/imperative.rs): parse_exile_ast now routes "exile all/each" through parse_mass_type_union, and the stack-constraint gate was changed from a brittle substring scan (scan_contains(rest_lower,"spell") — which mis-fired on "convoked this spell") to filter_targets_stack, a parser-is-the-detector check on the PARSED filter (StackSpell / InZone(Stack)).

TESTS (all pass): 5 building-block parser unit tests (convoke ref, exclusion suffix, repeated-all union, single-leg regression) + 2 runtime integration tests in a new file using GameScenario + GameRunner::cast().convoke_with().resolve() — one proving the convoke exception (convoker + Goblin tribe survive; Bird, artifact, enchantment exiled; land untouched) and one proving the no-convoke path (all creatures + artifact + enchantment exiled).

VERIFICATION (worktree run directly, not via Tilt): cargo fmt --check clean; cargo clippy --all-targets -D warnings clean (exit 0); cargo test -p engine = 14025 passed / 0 failed; targeted parser-combinator diff gate shows ZERO string-dispatch added by my changes; production oracle-gen (--features cli) export confirms 0 Unimplemented and the exact rules-correct AST.

REGRESSION FOUND & FIXED MID-IMPLEMENTATION: the full suite caught Jace, the Mind Sculptor's ultimate ("Exile all cards from target player's library") — my first filter_targets_stack treated TypeFilter::Card as a stack indicator, but "cards" also maps to Card, wrongly adding InZone(Stack). Fixed by keying only on StackSpell/StackAbility/InZone(Stack) (never bare Card). Re-verified Jace snapshot passes and Summary Dismissal ("exile all other spells") still parses to And[StackSpell, Typed{Another, InZone(Stack)}] unchanged.

DISK NOTE: the shared volume was at 100% (240Mi free, 61G of stale incremental deps in my worktree's own target/). I ran cargo clean (freed 64G; this worktree is mine and not under Tilt) before building. I also reverted an unrelated one-line regeneration of crates/engine/data/oracle-subtypes.json that the oracle-gen verification run produced as a side-effect.

## Files changed
- crates/engine/src/types/ability.rs
- crates/engine/src/game/filter.rs
- crates/engine/src/game/coverage.rs
- crates/engine/src/ai_support/filter.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/parser/oracle_effect/sequence.rs
- crates/engine/tests/everything_comes_to_dust_convoke_exile.rs

## CR references
- CR 702.51c — a creature tapped to pay a spell's total cost via convoke is said to have 'convoked' that spell (FilterProp::ConvokedSource eval + parser + test); grep '^702.51c' docs/MagicCompRules.txt
- CR 608.2c — read the whole text / apply the rules of English (exclusion suffix Not-negation, mass-union assembly, splitter guards); grep '^608.2c'
- CR 109.2 + CR 109.2b — a 'spell' head descriptor means a spell on the stack, but 'this spell' in a relative clause is an anaphoric self-reference, not the target head (target_phrase_mentions_spell_word guard + stack gate); grep '^109.2'
- CR 112.1 — a spell is a card on the stack (filter_targets_stack doc); grep '^112.1'
- CR 701.13a — to exile an object, move it to the exile zone (handler + test); grep '^701.13a'
- CR 205.3a — comma-separated type lists are set-union syntactic sugar (parse_mass_type_union, splitter guards; matches existing codebase convention at oracle_target.rs:2107); grep '^205.3a'
- CR 205.3m — creatures share their lists of subtypes (creature types); convoke exception + ConvokedSource doc; grep '^205.3m'

## Verification
- `cargo fmt --all` — pass
- `./scripts/check-parser-combinators.sh <upstream/main merge-base 7c1c1cf6>` — pass
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "everything comes to dust"` — pass
Cards confirmed re-parsed correctly: Everything Comes to Dust

🤖 Generated with [Claude Code](https://claude.com/claude-code)
