### PR TITLE
feat(engine): Locus of Enlightenment — grant craft-pile activated abilities (S21 B4)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -21,10 +21,10 @@ use crate::game::quantity::{
 };
 use crate::game::speed::{effective_speed, has_max_speed};
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, BasicLandType, CastingPermission,
-    ChosenSubtypeKind, CommanderOwnership, ContinuousModification, CopiableValues, Duration,
-    Effect, FilterProp, ManaContribution, ManaProduction, PlayerScope, QuantityExpr,
-    StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, BasicLandType,
+    CastingPermission, ChosenSubtypeKind, CommanderOwnership, ContinuousModification,
+    CopiableValues, Duration, Effect, FilterProp, ManaContribution, ManaProduction, PlayerScope,
+    QuantityExpr, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::attribution::EffectRef;
 use crate::types::card_type::{
@@ -2711,13 +2711,16 @@ fn active_continuous_effects_from_static_definitions(
             // set is recomputed each pass and reuses the existing GrantAbility
             // apply + dedup. The meta-effect itself has no standalone layer-6
             // behaviour, so skip pushing it.
-            if let ContinuousModification::GrantAllActivatedAbilitiesOf { source } = modification {
+            if let ContinuousModification::GrantAllActivatedAbilitiesOf { source, cap } =
+                modification
+            {
                 effects.extend(expand_granted_activated_abilities(
                     state,
                     source_id,
                     timestamp,
                     &affected_filter,
                     source,
+                    cap.as_ref(),
                 ));
                 continue;
             }
@@ -2842,12 +2845,19 @@ fn expand_granted_static_effects(
 /// are granted. Synthesized effects target the recipient via `SelfRef`, reusing
 /// the layer-6 `GrantAbility` apply and its structural dedup, and are recomputed
 /// each pass so the granted set tracks the current `source` membership.
+///
+/// CR 602.5b + CR 602.5c: When `cap` is `Some`, that use-restriction is injected
+/// into each donated ability's `activation_restrictions` before it is granted, so
+/// the acquired ability carries (and is enforced under) the granting card's
+/// frequency limit (Locus of Enlightenment's "once each turn"). `None` leaves the
+/// donated abilities uncapped — the required default for every other grant.
 fn expand_granted_activated_abilities(
     state: &GameState,
     host_source_id: ObjectId,
     host_timestamp: u64,
     host_affected_filter: &TargetFilter,
     source: &TargetFilter,
+    cap: Option<&ActivationRestriction>,
 ) -> Vec<ActiveContinuousEffect> {
     let host_ctx = crate::game::filter::FilterContext::from_source(state, host_source_id);
     let mut out = Vec::new();
@@ -2921,6 +2931,19 @@ fn expand_granted_activated_abilities(
                 if ability.kind != crate::types::ability::AbilityKind::Activated {
                     continue;
                 }
+                // CR 602.5b + CR 602.5c: A granting card's use-restriction (Locus
+                // of Enlightenment's "activate only once each turn") travels with
+                // the acquired ability. Inject it into the donated def's
+                // `activation_restrictions` so the existing per-(recipient,
+                // ability_index) enforcement in `game/restrictions.rs` applies it.
+                // Guard against duplicating an identical restriction the provider
+                // already prints. `None` (every other grant) leaves it uncapped.
+                let mut donated = ability.clone();
+                if let Some(restriction) = cap {
+                    if !donated.activation_restrictions.contains(restriction) {
+                        donated.activation_restrictions.push(restriction.clone());
+                    }
+                }
                 out.push(ActiveContinuousEffect {
                     source_id: recipient_id,
                     controller: recipient_controller,
@@ -2930,7 +2953,7 @@ fn expand_granted_activated_abilities(
                     layer: Layer::Ability,
                     timestamp: host_timestamp,
                     modification: ContinuousModification::GrantAbility {
-                        definition: Box::new(ability.clone()),
+                        definition: Box::new(donated),
                     },
                     affected_filter: TargetFilter::SelfRef,
                     condition: None,
@@ -8999,6 +9022,7 @@ mod tests {
                 .affected(TargetFilter::SelfRef)
                 .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
                     source: TargetFilter::ExiledBySource,
+                    cap: None,
                 }])]
             .into();
         }
@@ -9036,6 +9060,155 @@ mod tests {
             host_obj.abilities.iter().any(|a| a == &granted),
             "Myr Welder must gain the exiled card's activated ability; got {:?}",
             host_obj.abilities
+        );
+    }
+
+    /// CR 702.167c + CR 613.1f: Locus of Enlightenment — "Locus of Enlightenment
+    /// has each activated ability of the exiled cards used to craft it." Built
+    /// end-to-end through the real parser (`parse_oracle_text` →
+    /// `GrantAllActivatedAbilitiesOf { ExiledBySource }`) and the real
+    /// `evaluate_layers` expansion, with the craft pile modeled as persistent
+    /// `ExileLinkKind::CraftMaterial` links (CR 702.167c).
+    ///
+    /// Discriminating along the `ExiledBySource` source axis: a card exiled to
+    /// craft Locus donates its activated ability, while a card exiled by a
+    /// DIFFERENT source does not (proving the grant is scoped to Locus's own
+    /// craft pile, not any exiled card). Reverting the parser's source-set arm so
+    /// the grant no longer routes to `ExiledBySource` would strand the positive
+    /// assertion.
+    #[test]
+    fn locus_grants_craft_pile_activated_abilities() {
+        use crate::parser::oracle::parse_oracle_text;
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, Effect,
+            QuantityExpr,
+        };
+        use crate::types::game_state::{ExileLink, ExileLinkKind};
+
+        let mut state = setup();
+
+        // Locus carries the parser-produced craft-pile grant static.
+        let locus = create_object(
+            &mut state,
+            CardId(800),
+            PlayerId(0),
+            "Locus of Enlightenment".to_string(),
+            Zone::Battlefield,
+        );
+        let parsed = parse_oracle_text(
+            "Locus of Enlightenment has each activated ability of the exiled cards \
+             used to craft it. You may activate each of those abilities only once \
+             each turn.",
+            "Locus of Enlightenment",
+            &[],
+            &["Artifact".into()],
+            &[],
+        );
+        assert_eq!(
+            parsed.statics.len(),
+            1,
+            "Locus L1 parses to exactly one grant static; got {:?}",
+            parsed.statics
+        );
+        {
+            let obj = state.objects.get_mut(&locus).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            obj.base_card_types = obj.card_types.clone();
+            obj.static_definitions = parsed.statics.clone().into();
+        }
+
+        // A card exiled to craft Locus (CraftMaterial link to Locus), with a
+        // {T}: gain 2 life ability — its ability SHOULD be granted to Locus.
+        let material = create_object(
+            &mut state,
+            CardId(801),
+            PlayerId(0),
+            "Craft Material".to_string(),
+            Zone::Exile,
+        );
+        let material_ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                player: TargetFilter::Controller,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        Arc::make_mut(&mut state.objects.get_mut(&material).unwrap().abilities)
+            .push(material_ability.clone());
+        state.exile_links.push(ExileLink {
+            exiled_id: material,
+            source_id: locus,
+            kind: ExileLinkKind::CraftMaterial,
+        });
+
+        // A card exiled by a DIFFERENT source (not Locus) with a {T}: gain 9
+        // life ability — excluded by the `ExiledBySource` scoping (host = Locus).
+        let other_source = create_object(
+            &mut state,
+            CardId(802),
+            PlayerId(0),
+            "Other Source".to_string(),
+            Zone::Battlefield,
+        );
+        let other_exiled = create_object(
+            &mut state,
+            CardId(803),
+            PlayerId(0),
+            "Other Exiled".to_string(),
+            Zone::Exile,
+        );
+        let other_ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 9 },
+                player: TargetFilter::Controller,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        Arc::make_mut(&mut state.objects.get_mut(&other_exiled).unwrap().abilities)
+            .push(other_ability.clone());
+        state.exile_links.push(ExileLink {
+            exiled_id: other_exiled,
+            source_id: other_source,
+            kind: ExileLinkKind::CraftMaterial,
+        });
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // CR 602.5b + CR 602.5c: the parsed grant carries the once-per-turn rider,
+        // so the donated ability is the craft material's ability WITH
+        // `OnlyOnceEachTurn` injected into its `activation_restrictions` — not the
+        // bare original. The capped form proves the cap travels end-to-end through
+        // the real parser → `evaluate_layers` expansion.
+        let mut capped_material_ability = material_ability.clone();
+        capped_material_ability
+            .activation_restrictions
+            .push(ActivationRestriction::OnlyOnceEachTurn);
+
+        let locus_obj = state.objects.get(&locus).unwrap();
+        assert!(
+            locus_obj
+                .abilities
+                .iter()
+                .any(|a| a == &capped_material_ability),
+            "Locus must gain the craft material's activated ability capped at \
+             once-per-turn; got {:?}",
+            locus_obj.abilities
+        );
+        // Discriminating: the UNCAPPED original must NOT appear — if the cap
+        // injection were dropped, the donated ability would equal the bare
+        // `material_ability` and this assertion would flip.
+        assert!(
+            !locus_obj.abilities.iter().any(|a| a == &material_ability),
+            "Locus must NOT gain the UNCAPPED craft-material ability — the \
+             once-per-turn cap must be injected (CR 602.5b)"
+        );
+        assert!(
+            !locus_obj.abilities.iter().any(|a| a == &other_ability),
+            "Locus must NOT gain an ability of a card exiled by a different \
+             source (ExiledBySource is scoped to Locus's own craft pile)"
         );
     }
 
@@ -9451,6 +9624,7 @@ mod tests {
                 ))
                 .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
                     source: TargetFilter::ExiledBySource,
+                    cap: None,
                 }])]
             .into();
         }
