### PR TITLE
fix(parser): bind reflexive conditional riders (S01 reflexive-if-rider cluster)

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4200,6 +4200,17 @@ fn zone_change_record_matches_property(
             let actual = counter_count_from_map(&lki.counters, selector);
             comparator.evaluate(actual, resolve_filter_threshold(state, count, source))
         }),
+        // CR 120.6 + CR 120.9 + CR 608.2h: "was dealt damage this turn" is a
+        // turn-scoped historical fact, not a query against current marked damage.
+        // The `damage_dealt_this_turn` ledger is keyed by the battlefield ObjectId
+        // and survives the object's zone change, so a look-back rider ("Exile
+        // target creature. If it was dealt damage this turn, ..." — Sold Out)
+        // evaluating against the LKI snapshot reads the same ledger the live
+        // evaluator uses, by the snapshot's `object_id`. Mirrors the live arm.
+        FilterProp::WasDealtDamageThisTurn => state
+            .damage_dealt_this_turn
+            .iter()
+            .any(|r| matches!(r.target, TargetRef::Object(id) if id == record.object_id)),
         FilterProp::Tapped
         | FilterProp::IsSaddled
         | FilterProp::SaddledSource
@@ -4244,7 +4255,6 @@ fn zone_change_record_matches_property(
         | FilterProp::DifferentNameFrom { .. }
         | FilterProp::InAnyZone { .. }
         | FilterProp::SharesQuality { .. }
-        | FilterProp::WasDealtDamageThisTurn
         | FilterProp::EnteredThisTurn
         | FilterProp::ZoneChangedThisTurn { .. }
         // CR 122.6: counters-put-this-turn is a live-history join keyed on the

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1408,8 +1408,8 @@ fn parse_target_attacked_this_turn_condition_text(text: &str) -> Option<AbilityC
     parsed
 }
 
-/// Parse a trailing "N or less" / "N or greater" comparison threshold shared by
-/// the mana-value (CR 202.3) and power/toughness (CR 208.1) reflexive
+/// CR 202.3 + CR 208.1: Parse a trailing "N or less" / "N or greater"
+/// comparison threshold shared by the mana-value and power/toughness reflexive
 /// predicates. Returns the typed `Comparator` and the fixed threshold. Composed
 /// from `nom_primitives::parse_number` and a comparator `alt` — one combinator,
 /// not a flat product of full-string tags.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -5,7 +5,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
-use nom::combinator::{all_consuming, opt, peek, value};
+use nom::combinator::{all_consuming, map, opt, peek, value};
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -25,8 +25,8 @@ use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin, CastManaObjectScope,
     CastManaSpentMetric, CastVariantPaid, Comparator, ControllerRef, CountScope, DigSource,
