### PR TITLE
Fix PR review loop scan routing

### DIFF
--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -43,9 +43,10 @@ python3 scripts/pr_review.py compact
 ## Sweep Protocol
 
 1. Resolve the acting identity from GitHub. Do not review PRs authored by the acting login.
-2. Run `scan`. Treat its result as a triage packet, not a final approval gate.
+2. Run `scan`. Use `action_counts` / `candidates_by_action` for routing; do not infer legacy bucket names. Treat its result as a triage packet, not a final approval gate.
 3. For each candidate:
    - `hard_stop` / `request_changes` — surface the precise blocker; do not enqueue.
+   - `blocked` — current head already has blocking maintainer feedback; wait for a new head or author follow-up.
    - `defer` — record the deferral event; do not approve, label, enqueue, or merge.
    - `hold_ci` — record a non-terminal hold and wait for exact-head CI to finish.
    - `dequeue_stale_for_handler` / `update_branch_for_handler` / `approve_ready_for_handler` — advisory only; delegate execution to `pr-contribution-handler` in authorized mode.

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -101,6 +101,25 @@ def event_id(event: dict[str, Any]) -> str:
 
 def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(event)
+    if normalized.get("head_sha") is None and normalized.get("head") is not None:
+        normalized["head_sha"] = normalized["head"]
+    action = normalized.get("action")
+    if normalized.get("event_type") is None and action is not None:
+        normalized["event_type"] = action
+    summary = str(normalized.get("summary") or normalized.get("note") or "")
+    if normalized.get("event_type") in {None, "observation"} and (
+        summary.startswith("CHANGES_REQUESTED:")
+        or summary.startswith("Requested changes:")
+    ):
+        normalized["event_type"] = "changes_requested"
+    if normalized.get("outcome") is None and action in {
+        "changes_requested",
+        "blocked",
+        "approved_enqueued",
+        "deferred",
+        "held",
+    }:
+        normalized["outcome"] = action
     normalized.setdefault("timestamp", now_iso())
     normalized.setdefault("event_type", "observation")
     normalized.setdefault("schema_version", 1)
@@ -234,6 +253,17 @@ def all_events(state_dir: Path) -> list[dict[str, Any]]:
     return [json.loads(row[0]) for row in rows]
 
 