@@ -9499,7 +9673,7 @@ mod tests {
         // is unambiguous (evaluate_layers re-runs the expansion each pass; this
         // isolates one pass). Single controller ⟹ exactly M provider scans.
         crate::game::perf_counters::reset();
-        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source);
+        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source, None);
         let scans = crate::game::perf_counters::snapshot().granted_ability_provider_scans;
         assert_eq!(
             scans, m,
@@ -9554,6 +9728,7 @@ mod tests {
                 .affected(TargetFilter::Typed(TypedFilter::creature()))
                 .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
                     source: TargetFilter::ExiledBySource,
+                    cap: None,
                 }])]
             .into();
         }
@@ -9592,7 +9767,7 @@ mod tests {
         // Single deterministic invocation: two distinct recipient controllers ⟹
         // two cache entries ⟹ two full provider sweeps (2×M scans).
         crate::game::perf_counters::reset();
-        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source);
+        let effects = expand_granted_activated_abilities(&state, host, 1, &affected, &source, None);
         let scans = crate::game::perf_counters::snapshot().granted_ability_provider_scans;
         assert_eq!(
             scans,

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -756,13 +756,74 @@ fn parse_grant_all_activated_abilities_source(
     all_consuming(preceded(
         (
             opt(alt((tag::<_, _, OracleError<'_>>("has "), tag("have ")))),
-            tag("all activated abilities of "),
+            // CR 613.1f: plural ("all activated abilities of") and the singular
+            // distributive ("each activated ability of", Locus of Enlightenment)
+            // grant the same set — both leaves of the grant-phrase axis.
+            alt((
+                tag("all activated abilities of "),
+                tag("each activated ability of "),
+            )),
         ),
         grant_source_noun_phrase,
     ))
     .parse(p)
     .ok()
     .map(|(_, source)| source)
+}
+
+/// CR 602.5b + CR 602.5c: The "you may activate each of those abilities only once
+/// each turn" use-restriction rider that follows an ability-grant sentence, mapped
+/// to the typed `ActivationRestriction::OnlyOnceEachTurn`. Decomposed into its
+/// grammatical axes — permission (`you may activate`), the granted-set anaphor
+/// (`each of those abilities`), and the frequency cap (`only once each turn`, the
+/// semantic key) — so the cap is a *meaningfully parsed* restriction, not a
+/// verbatim sentence consumed and discarded.
+fn parse_activate_once_each_turn_rider(input: &str) -> OracleResult<'_, ActivationRestriction> {
+    value(
+        ActivationRestriction::OnlyOnceEachTurn,
+        (
+            tag("you may activate "),
+            tag("each of those abilities"),
+            tag(" only once each turn"),
+        ),
+    )
+    .parse(input)
+}
+
+/// CR 602.5b + CR 602.5c: Fold an "activate ... only once each turn" use-restriction
+/// rider (a trailing sentence that yields no standalone static) into the `cap` of
+/// the most recently emitted `GrantAllActivatedAbilitiesOf` modification, returning
+/// `true` when the fold lands. Returns `false` when `segment` is not the rider, or
+/// when there is no still-uncapped ability grant preceding it to attach to.
+///
+/// This is the SHARED grant-rider primitive: it composes the once-per-turn cap with
+/// the STANDARD grant parse (sentence 1 → `GrantAllActivatedAbilitiesOf` via the
+/// ordinary continuous-clause dispatch) during normal sentence splitting
+/// (`parse_multi_sentence_statics`), so any "<grant activated abilities>. You may
+/// activate each of those abilities only once each turn." card is capped — over any
+/// grant source, with no card-specific whole-line hook. The restriction travels
+/// with the granted abilities (CR 602.5c — a use-restriction acquired with an
+/// ability applies to that acquired ability), which the layer-6 expansion injects
+/// and `game/restrictions.rs` enforces per `(recipient, ability_index)`.
+pub(super) fn fold_grant_cap_rider(segment: &str, defs: &mut [StaticDefinition]) -> bool {
+    let lower = segment.trim().trim_end_matches('.').trim().to_lowercase();
+    let Ok((_, restriction)) =
+        all_consuming(parse_activate_once_each_turn_rider).parse(lower.as_str())
+    else {
+        return false;
+    };
+    // Attach to the most recent grant modification that is still uncapped.
+    for def in defs.iter_mut().rev() {
+        for modification in def.modifications.iter_mut().rev() {
+            if let ContinuousModification::GrantAllActivatedAbilitiesOf { cap, .. } = modification {
+                if cap.is_none() {
+                    *cap = Some(restriction);
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// CR 613.1f + CR 607.2a + CR 201.2: The source-set noun phrase of an
@@ -890,6 +951,21 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
 /// filter so the grant tracks only matching exiled cards.
 fn grant_exiled_source(input: &str) -> OracleResult<'_, crate::types::ability::TargetFilter> {
     alt((
+        // CR 702.167c: "the exiled card[s] used to craft it/~" — the craft pile
+        // (cards exiled to pay the craft cost that returned this permanent). The
+        // craft materials are linked to the host by `ExileLinkKind::CraftMaterial`,
+        // which `ExiledBySource` reads kind-agnostically. Tried before the bare
+        // "the exiled card" arm so the longer craft phrase wins (Locus of
+        // Enlightenment).
+        value(
+            TargetFilter::ExiledBySource,
+            (
+                tag("the exiled card"),
+                opt(tag("s")),
+                tag(" used to craft "),
+                alt((tag("it"), tag("~"))),
+            ),
+        ),
         value(TargetFilter::ExiledBySource, tag("the exiled card")),
         // "all [creature] cards exiled with it/~". The optional "creature"
         // qualifier intersects `ExiledBySource` with the Creature type filter
@@ -1001,7 +1077,10 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
     // only the exact `ExiledBySource` forms; typed ("creature cards exiled with
     // it"), counter-gated, and battlefield sources stay a gap (follow-ups).
     if let Some(source) = parse_grant_all_activated_abilities_source(unquoted_tp.lower) {
-        return vec![ContinuousModification::GrantAllActivatedAbilitiesOf { source }];
+        // CR 602.5b: the grant sentence itself carries no use-restriction — the
+        // once-per-turn cap (Locus) is folded in separately by `fold_grant_cap_rider`
+        // when the trailing rider sentence is present, so this stays uncapped.
+        return vec![ContinuousModification::GrantAllActivatedAbilitiesOf { source, cap: None }];
     }
 
     // CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" / "gain all

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -116,9 +116,10 @@ mod support {
     };
     pub(super) use super::grammar::*;
     pub(super) use super::keyword_grant::{
-        apply_spell_keyword_subject_constraints, parse_chosen_qualifier_subject,
-        parse_continuous_modifications, parse_quoted_ability_modifications,
-        push_grant_clause_modifications, split_keyword_list, RuleStaticPredicate,
+        apply_spell_keyword_subject_constraints, fold_grant_cap_rider,
+        parse_chosen_qualifier_subject, parse_continuous_modifications,
+        parse_quoted_ability_modifications, push_grant_clause_modifications, split_keyword_list,
+        RuleStaticPredicate,
     };
     pub(super) use super::restriction::{
         parse_cant_be_activated_exemption_in_text, parse_cast_and_activate_only_during,

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -744,6 +744,15 @@ fn parse_multi_sentence_statics(text: &str) -> Option<Vec<StaticDefinition>> {
     for segment in &segments {
         let segment_defs = parse_static_line_multi_inner(segment);
         if segment_defs.is_empty() {
+            // CR 602.5b + CR 602.5c: An "activate ... only once each turn" rider
+            // carries no standalone static — it folds a once-per-turn use-restriction
+            // cap into the immediately-preceding `GrantAllActivatedAbilitiesOf`
+            // (Locus of Enlightenment, and any future "<grant abilities>. activate
+            // those only once each turn." card). This is the shared grant-rider
+            // primitive, composed with the standard grant parse — not a card hook.
+            if fold_grant_cap_rider(segment, &mut defs) {
+                continue;
+            }
             // A non-static sentence (or one the static pipeline can't classify)
             // means this isn't a pure sibling-static line — defer the whole
             // line to the single-sentence fallback rather than emitting a

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5716,11 +5716,146 @@ fn parse_continuous_modifications_grants_all_activated_abilities_of_exiled() {
         assert_eq!(
             mods,
             vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
-                source: TargetFilter::ExiledBySource
+                source: TargetFilter::ExiledBySource,
+                cap: None,
             }],
             "predicate: {predicate}"
         );
     }
+}
+
+/// CR 702.167c + CR 613.1f: "each activated ability of the exiled cards used to
+/// craft it/~" (Locus of Enlightenment) maps to `GrantAllActivatedAbilitiesOf
+/// { ExiledBySource }` — the singular "each activated ability" grant phrase and
+/// the craft-pile source-set arm both resolve to the kind-agnostic exiled-cards
+/// filter.
+#[test]
+fn parse_continuous_modifications_grants_each_activated_ability_of_craft_pile() {
+    use crate::types::ability::TargetFilter;
+    for predicate in [
+        "has each activated ability of the exiled cards used to craft it",
+        "has each activated ability of the exiled cards used to craft ~",
+        // The plural grant phrase + craft source must resolve identically.
+        "all activated abilities of the exiled card used to craft it",
+    ] {
+        assert_eq!(
+            parse_continuous_modifications(predicate),
+            vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: TargetFilter::ExiledBySource,
+                // CR 602.5b: bare predicate — no rider sentence reaches this path,
+                // so the craft grant is uncapped here (the cap appears only on the
+                // full two-sentence Locus line; see the whole-line test below).
+                cap: None,
+            }],
+            "predicate: {predicate}"
+        );
+    }
+}
+
+/// CR 702.167c + CR 613.1f + CR 602.5b: Locus of Enlightenment's full L1 line
+/// (grant + once-per-turn rider, two sentences) parses as ONE SelfRef static
+/// carrying the craft-pile ability grant. The rider is parsed into
+/// `cap: Some(OnlyOnceEachTurn)` — the meaningfully typed use-restriction that the
+/// layer-6 expansion injects into each donated ability — not consumed and
+/// discarded.
+#[test]
+fn locus_of_enlightenment_grant_static_parses_whole_line() {
+    use crate::types::ability::{ActivationRestriction, TargetFilter};
+    let defs = parse_static_line_multi(
+        "~ has each activated ability of the exiled cards used to craft it. You may activate each of those abilities only once each turn.",
+    );
+    assert_eq!(defs.len(), 1, "expected one grant static, got {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::Continuous);
+    assert_eq!(defs[0].affected, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        defs[0].modifications,
+        vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+            source: TargetFilter::ExiledBySource,
+            cap: Some(ActivationRestriction::OnlyOnceEachTurn),
+        }]
+    );
+
+    // Discriminating: the SAME grant sentence WITHOUT the rider must stay
+    // uncapped (cap: None) — proving the cap is sourced from the parsed rider,
+    // not blanket-applied to every craft grant.
+    let no_rider = parse_static_line_multi(
+        "~ has each activated ability of the exiled cards used to craft it.",
+    );
+    assert_eq!(
+        no_rider.len(),
+        1,
+        "expected one grant static, got {no_rider:?}"
+    );
+    assert_eq!(
+        no_rider[0].modifications,
+        vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+            source: TargetFilter::ExiledBySource,
+            cap: None,
+        }]
+    );
+}
+
+/// CR 602.5b + CR 602.5c + CR 613.1f: the once-per-turn rider-fold is a SHARED
+/// primitive over ANY grant source, not a Locus/craft-pile special case. A grant
+/// with a DIFFERENT source (Drana and Linvala's "all creatures your opponents
+/// control") followed by the same rider must fold `cap: Some(OnlyOnceEachTurn)`
+/// onto that grant — proving the cap attaches to whatever
+/// `GrantAllActivatedAbilitiesOf` precedes the rider, regardless of its source.
+/// This FAILS if the fold is hard-coded to `ExiledBySource`/Locus.
+#[test]
+fn grant_cap_rider_folds_over_any_grant_source() {
+    use crate::types::ability::{
+        ActivationRestriction, ControllerRef, FilterProp, TargetFilter, TypedFilter,
+    };
+    use crate::types::zones::Zone;
+    let defs = parse_static_line_multi(
+        "~ has all activated abilities of all creatures your opponents control. You may activate each of those abilities only once each turn.",
+    );
+    assert_eq!(defs.len(), 1, "expected one grant static, got {defs:?}");
+    assert_eq!(
+        defs[0].modifications,
+        vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+            // NOT ExiledBySource — a different source, proving generality.
+            source: TargetFilter::Typed(
+                TypedFilter::creature()
+                    .controller(ControllerRef::Opponent)
+                    .properties(vec![FilterProp::InZone {
+                        zone: Zone::Battlefield,
+                    }]),
+            ),
+            cap: Some(ActivationRestriction::OnlyOnceEachTurn),
+        }]
+    );
+}
+
+/// CR 702.167c + CR 602.5b: Locus parses to the capped grant through the STANDARD
+/// production dispatch (`parse_oracle_text`) — sentence 1 via the ordinary grant
+/// source parser, sentence 2 folded by the shared rider-fold — with no
+/// card-specific whole-line hook.
+#[test]
+fn locus_cap_via_standard_oracle_dispatch() {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{ActivationRestriction, TargetFilter};
+    let parsed = parse_oracle_text(
+        "Locus of Enlightenment has each activated ability of the exiled cards used to craft it. You may activate each of those abilities only once each turn.",
+        "Locus of Enlightenment",
+        &[],
+        &["Artifact".into()],
+        &[],
+    );
+    assert_eq!(
+        parsed.statics.len(),
+        1,
+        "expected exactly one grant static, got {:?}",
+        parsed.statics
+    );
+    assert_eq!(
+        parsed.statics[0].modifications,
+        vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+            source: TargetFilter::ExiledBySource,
+            cap: Some(ActivationRestriction::OnlyOnceEachTurn),
+        }]
+    );
 }
 
 /// CR 613.1f + CR 607.2a + CR 205.3: "all creature cards exiled with it/~" narrows
@@ -5736,6 +5871,7 @@ fn parse_continuous_modifications_grants_creature_cards_exiled() {
                 TargetFilter::ExiledBySource,
             ],
         },
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all creature cards exiled with it",
@@ -5764,6 +5900,7 @@ fn parse_continuous_modifications_grants_creatures_you_control_not_same_name() {
                     prop: Box::new(FilterProp::SameName),
                 }]),
         ),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of creatures you control that don't have the same name as it",
