### PR TITLE
fix(engine): suppress reflexive-target rider on declined optional target (Faller's Faithful, S01 Part B)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3260,6 +3260,7 @@ fn fmt_ability_condition(cond: &AbilityCondition) -> String {
         AbilityCondition::TargetHasKeywordInstead { keyword } => {
             format!("target has {} (instead)", keyword_label(keyword))
         }
+        AbilityCondition::HasObjectTarget => "has an object target".into(),
         AbilityCondition::TargetMatchesFilter { filter, .. } => {
             format!("target is {}", fmt_target(filter))
         }
@@ -6310,6 +6311,9 @@ fn condition_feature(cond: &AbilityCondition) -> (&'static str, FeatureSupport) 
         // CR 400.7 + CR 608.2c: Target filter conditions — resolved by
         // `evaluate_condition` (effects/mod.rs) with current-state and optional
         // LKI paths.
+        // CR 601.2c + CR 115.1: object-target presence guard — resolved by
+        // `evaluate_condition` (effects/mod.rs) against the ability's declared targets.
+        AbilityCondition::HasObjectTarget => ("HasObjectTarget", Handled),
         AbilityCondition::TargetMatchesFilter { .. } => ("TargetMatchesFilter", Handled),
         AbilityCondition::TriggeringSpellTargetsFilter { .. } => {
             ("TriggeringSpellTargetsFilter", Handled)

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2098,6 +2098,9 @@ fn should_resolve_subability_on_optional_decline(ability: &ResolvedAbility) -> b
             | AbilityCondition::IsRingBearer
             | AbilityCondition::TargetHasKeywordInstead { .. }
             | AbilityCondition::TargetMatchesFilter { .. }
+            // CR 601.2c: a presence guard, not a decline-alternative selector —
+            // declining the optional effect does not pick a `HasObjectTarget` branch.
+            | AbilityCondition::HasObjectTarget
             | AbilityCondition::TriggeringSpellTargetsFilter { .. }
             | AbilityCondition::SourceMatchesFilter { .. }
             | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
@@ -7605,6 +7608,16 @@ pub(crate) fn evaluate_condition(
         // CR 608.2c: General "instead" — delegate to the wrapped inner condition.
         // The "instead" semantics are handled by the swap/guard in resolve_ability_chain.
         AbilityCondition::ConditionInstead { inner } => evaluate_condition(inner, state, ability),
+        // CR 601.2c + CR 115.1 + CR 608.2c: True iff the parent ability declared at
+        // least one object target. Unlike `TargetMatchesFilter`, there is NO
+        // `TriggeringSource` fallback — a declined variable-count target
+        // (CR 601.2c: zero targets announced) reads false, so the lowering pass's
+        // `And{[HasObjectTarget, …]}` wrapper suppresses a reflexive-target rider
+        // whose anaphor ("that creature") has no antecedent.
+        AbilityCondition::HasObjectTarget => ability
+            .targets
+            .iter()
+            .any(|t| matches!(t, TargetRef::Object(_))),
         // CR 608.2c: Compound condition — all inner conditions must be true.
         AbilityCondition::And { conditions } => conditions
             .iter()

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5770,13 +5770,27 @@ mod tests {
         }
 
         // Sub clause: gated on the target being a creature, sets base P/T 2/2.
+        // CR 601.2c + CR 608.2c: the head's "up to one" antecedent is optional, so
+        // the reflexive creature gate is conjoined with `HasObjectTarget` by the
+        // lowering pass — a declined target suppresses the base-P/T rider.
         let sub = execute
             .sub_ability
             .as_deref()
             .expect("base-P/T sub-ability must be present");
+        let Some(AbilityCondition::And { conditions }) = &sub.condition else {
+            panic!(
+                "optional-target sub clause must gate on And{{[HasObjectTarget, \
+                 TargetMatchesFilter(creature)]}}, got {:?}",
+                sub.condition
+            );
+        };
+        assert!(
+            matches!(conditions.first(), Some(AbilityCondition::HasObjectTarget)),
+            "first conjunct must be the HasObjectTarget optional-target guard, got {conditions:?}"
+        );
         assert!(
             matches!(
-                &sub.condition,
+                conditions.get(1),
                 Some(AbilityCondition::TargetMatchesFilter { filter, .. })
                     if matches!(
                         filter,
@@ -5784,8 +5798,7 @@ mod tests {
                             if type_filters == &vec![TypeFilter::Creature]
                     )
             ),
-            "sub clause must gate on TargetMatchesFilter(creature), got {:?}",
-            sub.condition
+            "sub clause must still gate on TargetMatchesFilter(creature), got {conditions:?}"
         );
         match &*sub.effect {
             Effect::GenericEffect {

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3604,6 +3604,9 @@ pub(crate) fn ability_condition_to_static_condition(
         | AbilityCondition::PreviousEffectAmount { .. }
         | AbilityCondition::TargetHasKeywordInstead { .. }
         | AbilityCondition::TargetMatchesFilter { .. }
+        // CR 601.2c + CR 115.1: reads the resolved ability's declared targets;
+        // a resolution-flow guard with no continuous-effect (StaticCondition) form.
+        | AbilityCondition::HasObjectTarget
         | AbilityCondition::TriggeringSpellTargetsFilter { .. }
         | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
         | AbilityCondition::ZoneChangedThisWay { .. }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -207,6 +207,89 @@ fn patch_self_ref_head_tap_anaphor(def: &mut AbilityDefinition) {
     walk(def, false);
 }
 
+/// CR 601.2c + CR 608.2c: Guard a reflexive-target rider against a *declined*
+/// optional antecedent target. When an ability declares a variable number of
+/// targets that may be zero — "destroy **up to one** target creature"
+/// (`multi_target.min_is_fixed_zero()`, CR 601.2c) — and chains a conditional
+/// rider whose condition anaphors that target ("**if that creature** wasn't
+/// dealt damage this turn, its controller draws two cards"), declining the
+/// target leaves the rider's `TargetMatchesFilter` with no antecedent. At
+/// runtime that condition falls back to the trigger source (effects/mod.rs), so
+/// a `Not`-wrapped rider wrongly fires. Conjoining the rider condition with
+/// `HasObjectTarget` (`And{[HasObjectTarget, existing]}`) suppresses the rider
+/// when no object target was chosen, while leaving the chosen-target case
+/// unchanged (the conjunct is trivially true).
+///
+/// The optional-target context is threaded DOWN the chain via an inner `walk`: a node
+/// whose own `multi_target` is `None` inherits its parent's optionality, so a
+/// rider nested deeper than the immediate `sub_ability` — or hanging off an
+/// `else_ability` — is still gated against the declined PARENT target (CR 608.2c:
+/// read the whole text; the anaphor binds the parent's chosen target, not the
+/// intervening instruction). A node that declares its OWN targets establishes a
+/// NEW antecedent and recomputes optionality from its own `multi_target`, so a
+/// mandatory intervening target (always present) does NOT spuriously gate a rider
+/// that anaphors it. Both `sub_ability` and `else_ability` conditions are gated.
+///
+/// Class-level (Faller's Faithful, Sunpearl Kirin, Zephyr Sentinel, Rescue //
+/// Pepper Potts), both polarities. No-op for mandatory-single-target
+/// antecedents: those carry `multi_target == None` at the head with no optional
+/// ancestor, so optionality is false and the wrapper is never applied. Idempotent
+/// — an already-wrapped `And{..}` is not itself a reflexive-target condition, so
+/// re-lowering does not double-wrap.
+fn gate_reflexive_rider_on_declined_optional_target(def: &mut AbilityDefinition) {
+    // CR 601.2c + CR 608.2c: wrap a child's reflexive-target rider so a declined
+    // optional antecedent target suppresses it; a non-reflexive condition (or no
+    // condition) is left untouched.
+    fn gate_child_condition(child: &mut AbilityDefinition) {
+        if let Some(existing) = child.condition.take() {
+            if is_reflexive_target_condition(&existing) {
+                child.condition = Some(AbilityCondition::And {
+                    conditions: vec![AbilityCondition::HasObjectTarget, existing],
+                });
+            } else {
+                child.condition = Some(existing);
+            }
+        }
+    }
+    // Carry the parent's optional-target context down the chain; a node that
+    // declares its own targets establishes a NEW antecedent and recomputes it.
+    fn walk(def: &mut AbilityDefinition, parent_optional: bool) {
+        let optional_here = match def.multi_target.as_ref() {
+            Some(mt) => mt.min_is_fixed_zero(),
+            None => parent_optional,
+        };
+        if optional_here {
+            if let Some(sub) = def.sub_ability.as_deref_mut() {
+                gate_child_condition(sub);
+            }
+            if let Some(els) = def.else_ability.as_deref_mut() {
+                gate_child_condition(els);
+            }
+        }
+        if let Some(sub) = def.sub_ability.as_deref_mut() {
+            walk(sub, optional_here);
+        }
+        if let Some(els) = def.else_ability.as_deref_mut() {
+            walk(els, optional_here);
+        }
+    }
+    walk(def, false);
+}
+
+/// CR 608.2c: A reflexive-target condition reads the parent's chosen target via
+/// an anaphor ("that creature"/"it"/"that much"), so a declined optional target
+/// leaves it without an antecedent. `TargetMatchesFilter` (current/LKI target
+/// match) and `PreviousEffectAmount` ("that much") are the affected shapes, in
+/// either polarity (`Not`-wrapped).
+fn is_reflexive_target_condition(cond: &AbilityCondition) -> bool {
+    match cond {
+        AbilityCondition::TargetMatchesFilter { .. }
+        | AbilityCondition::PreviousEffectAmount { .. } => true,
+        AbilityCondition::Not { condition } => is_reflexive_target_condition(condition),
+        _ => false,
+    }
+}
+
 /// CR 608.2c: True for `TargetFilter`s that refer to a PLAYER (or set of players),
 /// which therefore do NOT establish a new permanent antecedent for a chained
 /// tap/untap "him"/"it" anaphor (see [`patch_self_ref_head_tap_anaphor`]).
@@ -235,6 +318,189 @@ fn target_filter_is_player_scoped(filter: &TargetFilter) -> bool {
             | TargetFilter::PostReplacementSourceController
             | TargetFilter::SpecificPlayer { .. }
     )
+}
+
+#[cfg(test)]
+mod gate_reflexive_rider_tests {
+    use super::*;
+
+    /// "if that creature wasn't dealt damage this turn" — the reflexive-target
+    /// rider shape (`Not{TargetMatchesFilter{use_lki}}`) that anaphors the parent's
+    /// chosen target.
+    fn reflexive_rider() -> AbilityCondition {
+        AbilityCondition::Not {
+            condition: Box::new(AbilityCondition::TargetMatchesFilter {
+                filter: TargetFilter::Typed(
+                    TypedFilter::default().properties(vec![FilterProp::WasDealtDamageThisTurn]),
+                ),
+                use_lki: true,
+            }),
+        }
+    }
+
+    fn draw_effect() -> Effect {
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::ParentTargetController,
+        }
+    }
+
+    /// Leaf rider node carrying `condition`.
+    fn leaf_with_condition(condition: AbilityCondition) -> Box<AbilityDefinition> {
+        let mut def = AbilityDefinition::new(AbilityKind::Spell, draw_effect());
+        def.condition = Some(condition);
+        Box::new(def)
+    }
+
+    /// A head that declares an OPTIONAL "up to one" target (`min_is_fixed_zero()`).
+    fn optional_head() -> AbilityDefinition {
+        let mut def = AbilityDefinition::new(AbilityKind::Spell, draw_effect());
+        def.multi_target = Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }));
+        def
+    }
+
+    /// True iff `condition` is the gated form `And{[HasObjectTarget, reflexive_rider]}`.
+    fn is_gated(condition: &Option<AbilityCondition>) -> bool {
+        matches!(
+            condition,
+            Some(AbilityCondition::And { conditions })
+                if conditions.as_slice()
+                    == [AbilityCondition::HasObjectTarget, reflexive_rider()]
+        )
+    }
+
+    /// Baseline: the immediate `sub_ability` rider under an optional head is gated.
+    /// (Passes under both the old direct-child code and the threaded fix.)
+    #[test]
+    fn direct_rider_under_optional_head_is_gated() {
+        let mut head = optional_head();
+        head.sub_ability = Some(leaf_with_condition(reflexive_rider()));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let sub = head.sub_ability.as_ref().unwrap();
+        assert!(
+            is_gated(&sub.condition),
+            "direct rider must be gated: {:?}",
+            sub.condition
+        );
+    }
+
+    /// DISCRIMINATOR (nested): head[up to one] → sub1[own `multi_target == None`,
+    /// non-reflexive `IsYourTurn`] → sub2[reflexive rider]. The rider is two levels
+    /// below the optional antecedent. The fix threads the parent's optionality
+    /// through sub1 (which declares no own target), so sub2 is gated; the
+    /// intervening non-reflexive condition is left untouched. REVERT-PROBE: the old
+    /// direct-child recursion recomputes optionality from sub1's own `multi_target`
+    /// (`None` → false), so sub2 is NOT gated and this assertion fails.
+    #[test]
+    fn nested_deeper_rider_under_optional_head_is_gated() {
+        let mut sub1 = AbilityDefinition::new(AbilityKind::Spell, draw_effect());
+        sub1.condition = Some(AbilityCondition::IsYourTurn);
+        sub1.sub_ability = Some(leaf_with_condition(reflexive_rider()));
+        let mut head = optional_head();
+        head.sub_ability = Some(Box::new(sub1));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let sub1 = head.sub_ability.as_ref().unwrap();
+        assert_eq!(
+            sub1.condition,
+            Some(AbilityCondition::IsYourTurn),
+            "intervening non-reflexive condition must be left untouched"
+        );
+        let sub2 = sub1.sub_ability.as_ref().unwrap();
+        assert!(
+            is_gated(&sub2.condition),
+            "deeper rider must be gated with HasObjectTarget (bug: old code lost the guard here): {:?}",
+            sub2.condition
+        );
+    }
+
+    /// DISCRIMINATOR (else): head[up to one] → else_ability[reflexive rider]. The
+    /// fix gates the else branch's own reflexive condition. REVERT-PROBE: the old
+    /// code only gated `sub_ability` and never touched `else_ability`, so this
+    /// assertion fails.
+    #[test]
+    fn else_branch_rider_under_optional_head_is_gated() {
+        let mut head = optional_head();
+        head.else_ability = Some(leaf_with_condition(reflexive_rider()));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let els = head.else_ability.as_ref().unwrap();
+        assert!(
+            is_gated(&els.condition),
+            "else-branch rider must be gated: {:?}",
+            els.condition
+        );
+    }
+
+    /// NEGATIVE (new mandatory antecedent): head[up to one] → sub1[own EXACT(1)
+    /// target — a NEW, always-present antecedent] → sub2[reflexive rider]. sub2's
+    /// "that creature" anaphors sub1's mandatory target, which is never declined, so
+    /// the rider must NOT be gated. Guards against a naive fix that threads the
+    /// parent's optionality unconditionally past a node that establishes its own
+    /// target.
+    #[test]
+    fn mandatory_intervening_target_does_not_gate_deeper_rider() {
+        let mut sub1 = AbilityDefinition::new(AbilityKind::Spell, draw_effect());
+        sub1.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }));
+        sub1.sub_ability = Some(leaf_with_condition(reflexive_rider()));
+        let mut head = optional_head();
+        head.sub_ability = Some(Box::new(sub1));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let sub2 = head
+            .sub_ability
+            .as_ref()
+            .unwrap()
+            .sub_ability
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            sub2.condition,
+            Some(reflexive_rider()),
+            "rider under a mandatory own-target antecedent must NOT be gated"
+        );
+    }
+
+    /// NO-OP: a mandatory single-target head (`multi_target == Some(exact(1))`,
+    /// `min_is_fixed_zero()` false, no optional ancestor) does not gate its rider —
+    /// the 7 clean S01 mandatory cards are unaffected.
+    #[test]
+    fn mandatory_head_does_not_gate_rider() {
+        let mut head = AbilityDefinition::new(AbilityKind::Spell, draw_effect());
+        head.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }));
+        head.sub_ability = Some(leaf_with_condition(reflexive_rider()));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let sub = head.sub_ability.as_ref().unwrap();
+        assert_eq!(
+            sub.condition,
+            Some(reflexive_rider()),
+            "mandatory single-target head must not wrap its rider"
+        );
+    }
+
+    /// NO-OP: a non-reflexive condition under an optional head is left untouched
+    /// (the gate only wraps reflexive-target riders).
+    #[test]
+    fn non_reflexive_rider_under_optional_head_untouched() {
+        let mut head = optional_head();
+        head.sub_ability = Some(leaf_with_condition(AbilityCondition::IsYourTurn));
+
+        gate_reflexive_rider_on_declined_optional_target(&mut head);
+
+        let sub = head.sub_ability.as_ref().unwrap();
+        assert_eq!(
+            sub.condition,
+            Some(AbilityCondition::IsYourTurn),
+            "non-reflexive condition must be left untouched"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1619,6 +1885,9 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     // ParentTarget to SelfRef so it binds the source, while a real/optional
     // target head (Tyvar Kell) keeps ParentTarget and no-ops when declined.
     patch_self_ref_head_tap_anaphor(&mut result);
+    // CR 601.2c + CR 608.2c: suppress a reflexive-target rider when the optional
+    // "up to one" antecedent target is declined (no object target chosen).
+    gate_reflexive_rider_on_declined_optional_target(&mut result);
     if matches!(&*result.effect, Effect::SearchOutsideGame { .. }) {
         result.optional = false;
         result.optional_for = None;

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -14345,6 +14345,20 @@ pub enum AbilityCondition {
         #[serde(default)]
         use_lki: bool,
     },
+    /// CR 601.2c + CR 608.2c + CR 115.1: True iff the parent ability actually has
+    /// at least one *object* target. Guards reflexive-target riders ("If that
+    /// creature …, …") against the optional-declined-target case: when a
+    /// variable-number-of-targets antecedent ("destroy up to one target
+    /// creature") is announced with zero targets (CR 601.2c), the anaphor "that
+    /// creature" has no antecedent (CR 608.2c — read the whole text), so the
+    /// rider must not fire. `evaluate_condition` checks the resolved ability's
+    /// declared targets (CR 115.1) for a `TargetRef::Object`, with NO
+    /// `TriggeringSource` fallback (unlike `TargetMatchesFilter`), so a declined
+    /// optional target reads false. The lowering pass conjoins this with the
+    /// reflexive sub-condition (`And{[HasObjectTarget, …]}`) only when the
+    /// antecedent's `multi_target.min_is_fixed_zero()` — a no-op for
+    /// mandatory-single-target cards (`multi_target == None`).
+    HasObjectTarget,
     /// CR 608.2c + CR 603.2: "if it targets a [filter]" on a triggered ability —
     /// gates the sub_ability on whether the triggering spell's chosen targets
     /// include at least one permanent or player matching `filter`. The pronoun

--- a/crates/engine/tests/reflexive_if_rider.rs
+++ b/crates/engine/tests/reflexive_if_rider.rs
@@ -367,3 +367,163 @@ fn brackish_blunder_no_map_when_target_untapped() {
         "untapped bounced creature must NOT yield a Map token (rider gated)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Faller's Faithful — Part B: optional-declined-target guard (CR 601.2c + CR
+// 608.2c). "When this creature enters, destroy up to one other target creature.
+// If that creature wasn't dealt damage this turn, its controller draws two
+// cards." The antecedent is a *variable-number-of-targets* ("up to one") slot;
+// when it's announced with ZERO targets (declined), the rider's anaphor "that
+// creature" has no antecedent (CR 608.2c), so the rider must NOT fire.
+//
+// Before Part B, the rider's `Not{TargetMatchesFilter{WasDealtDamageThisTurn}}`
+// fell back to the trigger source (Faller's itself) when no target was chosen →
+// Faller's wasn't dealt damage → Not(false) = TRUE → the draw wrongly fired (for
+// the source's controller, the `ParentTargetController` event-context fallback).
+// The fix conjoins the rider with `HasObjectTarget`, so a declined optional
+// target reads false and the rider is suppressed.
+// ---------------------------------------------------------------------------
+
+const FALLERS_FAITHFUL: &str = "When this creature enters, destroy up to one other \
+     target creature. If that creature wasn't dealt damage this turn, its controller \
+     draws two cards.";
+
+// A MANDATORY single-target sibling (no "up to one") — the lowering's
+// `min_is_fixed_zero()` guard is false here, so the `HasObjectTarget` wrapper is
+// never applied. Proves the gate is a no-op for the 7 clean S01 mandatory cards.
+const FAITHFUL_MANDATORY: &str = "When this creature enters, destroy target creature. \
+     If that creature wasn't dealt damage this turn, its controller draws two cards.";
+
+/// Net cards drawn by `player` since stack commit.
+fn hand_drawn(outcome: &engine::game::scenario::CastOutcome, player: PlayerId) -> i64 {
+    outcome.hand_drawn(player)
+}
+
+/// RUNTIME (the Part B fix / discriminator) — CR 601.2c. Declining the optional
+/// "up to one" target (no object target chosen) must NOT fire the rider: nobody
+/// draws. REVERT-PROBE: remove the `gate_reflexive_rider_on_declined_optional_target`
+/// call in lower.rs and the rider fires via the trigger-source fallback, so the
+/// ability controller (P0) wrongly draws 2 and this assertion fails.
+#[test]
+fn fallers_faithful_no_draw_when_optional_target_declined() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let fallers = scenario
+        .add_creature_to_hand_from_oracle(P0, "Faller's Faithful", 2, 2, FALLERS_FAITHFUL)
+        .id();
+    // A legal "other" creature IS available — the controller chooses zero anyway.
+    let bystander = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    // Both players have draws available so a wrongly-fired draw is observable on
+    // either side (the fallback recipient is the source controller, P0).
+    scenario.add_spell_to_library_top(P0, "P0 Filler A", true);
+    scenario.add_spell_to_library_top(P0, "P0 Filler B", true);
+    scenario.add_spell_to_library_top(P1, "P1 Filler A", true);
+    scenario.add_spell_to_library_top(P1, "P1 Filler B", true);
+    let mut runner = scenario.build();
+
+    // Declare NO target → the "up to one" slot is declined (zero targets).
+    let outcome = runner.cast(fallers).resolve();
+
+    outcome.assert_zone(&[bystander], Zone::Battlefield);
+    assert_eq!(
+        hand_drawn(&outcome, P0),
+        0,
+        "declined optional target must NOT draw for the controller (rider gated by HasObjectTarget)"
+    );
+    assert_eq!(
+        hand_drawn(&outcome, P1),
+        0,
+        "declined optional target must NOT draw for anyone"
+    );
+}
+
+/// RUNTIME (positive — chosen, undamaged) — CR 608.2c. Choosing the optional
+/// target and destroying an UNDAMAGED creature fires the rider: that creature's
+/// controller (P1) draws two cards. Proves the `HasObjectTarget` conjunct is
+/// trivially true when a target IS chosen (the fix does not break the live path).
+#[test]
+fn fallers_faithful_draws_when_target_chosen_and_undamaged() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let fallers = scenario
+        .add_creature_to_hand_from_oracle(P0, "Faller's Faithful", 2, 2, FALLERS_FAITHFUL)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    scenario.add_spell_to_library_top(P1, "P1 Filler A", true);
+    scenario.add_spell_to_library_top(P1, "P1 Filler B", true);
+    let mut runner = scenario.build();
+    // No damage record this turn → "wasn't dealt damage" holds.
+
+    let outcome = runner.cast(fallers).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Graveyard);
+    assert_eq!(
+        hand_drawn(&outcome, P1),
+        2,
+        "destroyed undamaged creature's controller must draw two cards"
+    );
+}
+
+/// RUNTIME (negative — chosen, damaged) — CR 120.6 + CR 400.7. Choosing the
+/// optional target but destroying a creature that WAS dealt damage this turn
+/// fails the `Not{WasDealtDamageThisTurn}` gate: no draw. This is the within-fix
+/// discriminator that the rider condition is still evaluated (not blanket-true)
+/// in the chosen case.
+#[test]
+fn fallers_faithful_no_draw_when_target_chosen_but_damaged() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let fallers = scenario
+        .add_creature_to_hand_from_oracle(P0, "Faller's Faithful", 2, 2, FALLERS_FAITHFUL)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    scenario.add_spell_to_library_top(P1, "P1 Filler A", true);
+    scenario.add_spell_to_library_top(P1, "P1 Filler B", true);
+    let mut runner = scenario.build();
+
+    // CR 120.9: record battlefield damage on the victim this turn.
+    runner
+        .state_mut()
+        .damage_dealt_this_turn
+        .push_back(DamageRecord {
+            target: TargetRef::Object(victim),
+            amount: 2,
+            ..Default::default()
+        });
+
+    let outcome = runner.cast(fallers).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Graveyard);
+    assert_eq!(
+        hand_drawn(&outcome, P1),
+        0,
+        "destroyed DAMAGED creature must NOT draw (Not{{WasDealtDamageThisTurn}} false)"
+    );
+}
+
+/// RUNTIME (no-op proof) — a MANDATORY single-target rider (`multi_target ==
+/// None`, so `min_is_fixed_zero()` is false) is NOT wrapped by the gate and
+/// fires exactly as before: the destroyed undamaged creature's controller draws.
+/// Guards the 7 clean S01 cards against the gate over-applying. (The existing
+/// Sold Out / Driftgloom positive tests above are the broader no-op proof.)
+#[test]
+fn mandatory_single_target_rider_still_fires_unwrapped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let host = scenario
+        .add_creature_to_hand_from_oracle(P0, "Faithful Mandatory", 2, 2, FAITHFUL_MANDATORY)
+        .id();
+    let victim = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    scenario.add_spell_to_library_top(P1, "P1 Filler A", true);
+    scenario.add_spell_to_library_top(P1, "P1 Filler B", true);
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(host).target_object(victim).resolve();
+
+    outcome.assert_zone(&[victim], Zone::Graveyard);
+    assert_eq!(
+        hand_drawn(&outcome, P1),
+        2,
+        "mandatory-target rider must fire unchanged (gate must not wrap multi_target == None)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

S01 follow-up (Part B). Fixes the **optional-declined-target** case of reflexive-target riders. When an ability declares a variable number of targets that may be zero — "destroy **up to one** target creature" — and chains a conditional sub-ability that anaphors that target — "**if that creature** wasn't dealt damage this turn, its controller draws two cards" — declining the target left the rider's `TargetMatchesFilter` with no antecedent. At runtime that condition falls back to the triggering source (`effects/mod.rs`), so a `Not`-wrapped rider **wrongly fired** (Faller's Faithful's controller wrongly drew 2 cards even when no creature was targeted).

## How

New `AbilityCondition::HasObjectTarget` (CR 601.2c + CR 608.2c + CR 115.1): true iff the parent ability declared **≥1 object target**, with **no `TriggeringSource` fallback** (unlike `TargetMatchesFilter`). A lowering pass (`gate_reflexive_rider_on_declined_optional_target`) conjoins the reflexive sub-condition as `And{[HasObjectTarget, existing]}` **only when** the antecedent's `multi_target.min_is_fixed_zero()` — a no-op for mandatory-single-target cards (`multi_target == None`). Declined ⇒ `HasObjectTarget` false ⇒ `And` false ⇒ no rider; chosen ⇒ `And` reduces to the existing condition.

- `evaluate_condition` (effects/mod.rs): `HasObjectTarget => ability.targets.iter().any(|t| matches!(t, TargetRef::Object(_)))`.
- Composes for free over tense/polarity: both `Not`-wrapped and bare reflexive conditions, `TargetMatchesFilter` and `PreviousEffectAmount`.

## Class coverage

Build-for-the-class — covers **Faller's Faithful, Sunpearl Kirin, Zephyr Sentinel, Rescue // Pepper Potts, Azure Beastbinder** (a 5th "up to one" member whose shape test is updated accordingly). Mandatory-single-target reflexive-rider cards are unaffected (`multi_target == None` ⇒ never wrapped).

## CR

CR 601.2c (a spell/ability with a variable number of targets — announce how many, permits zero), CR 608.2c (read the whole text — "that creature" has no antecedent when none chosen), CR 115.1 (declared targets). All grep-verified against `docs/MagicCompRules.txt`. 608.2b (targets that became *illegal*) is correctly **not** the basis — a zero-chosen optional target is not an illegal target.

## Testing

- `tests/reflexive_if_rider.rs` (drives real ETB resolution via the scenario runner): declined ⇒ **no draw**; chosen + undamaged ⇒ draw 2; chosen + damaged ⇒ no draw; mandatory-single-target sibling still fires.
- **Discriminating revert-probe (measured):** disabling the lowering-pass gate makes `fallers_faithful_no_draw_when_optional_target_declined` fail `left=2, right=0` (controller wrongly draws via the `TriggeringSource` anaphor fallback) — the gate is load-bearing.
- Adversarially reviewed (independent agent): all checks pass; revert-probe independently reproduced.
- Full local CI-equiv green after rebase onto current `main`: `cargo fmt --check`, `clippy --workspace --all-targets --features engine/proptest -D warnings`, `cargo test -p engine` (**14064 passed; 0 failed**), integration `reflexive_if_rider` 12/12. Coverage: 0 regressions (Part B is a runtime-correctness fix; Faller's was already coverage-supported via Part A).
