### PR TITLE
feat(engine): static cost reduction for plot/unlock + dynamic activated-ability cost (S21)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -49116,6 +49116,297 @@ mod tests {
         }
     }
 
+    /// CR 601.2f + CR 208.1 + CR 113.7: End-to-end activation of an
+    /// Agatha-reduced creature ability through the PRODUCTION activation entry
+    /// (`GameAction::ActivateAbility` → `handle_activate_ability` →
+    /// `apply_cost_reduction`). Unlike
+    /// `agatha_dynamic_power_reduces_controlled_creature_ability_cost` (which
+    /// calls `apply_cost_reduction` directly), this proves the RUNTIME path —
+    /// the production seam the maintainer flagged — actually charges the reduced
+    /// cost when paying mana.
+    ///
+    /// Agatha of the Vile Cauldron (power 3) carries the dynamic
+    /// `ReduceAbilityCost { keyword: "activated", amount: 1, dynamic_count:
+    /// Power(Source) }` static; a creature P0 controls has a {4}-generic
+    /// activated ability. The reduction is 1 × 3 = 3, so the production path must
+    /// charge {1}.
+    ///
+    /// Discriminating (insufficient full-cost / sufficient reduced-cost mana):
+    ///   - WITH Agatha + exactly {1} in pool → activation SUCCEEDS, the {1}
+    ///     reduced cost drains the pool, and the ability reaches the stack.
+    ///   - WITHOUT Agatha + the SAME {1} → the full {4} is unaffordable, so the
+    ///     production path returns `Err` and spends no mana. Agatha's presence is
+    ///     the only delta, so a regression that dropped `apply_cost_reduction`
+    ///     from the activation seam would make the positive case fail identically
+    ///     (`auto_tap_and_pay_cost_excluding` rejects the unreduced {4}).
+    #[test]
+    fn agatha_reduced_creature_ability_activates_via_production_path() {
+        use crate::types::ability::{
+            Effect, ObjectScope, QuantityExpr, QuantityRef, StaticDefinition, TargetFilter,
+            TypedFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        // Builds a game with a P0 creature whose {4}-generic activated ability
+        // (no tap → no CR 302.6 summoning-sickness gate) is index 0, optionally
+        // with Agatha of the Vile Cauldron + her dynamic reduction static on the
+        // battlefield. Returns (state, creature id).
+        let build = |with_agatha: bool| -> (GameState, ObjectId) {
+            let mut state = setup_game_at_main_phase();
+
+            if with_agatha {
+                let agatha = create_object(
+                    &mut state,
+                    CardId(1),
+                    PlayerId(0),
+                    "Agatha of the Vile Cauldron".to_string(),
+                    Zone::Battlefield,
+                );
+                let statics = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Reduce,
+                    keyword: "activated".to_string(),
+                    amount: 1,
+                    minimum_mana: Some(1),
+                    dynamic_count: Some(QuantityRef::Power {
+                        scope: ObjectScope::Source,
+                    }),
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::You),
+                ))];
+                let obj = state.objects.get_mut(&agatha).unwrap();
+                obj.card_types
+                    .core_types
+                    .push(crate::types::card_type::CoreType::Creature);
+                // Set BASE power/statics too: the layer flush during cost payment
+                // resets `power = base_power` and `static_definitions =
+                // base_static_definitions`. Without bases set, the flush would
+                // zero Agatha's power (collapsing the dynamic multiplier to 0)
+                // and erase her static.
+                obj.power = Some(3);
+                obj.base_power = Some(3);
+                obj.toughness = Some(1);
+                obj.base_toughness = Some(1);
+                obj.base_static_definitions = Arc::new(statics.clone());
+                obj.static_definitions = statics.into();
+            }
+
+            let creature = create_object(
+                &mut state,
+                CardId(2),
+                PlayerId(0),
+                "Some Creature".to_string(),
+                Zone::Battlefield,
+            );
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic: 4,
+                },
+            });
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            // Set live + base abilities — the flush rebuilds `abilities` from
+            // `base_abilities` for battlefield permanents.
+            *Arc::make_mut(&mut obj.abilities) = vec![def.clone()];
+            *Arc::make_mut(&mut obj.base_abilities) = vec![def];
+
+            (state, creature)
+        };
+
+        // WITH Agatha: {4} → {1}; exactly {1} mana funds the reduced cost.
+        let (mut state, creature) = build(true);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: creature,
+                ability_index: 0,
+            },
+        )
+        .expect("Agatha-reduced {4}->{1} ability must activate with exactly {1} mana");
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "the production path charged the reduced {{1}}, draining the pool"
+        );
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "the reduced activation reached the stack"
+        );
+
+        // WITHOUT Agatha: the SAME {1} mana, but the full {4} is unaffordable.
+        let (mut state, creature) = build(false);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let result = apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: creature,
+                ability_index: 0,
+            },
+        );
+        assert!(
+            result.is_err(),
+            "without Agatha the full {{4}} cost is unaffordable with only {{1}} mana"
+        );
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            1,
+            "a failed activation spends no mana"
+        );
+        assert_eq!(
+            state.stack.len(),
+            0,
+            "a failed activation puts nothing on the stack"
+        );
+    }
+
+    /// CR 116.2k + CR 702.170 + CR 118.7a: End-to-end activation of a Doc
+    /// Aurlock-reduced SYNTHESIZED plot special action through the PRODUCTION
+    /// activation entry (`GameAction::ActivateAbility` → `handle_activate_ability`
+    /// → `apply_cost_reduction` → `reduce_special_action_in_ability_cost`).
+    /// Unlike `doc_aurlock_reduces_plot_special_action_cost` (which calls
+    /// `apply_cost_reduction` on a hand-built ability), the plot ability here is
+    /// produced by the production synthesizer `synthesize_plot`, so the exact
+    /// synthesized `Composite { Mana, Exile(self from hand) }` shape is paid by
+    /// the runtime seam.
+    ///
+    /// Doc Aurlock carries `ReduceActionCost { action: Plot, amount: 2 }`. A hand
+    /// card with `Plot {3}` synthesizes a {3}-generic plot cost; the reduction
+    /// must charge {1}.
+    ///
+    /// Discriminating (insufficient full-cost / sufficient reduced-cost mana):
+    ///   - WITH Doc Aurlock + exactly {1} in pool → the plot activation SUCCEEDS:
+    ///     the card moves Hand → Exile (the self-exile cost is paid) and the {1}
+    ///     reduced cost drains the pool.
+    ///   - WITHOUT Doc Aurlock + the SAME {1} → the full {3} plot cost is
+    ///     unaffordable, so the production path returns `Err`, the card stays in
+    ///     hand, and no mana is spent. Doc Aurlock's presence is the only delta.
+    #[test]
+    fn doc_aurlock_reduced_plot_activates_via_production_path() {
+        use crate::database::synthesis::synthesize_plot;
+        use crate::types::ability::StaticDefinition;
+        use crate::types::card::CardFace;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        // Builds a game with a P0 hand card carrying a synthesized `Plot {3}`
+        // activation (index 0), optionally with Doc Aurlock + his plot
+        // cost-reduction static on the battlefield. Returns (state, plot card id).
+        let build = |with_doc: bool| -> (GameState, ObjectId) {
+            let mut state = setup_game_at_main_phase();
+
+            if with_doc {
+                let doc = create_object(
+                    &mut state,
+                    CardId(1),
+                    PlayerId(0),
+                    "Doc Aurlock, Grizzled Genius".to_string(),
+                    Zone::Battlefield,
+                );
+                let statics = vec![StaticDefinition::new(StaticMode::ReduceActionCost {
+                    action: SpecialAction::Plot,
+                    mode: CostModifyMode::Reduce,
+                    amount: 2,
+                })];
+                let obj = state.objects.get_mut(&doc).unwrap();
+                obj.card_types
+                    .core_types
+                    .push(crate::types::card_type::CoreType::Creature);
+                obj.base_static_definitions = Arc::new(statics.clone());
+                obj.static_definitions = statics.into();
+            }
+
+            // Produce the plot activation from a fresh CardFace via the
+            // production synthesizer so the exact synthesized cost shape is used.
+            let mut face = CardFace::default();
+            face.keywords.push(Keyword::Plot(ManaCost::Cost {
+                shards: vec![],
+                generic: 3,
+            }));
+            synthesize_plot(&mut face);
+
+            let plot_card = create_object(
+                &mut state,
+                CardId(2),
+                PlayerId(0),
+                "Plotted Card".to_string(),
+                Zone::Hand,
+            );
+            let obj = state.objects.get_mut(&plot_card).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.keywords = face.keywords.clone();
+            obj.base_keywords = face.keywords.clone();
+            *Arc::make_mut(&mut obj.abilities) = face.abilities.clone();
+            *Arc::make_mut(&mut obj.base_abilities) = face.abilities.clone();
+
+            (state, plot_card)
+        };
+
+        // WITH Doc Aurlock: {3} → {1}; exactly {1} mana funds the reduced cost.
+        let (mut state, plot_card) = build(true);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: plot_card,
+                ability_index: 0,
+            },
+        )
+        .expect("Doc-Aurlock-reduced {3}->{1} plot must activate with exactly {1} mana");
+        assert_eq!(
+            state.objects[&plot_card].zone,
+            Zone::Exile,
+            "the synthesized plot self-exile cost moved the card Hand -> Exile"
+        );
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "the production path charged the reduced {{1}} plot cost"
+        );
+
+        // WITHOUT Doc Aurlock: the SAME {1} mana, but the full {3} is unaffordable.
+        let (mut state, plot_card) = build(false);
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+        let result = apply_as_current(
+            &mut state,
+            GameAction::ActivateAbility {
+                source_id: plot_card,
+                ability_index: 0,
+            },
+        );
+        assert!(
+            result.is_err(),
+            "without Doc Aurlock the full {{3}} plot cost is unaffordable with only {{1}} mana"
+        );
+        assert_eq!(
+            state.objects[&plot_card].zone,
+            Zone::Hand,
+            "a failed plot activation leaves the card in hand"
+        );
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            1,
+            "a failed plot activation spends no mana"
+        );
+    }
+
     /// CR 118.7 + CR 702.6a: Firion, Wild Rose Warrior's granted equip-cost
     /// reduction — "This Equipment's equip abilities cost {2} less to activate."
     /// (`mode: Reduce`, keyword `"equip"`, `SelfRef`).

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -18,7 +18,7 @@ use crate::types::game_state::{
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
 use crate::types::mana::{
-    ManaColor, ManaCost, ManaCostShard, ManaSpellGrant, PaymentContext, SpellMeta,
+    ManaColor, ManaCost, ManaCostShard, ManaSpellGrant, PaymentContext, SpecialAction, SpellMeta,
 };
 use crate::types::player::PlayerId;
 use crate::types::statics::{
@@ -13732,6 +13732,17 @@ fn apply_cost_reduction(
     }
 
     apply_static_activated_ability_cost_reduction(state, ability_def, source_id);
+
+    // CR 116.2k + CR 702.170: Plot is taken as a special action via a synthesized
+    // hand activation whose effect grants the `Plotted` casting permission. Its
+    // mana cost is reduced by `ReduceActionCost { action: Plot }` statics (Doc
+    // Aurlock) — the dedicated special-action axis, distinct from the generic
+    // activated-ability reducer above (plot payments carry no `AbilityTag`).
+    if is_plot_special_action(ability_def) {
+        if let Some(cost) = ability_def.cost.as_mut() {
+            reduce_special_action_in_ability_cost(state, player, SpecialAction::Plot, cost);
+        }
+    }
 }
 
 fn apply_static_activated_ability_cost_reduction(
@@ -13757,7 +13768,7 @@ fn apply_static_activated_ability_cost_reduction(
             keyword,
             amount,
             minimum_mana,
-            ..
+            dynamic_count,
         } = &def.mode
         else {
             continue;
@@ -13775,17 +13786,133 @@ fn apply_static_activated_ability_cost_reduction(
         }) {
             continue;
         }
+        // CR 601.2f + CR 208.1 + CR 113.7: When `dynamic_count` is present the
+        // per-unit `amount` is multiplied by the resolved quantity (Agatha of
+        // the Vile Cauldron: amount 1 × ~'s power). Resolve against the static's
+        // own source so "~'s power" reads Agatha's post-layer power. Mirrors the
+        // dynamic-count multiply in `keywords::apply_ability_cost_reduction`.
+        let multiplier = dynamic_count.as_ref().map_or(1u32, |qty_ref| {
+            let expr = crate::types::ability::QuantityExpr::Ref {
+                qty: qty_ref.clone(),
+            };
+            super::quantity::resolve_quantity(
+                state,
+                &expr,
+                static_source.controller,
+                static_source.id,
+            )
+            .max(0) as u32
+        });
+        let effective = amount.saturating_mul(multiplier);
         // CR 118.7: Apply the adjustment in the static's direction. `Reduce`
         // subtracts generic mana (honoring the optional one-mana floor);
         // `Raise` adds generic mana (Skyseer's Chariot). `Minimum` is not
         // emitted for activated-ability statics and is treated as a no-op.
         match mode {
             CostModifyMode::Reduce => {
-                reduce_generic_in_cost_with_minimum_mana(cost, *amount, minimum_mana.unwrap_or(0));
+                reduce_generic_in_cost_with_minimum_mana(
+                    cost,
+                    effective,
+                    minimum_mana.unwrap_or(0),
+                );
             }
-            CostModifyMode::Raise => increase_generic_in_cost(cost, *amount),
+            CostModifyMode::Raise => increase_generic_in_cost(cost, effective),
             CostModifyMode::Minimum => {}
         }
+    }
+}
+
+/// CR 116.2 + CR 118.7a: Reduce (or raise) the generic mana of a special
+/// action's cost by the net adjustment of `player`'s active
+/// `ReduceActionCost { action }` statics.
+///
+/// Single authority for plot (CR 116.2k / 702.170 — Doc Aurlock) and Room-door
+/// unlock (CR 116.2m / 709.5e — Inquisitive Glimmer) special-action cost
+/// reduction: both the plot activation path (`reduce_special_action_in_ability_cost`)
+/// and `engine::handle_unlock_room_door` delegate here rather than inlining the
+/// scan. CR 109.5: "your" plot / "you pay" unlock scopes to the static's
+/// controller, so only statics controlled by `player` apply. CR 118.7a:
+/// generic mana only — colored/colorless components are untouched.
+pub(crate) fn apply_special_action_cost_reduction(
+    state: &GameState,
+    player: PlayerId,
+    action: SpecialAction,
+    mut cost: ManaCost,
+) -> ManaCost {
+    // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
+    for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
+        if bf_obj.controller != player {
+            continue;
+        }
+        let StaticMode::ReduceActionCost {
+            action: static_action,
+            mode,
+            amount,
+        } = &def.mode
+        else {
+            continue;
+        };
+        if *static_action != action || *amount == 0 {
+            continue;
+        }
+        if let ManaCost::Cost {
+            ref mut generic, ..
+        } = cost
+        {
+            match mode {
+                CostModifyMode::Reduce => *generic = generic.saturating_sub(*amount),
+                CostModifyMode::Raise => *generic = generic.saturating_add(*amount),
+                // CR 116.2: Minimum is not emitted for special-action costs.
+                CostModifyMode::Minimum => {}
+            }
+        }
+    }
+    cost
+}
+
+/// CR 702.170a: True when `ability_def` is the synthesized plot special action —
+/// its effect grants the `Plotted` casting permission (see `synthesize_plot`).
+/// Used to apply `ReduceActionCost { action: Plot }` reductions to the plot
+/// mana cost without conflating plot with generic activated-ability reducers.
+fn is_plot_special_action(ability_def: &AbilityDefinition) -> bool {
+    matches!(
+        &*ability_def.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::Plotted { .. },
+            ..
+        }
+    )
+}
+
+/// CR 116.2 + CR 118.7a: Apply a special-action cost reduction to the mana
+/// sub-cost(s) of an `AbilityCost`. The plot activation's cost is a `Composite`
+/// wrapping the plot mana cost alongside the self-exile cost; this walks to the
+/// `Mana` component and delegates the generic-mana adjustment to the
+/// single-authority `apply_special_action_cost_reduction`.
+fn reduce_special_action_in_ability_cost(
+    state: &GameState,
+    player: PlayerId,
+    action: SpecialAction,
+    cost: &mut AbilityCost,
+) {
+    match cost {
+        AbilityCost::Mana { cost: mana } => {
+            let reduced = apply_special_action_cost_reduction(
+                state,
+                player,
+                action,
+                std::mem::replace(mana, ManaCost::NoCost),
+            );
+            *mana = reduced;
+        }
+        AbilityCost::Composite { costs } => {
+            for sub in costs.iter_mut() {
+                if matches!(sub, AbilityCost::Mana { .. }) {
+                    reduce_special_action_in_ability_cost(state, player, action, sub);
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -48727,6 +48854,266 @@ mod tests {
             3,
             "a source without the chosen name must not be taxed"
         );
+    }
+
+    /// CR 601.2f + CR 208.1 + CR 113.7: Agatha of the Vile Cauldron — "Activated
+    /// abilities of creatures you control cost {X} less to activate, where X is
+    /// ~'s power. ... can't reduce ... less than one mana." The reduction is
+    /// dynamic: 1 × the static source's power, floored to keep one mana.
+    ///
+    /// Drives the production seam `apply_cost_reduction` (reached by
+    /// `can_activate_ability` and the activation path). Discriminating:
+    ///   - Agatha at power 3, a controlled creature's {7} ability → {4}
+    ///     (reduce by exactly 3). Reverting the casting.rs `dynamic_count`
+    ///     destructure (back to `..`) defaults the multiplier to 1, reducing
+    ///     only by {1} → {6}, flipping this assertion.
+    ///   - Agatha at power 0 → no reduction ({7}). Pins the multiplier is read.
+    ///   - The one-mana floor caps the reduction: power 5 on a {4} ability → {1}.
+    #[test]
+    fn agatha_dynamic_power_reduces_controlled_creature_ability_cost() {
+        use crate::types::ability::{
+            Effect, ObjectScope, QuantityRef, StaticDefinition, TargetFilter, TypedFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let mut state = GameState::new_two_player(7);
+
+        // Agatha carries the dynamic reduction static and starts at power 3.
+        let agatha = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Agatha of the Vile Cauldron".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&agatha).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.power = Some(3);
+            obj.toughness = Some(1);
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
+                keyword: "activated".to_string(),
+                amount: 1,
+                minimum_mana: Some(1),
+                dynamic_count: Some(QuantityRef::Power {
+                    scope: ObjectScope::Source,
+                }),
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))]
+            .into();
+        }
+
+        // A separate controlled creature whose activated ability is being reduced.
+        let creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Some Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+
+        let make_def = |generic: u32| {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "ability".to_string(),
+                    description: None,
+                },
+            );
+            def.cost = Some(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![],
+                    generic,
+                },
+            });
+            def
+        };
+        let generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => *generic,
+            other => panic!("expected Mana cost, got {other:?}"),
+        };
+
+        // Power 3: {7} → reduce by 1 × 3 = 3 → {4} (floor not reached).
+        let mut def = make_def(7);
+        apply_cost_reduction(&state, &mut def, PlayerId(0), creature);
+        assert_eq!(
+            generic_of(&def),
+            4,
+            "Agatha (power 3) reduces a {{7}} ability by exactly {{3}}"
+        );
+
+        // Power 0: no reduction.
+        state.objects.get_mut(&agatha).unwrap().power = Some(0);
+        let mut def0 = make_def(7);
+        apply_cost_reduction(&state, &mut def0, PlayerId(0), creature);
+        assert_eq!(
+            generic_of(&def0),
+            7,
+            "Agatha at power 0 grants no reduction"
+        );
+
+        // Power 5 on a {4} ability: the one-mana floor caps the reduction at {3}.
+        state.objects.get_mut(&agatha).unwrap().power = Some(5);
+        let mut def_floor = make_def(4);
+        apply_cost_reduction(&state, &mut def_floor, PlayerId(0), creature);
+        assert_eq!(
+            generic_of(&def_floor),
+            1,
+            "the one-mana floor keeps the {{4}} ability at {{1}} even at power 5"
+        );
+    }
+
+    /// CR 116.2k + CR 702.170 + CR 118.7a: Doc Aurlock, Grizzled Genius —
+    /// "Plotting cards from your hand costs {2} less." The dedicated
+    /// `ReduceActionCost { action: Plot }` axis reduces the generic component of
+    /// the plot special action's mana cost in `apply_cost_reduction` when the
+    /// activated ability is the synthesized plot action (effect grants the
+    /// `Plotted` casting permission).
+    ///
+    /// Drives the production seam `apply_cost_reduction`. Discriminating:
+    ///   - A {3}-generic plot cost drops to {1} with Doc Aurlock out. Reverting
+    ///     the plot hook leaves it at {3}.
+    ///   - The {2} reduction floors at {0} (a {1} plot cost → {0}).
+    ///   - A non-plot activated ability (no `Plotted` grant) is untouched.
+    #[test]
+    fn doc_aurlock_reduces_plot_special_action_cost() {
+        use crate::types::ability::{
+            CastingPermission, Effect, PermissionGrantee, StaticDefinition, TargetFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let mut state = GameState::new_two_player(7);
+
+        // Doc Aurlock carries the plot cost-reduction static.
+        let doc = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Doc Aurlock, Grizzled Genius".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&doc).unwrap();
+            obj.card_types
+                .core_types
+                .push(crate::types::card_type::CoreType::Creature);
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceActionCost {
+                action: SpecialAction::Plot,
+                mode: CostModifyMode::Reduce,
+                amount: 2,
+            })]
+            .into();
+        }
+
+        // A card in hand whose synthesized plot activation is being reduced.
+        let plot_card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Plotted Card".to_string(),
+            Zone::Hand,
+        );
+
+        let make_plot_def = |generic: u32| {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::Plotted { turn_plotted: 0 },
+                    target: TargetFilter::SelfRef,
+                    grantee: PermissionGrantee::AbilityController,
+                },
+            );
+            def.cost = Some(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![],
+                            generic,
+                        },
+                    },
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: Some(Zone::Hand),
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            });
+            def.activation_zone = Some(Zone::Hand);
+            def
+        };
+        let plot_generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Composite { costs } => costs
+                .iter()
+                .find_map(|c| match c {
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost { generic, .. },
+                    } => Some(*generic),
+                    _ => None,
+                })
+                .expect("composite plot cost has a mana sub-cost"),
+            other => panic!("expected composite cost, got {other:?}"),
+        };
+
+        // {3} plot cost → {1}.
+        let mut def3 = make_plot_def(3);
+        apply_cost_reduction(&state, &mut def3, PlayerId(0), plot_card);
+        assert_eq!(
+            plot_generic_of(&def3),
+            1,
+            "Doc Aurlock reduces a {{3}} plot cost to {{1}}"
+        );
+
+        // {1} plot cost → {0} (CR 118.7: a reduction can't take a cost below {0}).
+        let mut def1 = make_plot_def(1);
+        apply_cost_reduction(&state, &mut def1, PlayerId(0), plot_card);
+        assert_eq!(
+            plot_generic_of(&def1),
+            0,
+            "the {{2}} reduction floors the plot cost at {{0}}"
+        );
+
+        // A non-plot activated ability is not the plot special action → untouched.
+        let mut non_plot = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Unimplemented {
+                name: "x".to_string(),
+                description: None,
+            },
+        );
+        non_plot.cost = Some(AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                shards: vec![],
+                generic: 3,
+            },
+        });
+        apply_cost_reduction(&state, &mut non_plot, PlayerId(0), plot_card);
+        match non_plot.cost.as_ref().unwrap() {
+            AbilityCost::Mana {
+                cost: ManaCost::Cost { generic, .. },
+            } => assert_eq!(
+                *generic, 3,
+                "a non-plot ability must not be reduced by ReduceActionCost{{Plot}}"
+            ),
+            other => panic!("expected mana cost, got {other:?}"),
+        }
     }
 
     /// CR 118.7 + CR 702.6a: Firion, Wild Rose Warrior's granted equip-cost

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -56,6 +56,13 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             // permanents. Not registry-keyed (mirrors the marker cluster).
             | StaticMode::CantBecomeSuspected
             | StaticMode::ReduceAbilityCost { .. }
