### PR TITLE
Fix counter-cost token counts

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -8401,11 +8401,12 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, Comparator, ControllerRef, Effect, FilterProp,
-        PtStat, PtValueScope, QuantityExpr, ReplacementDefinition, ReplacementMode,
+        PtStat, PtValue, PtValueScope, QuantityExpr, ReplacementDefinition, ReplacementMode,
         StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
+    use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::identifiers::CardId;
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::replacements::ReplacementEvent;
@@ -10898,6 +10899,103 @@ mod tests {
         assert_eq!(chosen_x, Some(2));
         assert_eq!(state.objects[&squirrel_a].zone, Zone::Graveyard);
         assert_eq!(state.objects[&squirrel_b].zone, Zone::Graveyard);
+    }
+
+    #[test]
+    fn remove_counter_cost_count_feeds_that_many_token_count() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Counter Cost Source".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.counters.insert(CounterType::Plus1Plus1, 3);
+        }
+
+        let token_effect = Effect::Token {
+            name: "Insect".to_string(),
+            power: PtValue::Fixed(1),
+            toughness: PtValue::Fixed(1),
+            types: vec!["Creature".to_string(), "Insect".to_string()],
+            colors: vec![ManaColor::Green],
+            keywords: vec![],
+            tapped: false,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+            owner: TargetFilter::Controller,
+            attach_to: None,
+            enters_attacking: false,
+            supertypes: vec![],
+            static_abilities: vec![],
+            enter_with_counters: vec![],
+        };
+
+        state.objects.get_mut(&source).unwrap().abilities = Arc::new(vec![AbilityDefinition::new(
+            AbilityKind::Activated,
+            token_effect.clone(),
+        )]);
+
+        let mut pending = make_pending(source);
+        pending.ability = ResolvedAbility::new(token_effect, Vec::new(), source, PlayerId(0));
+        pending.ability.set_chosen_x_recursive(2);
+        let legal = vec![source];
+        let chosen = vec![source];
+        let mut events = Vec::new();
+
+        handle_remove_counter_for_cost(
+            &mut state,
+            PlayerId(0),
+            pending,
+            2,
+            CounterMatch::OfType(CounterType::Plus1Plus1),
+            CounterCostSelection::SingleObject,
+            &legal,
+            &chosen,
+            &mut events,
+        )
+        .expect("remove-counter activation cost should be paid");
+
+        let Some(stack_entry) = state.stack.back() else {
+            panic!("activated ability should be pushed to the stack");
+        };
+        let chosen_x = match &stack_entry.kind {
+            StackEntryKind::ActivatedAbility { ability, .. } => ability.chosen_x,
+            other => panic!("expected activated ability on stack, got {other:?}"),
+        };
+        assert_eq!(chosen_x, Some(2));
+
+        super::stack::resolve_top(&mut state, &mut events);
+
+        let insects = state
+            .objects
+            .values()
+            .filter(|obj| {
+                obj.zone == Zone::Battlefield
+                    && obj.name == "Insect"
+                    && obj
+                        .card_types
+                        .subtypes
+                        .iter()
+                        .any(|subtype| subtype == "Insect")
+            })
+            .count();
+        assert_eq!(
+            insects, 2,
+            "that many must resolve to counters removed as a cost"
+        );
+        assert_eq!(
+            state.objects[&source]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied(),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2293,6 +2293,11 @@ fn resolve_ref(
             })
             .or(state.last_effect_count)
             .or(state.last_effect_amount)
+            // CR 107.3a + CR 601.2b + CR 602.2b: If "that many" has no live
+            // trigger/effect context, it may refer to the variable count chosen
+            // for the spell or activated ability's cost (for example, "Remove
+            // any number of counters: Create that many tokens.").
+            .or_else(|| chosen_x.map(u32_to_i32_saturating))
             // CR 603.10 + CR 608.2h + CR 122.2: A "leaves the battlefield / dies,
             // if it had one or more <X> counters on it, put that many <X> counters
             // on …" look-back (Reyhan, Last of the Abzan) resolves "that many" to


### PR DESCRIPTION
Model: codex-5
Thinking: medium
Tier: Standard

## Summary
- Fix `EventContextAmount` so "that many" can fall back to the resolving ability's announced `chosen_x` when no trigger/effect amount exists.
- Add a runtime regression for remove-counter activation costs creating that many tokens.
- Fixes #4219.

## Anchored on
- crates/engine/src/game/quantity.rs:2257 — existing `EventContextAmount` fallback chain for trigger/effect-derived quantities.
- crates/engine/src/game/quantity.rs:2859 — existing quantity resolution fallback from persisted X to `ResolvedAbility::chosen_x`.
- crates/engine/src/game/casting_costs.rs:10814 — existing variable-cost runtime test that verifies chosen X survives onto the activated ability stack entry.

## Rules
- CR 107.3a: X for spells and activated abilities is chosen/announced as part of casting or activation.
- CR 601.2b + CR 602.2b: activated abilities use the spell-casting announcement flow for variable costs.

## Gate A
`./scripts/check-parser-combinators.sh`

Passed. Full output was empty.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p engine game::casting_costs::tests::remove_counter_cost_count_feeds_that_many_token_count`
- `cargo clippy-strict`
- `git diff --check`

## Notes
- No parser changes.
- No frontend changes.