### PR TITLE
fix(parser): Namor the Sub-Mariner colored-pip cast trigger (#4370)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -575,6 +575,7 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::HasColor { .. }
         | FilterProp::NotColor { .. }
         | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
         | FilterProp::HasSupertype { .. }
         | FilterProp::NotSupertype { .. }
         | FilterProp::ToughnessGTPower

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -42995,6 +42995,100 @@ mod tests {
         }
     }
 
+    /// CR 107.4 + CR 202.1 + CR 603.2 + CR 603.4 (issue #4370): Namor the
+    /// Sub-Mariner — runtime cast-pipeline coverage. The parser-level shape is
+    /// asserted in `oracle_trigger`; these tests drive the whole cast → trigger
+    /// → token-creation pipeline to prove the count and the valid_card filter
+    /// behave at resolution time.
+    mod namor_colored_pip_cast_trigger {
+        use super::*;
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::types::mana::{ManaCost, ManaCostShard, ManaUnit};
+
+        const NAMOR_ORACLE: &str = "Whenever you cast a noncreature spell with one or more blue mana symbols in its mana cost, create that many 1/1 blue Merfolk creature tokens.";
+
+        /// Count token permanents a player controls on the battlefield.
+        fn token_count(runner: &crate::game::scenario::GameRunner, player: PlayerId) -> usize {
+            runner
+                .state()
+                .objects
+                .values()
+                .filter(|o| o.zone == Zone::Battlefield && o.controller == player && o.is_token)
+                .count()
+        }
+
+        /// CR 107.4 + CR 603.4: casting a noncreature spell with two blue pips
+        /// ({U}{U}) while Namor is on the battlefield creates exactly two 1/1
+        /// blue Merfolk tokens — the count back-references the cast spell's
+        /// blue-pip count (`ManaSymbolsInManaCost { EventSource, Blue }`), not the
+        /// generic `EventContextAmount` (which would resolve to 0 tokens).
+        #[test]
+        fn casting_two_blue_pip_spell_creates_two_merfolk_tokens() {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            scenario.add_creature_from_oracle(P0, "Namor the Sub-Mariner", 5, 5, NAMOR_ORACLE);
+            // Noncreature spell with two blue pips: {U}{U}. Benign resolution.
+            let spell = scenario
+                .add_spell_to_hand_from_oracle(P0, "Twin-Pip Bolt", true, "You gain 1 life.")
+                .with_mana_cost(ManaCost::Cost {
+                    shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+                    generic: 0,
+                })
+                .id();
+            // CR 601.2f: fund the {U}{U} cost from the pool so the driver auto-pays.
+            scenario.with_mana_pool(
+                P0,
+                vec![ManaUnit::new(ManaType::Blue, ObjectId(9_999), false, vec![]); 2],
+            );
+            let mut runner = scenario.build();
+
+            let outcome = runner.cast(spell).resolve();
+
+            assert_eq!(
+                token_count(&runner, P0),
+                2,
+                "two blue pips must create two Merfolk tokens, got {}",
+                token_count(&runner, P0)
+            );
+            // The spell itself still resolved (gain 1 life) on top of the trigger.
+            outcome.assert_life_delta(P0, 1);
+        }
+
+        /// CR 603.2 (issue #4370): a noncreature spell with NO blue mana symbols
+        /// ({R}) must NOT satisfy the trigger's `valid_card`
+        /// (`ManaSymbolCount { Blue, GE, 1 }`), so the trigger does not fire and
+        /// no tokens are created — the over-fire defect is fixed at runtime.
+        #[test]
+        fn casting_non_blue_spell_creates_no_tokens() {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            scenario.add_creature_from_oracle(P0, "Namor the Sub-Mariner", 5, 5, NAMOR_ORACLE);
+            // Noncreature spell with a single red pip and no blue: {R}.
+            let spell = scenario
+                .add_spell_to_hand_from_oracle(P0, "Red Spark", true, "You gain 1 life.")
+                .with_mana_cost(ManaCost::Cost {
+                    shards: vec![ManaCostShard::Red],
+                    generic: 0,
+                })
+                .id();
+            scenario.with_mana_pool(
+                P0,
+                vec![ManaUnit::new(ManaType::Red, ObjectId(9_999), false, vec![]); 1],
+            );
+            let mut runner = scenario.build();
+
+            let outcome = runner.cast(spell).resolve();
+
+            assert_eq!(
+                token_count(&runner, P0),
+                0,
+                "a non-blue spell must not fire Namor's trigger, got {} tokens",
+                token_count(&runner, P0)
+            );
+            outcome.assert_life_delta(P0, 1);
+        }
+    }
+
     /// CR 701.43a / CR 701.43b / CR 502.3: Exert cost — Arena of Glory class.
     mod exert_cost {
         use super::*;

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -711,6 +711,25 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 };
                 parts.push(label);
             }
