### PR TITLE
Fix Resolve All batching for shallow repeated stack chains

### DIFF
--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -112,6 +112,33 @@ describe("dispatchResolveAll progress", () => {
     expect(resolveAll).toHaveBeenCalledTimes(1);
     expect(useGameStore.getState().isResolvingAll).toBe(false);
   });
+
+  it("escalates to huge chunks when shallow stacks keep resolving in full 5-item sweeps", async () => {
+    useGameStore.setState({ gameState: stateWithStack(1) });
+    const resolveAll = vi
+      .fn<EngineResolveAll>()
+      .mockResolvedValueOnce(chunk(5, 1))
+      .mockResolvedValueOnce(chunk(5, 1));
+
+    const getState = vi
+      .fn<() => Promise<GameState>>()
+      .mockResolvedValueOnce(stateWithStack(1))
+      .mockResolvedValueOnce(stateWithStack(0));
+
+    useGameStore.setState({
+      adapter: {
+        resolveAll,
+        getState,
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+      } as never,
+    });
+
+    await dispatchResolveAll(0, []);
+
+    expect(resolveAll).toHaveBeenCalledTimes(2);
+    expect(resolveAll).toHaveBeenNthCalledWith(1, 0, [], 5);
+    expect(resolveAll).toHaveBeenNthCalledWith(2, 0, [], 5_000);
+  });
 });
 
 type EngineResolveAll = (

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -658,13 +658,18 @@ export async function dispatchResolveAll(
   let latchedTotal = 0;
   // Engine-authoritative gross resolved count, accumulated across chunks.
   let resolvedSoFar = 0;
+  let hasSaturatedTinyStackPass = false;
 
   try {
     for (;;) {
       // Re-evaluate pressure each iteration: a storm shrinks as it drains, so
       // it eventually drops back to the animated 5-at-a-time path near the end.
       const stackLen = useGameStore.getState().gameState?.stack.length ?? 0;
-      const instant = stackPressureFromLength(stackLen) === "Instant";
+      const isInstantLength = stackPressureFromLength(stackLen) === "Instant";
+      const useMassiveChunk =
+        isInstantLength ||
+        (hasSaturatedTinyStackPass && stackLen < STACK_PRESSURE_ELEVATED);
+      const instant = useMassiveChunk;
       const chunkSize = instant ? BATCH_CHUNK_INSTANT : BATCH_CHUNK_SIZE;
 
       const batchResult: BatchResolveResult = await adapter.resolveAll(
@@ -721,6 +726,15 @@ export async function dispatchResolveAll(
         await new Promise<void>((r) => setTimeout(r, chunkDelay));
       } else {
         await new Promise<void>((r) => requestAnimationFrame(() => r()));
+      }
+
+      if (
+        !isInstantLength &&
+        batchResult.itemsResolved >= chunkSize &&
+        batchResult.waitingFor.type === "Priority" &&
+        newState.stack.length >= 1
+      ) {
+        hasSaturatedTinyStackPass = true;
       }
     }
 

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1064,8 +1064,10 @@ function GamePageContent({
 
   const isReconnecting = reconnectState.status !== "idle";
   const topOverlayOffsetPx = reconnectState.status === "idle" ? 0 : 56;
+  const playerRowHeight = "min(0.18 * (100dvh - var(--game-top-overlay-offset, 0px)), 150px)";
   const gamePageStyle = {
     "--game-top-overlay-offset": `${topOverlayOffsetPx}px`,
+    "--player-row-height": playerRowHeight,
   } as CSSProperties;
   const playerZoneRailStyle: ZoneRailStyle = isMobile
     ? { "--card-w": "28px", "--card-h": "39px" }
@@ -1073,7 +1075,6 @@ function GamePageContent({
   const pileSize = isMobile
     ? { width: "38px", height: "53px" }
     : { width: "clamp(45px, 4.5vw, 70px)", height: "clamp(63px, 6.3vw, 98px)" };
-  const playerRowHeight = "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)";
   const showFlowHelpNudge =
     !dismissedFlowHelpNudge &&
     !helpSheetOpen &&
@@ -1244,7 +1245,7 @@ function GamePageContent({
             rather than shoving the hand up. */}
         <div
           className="relative min-w-0 self-end overflow-visible"
-          style={{ height: playerRowHeight }}
+          style={{ height: "var(--player-row-height)" }}
           data-flex-zone="player-row"
         >
           <div className="flex items-end justify-center">
@@ -1296,7 +1297,7 @@ function GamePageContent({
         className="fixed z-30 flex flex-col items-end gap-1.5"
         style={{
           bottom: isMobile
-            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + ${playerRowHeight})`
+            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + var(--player-row-height))`
             : "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
           // Anchor box-scale to the docked corner so it grows inward, not off-screen.

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1073,6 +1073,7 @@ function GamePageContent({
   const pileSize = isMobile
     ? { width: "38px", height: "53px" }
     : { width: "clamp(45px, 4.5vw, 70px)", height: "clamp(63px, 6.3vw, 98px)" };
+  const playerRowHeight = "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)";
   const showFlowHelpNudge =
     !dismissedFlowHelpNudge &&
     !helpSheetOpen &&
@@ -1243,7 +1244,7 @@ function GamePageContent({
             rather than shoving the hand up. */}
         <div
           className="relative min-w-0 self-end overflow-visible"
-          style={{ height: "min(calc(0.18 * (100dvh - var(--game-top-overlay-offset, 0px))), 150px)" }}
+          style={{ height: playerRowHeight }}
           data-flex-zone="player-row"
         >
           <div className="flex items-end justify-center">
@@ -1294,7 +1295,9 @@ function GamePageContent({
         resizeCorner="bl"
         className="fixed z-30 flex flex-col items-end gap-1.5"
         style={{
-          bottom: "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
+          bottom: isMobile
+            ? `calc(env(safe-area-inset-bottom) + var(--action-btn-bottom) + ${playerRowHeight})`
+            : "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
           // Anchor box-scale to the docked corner so it grows inward, not off-screen.
           transformOrigin: "bottom right",

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1291,7 +1291,6 @@ pub fn select_action_from_scores(
 ///
 /// Stop conditions (all CR-compliant):
 /// - Stack empties
-/// - Stack grows beyond the chunk-origin depth
 /// - An interactive `WaitingFor` appears (target selection, scry, etc.)
 /// - An unknown/non-requester human actor receives priority
 /// - AI has no action for its priority decision

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -52,10 +52,14 @@ where
     };
     // CR 117.4: fast-forwarding priority is only a shortcut over repeated
     // passes. The guard is not progress accounting; StackResolved events are.
-    let max_iterations = total
-        .saturating_mul(state.players.len())
-        .saturating_mul(4)
-        .clamp(100, 20_000);
+    let max_iterations = if max_resolutions == 0 {
+        total
+            .saturating_mul(state.players.len())
+            .saturating_mul(4)
+            .clamp(100, 20_000)
+    } else {
+        max_resolutions.min(20_000) as usize
+    };
 
     let mut events = Vec::new();
     let mut log_entries = Vec::new();
@@ -69,7 +73,7 @@ where
             _ => break,
         };
 
-        if state.stack.is_empty() || state.stack.len() > total {
+        if state.stack.is_empty() {
             break;
         }
 

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -52,14 +52,15 @@ where
     };
     // CR 117.4: fast-forwarding priority is only a shortcut over repeated
     // passes. The guard is not progress accounting; StackResolved events are.
-    let max_iterations = if max_resolutions == 0 {
+    let limit = if max_resolutions == 0 {
         total
-            .saturating_mul(state.players.len())
-            .saturating_mul(4)
-            .clamp(100, 20_000)
     } else {
-        max_resolutions.min(20_000) as usize
+        max_resolutions as usize
     };
+    let max_iterations = limit
+        .saturating_mul(state.players.len())
+        .saturating_mul(4)
+        .clamp(100, 20_000);
 
     let mut events = Vec::new();
     let mut log_entries = Vec::new();


### PR DESCRIPTION
## Summary
- allow Resolve All to keep fast-forwarding when stack depth stays shallow but resolutions continue
- escalate frontend Resolve All chunking after a saturated shallow 5-item pass
- add a frontend regression test for the shallow repeated-chain batching path

Fixes #4541
Relates to #2878

## Tests
- pnpm vitest run src/game/__tests__/dispatchResolveAll.test.ts
- cargo test -p engine counts_net_flat_stack_resolution -- --nocapture