### PR TITLE
feat(engine): plot from the top of your library (Fblthp, Lost on the Range)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -3136,6 +3136,35 @@ fn priority_actions(state: &GameState, player: PlayerId) -> Vec<CandidateAction>
         }
     }
 
+    // CR 702.170f + CR 116.2k: Plot the top card of the library as a special
+    // action (Fblthp, Lost on the Range). Surfaced as the runtime-granted
+    // activated plot ability that lives only on the authorized top card, offered
+    // via the existing `GameAction::ActivateAbility` — a top-card-only query,
+    // never a generic library loop (no non-top library card carries the ability).
+    // `can_activate_ability_now` independently enforces the CR 702.170a sorcery-
+    // speed timing (main phase + empty stack + active player); the `is_active`
+    // + `stack_empty` guard just short-circuits the battlefield scan off-turn.
+    if is_active && stack_empty {
+        if let Some((top_id, _src_id)) = casting::top_of_library_plot_source(state, player) {
+            for (i, ability_def) in casting::activated_ability_definitions(state, top_id) {
+                if ability_def.kind == crate::types::ability::AbilityKind::Activated
+                    && ability_def.activation_zone == Some(crate::types::zones::Zone::Library)
+                    && !crate::game::mana_abilities::is_mana_ability(&ability_def)
+                    && casting::can_activate_ability_now(state, player, top_id, i)
+                {
+                    actions.push(candidate(
+                        GameAction::ActivateAbility {
+                            source_id: top_id,
+                            ability_index: i,
+                        },
+                        TacticalClass::Ability,
+                        Some(player),
+                    ));
+                }
+            }
+        }
+    }
+
     // CR 702.61a: Crew/Saddle/Station are activated abilities — blocked by split second.
     if !split_second_active {
         // Loop-invariant hoist: the set of this player's untapped creatures (and

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8632,15 +8632,19 @@ pub fn synthesize_suspend(face: &mut CardFace) {
 /// Printed text (CR 702.170a): "Plot [cost]" means "Any time you have priority
 /// during your main phase while the stack is empty, you may exile this card
 /// from your hand and pay [cost]. It becomes a plotted card." Plotting is a
-/// special action (CR 116.2k / CR 702.170b) that doesn't use the stack; we
-/// approximate it as an activated ability with `activation_zone = Hand`, the
-/// `.sorcery_speed()` single-authority builder, and a composite cost
-/// `(pay [cost], exile self from hand)`. This is the same controlled
-/// approximation Suspend uses (see `synthesize_suspend`); no card today
-/// interacts with the "doesn't use the stack" distinction.
+/// special action (CR 116.2k / CR 702.170b) that doesn't use the stack. It is
+/// modeled as a sorcery-speed activated-ability *shape* (`activation_zone =
+/// Hand`, the `.sorcery_speed()` single-authority builder, and a composite cost
+/// `(pay [cost], exile self from hand)`) so the timing/cost machinery is reused,
+/// but the "doesn't use the stack" semantics are honored at runtime:
+/// `handle_activate_ability` intercepts plot via `is_plot_special_action` after
+/// cost payment and applies the grant IMMEDIATELY (no stack entry, no
+/// `AbilityActivated` event), rather than pushing the grant to the stack.
 ///
-/// On resolution the activation grants `CastingPermission::Plotted { turn_plotted: 0 }`
-/// to the now-exiled card (SelfRef). `grant_permission::resolve` stamps the
+/// As part of taking the special action (NOT on a later stack resolution) the
+/// activation grants `CastingPermission::Plotted { turn_plotted: 0 }` to the
+/// now-exiled card (SelfRef). `grant_permission::resolve` — called directly by
+/// the intercept, the same single authority the stack path used — stamps the
 /// real `state.turn_number` into `turn_plotted` (mirroring how it resolves
 /// `PlayFromExile { granted_to }` for the ability controller). The cast side
 /// is detected by `prepare_spell_cast` via `is_plot_cast` — exile-zone source
@@ -8693,20 +8697,24 @@ pub fn synthesize_plot(face: &mut CardFace) {
 }
 
 /// CR 702.170a + CR 702.170f: single-authority builder for the plot special
-/// action, modeled (like hand-Plot and Suspend) as a sorcery-speed activated
-/// ability. Parameterized over the two zone seams so it serves both the printed
-/// default (hand-Plot: `activation_zone` = `exile_zone` = `Hand`) and an
-/// effect-granted plot whose ability functions in another zone (CR 702.170f —
-/// "the card is exiled from the zone it is in"; e.g. Fblthp's plot-from-library,
-/// both = `Library`).
+/// action. It builds a sorcery-speed activated-ability *shape* to reuse the
+/// timing/cost machinery, but plot is a special action that doesn't use the
+/// stack (CR 702.170b): `handle_activate_ability` intercepts this shape via
+/// `is_plot_special_action` and applies the grant immediately (see that intercept
+/// and `synthesize_plot`). Parameterized over the two zone seams so it serves
+/// both the printed default (hand-Plot: `activation_zone` = `exile_zone` =
+/// `Hand`) and an effect-granted plot whose ability functions in another zone
+/// (CR 702.170f — "the card is exiled from the zone it is in"; e.g. Fblthp's
+/// plot-from-library, both = `Library`).
 ///
 /// Cost = `Composite[Mana(plot_cost), Exile{ self, from exile_zone }]`; effect =
-/// grant `CastingPermission::Plotted` (the real turn is stamped at resolution by
-/// `grant_permission::resolve`) to the now-exiled SelfRef for the ability
-/// controller. `.sorcery_speed()` is the single-authority timing builder
-/// (CR 702.170a: main phase + empty stack + active player). The Exile cost
-/// `zone` and `def.activation_zone` are the only parameterized seams — everything
-/// downstream of "exiled card carrying Plotted" is zone-of-origin agnostic.
+/// grant `CastingPermission::Plotted` (the real turn is stamped when the special
+/// action is taken by `grant_permission::resolve`) to the now-exiled SelfRef for
+/// the ability controller. `.sorcery_speed()` is the single-authority timing
+/// builder (CR 702.170a: main phase + empty stack + active player). The Exile
+/// cost `zone` and `def.activation_zone` are the only parameterized seams —
+/// everything downstream of "exiled card carrying Plotted" is zone-of-origin
+/// agnostic.
 pub(crate) fn build_plot_activation(
     plot_cost: ManaCost,
     activation_zone: Zone,

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8656,7 +8656,7 @@ pub fn synthesize_suspend(face: &mut CardFace) {
 /// same face). Build-for-the-class: every Plot card flows through this single
 /// synthesizer regardless of card type.
 pub fn synthesize_plot(face: &mut CardFace) {
-    use crate::types::ability::{ActivationRestriction, CastingPermission, PermissionGrantee};
+    use crate::types::ability::{ActivationRestriction, CastingPermission};
 
     // CR 702.170a: Find the first Plot keyword. Cards do not print multiple Plots.
     let Some(plot_cost) = face.keywords.iter().find_map(|k| match k {
@@ -8683,41 +8683,70 @@ pub fn synthesize_plot(face: &mut CardFace) {
             )
     });
     if !already_has_plot_activation {
-        let composite_cost = AbilityCost::Composite {
-            costs: vec![
-                AbilityCost::Mana {
-                    cost: plot_cost.clone(),
-                },
-                // CR 702.170a: "exile this card from your hand" — self-targeted
-                // exile from hand. Mirrors Suspend's self-exile cost component.
-                AbilityCost::Exile {
-                    count: 1,
-                    zone: Some(Zone::Hand),
-                    filter: Some(TargetFilter::SelfRef),
-                },
-            ],
-        };
-        let mut def = AbilityDefinition::new(
-            AbilityKind::Activated,
-            // CR 702.170a + CR 702.170d: Grant the `Plotted` casting permission
-            // to the exiled card. `turn_plotted: 0` is a placeholder stamped
-            // by `grant_permission::resolve` to `state.turn_number` at
-            // resolution. Grantee is the default `AbilityController` — the
-            // plot owner — which is the player allowed to cast it later.
-            Effect::GrantCastingPermission {
-                permission: CastingPermission::Plotted { turn_plotted: 0 },
-                target: TargetFilter::SelfRef,
-                grantee: PermissionGrantee::AbilityController,
-            },
-        )
-        .cost(composite_cost)
-        // CR 702.170a: "Any time you have priority during your main phase while
-        // the stack is empty" — i.e. sorcery-speed timing. `.sorcery_speed()`
-        // is the single-authority builder (see `AbilityDefinition::sorcery_speed`).
-        .sorcery_speed();
-        def.activation_zone = Some(Zone::Hand);
-        face.abilities.push(def);
+        // CR 702.170a: printed Plot functions from hand — activation and exile
+        // both occur in the Hand zone. `build_plot_activation` is the single
+        // authority for the cost/effect shape (shared with effect-granted plot
+        // from other zones per CR 702.170f).
+        face.abilities
+            .push(build_plot_activation(plot_cost, Zone::Hand, Zone::Hand));
     }
+}
+
+/// CR 702.170a + CR 702.170f: single-authority builder for the plot special
+/// action, modeled (like hand-Plot and Suspend) as a sorcery-speed activated
+/// ability. Parameterized over the two zone seams so it serves both the printed
+/// default (hand-Plot: `activation_zone` = `exile_zone` = `Hand`) and an
+/// effect-granted plot whose ability functions in another zone (CR 702.170f —
+/// "the card is exiled from the zone it is in"; e.g. Fblthp's plot-from-library,
+/// both = `Library`).
+///
+/// Cost = `Composite[Mana(plot_cost), Exile{ self, from exile_zone }]`; effect =
+/// grant `CastingPermission::Plotted` (the real turn is stamped at resolution by
+/// `grant_permission::resolve`) to the now-exiled SelfRef for the ability
+/// controller. `.sorcery_speed()` is the single-authority timing builder
+/// (CR 702.170a: main phase + empty stack + active player). The Exile cost
+/// `zone` and `def.activation_zone` are the only parameterized seams — everything
+/// downstream of "exiled card carrying Plotted" is zone-of-origin agnostic.
+fn build_plot_activation(
+    plot_cost: ManaCost,
+    activation_zone: Zone,
+    exile_zone: Zone,
+) -> AbilityDefinition {
+    use crate::types::ability::{CastingPermission, PermissionGrantee};
+
+    let composite_cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: plot_cost },
+            // CR 702.170a / CR 702.170f: "exile this card from <zone>" — self-
+            // targeted exile from the zone the card is in. Mirrors Suspend's
+            // self-exile cost component.
+            AbilityCost::Exile {
+                count: 1,
+                zone: Some(exile_zone),
+                filter: Some(TargetFilter::SelfRef),
+            },
+        ],
+    };
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Activated,
+        // CR 702.170a + CR 702.170d: Grant the `Plotted` casting permission to
+        // the exiled card. `turn_plotted: 0` is a placeholder stamped by
+        // `grant_permission::resolve` to `state.turn_number` at resolution.
+        // Grantee is the default `AbilityController` — the plot owner — which is
+        // the player allowed to cast it later.
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::Plotted { turn_plotted: 0 },
+            target: TargetFilter::SelfRef,
+            grantee: PermissionGrantee::AbilityController,
+        },
+    )
+    .cost(composite_cost)
+    // CR 702.170a: "Any time you have priority during your main phase while the
+    // stack is empty" — sorcery-speed timing. `.sorcery_speed()` is the
+    // single-authority builder (see `AbilityDefinition::sorcery_speed`).
+    .sorcery_speed();
+    def.activation_zone = Some(activation_zone);
+    def
 }
 
 /// CR 702.155a-b + CR 714.3b: Read Ahead — a Saga with read ahead lets its

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8707,7 +8707,7 @@ pub fn synthesize_plot(face: &mut CardFace) {
 /// (CR 702.170a: main phase + empty stack + active player). The Exile cost
 /// `zone` and `def.activation_zone` are the only parameterized seams — everything
 /// downstream of "exiled card carrying Plotted" is zone-of-origin agnostic.
-fn build_plot_activation(
+pub(crate) fn build_plot_activation(
     plot_cost: ManaCost,
     activation_zone: Zone,
     exile_zone: Zone,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12641,21 +12641,30 @@ pub fn can_activate_ability_now(
     if !obj.detained_by.is_empty() {
         return false;
     }
-    // CR 602.5 + CR 603.2a: Consult active CantBeActivated statics — a player can't
-    // begin to activate an ability that's prohibited from being activated. Note this
-    // only affects activated abilities (CR 603.2a: triggered abilities are unaffected
-    // and use SuppressTriggers instead).
-    // CR 605.1a: The ability definition is passed through so the prohibition can apply
-    // its mana-ability exemption (Pithing Needle class) via the single classifier authority.
-    if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
-        return false;
-    }
-    // CR 602.5 + CR 117.1b: Time-axis activation prohibition (City of Solitude class).
-    if is_blocked_by_cant_activate_during(state, player, &ability_def) {
-        return false;
-    }
-    if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
-        return false;
+    // CR 702.170b + CR 116.2k + CR 602.1c: Plot is a SPECIAL ACTION, not an activated
+    // ability, so the activated-ability prohibition gates must not block it. Mirrors
+    // the guard in `handle_activate_ability` so the legality gate and the runtime
+    // activation path agree (otherwise `candidates.rs` would never offer plot under a
+    // Pithing-Needle / City-of-Solitude / Damping-Matrix-class static while
+    // `handle_activate_ability` still permits it). Plot's timing is enforced by
+    // AsSorcery in check_activation_restrictions below, outside this guard.
+    if !is_plot_special_action(&ability_def) {
+        // CR 602.5 + CR 603.2a: Consult active CantBeActivated statics — a player can't
+        // begin to activate an ability that's prohibited from being activated. Note this
+        // only affects activated abilities (CR 603.2a: triggered abilities are unaffected
+        // and use SuppressTriggers instead).
+        // CR 605.1a: The ability definition is passed through so the prohibition can apply
+        // its mana-ability exemption (Pithing Needle class) via the single classifier authority.
+        if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
+            return false;
+        }
+        // CR 602.5 + CR 117.1b: Time-axis activation prohibition (City of Solitude class).
+        if is_blocked_by_cant_activate_during(state, player, &ability_def) {
+            return false;
+        }
+        if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
+            return false;
+        }
     }
     if restrictions::check_activation_restrictions(
         state,
@@ -12875,27 +12884,36 @@ pub fn handle_activate_ability(
         )));
     }
 