+            FilterProp::ManaSymbolCount {
+                color,
+                comparator,
+                value,
+            } => {
+                let symbol = match color {
+                    Some(c) => format!("{c:?} mana symbol").to_lowercase(),
+                    None => "colored mana symbol".into(),
+                };
+                let label = match comparator {
+                    Comparator::GE => format!("≥{value} {symbol}"),
+                    Comparator::LE => format!("≤{value} {symbol}"),
+                    Comparator::GT => format!(">{value} {symbol}"),
+                    Comparator::LT => format!("<{value} {symbol}"),
+                    Comparator::EQ => format!("{value} {symbol}"),
+                    Comparator::NE => format!("≠{value} {symbol}"),
+                };
+                parts.push(label);
+            }
             FilterProp::HasSupertype { value } => {
                 parts.push(format!("{value}").to_lowercase());
             }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -141,12 +141,14 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         // single-object, or carry no QuantityExpr threshold, so a board entry/exit
         // cannot change whether a pre-existing object satisfies them.
         // `ColorCount` carries a `u8` constant, not a QuantityExpr.
+        // `ManaSymbolCount` reads only the candidate's own printed mana cost.
         FilterProp::CanEnchant { .. }
         | FilterProp::HasAttachment { .. }
         | FilterProp::HasAnyAttachmentOf { .. }
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }
         | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
         | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
@@ -357,6 +359,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }
         | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
         | FilterProp::ManaValueParity { .. }
         | FilterProp::Token
         | FilterProp::NonToken
@@ -2791,6 +2794,11 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         FilterProp::ManaValueParity { parity } => {
             mana_value_matches_parity_source(record.mana_value, parity, None)
         }
+        // CR 202.1: SpellCastRecord retains colors + mana_value but no per-shard
+        // ManaCost, so colored-pip count is unsupported here. RUNTIME: TODO.
+        // (Namor correctness comes from valid_card matching the live stack object
+        // via matches_filter_prop, not from this cast-history record.)
+        FilterProp::ManaSymbolCount { .. } => false,
         // CR 202.1: Exact printed mana cost is not captured in cast-history
         // snapshots. Fail closed rather than approximating with mana value
         // (CR 202.3), which would conflate {W} with {1}.
@@ -3305,6 +3313,14 @@ fn matches_filter_prop(
             let mana_value = obj.mana_cost.mana_value_with_x(obj.zone, obj.cost_x_paid);
             mana_value_matches_parity_source(mana_value, parity, state.last_named_choice.as_ref())
         }
+        // CR 107.4 + CR 202.1: count colored mana symbols in the object's printed
+        // mana cost via the single counting authority, then compare with the
+        // parameterized comparator (Namor's "with one or more blue mana symbols").
+        FilterProp::ManaSymbolCount {
+            color,
+            comparator,
+            value,
+        } => comparator.evaluate(obj.mana_cost.count_colored_pips(*color), *value),
         // CR 202.1: Compare exact printed mana cost, not mana value (CR 202.3).
         FilterProp::ManaCostIn { costs } => costs.iter().any(|cost| cost == &obj.mana_cost),
         // CR 702.143c-d: Foretold is a designation of a card in exile, tracked
