### PR TITLE
fix(parser): Kishla Skimmer leaves-graveyard "during your turn" trigger (#4521)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7976,7 +7976,14 @@ fn try_parse_event(
         // `parse_zone_change_clause`, the same building block the
         // disjunctive-condition path uses for Syr Konrad's "leaves graveyard"
         // clause, so the runtime `zone_change_clause_matches` path is shared.
-        if let Some(clause) = parse_zone_change_clause(subject, rest) {
+        // CR 603.4: peel the trailing "during your turn" intervening-if condition
+        // off the full verb phrase before the zone-change clause parser (which
+        // requires an empty tail) — the singular "card leaves your graveyard
+        // during your turn" form (Kishla Skimmer) otherwise collapses to Unknown.
+        // Mirrors the LeavesBattlefield branch above and the plural batched-leave
+        // path; `turn_condition` was already derived from the same trailing peel.
+        let (rest_peeled, _) = peel_trailing_turn_constraint(rest);
+        if let Some(clause) = parse_zone_change_clause(subject, rest_peeled) {
             let mut def = make_base();
             def.mode = TriggerMode::ChangesZone;
             // CR 113.6k + CR 603.10: a self-referential leaves trigger resolves
@@ -7987,6 +7994,9 @@ fn try_parse_event(
                 def.trigger_zones = vec![Zone::Battlefield, Zone::Graveyard, Zone::Exile];
             }
             def.zone_change_clauses = vec![clause];
+            if let Some(condition) = turn_condition {
+                def.condition = Some(condition);
+            }
             return Some((TriggerMode::ChangesZone, def));
         }
     }
@@ -14365,6 +14375,44 @@ mod tests {
         );
         assert_eq!(clause.destination, Some(Zone::Battlefield));
         assert_eq!(clause.valid_card, Some(TargetFilter::SelfRef));
+        assert!(def.execute.is_some());
+    }
+
+    /// CR 603.10a + CR 603.4 (issue #4521): Kishla Skimmer — "Whenever a card
+    /// leaves your graveyard during your turn, draw a card. This ability
+    /// triggers only once each turn." The singular leaves-a-graveyard form must
+    /// route through `ChangesZone` with a graveyard-origin clause AND carry the
+    /// trailing "during your turn" as a `DuringPlayersTurn { Controller }`
+    /// intervening-if. Before the fix the un-peeled "during your turn" suffix
+    /// made `parse_zone_change_clause` reject the clause and the trigger
+    /// collapsed to `Unknown` (never firing). The plural batched-leave path and
+    /// the `LeavesBattlefield` branch already peel this suffix; the singular
+    /// non-battlefield-zone branch did not.
+    #[test]
+    fn trigger_card_leaves_your_graveyard_during_your_turn_once_each_turn() {
+        let def = parse_trigger_line(
+            "Whenever a card leaves your graveyard during your turn, draw a card. \
+             This ability triggers only once each turn.",
+            "Kishla Skimmer",
+        );
+        assert_eq!(def.mode, TriggerMode::ChangesZone);
+        assert_eq!(def.zone_change_clauses.len(), 1);
+        let clause = &def.zone_change_clauses[0];
+        // CR 603.10a: origin is the graveyard; destination is unconstrained.
+        assert_eq!(clause.origin, OriginConstraint::Equals(Zone::Graveyard));
+        assert_eq!(clause.destination, None);
+        // CR 603.4: the "during your turn" suffix becomes an intervening-if.
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::DuringPlayersTurn {
+                player: PlayerFilter::Controller,
+            }),
+        );
+        // CR 603.2h: "triggers only once each turn" → OncePerTurn.
+        assert_eq!(
+            def.constraint,
+            Some(crate::types::ability::TriggerConstraint::OncePerTurn),
+        );
         assert!(def.execute.is_some());
     }
 


### PR DESCRIPTION
Closes #4521

## Problem

Kishla Skimmer — *"Whenever a card leaves your graveyard during your turn,
draw a card. This ability triggers only once each turn."* — never fired.
The trigger collapsed to `Unknown` at parse time, so activating any ability
that moved a card out of your graveyard (e.g. Psychic Frog, Relic of
Progenitus) drew nothing.

## Root cause

The singular "leaves a non-battlefield zone" branch in
`parser/oracle_trigger.rs` passed the **un-peeled** verb phrase
`"leaves your graveyard during your turn"` to `parse_zone_change_clause`.
That clause parser matches `"leaves your graveyard"` (CR 603.10a) and then
requires an empty tail; the leftover `" during your turn"` is non-empty, so
it returned `None` and the whole trigger fell through to `Unknown`.

The sibling paths already handle this suffix: the `LeavesBattlefield`
branch and the plural batched-leave path both peel the trailing
`"during your turn"` first. Only the singular non-battlefield-zone branch
missed it.

## Fix

Peel the trailing turn condition off the verb phrase before the clause
parser (reusing the existing `peel_trailing_turn_constraint` helper), then
apply it as a `TriggerCondition::DuringPlayersTurn { Controller }`
intervening-if (CR 603.4). The trigger now parses to `ChangesZone` with a
graveyard-origin zone-change clause plus the turn condition; the
independent `OncePerTurn` constraint scan already worked.

**No behavior change for the no-constraint case** (e.g. Murktide Regent's
*"whenever an instant or sorcery card leaves your graveyard"*): when there
is no trailing `during` clause, the peel returns the input unchanged and
the condition stays `None`, so the string handed to
`parse_zone_change_clause` is byte-identical to before.

This is the complete fix — no engine plumbing needed. The leave-graveyard
runtime event, the `zone_change_clause_matches` matcher, and
`DuringPlayersTurn` evaluation all already exist and are exercised by
Murktide Regent (singular leave) and Soul Enervation (plural leave +
during-your-turn).

## Tests

Added `trigger_card_leaves_your_graveyard_during_your_turn_once_each_turn`:
asserts `mode == ChangesZone`, a single graveyard-origin zone-change clause
(`origin == Equals(Graveyard)`, `destination == None`),
`condition == DuringPlayersTurn { Controller }`, and
`constraint == OncePerTurn`.

## Verification

- `cargo fmt --all` — clean
- Parser combinator gate — pass
- `cargo clippy -p engine --lib` — exit 0, no warnings
- `cargo test -p engine --lib` — **14060 passed, 0 failed**