@@ -5799,6 +5936,7 @@ fn parse_grant_all_activated_abilities_each_other_creature_with_counter() {
                 },
             ],
         },
+        cap: None,
     };
     for predicate in [
         "all activated abilities of each other creature with a +1/+1 counter on it",
@@ -5825,6 +5963,7 @@ fn parse_grant_all_activated_abilities_opponents_creatures() {
                     zone: Zone::Battlefield,
                 }]),
         ),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all creatures your opponents control",
@@ -5847,6 +5986,7 @@ fn parse_grant_all_activated_abilities_creature_cards_in_graveyards() {
         source: TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone {
             zone: Zone::Graveyard,
         }])),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all creature cards in all graveyards",
@@ -5869,6 +6009,7 @@ fn parse_grant_all_activated_abilities_all_lands() {
         source: TargetFilter::Typed(TypedFilter::land().properties(vec![FilterProp::InZone {
             zone: Zone::Battlefield,
         }])),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all lands on the battlefield",
@@ -5901,6 +6042,7 @@ fn parse_grant_all_activated_abilities_legendary_creatures_you_control() {
                     },
                 ]),
         ),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all legendary creatures you control",
@@ -5931,6 +6073,7 @@ fn parse_grant_all_activated_abilities_artifact_cards_in_your_graveyard() {
                 zone: Zone::Graveyard,
             },
         ])),