-    // CR 602.5 + CR 603.2a: Reject activation if any CantBeActivated static prohibits
-    // the player from activating this permanent's activated abilities.
-    // CR 605.1a: The exemption gate (Pithing Needle's "unless they're mana abilities")
-    // is applied inside `is_blocked_by_cant_be_activated` via `mana_abilities::is_mana_ability`.
-    if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
-        return Err(EngineError::ActionNotAllowed(
-            "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
-        ));
-    }
-    // CR 602.5 + CR 117.1b: Reject activation if any CantActivateDuring static
-    // prohibits activation during the current turn condition (City of Solitude class).
-    if is_blocked_by_cant_activate_during(state, player, &ability_def) {
-        return Err(EngineError::ActionNotAllowed(
-            "Activated abilities can't be activated during this turn (CR 602.5 + CR 117.1b)"
-                .to_string(),
-        ));
-    }
-    if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
-        return Err(EngineError::ActionNotAllowed(
-            "A temporary effect prevents activating this ability".to_string(),
-        ));
+    // CR 702.170b + CR 116.2k + CR 602.1c: Plot is a SPECIAL ACTION, not the
+    // activation of an ability. CR 602.5/603.2a prohibitions ("can't activate
+    // abilities") are typed to activated abilities only, so none of the three gates
+    // below may block plot. Plot's own-turn / main-phase / empty-stack timing is
+    // enforced separately by ActivationRestriction::AsSorcery via
+    // check_activation_restrictions (below), which stays outside this guard — so
+    // skipping these gates loses no timing protection.
+    if !is_plot_special_action(&ability_def) {
+        // CR 602.5 + CR 603.2a: Reject activation if any CantBeActivated static
+        // prohibits the player from activating this permanent's activated abilities.
+        // CR 605.1a: The exemption gate (Pithing Needle's "unless they're mana
+        // abilities") is applied inside `is_blocked_by_cant_be_activated`.
+        if is_blocked_by_cant_be_activated(state, player, source_id, &ability_def) {
+            return Err(EngineError::ActionNotAllowed(
+                "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
+            ));
+        }
+        // CR 602.5 + CR 117.1b: Reject activation if any CantActivateDuring static
+        // prohibits activation during the current turn condition (City of Solitude class).
+        if is_blocked_by_cant_activate_during(state, player, &ability_def) {
+            return Err(EngineError::ActionNotAllowed(
+                "Activated abilities can't be activated during this turn (CR 602.5 + CR 117.1b)"
+                    .to_string(),
+            ));
+        }
+        if is_blocked_by_cant_activate_abilities(state, player, &ability_def) {
+            return Err(EngineError::ActionNotAllowed(
+                "A temporary effect prevents activating this ability".to_string(),
+            ));
+        }
     }
 
     // CR 601.2f: Apply self-referential cost reduction before any cost payment.
@@ -13909,13 +13927,26 @@ fn apply_cost_reduction(
         }
     }
 
-    apply_static_activated_ability_cost_reduction(state, ability_def, source_id);
+    // CR 702.170b + CR 116.2k: Plot is a SPECIAL ACTION, not the activation of an
+    // ability. The activated-ability reducer's `keyword == "activated"` blanket arm
+    // matches ANY ability regardless of tag and adjusts in BOTH directions, so it
+    // would wrongly change a plot cost. Skip it for the synthesized plot shape; plot's
+    // only cost adjustment is its dedicated special-action axis below
+    // (ReduceActionCost { action: Plot }). A tag-keyed reducer can never match plot
+    // anyway — the synthesized plot ability carries no `ability_tag`
+    // (active_keyword == None) — so skipping the whole function is equivalent to
+    // skipping just the "activated" arm, and clearer.
+    if !is_plot_special_action(ability_def) {
+        apply_static_activated_ability_cost_reduction(state, ability_def, source_id);
+    }
 
     // CR 116.2k + CR 702.170: Plot is taken as a special action via a synthesized