@@ -3980,6 +3996,9 @@ fn zone_change_record_matches_property(
         // CR 202.1: Zone-change records currently snapshot mana value, not the
         // full printed mana cost. Exact-cost predicates fail closed here.
         FilterProp::ManaCostIn { .. } => false,
+        // CR 202.1: Zone-change record carries no per-shard ManaCost, so
+        // colored-pip count is unsupported here. RUNTIME: TODO.
+        FilterProp::ManaSymbolCount { .. } => false,
         // CR 105.1 / CR 202.2: Color membership on the event-time object.
         FilterProp::HasColor { color } => record.colors.contains(color),
         FilterProp::NotColor { color } => !record.colors.contains(color),

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3693,18 +3693,7 @@ fn resolve_mana_symbols_in_mana_cost(
     targets: &[TargetRef],
 ) -> i32 {
     object_for_scope(state, scope, ctx, targets)
-        .map(|obj| match &obj.mana_cost {
-            ManaCost::Cost { shards, .. } => usize_to_i32_saturating(
-                shards
-                    .iter()
-                    .filter(|shard| match color {
-                        Some(c) => shard.contributes_to(c),
-                        None => ManaColor::ALL.iter().any(|c| shard.contributes_to(*c)),
-                    })
-                    .count(),
-            ),
-            ManaCost::NoCost | ManaCost::SelfManaCost | ManaCost::SelfManaValue => 0,
-        })
+        .map(|obj| obj.mana_cost.count_colored_pips(color))
         .unwrap_or(0)
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20602,6 +20602,12 @@ pub(crate) fn parse_effect_chain_ir(
             // chunks inside it share the flag — the head "turn this creature face
             // up" clause (Etrata) needs it to lower to TurnFaceUp { SelfRef }.
             in_granted_activated_ability: ctx.in_granted_activated_ability,
+            // CR 107.4 + CR 603.4: the colored-mana-symbol cast qualifier (Namor)
+            // is a property of the whole trigger body, not of an individual chunk,
+            // so every chunk inside it must share the staged color — the "create
+            // that many tokens" chunk needs it to back-reference the cast spell's
+            // colored-pip count instead of the generic EventContextAmount.
+            pending_mana_symbol_count_color: ctx.pending_mana_symbol_count_color,
             ..Default::default()
         };
         let ctx = &mut chunk_ctx;

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -9,8 +9,8 @@ use nom::Parser;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_nom::error::OracleResult;
 use crate::types::ability::{
-    ContinuousModification, ControllerRef, Effect, FilterProp, PtValue, QuantityExpr, QuantityRef,
-    StaticDefinition, TargetFilter,
+    ContinuousModification, ControllerRef, Effect, FilterProp, ObjectScope, PtValue, QuantityExpr,
+    QuantityRef, StaticDefinition, TargetFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::keywords::Keyword;
@@ -417,6 +417,29 @@ fn parse_token_description_with_context(
         } else {
             return None;
         };
+    // CR 603.2 + CR 603.4 + CR 107.4: "create that many tokens" on a colored-pip
+    // cast trigger (Namor the Sub-Mariner) back-references the cast spell's
+    // colored-symbol count (EventSource), not the generic EventContextAmount —
+    // a SpellCast event carries no amount, so EventContextAmount resolves to 0.
+    // The qualifier color was staged onto the context from the trigger's
+    // "with one or more <color> mana symbols in its mana cost" valid_card phrase.
+    // Gated on `pending_mana_symbol_count_color`, so Chatterfang-style "that many"
+    // counters (color None) are untouched.
+    if matches!(
+        &count,
+        QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount
+        }
+    ) {
+        if let Some(color) = ctx.pending_mana_symbol_count_color {
+            count = QuantityExpr::Ref {
+                qty: QuantityRef::ManaSymbolsInManaCost {
+                    scope: ObjectScope::EventSource,
+                    color: Some(color),
+                },
+            };
+        }
+    }
     // CR 508.4: Seed `tapped` from the inline "tapped and attacking" suffix
     // detected earlier so the "tapped " / "untapped " leading-word loop below
     // can still flip it if the token text also carries a leading "tapped".

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -128,6 +128,17 @@ pub(crate) struct ParseContext {
     /// Set when the meld gate is recognized; consumed by the meld effect
     /// combinator. `None` for non-meld faces.
     pub pending_meld_partner: Option<String>,
+    /// CR 107.4 + CR 202.1 + CR 603.4: The named color from a cast-trigger's
+    /// "with one or more `<color>` mana symbol(s) in its mana cost" spell
+    /// qualifier (Namor the Sub-Mariner). The qualifier is parsed into the
+    /// trigger's `valid_card` (a `FilterProp::ManaSymbolCount`), but the EFFECT
+    /// clause "create that many tokens" must back-reference the cast spell's
+    /// colored-symbol count rather than the generic `EventContextAmount` (which
+    /// has no SpellCast amount and resolves to 0). Set from the finalized
+    /// condition/qualifier text before the effect body parses; consumed by the
+    /// token-count override in `oracle_effect::token`. `None` for triggers
+    /// without a colored-pip qualifier.
+    pub pending_mana_symbol_count_color: Option<crate::types::mana::ManaColor>,
     /// CR 116.2b + CR 708.7: True while parsing the body of an explicit granted
     /// activated ability (a quoted `"{cost}: ..."` granted to another object).
     /// In that context, a head clause of "turn this/~ creature face up" is the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -946,6 +946,13 @@ pub(crate) fn parse_trigger_line_with_index_ir(
 
     // CR 608.2k: Extract trigger subject for pronoun resolution in effect text.
     let trigger_subject = extract_trigger_subject_for_context(condition_text, ctx);
+    // CR 107.4 + CR 202.1 + CR 603.4: Stage the cast-trigger's colored-mana-symbol
+    // qualifier color (Namor) so a "create that many tokens" effect clause can
+    // back-reference the cast spell's colored-pip count instead of the generic
+    // EventContextAmount. Derived from the same condition/qualifier text whose
+    // spell qualifier becomes the trigger's `valid_card`.
+    let pending_mana_symbol_count_color =
+        extract_colored_mana_symbol_spell_qualifier(condition_text);
     let mut effect_ctx = ParseContext {
         subject: Some(trigger_subject.clone()),
         card_name: Some(card_name.to_string()),
@@ -960,6 +967,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         // stamp `Effect::Meld { source, partner, .. }` (the context carries the
         // source name; the gate carried the partner name).
         pending_meld_partner: meld_partner,
+        pending_mana_symbol_count_color,
         ..Default::default()
     };
 
@@ -12198,6 +12206,38 @@ fn type_only_filter(qualifier: &str) -> Option<TargetFilter> {
 /// Shared with `oracle_effect::try_parse_when_next_event` (delayed-trigger variant
 /// of the same filter shape) — exposed as `pub(crate)` to keep the combinator
 /// definition in a single place.
+/// CR 107.4 + CR 202.1: Pure-nom recognizer for the spell-qualifier phrase
+/// "with one or more `<color>` mana symbol(s) in its mana cost"
+/// (Namor the Sub-Mariner — "Whenever you cast a noncreature spell with one or
+/// more blue mana symbols in its mana cost"). Returns the named `ManaColor`;
+/// the implied comparison is `Comparator::GE` against `1` ("one or more").
+///
+/// Reuses the shared atomic combinator `parse_color` rather than re-implementing
+/// color recognition or pip counting. This is a different grammatical position
+/// from `parse_colored_mana_symbol_count_target_condition` (a target eligibility
+/// condition, "it has N or more colored mana symbols in its mana cost"), so it
+/// is a separate recognizer that shares the atomics, not the call shape.
+fn parse_colored_mana_symbol_spell_qualifier(input: &str) -> OracleResult<'_, ManaColor> {
+    delimited(
+        tag("with one or more "),
+        nom_primitives::parse_color,
+        (tag(" mana symbol"), opt(tag("s")), tag(" in its mana cost")),
+    )
+    .parse(input)
+}
+
+/// CR 107.4 + CR 202.1: Pre-extraction helper for trigger plumbing. Locates the
+/// colored-mana-symbol spell qualifier inside finalized condition/qualifier text
+/// (e.g. the "noncreature spell with one or more blue mana symbols in its mana
+/// cost" valid-card phrase) and returns the named color so the effect-context can
+/// thread it to the token-count override (Namor "create that many" → EventSource
+/// pip count). Scans word boundaries so the qualifier need not begin the string.
+pub(crate) fn extract_colored_mana_symbol_spell_qualifier(text: &str) -> Option<ManaColor> {
+    let lower = text.to_lowercase();
+    nom_primitives::scan_preceded(&lower, parse_colored_mana_symbol_spell_qualifier)
+        .map(|(_, color, _)| color)
+}
+
 pub(crate) fn parse_post_spell_modifier(modifier: &str) -> Option<TargetFilter> {
     use crate::types::ability::{FilterProp, TypedFilter};
 
@@ -12274,6 +12314,23 @@ pub(crate) fn parse_post_spell_modifier(modifier: &str) -> Option<TargetFilter> 
             return Some(TargetFilter::Typed(
                 TypedFilter::default().properties(vec![FilterProp::InZone { zone }]),
             ));
+        }
+    }
+
+    // CR 107.4 + CR 202.1 + CR 603.2: "with one or more <color> mana symbol(s) in
+    // its mana cost" (Namor the Sub-Mariner). The implied comparison is
+    // Comparator::GE against 1 ("one or more"). Emits the colored-pip filter prop
+    // so the trigger's valid_card only matches spells with at least one such
+    // symbol, fixing the over-fire on every noncreature spell.
+    if let Ok((rest, color)) = parse_colored_mana_symbol_spell_qualifier(modifier) {
+        if rest.trim().is_empty() {
+            return Some(TargetFilter::Typed(TypedFilter::default().properties(
+                vec![FilterProp::ManaSymbolCount {
+                    color: Some(color),
+                    comparator: Comparator::GE,
+                    value: 1,
+                }],
+            )));
         }
     }
 
@@ -35145,7 +35202,9 @@ mod controlled_chosen_type_enters_tests {
 #[cfg(test)]
 mod enchanted_player_controls_tests {
     use super::*;
-    use crate::types::ability::{ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter};
+    use crate::types::ability::{
+        Comparator, ControllerRef, FilterProp, TargetFilter, TypeFilter, TypedFilter,
+    };
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
 
@@ -35211,5 +35270,129 @@ mod enchanted_player_controls_tests {
                 TypedFilter::land().controller(ControllerRef::EnchantedPlayer)
             ))
         );
+    }
+
+    /// CR 107.4 + CR 202.1 + CR 603.2 + CR 603.4 (issue #4370): Namor the
+    /// Sub-Mariner — "Whenever you cast a noncreature spell with one or more
+    /// blue mana symbols in its mana cost, create that many 1/1 blue Merfolk
+    /// creature tokens." (1) the trigger's `valid_card` must carry the
+    /// colored-pip constraint (`FilterProp::ManaSymbolCount { Blue, GE, 1 }`)
+    /// AND the noncreature type filter, so it does not over-fire on every
+    /// noncreature spell; (2) the "create that many" count must back-reference
+    /// the cast spell's blue-pip count (`ManaSymbolsInManaCost { EventSource,
+    /// Some(Blue) }`), not the generic `EventContextAmount` (which resolves to
+    /// 0 → zero tokens).
+    /// Collect every `Effect` reachable through the `sub_ability` chain.
+    fn collect_effects(def: &crate::types::ability::AbilityDefinition) -> Vec<&Effect> {
+        let mut out = Vec::new();
+        let mut node = Some(def);
+        while let Some(d) = node {
+            out.push(&*d.effect);
+            node = d.sub_ability.as_deref();
+        }
+        out
+    }
+
+    /// Walk an `And`/`Typed` valid_card looking for a `ManaSymbolCount` prop.
+    fn valid_card_has_blue_pip(f: &TargetFilter) -> bool {
+        use crate::types::mana::ManaColor;
+        match f {
+            TargetFilter::And { filters } => filters.iter().any(valid_card_has_blue_pip),
+            TargetFilter::Typed(tf) => tf.properties.iter().any(|p| {
+                matches!(
+                    p,
+                    FilterProp::ManaSymbolCount {
+                        color: Some(ManaColor::Blue),
+                        comparator: Comparator::GE,
+                        value: 1,
+                    }
+                )
+            }),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn namor_blue_pip_cast_trigger_valid_card_and_token_count() {
+        use crate::types::ability::{Effect, ObjectScope, QuantityExpr, QuantityRef};
+        use crate::types::mana::ManaColor;
+
+        let def = parse_trigger_line(
+            "Whenever you cast a noncreature spell with one or more blue mana symbols in its mana cost, create that many 1/1 blue Merfolk creature tokens.",
+            "Namor the Sub-Mariner",
+        );
+
+        // (1) valid_card carries the blue-pip constraint so the trigger does not
+        // over-fire on every noncreature spell.
+        let vc = def.valid_card.as_ref().expect("Namor trigger valid_card");
+        assert!(
+            valid_card_has_blue_pip(vc),
+            "valid_card must contain ManaSymbolCount {{ Blue, GE, 1 }}, got {vc:?}"
+        );
+
+        // (2) token count back-references the blue-pip count of the cast spell.
+        let execute = def.execute.as_deref().expect("Namor trigger execute body");
+        let token_count = collect_effects(execute)
+            .into_iter()
+            .find_map(|e| match e {
+                Effect::Token { count, .. } => Some(count.clone()),
+                _ => None,
+            })
+            .expect("Namor trigger should create tokens");
+        assert_eq!(
+            token_count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ManaSymbolsInManaCost {
+                    scope: ObjectScope::EventSource,
+                    color: Some(ManaColor::Blue),
+                },
+            },
+            "token count must back-reference the cast spell's blue-pip count"
+        );
+    }
+
+    /// CR 603.2 (issue #4370): Leakage guard — a cast trigger WITHOUT a
+    /// colored-pip qualifier ("Whenever you cast a noncreature spell, create
+    /// that many ... tokens") must NOT pick up the Namor override: the count
+    /// stays `EventContextAmount` and the valid_card carries no
+    /// `ManaSymbolCount`. Confirms the override is gated on the staged color.
+    #[test]
+    fn cast_trigger_without_pip_qualifier_keeps_event_context_count() {
+        use crate::types::ability::{Effect, QuantityExpr, QuantityRef};
+
+        let def = parse_trigger_line(
+            "Whenever you cast a noncreature spell, create that many 1/1 blue Merfolk creature tokens.",
+            "Test Card",
+        );
+
+        // valid_card must NOT contain a ManaSymbolCount prop anywhere.
+        fn has_pip(f: &TargetFilter) -> bool {
+            match f {
+                TargetFilter::And { filters } => filters.iter().any(has_pip),
+                TargetFilter::Typed(tf) => tf
+                    .properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::ManaSymbolCount { .. })),
+                _ => false,
+            }
+        }
+        if let Some(vc) = def.valid_card.as_ref() {
+            assert!(!has_pip(vc), "no ManaSymbolCount expected, got {vc:?}");
+        }
+
+        if let Some(execute) = def.execute.as_deref() {
+            if let Some(count) = collect_effects(execute).into_iter().find_map(|e| match e {
+                Effect::Token { count, .. } => Some(count.clone()),
+                _ => None,
+            }) {
+                assert_eq!(
+                    count,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::EventContextAmount
+                    },
+                    "without a pip qualifier the count must stay EventContextAmount"
+                );
+            }
+        }
     }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2837,6 +2837,19 @@ pub enum FilterProp {
         comparator: Comparator,
         count: u8,
     },