-    Duration, Effect, FilterProp, ObjectScope, ParsedCondition, PlayerScope, QuantityExpr,
-    QuantityRef, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
+    Duration, Effect, FilterProp, ObjectScope, ParsedCondition, PlayerScope, PtStat, PtValueScope,
+    QuantityExpr, QuantityRef, StaticCondition, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -1333,6 +1333,11 @@ fn parse_target_anaphoric_tense_polarity(
         value((true, true), alt((tag(" wasn't "), tag(" was not ")))),
         // Positive past
         value((false, true), tag(" was ")),
+        // CR 400.7: past-tense possession ("it had mana value 3 or less", "that
+        // creature had power 2 or less") → LKI snapshot. None of the recognized
+        // reflexive predicates use a negated " hadn't "/" didn't have " form, so
+        // only the positive arm is supplied.
+        value((false, true), tag(" had ")),
         // Negated present — must precede positive present
         value(
             (true, false),
@@ -1397,6 +1402,122 @@ fn parse_anaphoric_attacked_tense_polarity(input: &str) -> OracleResult<'_, bool
 fn parse_target_attacked_this_turn_condition_text(text: &str) -> Option<AbilityCondition> {
     let lower = text.trim().trim_end_matches('.').to_ascii_lowercase();
     let parsed = all_consuming(parse_target_attacked_this_turn_condition)
+        .parse(lower.as_str())
+        .ok()
+        .map(|(_, c)| c);
+    parsed
+}
+
+/// Parse a trailing "N or less" / "N or greater" comparison threshold shared by
+/// the mana-value (CR 202.3) and power/toughness (CR 208.1) reflexive
+/// predicates. Returns the typed `Comparator` and the fixed threshold. Composed
+/// from `nom_primitives::parse_number` and a comparator `alt` — one combinator,
+/// not a flat product of full-string tags.
+fn parse_or_threshold(input: &str) -> OracleResult<'_, (Comparator, i32)> {
+    let (rest, n) = nom_primitives::parse_number(input)?;
+    let (rest, _) = tag(" or ").parse(rest)?;
+    let (rest, comparator) = alt((
+        value(Comparator::LE, alt((tag("less"), tag("fewer")))),
+        value(Comparator::GE, alt((tag("greater"), tag("more")))),
+    ))
+    .parse(rest)?;
+    Ok((rest, (comparator, n as i32)))
+}
+
+/// CR 208.1: consume a P/T-stat keyword (with its trailing space) for the
+/// reflexive power/toughness predicate. Power and toughness are a leaf-level
+/// parameterization of the same CR 208 characteristic pair (`PtStat`).
+fn parse_reflexive_pt_stat(input: &str) -> OracleResult<'_, PtStat> {
+    alt((
+        value(PtStat::Power, tag("power ")),
+        value(PtStat::Toughness, tag("toughness ")),
+    ))
+    .parse(input)
+}
+
+/// CR 608.2c: the reflexive predicate following a target-anaphoric subject +
+/// tense — one branch per object characteristic. This `alt` IS the parameterized
+/// predicate axis: a single combinator per characteristic, composed, not a flat
+/// product of full-sentence tags. Each branch yields the `FilterProp` the
+/// condition tests against the prior clause's first object target.
+fn parse_reflexive_object_property(input: &str) -> OracleResult<'_, FilterProp> {
+    alt((
+        // CR 120.6 + CR 120.9: historical "was dealt damage this turn" (Sold Out).
+        // NOTE: `FilterProp::Tapped` ("it was tapped", Brackish Blunder) is
+        // deliberately NOT recognized here. Tap status is not captured in the
+        // `LKISnapshot` / `ZoneChangeRecord` look-back snapshot, so a past-tense
+        // "was tapped" rider (use_lki) would evaluate fail-closed (always false)
+        // after the antecedent leaves the battlefield — silently under-firing.
+        // Recognizing it would turn the honest red swallow into a green parse with
+        // broken runtime semantics; left swallowed until the snapshot carries tap
+        // state (see implementation report).
+        value(
+            FilterProp::WasDealtDamageThisTurn,
+            tag("dealt damage this turn"),
+        ),
+        // CR 508.1b: combat status (Wisecrack "is attacking").
+        value(FilterProp::Attacking { defender: None }, tag("attacking")),
+        // CR 509.1a: combat status (blocking sibling).
+        value(FilterProp::Blocking, tag("blocking")),
+        // CR 202.3: "mana value N or less/greater" (Consuming Ashes).
+        map(
+            preceded(tag("mana value "), parse_or_threshold),
+            |(comparator, value)| FilterProp::Cmc {
+                comparator,
+                value: QuantityExpr::Fixed { value },
+            },
+        ),
+        // CR 208.1: "power/toughness N or less/greater" (Driftgloom Coyote).
+        map(
+            (parse_reflexive_pt_stat, parse_or_threshold),
+            |(stat, (comparator, value))| FilterProp::PtComparison {
+                stat,
+                scope: PtValueScope::Current,
+                comparator,
+                value: QuantityExpr::Fixed { value },
+            },
+        ),
+    ))
+    .parse(input)
+}
+
+/// CR 608.2c + CR 400.7: target-anaphoric reflexive object-property gate — the
+/// rider condition for the "removal/bounce/damage, then conditional bonus"
+/// class ("it was dealt damage this turn", "it had mana value 3 or less", "that
+/// creature had power 2 or less", "that creature is attacking"). Composes three
+/// orthogonal axes:
+///
+///   - subject: `it` / `that creature` / `that permanent` / `that card`
+///     (`parse_target_anaphoric_subject`)
+///   - tense + polarity: `parse_target_anaphoric_tense_polarity` →
+///     `(negated, use_lki)` — past tense (`was`/`had`) reads LKI per CR 400.7 /
+///     CR 608.2h; present tense (`is`) reads live state.
+///   - predicate: a parameterized `FilterProp` axis
+///     (`parse_reflexive_object_property`).
+///
+/// Emits `TargetMatchesFilter` (wrapped in `Not` when negated) resolving against
+/// the resolving ability's first object target.
+fn parse_target_reflexive_property_condition(
+    input: &str,
+) -> super::super::oracle_nom::error::OracleResult<'_, AbilityCondition> {
+    let (rest, _) = parse_target_anaphoric_subject(input)?;
+    let (rest, (negated, use_lki)) = parse_target_anaphoric_tense_polarity(rest)?;
+    let (rest, prop) = parse_reflexive_object_property(rest)?;
+    Ok((
+        rest,
+        maybe_negate(
+            AbilityCondition::TargetMatchesFilter {
+                filter: TargetFilter::Typed(TypedFilter::default().properties(vec![prop])),
+                use_lki,
+            },
+            negated,
+        ),
+    ))
+}
+
+fn parse_target_reflexive_property_condition_text(text: &str) -> Option<AbilityCondition> {
+    let lower = text.trim().trim_end_matches('.').to_ascii_lowercase();
+    let parsed = all_consuming(parse_target_reflexive_property_condition)
         .parse(lower.as_str())
         .ok()
         .map(|(_, c)| c);
@@ -3770,6 +3891,19 @@ pub(super) fn try_nom_condition_as_ability_condition(
     // a type/subtype phrase, so it does not collide with the bare-color form
     // (which `parse_condition_text` handles separately).
     if let Some(condition) = parse_target_type_membership_condition_text(lower.as_str()) {
+        return Some(condition);
+    }
+
+    // CR 608.2c + CR 400.7: target-anaphoric reflexive object-property gate —
+    // "it was dealt damage this turn" / "it had mana value 3 or less" / "that
+    // creature had power 2 or less" / "that creature is attacking". The rider
+    // condition for the "<removal/bounce/damage>, then conditional bonus" class
+    // (Consuming Ashes, Sold Out, Driftgloom Coyote, Wisecrack). Placed after the
+    // more specific combat-history and type-membership forms above and before the
+    // bare-color / parse_inner_condition fallbacks: the predicate is a
+    // parameterized object characteristic (dealt-damage, combat status, mana
+    // value, P/T), so it must not preempt the type/color recognizers.
+    if let Some(condition) = parse_target_reflexive_property_condition_text(lower.as_str()) {
         return Some(condition);
     }
 
@@ -6334,6 +6468,195 @@ mod tests {
             *condition,
             AbilityCondition::TargetMatchesFilter { .. }
         ));
+    }
+
+    // ---- reflexive-if-rider recognizer (S01) ----
+    //
+    // Discrimination / revert-probe: reverting the `parse_reflexive_object_property`
+    // arm (or the `try_nom_condition_as_ability_condition` registration) makes
+    // `parse_target_reflexive_property_condition_text` return `None`, reproducing
+    // the pre-fix swallow (`condition: null` on the rider sub-ability, measured in
+    // card-data.json for Sold Out / Consuming Ashes / Brackish Blunder). Each
+    // sibling negative proves a distinct axis (predicate / comparator / tense /
+    // polarity) is load-bearing.
+
+    fn single_prop(cond: &AbilityCondition) -> (&FilterProp, bool) {
+        let AbilityCondition::TargetMatchesFilter { filter, use_lki } = cond else {
+            panic!("expected TargetMatchesFilter, got {cond:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert_eq!(tf.type_filters.len(), 0, "reflexive filter carries no type");
+        assert_eq!(tf.properties.len(), 1, "exactly one predicate prop");
+        (&tf.properties[0], *use_lki)
+    }
+
+    /// Honesty guard: "it was tapped" (Brackish Blunder) is deliberately NOT
+    /// recognized — tap status is absent from the LKI snapshot, so a use_lki
+    /// "was tapped" rider would under-fire. Leaving it unrecognized keeps the
+    /// coverage swallow honest (red) until the snapshot carries tap state.
+    #[test]
+    fn reflexive_was_tapped_is_deliberately_unrecognized() {
+        assert!(
+            parse_target_reflexive_property_condition_text("it was tapped").is_none(),
+            "'was tapped' must stay unrecognized (LKI tap state unsupported)"
+        );
+    }
+
+    /// Sibling: negated present "that creature isn't attacking" → Not +
+    /// use_lki:false. Proves the polarity AND tense axes are load-bearing on a
+    /// runtime-supported predicate.
+    #[test]
+    fn reflexive_isnt_attacking_emits_negated_present() {
+        let cond = parse_target_reflexive_property_condition_text("that creature isn't attacking")
+            .unwrap();
+        let AbilityCondition::Not { condition } = &cond else {
+            panic!("expected Not, got {cond:?}");
+        };
+        let (prop, use_lki) = single_prop(condition);
+        assert_eq!(*prop, FilterProp::Attacking { defender: None });
+        assert!(!use_lki, "present-tense 'isn't' must read live state");
+    }
+
+    /// CR 202.3: Consuming Ashes "it had mana value 3 or less" → Cmc LE 3, LKI.
+    #[test]
+    fn reflexive_had_mana_value_le3() {
+        let cond =
+            parse_target_reflexive_property_condition_text("it had mana value 3 or less").unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(
+            *prop,
+            FilterProp::Cmc {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 3 },
+            }
+        );
+        assert!(use_lki, "past-tense 'had' must use LKI per CR 400.7");
+    }
+
+    /// Sibling: comparator axis — "4 or greater" → GE 4.
+    #[test]
+    fn reflexive_had_mana_value_ge4() {
+        let cond = parse_target_reflexive_property_condition_text("it had mana value 4 or greater")
+            .unwrap();
+        let (prop, _) = single_prop(&cond);
+        assert_eq!(
+            *prop,
+            FilterProp::Cmc {
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 4 },
+            }
+        );
+    }
+
+    /// CR 208.1: Driftgloom Coyote "that creature had power 2 or less" →
+    /// PtComparison{Power, LE, 2}, LKI.
+    #[test]
+    fn reflexive_had_power_le2() {
+        let cond =
+            parse_target_reflexive_property_condition_text("that creature had power 2 or less")
+                .unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(
+            *prop,
+            FilterProp::PtComparison {
+                stat: PtStat::Power,
+                scope: PtValueScope::Current,
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 2 },
+            }
+        );
+        assert!(use_lki, "past-tense 'had' must use LKI per CR 400.7");
+    }
+
+    /// Sibling: stat axis — toughness, GE.
+    #[test]
+    fn reflexive_had_toughness_ge3() {
+        let cond = parse_target_reflexive_property_condition_text(
+            "that creature had toughness 3 or greater",
+        )
+        .unwrap();
+        let (prop, _) = single_prop(&cond);
+        assert_eq!(
+            *prop,
+            FilterProp::PtComparison {
+                stat: PtStat::Toughness,
+                scope: PtValueScope::Current,
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 3 },
+            }
+        );
+    }
+
+    /// CR 508.1b: Wisecrack "that creature is attacking" → Attacking, present
+    /// tense reads live state (use_lki:false).
+    #[test]
+    fn reflexive_is_attacking_live() {
+        let cond =
+            parse_target_reflexive_property_condition_text("that creature is attacking").unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(*prop, FilterProp::Attacking { defender: None });
+        assert!(!use_lki, "present-tense 'is attacking' reads live combat");
+    }
+
+    /// Sibling: combat-status predicate axis — blocking.
+    #[test]
+    fn reflexive_is_blocking_live() {
+        let cond =
+            parse_target_reflexive_property_condition_text("that creature is blocking").unwrap();
+        let (prop, _) = single_prop(&cond);
+        assert_eq!(*prop, FilterProp::Blocking);
+    }
+
+    /// CR 120.6 + CR 120.9: Sold Out "it was dealt damage this turn" →
+    /// WasDealtDamageThisTurn, LKI.
+    #[test]
+    fn reflexive_was_dealt_damage_this_turn() {
+        let cond = parse_target_reflexive_property_condition_text("it was dealt damage this turn")
+            .unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(*prop, FilterProp::WasDealtDamageThisTurn);
+        assert!(use_lki, "past-tense look-back must use LKI per CR 400.7");
+    }
+
+    /// CR 608.2c: Faller's Faithful "that creature wasn't dealt damage this turn"
+    /// → Not{WasDealtDamageThisTurn, LKI}. (Part B card; recognizer-side proof.)
+    #[test]
+    fn reflexive_wasnt_dealt_damage_negated() {
+        let cond = parse_target_reflexive_property_condition_text(
+            "that creature wasn't dealt damage this turn",
+        )
+        .unwrap();
+        let AbilityCondition::Not { condition } = &cond else {
+            panic!("expected Not, got {cond:?}");
+        };
+        let (prop, use_lki) = single_prop(condition);
+        assert_eq!(*prop, FilterProp::WasDealtDamageThisTurn);
+        assert!(use_lki, "negated past-tense look-back uses LKI");
+    }
+
+    /// Coverage-regression guard (Zemo / Isochron class): a board-state leading
+    /// conditional whose subject is NOT a target anaphor ("you control a
+    /// creature") must NOT be folded into a `TargetMatchesFilter`. The reflexive
+    /// recognizer returns `None`, and the full dispatch routes it to its existing
+    /// control-presence condition.
+    #[test]
+    fn reflexive_recognizer_ignores_board_state_conditional() {
+        assert!(
+            parse_target_reflexive_property_condition_text("you control a creature").is_none(),
+            "board-state 'you control a creature' must not match the reflexive recognizer"
+        );
+        let mut ctx = ParseContext::default();
+        let routed = try_nom_condition_as_ability_condition("you control a creature", &mut ctx);
+        assert!(
+            !matches!(
+                routed,
+                Some(AbilityCondition::TargetMatchesFilter { .. })
+                    | Some(AbilityCondition::Not { .. })
+            ),
+            "control-presence gate must not be mis-folded into TargetMatchesFilter, got {routed:?}"
+        );
     }
 
     /// CR 608.2c: "permanent" is not a CoreType — strip_card_type_conditional must

