### PR TITLE
fix(parser,engine): bind "if it was tapped" reflexive rider + LKI-tapped plumbing (Brackish Blunder)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -10109,6 +10109,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: std::collections::HashMap::new(),
+                tapped: false,
             },
         });
 

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -2989,6 +2989,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: vec![],
                 counters: Default::default(),
+                tapped: false,
             },
         });
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -3144,6 +3144,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: lki_counters,
+                tapped: false,
             },
         );
 

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -1916,6 +1916,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: lki_counters,
+                tapped: false,
             },
         );
 

--- a/crates/engine/src/game/effects/manifest.rs
+++ b/crates/engine/src/game/effects/manifest.rs
@@ -306,6 +306,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: std::collections::HashMap::new(),
+                tapped: false,
             },
         });
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -1257,6 +1257,7 @@ fn lki_snapshot_from_zone_change_record(record: &ZoneChangeRecord) -> LKISnapsho
         colors: record.colors.clone(),
         chosen_attributes: Vec::new(),
         counters: Default::default(),
+        tapped: false,
     }
 }
 
@@ -8386,6 +8387,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: vec![ChosenAttribute::Player(PlayerId(1))],
                 counters: HashMap::new(),
+                tapped: false,
             },
         );
 
@@ -10537,6 +10539,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: Default::default(),
+                tapped: false,
             },
         );
         let events = vec![

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4241,10 +4241,18 @@ fn zone_change_record_matches_property(
             .lki_cache
             .get(&record.object_id)
             .is_some_and(|lki| lki.tapped),
+        // CR 110.5 + CR 110.5d: symmetric sibling of `Tapped`. A look-back
+        // "was untapped" rider reads the exit-time tap state from the LKI
+        // snapshot and asserts it was NOT tapped. Fail-closed (no snapshot ⇒
+        // false) mirrors the `Tapped` arm: a card not on the battlefield is
+        // neither tapped nor untapped, so absence of a snapshot answers neither.
+        FilterProp::Untapped => state
+            .lki_cache
+            .get(&record.object_id)
+            .is_some_and(|lki| !lki.tapped),
         FilterProp::IsSaddled
         | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
-        | FilterProp::Untapped
         | FilterProp::HasHasteOrControlledSinceTurnBegan
         | FilterProp::AttackedThisTurn
         | FilterProp::BlockedThisTurn
@@ -8810,6 +8818,110 @@ mod tests {
             &FilterProp::Historic,
             &state,
             &vanilla_record,
+            &source_ctx,
+        ));
+    }
+
+    /// CR 110.5 + CR 110.5d + CR 400.7: the tap-status LKI-lookback arms of
+    /// `zone_change_record_matches_property` read exit-time tap state from the
+    /// snapshot. `Tapped` matches iff the snapshot recorded a tapped exit;
+    /// `Untapped` is the symmetric sibling, matching iff it recorded an untapped
+    /// exit. Both fail closed when no snapshot exists (a card off the battlefield
+    /// is neither tapped nor untapped, so absence answers neither — CR 110.5d).
+    ///
+    /// Revert-probe: returning `FilterProp::Untapped` to the fail-closed bucket
+    /// (its state on PR #4559 head 428481a) makes the `Untapped`/`untapped_record`
+    /// assertion fail — it returns false despite the snapshot recording an
+    /// untapped exit. This is the exact sibling gap the maintainer flagged.
+    #[test]
+    fn zone_change_record_tap_status_reads_lki_snapshot() {
+        use crate::types::game_state::{LKISnapshot, ZoneChangeRecord};
+
+        let mut state = GameState::default();
+        let source_ctx = SourceContext {
+            id: ObjectId(1),
+            controller: Some(PlayerId(0)),
+            attached_to: None,
+            source_is_aura: false,
+            source_is_equipment: false,
+            chosen_creature_type: None,
+            chosen_attributes: &[],
+            ability: None,
+            recipient_id: None,
+        };
+
+        let lki = |tapped: bool| LKISnapshot {
+            name: "Tap Probe".to_string(),
+            power: None,
+            toughness: None,
+            base_power: None,
+            base_toughness: None,
+            mana_value: 0,
+            controller: PlayerId(0),
+            owner: PlayerId(0),
+            card_types: vec![CoreType::Creature],
+            subtypes: vec![],
+            supertypes: vec![],
+            keywords: vec![],
+            colors: vec![],
+            chosen_attributes: vec![],
+            counters: Default::default(),
+            tapped,
+        };
+
+        // Left the battlefield TAPPED.
+        let tapped_id = ObjectId(60);
+        let tapped_record =
+            ZoneChangeRecord::test_minimal(tapped_id, Some(Zone::Battlefield), Zone::Hand);
+        state.lki_cache.insert(tapped_id, lki(true));
+
+        // Left the battlefield UNTAPPED.
+        let untapped_id = ObjectId(61);
+        let untapped_record =
+            ZoneChangeRecord::test_minimal(untapped_id, Some(Zone::Battlefield), Zone::Hand);
+        state.lki_cache.insert(untapped_id, lki(false));
+
+        // `Tapped`: matches the tapped exit, not the untapped exit.
+        assert!(zone_change_record_matches_property(
+            &FilterProp::Tapped,
+            &state,
+            &tapped_record,
+            &source_ctx,
+        ));
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::Tapped,
+            &state,
+            &untapped_record,
+            &source_ctx,
+        ));
+
+        // `Untapped` (new sibling): matches the untapped exit, not the tapped exit.
+        assert!(zone_change_record_matches_property(
+            &FilterProp::Untapped,
+            &state,
+            &untapped_record,
+            &source_ctx,
+        ));
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::Untapped,
+            &state,
+            &tapped_record,
+            &source_ctx,
+        ));
+
+        // Fail-closed symmetry: no snapshot ⇒ neither predicate matches.
+        let no_lki_record =
+            ZoneChangeRecord::test_minimal(ObjectId(62), Some(Zone::Battlefield), Zone::Hand);
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::Tapped,
+            &state,
+            &no_lki_record,
+            &source_ctx,
+        ));
+        assert!(!zone_change_record_matches_property(
+            &FilterProp::Untapped,
+            &state,
+            &no_lki_record,
             &source_ctx,
         ));
     }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4204,9 +4204,10 @@ fn zone_change_record_matches_property(
             .get(&record.object_id)
             .is_some_and(|obj| obj.paired_with.is_none()),
 
-        // These predicates query live battlefield state (tap status, attachment,
-        // current counters, face-down). The snapshot has already left its public
-        // zone, so the predicate is semantically not applicable.
+        // CR 608.2h: predicates whose state IS captured into the exit-time LKI
+        // snapshot (counters, tap status) are answered from `lki_cache`, keyed by
+        // the record's object id. Predicates that are NOT snapshotted (attachment,
+        // face-down, etc.) fall through to the fail-closed group below.
         FilterProp::Counters {
             counters,
             comparator,
@@ -4230,8 +4231,17 @@ fn zone_change_record_matches_property(
             .damage_dealt_this_turn
             .iter()
             .any(|r| matches!(r.target, TargetRef::Object(id) if id == record.object_id)),
-        FilterProp::Tapped
-        | FilterProp::IsSaddled
+        // CR 110.5 + CR 110.5d + CR 608.2h: tap status is battlefield-only — once
+        // the object has left its public zone it is neither tapped nor untapped, so
+        // the live object can't answer a look-back "was tapped" rider (Brackish
+        // Blunder, evaluated after the bounce/exile). Read the exit-time tap state
+        // captured into the LKI snapshot at zone exit (zones.rs), keyed by the
+        // record's object id — mirrors the `Counters` arm's `lki_cache` lookup.
+        FilterProp::Tapped => state
+            .lki_cache
+            .get(&record.object_id)
+            .is_some_and(|lki| lki.tapped),
+        FilterProp::IsSaddled
         | FilterProp::SaddledSource
         | FilterProp::ProtectorMatches { .. }
         | FilterProp::Untapped
@@ -5275,6 +5285,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: vec![],
                 counters: Default::default(),
+                tapped: false,
             },
         );
 
@@ -8659,6 +8670,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: Default::default(),
+            tapped: false,
         };
         let filter =
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Cmc {
@@ -8701,6 +8713,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: Default::default(),
+            tapped: false,
         };
         let filter =
             TargetFilter::Typed(
@@ -9594,6 +9607,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: HashMap::new(),
+            tapped: false,
         };
         let land_lki = LKISnapshot {
             name: "Test Land".to_string(),
@@ -9611,6 +9625,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: HashMap::new(),
+            tapped: false,
         };
 
         let filter =