+    /// CR 107.4 + CR 202.1: Matches objects whose count of colored mana symbols
+    /// in the printed mana cost satisfies `comparator` against `value`.
+    /// `color: Some(c)` counts symbols contributing to color `c` (hybrid /
+    /// monocolored-hybrid / Phyrexian via `ManaCostShard::contributes_to`,
+    /// CR 107.4a/107.4e/107.4f); `color: None` counts each colored symbol once.
+    /// `value` is a printed constant. Filter sibling of
+    /// `QuantityRef::ManaSymbolsInManaCost`; both delegate the pip count to the
+    /// single counting authority `ManaCost::count_colored_pips`.
+    ManaSymbolCount {
+        color: Option<ManaColor>,
+        comparator: Comparator,
+        value: i32,
+    },
     /// Matches objects with a specific supertype (Basic, Legendary, Snow).
     HasSupertype {
         value: Supertype,

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -1295,6 +1295,34 @@ impl ManaCost {
         }
     }
 
+    /// CR 107.4 + CR 202.1: Count colored mana symbols in this mana cost.
+    /// `Some(c)` counts symbols contributing to color `c` (hybrid /
+    /// monocolored-hybrid / Phyrexian symbols included via
+    /// `ManaCostShard::contributes_to`). `None` counts each colored shard once
+    /// regardless of color — CR 107.4a/107.4e/107.4f: a hybrid or Phyrexian
+    /// symbol is a single colored mana symbol even though it is all of its
+    /// component colors, so `{G/W}{G/W}` counts as 2 (not 4). Generic, X,
+    /// colorless, and snow shards are not colored and never count.
+    /// `NoCost`/`SelfManaCost`/`SelfManaValue` have no per-shard cost → 0.
+    ///
+    /// Single counting authority shared by `QuantityRef::ManaSymbolsInManaCost`
+    /// (game/quantity.rs) and `FilterProp::ManaSymbolCount` (game/filter.rs).
+    pub fn count_colored_pips(&self, color: Option<ManaColor>) -> i32 {
+        match self {
+            ManaCost::Cost { shards, .. } => {
+                let count = shards
+                    .iter()
+                    .filter(|shard| match color {
+                        Some(c) => shard.contributes_to(c),
+                        None => ManaColor::ALL.iter().any(|c| shard.contributes_to(*c)),
+                    })
+                    .count();
+                i32::try_from(count).unwrap_or(i32::MAX)
+            }
+            ManaCost::NoCost | ManaCost::SelfManaCost | ManaCost::SelfManaValue => 0,
+        }
+    }
+
     /// CR 202.3e: X in a mana cost equals the announced value only while the
     /// object is on the stack; in every other zone, X contributes 0.
     pub fn mana_value_with_x(&self, zone: Zone, cost_x_paid: Option<u32>) -> u32 {


### PR DESCRIPTION
Closes #4370

## Problem

Namor the Sub-Mariner — *"Whenever you cast a noncreature spell with one
or more blue mana symbols in its mana cost, create that many 1/1 blue
Merfolk creature tokens."* — had two defects in its parsed AST:

1. **Zero tokens.** The token count parsed to
   `QuantityRef::EventContextAmount`, but a `SpellCast` event carries no
   amount, so it resolved to `0` → no tokens were ever created.
2. **Over-fired on every noncreature spell.** The trigger's `valid_card`
   carried only the `Non:Creature` type filter and no blue-pip
   constraint, so it triggered on *every* noncreature spell, violating
   CR 603.2 (the trigger shouldn't even go on the stack).

## Fix

Built as a class-general pattern, not a one-off for Namor:

- **New predicate** `FilterProp::ManaSymbolCount { color, comparator, value }`
  (CR 107.4 + CR 202.1) — sibling of `QuantityRef::ManaSymbolsInManaCost`,
  parameterized by color/comparator/threshold. The trigger's `valid_card`
  now carries `ManaSymbolCount { Blue, GE, 1 }` ("one or more blue mana
  symbols"), so it only fires on qualifying spells.
- **Count fix:** the "create that many tokens" clause now back-references
  the cast spell's blue-pip count via
  `QuantityRef::ManaSymbolsInManaCost { scope: EventSource, color: Some(Blue) }`
  (CR 603.2 / CR 603.4).
- **Single counting authority:** `ManaCost::count_colored_pips` is the one
  place colored mana symbols are counted (hybrid / monocolored-hybrid /
  Phyrexian via `ManaCostShard::contributes_to`, CR 107.4a/e/f). Both the
  `QuantityRef` resolver and the new `FilterProp` delegate to it — no
  duplicated counting logic.
- **Parser threading:** the qualifier color is staged on `ParseContext`
  from the trigger condition, propagated through the effect-chain
  per-chunk context, and consumed by a token-count override that is
  **gated on the staged color** — so generic "create that many tokens"
  effects (e.g. Chatterfang) are untouched.

## Tests

- Parser-shape: `valid_card` carries `ManaSymbolCount { Blue, GE, 1 }` and
  the token count back-references the blue-pip count.
- Leakage guard: a cast trigger *without* a colored-pip qualifier keeps
  `EventContextAmount` and gains no `ManaSymbolCount` constraint.
- Runtime cast-pipeline (drives cast → trigger → resolution):
  - `{U}{U}` noncreature spell with Namor out → **exactly 2** Merfolk tokens.
  - `{R}` noncreature spell → trigger does **not** fire, **0** tokens.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p engine --lib` — exit 0, no warnings
- Parser combinator gate — pass
- `cargo test -p engine --lib` — **13940 passed, 0 failed**
- `cargo test -p phase-ai` — pass