+def latest_events_by_pr_head(state_dir: Path) -> dict[tuple[int, str], dict[str, Any]]:
+    latest: dict[tuple[int, str], dict[str, Any]] = {}
+    for event in all_events(state_dir):
+        pr = event.get("pr")
+        head_sha = event.get("head_sha")
+        if pr is None or not head_sha:
+            continue
+        latest[(int(pr), str(head_sha))] = event
+    return latest
+
+
 def matches_any(path: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
 
@@ -304,7 +334,7 @@ def pr_files_from_view(pr: dict[str, Any]) -> list[str]:
 def latest_review_commit(pr: dict[str, Any], acting_login: str) -> str | None:
     reviews = [
         review
-        for review in pr.get("reviews", [])
+        for review in pr.get("reviews", pr.get("latestReviews", []))
         if review.get("author", {}).get("login") == acting_login
     ]
     if not reviews:
@@ -366,6 +396,9 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     latest_commit = packet.get("latest_maintainer_review_commit")
     review_decision = pr.get("reviewDecision")
     queue = bool(pr.get("isInMergeQueue"))
+    local_event = packet.get("local_current_event") or {}
+    local_event_type = local_event.get("event_type")
+    local_outcome = local_event.get("outcome")
 
     if pr.get("state") == "MERGED":
         action = "merged_prune"
@@ -379,8 +412,25 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif classification.get("hard_stop_paths"):
         action = "request_changes"
         reason = "hard_stop"
+    elif local_outcome == "DEFER-FE":
+        action = "defer"
+        reason = "local_defer_fe_current_head"
+    elif local_event_type == "held":
+        action = "blocked"
+        reason = "local_hold_current_head"
+    elif local_event_type in {
+        "review_blocked",
+        "changes_requested",
+        "blocked",
+    } or local_outcome in {
+        "changes_requested",
+        "reviewed_request_changes",
+        "blocked",
+    }:
+        action = "blocked"
+        reason = "local_block_current_head"
     elif latest_commit and latest_commit != head and review_decision == "APPROVED":
-        action = "dequeue_stale_for_handler" if queue else "hold_ci"
+        action = "dequeue_stale_for_handler" if queue else "review"
         reason = "stale_approval"
     elif queue and review_decision == "APPROVED":
         action = "queued"
@@ -394,9 +444,21 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif classification.get("surface") == "frontend":
         action = "defer"
         reason = "frontend_policy"
+    elif local_event_type == "approved_enqueued":
+        action = "approve_ready_for_handler"
+        reason = "local_approved_enqueued_live_check"
+    elif review_decision == "CHANGES_REQUESTED" and latest_commit == head:
+        action = "blocked"
+        reason = "changes_requested_current_head"
     elif review_decision == "CHANGES_REQUESTED":
         action = "review"
-        reason = "changes_requested"
+        reason = "stale_changes_requested"
+    elif review_decision == "APPROVED" and pr.get("mergeStateStatus") == "BEHIND":
+        action = "update_branch_for_handler"
+        reason = "approved_behind"
+    elif review_decision == "APPROVED":
+        action = "approve_ready_for_handler"
+        reason = "approved_needs_live_queue_check"
     else:
         action = "review"
         reason = "needs_review"
@@ -445,7 +507,7 @@ def policy_trace(classification: dict[str, Any]) -> list[str]:
 
 def gh_pr_view(repo: str, pr_number: int) -> dict[str, Any]:
     fields = (
-        "number,title,body,state,isDraft,url,author,headRefName,headRefOid,"
+        "number,title,body,state,isDraft,url,author,createdAt,updatedAt,headRefName,headRefOid,"
         "baseRefName,mergeStateStatus,reviewDecision,labels,assignees,"
         "statusCheckRollup,latestReviews,reviews,comments,files"
     )
@@ -491,6 +553,7 @@ def gh_queue_state(repo: str, pr_number: int) -> dict[str, Any]:
 def command_scan(args: argparse.Namespace) -> int:
     policy = load_policy(args.config)
     acting_login = args.acting_login or gh_user()
+    local_events = latest_events_by_pr_head(args.state_dir)
     prs = run_json(
         [
             "gh",
@@ -503,17 +566,34 @@ def command_scan(args: argparse.Namespace) -> int:
             "--limit",
             str(args.limit),
             "--json",
-            "number,title,author,headRefOid,isDraft,mergeStateStatus,reviewDecision,labels,statusCheckRollup,files",
+            "number,title,author,createdAt,updatedAt,headRefOid,isDraft,mergeStateStatus,reviewDecision,latestReviews,labels,statusCheckRollup,files",
         ]
     )
     candidates = []
     for pr in prs:
-        pr.update(gh_queue_state(args.repo, int(pr["number"])))
+        pr_number = int(pr["number"])
         packet = make_packet(pr, policy, acting_login, "light")
+        packet["local_current_event"] = local_events.get((pr_number, pr.get("headRefOid") or ""))
+        packet["recommendation"] = recommend_from_packet(packet)
+        if packet["recommendation"]["reason"] == "stale_changes_requested" or packet[
+            "recommendation"
+        ]["advisory_action"] in {
+            "approve_ready_for_handler",
+            "update_branch_for_handler",
+            "dequeue_stale_for_handler",
+        }:
+            pr = gh_pr_view(args.repo, pr_number)
+            packet = make_packet(pr, policy, acting_login, "full")
+            packet["local_current_event"] = local_events.get(
+                (pr_number, pr.get("headRefOid") or "")
+            )
+            packet["recommendation"] = recommend_from_packet(packet)
         candidates.append(
             {
                 "pr": pr.get("number"),
                 "title": pr.get("title"),
+                "created_at": pr.get("createdAt"),
+                "updated_at": pr.get("updatedAt"),
                 "head_sha": pr.get("headRefOid"),
                 "author_login": packet["pr"].get("author_login"),
                 "self_authored": packet["pr"].get("self_authored"),
@@ -529,7 +609,48 @@ def command_scan(args: argparse.Namespace) -> int:
                 "policy_trace": packet["policy_trace"],
             }
         )
-    print(json_dumps({"acting_login": acting_login, "completeness": "triage", "candidates": candidates}))
+
+    action_order = {
+        "dequeue_stale_for_handler": 0,
+        "update_branch_for_handler": 1,
+        "approve_ready_for_handler": 2,
+        "review": 3,
+        "hold_ci": 4,
+        "request_changes": 5,
+        "blocked": 6,
+        "defer": 7,
+        "queued": 8,
+        "merged_prune": 9,
+        "skip": 10,
+    }
+
+    def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
+        action = candidate.get("advisory_action") or ""
+        created = candidate.get("created_at") or ""
+        updated = candidate.get("updated_at") or ""
+        pr_number = candidate.get("pr") or 0
+        if action == "review":
+            return (action_order.get(action, 99), created, pr_number)
+        if action in {"dequeue_stale_for_handler", "update_branch_for_handler", "approve_ready_for_handler"}:
+            return (action_order.get(action, 99), updated, created, pr_number)
+        return (action_order.get(action, 99), pr_number)
+
+    candidates.sort(key=candidate_sort_key)
+    candidates_by_action: dict[str, list[dict[str, Any]]] = {}
+    for candidate in candidates:
+        candidates_by_action.setdefault(candidate["advisory_action"], []).append(candidate)
+    action_counts = {action: len(items) for action, items in candidates_by_action.items()}
+    print(
+        json_dumps(
+            {
+                "acting_login": acting_login,
+                "completeness": "triage",
+                "action_counts": action_counts,
+                "candidates_by_action": candidates_by_action,
+                "candidates": candidates,
+            }
+        )
+    )
     return 0
 
 
@@ -726,6 +847,11 @@ def add_common(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--acting-login", default=None)
 
 
+def add_state(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", default="phase-rs/phase")
+    parser.add_argument("--state-dir", type=Path, default=None)
+
+
 def finalize_state_dir(args: argparse.Namespace) -> None:
     if getattr(args, "state_dir", None) is None:
         args.state_dir = default_state_dir(getattr(args, "repo", None))
@@ -753,22 +879,22 @@ def build_parser() -> argparse.ArgumentParser:
     recommend.set_defaults(func=command_recommend)
 
     record = sub.add_parser("record")
-    record.add_argument("--state-dir", type=Path, default=None)
+    add_state(record)
     record.add_argument("--event-json", required=True)
     record.set_defaults(func=command_record)
 
     import_cmd = sub.add_parser("import")
-    import_cmd.add_argument("--state-dir", type=Path, default=None)
+    add_state(import_cmd)
     import_cmd.add_argument("--tracker", type=existing_path)
     import_cmd.add_argument("--quality", type=existing_path)
     import_cmd.set_defaults(func=command_import)
 
     compact = sub.add_parser("compact")
-    compact.add_argument("--state-dir", type=Path, default=None)
+    add_state(compact)
     compact.set_defaults(func=command_compact)
 
     rebuild = sub.add_parser("rebuild-index")
-    rebuild.add_argument("--state-dir", type=Path, default=None)
+    add_state(rebuild)
     rebuild.set_defaults(func=command_rebuild_index)
 
     skill_sync = sub.add_parser("check-skill-sync")

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -334,7 +334,7 @@ def pr_files_from_view(pr: dict[str, Any]) -> list[str]:
 def latest_review_commit(pr: dict[str, Any], acting_login: str) -> str | None:
     reviews = [
         review
-        for review in pr.get("reviews", pr.get("latestReviews", []))
+        for review in (pr.get("reviews") or pr.get("latestReviews") or [])
         if review.get("author", {}).get("login") == acting_login
     ]
     if not reviews:
@@ -575,9 +575,10 @@ def command_scan(args: argparse.Namespace) -> int:
         packet = make_packet(pr, policy, acting_login, "light")
         packet["local_current_event"] = local_events.get((pr_number, pr.get("headRefOid") or ""))
         packet["recommendation"] = recommend_from_packet(packet)
-        if packet["recommendation"]["reason"] == "stale_changes_requested" or packet[
-            "recommendation"
-        ]["advisory_action"] in {
+        if packet["recommendation"]["reason"] in {
+            "stale_changes_requested",
+            "stale_approval",
+        } or packet["recommendation"]["advisory_action"] in {
             "approve_ready_for_handler",
             "update_branch_for_handler",
             "dequeue_stale_for_handler",


### PR DESCRIPTION
## Summary
- normalize legacy review-loop event records so current-head local decisions are honored
- add targeted hydration for ambiguous stale reviews and approved handler rows
- expose scan action counts / grouped candidates and document the blocked bucket in the skill

## Verification
- python3 -m py_compile scripts/pr_review.py
- python3 scripts/pr_review.py check-skill-sync
- git diff --check -- .claude/skills/pr-review-loop/SKILL.md scripts/pr_review.py
- pre-push checks completed through cargo fmt --check, clippy, card-data release validation, parser combinator gate, engine parser tests, and phase-ai tests before the duplicate hook was stopped after --no-verify push