@@ -9753,6 +9768,7 @@ mod tests {
                 colors: vec![],
                 counters: Default::default(),
                 chosen_attributes: vec![],
+                tapped: false,
             },
         );
 
@@ -9820,6 +9836,7 @@ mod tests {
                 colors: vec![],
                 counters: Default::default(),
                 chosen_attributes: vec![],
+                tapped: false,
             },
         );
 

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1380,6 +1380,10 @@ impl GameObject {
             colors: self.color.clone(),
             chosen_attributes: self.chosen_attributes.clone(),
             counters: self.counters.clone(),
+            // CR 110.5: Capture live tap status. This snapshot is taken while the
+            // object is still in its public zone (mana-spent / attack-declaration
+            // captures), so `self.tapped` is authoritative.
+            tapped: self.tapped,
         }
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -13484,6 +13484,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: std::collections::HashMap::new(),
+                tapped: false,
             },
         );
 

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -1328,6 +1328,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         );
         assert_eq!(resolve_object_name(&state, ObjectId(42)), "Grizzly Bears");

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -5017,6 +5017,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: HashMap::new(),
+            tapped: false,
         };
 
         state.attacker_declarations_this_turn = vec![
@@ -10690,6 +10691,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         );
         state.current_trigger_event =
@@ -10750,6 +10752,7 @@ mod tests {
                 colors: vec![ManaColor::Green],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         });
         let power = resolve_quantity_with_targets(
@@ -10895,6 +10898,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         });
         let resolved = resolve_quantity_with_targets(
@@ -10958,6 +10962,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         });
         assert!(
@@ -11019,6 +11024,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         };
         // Both fields set, with DIFFERENT mana values so the winning path is