-    // hand activation whose effect grants the `Plotted` casting permission. Its
-    // mana cost is reduced by `ReduceActionCost { action: Plot }` statics (Doc
-    // Aurlock) — the dedicated special-action axis, distinct from the generic
-    // activated-ability reducer above (plot payments carry no `AbilityTag`).
+    // hand activation whose effect grants the `Plotted` casting permission. Its mana
+    // cost is adjusted ONLY by `ReduceActionCost { action: Plot }` statics (Doc
+    // Aurlock) — the dedicated special-action axis. The generic activated-ability
+    // reducer is skipped above for plot: its `keyword == "activated"` blanket arm
+    // would otherwise match (and adjust) a plot cost even though plot is not the
+    // activation of an ability (CR 702.170b).
     if is_plot_special_action(ability_def) {
         if let Some(cost) = ability_def.cost.as_mut() {
             reduce_special_action_in_ability_cost(state, player, SpecialAction::Plot, cost);
@@ -49700,6 +49731,486 @@ mod tests {
             1,
             "a failed plot activation spends no mana"
         );
+    }
+
+    /// Build a P0 hand card carrying a synthesized `Plot {generic}` activation
+    /// (index 0) on P0's main phase with an empty stack. Mirrors the production
+    /// `build` closure in `doc_aurlock_reduced_plot_activates_via_production_path`
+    /// so the runtime activation seam (`GameAction::ActivateAbility` →
+    /// `handle_activate_ability`) and the legality gate (`can_activate_ability_now`)
+    /// both see the exact synthesized plot shape. Returns (state, plot card id);
+    /// the caller adds prohibiting statics / mana / timing changes.
+    fn build_p0_plot_card_in_hand(generic: u32) -> (GameState, ObjectId) {
+        use crate::database::synthesis::synthesize_plot;
+        use crate::types::card::CardFace;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+
+        let mut state = setup_game_at_main_phase();
+
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Plot(ManaCost::Cost {
+            shards: vec![],
+            generic,
+        }));
+        synthesize_plot(&mut face);
+
+        let plot_card = create_object(
+            &mut state,
+            CardId(0x9701),
+            PlayerId(0),
+            "Plotted Card".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&plot_card).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.keywords = face.keywords.clone();
+        obj.base_keywords = face.keywords.clone();
+        *Arc::make_mut(&mut obj.abilities) = face.abilities.clone();
+        *Arc::make_mut(&mut obj.base_abilities) = face.abilities.clone();
+
+        (state, plot_card)
+    }
+
+    /// CR 702.170b + CR 116.2k + CR 602.1c + CR 602.5 + CR 603.2a: Plot is a SPECIAL
+    /// ACTION, not the activation of an ability, so none of the three
+    /// activated-ability prohibition gates may block it — at EITHER the runtime
+    /// activation seam (`handle_activate_ability`, Edit 1) OR the legality/offer gate
+    /// (`can_activate_ability_now`, Edit 2 — the path `candidates.rs` consults to
+    /// offer plot to the AI/UI). Covers all three gate classes: CantBeActivated
+    /// (Pithing Needle), the ActivateAbilities prohibition (Damping Matrix class),
+    /// and CantActivateDuring active during P0's own main phase.
+    ///
+    /// Discriminating / non-vacuous:
+    ///   - Each sub-case first asserts the gate is LIVE against the plot source
+    ///     (`is_blocked_by_*` returns `true` for the plot ability) — so absent the
+    ///     guard the activation WOULD be blocked. The activation succeeds anyway,
+    ///     proving the guard is doing the work.
+    ///   - Revert-probe (Edit 1): unwrapping the `handle_activate_ability` gates
+    ///     makes `apply_as_current` return `Err(ActionNotAllowed)` and leaves the
+    ///     card in hand for all three sub-cases.
+    ///   - Revert-probe (Edit 2): unwrapping the `can_activate_ability_now` mirror
+    ///     gates makes the `can_activate_ability_now(..) == true` assertion fail
+    ///     (returns `false`), diverging the offer path from the runtime path.
+    #[test]
+    fn plot_special_action_bypasses_activated_ability_prohibitions() {
+        use crate::types::ability::{
+            ChosenAttribute, GameRestriction, ProhibitedActivity, RestrictionExpiry,
+            RestrictionPlayerScope, StaticDefinition, TargetFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::statics::{
+            ActivationExemption, CastingProhibitionCondition, ProhibitionScope, StaticMode,
+        };
+
+        // Given a state where the relevant gate is already LIVE for the plot source,
+        // assert plot succeeds at BOTH the legality gate (Edit 2) and the runtime
+        // seam (Edit 1). A {1} plot cost is funded by exactly {1} colorless mana.
+        let assert_plot_bypasses = |mut state: GameState, plot_card: ObjectId, label: &str| {
+            add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+
+            assert!(
+                can_activate_ability_now(&state, PlayerId(0), plot_card, 0),
+                "{label}: can_activate_ability_now must offer plot (Edit 2 mirror guard); \
+                 reverting Edit 2 makes this return false"
+            );
+
+            apply_as_current(
+                &mut state,
+                GameAction::ActivateAbility {
+                    source_id: plot_card,
+                    ability_index: 0,
+                },
+            )
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{label}: plot special action must activate (Edit 1 guard); \
+                     reverting Edit 1 yields Err: {e:?}"
+                )
+            });
+
+            assert_eq!(
+                state.objects[&plot_card].zone,
+                Zone::Exile,
+                "{label}: the plot self-exile cost moved the card Hand -> Exile"
+            );
+            assert!(
+                state.stack.is_empty(),
+                "{label}: plot is a special action (CR 702.170b) — it must not use the stack"
+            );
+            assert!(
+                state.objects[&plot_card]
+                    .casting_permissions
+                    .iter()
+                    .any(|p| matches!(p, CastingPermission::Plotted { .. })),
+                "{label}: plot must grant Plotted immediately"
+            );
+        };
+
+        // A1 — Pithing Needle naming the plot card (CantBeActivated, HasChosenName).
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            let needle = create_object(
+                &mut state,
+                CardId(0x9EED1E),
+                PlayerId(0),
+                "Pithing Needle".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&needle).unwrap();
+                obj.card_types.core_types.push(CoreType::Artifact);
+                obj.entered_battlefield_turn = Some(0);
+                obj.chosen_attributes
+                    .push(ChosenAttribute::CardName("Plotted Card".to_string()));
+                obj.static_definitions
+                    .push(StaticDefinition::new(StaticMode::CantBeActivated {
+                        who: ProhibitionScope::AllPlayers,
+                        source_filter: TargetFilter::HasChosenName,
+                        exemption: ActivationExemption::ManaAbilities,
+                    }));
+            }
+            let plot_def = state.objects[&plot_card].abilities[0].clone();
+            assert!(
+                is_blocked_by_cant_be_activated(&state, PlayerId(0), plot_card, &plot_def),
+                "A1 sanity: Pithing Needle naming the card blocks its (non-mana) activation \
+                 absent the plot guard — proves the gate is live"
+            );
+            assert_plot_bypasses(state, plot_card, "A1 Pithing Needle");
+        }
+
+        // A2 — Damping Matrix / Linvala class (ProhibitActivity::ActivateAbilities).
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            let matrix = create_object(
+                &mut state,
+                CardId(0xDA33),
+                PlayerId(0),
+                "Damping Matrix".to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&matrix)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Artifact);
+            state.restrictions.push(GameRestriction::ProhibitActivity {
+                source: matrix,
+                affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(0)),
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::ActivateAbilities {
+                    exemption: ActivationExemption::None,
+                    only_tag: None,
+                },
+            });
+            let plot_def = state.objects[&plot_card].abilities[0].clone();
+            assert!(
+                is_blocked_by_cant_activate_abilities(&state, PlayerId(0), &plot_def),
+                "A2 sanity: the ActivateAbilities prohibition blocks plot absent the guard \
+                 — proves the gate is live"
+            );
+            assert_plot_bypasses(state, plot_card, "A2 Damping Matrix");
+        }
+
+        // A3 — CantActivateDuring active during P0's OWN main phase. NOTE: this uses
+        // `DuringYourTurn`, NOT City of Solitude's `NotDuringAffectedPlayersTurn`.
+        // Plot is legal ONLY during the controller's own turn / main phase / empty
+        // stack (CR 702.170a via AsSorcery), and `NotDuringAffectedPlayersTurn` fires
+        // only on OTHER players' turns — so it can never overlap plot's window and a
+        // City-of-Solitude test would be VACUOUS (the gate never fires while plot is
+        // legal, so the guard would have nothing to bypass). `DuringYourTurn`
+        // (controlled by P0, AllPlayers scope) is the only `CantActivateDuring` shape
+        // whose active window coincides with plot's, making it the discriminating
+        // choice that genuinely exercises Edits 1/2.
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            add_cant_activate_during_permanent(
+                &mut state,
+                PlayerId(0),
+                ProhibitionScope::AllPlayers,
+                CastingProhibitionCondition::DuringYourTurn,
+                ActivationExemption::None,
+            );
+            let plot_def = state.objects[&plot_card].abilities[0].clone();
+            assert!(
+                is_blocked_by_cant_activate_during(&state, PlayerId(0), &plot_def),
+                "A3 sanity: a CantActivateDuring static active on P0's own turn blocks plot \
+                 absent the guard — proves the gate is live during plot's window"
+            );
+            assert_plot_bypasses(state, plot_card, "A3 CantActivateDuring");
+        }
+    }
+
+    /// CR 702.170b + CR 116.2k + CR 118.7a: Plot is a SPECIAL ACTION, so the generic
+    /// activated-ability cost reducer (`ReduceAbilityCost { keyword: "activated" }`,
+    /// whose blanket arm matches ANY ability regardless of tag and adjusts in BOTH
+    /// directions) must NOT change a plot cost. Only the dedicated special-action
+    /// axis (`ReduceActionCost { action: Plot }`, Doc Aurlock) may adjust it.
+    ///
+    /// Drives the production seam `apply_cost_reduction`. Discriminating /
+    /// non-vacuous (revert-probe Edit 3 — unguarding
+    /// `apply_static_activated_ability_cost_reduction`):
+    ///   - B1 Raise: with Edit 3 reverted the {3} plot cost would read {4}; B1 Reduce
+    ///     would read {2}. With the guard both stay {3}.
+    ///   - B2: Doc Aurlock's special-action axis still reduces {3} -> {1} (regression
+    ///     guard that Edit 3 did not disturb `reduce_special_action_in_ability_cost`).
+    ///   - B3 combined: net {1} (Plot −2, blanket +1 skipped), NOT {2} (+1 −2).
+    #[test]
+    fn plot_special_action_ignores_generic_activated_ability_cost_modifiers() {
+        use crate::types::ability::{
+            CastingPermission, Effect, PermissionGrantee, StaticDefinition, TargetFilter,
+        };
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::{CostModifyMode, StaticMode};
+
+        let make_plot_def = |generic: u32| {
+            let mut def = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GrantCastingPermission {
+                    permission: CastingPermission::Plotted { turn_plotted: 0 },
+                    target: TargetFilter::SelfRef,
+                    grantee: PermissionGrantee::AbilityController,
+                },
+            );
+            def.cost = Some(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![],
+                            generic,
+                        },
+                    },
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: Some(Zone::Hand),
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            });
+            def.activation_zone = Some(Zone::Hand);
+            def
+        };
+        let plot_generic_of = |def: &AbilityDefinition| match def.cost.as_ref().unwrap() {
+            AbilityCost::Composite { costs } => costs
+                .iter()
+                .find_map(|c| match c {
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost { generic, .. },
+                    } => Some(*generic),
+                    _ => None,
+                })
+                .expect("composite plot cost has a mana sub-cost"),
+            other => panic!("expected composite cost, got {other:?}"),
+        };
+
+        // A hand card supplies the plot source id (filter context for the reducer).
+        let setup = || -> (GameState, ObjectId) {
+            let mut state = setup_game_at_main_phase();
+            let plot_card = create_object(
+                &mut state,
+                CardId(2),
+                PlayerId(0),
+                "Plotted Card".to_string(),
+                Zone::Hand,
+            );
+            (state, plot_card)
+        };
+        let blanket = |mode: CostModifyMode| {
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode,
+                keyword: "activated".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+            })
+        };
+        let doc_axis = || {
+            StaticDefinition::new(StaticMode::ReduceActionCost {
+                action: SpecialAction::Plot,
+                mode: CostModifyMode::Reduce,
+                amount: 2,
+            })
+        };
+
+        // B1 Raise — "activated abilities cost {1} more" must NOT touch plot.
+        {
+            let (mut state, plot_card) = setup();
+            let src = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Blanket Reducer".to_string(),
+                Zone::Battlefield,
+            );
+            state.objects.get_mut(&src).unwrap().static_definitions =
+                vec![blanket(CostModifyMode::Raise)].into();
+            let mut def = make_plot_def(3);
+            apply_cost_reduction(&state, &mut def, PlayerId(0), plot_card);
+            assert_eq!(
+                plot_generic_of(&def),
+                3,
+                "B1 Raise: a blanket activated-ability raise must not change plot \
+                 (reverting Edit 3 yields {{4}})"
+            );
+        }
+        // B1 Reduce — symmetric: a blanket activated reduce must not touch plot either.
+        {
+            let (mut state, plot_card) = setup();
+            let src = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Blanket Reducer".to_string(),
+                Zone::Battlefield,
+            );
+            state.objects.get_mut(&src).unwrap().static_definitions =
+                vec![blanket(CostModifyMode::Reduce)].into();
+            let mut def = make_plot_def(3);
+            apply_cost_reduction(&state, &mut def, PlayerId(0), plot_card);
+            assert_eq!(
+                plot_generic_of(&def),
+                3,
+                "B1 Reduce: a blanket activated-ability reduce must not change plot \
+                 (reverting Edit 3 yields {{2}})"
+            );
+        }
+        // B2 — Doc Aurlock's special-action axis STILL reduces plot {3} -> {1}.
+        {
+            let (mut state, plot_card) = setup();
+            let doc = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Doc Aurlock, Grizzled Genius".to_string(),
+                Zone::Battlefield,
+            );
+            state.objects.get_mut(&doc).unwrap().static_definitions = vec![doc_axis()].into();
+            let mut def = make_plot_def(3);
+            apply_cost_reduction(&state, &mut def, PlayerId(0), plot_card);
+            assert_eq!(
+                plot_generic_of(&def),
+                1,
+                "B2: Doc Aurlock's ReduceActionCost{{Plot}} still reduces plot {{3}} -> {{1}}"
+            );
+        }
+        // B3 — combined: blanket Raise{1} (skipped) + Doc Aurlock Reduce{2} = {1}, NOT {2}.
+        {
+            let (mut state, plot_card) = setup();
+            let doc = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Doc Aurlock, Grizzled Genius".to_string(),
+                Zone::Battlefield,
+            );
+            state.objects.get_mut(&doc).unwrap().static_definitions = vec![doc_axis()].into();
+            let blanketer = create_object(
+                &mut state,
+                CardId(3),
+                PlayerId(0),
+                "Blanket Reducer".to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&blanketer)
+                .unwrap()
+                .static_definitions = vec![blanket(CostModifyMode::Raise)].into();
+            let mut def = make_plot_def(3);
+            apply_cost_reduction(&state, &mut def, PlayerId(0), plot_card);
+            assert_eq!(
+                plot_generic_of(&def),
+                1,
+                "B3 combined: only the Plot axis (−2) applies, the blanket (+1) is skipped \
+                 -> {{1}} (a buggy build that applied the blanket reads {{2}})"
+            );
+        }
+    }
+
+    /// CR 702.170a + CR 116.2k: Negative control — plot's own-turn / main-phase /
+    /// empty-stack timing (CR 702.170a) is enforced by `ActivationRestriction::
+    /// AsSorcery` via `check_activation_restrictions`, which stays OUTSIDE the
+    /// prohibition guards added by Edits 1/2. So the guards must not have widened to
+    /// swallow timing: plot is still REJECTED when any timing dimension is wrong.
+    /// Proves no over-skip.
+    ///
+    /// Discriminating: a C0 positive baseline (correct timing, no prohibiting static)
+    /// SUCCEEDS, then C1/C2/C3 flip exactly one timing dimension and must each fail —
+    /// so the rejection is caused by the timing change, not unrelated setup. If a
+    /// future change folded `check_activation_restrictions` inside a guard, C1–C3
+    /// flip to `Ok` and this test catches it.
+    #[test]
+    fn plot_special_action_still_enforces_sorcery_speed_timing() {
+        let expect_rejected = |mut state: GameState, plot_card: ObjectId, label: &str| {
+            add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+            let result = apply_as_current(
+                &mut state,
+                GameAction::ActivateAbility {
+                    source_id: plot_card,
+                    ability_index: 0,
+                },
+            );
+            assert!(
+                result.is_err(),
+                "{label}: plot must be rejected by AsSorcery timing (outside the prohibition guards)"
+            );
+            assert_eq!(
+                state.objects[&plot_card].zone,
+                Zone::Hand,
+                "{label}: a rejected plot leaves the card in hand (no self-exile)"
+            );
+        };
+
+        // C0 — positive baseline: correct timing, no prohibiting static → SUCCEEDS.
+        // Establishes that the only delta in C1/C2/C3 is the broken timing dimension.
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+            apply_as_current(
+                &mut state,
+                GameAction::ActivateAbility {
+                    source_id: plot_card,
+                    ability_index: 0,
+                },
+            )
+            .expect("C0 baseline: plot on own main phase with empty stack must succeed");
+            assert_eq!(state.objects[&plot_card].zone, Zone::Exile);
+        }
+
+        // C1 — opponent's turn: CR 702.170a requires the controller's own turn.
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            state.active_player = PlayerId(1);
+            expect_rejected(state, plot_card, "C1 opponent's turn");
+        }
+
+        // C2 — non-empty stack: CR 702.170a requires an empty stack.
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            state.stack.push_back(crate::types::game_state::StackEntry {
+                id: ObjectId(0xDEAD),
+                source_id: ObjectId(0xDEAD),
+                controller: PlayerId(0),
+                kind: crate::types::game_state::StackEntryKind::Spell {
+                    card_id: crate::types::identifiers::CardId(99),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+            expect_rejected(state, plot_card, "C2 non-empty stack");
+        }
+
+        // C3 — wrong phase: CR 702.170a requires a main phase.
+        {
+            let (mut state, plot_card) = build_p0_plot_card_in_hand(1);
+            state.phase = Phase::BeginCombat;
+            expect_rejected(state, plot_card, "C3 begin-combat step");
+        }
     }
 
     /// CR 118.7 + CR 702.6a: Firion, Wild Rose Warrior's granted equip-cost

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -117,6 +117,56 @@ fn runtime_granted_graveyard_activated_abilities(
         .collect()
 }
 
+/// CR 702.170f + CR 702.170a: synthesize the plot special action as a runtime-
+/// granted activated ability on the *authorized top card* of a player's library
+/// (Fblthp, Lost on the Range). CR 702.170f authorizes plot to function from a
+/// zone other than hand (here the library) and to exile from that zone; the
+/// nonland eligibility is Fblthp's printed L4 scope (NOT a CR 702.170f clause),
+/// enforced by the delegated `top_of_library_plot_source` predicate. Returns
+/// `vec![]` for every object that is not the current authorized top card, so no
+/// non-top library card can ever carry a plot ability. Mirrors
+/// `runtime_granted_graveyard_activated_abilities`.
+///
+/// `activation_zone = Some(Zone::Library)` (set by `build_plot_activation`) is a
+/// first-of-its-kind value. It is safe ONLY because this ability is present
+/// exclusively on the positional top card — `top_of_library_plot_source`
+/// re-derives `library.front()` each call, so the activation gate's
+/// `obj.zone == Library` check passes just that one card. A future change that
+/// grants an ability with `activation_zone = Library` by a NON-positional path
+/// would authorize every library card; do not copy this value blindly.
+fn runtime_granted_top_of_library_plot_abilities(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<AbilityDefinition> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    // Cheap zone guard before the battlefield scan: plot-from-library functions
+    // only in the Library zone (CR 702.170f).
+    if obj.zone != Zone::Library {
+        return Vec::new();
+    }
+    // CR 702.170d: the plot grant belongs to the library's owner — the player
+    // who may later cast the plotted card. Delegate authorization to the
+    // single-authority predicate; it must return exactly this top card.
+    let player = obj.owner;
+    let Some((top_id, _src_id)) = top_of_library_plot_source(state, player) else {
+        return Vec::new();
+    };
+    if top_id != source_id {
+        return Vec::new();
+    }
+    // CR 702.170a: plot cost = the card's mana cost, computed live from the top
+    // card (not stored on the static). CR 702.170f: the ability functions in,
+    // and exiles from, the Library zone. `build_plot_activation` is the single
+    // authority for the cost/effect shape (shared verbatim with hand-Plot).
+    vec![crate::database::synthesis::build_plot_activation(
+        obj.mana_cost.clone(),
+        Zone::Library,
+        Zone::Library,
+    )]
+}
+
 pub fn activated_ability_definitions(
     state: &GameState,
     source_id: ObjectId,
@@ -131,6 +181,13 @@ pub fn activated_ability_definitions(
         runtime_granted_cycling_abilities(state, source_id)
             .into_iter()
             .chain(runtime_granted_graveyard_activated_abilities(
+                state, source_id,
+            ))
+            // CR 702.170f: plot-from-library (Fblthp) chained LAST — must use
+            // the identical append order in `activation_ability_definition` so
+            // the `ability_index` stays consistent between enumeration and
+            // activation. Empty for every object except the authorized top card.
+            .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
             .enumerate()
@@ -151,10 +208,15 @@ fn activation_ability_definition(
         let offset = ability_index.checked_sub(obj.abilities.len())?;
         // Must match the append order in `activated_ability_definitions`: printed
         // abilities first, then runtime-granted cycling, then runtime-granted
-        // graveyard activated (Encore/Scavenge).
+        // graveyard activated (Encore/Scavenge), then runtime-granted
+        // plot-from-library (Fblthp). Identical order is REQUIRED for
+        // `ability_index` consistency.
         runtime_granted_cycling_abilities(state, source_id)
             .into_iter()
             .chain(runtime_granted_graveyard_activated_abilities(
+                state, source_id,
+            ))
+            .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
             .nth(offset)?
@@ -2846,6 +2908,93 @@ pub(crate) fn top_of_library_permission_source(
         }
     }
     selected.map(|(src_id, frequency, alt_cost)| (top_id, src_id, frequency, alt_cost))
+}
+
+/// CR 702.170a + CR 702.170f: Return the `(top_library_card, grant_source)` pair
+/// when the player may take the plot special action on the top card of their
+/// library. Fblthp, Lost on the Range is the type specimen ("The top card of
+/// your library has plot." + "You may plot nonland cards from the top of your
+/// library.").
+///
+/// Plot-from-library is two distinct CR roles, modeled as two statics, and BOTH
+/// must hold for the top card:
+/// - GRANT (`StaticMode::TopOfLibraryHasPlot`, CR 702.170a) — the top card *has*
+///   the plot ability. Eligible iff the top card matches the UNION of all active
+///   grants' `affected` filters (Fblthp L3 = `Any`).
+/// - PERMISSION (`StaticMode::TopOfLibraryPlotPermission`, CR 702.170f) — an
+///   effect lets the plot ability function from a zone other than hand and
+///   permits taking the action there. Eligible iff the top card matches the
+///   UNION of all active permissions' `affected` filters (Fblthp L4 = nonland).
+///
+/// Requiring both is rules-correct: a grant alone leaves a plot ability that
+/// (CR 702.170a) only functions in hand, so a library card can't be plotted
+/// without a CR 702.170f permission; a permission alone has no plot ability to
+/// act on. UNION within each role means two INDEPENDENT plot-from-top sources
+/// each authorize their own eligibility (no cross-source veto), while AND across
+/// the two roles enforces "has plot" ∧ "may plot it here". For Fblthp the net
+/// eligible set is `Any ∩ nonland = nonland`; the nonland restriction is purely
+/// the permission's filter (Fblthp's printed L4) — CR 702.170f itself has no
+/// land/nonland clause, so there is NO separate hard-gate (a future land-
+/// permitting plot-from-top card would correctly allow lands).
+///
+/// Categorically distinct from [`top_of_library_permission_source`] (CR 601.2a —
+/// a `Library → Stack` cast with no exile). This authorizes the CR 702.170 plot
+/// special action: `Library → Exile` face up now, then a free `Exile → Stack`
+/// cast on a later turn. The positional top-only restriction (CR 702.170f — "the
+/// card is exiled from the zone it is in") lives HERE, not in the activation-zone
+/// gate; the top of library is re-derived each call because it changes between
+/// priority windows. The returned source is an authorizing grant permanent.
+pub(crate) fn top_of_library_plot_source(
+    state: &GameState,
+    player: PlayerId,
+) -> Option<(ObjectId, ObjectId)> {
+    let player_data = state.players.iter().find(|p| p.id == player)?;
+    let &top_id = player_data.library.front()?;
+
+    // Scan the player's battlefield once, classifying active plot statics into
+    // the two CR roles and UNION-matching each role's `affected` filter against
+    // the current top card.
+    let mut grant_source: Option<ObjectId> = None; // first grant whose filter matches
+    let mut has_permission = false; // any permission whose filter matches
+    for &src_id in &state.battlefield {
+        let Some(obj) = state.objects.get(&src_id) else {
+            continue;
+        };
+        if obj.controller != player {
+            continue;
+        }
+        for s in active_static_definitions(state, obj) {
+            let role_is_grant = match s.mode {
+                StaticMode::TopOfLibraryHasPlot => true,
+                StaticMode::TopOfLibraryPlotPermission => false,
+                _ => continue,
+            };
+            // A `None` filter means no restriction (matches any top card).
+            let matches = s.affected.as_ref().is_none_or(|f| {
+                super::filter::matches_target_filter(
+                    state,
+                    top_id,
+                    f,
+                    &super::filter::FilterContext::from_source_with_controller(src_id, player),
+                )
+            });
+            if !matches {
+                continue;
+            }
+            if role_is_grant {
+                grant_source.get_or_insert(src_id);
+            } else {
+                has_permission = true;
+            }
+        }
+    }
+
+    // CR 702.170a grant ∧ CR 702.170f permission: the top card must both HAVE
+    // plot and be permitted to be plotted from the library.
+    match grant_source {
+        Some(src_id) if has_permission => Some((top_id, src_id)),
+        _ => None,
+    }
 }
 
 /// CR 401.5 + CR 305.1: Return the top-of-library land + source pair when a
@@ -50528,5 +50677,650 @@ mod tests {
             cast_permission_constraint_allows_cast(&state, obj, &constraint, None),
             "offer-time check (resulting MV unknown) must be permissive"
         );
+    }
+
+    /// CR 702.170f end-to-end runtime: plot-from-library (Fblthp, Lost on the
+    /// Range). These tests drive the real legal-action / activation pipeline —
+    /// `top_of_library_plot_source` → runtime-granted plot ability →
+    /// `GameAction::ActivateAbility` → exile-from-library face up → Plotted →
+    /// (reused) later free cast — never the parser shape in isolation.
+    mod plot_from_library {
+        use super::*;
+        use crate::ai_support::legal_actions;
+        use crate::game::derived::derive_display_state;
+        use crate::game::scenario::{GameRunner, GameScenario, P0, P1};
+        use crate::game::visibility::filter_state_for_viewer;
+        use crate::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+
+        // Fblthp's plot-from-library lines (Ward omitted — irrelevant here and
+        // needs a keyword hint to parse). Routed through the real PR-B parser by
+        // `from_oracle_text`, so this exercises parser → static → runtime.
+        const FBLTHP_ORACLE: &str = "You may look at the top card of your library any time.\n\
+             The top card of your library has plot. The plot cost is equal to its mana cost.\n\
+             You may plot nonland cards from the top of your library.";
+
+        fn blue_one_u() -> ManaCost {
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
+            }
+        }
+
+        /// Turn a generic library-top object into a nonland creature with a
+        /// {1}{U} cost (a colored pip distinct from any fixed Foretell-style
+        /// cost, so the EXECUTE test can prove cost = the card's mana cost).
+        fn make_nonland_blue(state: &mut GameState, id: ObjectId) {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Creature];
+            obj.mana_cost = blue_one_u();
+        }
+
+        fn make_land(state: &mut GameState, id: ObjectId) {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types = vec![CoreType::Land];
+            obj.mana_cost = ManaCost::NoCost;
+        }
+
+        /// Fblthp on P0's battlefield (statics parsed from Oracle text) + a
+        /// nonland {1}{U} creature on top of P0's library. Returns the runner,
+        /// Fblthp's id, and the top card's id. Phase = P0's precombat main,
+        /// empty stack, P0 priority.
+        fn fblthp_with_nonland_top() -> (GameRunner, ObjectId, ObjectId) {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            let fblthp = {
+                let mut b = scenario.add_creature(P0, "Fblthp, Lost on the Range", 1, 1);
+                b.from_oracle_text(FBLTHP_ORACLE);
+                b.id()
+            };
+            let top = scenario.add_card_to_library_top(P0, "Augury Owl");
+            let mut runner = scenario.build();
+            make_nonland_blue(runner.state_mut(), top);
+            derive_display_state(runner.state_mut());
+            (runner, fblthp, top)
+        }
+
+        fn plot_action_for(state: &GameState, top_id: ObjectId) -> Option<GameAction> {
+            legal_actions(state).into_iter().find(|a| {
+                matches!(a, GameAction::ActivateAbility { source_id, .. } if *source_id == top_id)
+            })
+        }
+
+        /// Fund P0 generously so CR 601.2b affordability is never the gating
+        /// factor in the OFFER tests (which isolate GRANT / position / nonland /
+        /// authorizer conditions, not mana). Covers the {1}{U} top-card cost.
+        fn fund_for_plot(runner: &mut GameRunner) {
+            add_mana(runner.state_mut(), P0, ManaType::Blue, 2);
+            add_mana(runner.state_mut(), P0, ManaType::Colorless, 2);
+        }
+
+        fn plot_ability_index(state: &GameState, top_id: ObjectId) -> usize {
+            activated_ability_definitions(state, top_id)
+                .into_iter()
+                .find(|(_, def)| def.activation_zone == Some(Zone::Library))
+                .map(|(i, _)| i)
+                .expect("authorized top card must carry the runtime-granted plot ability")
+        }
+
+        /// Confirm Fblthp's Oracle text produced the split roles: exactly one
+        /// `TopOfLibraryHasPlot` GRANT (L3) and one `TopOfLibraryPlotPermission`
+        /// (L4) — not two of the same conflated mode (parser → runtime sanity).
+        fn assert_fblthp_statics(state: &GameState, fblthp: ObjectId) {
+            let grants = state.objects[&fblthp]
+                .static_definitions
+                .iter_all()
+                .filter(|s| matches!(s.mode, StaticMode::TopOfLibraryHasPlot))
+                .count();
+            let permissions = state.objects[&fblthp]
+                .static_definitions
+                .iter_all()
+                .filter(|s| matches!(s.mode, StaticMode::TopOfLibraryPlotPermission))
+                .count();
+            assert_eq!(grants, 1, "Fblthp L3 must be exactly one grant static");
+            assert_eq!(
+                permissions, 1,
+                "Fblthp L4 must be exactly one permission static"
+            );
+        }
+
+        /// test_plan #1: GRANT + OFFER, plus ABSENT off-turn / non-empty stack /
+        /// non-main phase. Also test_plan #12 (helper-level) for the Some case.
+        #[test]
+        fn plot_offered_for_nonland_top_only_on_own_empty_main() {
+            let (mut runner, fblthp, top) = fblthp_with_nonland_top();
+            fund_for_plot(&mut runner);
+            assert_fblthp_statics(runner.state(), fblthp);
+            assert_eq!(
+                runner.state().players[0].library.front().copied(),
+                Some(top)
+            );
+
+            // GRANT + OFFER on P0's main phase, empty stack.
+            assert!(
+                plot_action_for(runner.state(), top).is_some(),
+                "plot must be offered for the nonland top on P0's own empty main phase"
+            );
+            // Helper-level (test_plan #12): the source predicate authorizes it.
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                Some((top, fblthp)),
+                "top_of_library_plot_source must return (top, fblthp) for a nonland top"
+            );
+
+            // ABSENT during an opponent's turn (CR 116.2k — own turn only): P0
+            // still holds priority (instant window) but plot is sorcery-speed.
+            runner.state_mut().active_player = P1;
+            derive_display_state(runner.state_mut());
+            assert!(
+                plot_action_for(runner.state(), top).is_none(),
+                "plot must NOT be offered while it is the opponent's turn"
+            );
+            runner.state_mut().active_player = P0;
+
+            // ABSENT with a non-empty stack (CR 702.170a — empty stack only).
+            let filler = zones::create_object(
+                runner.state_mut(),
+                CardId(7777),
+                P0,
+                "Stack Filler".to_string(),
+                Zone::Stack,
+            );
+            runner.state_mut().stack.push_back(StackEntry {
+                id: filler,
+                source_id: filler,
+                controller: P0,
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(7777),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+            derive_display_state(runner.state_mut());
+            assert!(
+                plot_action_for(runner.state(), top).is_none(),
+                "plot must NOT be offered while the stack is non-empty"
+            );
+            runner.state_mut().stack.clear();
+
+            // ABSENT outside a main phase (CR 702.170a). can_activate_ability_now
+            // enforces the AsSorcery timing independently of the candidate guard.
+            runner.state_mut().phase = Phase::BeginCombat;
+            derive_display_state(runner.state_mut());
+            assert!(
+                plot_action_for(runner.state(), top).is_none(),
+                "plot must NOT be offered outside a main phase"
+            );
+        }
+
+        /// test_plan #2: positional discriminator — only `library.front()` is
+        /// plottable, never a deeper library card.
+        #[test]
+        fn plot_offered_only_for_the_top_card_not_second_from_top() {
+            let (mut runner, _fblthp, top) = fblthp_with_nonland_top();
+            fund_for_plot(&mut runner);
+            // Insert a second nonland card just under the top.
+            let second = {
+                let id = {
+                    let s = runner.state_mut();
+                    let card_id = CardId(s.next_object_id);
+                    zones::create_object(s, card_id, P0, "Second Card".to_string(), Zone::Library)
+                };
+                // Re-seat at index 1 (just under the current top).
+                let p = runner
+                    .state_mut()
+                    .players
+                    .iter_mut()
+                    .find(|p| p.id == P0)
+                    .unwrap();
+                p.library.retain(|&o| o != id);
+                p.library.insert(1, id);
+                id
+            };
+            make_nonland_blue(runner.state_mut(), second);
+            derive_display_state(runner.state_mut());
+
+            assert_eq!(
+                runner.state().players[0].library.front().copied(),
+                Some(top)
+            );
+            assert!(
+                plot_action_for(runner.state(), top).is_some(),
+                "the actual top card must be plottable"
+            );
+            assert!(
+                plot_action_for(runner.state(), second).is_none(),
+                "the second-from-top card must NOT be plottable — top-card-only"
+            );
+            // The runtime-granted ability is present ONLY on the top card.
+            assert!(
+                runtime_granted_top_of_library_plot_abilities(runner.state(), second).is_empty(),
+                "no non-top library card may carry the plot ability"
+            );
+        }
+
+        /// test_plan #3: nonland discriminator (non-vacuous flip). A land top is
+        /// never plottable; swapping it to a nonland makes it plottable.
+        #[test]
+        fn plot_requires_nonland_top() {
+            let (mut runner, _fblthp, top) = fblthp_with_nonland_top();
+            fund_for_plot(&mut runner);
+            // Land top → no offer: rejected purely by the permission's nonland
+            // filter (the hard-gate is gone). CR 702.170f covers the zone, not
+            // the land/nonland restriction.
+            make_land(runner.state_mut(), top);
+            derive_display_state(runner.state_mut());
+            assert!(
+                plot_action_for(runner.state(), top).is_none(),
+                "a land top must NOT be plottable"
+            );
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "top_of_library_plot_source must reject a land top"
+            );
+
+            // Swap the same top object to a nonland → now plottable.
+            make_nonland_blue(runner.state_mut(), top);
+            derive_display_state(runner.state_mut());
+            assert!(
+                plot_action_for(runner.state(), top).is_some(),
+                "swapping the top to a nonland must make it plottable"
+            );
+        }
+
+        /// test_plan #7: STATIC-GONE revert-probe (load-bearing). Remove Fblthp
+        /// from the battlefield and the plot offer vanishes — the authorizer is
+        /// the battlefield static, not an intrinsic property of the library card.
+        #[test]
+        fn plot_offer_vanishes_when_authorizer_leaves() {
+            let (mut runner, fblthp, top) = fblthp_with_nonland_top();
+            fund_for_plot(&mut runner);
+            assert!(plot_action_for(runner.state(), top).is_some());
+
+            // Fblthp leaves the battlefield.
+            zones::remove_from_zone(runner.state_mut(), fblthp, Zone::Battlefield, P0);
+            runner.state_mut().objects.get_mut(&fblthp).unwrap().zone = Zone::Graveyard;
+            zones::add_to_zone(runner.state_mut(), fblthp, Zone::Graveyard, P0);
+            derive_display_state(runner.state_mut());
+
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "with no authorizing static, the top must not be plottable"
+            );
+            assert!(
+                plot_action_for(runner.state(), top).is_none(),
+                "plot offer must vanish when Fblthp leaves the battlefield"
+            );
+        }
+
+        /// test_plan #8: INVARIANT — the cast-permission family is byte-untouched.
+        /// A `TopOfLibraryCastPermission` source (Future Sight class) is NOT a
+        /// plot authorizer: `top_of_library_plot_source` returns None even though
+        /// the top is castable Library→Stack. The two helpers are disjoint.
+        #[test]
+        fn cast_permission_source_is_not_a_plot_authorizer() {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            let _future_sight = {
+                let mut b = scenario.add_creature(P0, "Future Sight Stand-in", 1, 1);
+                b.from_oracle_text(
+                    "You may play lands and cast spells from the top of your library.",
+                );
+                b.id()
+            };
+            let top = scenario.add_card_to_library_top(P0, "Augury Owl");
+            let mut runner = scenario.build();
+            make_nonland_blue(runner.state_mut(), top);
+            derive_display_state(runner.state_mut());
+
+            // The cast family still authorizes a Library→Stack cast.
+            assert!(
+                top_of_library_permission_source(runner.state(), P0, Some(CardPlayMode::Cast))
+                    .is_some(),
+                "Future Sight class must still authorize casting the top card"
+            );
+            // But it is NOT a plot authorizer — the dedicated path is disjoint.
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "TopOfLibraryCastPermission must never authorize plot-from-library"
+            );
+            // No exile-from-library plot ability is granted on the top card.
+            assert!(
+                runtime_granted_top_of_library_plot_abilities(runner.state(), top).is_empty(),
+                "cast permission must not synthesize a plot ability"
+            );
+        }
+
+        /// test_plan #4 + #6: EXECUTE the plot special action, then the SAME-TURN
+        /// revert-probe. Drives the real activation pipeline: pay {1}{U} (the top
+        /// card's mana cost, INCLUDING the colored pip), exile from library FACE
+        /// UP, grant `Plotted{turn_plotted == turn_number}`, emit BecomesPlotted.
+        #[test]
+        fn execute_plot_exiles_face_up_and_grants_plotted() {
+            let (mut runner, _fblthp, top) = fblthp_with_nonland_top();
+            let idx = plot_ability_index(runner.state(), top);
+            // Colored-pip discriminator: two colorless cannot pay {1}{U}. If the
+            // plot cost were free or all-generic this would (wrongly) be payable.
+            add_mana(runner.state_mut(), P0, ManaType::Colorless, 2);
+            assert!(
+                !can_activate_ability_now(runner.state(), P0, top, idx),
+                "without blue, {{1}}{{U}} is unpayable — the plot cost carries the colored pip"
+            );
+            // Drain, then fund EXACTLY {1}{U} so a clean pool==0 after activation
+            // proves cost == the card's printed mana cost (colored pip included).
+            runner.state_mut().players[0].mana_pool = Default::default();
+            add_mana(runner.state_mut(), P0, ManaType::Blue, 1);
+            add_mana(runner.state_mut(), P0, ManaType::Colorless, 1);
+            let turn = runner.state().turn_number;
+
+            // Announce + pay; then drive to resolution, capturing events.
+            let mut events = apply_as_current(
+                runner.state_mut(),
+                GameAction::ActivateAbility {
+                    source_id: top,
+                    ability_index: idx,
+                },
+            )
+            .expect("activating plot-from-library must be accepted")
+            .events;
+            // The Exile cost is paid during activation — the card is already gone
+            // from the library before the ability hits the stack.
+            assert_eq!(
+                runner.state().objects[&top].zone,
+                Zone::Exile,
+                "paying the plot cost must exile the top card from the library"
+            );
+            assert_ne!(
+                runner.state().players[0].library.front().copied(),
+                Some(top),
+                "the plotted card must have left the library"
+            );
+            // Resolve the on-stack grant ability (pass priority both players).
+            for _ in 0..16 {
+                if runner.state().objects[&top]
+                    .casting_permissions
+                    .iter()
+                    .any(|p| matches!(p, CastingPermission::Plotted { .. }))
+                {
+                    break;
+                }
+                match apply_as_current(runner.state_mut(), GameAction::PassPriority) {
+                    Ok(r) => events.extend(r.events),
+                    Err(_) => break,
+                }
+            }
+
+            // FACE-UP exile (revert-probe vs the refuted face-down claim — CR
+            // 702.170 has no face-down clause, unlike Foretell CR 116.2h).
+            assert!(
+                !runner.state().objects[&top].face_down,
+                "plot exiles FACE UP — CR 702.170 has no face-down clause"
+            );
+            // Plotted granted, stamped to the current turn (CR 702.170a/d).
+            let plotted_turn = runner.state().objects[&top]
+                .casting_permissions
+                .iter()
+                .find_map(|p| match p {
+                    CastingPermission::Plotted { turn_plotted } => Some(*turn_plotted),
+                    _ => None,
+                })
+                .expect("the exiled card must carry the Plotted permission");
+            assert_eq!(
+                plotted_turn, turn,
+                "turn_plotted must be stamped to the turn the card was plotted"
+            );
+            // BecomesPlotted emitted for the owner.
+            assert!(
+                events.iter().any(|e| matches!(
+                    e,
+                    GameEvent::BecomesPlotted { object_id, player_id }
+                        if *object_id == top && *player_id == P0
+                )),
+                "a BecomesPlotted event must be emitted for the plotting player"
+            );
+            // The {1}{U} pool was fully consumed — cost == the card's mana cost.
+            assert_eq!(
+                runner.state().players[0].mana_pool.total(),
+                0,
+                "exactly {{1}}{{U}} must be spent — the plot cost equals the card's mana cost"
+            );
+
+            // test_plan #6: SAME-TURN revert-probe — NOT free-castable the turn
+            // it was plotted (CR 702.170d: only a LATER turn; the gate is `>`).
+            let same_turn = runner.state().turn_number;
+            let top_obj = runner.state().objects[&top].clone();
+            assert!(
+                !has_exile_cast_permission(runner.state(), &top_obj, P0, same_turn),
+                "a card plotted this turn must NOT be free-castable until a later turn"
+            );
+            // LATER-TURN probe (CR 702.170d, gate is `>`): a turn later it IS
+            // free-castable — proving the reused Plotted lifecycle is intact.
+            assert!(
+                has_exile_cast_permission(runner.state(), &top_obj, P0, same_turn + 1),
+                "on a later turn the plotted card must be free-castable"
+            );
+        }
+
+        /// Frontend exposure (design risk #4): a player with MayLookAtTopOfLibrary
+        /// (which Fblthp grants) sees their OWN library top in the viewer-filtered
+        /// state, so `ActivateAbility{source_id: top}` has a render target. The
+        /// opponent does not. Engine-authoritative — never computed client-side.
+        #[test]
+        fn maylook_exposes_own_library_top_to_viewer_only() {
+            let (mut runner, _fblthp, top) = fblthp_with_nonland_top();
+            derive_display_state(runner.state_mut());
+            assert!(
+                runner.state().players[0].can_look_at_top_of_library,
+                "Fblthp must grant P0 the look-at-top permission"
+            );
+
+            // P0 (the looker) sees the top card's identity.
+            let p0_view = filter_state_for_viewer(runner.state(), P0);
+            assert_eq!(
+                p0_view.objects[&top].name, "Augury Owl",
+                "the looking player must see their own library top (render target for plot)"
+            );
+            // The opponent does not.
+            let p1_view = filter_state_for_viewer(runner.state(), P1);
+            assert_ne!(
+                p1_view.objects[&top].name, "Augury Owl",
+                "an opponent must NOT see the hidden library top"
+            );
+        }
+
+        /// Parse a plot line into its real `StaticDefinition` (canonical filters).
+        fn plot_static(line: &str) -> StaticDefinition {
+            crate::parser::oracle_static::parse_static_line(line)
+                .expect("plot line must parse to a static")
+        }
+
+        /// Battlefield permanent carrying exactly the given plot statics + a top
+        /// library card (land or nonland). Returns (runner, source_id, top_id).
+        fn scenario_with_plot_statics(
+            statics: &[StaticDefinition],
+            top_is_land: bool,
+        ) -> (GameRunner, ObjectId, ObjectId) {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            let src = {
+                let mut b = scenario.add_creature(P0, "Plot Source", 1, 1);
+                for s in statics {
+                    b.with_static_definition(s.clone());
+                }
+                b.id()
+            };
+            let top = scenario.add_card_to_library_top(P0, "Augury Owl");
+            let mut runner = scenario.build();
+            if top_is_land {
+                make_land(runner.state_mut(), top);
+            } else {
+                make_nonland_blue(runner.state_mut(), top);
+            }
+            derive_display_state(runner.state_mut());
+            (runner, src, top)
+        }
+
+        /// matthewevans [MED] split — discriminating revert-probe: plot-from-
+        /// library requires BOTH the CR 702.170a grant AND the CR 702.170f
+        /// permission. A runtime that regresses to treating one mode as both (the
+        /// pre-split conflation) would offer plot with only one role present, so
+        /// the grant-only / permission-only cases below would wrongly return
+        /// `Some` and fail. The nonland restriction is the PERMISSION's filter
+        /// (no hard-gate), so it only applies when a permission is present.
+        #[test]
+        fn plot_requires_both_grant_and_permission_roles() {
+            let grant = plot_static(
+                "The top card of your library has plot. The plot cost is equal to its mana cost.",
+            );
+            let permission =
+                plot_static("You may plot nonland cards from the top of your library.");
+            // Sanity: the two lines lower to the two distinct roles.
+            assert_eq!(grant.mode, StaticMode::TopOfLibraryHasPlot);
+            assert_eq!(permission.mode, StaticMode::TopOfLibraryPlotPermission);
+
+            // (a) GRANT-ONLY → None. CR 702.170a: a plot ability functions in
+            // hand; without a CR 702.170f permission the library card can't be
+            // plotted, even though it "has plot".
+            let (runner, _src, _top) =
+                scenario_with_plot_statics(std::slice::from_ref(&grant), false);
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "grant alone must NOT authorize plot-from-library (no permission)"
+            );
+
+            // (b) PERMISSION-ONLY → None. The permission allows plotting from the
+            // library, but the top card has no plot ability to act on.
+            let (runner, _src, _top) =
+                scenario_with_plot_statics(std::slice::from_ref(&permission), false);
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "permission alone must NOT authorize plot-from-library (no grant)"
+            );
+
+            // (c) BOTH → nonland top authorized (returns the grant source); a LAND
+            // top is rejected purely by the permission's nonland filter.
+            let (runner, src, top) =
+                scenario_with_plot_statics(&[grant.clone(), permission.clone()], false);
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                Some((top, src)),
+                "grant + permission must authorize a nonland top"
+            );
+            let (runner, _src, _top) = scenario_with_plot_statics(&[grant, permission], true);
+            assert_eq!(
+                top_of_library_plot_source(runner.state(), P0),
+                None,
+                "a land top must be rejected by the permission's nonland filter"
+            );
+        }
+
+        /// Two SEPARATE P0 battlefield permanents, each carrying its own plot
+        /// statics, plus a nonland {1}{U} top. Models two INDEPENDENT plot-from-
+        /// top sources (the UNION-within-role claim). Returns
+        /// (runner, src_a, src_b, top).
+        fn scenario_with_two_plot_sources(
+            statics_a: &[StaticDefinition],
+            statics_b: &[StaticDefinition],
+            top_is_land: bool,
+        ) -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            let src_a = {
+                let mut b = scenario.add_creature(P0, "Plot Source A", 1, 1);
+                for s in statics_a {
+                    b.with_static_definition(s.clone());
+                }
+                b.id()
+            };
+            let src_b = {
+                let mut b = scenario.add_creature(P0, "Plot Source B", 1, 1);
+                for s in statics_b {
+                    b.with_static_definition(s.clone());
+                }
+                b.id()
+            };
+            let top = scenario.add_card_to_library_top(P0, "Augury Owl");
+            let mut runner = scenario.build();
+            if top_is_land {
+                make_land(runner.state_mut(), top);
+            } else {
+                make_nonland_blue(runner.state_mut(), top);
+            }
+            derive_display_state(runner.state_mut());
+            (runner, src_a, src_b, top)
+        }
+
+        /// Adversarial revert-probe for the UNION-WITHIN-role claim that anchors
+        /// the grant/permission split (see `top_of_library_plot_source` doc, CR
+        /// 702.170a + CR 702.170f): "two INDEPENDENT plot-from-top sources each
+        /// authorize their own eligibility (no cross-source veto)." Every other
+        /// plot test uses exactly ONE grant + ONE permission, so a regression
+        /// from per-source UNION (`grant_source.get_or_insert` /
+        /// `has_permission = true`) to a cross-source intersection (require ALL
+        /// grants — or ALL permissions — to match the top) would pass them all.
+        ///
+        /// Here a SECOND, deliberately NON-MATCHING source of each role is
+        /// load-bearing: it carries a land-only `affected` filter that the
+        /// nonland-blue top FAILS. Under an all-match regression that non-
+        /// matching source would veto the matching one → `None` → this test
+        /// fails. (If both sources matched, the test could not distinguish UNION
+        /// from intersection — the non-matching source is the discriminator.)
+        #[test]
+        fn plot_union_within_role_no_cross_source_veto() {
+            // Land-only filter: the nonland-blue top FAILS it. A future "lands on
+            // top have plot" card would carry such a grant; it must not veto a
+            // matching source. Parser only emits `Any` grants, so build directly.
+            let land_only = TargetFilter::Typed(TypedFilter::new(TypeFilter::Land));
+
+            let grant_any = plot_static(
+                "The top card of your library has plot. The plot cost is equal to its mana cost.",
+            );
+            assert_eq!(grant_any.mode, StaticMode::TopOfLibraryHasPlot);
+            let grant_land_only =
+                StaticDefinition::new(StaticMode::TopOfLibraryHasPlot).affected(land_only.clone());
+
+            let permission_nonland =
+                plot_static("You may plot nonland cards from the top of your library.");
+            assert_eq!(
+                permission_nonland.mode,
+                StaticMode::TopOfLibraryPlotPermission
+            );
+            let permission_land_only =
+                StaticDefinition::new(StaticMode::TopOfLibraryPlotPermission).affected(land_only);
+
+            // (a) UNION within the GRANT role: source A has a matching grant
+            // (`Any`) + the matching permission; source B has a NON-matching
+            // grant (land-only). The matching grant authorizes via UNION; the
+            // non-matching grant must NOT veto.
+            let (runner, _a, _b, top) = scenario_with_two_plot_sources(
+                &[grant_any.clone(), permission_nonland.clone()],
+                std::slice::from_ref(&grant_land_only),
+                false,
+            );
+            assert!(
+                matches!(top_of_library_plot_source(runner.state(), P0), Some((t, _)) if t == top),
+                "a matching grant must authorize via UNION even when a second grant \
+                 source does not match the top (no cross-source grant veto)"
+            );
+
+            // (b) UNION within the PERMISSION role: source A has the matching
+            // grant + a matching permission (nonland); source B has a NON-matching
+            // permission (land-only). No cross-source permission veto.
+            let (runner, _a, _b, top) = scenario_with_two_plot_sources(
+                &[grant_any, permission_nonland],
+                std::slice::from_ref(&permission_land_only),
+                false,
+            );
+            assert!(
+                matches!(top_of_library_plot_source(runner.state(), P0), Some((t, _)) if t == top),
+                "a matching permission must authorize via UNION even when a second \
+                 permission source does not match the top (no cross-source permission veto)"
+            );
+        }
     }
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13486,6 +13486,16 @@ pub fn handle_activate_ability(
             let assigned_targets = flatten_targets_in_chain(&resolved);
             emit_targeting_events(state, &assigned_targets, source_id, player, events);
 
+            // CR 702.170b: plot's grant targets SelfRef (a context-ref), so
+            // `build_target_slots` yields no slot and plot never takes this target
+            // branch — it is intercepted in the no-target path below. Guard the
+            // invariant: a future plot variant reaching here would silently revert
+            // to the on-stack model, so relocate the intercept if this ever fires.
+            debug_assert!(
+                !is_plot_special_action(&ability_def),
+                "plot special action reached the target branch; SelfRef should suppress its target slot"
+            );
+
             let entry_id = ObjectId(state.next_object_id);
             state.next_object_id += 1;
 
@@ -13575,6 +13585,25 @@ pub fn handle_activate_ability(
             )));
             return Ok(state.waiting_for.clone());
         }