--- a/crates/engine/tests/reflexive_if_rider.rs
+++ b/crates/engine/tests/reflexive_if_rider.rs
@@ -1,0 +1,299 @@
+//! Runtime regression coverage for the reflexive-if-rider class (S01): a spell or
+//! ability whose second clause is gated by a condition that anaphorically refers
+//! to the object the first clause acted on — "Exile target creature. If it was
+//! dealt damage this turn, create a Clue token." (Sold Out), "If it had mana
+//! value 3 or less, surveil 2." (Consuming Ashes), "If that creature is
+//! attacking, ~ deals 2 damage to that creature's controller." (Wisecrack).
+//!
+//! Before this change the rider's condition parsed to `null`, so the rider fired
+//! UNCONDITIONALLY (measured in `card-data.json`). Each test drives the real cast
+//! pipeline (`GameRunner::cast(..).resolve()`) and asserts the rider fires ONLY
+//! when its condition holds — the negative case is the discriminator: reverting
+//! the recognizer makes the condition `null` again and the negative assertion
+//! fails (the rider fires when it must not).
+//!
+//! CR 608.2c: later text in the same effect refers to an object mentioned
+//! earlier. CR 400.7 / CR 608.2h: past-tense predicates ("was dealt damage",
+//! "had mana value") read last-known information after the object leaves the
+//! battlefield; present-tense ("is attacking") reads live state.
+
+use engine::game::combat::{AttackerInfo, CombatState};
+use engine::game::scenario::GameScenario;
+use engine::types::ability::TargetRef;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{DamageRecord, WaitingFor};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+// Verified identical to the engine's authoritative card data (client/public/card-data.json).
+const SOLD_OUT: &str =
+    "Exile target creature. If it was dealt damage this turn, create a Clue token. \
+     (It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")";
+const CONSUMING_ASHES: &str = "Exile target creature. If it had mana value 3 or less, surveil 2. \
+     (Look at the top two cards of your library, then put any number of them into your \
+     graveyard and the rest on top of your library in any order.)";
+const WISECRACK: &str =
+    "Target creature deals damage equal to its power to itself. If that creature is \
+     attacking, Wisecrack deals 2 damage to that creature's controller.";
+const DRIFTGLOOM: &str =
+    "When this creature enters, exile target creature an opponent controls until this \
+     creature leaves the battlefield. If that creature had power 2 or less, put a +1/+1 \
+     counter on this creature.";
+
+/// Number of `+1/+1` counters on `object`.
+fn plus_counters(
+    state: &engine::types::game_state::GameState,
+    object: engine::types::identifiers::ObjectId,
+) -> u32 {
+    state
+        .objects
+        .get(&object)
+        .and_then(|o| o.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+/// Count battlefield objects named `name` (token-presence assertion).
+fn battlefield_named(state: &engine::types::game_state::GameState, name: &str) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|o| o.zone == Zone::Battlefield && o.name == name)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// Sold Out — "If it was dealt damage this turn" (WasDealtDamageThisTurn, LKI
+// ledger join). Exercises the zone-change/LKI `WasDealtDamageThisTurn` arm.
+// ---------------------------------------------------------------------------
+
+/// RUNTIME (positive) — CR 120.6 + CR 120.9 + CR 608.2h. A creature with a
+/// damage record this turn, exiled by Sold Out, satisfies "was dealt damage this
+/// turn" via the turn-scoped ledger (keyed by the battlefield ObjectId, survives
+/// the exile), so the Clue token is created.
+#[test]
+fn sold_out_creates_clue_when_target_was_dealt_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Sold Out", true, SOLD_OUT)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // CR 120.9: the turn's damage ledger records the victim's battlefield id.
+    runner
+        .state_mut()
+        .damage_dealt_this_turn
+        .push_back(DamageRecord {
+            target: TargetRef::Object(victim),
+            amount: 2,
+            ..Default::default()
+        });
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert_eq!(
+        battlefield_named(outcome.state(), "Clue"),
+        1,
+        "damaged target must yield a Clue token"
+    );
+}
+
+/// RUNTIME (negative / discriminator) — an UNDAMAGED target yields NO Clue. With
+/// the pre-fix `condition: null` the rider would fire unconditionally and this
+/// assertion would fail.
+#[test]
+fn sold_out_no_clue_when_target_undamaged() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Sold Out", true, SOLD_OUT)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+    // No damage record this turn.
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert_eq!(
+        battlefield_named(outcome.state(), "Clue"),
+        0,
+        "undamaged target must NOT yield a Clue token (rider must be gated)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Consuming Ashes — "If it had mana value 3 or less" (Cmc, LKI snapshot).
+// Surveil is not auto-answered by the driver, so the resolved-and-gated surveil
+// surfaces as a `SurveilChoice` halt; an ungated path resolves to Priority.
+// ---------------------------------------------------------------------------
+
+/// RUNTIME (positive) — CR 202.3 + CR 400.7. A mana-value-2 creature exiled by
+/// Consuming Ashes satisfies "had mana value 3 or less" against its LKI snapshot,
+/// so surveil 2 resolves and the pipeline halts at the SurveilChoice prompt.
+#[test]
+fn consuming_ashes_surveils_when_target_mana_value_le_3() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Consuming Ashes", true, CONSUMING_ASHES)
+        .id();
+    // MV 2 ≤ 3.
+    let mut victim_builder = scenario.add_creature(P1, "Grizzly Bears", 2, 2);
+    victim_builder.with_mana_cost(ManaCost::generic(2));
+    let victim = victim_builder.id();
+    // Library cards so surveil 2 has something to look at (else no prompt).
+    scenario.add_spell_to_library_top(P0, "Filler A", true);
+    scenario.add_spell_to_library_top(P0, "Filler B", true);
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::SurveilChoice { .. }
+        ),
+        "MV-2 target must gate surveil ON (halt at SurveilChoice), got {:?}",
+        outcome.final_waiting_for()
+    );
+}
+
+/// RUNTIME (negative / discriminator) — a mana-value-5 creature fails the gate;
+/// surveil does NOT happen and the pipeline never surfaces a SurveilChoice. With
+/// the pre-fix `condition: null` the surveil would fire and this would fail.
+#[test]
+fn consuming_ashes_no_surveil_when_target_mana_value_gt_3() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Consuming Ashes", true, CONSUMING_ASHES)
+        .id();
+    // MV 5 > 3.
+    let mut victim_builder = scenario.add_creature(P1, "Hulking Brute", 5, 5);
+    victim_builder.with_mana_cost(ManaCost::generic(5));
+    let victim = victim_builder.id();
+    scenario.add_spell_to_library_top(P0, "Filler A", true);
+    scenario.add_spell_to_library_top(P0, "Filler B", true);
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert!(
+        !matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::SurveilChoice { .. }
+        ),
+        "MV-5 target must gate surveil OFF (no SurveilChoice), got {:?}",
+        outcome.final_waiting_for()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Wisecrack — "If that creature is attacking" (Attacking, present-tense LIVE).
+// ---------------------------------------------------------------------------
+
+/// RUNTIME (positive) — CR 508.1b. An ATTACKING target creature triggers the
+/// rider: Wisecrack deals 2 damage to that creature's controller (P1).
+#[test]
+fn wisecrack_damages_controller_when_target_attacking() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Wisecrack", true, WISECRACK)
+        .id();
+    let victim = scenario.add_creature(P1, "Bear", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // CR 508.1b: P1's creature is attacking (live combat state read by the
+    // present-tense "is attacking" predicate).
+    runner.state_mut().combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(victim, P0)],
+        ..Default::default()
+    });
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_life_delta(P1, -2);
+}
+
+/// RUNTIME (negative / discriminator) — a NON-attacking target leaves the
+/// controller's life unchanged. With the pre-fix `condition: null` the 2 damage
+/// would land unconditionally and this would fail.
+#[test]
+fn wisecrack_no_controller_damage_when_target_not_attacking() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Wisecrack", true, WISECRACK)
+        .id();
+    let victim = scenario.add_creature(P1, "Bear", 2, 2).id();
+    let mut runner = scenario.build();
+    // No combat — the creature is not attacking.
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_life_delta(P1, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Driftgloom Coyote — ETB trigger "If that creature had power 2 or less"
+// (PtComparison, LKI snapshot). Drives the real ETB-trigger path: the creature
+// is cast from hand, enters, its ETB trigger goes on the stack, targets the
+// opponent's creature, exiles it, and reads the exiled creature's LKI power.
+// ---------------------------------------------------------------------------
+
+/// RUNTIME (positive) — CR 208.1 + CR 400.7. A power-2 creature exiled by
+/// Driftgloom's ETB satisfies "had power 2 or less" against its LKI snapshot, so
+/// Driftgloom gets a +1/+1 counter.
+#[test]
+fn driftgloom_counter_when_exiled_creature_power_le_2() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let coyote = scenario
+        .add_creature_to_hand_from_oracle(P0, "Driftgloom Coyote", 2, 2, DRIFTGLOOM)
+        .id();
+    let victim = scenario.add_creature(P1, "Power Two", 2, 2).id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(coyote).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert_eq!(
+        plus_counters(outcome.state(), coyote),
+        1,
+        "power-2 exiled creature must yield a +1/+1 counter on Driftgloom"
+    );
+}
+
+/// RUNTIME (negative / discriminator) — a power-3 creature fails the gate; no
+/// counter. With the pre-fix `condition: null` the counter would land
+/// unconditionally and this would fail.
+#[test]
+fn driftgloom_no_counter_when_exiled_creature_power_gt_2() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let coyote = scenario
+        .add_creature_to_hand_from_oracle(P0, "Driftgloom Coyote", 2, 2, DRIFTGLOOM)
+        .id();
+    let victim = scenario.add_creature(P1, "Power Three", 3, 3).id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(coyote).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Exile);
+    assert_eq!(
+        plus_counters(outcome.state(), coyote),
+        0,
+        "power-3 exiled creature must NOT yield a counter (rider must be gated)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Reflexive conditional riders — `<effect>. If <it/that …> <cond>, <rider>` (S01)

### The bug (correctness, not just coverage)
The reflexive conditional rider on removal/bounce/damage spells and ETB triggers — e.g. *"Exile target creature. **If it was dealt damage this turn**, create a Clue token"* — parsed with the rider effect attached as a sub-ability but its **condition dropped to `null`**, so the rider fired **unconditionally**. Verified against `card-data.json` for Sold Out, Consuming Ashes, Brackish Blunder, and others.

### The fix (one building block)
- A parameterized **reflexive-anaphor condition recognizer** (subject × tense/polarity × `FilterProp` predicate), registered in `try_nom_condition_as_ability_condition` — the single dispatch point used by both the `parse_clause_ast` swallow path and the chunk loop. nom-combinator-only; registered after the type-membership arm and before the fallbacks so existing conditions are untouched. No new enum variants.
- A small engine fix: the `WasDealtDamageThisTurn` LKI-snapshot arm now queries the turn-scoped damage ledger by `ObjectId` (CR 120.9), mirroring the live arm, so the predicate evaluates correctly after the target changes zones.

### Evidence
- **Flips 11 cards** false→true (Consuming Ashes, Sold Out, Driftgloom Coyote, Wisecrack + 7 class members incl. serum snare, sewers of estark, battlefield improvisation, sweep away, will of the all-hunter, grave choice) — the building block working across the class.
- **0 coverage regressions** over the full 35,396-card corpus: swallows −11 (Condition_If −9, Duration_ThisTurn −2), **every other detector +0**, no card newly swallowed. Independently reproduced by an isolated-toggle diff (exactly 11 cards changed, all `condition:null → correct`).
- Gates: `cargo fmt`, `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -D warnings`, `cargo test -p engine` (11 new parser unit tests + 8 runtime card-tests, each with positive+negative pairs through the real cast/ETB pipeline and load-bearing revert-probes), parser-combinator gate, `semantic-audit` — all clean. CR 120.6/120.9/202.3/208.1/400.7/508.1b/509.1a/608.2c/608.2h grep-verified. Rebased onto current `main` with the full workspace build re-run.
- A guard test confirms board-state conditionals (*"If you control a creature, …"*) are **not** mis-folded — the Isochron/Zemo coverage-regression class.

### Honest scope notes (documented follow-ups, no regression)
- **Brackish Blunder ("was tapped") deliberately not shipped:** `FilterProp::Tapped` fails closed on the LKI snapshot (no tap state in `LKISnapshot`/`ZoneChangeRecord`); recognizing it would flip the swallow green while the runtime silently under-fires. Kept as an honest red swallow; the LKI tap-state plumbing is its own follow-up cluster.
- **Faller's Faithful Part B:** the recognizer parses its `Not{WasDealtDamageThisTurn}` rider; the declined-"up to one" optional-target guard is deferred. Net improvement over baseline (chosen-target path now correct; declined path unchanged) — no regression.