@@ -11077,6 +11083,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         });
         let expr = QuantityExpr::Ref {
@@ -11128,6 +11135,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         };
         ability.set_effect_context_object_recursive(snapshot("Effect Context", 7));
@@ -11190,6 +11198,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         };
         ability.set_effect_context_object_recursive(snapshot("Effect Context", 5));
@@ -11229,6 +11238,7 @@ mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters: HashMap::new(),
+                tapped: false,
             },
         );
         assert!(!state.lki_cache.is_empty());
@@ -11847,6 +11857,7 @@ mod tests {
                     colors: vec![],
                     counters: Default::default(),
                     chosen_attributes: vec![],
+                    tapped: false,
                 },
             );
             state.exile_links.push(ExileLink {

--- a/crates/engine/src/game/specialize.rs
+++ b/crates/engine/src/game/specialize.rs
@@ -185,6 +185,7 @@ mod tests {
             colors: vec![],
             chosen_attributes: vec![],
             counters: Default::default(),
+            tapped: false,
         }
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -10098,6 +10098,7 @@ pub mod tests {
                 colors: vec![],
                 chosen_attributes: Vec::new(),
                 counters,
+                tapped: false,
             },
         );
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -169,6 +169,11 @@ pub(crate) fn apply_zone_exit_cleanup(
                 chosen_attributes: obj.chosen_attributes.clone(),
                 // CR 400.7: Capture counters for "if it had counters on it" patterns.
                 counters: obj.counters.clone(),
+                // CR 110.5 + CR 110.5d: Capture tap status AT zone exit. Once the
+                // object leaves the battlefield it is neither tapped nor untapped,
+                // so a use_lki rider ("if it was tapped", Brackish Blunder) reads
+                // this captured value instead of the live (now-absent) object.
+                tapped: obj.tapped,
             };
             state.lki_cache.insert(object_id, lki);
         }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1456,6 +1456,13 @@ fn parse_reflexive_object_property(input: &str) -> OracleResult<'_, FilterProp> 
         // tapped") form reads live state. Must precede `attacking`/`blocking`:
         // distinct word, no shared prefix, but kept adjacent to the status leaves.
         value(FilterProp::Tapped, tag("tapped")),