+    }
+
+    // CR 702.170b + CR 116.2k: Exiling a card using its plot ability is a
+    // SPECIAL ACTION that doesn't use the stack. The self-exile cost paid above
+    // already moved the card to exile (face up — CR 702.170 has no face-down
+    // clause). Apply the `Plotted` grant IMMEDIATELY via the same single-
+    // authority resolver the stack would otherwise have used on resolution, then
+    // keep priority. No stack entry is created, and crucially no
+    // `AbilityActivated` event is emitted: plot is a special action, not an
+    // activated ability (CR 702.170b), so "whenever you activate an ability"
+    // triggers must not fire and per-turn activation caps (`record_ability_
+    // activation`) do not apply. `resolve` cannot fail for the SelfRef grant, but
+    // the Result is mapped to `EngineError` rather than unwrapped.
+    if is_plot_special_action(&ability_def) {
+        super::effects::grant_permission::resolve(state, &resolved, events).map_err(|e| {
+            EngineError::ActionNotAllowed(format!("plot special action failed: {e}"))
+        })?;
+        priority::clear_priority_passes(state);
+        return Ok(WaitingFor::Priority { player });
     }
 
     // Push to stack
@@ -14019,18 +14048,28 @@ pub(crate) fn apply_special_action_cost_reduction(
     cost
 }
 