+            // CR 116.2 + CR 118.7a: ReduceActionCost carries `action`
+            // (SpecialAction), `mode`, and `amount`. Runtime enforcement is the
+            // special-action cost-reduction resolver
+            // (casting.rs::apply_special_action_cost_reduction), consulted at the
+            // plot activation and Room-door unlock payment sites. Not
+            // registry-keyed (SpecialAction is open value space).
+            | StaticMode::ReduceActionCost { .. }
             | StaticMode::ModifyActivationLimit { .. }
             | StaticMode::AdditionalLandDrop { .. }
             | StaticMode::ModifyCost { .. }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -128,6 +128,17 @@ fn handle_unlock_room_door(
         }
     };
 
+    // CR 116.2m + CR 118.7a: Reduce the door's generic unlock cost by the
+    // player's active `ReduceActionCost { action: UnlockDoor }` statics
+    // (Inquisitive Glimmer — "Unlock costs you pay cost {1} less") before
+    // payment. Single authority shared with the plot path.
+    let cost = casting::apply_special_action_cost_reduction(
+        state,
+        player,
+        crate::types::mana::SpecialAction::UnlockDoor,
+        cost,
+    );
+
     // CR 116.2m + CR 709.5e + CR 106.6: The unlock cost is a special action's
     // mana cost. Route payment through `PaymentContext::SpecialAction(UnlockDoor)`
     // so spend-restricted mana ("only to … unlock doors", Smoky Lounge) is