+        // CR 110.5: untapped is the symmetric tap-status sibling ("if it was
+        // untapped"). "untapped" is a distinct lexeme, not "not tapped" — it
+        // shares no prefix with "tapped" (begins with "un"), so leaf order vs
+        // `tapped` is immaterial. Tense/polarity compose for free: past-tense
+        // "was untapped" sets use_lki (reads the snapshot), present-tense "is
+        // untapped" reads live state, and "isn't untapped" wraps in `Not`.
+        value(FilterProp::Untapped, tag("untapped")),
         // CR 508.1b: combat status (Wisecrack "is attacking").
         value(FilterProp::Attacking { defender: None }, tag("attacking")),
         // CR 509.1a: combat status (blocking sibling).
@@ -6535,6 +6542,41 @@ mod tests {
         let (prop, use_lki) = single_prop(condition);
         assert_eq!(*prop, FilterProp::Tapped);
         assert!(!use_lki, "present-tense 'isn't tapped' reads live state");
+    }
+
+    /// CR 110.5 + CR 400.7: untapped sibling of `reflexive_was_tapped_uses_lki`.
+    /// "it was untapped" → Untapped, LKI — the past-tense rider reads the LKI
+    /// snapshot's exit-time tap state after the antecedent leaves the battlefield.
+    ///
+    /// Revert-probe: deleting the `value(FilterProp::Untapped, tag("untapped"))`
+    /// leaf in `parse_reflexive_object_property` makes this return `None` — the
+    /// leaf is load-bearing for the whole "untapped" predicate class (the gap
+    /// the maintainer flagged on PR #4559).
+    #[test]
+    fn reflexive_was_untapped_uses_lki() {
+        let cond = parse_target_reflexive_property_condition_text("it was untapped").unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(*prop, FilterProp::Untapped);
+        assert!(
+            use_lki,
+            "past-tense 'was untapped' must use LKI per CR 400.7"
+        );
+    }
+
+    /// CR 110.5: present-tense "that permanent isn't untapped" → Not{Untapped,
+    /// LIVE}. Proves the composed axes (tense ⇒ live, polarity ⇒ Not) carry over
+    /// the new `untapped` leaf for free — the same axes the `tapped` siblings
+    /// exercise, confirming the sibling is a true parameterization, not a one-off.
+    #[test]
+    fn reflexive_isnt_untapped_negated_live() {
+        let cond = parse_target_reflexive_property_condition_text("that permanent isn't untapped")
+            .unwrap();
+        let AbilityCondition::Not { condition } = &cond else {
+            panic!("expected Not, got {cond:?}");
+        };
+        let (prop, use_lki) = single_prop(condition);
+        assert_eq!(*prop, FilterProp::Untapped);
+        assert!(!use_lki, "present-tense 'isn't untapped' reads live state");
     }
 
     /// Sibling: negated present "that creature isn't attacking" → Not +

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1443,18 +1443,19 @@ fn parse_reflexive_pt_stat(input: &str) -> OracleResult<'_, PtStat> {
 fn parse_reflexive_object_property(input: &str) -> OracleResult<'_, FilterProp> {
     alt((
         // CR 120.6 + CR 120.9: historical "was dealt damage this turn" (Sold Out).
-        // NOTE: `FilterProp::Tapped` ("it was tapped", Brackish Blunder) is
-        // deliberately NOT recognized here. Tap status is not captured in the
-        // `LKISnapshot` / `ZoneChangeRecord` look-back snapshot, so a past-tense
-        // "was tapped" rider (use_lki) would evaluate fail-closed (always false)
-        // after the antecedent leaves the battlefield — silently under-firing.
-        // Recognizing it would turn the honest red swallow into a green parse with
-        // broken runtime semantics; left swallowed until the snapshot carries tap
-        // state (see implementation report).
         value(
             FilterProp::WasDealtDamageThisTurn,
             tag("dealt damage this turn"),
         ),
+        // CR 110.5: tap status is a permanent's status (Brackish Blunder "if it
+        // was tapped"). The past-tense ("was tapped") form sets use_lki, reading
+        // the LKI snapshot's captured exit-time tap state — the antecedent (a
+        // bounced/destroyed permanent) has left the battlefield before the rider
+        // resolves (CR 110.5d: cards not on the battlefield are neither tapped nor
+        // untapped, so the live object cannot answer). The present-tense ("is
+        // tapped") form reads live state. Must precede `attacking`/`blocking`:
+        // distinct word, no shared prefix, but kept adjacent to the status leaves.
+        value(FilterProp::Tapped, tag("tapped")),
         // CR 508.1b: combat status (Wisecrack "is attacking").
         value(FilterProp::Attacking { defender: None }, tag("attacking")),
         // CR 509.1a: combat status (blocking sibling).
@@ -6492,16 +6493,48 @@ mod tests {
         (&tf.properties[0], *use_lki)
     }
 
-    /// Honesty guard: "it was tapped" (Brackish Blunder) is deliberately NOT
-    /// recognized — tap status is absent from the LKI snapshot, so a use_lki
-    /// "was tapped" rider would under-fire. Leaving it unrecognized keeps the
-    /// coverage swallow honest (red) until the snapshot carries tap state.
+    /// CR 110.5 + CR 400.7: Brackish Blunder "if it was tapped" → Tapped, LKI.
+    /// The LKI snapshot now carries exit-time tap state, so the past-tense rider
+    /// reads it after the antecedent leaves the battlefield (no longer the honest
+    /// red swallow this assertion previously guarded).
+    ///
+    /// Revert-probe: deleting the `value(FilterProp::Tapped, tag("tapped"))` leaf
+    /// in `parse_reflexive_object_property` makes this return `None` — the leaf is
+    /// load-bearing for the whole "tapped" predicate class.
     #[test]
-    fn reflexive_was_tapped_is_deliberately_unrecognized() {
-        assert!(
-            parse_target_reflexive_property_condition_text("it was tapped").is_none(),
-            "'was tapped' must stay unrecognized (LKI tap state unsupported)"
-        );
+    fn reflexive_was_tapped_uses_lki() {
+        let cond = parse_target_reflexive_property_condition_text("it was tapped").unwrap();
+        let (prop, use_lki) = single_prop(&cond);
+        assert_eq!(*prop, FilterProp::Tapped);
+        assert!(use_lki, "past-tense 'was tapped' must use LKI per CR 400.7");
+    }
+
+    /// CR 608.2c: negated past "it wasn't tapped" → Not{Tapped, LKI}. Proves the
+    /// polarity axis composes for free over the new `tapped` leaf.
+    #[test]
+    fn reflexive_wasnt_tapped_negated_uses_lki() {
+        let cond = parse_target_reflexive_property_condition_text("it wasn't tapped").unwrap();
+        let AbilityCondition::Not { condition } = &cond else {
+            panic!("expected Not, got {cond:?}");
+        };
+        let (prop, use_lki) = single_prop(condition);
+        assert_eq!(*prop, FilterProp::Tapped);
+        assert!(use_lki, "negated past-tense 'wasn't tapped' uses LKI");
+    }
+
+    /// CR 110.5: present-tense "that permanent isn't tapped" → Not{Tapped, LIVE}.
+    /// Proves the tense axis (present ⇒ use_lki:false, live state) composes over
+    /// the new `tapped` leaf without a dedicated arm.
+    #[test]
+    fn reflexive_isnt_tapped_negated_live() {
+        let cond =
+            parse_target_reflexive_property_condition_text("that permanent isn't tapped").unwrap();
+        let AbilityCondition::Not { condition } = &cond else {
+            panic!("expected Not, got {cond:?}");
+        };
+        let (prop, use_lki) = single_prop(condition);
+        assert_eq!(*prop, FilterProp::Tapped);
+        assert!(!use_lki, "present-tense 'isn't tapped' reads live state");
     }
 
     /// Sibling: negated present "that creature isn't attacking" → Not +

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -233,6 +233,15 @@ pub struct LKISnapshot {
     /// Used by `TriggerCondition::HadCounters` for "if it had counters on it" patterns.
     #[serde(default, with = "counter_map_serde")]
     pub counters: HashMap<CounterType, u32>,
+    /// CR 110.5 + CR 110.5d: Tap status as it last existed on the battlefield.
+    /// A permanent's tapped/untapped status is battlefield-only — once the object
+    /// leaves a public zone it is neither tapped nor untapped, so a look-back rider
+    /// ("Return target creature to its owner's hand. If it was tapped, ..." —
+    /// Brackish Blunder) must read this captured value via `FilterProp::Tapped`
+    /// (use_lki). `#[serde(default)]` ⇒ pre-existing saved states deserialize to
+    /// `tapped = false`.
+    #[serde(default)]
+    pub tapped: bool,
 }
 
 /// CR 106.3 + CR 601.2h: Snapshot of the source of one mana spent to cast a spell.

--- a/crates/engine/tests/integration/issue_2890_reality_shift.rs
+++ b/crates/engine/tests/integration/issue_2890_reality_shift.rs
@@ -156,6 +156,7 @@ fn reality_shift_manifest_resolves_via_effect_context_object_snapshot() {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: HashMap::new(),
+            tapped: false,
         },
     });
 

--- a/crates/engine/tests/integration/madame_null_integration.rs
+++ b/crates/engine/tests/integration/madame_null_integration.rs
@@ -221,6 +221,7 @@ fn lki_fallback_resolves_source_power_after_zone_change() {
             colors: vec![],
             chosen_attributes: Vec::new(),
             counters: HashMap::new(),
+            tapped: false,
         },
     );
     set_etb_event(&mut state, dead_id);