-/// CR 702.170a: True when `ability_def` is the synthesized plot special action —
-/// its effect grants the `Plotted` casting permission (see `synthesize_plot`).
-/// Used to apply `ReduceActionCost { action: Plot }` reductions to the plot
-/// mana cost without conflating plot with generic activated-ability reducers.
-fn is_plot_special_action(ability_def: &AbilityDefinition) -> bool {
+/// CR 702.170a: True when `effect` is the synthesized plot special action's
+/// effect — a `Plotted` casting-permission grant (see `synthesize_plot`). Shared
+/// predicate so both the `AbilityDefinition` shape (`is_plot_special_action`) and
+/// the `ResolvedAbility.effect` shape (the cost-pause resume-path invariant in
+/// `casting_costs::push_activated_ability_to_stack`) classify plot identically.
+pub(super) fn effect_is_plot_grant(effect: &Effect) -> bool {
     matches!(
-        &*ability_def.effect,
+        effect,
         Effect::GrantCastingPermission {
             permission: CastingPermission::Plotted { .. },
             ..
         }
     )
+}
+
+/// CR 702.170a: True when `ability_def` is the synthesized plot special action —
+/// its effect grants the `Plotted` casting permission (see `synthesize_plot`).
+/// Used to apply `ReduceActionCost { action: Plot }` reductions to the plot mana
+/// cost without conflating plot with generic activated-ability reducers, and to
+/// gate the CR 702.170b special-action intercept in `handle_activate_ability`.
+fn is_plot_special_action(ability_def: &AbilityDefinition) -> bool {
+    effect_is_plot_grant(&ability_def.effect)
 }
 
 /// CR 116.2 + CR 118.7a: Apply a special-action cost reduction to the mana
@@ -49623,6 +49662,19 @@ mod tests {
             0,
             "the production path charged the reduced {{1}} plot cost"
         );
+        // CR 702.170b: printed hand-Plot is also a special action — the stack
+        // stays empty and the card is plotted immediately (no on-stack grant).
+        assert!(
+            state.stack.is_empty(),
+            "printed hand-Plot is a special action (CR 702.170b) — it must not use the stack"
+        );
+        assert!(
+            state.objects[&plot_card]
+                .casting_permissions
+                .iter()
+                .any(|p| matches!(p, CastingPermission::Plotted { .. })),
+            "printed hand-Plot must grant Plotted immediately as part of the special action"
+        );
 
         // WITHOUT Doc Aurlock: the SAME {1} mana, but the full {3} is unaffordable.
         let (mut state, plot_card) = build(false);
@@ -51016,8 +51068,12 @@ mod tests {
             add_mana(runner.state_mut(), P0, ManaType::Colorless, 1);
             let turn = runner.state().turn_number;
 
-            // Announce + pay; then drive to resolution, capturing events.
-            let mut events = apply_as_current(
+            // Take the plot SPECIAL ACTION. CR 702.170b: it does NOT use the
+            // stack — the card becomes plotted IMMEDIATELY as part of the action,
+            // with NO intervening priority passing or stack resolution. No
+            // PassPriority loop: everything below must hold directly after the
+            // single `ActivateAbility` returns.
+            let events = apply_as_current(
                 runner.state_mut(),
                 GameAction::ActivateAbility {
                     source_id: top,
@@ -51026,8 +51082,8 @@ mod tests {
             )
             .expect("activating plot-from-library must be accepted")
             .events;
-            // The Exile cost is paid during activation — the card is already gone
-            // from the library before the ability hits the stack.
+            // The Exile cost is paid during the action — the card is already gone
+            // from the library.
             assert_eq!(
                 runner.state().objects[&top].zone,
                 Zone::Exile,
@@ -51038,20 +51094,34 @@ mod tests {
                 Some(top),
                 "the plotted card must have left the library"
             );
-            // Resolve the on-stack grant ability (pass priority both players).
-            for _ in 0..16 {
-                if runner.state().objects[&top]
+            // CR 702.170b discriminator (revert-probe vs the old on-stack model):
+            // the stack is EMPTY — plotting created no stack entry. Under the
+            // reverted model an `ActivatedAbility` entry would sit here awaiting
+            // resolution.
+            assert!(
+                runner.state().stack.is_empty(),
+                "plot is a special action (CR 702.170b) — it must NOT use the stack"
+            );
+            // CR 702.170b discriminator: the card is plotted IMMEDIATELY, with no
+            // priority passing. The old model required resolving an on-stack grant
+            // (passing priority) before `Plotted` appeared; this runs directly
+            // after the action and fails if plotting is deferred to the stack.
+            assert!(
+                runner.state().objects[&top]
                     .casting_permissions
                     .iter()
-                    .any(|p| matches!(p, CastingPermission::Plotted { .. }))
-                {
-                    break;
-                }
-                match apply_as_current(runner.state_mut(), GameAction::PassPriority) {
-                    Ok(r) => events.extend(r.events),
-                    Err(_) => break,
-                }
-            }
+                    .any(|p| matches!(p, CastingPermission::Plotted { .. })),
+                "the card must be plotted immediately as part of the special action"
+            );
+            // CR 702.170b: plot is a special action, NOT an activated ability — no
+            // `AbilityActivated` event (so "whenever you activate an ability"
+            // triggers must not fire). `BecomesPlotted` IS emitted (asserted below).
+            assert!(
+                !events
+                    .iter()
+                    .any(|e| matches!(e, GameEvent::AbilityActivated { .. })),
+                "a special action must not emit AbilityActivated (CR 702.170b)"
+            );
 
             // FACE-UP exile (revert-probe vs the refuted face-down claim — CR
             // 702.170 has no face-down clause, unlike Foretell CR 116.2h).

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2297,6 +2297,17 @@ pub(super) fn push_activated_ability_to_stack(
     activation_residual: ActivationResidual,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    // CR 702.170b: plot is a special action that never uses the stack — it is
+    // intercepted in `handle_activate_ability` before any stack push. No current
+    // plot cost can pause (mana auto-pays, the self-exile auto-moves), so this
+    // cost-pause resume path is unreachable for plot. If a future plot variant
+    // carries a pausing sub-cost it would reach here — relocate the special-action
+    // guard to this chokepoint then.
+    debug_assert!(
+        !super::casting::effect_is_plot_grant(&resolved.effect),
+        "plot special action reached the cost-pause resume path; relocate the CR 702.170b intercept to this chokepoint"
+    );
+
     // Pay any activation-cost tail still outstanding. Cost-selection flows may
     // pass the original full cost; choice-based sub-costs already paid by a
     // WaitingFor handler are no-ops here.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -79,6 +79,20 @@ fn is_data_carrying_static(mode: &StaticMode) -> bool {
             | StaticMode::PerTurnDrawLimit { .. }
             | StaticMode::GraveyardCastPermission { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
+            // CR 702.170a grant + CR 702.170f permission: the two nullary
+            // plot-from-library markers (Fblthp's L3 "has plot" grant and L4
+            // "you may plot nonland cards" permission). The nonland scope is the
+            // permission's printed L4 filter (NOT a CR 702.170f clause) on
+            // `affected`; the plot cost is the top card's mana cost, computed
+            // live at synthesis. Runtime enforcement is end-to-end:
+            // casting.rs::top_of_library_plot_source requires both roles,
+            // runtime_granted_top_of_library_plot_abilities synthesizes the
+            // plot special action on the top card, candidates.rs offers it as
+            // ActivateAbility, and the existing Plotted later-cast lifecycle
+            // (CR 702.170d) is reused. Not registry-keyed (mirrors the
+            // cast-permission cluster).
+            | StaticMode::TopOfLibraryHasPlot
+            | StaticMode::TopOfLibraryPlotPermission
             | StaticMode::CastFromHandFree { .. }
             // CR 601.2a + CR 113.6b: ExileCastPermission carries frequency,
             // play_mode, and the `without_paying_mana_cost` flag. Runtime
@@ -7765,6 +7779,15 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             // that the static description will contain.
             StaticMode::TopOfLibraryCastPermission { .. } => {
                 effective_lower.contains("you may cast") || effective_lower.contains("you may play")
+            }
+            // CR 702.170a grant + CR 702.170f permission: plot-from-library
+            // (Fblthp). Both descriptions ("the top card of your library has
+            // plot" / "you may plot nonland cards from the top of your library")
+            // carry "plot" + "library". The role/discriminator is already
+            // enforced by the parser; coverage just needs a phrase the
+            // description will contain.
+            StaticMode::TopOfLibraryHasPlot | StaticMode::TopOfLibraryPlotPermission => {
+                effective_lower.contains("plot") && effective_lower.contains("library")
             }
             // CR 601.2a + CR 113.6b: Maralen-class exile-cast permission. The
             // discriminator phrase ("from among cards exiled with") is

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -143,6 +143,23 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
     // surfaced as draw order anywhere the viewer can observe it.
     let sandbox_self_library_visible =
         state.format_config.allow_debug_actions && state.debug_permitted.contains(&viewer);
+    // CR 701.20e + CR 400.2: "looking at a card ... is shown only to the
+    // specified player." A player with a continuous "you may look at the top
+    // card of your library" permission (MayLookAtTopOfLibrary — Vizier of the
+    // Menagerie, Fblthp, Lost on the Range, etc.) privately sees their OWN
+    // library top. Engine-authoritative exposure (never client-side): the
+    // top-of-library object is the source/render target of cast-from-top
+    // (CR 601.2a) and plot-from-top (CR 702.170f) actions, so without this it
+    // would be redacted for the very player allowed to act on it. The derived
+    // `can_look_at_top_of_library` flag already encodes the static check;
+    // `can_view_private_for_player` extends the look to a player controlling
+    // this player's turn, mirroring the private-look / face-down look paths.
+    let look_top_visible: HashSet<ObjectId> = filtered
+        .players
+        .iter()
+        .filter(|p| p.can_look_at_top_of_library && can_view_private_for_player(p.id))
+        .filter_map(|p| p.library.front().copied())
+        .collect();
     let all_library_ids: Vec<ObjectId> = filtered
         .players
         .iter()
@@ -163,6 +180,9 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
             // contain dig cards, so the exclusion still applies.
             || (state.revealed_cards.contains(&obj_id)
                 && !manifest_dread_cards.contains(&obj_id))
+            // CR 701.20e: own (or controlled-turn) library top under a
+            // MayLookAtTopOfLibrary permission — see `look_top_visible` above.
+            || look_top_visible.contains(&obj_id)
             || (sandbox_self_library_visible && owner == Some(viewer));
         if !visible
             && !effect_zone_hand_cards.contains(&obj_id)

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -701,6 +701,25 @@ pub(crate) fn parse_static_line_inner(
         }
     }
 
+    // CR 702.170f: "You may plot [filter] cards from the top of your library."
+    // Plot-from-library permission (Fblthp, Lost on the Range). Dispatched
+    // BEFORE the cast-permission arm so plot lines are claimed by the plot
+    // parser. The cast arm anchors on "you may play"/"you may cast" while this
+    // anchors on "you may plot", so there is no real collision — ordering
+    // documents intent and guards against future drift. Plot is a CR 702.170
+    // special action (Library → Exile, later Exile → Stack), categorically
+    // distinct from the cast permission's CR 601.2a Library → Stack cast.
+    if let Some(result) = try_parse_top_of_library_plot_permission(&text, &lower) {
+        return Some(result);
+    }
+
+    // CR 702.170f + CR 702.170a: "The top card of your library has plot[. The
+    // plot cost is equal to its mana cost]." Mechanic-establishing plot grant
+    // for the top library card (Fblthp). Also claimed ahead of the cast arm.
+    if let Some(result) = try_parse_top_of_library_has_plot(&text, &lower) {
+        return Some(result);
+    }
+
     // CR 401.5 + CR 118.9 + CR 601.2a: "You may [play|cast] [filter] from the
     // top of your library [rider]." Top-of-library cast permission class
     // (Realmwalker, Future Sight, Bolas's Citadel, Magus of the Future, Vivien

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2409,6 +2409,93 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
     Some(def)
 }
 
+/// CR 702.170f: Parse "You may plot [filter] cards from the top of your library"
+/// — the plot-from-library *permission* line (Fblthp, Lost on the Range L4).
+/// Structurally a clone of [`try_parse_top_of_library_cast_permission`], but
+/// anchored on the plot verb ("you may plot ") and emitting the categorically
+/// distinct [`StaticMode::TopOfLibraryHasPlot`] rather than the cast-permission
+/// variant: plot is a CR 702.170 special action (Library → Exile, then a later
+/// Exile → Stack free cast), not a CR 601.2a Library → Stack cast.
+///
+/// The eligibility filter ("nonland") rides `StaticDefinition.affected`, exactly
+/// as the cast-permission sibling carries its eligibility. Built for the class:
+/// any type/subtype phrase the cast arm accepts is accepted here, so future
+/// "you may plot <type> cards from the top of your library" printings slot in
+/// without parser changes.
+pub(crate) fn try_parse_top_of_library_plot_permission(
+    text: &str,
+    lower: &str,
+) -> Option<StaticDefinition> {
+    // "you may plot <filter> from the top of your library"
+    let rest = nom_tag_lower(lower, lower, "you may plot ")?;
+
+    // Anchor on " from the top of your library"; the filter text precedes it.
+    let (filter_text, _trailing) =
+        nom_primitives::split_once_on(rest, " from the top of your library")
+            .ok()
+            .map(|(_, pair)| pair)?;
+
+    // Strip a leading article so `parse_type_phrase` sees the bare noun.
+    let filter_text = nom_tag_lower(filter_text, filter_text, "a ")
+        .or_else(|| nom_tag_lower(filter_text, filter_text, "an "))
+        .unwrap_or(filter_text);
+
+    // Drop trailing " cards"/" card" so `parse_type_phrase` sees the bare
+    // type/subtype phrase ("nonland cards" → "nonland"). Mirrors the
+    // " spells"/" spell" replacen idiom of the cast-permission arm; plot
+    // operates on cards (it exiles a card), so the noun is "card(s)".
+    let cleaned: Cow<str> = if nom_primitives::scan_contains(filter_text, "cards") {
+        Cow::Owned(filter_text.replacen(" cards", "", 1))
+    } else if nom_primitives::scan_contains(filter_text, "card") {
+        Cow::Owned(filter_text.replacen(" card", "", 1))
+    } else {
+        Cow::Borrowed(filter_text)
+    };
+
+    let (filter, _) = parse_type_phrase(&cleaned);
+
+    Some(
+        StaticDefinition::new(StaticMode::TopOfLibraryHasPlot)
+            .affected(filter)
+            .description(text.to_string()),
+    )
+}
+
+/// CR 702.170f + CR 702.170a: Parse "The top card of your library has plot[. The
+/// plot cost is equal to its mana cost]" — the mechanic-establishing line that
+/// grants plot to the top library card (Fblthp, Lost on the Range L3).
+///
+/// The optional second sentence is consumed (no capture) so the full line
+/// classifies: the plot cost is the card's own mana cost (CR 702.170a),
+/// computed at activation synthesis from the live top card, not data carried on
+/// the static. `affected` is `TargetFilter::Any` — the nonland narrowing comes
+/// from the companion L4 permission; the two AND-compose at runtime. The
+/// remainder must be empty after consuming the known sentences so an unexpected
+/// longer line is not silently swallowed.
+pub(crate) fn try_parse_top_of_library_has_plot(
+    text: &str,
+    lower: &str,
+) -> Option<StaticDefinition> {
+    let rest = nom_tag_lower(lower, lower, "the top card of your library has plot")?;
+
+    // CR 702.170a: optional intrinsic cost sentence — consumed, never captured.
+    let rest =
+        nom_tag_lower(rest, rest, ". the plot cost is equal to its mana cost").unwrap_or(rest);
+
+    // Allow a trailing sentence period after either sentence.
+    let rest = nom_tag_lower(rest, rest, ".").unwrap_or(rest);
+
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    Some(
+        StaticDefinition::new(StaticMode::TopOfLibraryHasPlot)
+            .affected(TargetFilter::Any)
+            .description(text.to_string()),
+    )
+}
+
 /// CR 305.1 + CR 601.2a + CR 700.6: Parse the disjunctive filtered top-of-
 /// library play/cast permission — "You may play <land-filter> and cast
 /// <spell-filter> from the top of your library." — into a single

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2410,18 +2410,22 @@ pub(crate) fn try_parse_top_of_library_cast_permission(
 }
 
 /// CR 702.170f: Parse "You may plot [filter] cards from the top of your library"
-/// — the plot-from-library *permission* line (Fblthp, Lost on the Range L4).
-/// Structurally a clone of [`try_parse_top_of_library_cast_permission`], but
-/// anchored on the plot verb ("you may plot ") and emitting the categorically
-/// distinct [`StaticMode::TopOfLibraryHasPlot`] rather than the cast-permission
-/// variant: plot is a CR 702.170 special action (Library → Exile, then a later
-/// Exile → Stack free cast), not a CR 601.2a Library → Stack cast.
+/// — the plot-from-library PERMISSION line (Fblthp, Lost on the Range L4). This
+/// is the CR 702.170f effect that allows the plot ability to function in a zone
+/// other than hand and authorizes taking the special action there; it emits
+/// [`StaticMode::TopOfLibraryPlotPermission`], the permission role — DISTINCT
+/// from [`StaticMode::TopOfLibraryHasPlot`] (the L3 grant that the top card
+/// *has* plot). The runtime requires both. (Both are also categorically
+/// distinct from the cast-permission family: plot is a CR 702.170 special action
+/// — Library → Exile, then a later Exile → Stack free cast — not a CR 601.2a
+/// Library → Stack cast.)
 ///
-/// The eligibility filter ("nonland") rides `StaticDefinition.affected`, exactly
-/// as the cast-permission sibling carries its eligibility. Built for the class:
-/// any type/subtype phrase the cast arm accepts is accepted here, so future
-/// "you may plot <type> cards from the top of your library" printings slot in
-/// without parser changes.
+/// Structurally a clone of [`try_parse_top_of_library_cast_permission`], anchored
+/// on the plot verb ("you may plot "). The eligibility filter ("nonland") rides
+/// `StaticDefinition.affected`, exactly as the cast-permission sibling carries
+/// its eligibility. Built for the class: any type/subtype phrase the cast arm
+/// accepts is accepted here, so future "you may plot <type> cards from the top
+/// of your library" printings slot in without parser changes.
 pub(crate) fn try_parse_top_of_library_plot_permission(
     text: &str,
     lower: &str,
@@ -2455,23 +2459,25 @@ pub(crate) fn try_parse_top_of_library_plot_permission(
     let (filter, _) = parse_type_phrase(&cleaned);
 
     Some(
-        StaticDefinition::new(StaticMode::TopOfLibraryHasPlot)
+        StaticDefinition::new(StaticMode::TopOfLibraryPlotPermission)
             .affected(filter)
             .description(text.to_string()),
     )
 }
 
-/// CR 702.170f + CR 702.170a: Parse "The top card of your library has plot[. The
-/// plot cost is equal to its mana cost]" — the mechanic-establishing line that
-/// grants plot to the top library card (Fblthp, Lost on the Range L3).
+/// CR 702.170a + CR 702.170f: Parse "The top card of your library has plot[. The
+/// plot cost is equal to its mana cost]" — the GRANT line that gives the top
+/// library card the plot ability (Fblthp, Lost on the Range L3). Emits
+/// [`StaticMode::TopOfLibraryHasPlot`] (the grant role) with `affected =
+/// TargetFilter::Any`; the *permission* to actually plot from the library (and
+/// its nonland scope) is the companion L4 `TopOfLibraryPlotPermission` — the
+/// runtime requires both.
 ///
 /// The optional second sentence is consumed (no capture) so the full line
 /// classifies: the plot cost is the card's own mana cost (CR 702.170a),
 /// computed at activation synthesis from the live top card, not data carried on
-/// the static. `affected` is `TargetFilter::Any` — the nonland narrowing comes
-/// from the companion L4 permission; the two AND-compose at runtime. The
-/// remainder must be empty after consuming the known sentences so an unexpected
-/// longer line is not silently swallowed.
+/// the static. The remainder must be empty after consuming the known sentences
+/// so an unexpected longer line is not silently swallowed.
 pub(crate) fn try_parse_top_of_library_has_plot(
     text: &str,
     lower: &str,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18933,6 +18933,125 @@ fn top_of_library_cast_permission_rejects_other_anchors() {
     .is_none());
 }
 
+/// CR 702.170f: Fblthp L4 — "You may plot nonland cards from the top of your
+/// library." must lower to the categorically distinct
+/// `StaticMode::TopOfLibraryHasPlot` (plot is CR 702.170 Library → Exile, NOT
+/// CR 601.2a Library → Stack cast) with the nonland filter on `affected`.
+/// Discriminating: asserts the mode is `TopOfLibraryHasPlot`, NOT
+/// `TopOfLibraryCastPermission` — reverting the plot dispatch arm (so the cast
+/// arm claims the line) flips this assertion.
+#[test]
+fn top_of_library_has_plot_permission_fblthp_nonland() {
+    let def = parse_static_line("You may plot nonland cards from the top of your library.")
+        .expect("Fblthp plot-from-library permission must parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::TopOfLibraryHasPlot,
+        "L4 must be the dedicated plot static, not a cast permission, got {:?}",
+        def.mode
+    );
+    // Nonland scope rides `affected`: a `Typed` filter carrying `Non(Land)`.
+    let affected = def.affected.expect("nonland affected filter set");
+    match affected {
+        TargetFilter::Typed(tf) => {
+            assert!(
+                tf.type_filters.iter().any(|t| matches!(
+                    t,
+                    TypeFilter::Non(inner) if **inner == TypeFilter::Land
+                )),
+                "expected Non(Land) in type filters, got {:?}",
+                tf.type_filters
+            );
+        }
+        other => panic!("expected Typed nonland filter, got {other:?}"),
+    }
+}
+
+/// CR 702.170f + CR 702.170a: Fblthp L3 — "The top card of your library has
+/// plot. The plot cost is equal to its mana cost." must fully classify to
+/// `StaticMode::TopOfLibraryHasPlot` with `affected = Any` (the nonland
+/// narrowing comes from the companion L4 permission). The optional cost-spec
+/// second sentence is consumed (no captured field) so the whole line is owned
+/// by the static parser.
+#[test]
+fn top_of_library_has_plot_l3_full_classification() {
+    let def = parse_static_line(
+        "The top card of your library has plot. The plot cost is equal to its mana cost.",
+    )
+    .expect("Fblthp has-plot line must parse");
+    assert_eq!(def.mode, StaticMode::TopOfLibraryHasPlot);
+    assert!(
+        matches!(def.affected, Some(TargetFilter::Any)),
+        "L3 affected must be Any, got {:?}",
+        def.affected
+    );
+
+    // The bare first sentence (a hypothetical L3-only printing) also classifies.
+    let bare = parse_static_line("The top card of your library has plot.")
+        .expect("bare has-plot sentence must parse");
+    assert_eq!(bare.mode, StaticMode::TopOfLibraryHasPlot);
+}
+
+/// Cross-contamination guard: the cast-permission family must be untouched.
+/// "You may cast nonland cards from the top of your library." still lowers to
+/// `TopOfLibraryCastPermission` (Library → Stack cast), proving the plot
+/// dispatch arms (anchored on "you may plot" / "the top card ... has plot")
+/// do not steal cast lines. Reverting the categorical split (folding plot into
+/// the cast variant) flips this discriminating assertion.
+#[test]
+fn top_of_library_plot_does_not_contaminate_cast_permission() {
+    let def = parse_static_line("You may cast nonland cards from the top of your library.")
+        .expect("cast-from-top permission must still parse");
+    assert!(
+        matches!(def.mode, StaticMode::TopOfLibraryCastPermission { .. }),
+        "cast family must stay TopOfLibraryCastPermission, got {:?}",
+        def.mode
+    );
+}
+
+/// CR 702.170f reach gate (PR-B required-change #4): drive the FULL oracle
+/// pipeline (`parse_oracle_text`), not just the static parser in isolation, to
+/// prove Fblthp's L3/L4 are claimed by the static dispatch BEFORE the effect
+/// fallback — i.e. they are recognized statics, not `Effect::Unimplemented`
+/// GAPs. NOTE (PR-B phasing): this proves the lines PARSE to a static; coverage
+/// stays RED because PR-B intentionally does NOT add the variant to
+/// `is_data_carrying_static` / `covered_by_static_mode` — the honest flip lands
+/// with the runtime in PR-C.
+#[test]
+fn fblthp_plot_lines_classify_as_static_not_unimplemented() {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::Effect;
+
+    for line in [
+        "You may plot nonland cards from the top of your library.",
+        "The top card of your library has plot. The plot cost is equal to its mana cost.",
+    ] {
+        let parsed = parse_oracle_text(
+            line,
+            "Fblthp, Lost on the Range",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        assert!(
+            parsed
+                .statics
+                .iter()
+                .any(|d| d.mode == StaticMode::TopOfLibraryHasPlot),
+            "line {line:?} must produce a TopOfLibraryHasPlot static, got statics {:?}",
+            parsed.statics
+        );
+        assert!(
+            !parsed
+                .abilities
+                .iter()
+                .any(|a| matches!(*a.effect, Effect::Unimplemented { .. })),
+            "line {line:?} must not fall through to Unimplemented, got abilities {:?}",
+            parsed.abilities
+        );
+    }
+}
+
 #[test]
 fn subtype_or_list_single() {
     let f = parse_subtype_or_list("Wolf").unwrap();

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -18934,20 +18934,23 @@ fn top_of_library_cast_permission_rejects_other_anchors() {
 }
 
 /// CR 702.170f: Fblthp L4 — "You may plot nonland cards from the top of your
-/// library." must lower to the categorically distinct
-/// `StaticMode::TopOfLibraryHasPlot` (plot is CR 702.170 Library → Exile, NOT
-/// CR 601.2a Library → Stack cast) with the nonland filter on `affected`.
-/// Discriminating: asserts the mode is `TopOfLibraryHasPlot`, NOT
-/// `TopOfLibraryCastPermission` — reverting the plot dispatch arm (so the cast
-/// arm claims the line) flips this assertion.
+/// library." must lower to the PERMISSION role
+/// `StaticMode::TopOfLibraryPlotPermission` (the CR 702.170f effect that lets
+/// plot function from the library), NOT the grant `TopOfLibraryHasPlot` and NOT
+/// the cast-permission family (plot is CR 702.170 Library → Exile, not CR 601.2a
+/// Library → Stack). CR 702.170f authorizes plot from a zone other than hand;
+/// the nonland filter on `affected` is this printed L4 text's own scope, not a
+/// CR 702.170f clause.
+/// Discriminating on the grant/permission split: reverting L4 to emit
+/// `TopOfLibraryHasPlot` (the grant) — re-conflating the two roles — flips this.
 #[test]
 fn top_of_library_has_plot_permission_fblthp_nonland() {
     let def = parse_static_line("You may plot nonland cards from the top of your library.")
         .expect("Fblthp plot-from-library permission must parse");
     assert_eq!(
         def.mode,
-        StaticMode::TopOfLibraryHasPlot,
-        "L4 must be the dedicated plot static, not a cast permission, got {:?}",
+        StaticMode::TopOfLibraryPlotPermission,
+        "L4 must be the PERMISSION role, not the grant or a cast permission, got {:?}",
         def.mode
     );
     // Nonland scope rides `affected`: a `Typed` filter carrying `Non(Land)`.
@@ -18967,12 +18970,13 @@ fn top_of_library_has_plot_permission_fblthp_nonland() {
     }
 }
 
-/// CR 702.170f + CR 702.170a: Fblthp L3 — "The top card of your library has
-/// plot. The plot cost is equal to its mana cost." must fully classify to
-/// `StaticMode::TopOfLibraryHasPlot` with `affected = Any` (the nonland
-/// narrowing comes from the companion L4 permission). The optional cost-spec
-/// second sentence is consumed (no captured field) so the whole line is owned
-/// by the static parser.
+/// CR 702.170a + CR 702.170f: Fblthp L3 — "The top card of your library has
+/// plot. The plot cost is equal to its mana cost." must fully classify to the
+/// GRANT role `StaticMode::TopOfLibraryHasPlot` with `affected = Any` (the
+/// nonland scope and the permission to plot from the library are the companion
+/// L4 `TopOfLibraryPlotPermission`; the runtime requires both). The optional
+/// cost-spec second sentence is consumed (no captured field) so the whole line
+/// is owned by the static parser.
 #[test]
 fn top_of_library_has_plot_l3_full_classification() {
     let def = parse_static_line(
@@ -19009,22 +19013,26 @@ fn top_of_library_plot_does_not_contaminate_cast_permission() {
     );
 }
 
-/// CR 702.170f reach gate (PR-B required-change #4): drive the FULL oracle
-/// pipeline (`parse_oracle_text`), not just the static parser in isolation, to
-/// prove Fblthp's L3/L4 are claimed by the static dispatch BEFORE the effect
-/// fallback — i.e. they are recognized statics, not `Effect::Unimplemented`
-/// GAPs. NOTE (PR-B phasing): this proves the lines PARSE to a static; coverage
-/// stays RED because PR-B intentionally does NOT add the variant to
-/// `is_data_carrying_static` / `covered_by_static_mode` — the honest flip lands
-/// with the runtime in PR-C.
+/// CR 702.170f reach gate: drive the FULL oracle pipeline (`parse_oracle_text`),
+/// not just the static parser in isolation, to prove Fblthp's L3/L4 are claimed
+/// by the static dispatch BEFORE the effect fallback — i.e. they are recognized
+/// statics, not `Effect::Unimplemented` GAPs. Each line must produce its
+/// role-correct static (L3 → grant `TopOfLibraryHasPlot`, L4 → permission
+/// `TopOfLibraryPlotPermission`).
 #[test]
 fn fblthp_plot_lines_classify_as_static_not_unimplemented() {
     use crate::parser::oracle::parse_oracle_text;
     use crate::types::ability::Effect;
 
-    for line in [
-        "You may plot nonland cards from the top of your library.",
-        "The top card of your library has plot. The plot cost is equal to its mana cost.",
+    for (line, expected_mode) in [
+        (
+            "You may plot nonland cards from the top of your library.",
+            StaticMode::TopOfLibraryPlotPermission,
+        ),
+        (
+            "The top card of your library has plot. The plot cost is equal to its mana cost.",
+            StaticMode::TopOfLibraryHasPlot,
+        ),
     ] {
         let parsed = parse_oracle_text(
             line,
@@ -19034,11 +19042,8 @@ fn fblthp_plot_lines_classify_as_static_not_unimplemented() {
             &[],
         );
         assert!(
-            parsed
-                .statics
-                .iter()
-                .any(|d| d.mode == StaticMode::TopOfLibraryHasPlot),
-            "line {line:?} must produce a TopOfLibraryHasPlot static, got statics {:?}",
+            parsed.statics.iter().any(|d| d.mode == expected_mode),
+            "line {line:?} must produce a {expected_mode:?} static, got statics {:?}",
             parsed.statics
         );
         assert!(

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -601,6 +601,11 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             | StaticMode::MayPlayAdditionalLand
             | StaticMode::AdditionalLandDrop { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
+            // CR 702.170f: "You may plot [filter] cards from the top of your
+            // library" / "The top card of your library has plot" — opt-in
+            // plot-from-library permission (Fblthp). The plot special action
+            // (CR 702.170b) is taken at the player's discretion.
+            | StaticMode::TopOfLibraryHasPlot
             // CR 702.8: "You may cast this spell as though it had flash" —
             // opt-in cast-timing permission.
             | StaticMode::CastWithFlash

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -601,11 +601,12 @@ fn static_mode_is_optional_permission(mode: &StaticMode) -> bool {
             | StaticMode::MayPlayAdditionalLand
             | StaticMode::AdditionalLandDrop { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
-            // CR 702.170f: "You may plot [filter] cards from the top of your
-            // library" / "The top card of your library has plot" — opt-in
-            // plot-from-library permission (Fblthp). The plot special action
-            // (CR 702.170b) is taken at the player's discretion.
+            // CR 702.170a grant + CR 702.170f permission: "The top card of your
+            // library has plot" / "You may plot [filter] cards from the top of
+            // your library" — opt-in plot-from-library (Fblthp). The plot special
+            // action (CR 702.170b) is taken at the player's discretion.
             | StaticMode::TopOfLibraryHasPlot
+            | StaticMode::TopOfLibraryPlotPermission
             // CR 702.8: "You may cast this spell as though it had flash" —
             // opt-in cast-timing permission.
             | StaticMode::CastWithFlash
@@ -1447,6 +1448,13 @@ fn detect_dynamic_qty(
         "SelfManaCost",
         "SelfManaValue",
         "TargetManaCost",
+        // CR 702.170a: "The plot cost is equal to its mana cost" — the plot cost
+        // is intrinsic to the `TopOfLibraryHasPlot` static (computed at synthesis
+        // from the live top card's mana_cost), not a stored `QuantityExpr`. The
+        // static's presence in the AST is the coverage marker, mirroring the
+        // `SelfManaCost` precedent for Flashback/Scavenge "cost equal to its mana
+        // cost" (Fblthp, Lost on the Range).
+        "TopOfLibraryHasPlot",
         // CR 702.20a: "assigns combat damage equal to its toughness
         // rather than its power" — Brontodon class. Encoded as a typed
         // continuous-modification variant, not a quantity expression.
@@ -4755,6 +4763,24 @@ this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
         let parsed = parse(
             "Put a +1/+1 counter on target creature you control, then double the number of +1/+1 counters on that creature.",
             &["Instant"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "DynamicQty"));
+    }
+
+    /// CR 702.170a: Fblthp's "The plot cost is equal to its mana cost" is the
+    /// intrinsic plot cost of the `TopOfLibraryHasPlot` static (computed at
+    /// synthesis, no stored `QuantityExpr`), so the " equal to " marker must NOT
+    /// raise a DynamicQty swallow warning — the static's presence is the carrier
+    /// (mirrors the SelfManaCost precedent). Reverting the marker re-reds Fblthp.
+    #[test]
+    fn dynamic_qty_accepts_plot_cost_equal_to_mana_cost() {
+        let parsed = parse_named(
+            "You may look at the top card of your library any time.\n\
+             The top card of your library has plot. The plot cost is equal to its mana cost.\n\
+             You may plot nonland cards from the top of your library.",
+            "Fblthp, Lost on the Range",
+            &["Creature"],
         );
 
         assert!(!has_swallowed_detector(&parsed, "DynamicQty"));

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1122,6 +1122,34 @@ pub enum StaticMode {
         /// `pay_additional_cost` (mirrors the `ExileWithAltAbilityCost` flow).
         alt_cost: Option<AbilityCost>,
     },
+    /// CR 702.170f: Static ability allowing the plot keyword ability to function
+    /// in a zone other than a player's hand — specifically, the top card of the
+    /// controller's library. "In that case, the card is exiled from the zone it
+    /// is in as the action is taken rather than from its owner's hand." Class
+    /// specimen: Fblthp, Lost on the Range ("The top card of your library has
+    /// plot. The plot cost is equal to its mana cost." + "You may plot nonland
+    /// cards from the top of your library.").
+    ///
+    /// Categorically distinct from `TopOfLibraryCastPermission`, and that
+    /// distinction is why this is a dedicated variant rather than a parameter on
+    /// the cast-permission axis:
+    /// - `TopOfLibraryCastPermission` is CR 601.2a: casting moves the card
+    ///   `Library → Stack` directly, with NO exile step — a single zone change,
+    ///   a normal spell cast.
+    /// - This is CR 702.170: plotting is a *special action* (CR 702.170b) that
+    ///   moves the card `Library → Exile` face up now, and only on a *later*
+    ///   turn `Exile → Stack` for free — two zone changes, a different runtime
+    ///   action in a different CR section.
+    ///
+    /// Unifying the two under one parameterized variant would conflate CR 601.2a
+    /// and CR 702.170 at the leaf reference layer, against the categorical
+    /// boundary rule. The eligibility scope (Fblthp's "nonland") rides the
+    /// existing `StaticDefinition.affected: Option<TargetFilter>` slot exactly as
+    /// the cast-permission sibling carries its eligibility — no new field. The
+    /// plot cost ("equal to its mana cost") needs no stored parameter: it is the
+    /// live top card's `mana_cost`, computed at activation synthesis time (the
+    /// defining invariant of the mechanic), not data carried on the static.
+    TopOfLibraryHasPlot,
     /// CR 601.2b + CR 118.9a: Static ability granting permission to cast matching
     /// spells without paying their mana costs. `Unlimited` = Omniscience,
     /// Tamiyo emblem, Dracogenesis. `OncePerTurn` = Zaffai and the Tempests.
@@ -1950,6 +1978,7 @@ impl StaticMode {
             | StaticMode::RevealHand { .. }
             | StaticMode::GraveyardCastPermission { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
+            | StaticMode::TopOfLibraryHasPlot
             | StaticMode::CastFromHandFree { .. }
             | StaticMode::ExileCastPermission { .. }
             | StaticMode::CountersPersistAcrossZones { .. }
@@ -2171,6 +2200,9 @@ impl fmt::Display for StaticMode {
                     write!(f, "TopOfLibraryCastPermission({play_mode}{freq_seg})")
                 }
             }
+            // CR 702.170f: nullary marker; nonland scope rides
+            // `StaticDefinition.affected`, not the Display payload.
+            StaticMode::TopOfLibraryHasPlot => write!(f, "TopOfLibraryHasPlot"),
             StaticMode::CastFromHandFree { frequency, origin } => {
                 if matches!(origin, CastFreeOrigin::Hand) {
                     write!(f, "CastFromHandFree({frequency})")
@@ -2632,6 +2664,9 @@ impl FromStr for StaticMode {
                     alt_cost: None,
                 }
             }
+            // CR 702.170f: nullary marker; the nonland scope is carried on
+            // `StaticDefinition.affected`, so there is no Display payload to parse.
+            "TopOfLibraryHasPlot" => StaticMode::TopOfLibraryHasPlot,
             "CastFromHandFree" => StaticMode::CastFromHandFree {
                 frequency: CastFrequency::Unlimited,
                 origin: CastFreeOrigin::Hand,
@@ -3318,6 +3353,10 @@ mod tests {
             },
             StaticMode::CantCrew,
             StaticMode::MayLookAtTopOfLibrary,
+            // CR 702.170f: nullary plot-from-library marker (Fblthp). The
+            // nonland scope rides `StaticDefinition.affected`, not the Display
+            // payload, so the bare marker round-trips cleanly here.
+            StaticMode::TopOfLibraryHasPlot,
             StaticMode::MayLookAtFaceDown,
             StaticMode::CantBeTurnedFaceUp,
             // Tier 3: parser-produced statics

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1122,34 +1122,49 @@ pub enum StaticMode {
         /// `pay_additional_cost` (mirrors the `ExileWithAltAbilityCost` flow).
         alt_cost: Option<AbilityCost>,
     },
-    /// CR 702.170f: Static ability allowing the plot keyword ability to function
-    /// in a zone other than a player's hand — specifically, the top card of the
-    /// controller's library. "In that case, the card is exiled from the zone it
-    /// is in as the action is taken rather than from its owner's hand." Class
-    /// specimen: Fblthp, Lost on the Range ("The top card of your library has
-    /// plot. The plot cost is equal to its mana cost." + "You may plot nonland
-    /// cards from the top of your library.").
+    /// CR 702.170a + CR 702.170f: GRANT half of plot-from-library — "The top
+    /// card of your library has plot." The top card of the controller's library
+    /// *has* the plot ability (with plot cost equal to its mana cost). This is
+    /// only the grant that the card carries plot; it does NOT by itself permit
+    /// plotting from the library — per CR 702.170a a plot ability functions in
+    /// the hand, so a separate `TopOfLibraryPlotPermission` (the CR 702.170f
+    /// "function in a zone other than hand" effect) is required to actually take
+    /// the special action from the library. `affected` scopes which top cards are
+    /// granted plot (`TargetFilter::Any` for Fblthp's L3).
     ///
-    /// Categorically distinct from `TopOfLibraryCastPermission`, and that
-    /// distinction is why this is a dedicated variant rather than a parameter on
-    /// the cast-permission axis:
-    /// - `TopOfLibraryCastPermission` is CR 601.2a: casting moves the card
-    ///   `Library → Stack` directly, with NO exile step — a single zone change,
-    ///   a normal spell cast.
-    /// - This is CR 702.170: plotting is a *special action* (CR 702.170b) that
-    ///   moves the card `Library → Exile` face up now, and only on a *later*
-    ///   turn `Exile → Stack` for free — two zone changes, a different runtime
-    ///   action in a different CR section.
+    /// The plot cost ("equal to its mana cost") needs no stored parameter: it is
+    /// the live top card's `mana_cost`, computed at activation synthesis time
+    /// (the defining invariant of the mechanic), not data carried on the static.
     ///
-    /// Unifying the two under one parameterized variant would conflate CR 601.2a
-    /// and CR 702.170 at the leaf reference layer, against the categorical
-    /// boundary rule. The eligibility scope (Fblthp's "nonland") rides the
-    /// existing `StaticDefinition.affected: Option<TargetFilter>` slot exactly as
-    /// the cast-permission sibling carries its eligibility — no new field. The
-    /// plot cost ("equal to its mana cost") needs no stored parameter: it is the
-    /// live top card's `mana_cost`, computed at activation synthesis time (the
-    /// defining invariant of the mechanic), not data carried on the static.
+    /// Categorically distinct from `TopOfLibraryCastPermission` (CR 601.2a:
+    /// `Library → Stack` cast, NO exile, one zone change). Plot is CR 702.170 — a
+    /// special action (CR 702.170b) that moves `Library → Exile` face up now,
+    /// then `Exile → Stack` free on a later turn (two zone changes, a different
+    /// CR section). Unifying them at the leaf reference layer would conflate the
+    /// two against the categorical-boundary rule.
+    ///
+    /// Class specimen: Fblthp, Lost on the Range ("The top card of your library
+    /// has plot. The plot cost is equal to its mana cost.").
     TopOfLibraryHasPlot,
+    /// CR 702.170f: PERMISSION half of plot-from-library — "You may plot [filter]
+    /// cards from the top of your library." This is the CR 702.170f effect that
+    /// allows a plot ability to function in a zone other than the hand (here, the
+    /// top of the library), and authorizes the player to take the plot special
+    /// action there for cards matching `affected` ("nonland" for Fblthp's L4).
+    ///
+    /// Split from `TopOfLibraryHasPlot` because the two encode distinct CR roles:
+    /// the grant says the card *has* plot; this permission says the player *may
+    /// plot it from the library*. The runtime requires BOTH (an active grant
+    /// matching the top card AND an active permission matching it), so the
+    /// eligible set is `(union of grant filters) ∩ (union of permission
+    /// filters)`. Modeling each line as its own static means two INDEPENDENT
+    /// plot-from-top sources UNION correctly (each independently authorizes its
+    /// own eligibility), which a single conflated static could not express.
+    ///
+    /// The nonland scope rides `StaticDefinition.affected` (Fblthp's printed L4
+    /// text — CR 702.170f itself has no land/nonland clause), exactly as
+    /// `TopOfLibraryHasPlot` carries its grant scope.
+    TopOfLibraryPlotPermission,
     /// CR 601.2b + CR 118.9a: Static ability granting permission to cast matching
     /// spells without paying their mana costs. `Unlimited` = Omniscience,
     /// Tamiyo emblem, Dracogenesis. `OncePerTurn` = Zaffai and the Tempests.
@@ -1979,6 +1994,7 @@ impl StaticMode {
             | StaticMode::GraveyardCastPermission { .. }
             | StaticMode::TopOfLibraryCastPermission { .. }
             | StaticMode::TopOfLibraryHasPlot
+            | StaticMode::TopOfLibraryPlotPermission
             | StaticMode::CastFromHandFree { .. }
             | StaticMode::ExileCastPermission { .. }
             | StaticMode::CountersPersistAcrossZones { .. }
@@ -2200,9 +2216,11 @@ impl fmt::Display for StaticMode {
                     write!(f, "TopOfLibraryCastPermission({play_mode}{freq_seg})")
                 }
             }
-            // CR 702.170f: nullary marker; nonland scope rides
-            // `StaticDefinition.affected`, not the Display payload.
+            // CR 702.170a grant + CR 702.170f permission markers; both nullary —
+            // the grant/permission scope rides `StaticDefinition.affected`, not
+            // the Display payload.
             StaticMode::TopOfLibraryHasPlot => write!(f, "TopOfLibraryHasPlot"),
+            StaticMode::TopOfLibraryPlotPermission => write!(f, "TopOfLibraryPlotPermission"),
             StaticMode::CastFromHandFree { frequency, origin } => {
                 if matches!(origin, CastFreeOrigin::Hand) {
                     write!(f, "CastFromHandFree({frequency})")
@@ -2664,9 +2682,11 @@ impl FromStr for StaticMode {
                     alt_cost: None,
                 }
             }
-            // CR 702.170f: nullary marker; the nonland scope is carried on
-            // `StaticDefinition.affected`, so there is no Display payload to parse.
+            // CR 702.170a grant + CR 702.170f permission markers; both nullary —
+            // the scope rides `StaticDefinition.affected`, so there is no Display
+            // payload to parse.
             "TopOfLibraryHasPlot" => StaticMode::TopOfLibraryHasPlot,
+            "TopOfLibraryPlotPermission" => StaticMode::TopOfLibraryPlotPermission,
             "CastFromHandFree" => StaticMode::CastFromHandFree {
                 frequency: CastFrequency::Unlimited,
                 origin: CastFreeOrigin::Hand,
@@ -3353,10 +3373,11 @@ mod tests {
             },
             StaticMode::CantCrew,
             StaticMode::MayLookAtTopOfLibrary,
-            // CR 702.170f: nullary plot-from-library marker (Fblthp). The
-            // nonland scope rides `StaticDefinition.affected`, not the Display
-            // payload, so the bare marker round-trips cleanly here.
+            // CR 702.170a grant + CR 702.170f permission — nullary plot-from-
+            // library markers (Fblthp). Scope rides `StaticDefinition.affected`,
+            // not the Display payload, so the bare markers round-trip cleanly.
             StaticMode::TopOfLibraryHasPlot,
+            StaticMode::TopOfLibraryPlotPermission,
             StaticMode::MayLookAtFaceDown,
             StaticMode::CantBeTurnedFaceUp,
             // Tier 3: parser-produced statics


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary
Implements **plot from the top of your library** — a static permission letting a player plot the top card of their library (CR 702.170f), exiled **face-up** and cast on a later turn for its plot cost. Enables **Fblthp, Lost on the Range**.

Three commits:
- `feat(parser)`: recognize plot-from-library statics (`StaticMode::TopOfLibraryHasPlot`) — L3 *"the top card of your library has plot. the plot cost is equal to its mana cost"* + L4 *"you may plot nonland cards from the top of your library"*.
- `refactor(engine)`: extract `build_plot_activation(plot_cost, activation_zone, exile_zone)` single-authority plot builder so hand-plot and library-plot share one construction path.
- `feat(engine)`: plot-from-library runtime + coverage flip.

## Runtime (CR 702.170)
- `top_of_library_plot_source` authorizes; `runtime_granted_top_of_library_plot_abilities` synthesizes the plot special action on the top card; offered as `ActivateAbility` (no new `GameAction`). Reuses the existing `Plotted` later-cast lifecycle (CR 702.170d — can't cast the turn it was plotted).
- Exiled **face-up** — CR 702.170 has no face-down clause (contrast Foretell, CR 116.2h, which exiles face-down).
- Plot cost = the top card's full mana cost incl. colored pips, computed live at synthesis.
- Frontend exposure: `MayLookAtTopOfLibrary` now surfaces the viewer's own (or controlled-turn) library top in `filter_state_for_viewer` (CR 701.20e — "look at" is shown only to the specified player). This fixed a pre-existing **class-wide** redaction gap (Vizier of the Menagerie too). Engine-authoritative, never client-side.

## Coverage (honest flip, coupled to the runtime)
Fblthp RED→GREEN; `supported_cards` 31116→31117 (Δ+1 = exactly Fblthp — the sole card with this static across 35,396). 0 regressions.

## Tests
8 end-to-end tests through the real `legal_actions`/activation pipeline — offer gating (own empty main only, top-card-only, nonland-only, authorizer-leaves), cast-family disjointness (the plot authorizer is provably distinct from the `TopOfLibraryCastPermission` family), face-up execute + same-turn-blocked/later-turn-allowed, colored-pip cost, viewer-only exposure — plus a swallow-check test. Revert-probes for face-up / static-gone / colored-pip / same-turn-gate.

## CR annotations
702.170 / 170a / 170d / 170f, 116.2k / 116.2h, 701.20e, 601.2a / 601.2b, 400.2 — all grep-verified against `docs/MagicCompRules.txt`.

## Notes
Reviewed via a 4-lens adversarial pass (visibility/redaction leak · runtime + cast-family disjointness · CR fidelity · coverage honesty); two comment-only refinements applied — re-attributing the nonland scope to Fblthp's printed L4 text (CR 702.170f imposes no land clause; it covers only the exile-from-a-zone-other-than-hand semantics), and documenting that the cross-static AND-intersection is a deliberate single-card simplification (two independent plot-from-top sources should UNION per CR 702.170f — dormant, revisit when a second such card prints).
