### PR TITLE
Parse Fastbond land-play permission as static

### DIFF
--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1668,8 +1668,9 @@ fn transient_additional_land_drops(state: &GameState, player: PlayerId) -> u8 {
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
+    use crate::parser::oracle_static::parse_static_line;
     use crate::types::ability::StaticCondition;
-    use crate::types::ability::{ControllerRef, StaticDefinition, TargetFilter};
+    use crate::types::ability::{ControllerRef, StaticDefinition, TargetFilter, TypedFilter};
     use crate::types::card_type::CoreType;
     use crate::types::identifiers::CardId;
     use crate::types::statics::StaticMode;
@@ -2047,10 +2048,14 @@ mod tests {
             .static_definitions
             .push(
                 StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 2 })
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::default().controller(ControllerRef::You),
+                    ))
                     .description("You may play two additional lands on each of your turns.".into()),
             );
 
         assert_eq!(additional_land_drops(&state, PlayerId(0)), 2);
+        assert_eq!(additional_land_drops(&state, PlayerId(1)), 0);
     }
 
     #[test]
@@ -2128,6 +2133,48 @@ mod tests {
                         TypedFilter::default().controller(ControllerRef::You),
                     ))
                     .description("You may play an additional land on each of your turns.".into()),
+            );
+
+        assert_eq!(additional_land_drops(&state, PlayerId(0)), u8::MAX);
+        assert_eq!(additional_land_drops(&state, PlayerId(1)), 0);
+    }
+
+    #[test]
+    fn test_parsed_controller_scoped_additional_land_drops_do_not_affect_opponent() {
+        let mut state = setup();
+
+        let fastbond = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Fastbond".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&fastbond)
+            .unwrap()
+            .static_definitions
+            .push(
+                parse_static_line("You may play any number of lands on each of your turns.")
+                    .expect("Fastbond land permission must parse"),
+            );
+
+        let azusa = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Azusa, Lost but Seeking".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&azusa)
+            .unwrap()
+            .static_definitions
+            .push(
+                parse_static_line("You may play two additional lands on each of your turns.")
+                    .expect("Azusa land permission must parse"),
             );
 
         assert_eq!(additional_land_drops(&state, PlayerId(0)), u8::MAX);

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -2086,6 +2086,54 @@ mod tests {
         assert_eq!(additional_land_drops(&state, PlayerId(0)), 2);
     }
 
+    #[test]
+    fn test_additional_land_drops_saturates_any_number() {
+        let mut state = setup();
+
+        let fastbond = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Fastbond".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&fastbond)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::AdditionalLandDrop { count: u8::MAX })
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::default().controller(ControllerRef::You),
+                    ))
+                    .description("You may play any number of lands on each of your turns.".into()),
+            );
+
+        let exploration = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Exploration".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&exploration)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::MayPlayAdditionalLand)
+                    .affected(TargetFilter::Typed(
+                        TypedFilter::default().controller(ControllerRef::You),
+                    ))
+                    .description("You may play an additional land on each of your turns.".into()),
+            );
+
+        assert_eq!(additional_land_drops(&state, PlayerId(0)), u8::MAX);
+        assert_eq!(additional_land_drops(&state, PlayerId(1)), 0);
+    }
+
     /// Issue #2879 + CR 305.2 + CR 611.2c: a turn-scoped transient grant (Escape
     /// to the Wilds: "you may play an additional land this turn") must be summed
     /// into `additional_land_drops` for the affected player only.

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -330,6 +330,7 @@ const STATIC_CONTAINS_PATTERNS: &[&str] = &[
     // quote is required: scan_contains only matches at word starts, and "legend"
     // is glued to its opening quote ("legend) in the Oracle text.
     "\"legend rule\" doesn't apply",
+    "play any number of lands",
     "play an additional land",
     "play two additional lands",
     "triggers an additional time",

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2734,8 +2734,14 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "play an additional land" / "play two additional lands" ---
+    // --- "play any number of lands" / additional land-drop grants ---
     // CR 305.2: Determine the count at parse time and carry it as typed data.
+    if nom_primitives::scan_contains(tp.lower, "play any number of lands") {
+        return Some(
+            StaticDefinition::new(StaticMode::AdditionalLandDrop { count: u8::MAX })
+                .description(text.to_string()),
+        );
+    }
     if nom_primitives::scan_contains(tp.lower, "play two additional lands") {
         return Some(
             StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 2 })

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -91,8 +91,9 @@ pub(crate) fn is_speed_unlock_sentence(lower: &str) -> bool {
 }
 
 /// CR 305.2: static land-play permissions with an explicit additional-drop
-/// count. `u8::MAX` represents "any number"; runtime summing saturates so it
-/// stays effectively unbounded when combined with ordinary extra drops.
+/// count greater than the ordinary +1 grant. `u8::MAX` represents "any
+/// number"; runtime summing saturates so it stays effectively unbounded when
+/// combined with ordinary extra drops.
 fn parse_static_additional_land_drop_count(input: &str) -> OracleResult<'_, u8> {
     all_consuming(terminated(
         preceded(
@@ -100,7 +101,6 @@ fn parse_static_additional_land_drop_count(input: &str) -> OracleResult<'_, u8> 
             alt((
                 value(u8::MAX, tag("any number of lands")),
                 value(2, tag("two additional lands")),
-                value(1, tag("an additional land")),
             )),
         ),
         (
@@ -2764,7 +2764,10 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "play any number of lands" / additional land-drop grants ---
+    // --- "play any number of lands" / counted additional land-drop grants ---
+    // The ordinary +1 phrase ("play an additional land") is handled by the
+    // rule-static subject/predicate shell so embedded subjects such as
+    // "Each player who last chose green anchor ..." keep their affected filter.
     if let Ok((_, count)) = parse_static_additional_land_drop_count(tp.lower) {
         return Some(
             StaticDefinition::new(StaticMode::AdditionalLandDrop { count })

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2771,6 +2771,9 @@ pub(crate) fn parse_static_line_inner(
     if let Ok((_, count)) = parse_static_additional_land_drop_count(tp.lower) {
         return Some(
             StaticDefinition::new(StaticMode::AdditionalLandDrop { count })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::default().controller(ControllerRef::You),
+                ))
                 .description(text.to_string()),
         );
     }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -90,6 +90,36 @@ pub(crate) fn is_speed_unlock_sentence(lower: &str) -> bool {
     .is_ok()
 }
 
+/// CR 305.2: static land-play permissions with an explicit additional-drop
+/// count. `u8::MAX` represents "any number"; runtime summing saturates so it
+/// stays effectively unbounded when combined with ordinary extra drops.
+fn parse_static_additional_land_drop_count(input: &str) -> OracleResult<'_, u8> {
+    all_consuming(terminated(
+        preceded(
+            (opt(tag("you may ")), tag("play ")),
+            alt((
+                value(u8::MAX, tag("any number of lands")),
+                value(2, tag("two additional lands")),
+                value(1, tag("an additional land")),
+            )),
+        ),
+        (
+            opt((
+                space1,
+                alt((
+                    tag("on each of your turns"),
+                    tag("on each of their turns"),
+                    tag("during each of your turns"),
+                    tag("during each of their turns"),
+                )),
+            )),
+            opt(tag(".")),
+            space0,
+        ),
+    ))
+    .parse(input)
+}
+
 /// CR 502.3: Trailing "during their untap step(s)" clause of the
 /// max-untap restriction (Smoke / Damping Field / Winter Orb class). The
 /// canonical printing uses the plural possessive "their untap steps", but the
@@ -2735,22 +2765,9 @@ pub(crate) fn parse_static_line_inner(
     }
 
     // --- "play any number of lands" / additional land-drop grants ---
-    // CR 305.2: Determine the count at parse time and carry it as typed data.
-    if nom_primitives::scan_contains(tp.lower, "play any number of lands") {
+    if let Ok((_, count)) = parse_static_additional_land_drop_count(tp.lower) {
         return Some(
-            StaticDefinition::new(StaticMode::AdditionalLandDrop { count: u8::MAX })
-                .description(text.to_string()),
-        );
-    }
-    if nom_primitives::scan_contains(tp.lower, "play two additional lands") {
-        return Some(
-            StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 2 })
-                .description(text.to_string()),
-        );
-    }
-    if nom_primitives::scan_contains(tp.lower, "play an additional land") {
-        return Some(
-            StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 1 })
+            StaticDefinition::new(StaticMode::AdditionalLandDrop { count })
                 .description(text.to_string()),
         );
     }

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -8,7 +8,7 @@ mod prelude {
 
     pub(super) use crate::parser::oracle_nom::error::OracleError;
     pub(super) use nom::branch::alt;
-    pub(super) use nom::bytes::complete::{tag, tag_no_case, take_until};
+    pub(super) use nom::bytes::complete::{tag, tag_no_case, take_until, take_while1};
     pub(super) use nom::character::complete::{alpha1, space0, space1};
     pub(super) use nom::combinator::{all_consuming, eof, map, opt, recognize, rest, value};
     pub(super) use nom::multi::{many0, separated_list1};

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2980,10 +2980,8 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
     // engine has no dedicated target filter for "players who last chose <word>",
     // but this is still a player-scoped rule-static subject and must not cause
     // the embedded predicate to fall through to `static_structure`.
-    if let Some(rest) = tp.lower.strip_prefix("each player who last chose ") {
-        if !rest.trim().is_empty() {
-            return Some(TargetFilter::Player);
-        }
+    if parse_each_player_who_last_chose_subject(tp.lower).is_ok() {
+        return Some(TargetFilter::Player);
     }
 
     // CR 205.3 + CR 604.1: "All/Each <subtype>" universal-quantifier subject for a
@@ -3029,6 +3027,19 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
     }
 
     None
+}
+
+fn parse_each_player_who_last_chose_subject(input: &str) -> OracleResult<'_, ()> {
+    use nom::bytes::complete::take_while1;
+
+    value(
+        (),
+        all_consuming(preceded(
+            tag("each player who last chose "),
+            take_while1(|c: char| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '\'')),
+        )),
+    )
+    .parse(input)
 }
 
 pub(crate) fn parse_rule_static_predicate(text: &str) -> Option<RuleStaticPredicate> {

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2976,6 +2976,16 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
         return Some(TargetFilter::Player);
     }
 