@@ -8991,6 +9002,115 @@ mod tests {
         assert_eq!(
             pool_left, 0,
             "the restricted mana must be spent on the unlock"
+        );
+    }
+
+    /// CR 116.2m + CR 709.5e + CR 118.7a: Inquisitive Glimmer — "Unlock costs
+    /// you pay cost {1} less." Reduces the generic component of a Room door's
+    /// unlock cost before payment, via the single-authority special-action
+    /// reducer shared with the plot path.
+    ///
+    /// Drives the full `apply()` pipeline (`GameAction::UnlockRoomDoor` →
+    /// `handle_unlock_room_door`). Discriminating: a {3}-generic door with
+    /// Inquisitive out is payable with only {2} in the pool (cost reduced to
+    /// {2}); WITHOUT the static the same {2} pool can't pay {3} and the unlock
+    /// errors. Reverting the engine.rs reduction line makes the with-static case
+    /// require {3} and fail.
+    #[test]
+    fn inquisitive_glimmer_reduces_room_unlock_cost() {
+        use crate::types::ability::StaticDefinition;
+        use crate::types::mana::{ManaType, ManaUnit};
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let make_state = |with_glimmer: bool| {
+            let mut state = setup_game_at_main_phase();
+            let room = create_object(
+                &mut state,
+                CardId(950),
+                PlayerId(0),
+                "Test Room".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&room).unwrap();
+                obj.card_types.subtypes.push("Room".to_string());
+                obj.room_unlocks = Some(Default::default());
+                // CR 709.5e: the left door's unlock cost is the object's mana
+                // cost — a flat {3} generic here.
+                obj.mana_cost = ManaCost::Cost {
+                    shards: vec![],
+                    generic: 3,
+                };
+            }
+            if with_glimmer {
+                let glimmer = create_object(
+                    &mut state,
+                    CardId(951),
+                    PlayerId(0),
+                    "Inquisitive Glimmer".to_string(),
+                    Zone::Battlefield,
+                );
+                let obj = state.objects.get_mut(&glimmer).unwrap();
+                obj.card_types
+                    .core_types
+                    .push(crate::types::card_type::CoreType::Creature);
+                obj.static_definitions =
+                    vec![StaticDefinition::new(StaticMode::ReduceActionCost {
+                        action: crate::types::mana::SpecialAction::UnlockDoor,
+                        mode: CostModifyMode::Reduce,
+                        amount: 1,
+                    })]
+                    .into();
+            }
+            // Fund exactly {2} of generic-payable mana.
+            {
+                let player = state
+                    .players
+                    .iter_mut()
+                    .find(|p| p.id == PlayerId(0))
+                    .unwrap();
+                for _ in 0..2 {
+                    player
+                        .mana_pool
+                        .add(ManaUnit::new(ManaType::Colorless, room, false, vec![]));
+                }
+            }
+            (state, room)
+        };
+
+        // With Inquisitive: {3} → {2}, payable with the {2} pool → door unlocks.
+        let (mut state, room) = make_state(true);
+        apply_as_current(
+            &mut state,
+            GameAction::UnlockRoomDoor {
+                object_id: room,
+                door: RoomDoor::Left,
+            },
+        )
+        .expect("reduced unlock cost ({2}) must be payable with {2} in pool");
+        assert!(
+            state
+                .objects
+                .get(&room)
+                .unwrap()
+                .room_unlocks
+                .unwrap()
+                .left_unlocked,
+            "door must unlock at the reduced cost"
+        );
+
+        // Without Inquisitive: {3} > {2} pool → unlock fails.
+        let (mut state2, room2) = make_state(false);
+        assert!(
+            apply_as_current(
+                &mut state2,
+                GameAction::UnlockRoomDoor {
+                    object_id: room2,
+                    door: RoomDoor::Left,
+                },
+            )
+            .is_err(),
+            "without the reduction the {{3}} unlock cost exceeds the {{2}} pool"
         );
     }
 

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -30,6 +30,70 @@ pub(crate) fn parse_taggable_ability_keyword(input: &str) -> OracleResult<'_, &'
     .parse(input)
 }
 
