### PR TITLE
test(engine): regression coverage for counter spell non-mana unless costs (#3466)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -28353,6 +28353,54 @@ mod tests {
         );
     }
 
+    /// Issue #3466: counter spells with non-mana unless costs must not silently
+    /// drop the unless clause. CR 118.12 / CR 119.4 / CR 608.2c.
+    #[test]
+    fn effect_counter_unless_parses_non_mana_costs() {
+        let dash = parse_effect_chain(
+            "Counter target spell unless its controller pays 5 life.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(*dash.effect, Effect::Counter { .. }));
+        let unless_pay = dash.unless_pay.expect("life unless must attach unless_pay");
+        assert_eq!(unless_pay.payer, TargetFilter::ParentTargetController);
+        assert_eq!(
+            unless_pay.cost,
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 5 }
+            }
+        );
+
+        let sacrifice = parse_effect_chain(
+            "Counter target spell unless its controller sacrifices a creature.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(*sacrifice.effect, Effect::Counter { .. }));
+        assert!(
+            matches!(
+                sacrifice.unless_pay.as_ref().map(|u| &u.cost),
+                Some(AbilityCost::Sacrifice(_))
+            ),
+            "sacrifice unless must parse, got {:?}",
+            sacrifice.unless_pay
+        );
+
+        let discard = parse_effect_chain(
+            "Counter target spell unless its controller discards a card.",
+            AbilityKind::Spell,
+        );
+        assert!(matches!(*discard.effect, Effect::Counter { .. }));
+        assert!(
+            matches!(
+                discard.unless_pay.as_ref().map(|u| &u.cost),
+                Some(AbilityCost::Discard { count, .. })
+                    if *count == QuantityExpr::Fixed { value: 1 }
+            ),
+            "discard unless must parse, got {:?}",
+            discard.unless_pay
+        );
+    }
+
     #[test]
     fn then_if_control_count_conditions_followup_transform() {
         let def = parse_effect_chain(

--- a/crates/engine/tests/integration/issue_3466_counter_unless_non_mana.rs
+++ b/crates/engine/tests/integration/issue_3466_counter_unless_non_mana.rs
@@ -127,11 +127,11 @@ fn dash_hopes_prompts_life_payment_then_counters_on_decline() {
     let mut dash = scenario.add_spell_to_hand_from_oracle(P0, "Dash Hopes", true, DASH_HOPES);
     dash.with_mana_cost(ManaCost::Cost {
         generic: 0,
-        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+        shards: vec![ManaCostShard::Black, ManaCostShard::Black],
     });
     let dash_hopes = dash.id();
-    scenario.add_basic_land(P0, ManaColor::Red);
-    scenario.add_basic_land(P0, ManaColor::Red);
+    scenario.add_basic_land(P0, ManaColor::Black);
+    scenario.add_basic_land(P0, ManaColor::Black);
 
     let mut runner = scenario.build();
     let opponent_spell = put_instant_on_stack(&mut runner, P1);
@@ -172,11 +172,11 @@ fn dash_hopes_paying_life_leaves_target_spell_on_stack() {
     let mut dash = scenario.add_spell_to_hand_from_oracle(P0, "Dash Hopes", true, DASH_HOPES);
     dash.with_mana_cost(ManaCost::Cost {
         generic: 0,
-        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+        shards: vec![ManaCostShard::Black, ManaCostShard::Black],
     });
     let dash_hopes = dash.id();
-    scenario.add_basic_land(P0, ManaColor::Red);
-    scenario.add_basic_land(P0, ManaColor::Red);
+    scenario.add_basic_land(P0, ManaColor::Black);
+    scenario.add_basic_land(P0, ManaColor::Black);
 
     let mut runner = scenario.build();
     let opponent_spell = put_instant_on_stack(&mut runner, P1);

--- a/crates/engine/tests/integration/issue_3466_counter_unless_non_mana.rs
+++ b/crates/engine/tests/integration/issue_3466_counter_unless_non_mana.rs
@@ -1,0 +1,207 @@
+//! GitHub issue #3466 — Counter spells with non-mana "unless" costs must not
+//! silently parse as unconditional counters.
+//!
+//! Dash Hopes ("Counter target spell unless its controller pays 5 life.") and
+//! similar cards must carry `unless_pay` with `PayLife` / `Sacrifice` / `Discard`
+//! (CR 118.12 / CR 119.4 / CR 608.2c), and deck validation must not mark them
+//! fully supported when the unless clause is dropped.
+
+use engine::game::coverage::card_face_gaps;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCost, AbilityKind, Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card::CardFace;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{StackEntry, StackEntryKind, WaitingFor};
+use engine::types::identifiers::CardId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DASH_HOPES: &str = "Counter target spell unless its controller pays 5 life.";
+const MANA_LEAK: &str = "Counter target spell unless its controller pays {3}.";
+const COUNTER_SACRIFICE: &str = "Counter target spell unless its controller sacrifices a creature.";
+const COUNTER_DISCARD: &str = "Counter target spell unless its controller discards a card.";
+
+fn card_face(name: &str, oracle: &str) -> CardFace {
+    let parsed = parse_oracle_text(oracle, name, &[], &["Instant".to_string()], &[]);
+    CardFace {
+        name: name.to_string(),
+        oracle_text: Some(oracle.to_string()),
+        abilities: parsed.abilities,
+        triggers: parsed.triggers,
+        static_abilities: parsed.statics,
+        replacements: parsed.replacements,
+        ..Default::default()
+    }
+}
+
+fn spell_ability(name: &str, oracle: &str) -> engine::types::ability::AbilityDefinition {
+    let parsed = parse_oracle_text(oracle, name, &[], &["Instant".to_string()], &[]);
+    parsed
+        .abilities
+        .into_iter()
+        .find(|a| a.kind == AbilityKind::Spell)
+        .expect("spell ability")
+}
+
+fn put_instant_on_stack(
+    runner: &mut engine::game::scenario::GameRunner,
+    controller: engine::types::player::PlayerId,
+) -> engine::types::identifiers::ObjectId {
+    let spell = engine::game::zones::create_object(
+        runner.state_mut(),
+        CardId(901),
+        controller,
+        "Shock".to_string(),
+        Zone::Stack,
+    );
+    if let Some(obj) = runner.state_mut().objects.get_mut(&spell) {
+        obj.card_types.core_types = vec![CoreType::Instant];
+    }
+    runner.state_mut().stack.push_back(StackEntry {
+        id: spell,
+        source_id: spell,
+        controller,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(901),
+            ability: None,
+            casting_variant: engine::types::game_state::CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    spell
+}
+
+#[test]
+fn dash_hopes_parses_conditional_counter_with_pay_life_unless() {
+    let ability = spell_ability("Dash Hopes", DASH_HOPES);
+    assert!(
+        matches!(ability.effect.as_ref(), Effect::Counter { .. }),
+        "expected Counter, got {:?}",
+        ability.effect
+    );
+    let unless_pay = ability
+        .unless_pay
+        .as_ref()
+        .expect("Dash Hopes must carry unless_pay, not an unconditional counter");
+    assert_eq!(unless_pay.payer, TargetFilter::ParentTargetController);
+    assert_eq!(
+        unless_pay.cost,
+        AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value: 5 }
+        }
+    );
+}
+
+#[test]
+fn counter_unless_non_mana_costs_have_no_coverage_gaps() {
+    for (name, oracle) in [
+        ("Dash Hopes", DASH_HOPES),
+        ("Counter-Sacrifice", COUNTER_SACRIFICE),
+        ("Counter-Discard", COUNTER_DISCARD),
+    ] {
+        let gaps = card_face_gaps(&card_face(name, oracle));
+        assert!(
+            gaps.is_empty(),
+            "{name} should report no face gaps when unless_pay is present, got {gaps:?}"
+        );
+    }
+}
+
+#[test]
+fn mana_leak_control_has_unless_pay_for_regression() {
+    let ability = spell_ability("Mana Leak", MANA_LEAK);
+    assert!(
+        ability.unless_pay.is_some(),
+        "Mana Leak control must keep unless_pay"
+    );
+}
+
+#[test]
+fn dash_hopes_prompts_life_payment_then_counters_on_decline() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P1, 20);
+    let mut dash = scenario.add_spell_to_hand_from_oracle(P0, "Dash Hopes", true, DASH_HOPES);
+    dash.with_mana_cost(ManaCost::Cost {
+        generic: 0,
+        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+    });
+    let dash_hopes = dash.id();
+    scenario.add_basic_land(P0, ManaColor::Red);
+    scenario.add_basic_land(P0, ManaColor::Red);
+
+    let mut runner = scenario.build();
+    let opponent_spell = put_instant_on_stack(&mut runner, P1);
+
+    runner
+        .cast(dash_hopes)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P1, .. }
+        ),
+        "Dash Hopes must prompt P1 to pay 5 life, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("P1 declines to pay life");
+
+    assert!(
+        runner.state().stack.is_empty(),
+        "declining life payment must counter the targeted spell"
+    );
+    assert_eq!(
+        runner.state().objects.get(&opponent_spell).map(|o| o.zone),
+        Some(Zone::Graveyard)
+    );
+}
+
+#[test]
+fn dash_hopes_paying_life_leaves_target_spell_on_stack() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P1, 20);
+    let mut dash = scenario.add_spell_to_hand_from_oracle(P0, "Dash Hopes", true, DASH_HOPES);
+    dash.with_mana_cost(ManaCost::Cost {
+        generic: 0,
+        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+    });
+    let dash_hopes = dash.id();
+    scenario.add_basic_land(P0, ManaColor::Red);
+    scenario.add_basic_land(P0, ManaColor::Red);
+
+    let mut runner = scenario.build();
+    let opponent_spell = put_instant_on_stack(&mut runner, P1);
+    let life_before = runner.state().players[P1.0 as usize].life;
+
+    runner
+        .cast(dash_hopes)
+        .target_objects(&[opponent_spell])
+        .resolve();
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("P1 pays 5 life");
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        life_before - 5,
+        "paying the unless cost must deduct 5 life (CR 119.4)"
+    );
+    assert!(
+        runner.state().stack.iter().any(|e| e.id == opponent_spell),
+        "target spell must remain on stack when unless cost is paid"
+    );
+    assert_eq!(
+        runner.state().objects.get(&opponent_spell).map(|o| o.zone),
+        Some(Zone::Stack)
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -330,6 +330,7 @@ mod issue_3323_nexus_of_fate_extra_turn;
 mod issue_3324_haunted_one;
 mod issue_3325_umbral_mantle;
 mod issue_3425_legend_rule_exemption_scopes;
+mod issue_3466_counter_unless_non_mana;
 mod issue_3647_gaeas_cradle;
 mod issue_3648_ninjutsu_combat_flow;
 mod issue_3649_tetsuko;


### PR DESCRIPTION
## Summary

[Dash Hopes](https://github.com/phase-rs/phase/issues/3466) and other "counter target spell unless its controller pays N life / sacrifices / discards" cards were silently parsing as **unconditional** `Effect::Counter` because the counter-path `parse_unless_payment` helper only recognized brace-delimited mana costs. The engine data model and trigger-side parser already supported `PayLife`, `Sacrifice`, and `Discard` via `UnlessPayModifier` — the counter path simply did not reuse that authority.

## Root cause

`parse_unless_payment` in the counter/resolution path required a `{...}` mana cost after `"pays "`. For `"pays 5 life"` it extracted `"5"`, saw no braces, and returned `None`; for `"sacrifices …"` / `"discards …"` there was no `"pays "` at all. Callers then built `Counter { unless_pay: None }` — a clean AST with no missing part, so `card_face_gaps` reported zero gaps and deck validation marked the card fully supported.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/parser/oracle_effect/mod.rs` | Route non-mana counter unless costs through `normalize_counter_unless_subject` → `parse_unless_they_alt_cost_chain` (shared trigger-side authority); extract mana/energy parsing into `parse_unless_mana_or_energy_payment` |
| `crates/engine/src/parser/swallow_check.rs` | Regression cases for Dash Hopes / sacrifice / discard counter unless (no `Condition_Unless` swallow) |
| `crates/engine/src/parser/oracle_effect/mod.rs` (tests) | `effect_counter_unless_parses_non_mana_costs` — life / sacrifice / discard parse to typed `unless_pay` |
| `crates/engine/tests/integration/issue_3466_counter_unless_non_mana.rs` | End-to-end parse, coverage, and runtime tests for Dash Hopes life payment |
| `crates/engine/tests/integration/main.rs` | Register integration module |

## Test plan

- [x] `effect_counter_unless_parses_non_mana_costs` — parser attaches `PayLife` / `Sacrifice` / `Discard` to counter spells
- [x] `swallow_check::condition_unless_not_swallowed` — Dash Hopes / sacrifice / discard counter lines emit no `Condition_Unless` swallow
- [x] `dash_hopes_parses_conditional_counter_with_pay_life_unless` — full `parse_oracle_text` path carries `unless_pay`
- [x] `counter_unless_non_mana_costs_have_no_coverage_gaps` — `card_face_gaps` empty when AST is correct
- [x] `dash_hopes_prompts_life_payment_then_counters_on_decline` — runtime `UnlessPayment` prompt; decline counters spell (CR 118.12)
- [x] `dash_hopes_paying_life_leaves_target_spell_on_stack` — paying 5 life leaves target on stack (CR 119.4)
- [ ] Manual: cast Dash Hopes vs opponent instant — verify life payment UI and both pay/decline outcomes

## Closes

Fixes https://github.com/phase-rs/phase/issues/3466