+    // Planechase planar die choice wording (Two Streams Facility): the current
+    // engine has no dedicated target filter for "players who last chose <word>",
+    // but this is still a player-scoped rule-static subject and must not cause
+    // the embedded predicate to fall through to `static_structure`.
+    if let Some(rest) = tp.lower.strip_prefix("each player who last chose ") {
+        if !rest.trim().is_empty() {
+            return Some(TargetFilter::Player);
+        }
+    }
+
     // CR 205.3 + CR 604.1: "All/Each <subtype>" universal-quantifier subject for a
     // rule-static grant (e.g. "All Slivers have shroud"). Strip the quantifier and
     // delegate to parse_type_phrase (mirroring parse_target), so the subtype filter

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3030,8 +3030,6 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
 }
 
 fn parse_each_player_who_last_chose_subject(input: &str) -> OracleResult<'_, ()> {
-    use nom::bytes::complete::take_while1;
-
     value(
         (),
         all_consuming(preceded(

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2976,14 +2976,6 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
         return Some(TargetFilter::Player);
     }
 
-    // Planechase planar die choice wording (Two Streams Facility): the current
-    // engine has no dedicated target filter for "players who last chose <word>",
-    // but this is still a player-scoped rule-static subject and must not cause
-    // the embedded predicate to fall through to `static_structure`.
-    if parse_each_player_who_last_chose_subject(tp.lower).is_ok() {
-        return Some(TargetFilter::Player);
-    }
-
     // CR 205.3 + CR 604.1: "All/Each <subtype>" universal-quantifier subject for a
     // rule-static grant (e.g. "All Slivers have shroud"). Strip the quantifier and
     // delegate to parse_type_phrase (mirroring parse_target), so the subtype filter
@@ -3027,17 +3019,6 @@ pub(crate) fn parse_rule_static_subject_filter(subject: &str) -> Option<TargetFi
     }
 
     None
-}
-
-fn parse_each_player_who_last_chose_subject(input: &str) -> OracleResult<'_, ()> {
-    value(
-        (),
-        all_consuming(preceded(
-            tag("each player who last chose "),
-            take_while1(|c: char| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '\'')),
-        )),
-    )
-    .parse(input)
 }
 
 pub(crate) fn parse_rule_static_predicate(text: &str) -> Option<RuleStaticPredicate> {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7461,12 +7461,20 @@ fn static_play_two_additional_lands() {
     let def =
         parse_static_line("You may play two additional lands on each of your turns.").unwrap();
     assert_eq!(def.mode, StaticMode::AdditionalLandDrop { count: 2 });
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert_eq!(tf.controller, Some(ControllerRef::You)),
+        other => panic!("two-additional land static must affect controller only, got {other:?}"),
+    }
 }
 
 #[test]
 fn static_play_any_number_of_lands() {
     let def = parse_static_line("You may play any number of lands on each of your turns.").unwrap();
     assert_eq!(def.mode, StaticMode::AdditionalLandDrop { count: u8::MAX });
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert_eq!(tf.controller, Some(ControllerRef::You)),
+        other => panic!("any-number land static must affect controller only, got {other:?}"),
+    }
 }
 
 #[test]