+/// CR 116.2 + CR 118.7a: Parse a special-action cost-reduction static.
+///
+/// - "Plotting cards from your hand costs {N} less" → `ReduceActionCost { action: Plot }`
+///   (Doc Aurlock, CR 116.2k / 702.170). Note the singular verb "costs".
+/// - "Unlock costs you pay cost {N} less" → `ReduceActionCost { action: UnlockDoor }`
+///   (Inquisitive Glimmer, CR 116.2m / 709.5e).
+///
+/// Composed end-to-end from nom combinators (no verbatim full-string match):
+/// each axis (subject → verb → `{N}` → direction) is its own `tag`/`alt`. The
+/// verb axis accepts both "costs" (singular) and "cost" so a future
+/// "[special action] cost{,s} you pay cost {N} less" lands without a new arm.
+/// The reduction targets generic mana only (CR 118.7a).
+pub(crate) fn parse_action_cost_reduction(text: &str, lower: &str) -> Option<StaticDefinition> {
+    let trimmed = lower.trim().trim_end_matches('.').trim_end();
+    let parsed: OracleResult<'_, (SpecialAction, CostModifyMode, u32)> = (|| {
+        let (i, action) = alt((
+            value(
+                SpecialAction::Plot,
+                tag::<_, _, OracleError<'_>>("plotting cards from your hand"),
+            ),
+            value(
+                SpecialAction::UnlockDoor,
+                tag::<_, _, OracleError<'_>>("unlock costs you pay"),
+            ),
+        ))
+        .parse(trimmed)?;
+        // CR 116.2: Doc Aurlock prints the singular verb "costs"; Inquisitive
+        // Glimmer prints "cost". Accept both as one verb axis.
+        let (i, _) = alt((
+            tag::<_, _, OracleError<'_>>(" costs "),
+            tag::<_, _, OracleError<'_>>(" cost "),
+        ))
+        .parse(i)?;
+        let (i, amount) = nom::sequence::delimited(
+            tag::<_, _, OracleError<'_>>("{"),
+            nom_primitives::parse_number,
+            tag::<_, _, OracleError<'_>>("}"),
+        )
+        .parse(i)?;
+        let (i, _) = tag::<_, _, OracleError<'_>>(" ").parse(i)?;
+        let (i, mode) = alt((
+            value(CostModifyMode::Reduce, tag::<_, _, OracleError<'_>>("less")),
+            value(CostModifyMode::Raise, tag::<_, _, OracleError<'_>>("more")),
+        ))
+        .parse(i)?;
+        Ok((i, (action, mode, amount)))
+    })();
+    let (rest, (action, mode, amount)) = parsed.ok()?;
+    // The line must be fully consumed (modulo trailing whitespace) so a longer
+    // unrelated cost clause is never silently truncated into a special-action
+    // reduction.
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(
+        StaticDefinition::new(StaticMode::ReduceActionCost {
+            action,
+            mode,
+            amount,
+        })
+        .description(text.to_string()),
+    )
+}
+
 pub(crate) fn parse_activated_cost_reduction_minimum_mana(lower: &str) -> Option<u32> {
     preceded(
         take_until::<_, _, OracleError<'_>>(

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1,4 +1,5 @@
 // CR 604 — `parse_static_line_inner` category dispatch.
+use super::super::oracle_nom::error::oracle_err;
 #[allow(unused_imports)]
 use super::prelude::*;
 #[allow(unused_imports)]
@@ -8,6 +9,56 @@ use super::{
     restriction::*, type_change::*,
 };
 use crate::types::statics::ProhibitionScope;
+
+/// CR 201.5: Consume a self-reference subject — `~` (produced by
+/// `normalize_card_name_refs` for "text that refers to the object it's on by
+/// name") or a typed self-reference phrase ("this creature", "this permanent",
+/// …). Used by dynamic referent parsing where the subject is the static's own
+/// source ("where X is ~'s power").
+fn parse_self_reference_subject(input: &str) -> OracleResult<'_, ()> {
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("~").parse(input) {
+        return Ok((rest, ()));
+    }
+    for phrase in SELF_REF_TYPE_PHRASES {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(*phrase).parse(input) {
+            return Ok((rest, ()));
+        }
+    }
+    Err(oracle_err(input))
+}
+
+/// CR 208.1 + CR 113.7: Parse the dynamic referent of a "{X} … less to activate,
+/// where X is [source]'s {power|toughness|mana value}" activated-ability cost
+/// reduction (Agatha of the Vile Cauldron — "where X is Agatha's power", which
+/// `normalize_card_name_refs` rewrites to "where X is ~'s power"). Returns the
+/// typed `QuantityRef` scoped to the static's source object (`ObjectScope::Source`),
+/// so the reduction reads the source's post-layer characteristic at
+/// cost-determination time (CR 113.7).
+fn parse_where_x_is_self_stat(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (input, _) = tag(", where x is ").parse(input)?;
+    let (input, _) = parse_self_reference_subject(input)?;
+    alt((
+        value(
+            QuantityRef::Power {
+                scope: ObjectScope::Source,
+            },
+            tag("'s power"),
+        ),
+        value(
+            QuantityRef::Toughness {
+                scope: ObjectScope::Source,
+            },
+            tag("'s toughness"),
+        ),
+        value(
+            QuantityRef::ObjectManaValue {
+                scope: ObjectScope::Source,
+            },
+            tag("'s mana value"),
+        ),
+    ))
+    .parse(input)
+}
 
 /// Whether the inverted `"As long as <cond>, <effect>"` detector may fire.
 ///
@@ -2499,39 +2550,79 @@ pub(crate) fn parse_static_line_inner(
     // abilities of sources with the chosen name cost {2} more to activate").
     // Combinator: prefix → subject → " cost {N} " → direction. The subject is
     // either the chosen-name source phrase (→ HasChosenName) or a type phrase.
-    if let Some(((amount, mode, subject_filter), _)) = nom_on_lower(tp.original, tp.lower, |i| {
-        let (i, _) = tag("activated abilities of ").parse(i)?;
-        let (i, subject) = take_until(" cost ").parse(i)?;
-        let (i, _) = tag(" cost ").parse(i)?;
-        let (i, amount) =
-            nom::sequence::delimited(tag("{"), nom_primitives::parse_number, tag("}")).parse(i)?;
-        let (i, _) = tag(" ").parse(i)?;
-        let (i, mode) = alt((
-            value(CostModifyMode::Reduce, tag("less to activate")),
-            value(CostModifyMode::Raise, tag("more to activate")),
-        ))
-        .parse(i)?;
-        Ok((i, (amount, mode, subject.to_string())))
-    }) {
-        // CR 113.6 + CR 201.2: "sources with the chosen name" → HasChosenName,
-        // shared with the CantBeActivated name-picker class. Otherwise a type phrase.
-        let affected = parse_chosen_name_source_filter(&subject_filter)
-            .unwrap_or_else(|| parse_type_phrase(&subject_filter).0);
-        // CR 118.7: a one-mana floor only applies to reductions.
-        let minimum_mana = matches!(mode, CostModifyMode::Reduce)
-            .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
-            .flatten();
-        return Some(
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode,
-                keyword: "activated".to_string(),
-                amount,
-                minimum_mana,
-                dynamic_count: None,
-            })
-            .affected(affected)
-            .description(text.to_string()),
-        );
+    if let Some(((amount_n, is_x, mode, subject_filter, dynamic_count), _)) =
+        nom_on_lower(tp.original, tp.lower, |i| {
+            let (i, _) = tag("activated abilities of ").parse(i)?;
+            let (i, subject) = take_until(" cost ").parse(i)?;
+            let (i, _) = tag(" cost ").parse(i)?;
+            // CR 107.3 + CR 601.2f: the amount is a fixed `{N}` (Training Grounds)
+            // or the variable `{X}` (Agatha), whose value is supplied by the
+            // trailing "where X is …" referent parsed below.
+            let (i, (amount_n, is_x)) = nom::sequence::delimited(
+                tag("{"),
+                alt((
+                    map(nom_primitives::parse_number, |n| (n, false)),
+                    value((0u32, true), tag("x")),
+                )),
+                tag("}"),
+            )
+            .parse(i)?;
+            let (i, _) = tag(" ").parse(i)?;
+            let (i, mode) = alt((
+                value(CostModifyMode::Reduce, tag("less to activate")),
+                value(CostModifyMode::Raise, tag("more to activate")),
+            ))
+            .parse(i)?;
+            // CR 208.1 + CR 113.7: optional dynamic referent for `{X}`
+            // ("where X is ~'s power", Agatha).
+            let (i, dynamic_count) = opt(parse_where_x_is_self_stat).parse(i)?;
+            Ok((
+                i,
+                (amount_n, is_x, mode, subject.to_string(), dynamic_count),
+            ))
+        })
+    {
+        // CR 601.2f: A fixed `{N}` reduces by exactly `N`; a `{X}` reduces by
+        // `1 × resolve_quantity(dynamic_count)` (Agatha: X = ~'s power). A bare
+        // `{X}` with no recognized referent is unresolvable — leave it for a
+        // later branch (ultimately unsupported) rather than emit a wrong amount.
+        let resolved: Option<(u32, Option<QuantityRef>)> = if is_x {
+            dynamic_count.map(|qty| (1u32, Some(qty)))
+        } else {
+            Some((amount_n, None))
+        };
+        if let Some((amount, dynamic_count)) = resolved {
+            // CR 113.6 + CR 201.2: "sources with the chosen name" → HasChosenName,
+            // shared with the CantBeActivated name-picker class. Otherwise a type phrase.
+            let affected = parse_chosen_name_source_filter(&subject_filter)
+                .unwrap_or_else(|| parse_type_phrase(&subject_filter).0);
+            // CR 118.7: a one-mana floor only applies to reductions.
+            let minimum_mana = matches!(mode, CostModifyMode::Reduce)
+                .then(|| parse_activated_cost_reduction_minimum_mana(tp.lower))
+                .flatten();
+            return Some(
+                StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode,
+                    keyword: "activated".to_string(),
+                    amount,
+                    minimum_mana,
+                    dynamic_count,
+                })
+                .affected(affected)
+                .description(text.to_string()),
+            );
+        }
+    }
+
+    // --- CR 116.2 + CR 118.7a: special-action (plot/unlock) cost reduction ---
+    // "Plotting cards from your hand costs {N} less" (Doc Aurlock, CR 116.2k) /
+    // "Unlock costs you pay cost {N} less" (Inquisitive Glimmer, CR 116.2m). A
+    // dedicated `SpecialAction` axis, NOT the generic activated-ability reducer
+    // above — plot/unlock payments carry no `AbilityTag`, so routing them
+    // through `ReduceAbilityCost { keyword: "activated" }` would never fire and
+    // would wrongly let "activated abilities cost less" reduce plot costs.
+    if let Some(def) = parse_action_cost_reduction(&text, &lower) {
+        return Some(def);
     }
 
     // --- CR 601.2f: Cost-floor statics (Trinisphere class) ---

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -55,7 +55,7 @@ mod prelude {
     };
     pub(super) use crate::types::counter::{parse_counter_type, CounterMatch};
     pub(super) use crate::types::keywords::{Keyword, KeywordKind};