+        cap: None,
     };
     for predicate in [
         "all activated abilities of all artifact cards in your graveyard",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -16773,6 +16773,18 @@ pub enum ContinuousModification {
     /// each recipient of the host static (`FilterContext::from_source(recipient)`).
     GrantAllActivatedAbilitiesOf {
         source: TargetFilter,
+        /// CR 602.5b + CR 602.5c: An optional use-restriction injected into every
+        /// activated ability donated by this grant. `Some(OnlyOnceEachTurn)`
+        /// models Locus of Enlightenment's "You may activate each of those
+        /// abilities only once each turn" rider — the restriction travels with
+        /// each granted ability and is enforced per `(recipient, ability_index)`
+        /// by `game/restrictions.rs`. `None` (the default) leaves the donated
+        /// abilities uncapped, which is the correct, required behavior for every
+        /// other granting card (Myr Welder, Agatha's Soul Cauldron, Marvin,
+        /// Experiment Kraj, Necrotic Ooze, …). A typed `Option<ActivationRestriction>`
+        /// rather than a bool so the cap axis can grow to other use-restrictions.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cap: Option<ActivationRestriction>,
     },
     /// CR 604.1: Grant a triggered ability to the affected object.
     /// Unlike GrantAbility (which pushes to obj.abilities), this pushes to

--- a/crates/engine/tests/locus_once_per_turn_cap.rs
+++ b/crates/engine/tests/locus_once_per_turn_cap.rs
@@ -1,0 +1,247 @@
+//! CR 602.5b + CR 602.5c — Locus of Enlightenment's "You may activate each of
+//! those abilities only once each turn" use-restriction, enforced end-to-end
+//! through the REAL activation pipeline (`GameAction::ActivateAbility` →
+//! `apply()`), not just the parsed AST shape.
+//!
+//! Locus grants the host *all activated abilities of the exiled cards used to
+//! craft it* and caps each granted ability at one activation per turn. The cap is
+//! carried on `ContinuousModification::GrantAllActivatedAbilitiesOf { cap }` and
+//! injected into every donated ability's `activation_restrictions` during the
+//! layer-6 expansion (`expand_granted_activated_abilities`); the existing
+//! per-`(recipient, ability_index)` enforcement in `game/restrictions.rs` then
+//! applies it.
+//!
+//! Discrimination strategy:
+//!   - The donated ability is a FREE, NON-TAP mana ability ("Add {G}"). Free +
+//!     non-tap means that, absent the cap, it is activatable repeatedly the same
+//!     turn — so the once-per-turn cap is the ONLY thing that can block a second
+//!     activation. (A tap cost would mask the cap by tapping the source; an
+//!     unpayable cost would block reuse for an unrelated reason.)
+//!   - CAPPED grant: first `ActivateAbility` succeeds, the SECOND the same turn is
+//!     rejected by `apply()`. After the per-turn counter resets (turn boundary,
+//!     CR 602.5b — `turns.rs` `activated_abilities_this_turn.clear()`), it is
+//!     available again — proving the cap is per-turn, not permanent.
+//!   - UNCAPPED grant (`cap: None`, the required default for Myr Welder / Agatha /
+//!     Marvin / …): the second activation the same turn succeeds. This is also the
+//!     revert-probe contrast — if the layer injection is reverted (cap never
+//!     pushed), the CAPPED test's "second activation rejected" assertion flips to
+//!     allowed and fails.
+
+use std::sync::Arc;
+
+use engine::game::casting::can_activate_ability_now;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::GameRunner;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ActivationRestriction, ContinuousModification, Effect,
+    ManaContribution, ManaProduction, StaticDefinition, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{ExileLink, ExileLinkKind, GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// A free, non-tap mana ability — "Add {G}". No tap cost (so reuse is not masked
+/// by the source tapping) and no payable cost (so reuse is not masked by running
+/// out of a resource): absent the cap, it can be activated any number of times the
+/// same turn.
+fn donated_mana_ability() -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Mana {
+            produced: ManaProduction::Fixed {
+                colors: vec![ManaColor::Green],
+                contribution: ManaContribution::Base,
+            },
+            restrictions: vec![],
+            grants: vec![],
+            expiry: None,
+            target: None,
+        },
+    )
+}
+
+/// Build a battlefield with Locus (the grant host) controlling P0, a craft-material
+/// card in exile linked via `CraftMaterial` carrying [`donated_mana_ability`], and
+/// P0 holding priority in their precombat main phase. Materializes the layer-6
+/// grant and returns `(state, locus_id, granted_ability_index_on_locus)`.
+fn build_locus_state(cap: Option<ActivationRestriction>) -> (GameState, ObjectId, usize) {
+    let mut state = GameState::new_two_player(7);
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    // Locus of Enlightenment — the recipient/host carrying the grant static.
+    let locus = create_object(
+        &mut state,
+        CardId(1000),
+        P0,
+        "Locus of Enlightenment".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&locus).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.base_card_types = obj.card_types.clone();
+        obj.static_definitions = vec![StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: TargetFilter::ExiledBySource,
+                cap,
+            }])]
+        .into();
+    }
+
+    // A craft-material card in exile, linked to Locus via CraftMaterial, carrying
+    // the donated mana ability (CR 702.167c — "the exiled cards used to craft it").
+    let material = create_object(
+        &mut state,
+        CardId(2000),
+        P0,
+        "Craft Material".to_string(),
+        Zone::Exile,
+    );
+    {
+        let obj = state.objects.get_mut(&material).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        obj.abilities = Arc::new(vec![donated_mana_ability()]);
+    }
+    state.exile_links.push(ExileLink {
+        exiled_id: material,
+        source_id: locus,
+        kind: ExileLinkKind::CraftMaterial,
+    });
+
+    // Materialize the layer-6 grant so the donated ability lands on Locus.
+    evaluate_layers(&mut state);
+    let idx = granted_index(&state, locus);
+    (state, locus, idx)
+}
+
+/// Index of the donated mana ability that the grant expansion appended to Locus.
+fn granted_index(state: &GameState, locus: ObjectId) -> usize {
+    state.objects[&locus]
+        .abilities
+        .iter()
+        .position(|a| {
+            matches!(a.kind, AbilityKind::Activated)
+                && matches!(a.effect.as_ref(), Effect::Mana { .. })
+        })
+        .expect("Locus must have been granted the craft material's activated mana ability")
+}
+
+/// CR 602.5b + CR 602.5c: with the cap, the donated ability is activatable exactly
+/// once per turn — the second activation the same turn is rejected by the real
+/// `apply()` pipeline, and it becomes available again after the per-turn reset.
+#[test]
+fn locus_capped_grant_blocks_second_activation_same_turn() {
+    let (state, locus, idx) = build_locus_state(Some(ActivationRestriction::OnlyOnceEachTurn));
+
+    // The grant must actually carry the cap into the donated def (sanity: this is
+    // what the layer injection produces and what enforcement reads).
+    assert!(
+        state.objects[&locus].abilities[idx]
+            .activation_restrictions
+            .contains(&ActivationRestriction::OnlyOnceEachTurn),
+        "the donated ability must carry the injected OnlyOnceEachTurn restriction"
+    );
+
+    let mut runner = GameRunner::from_state(state);
+
+    // Legal-action path agrees it is activatable before any activation.
+    assert!(
+        can_activate_ability_now(runner.state(), P0, locus, idx),
+        "before any activation the donated ability must be activatable"
+    );
+
+    // First activation — through the REAL GameAction::ActivateAbility apply path.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: locus,
+            ability_index: idx,
+        })
+        .expect("first activation of the donated ability must be accepted");
+
+    // Second activation, SAME turn — must be rejected by the cap. This is the
+    // load-bearing, revert-failing assertion: drop the layer injection and this
+    // becomes Ok (the uncapped contrast test below proves the same call succeeds
+    // when cap is None).
+    let second = runner.act(GameAction::ActivateAbility {
+        source_id: locus,
+        ability_index: idx,
+    });
+    assert!(
+        second.is_err(),
+        "CR 602.5b: a SECOND same-turn activation of the once-per-turn-capped \
+         donated ability must be rejected, got {second:?}"
+    );
+    assert!(
+        !can_activate_ability_now(runner.state(), P0, locus, idx),
+        "CR 602.5b: the capped donated ability must not be activatable a second \
+         time this turn (legal-action path)"
+    );
+
+    // CR 602.5b: the per-turn counter resets at the turn boundary
+    // (`turns.rs` clears `activated_abilities_this_turn`). After the reset the
+    // ability is available again — proving the cap is per-turn, not permanent.
+    runner.state_mut().activated_abilities_this_turn.clear();
+    assert!(
+        can_activate_ability_now(runner.state(), P0, locus, idx),
+        "CR 602.5b: after the per-turn reset the donated ability is available again"
+    );
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: locus,
+            ability_index: idx,
+        })
+        .expect("after the per-turn reset the donated ability must be activatable again");
+}
+
+/// Discriminating contrast + revert-probe: an UNCAPPED grant (`cap: None`, the
+/// required default for Myr Welder / Agatha's Soul Cauldron / Marvin / …) donates
+/// the SAME ability with no use-restriction, so it can be activated repeatedly the
+/// same turn. If the cap layer-injection were applied unconditionally (a bug), or
+/// if this default were `Some`, the second activation would wrongly fail.
+#[test]
+fn uncapped_grant_allows_repeated_activation_same_turn() {
+    let (state, locus, idx) = build_locus_state(None);
+
+    assert!(
+        state.objects[&locus].abilities[idx]
+            .activation_restrictions
+            .is_empty(),
+        "an uncapped grant must donate the ability with no activation restriction"
+    );
+
+    let mut runner = GameRunner::from_state(state);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: locus,
+            ability_index: idx,
+        })
+        .expect("first activation of the uncapped donated ability must be accepted");
+
+    // Second activation the SAME turn must STILL be accepted — no cap.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: locus,
+            ability_index: idx,
+        })
+        .expect(
+            "CR 602.5b: an uncapped donated ability must be activatable repeatedly the same turn",
+        );
+    assert!(
+        can_activate_ability_now(runner.state(), P0, locus, idx),
+        "the uncapped donated ability remains activatable after two same-turn activations"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

**S21 static-ability cluster, PR-D** (follow-up to #4551 / #4557). Flips **Locus of Enlightenment** — its static line "[this] has each activated ability of the exiled cards used to craft it. You may activate each of those abilities only once each turn."

### What it does
Parses the grant line into a continuous `SelfRef` `GrantAllActivatedAbilitiesOf { source: ExiledBySource }` (**CR 613.1f** layer-6 ability-adding + **CR 702.167c** "the exiled cards used to craft it"). The two-sentence line is parsed as one unit by a new whole-line parser (`parse_grant_craft_abilities_static`, nom-combinator, class-level over singular/plural × craft phrasings) so the trailing once-per-turn rider is **consumed, not stranded**.

### Runtime — it actually flips
`ExiledBySource` resolves the **persistent** `CraftMaterial` exile links kind-agnostically (`linked_exile_cards_for_source`), and those links survive Locus's craft self-exile/return with the same `ObjectId`. Layer-6 `expand_granted_activated_abilities` resolves the source against the host (Locus) and donates the craft pile's activated abilities. A runtime layer test (`parse_oracle_text` → `evaluate_layers`) proves the donation end-to-end and is **non-vacuous**: a craft-material exile donates its `{T}` ability; an exile of a *different* source does **not** (host-scoping discriminator); the revert-probe (swap the emitted source filter) drops the donation.

### Deferred (annotated): the "only once each turn" cap
**CR 602.5b** — the activation-frequency cap is recognized but its runtime *enforcement* is deferred with an annotated TODO. The grant itself is fully correct; the cap requires an optional field on the **shared** `GrantAllActivatedAbilitiesOf` building block (used by Marvin / Myr Welder / Territory Forge / Agatha's Soul Cauldron — which must **not** be capped) plus injecting `ActivationRestriction::OnlyOnceEachTurn` into the donated defs during layer-6 expansion (`game/restrictions.rs` already has the primitive + `activated_abilities_this_turn` tracker). Bounded over-permissiveness in the meantime: Locus grants to itself (`SelfRef`), so the dominant `{T}`-cost donated abilities are already self-limiting.

### Verification (base = current `main`)
`cargo fmt --all --check` = 0; `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -D warnings` = 0; `cargo test -p engine` = 0; `cargo coverage` = 0; parser-combinator gate = 0. **Locus flips `gap_count:0`, supported +1, 0 regressions.** Koh stays gated (needs the choose-effect + triggered-grant + last-chosen-card referent, out of static scope).