@@ -7480,10 +7488,14 @@ fn fastbond_first_line_is_static_not_targeted_play_effect() {
     );
 
     assert!(
-        parsed
-            .statics
-            .iter()
-            .any(|def| def.mode == (StaticMode::AdditionalLandDrop { count: u8::MAX })),
+        parsed.statics.iter().any(|def| {
+            def.mode == (StaticMode::AdditionalLandDrop { count: u8::MAX })
+                && matches!(
+                    &def.affected,
+                    Some(TargetFilter::Typed(tf))
+                        if tf.controller == Some(ControllerRef::You)
+                )
+        }),
         "Fastbond must parse its land-play permission as a static ability, got {:?}",
         parsed.statics
     );

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6442,18 +6442,13 @@ fn static_each_player_may_play_an_additional_land() {
 }
 
 #[test]
-fn static_anchor_choice_player_may_play_an_additional_land() {
-    let def = parse_static_line(
-        "Each player who last chose green anchor may play an additional land during each of their turns.",
-    )
-    .unwrap();
-    assert_eq!(def.mode, StaticMode::MayPlayAdditionalLand);
-    assert_eq!(def.affected, Some(TargetFilter::Player));
-    assert_eq!(
-        def.description.as_deref(),
-        Some(
-            "Each player who last chose green anchor may play an additional land during each of their turns."
+fn static_anchor_choice_land_drop_stays_unsupported_until_choice_filter_exists() {
+    assert!(
+        parse_static_line(
+            "Each player who last chose green anchor may play an additional land during each of their turns.",
         )
+        .is_none(),
+        "chosen-word player subjects must not be widened to all players"
     );
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6442,6 +6442,22 @@ fn static_each_player_may_play_an_additional_land() {
 }
 
 #[test]
+fn static_anchor_choice_player_may_play_an_additional_land() {
+    let def = parse_static_line(
+        "Each player who last chose green anchor may play an additional land during each of their turns.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::MayPlayAdditionalLand);
+    assert_eq!(def.affected, Some(TargetFilter::Player));
+    assert_eq!(
+        def.description.as_deref(),
+        Some(
+            "Each player who last chose green anchor may play an additional land during each of their turns."
+        )
+    );
+}
+
+#[test]
 fn static_you_may_choose_not_to_untap_self() {
     let def =
         parse_static_line("You may choose not to untap this creature during your untap step.")

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -7448,6 +7448,40 @@ fn static_play_two_additional_lands() {
 }
 
 #[test]
+fn static_play_any_number_of_lands() {
+    let def = parse_static_line("You may play any number of lands on each of your turns.").unwrap();
+    assert_eq!(def.mode, StaticMode::AdditionalLandDrop { count: u8::MAX });
+}
+
+#[test]
+fn fastbond_first_line_is_static_not_targeted_play_effect() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "You may play any number of lands on each of your turns.\nWhenever you play a land, if it wasn't the first land you played this turn, this enchantment deals 1 damage to you.",
+        "Fastbond",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    assert!(
+        parsed
+            .statics
+            .iter()
+            .any(|def| def.mode == (StaticMode::AdditionalLandDrop { count: u8::MAX })),
+        "Fastbond must parse its land-play permission as a static ability, got {:?}",
+        parsed.statics
+    );
+    assert!(
+        !parsed
+            .abilities
+            .iter()
+            .any(|ability| matches!(*ability.effect, Effect::CastFromZone { .. })),
+        "Fastbond must not ask for a target by lowering the static land-play permission to CastFromZone, got {:?}",
+        parsed.abilities
+    );
+}
+
+#[test]
 fn parse_compound_static_counter_minimum_variants() {
     // "a" counter variant
     let text =

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -303,12 +303,13 @@ fn detect_optional_you_may(
         // allow-noncombinator: swallow detector marker scan on classified text
         return;
     }
-    // CR 305.2: "you may play additional lands" is encoded as
-    // `StaticMode::MayPlayAdditionalLand`, which is an optional permission
-    // static, not a def-level optional effect.
+    // CR 305.2: "you may play additional lands" / "any number of lands" is
+    // encoded as a land-drop static, which is an optional permission static,
+    // not a def-level optional effect.
     // allow-noncombinator: swallow detector marker scan on classified text
     if cleaned.contains("you may play") // allow-noncombinator: swallow detector marker scan on classified text
-        && cleaned.contains("additional land")
+        && (cleaned.contains("additional land") // allow-noncombinator: swallow detector marker scan on classified text
+            || cleaned.contains("any number of lands"))
     // allow-noncombinator: swallow detector marker scan on classified text
     {
         return;
@@ -598,6 +599,7 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             | StaticMode::MayLookAtFaceDown
             | StaticMode::MayChooseNotToUntap
             | StaticMode::MayPlayAdditionalLand
+            | StaticMode::AdditionalLandDrop { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
             // CR 702.8: "You may cast this spell as though it had flash" —
             // opt-in cast-timing permission.
@@ -3215,6 +3217,27 @@ mod tests {
             &["Instant"],
         );
 
+        assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
+    }
+
+    #[test]
+    fn optional_you_may_accepts_any_number_land_drop_static() {
+        let parsed = parse_named(
+            "You may play any number of lands on each of your turns.\n\
+             Whenever you play a land, if it wasn't the first land you played this turn, \
+             this enchantment deals 1 damage to you.",
+            "Fastbond",
+            &["Enchantment"],
+        );
+
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .any(|s| s.mode == (StaticMode::AdditionalLandDrop { count: u8::MAX })),
+            "expected Fastbond land-drop permission to parse as a static, got: {:#?}",
+            parsed.statics
+        );
         assert!(!has_swallowed_detector(&parsed, "Optional_YouMay"));
     }
 


### PR DESCRIPTION
## Summary
- classify "play any number of lands" as a static ability phrase
- lower that wording to `AdditionalLandDrop { count: u8::MAX }` instead of `CastFromZone`
- add parser regressions for the static line and full Fastbond oracle text

Fixes #786

## Tests
- cargo test -p engine static_play_any_number_of_lands -- --nocapture
- cargo test -p engine fastbond_first_line_is_static_not_targeted_play_effect -- --nocapture