-    pub(super) use crate::types::mana::{ManaColor, ManaCost, ManaType};
+    pub(super) use crate::types::mana::{ManaColor, ManaCost, ManaType, SpecialAction};
     pub(super) use crate::types::phase::Phase;
     pub(super) use crate::types::statics::{
         ActivationExemption, AdditionalCostTaxAction, AttackDefenderScope, BlockExceptionKind,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15291,6 +15291,130 @@ fn static_reduce_ability_cost_registry_round_trip_preserves_direction() {
     }
 }
 
+#[test]
+fn static_reduce_activated_ability_cost_dynamic_power() {
+    // Agatha of the Vile Cauldron, post `normalize_card_name_refs` ("Agatha's"
+    // → "~'s"): "Activated abilities of creatures you control cost {X} less to
+    // activate, where X is ~'s power. This effect can't reduce the mana in that
+    // cost to less than one mana." The `{X}` amount is the per-unit multiplier 1
+    // and the dynamic count is the source's power (CR 208.1 + CR 113.7).
+    let def = parse_static_line(
+        "Activated abilities of creatures you control cost {X} less to activate, where X is ~'s power. This effect can't reduce the mana in that cost to less than one mana.",
+    )
+    .expect("Agatha dynamic activated-ability cost reduction must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
+            keyword: "activated".to_string(),
+            amount: 1,
+            minimum_mana: Some(1),
+            dynamic_count: Some(QuantityRef::Power {
+                scope: ObjectScope::Source,
+            }),
+        }
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+        }
+        other => panic!("expected creatures you control, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_where_x_is_source_power_yields_power_source_ref() {
+    // Amendment item 2: the dynamic referent combinator must map
+    // "{X} ... where X is ~'s power" → `QuantityRef::Power { scope: Source }`,
+    // with the per-unit amount pinned to 1. Drops the second sentence to prove
+    // the dynamic arm does not depend on the minimum-mana clause.
+    let def = parse_static_line(
+        "Activated abilities of creatures you control cost {X} less to activate, where X is ~'s power.",
+    )
+    .expect("dynamic referent must parse without the minimum-mana clause");
+    match def.mode {
+        StaticMode::ReduceAbilityCost {
+            amount,
+            dynamic_count: Some(QuantityRef::Power { scope }),
+            ..
+        } => {
+            assert_eq!(scope, ObjectScope::Source);
+            assert_eq!(amount, 1);
+        }
+        other => panic!("expected dynamic Power{{Source}} reduction, got {other:?}"),
+    }
+}
+
+// --- Group B': Special-action (plot / unlock) cost reduction ---
+
+#[test]
+fn static_reduce_action_cost_plot() {
+    // Doc Aurlock, Grizzled Genius: "Plotting cards from your hand costs {2}
+    // less." (CR 116.2k / 702.170). Note the singular verb "costs".
+    let def = parse_static_line("Plotting cards from your hand costs {2} less.")
+        .expect("Doc Aurlock plot cost reduction must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceActionCost {
+            action: SpecialAction::Plot,
+            mode: CostModifyMode::Reduce,
+            amount: 2,
+        }
+    );
+}
+
+#[test]
+fn static_reduce_action_cost_unlock() {
+    // Inquisitive Glimmer: "Unlock costs you pay cost {1} less." (CR 116.2m /
+    // 709.5e). The "cost" (not "costs") verb form.
+    let def = parse_static_line("Unlock costs you pay cost {1} less.")
+        .expect("Inquisitive Glimmer unlock cost reduction must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::ReduceActionCost {
+            action: SpecialAction::UnlockDoor,
+            mode: CostModifyMode::Reduce,
+            amount: 1,
+        }
+    );
+}
+
+#[test]
+fn spell_cost_reduction_does_not_become_action_cost() {
+    // Discriminator: a spell-cost reduction (Inquisitive Glimmer L1) must route
+    // to `ModifyCost`, NEVER the special-action `ReduceActionCost`. Pins the
+    // plot/unlock subject tags so they don't over-match generic "cost {N} less".
+    let def = parse_static_line("Enchantment spells you cast cost {1} less to cast.")
+        .expect("spell cost reduction parses");
+    assert!(
+        matches!(def.mode, StaticMode::ModifyCost { .. }),
+        "spell cost reduction must be ModifyCost, got {:?}",
+        def.mode
+    );
+}
+
+#[test]
+fn static_reduce_action_cost_registry_round_trip() {
+    // CR 116.2: Display/from_str must round-trip the action + direction so a
+    // serialized special-action reduction does not silently decode wrong.
+    for (action, mode) in [
+        (SpecialAction::Plot, CostModifyMode::Reduce),
+        (SpecialAction::UnlockDoor, CostModifyMode::Reduce),
+        (SpecialAction::Plot, CostModifyMode::Raise),
+    ] {
+        let original = StaticMode::ReduceActionCost {
+            action,
+            mode,
+            amount: 2,
+        };
+        let encoded = original.to_string();
+        let decoded = encoded
+            .parse::<StaticMode>()
+            .expect("registry string parses back into a StaticMode");
+        assert_eq!(decoded, original, "round trip changed value: {encoded}");
+    }
+}
+
 // --- Group C: Spells you cast have keyword ---
 
 #[test]

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -343,6 +343,13 @@ pub enum SpecialAction {
     /// CR 116.2m + CR 709.5e: Paying a locked Room half's unlock cost to give
     /// the permanent the appropriate unlocked designation.
     UnlockDoor,
+    /// CR 116.2k + CR 702.170a: Exiling a card from hand and paying its plot
+    /// cost to make it a plotted card. The plot ability is synthesized as a
+    /// hand-zone activated ability (`synthesize_plot`); this variant lets a
+    /// `StaticMode::ReduceActionCost { action: Plot, .. }` (Doc Aurlock) reduce
+    /// that plot cost without conflating plot with generic activated-ability
+    /// cost reducers.
+    Plot,
     /// CR 116.2b + CR 702.37e: Paying a face-down permanent's morph/disguise
     /// cost to turn it face up. No payment site emits
     /// `PaymentContext::SpecialAction(TurnFaceUp)` yet (turn-face-up is free in

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -10,7 +10,7 @@ use super::ability::{
 };
 use super::identifiers::ObjectId;
 use super::keywords::{Keyword, KeywordKind};
-use super::mana::{ManaColor, ManaCost, StepEndManaAction};
+use super::mana::{ManaColor, ManaCost, SpecialAction, StepEndManaAction};
 use super::phase::Phase;
 use super::player::PlayerId;
 use super::zones::Zone;
@@ -634,6 +634,28 @@ fn cost_modify_mode_reduce() -> CostModifyMode {
     CostModifyMode::Reduce
 }
 
+/// CR 116.2: Stable registry string for a [`SpecialAction`], used by the
+/// `StaticMode::ReduceActionCost` Display/FromStr round-trip.
+fn special_action_registry_str(action: SpecialAction) -> &'static str {
+    match action {
+        SpecialAction::Plot => "Plot",
+        SpecialAction::UnlockDoor => "UnlockDoor",
+        SpecialAction::TurnFaceUp => "TurnFaceUp",
+        SpecialAction::RollPlanarDie => "RollPlanarDie",
+    }
+}
+
+/// Inverse of [`special_action_registry_str`].
+fn special_action_from_registry_str(s: &str) -> Option<SpecialAction> {
+    match s {
+        "Plot" => Some(SpecialAction::Plot),
+        "UnlockDoor" => Some(SpecialAction::UnlockDoor),
+        "TurnFaceUp" => Some(SpecialAction::TurnFaceUp),
+        "RollPlanarDie" => Some(SpecialAction::RollPlanarDie),
+        _ => None,
+    }
+}
+
 /// CR 601.2f: Whether a static-imposed additional cost applies to spell casting.
 /// Distinct from [`CostModifyMode`], which only adjusts the mana component.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -906,6 +928,28 @@ pub enum StaticMode {
         /// When present, the total adjustment is `amount * resolve_quantity(dynamic_count)`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         dynamic_count: Option<QuantityRef>,