--- a/crates/engine/tests/reflexive_if_rider.rs
+++ b/crates/engine/tests/reflexive_if_rider.rs
@@ -44,6 +44,10 @@ const DRIFTGLOOM: &str =
     "When this creature enters, exile target creature an opponent controls until this \
      creature leaves the battlefield. If that creature had power 2 or less, put a +1/+1 \
      counter on this creature.";
+// Verified identical to the engine's authoritative card data (data/mtgish-cards.json:
+// PutPermanentIntoItsOwnersHand → If(IsTapped) → CreateTokens(MapToken)).
+const BRACKISH_BLUNDER: &str =
+    "Return target creature to its owner's hand. If it was tapped, create a Map token.";
 
 /// Number of `+1/+1` counters on `object`.
 fn plus_counters(
@@ -295,5 +299,71 @@ fn driftgloom_no_counter_when_exiled_creature_power_gt_2() {
         plus_counters(outcome.state(), coyote),
         0,
         "power-3 exiled creature must NOT yield a counter (rider must be gated)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Brackish Blunder — "If it was tapped" (Tapped, LKI snapshot). The bounce
+// (Return to hand) moves the creature OFF the battlefield BEFORE the rider
+// resolves, so the rider reads the exit-time tap state captured into the LKI
+// snapshot (CR 110.5d: an object not on the battlefield is neither tapped nor
+// untapped — the live object cannot answer). This pair is the discriminator:
+// tapped → Map token; untapped → none.
+//
+// Revert-probe (MEASURED): reverting the `filter.rs` zone-change `Tapped` arm
+// from the `lki_cache` read back to `=> false` makes the TAPPED case fail —
+// the Map token never appears (the rider reads false post-bounce).
+// ---------------------------------------------------------------------------
+
+/// RUNTIME (positive) — CR 110.5 + CR 400.7. A TAPPED creature bounced by
+/// Brackish Blunder satisfies "if it was tapped" against its exit-time LKI
+/// snapshot, so a Map token is created.
+#[test]
+fn brackish_blunder_creates_map_when_target_was_tapped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Brackish Blunder", true, BRACKISH_BLUNDER)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // CR 110.5a: tap the victim so the exit-time LKI snapshot records tapped=true.
+    runner.state_mut().objects.get_mut(&victim).unwrap().tapped = true;
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Hand);
+    assert_eq!(
+        battlefield_named(outcome.state(), "Map"),
+        1,
+        "tapped bounced creature must yield a Map token (rider fires)"
+    );
+}
+
+/// RUNTIME (negative / discriminator) — an UNTAPPED bounced creature fails the
+/// gate; NO Map token. This negative guards the PARSER half: if the rider's
+/// condition parsed to `null` (pre-recognizer), it would fire UNCONDITIONALLY and
+/// the untapped case would wrongly create a Map, failing this assertion. The
+/// POSITIVE test above guards the RUNTIME half (the `filter.rs` lki_cache arm).
+/// Together the pair is non-vacuous on both halves.
+#[test]
+fn brackish_blunder_no_map_when_target_untapped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Brackish Blunder", true, BRACKISH_BLUNDER)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let mut runner = scenario.build();
+    // Victim left UNTAPPED (default).
+
+    let outcome = runner.cast(spell).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Hand);
+    assert_eq!(
+        battlefield_named(outcome.state(), "Map"),
+        0,
+        "untapped bounced creature must NOT yield a Map token (rider gated)"
     );
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