+    },
+    /// CR 116.2 + CR 118.7a: Modifies the generic mana cost of a *special action*
+    /// (plot per CR 116.2k / 702.170, unlock per CR 116.2m / 709.5e), in the
+    /// direction given by `mode`. Doc Aurlock ("Plotting cards from your hand
+    /// costs {2} less") and Inquisitive Glimmer ("Unlock costs you pay cost {1}
+    /// less").
+    ///
+    /// Parameterized over [`SpecialAction`] rather than proliferating one variant
+    /// per action — any future "[special action] costs you pay cost {N} less"
+    /// lands without a new variant. Distinct from [`StaticMode::ReduceAbilityCost`]
+    /// (which keys on an `AbilityTag` and never matches a special action, since
+    /// plot/unlock payments carry no tag) and from [`StaticMode::ModifyCost`]
+    /// (spell costs, CR 601.2f). `amount` is generic mana only (CR 118.7a — a
+    /// generic cost reduction can't touch colored/colorless components).
+    /// `Minimum` is not meaningful here — only `Reduce` and `Raise` are
+    /// emitted/applied.
+    ReduceActionCost {
+        action: SpecialAction,
+        /// CR 118.7: Direction of the adjustment.
+        mode: CostModifyMode,
+        /// Generic mana adjustment per the special action (CR 118.7a).
+        amount: u32,
     },
     /// CR 702.142b: Modifies the per-turn activation limit for abilities matching
     /// a keyword tag. E.g., "Creatures you control can boast twice during each of