**S01 reflexive-if-rider follow-up** (#4553 shipped the recognizer; this closes one of the two deliberately-deferred cards). Flips **Brackish Blunder** — "Return target creature to its owner's hand. If it was tapped, create a Map token."

### Parser — the `was tapped` leaf
Adds `value(FilterProp::Tapped, tag("tapped"))` to the S01 reflexive-rider recognizer (`parse_reflexive_object_property`). Tense/polarity composes through the existing `parse_target_anaphoric_tense_polarity` axis, so the leaf covers the whole class: "was tapped" → `use_lki:true`; "is tapped" → live; "wasn't tapped" → `Not{..}` `use_lki:true`; "isn't tapped" → `Not{..}` live. nom-combinator only; the `all_consuming` wrapper prevents greedy mis-fire (e.g. "tapped down" → `None`).

### Runtime — LKI-tapped plumbing (the deferral fix)
The bounce moves the creature off the battlefield *before* the rider resolves, so `FilterProp::Tapped` must read last-known information (CR 400.7 / 113.7a / 608.2h; CR 110.5d — a card not on the battlefield is neither tapped nor untapped, so the live object can't answer). Changes:
- `LKISnapshot` gains `#[serde(default)] pub tapped: bool` (old saved states deserialize to `false`).
- Captured at the two live-object snapshot sites: the zone-change capture (`zones.rs`) and `snapshot_public_characteristics` (`game_object.rs`). Every other `LKISnapshot` literal sets `false` — the struct has **no `Default` derive**, so any missed site is a compile error (the compiler caught two test-fixture literals).
- The `zone_change_record_matches_property` arm for `FilterProp::Tapped` now reads `lki_cache` by object id (mirroring the `Counters` / `WasDealtDamageThisTurn` arms) instead of failing closed.

### Tests
- Parser: `reflexive_was_tapped_uses_lki` (→ `Tapped`, `use_lki:true`), `reflexive_wasnt_tapped_negated_uses_lki` (→ `Not`, `use_lki:true`), `reflexive_isnt_tapped_negated_live` (→ `Not`, live). (The old "deliberately unrecognized" honesty-guard test is removed.)
- Runtime (discriminator): `brackish_blunder_creates_map_when_target_was_tapped` (tapped bounce → **1 Map token**) vs `brackish_blunder_no_map_when_target_untapped` (untapped → **0**).
- Revert-probe (measured non-vacuity): reverting the `filter.rs` arm to fail-closed `=> false` makes the tapped case **fail** (no Map token), so the `lki_cache` arm is load-bearing.

### Verification (base = current `main`)
`cargo fmt --all` = 0; parser-combinator gate = 0; `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -D warnings` = 0; `cargo test -p engine` = 0; coverage-regression-check vs baseline (`--fail-on-engine`) = 0. **Brackish Blunder flips `gap_count:0`, supported +1, 0 regressions** (swallowed-clause diagnostic 976 → 975).