@@ -1829,6 +1873,10 @@ impl Hash for StaticMode {
             // CR 614.1c: data-carrying (CounterType + count); consumed by direct
             // match in change_zone.rs, never used as a HashMap key.
             | StaticMode::EntersWithAdditionalCounters { .. }
+            // CR 116.2 + CR 118.7a: data-carrying (SpecialAction is not Hash);
+            // consumed by direct match in the special-action cost-reduction
+            // resolver, never used as a HashMap key.
+            | StaticMode::ReduceActionCost { .. }
             | StaticMode::SuppressTriggers { .. } => {}
             // All other variants are unit variants — discriminant suffices.
             _ => {}
@@ -1871,6 +1919,7 @@ impl StaticMode {
             | StaticMode::ModifyCost { .. }
             | StaticMode::ImposeAdditionalCost { .. }
             | StaticMode::ReduceAbilityCost { .. }
+            | StaticMode::ReduceActionCost { .. }
             | StaticMode::ModifyActivationLimit { .. }
             | StaticMode::ActivateAsInstant { .. }
             | StaticMode::CantPayCost { .. }
@@ -2029,6 +2078,23 @@ impl fmt::Display for StaticMode {
                 } else {
                     write!(f, "ReduceAbilityCost({sign}{keyword},{amount})")
                 }
+            }
+            StaticMode::ReduceActionCost {
+                action,
+                mode,
+                amount,
+            } => {
+                // CR 118.7: Encode direction lossless ("+"/"-"); legacy default
+                // is Reduce in `from_str`.
+                let sign = match mode {
+                    CostModifyMode::Raise => "+",
+                    _ => "-",
+                };
+                write!(
+                    f,
+                    "ReduceActionCost({},{sign}{amount})",
+                    special_action_registry_str(*action)
+                )
             }
             StaticMode::ModifyActivationLimit { keyword, new_limit } => {
                 write!(f, "ModifyActivationLimit({keyword},{new_limit})")
@@ -2397,6 +2463,31 @@ impl FromStr for StaticMode {
                 } else {
                     StaticMode::Other(s.to_string())
                 }
+            }
+            s if s.starts_with("ReduceActionCost(") => {
+                // CR 116.2 + CR 118.7: Parse "ReduceActionCost(Action,[+|-]amount)".
+                // A leading "+"/"-" on the amount marks Raise/Reduce; legacy
+                // strings without a marker default to Reduce.
+                let parsed = s
+                    .strip_prefix("ReduceActionCost(")
+                    .and_then(|inner| inner.strip_suffix(')'))
+                    .and_then(|inner| inner.split_once(','))
+                    .and_then(|(action_str, amt_str)| {
+                        let action = special_action_from_registry_str(action_str)?;
+                        let (mode, amount_str) = if let Some(rest) = amt_str.strip_prefix('+') {
+                            (CostModifyMode::Raise, rest)
+                        } else if let Some(rest) = amt_str.strip_prefix('-') {
+                            (CostModifyMode::Reduce, rest)
+                        } else {
+                            (CostModifyMode::Reduce, amt_str)
+                        };
+                        Some(StaticMode::ReduceActionCost {
+                            action,
+                            mode,
+                            amount: amount_str.parse().ok()?,
+                        })
+                    });
+                parsed.unwrap_or_else(|| StaticMode::Other(s.to_string()))
             }
             s if s.starts_with("ModifyActivationLimit(") => {
                 let inner = s


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## S21 static cost-reduction — Doc Aurlock, Inquisitive Glimmer, Agatha

First pass of the `S21-static-ability` cluster: two cost-reduction static building blocks, each built for the class.

### B2 — special-action cost reduction (plot / unlock)
- New `StaticMode::ReduceActionCost { action, mode, amount }` + `SpecialAction::Plot`.
- A single-authority `apply_special_action_cost_reduction` called from **both** the plot payment site (`casting.rs`) and the unlock-door site (`engine.rs`) — no inlined duplication.
- Generic-only reduction (CR 118.7a), floors at 0.
- Covers **Doc Aurlock, Grizzled Genius** ("Plotting cards from your hand cost {2} less") and **Inquisitive Glimmer** ("Unlock costs you pay cost {1} less"). The parser accepts both the `costs`/`cost` verb forms.
- Plot is kept on a dedicated `SpecialAction` axis rather than routed through `ReduceAbilityCost{keyword:"activated"}`, which would wrongly reduce plot via Zirda/Training-Grounds-style statics.

### B1 — dynamic activated-ability cost reduction
- Extends the existing `ReduceAbilityCost` path to honor a `dynamic_count` (`QuantityRef::Power{Source}`), so **Agatha of the Vile Cauldron** ("Activated abilities of creatures you control cost {X} less to activate, where X is Agatha's power") reads the source's post-layer power with a one-mana floor.
- Existing static reductions (`dynamic_count: None`) are behaviorally **unchanged** (multiplier 1).

### Evidence
- Coverage: **+3 supported** (Doc Aurlock, Inquisitive Glimmer, Agatha), **0 regressions** (no card supported→unsupported, no `gap_count` rose anywhere) over the full 35,396-card corpus.
- Gates: `cargo fmt` clean; `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -D warnings` clean; `cargo test -p engine` green (9 new discriminating tests with revert-probes — plot drops 2/floor 0, unlock drops 1, Agatha's 3-way power split incl. floor); parser-combinator gate clean; `semantic-audit` clean. All CR numbers verified against the Comprehensive Rules.
- New `SpecialAction`/`StaticMode` variants ran through the add-engine-variant checklist (Display/FromStr/Hash arms, round-trip test, `engine-inventory` no sibling-cluster smell); rebased onto current `main` with the full workspace build re-run.

### Scope
This is pass 1 of the cluster. The remaining `S21` cards (Nowhere to Run, Locus of Enlightenment, Fblthp, Koh, Sandswirl) need separate building blocks (hexproof/ward, grant-from-exiled, play-from-top) and are follow-up PRs; two of them also have non-static gaps to be re-homed.