### PR TITLE
fix(parser): UNSUPPORTED one-off: The Master, Formed Anew

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2787,6 +2787,71 @@ mod tests {
         );
     }
 
+    /// CR 400.1 + CR 122.1: The Master, Formed Anew — the copy source is "a
+    /// creature card in exile with a takeover counter on it". `find_copy_targets`
+    /// must scan EXILE (per `InZone { Exile }`) and honor the takeover-counter
+    /// `FilterProp::Counters` predicate, returning only the marked exile card and
+    /// excluding an unmarked exile creature (and the battlefield entirely). This
+    /// is the runtime proof that the parsed source filter selects correctly.
+    #[test]
+    fn find_copy_targets_honors_exile_zone_and_takeover_counter_predicate() {
+        use crate::types::ability::{Comparator, FilterProp, TypeFilter, TypedFilter};
+        use crate::types::counter::CounterMatch;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+
+        let make_creature = |state: &mut GameState, card: u64, zone: Zone| {
+            let id = create_object(
+                state,
+                CardId(card),
+                PlayerId(0),
+                format!("Bear {card}"),
+                zone,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.base_card_types.core_types = vec![CoreType::Creature];
+            obj.card_types.core_types = vec![CoreType::Creature];
+            id
+        };
+
+        let marked_exile = make_creature(&mut state, 1, Zone::Exile);
+        state
+            .objects
+            .get_mut(&marked_exile)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("takeover".to_string()), 1);
+        let unmarked_exile = make_creature(&mut state, 2, Zone::Exile);
+        let bf_creature = make_creature(&mut state, 3, Zone::Battlefield);
+        let source = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "The Master".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Filter: "a creature card in exile with a takeover counter on it"
+        let filter = TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature).properties(vec![
+            FilterProp::InZone { zone: Zone::Exile },
+            FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Generic("takeover".to_string())),
+                comparator: Comparator::GE,
+                count: QuantityExpr::Fixed { value: 1 },
+            },
+        ]));
+
+        let targets = find_copy_targets(&state, &filter, source, PlayerId(0), None);
+        assert_eq!(
+            targets,
+            vec![marked_exile],
+            "only the takeover-marked exile creature is a legal copy source"
+        );
+        assert!(!targets.contains(&unmarked_exile));
+        assert!(!targets.contains(&bf_creature));
+    }
+
     /// 2026-05-09 audit M4 regression: the unified
     /// `post_replacement_continuation` slot dispatches a `Template` arm by
     /// resolving the AST against the supplied source — the pre-fold path

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -13028,6 +13028,62 @@ mod tests {
         assert!(matches!(def.mode, ReplacementMode::Optional { .. }));
     }
 
+    /// CR 614.1c + CR 707.9: The Master, Formed Anew — "you may have ~ enter as a
+    /// copy of a creature card in exile with a takeover counter on it." The copy
+    /// SOURCE is an exile-zoned card constrained by a takeover-counter predicate.
+    /// The full source phrase (zone clause THEN counter clause) must flow through
+    /// `parse_type_phrase` with no leftover, so the optional Moved/Battlefield
+    /// clone replacement registers and its `BecomeCopy` target filter carries both
+    /// `InZone { Exile }` and the `Counters { OfType("takeover"), GE, 1 }` source
+    /// predicate (honored at runtime by `find_copy_targets` scanning exile).
+    #[test]
+    fn the_master_enter_as_copy_of_exile_card_with_takeover_counter() {
+        let def = parse_replacement_line(
+            "You may have The Master enter as a copy of a creature card in exile with a takeover counter on it.",
+            "The Master, Formed Anew",
+        )
+        .expect("must register a clone replacement");
+
+        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert!(matches!(def.mode, ReplacementMode::Optional { .. }));
+        assert_eq!(def.destination_zone, Some(Zone::Battlefield));
+
+        let execute = def.execute.as_ref().expect("execute must be present");
+        let Effect::BecomeCopy { target, .. } = &*execute.effect else {
+            panic!(
+                "non-tapped clone must have BecomeCopy, got {:?}",
+                execute.effect
+            );
+        };
+        let TargetFilter::Typed(tf) = target else {
+            panic!("expected Typed copy-source filter, got {target:?}");
+        };
+        assert!(
+            tf.type_filters.contains(&TypeFilter::Creature),
+            "copy source must be a creature filter, got {:?}",
+            tf.type_filters
+        );
+        assert!(
+            tf.properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::InZone { zone: Zone::Exile })),
+            "copy source zone must be exile, got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Counters {
+                    counters: CounterMatch::OfType(CounterType::Generic(ct)),
+                    comparator: Comparator::GE,
+                    count: QuantityExpr::Fixed { value: 1 },
+                } if ct == "takeover"
+            )),
+            "copy source must require a takeover counter, got {:?}",
+            tf.properties
+        );
+    }
+
     #[test]
     fn mockingbird_clone_replacement_uses_typed_copy_metadata() {
         let def = parse_replacement_line(

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2537,6 +2537,17 @@ pub fn parse_type_phrase_with_ctx<'a>(
         }
     }
 
+    // CR 122.1 + CR 400.1: A counter-presence clause may TRAIL a zone clause
+    // ("a creature card in exile with a takeover counter on it" — The Master,
+    // Formed Anew). The pre-zone `parse_counter_suffix` pass above only catches
+    // counters that precede the zone; this second pass catches the
+    // zone-then-counter ordering so the full source-filter phrase is consumed and
+    // no leftover remains (a leftover that the clone-replacement guard rejects).
+    if let Some((prop, consumed)) = parse_counter_suffix(&lower[pos..]) {
+        properties.push(prop);
+        pos += consumed;
+    }
+
     let mut exclude_chosen_type = false;
     let mut exclude_owned_by_controller: Option<ControllerRef> = None;
     let remaining_not_owned = lower[pos..].trim_start();
@@ -9746,6 +9757,69 @@ mod tests {
                 }
             );
         }
+    }
+
+    /// CR 122.1 + CR 400.1: a zone clause followed by a counter-presence clause
+    /// ("creature card in exile with a takeover counter on it" — The Master,
+    /// Formed Anew). The whole source-filter phrase must be consumed (no
+    /// leftover) and both the zone (`InZone { Exile }`) and the counter
+    /// constraint (`Counters { OfType("takeover"), GE, 1 }`) must land on the
+    /// filter. Exercises the second `parse_counter_suffix` pass that runs after
+    /// the zone-suffix handling; the pre-zone pass only covers counter-then-zone.
+    #[test]
+    fn parse_type_phrase_zone_then_counter_suffix_consumes_both() {
+        let (filter, leftover) =
+            parse_type_phrase("creature card in exile with a takeover counter on it");
+        assert_eq!(
+            leftover.trim(),
+            "",
+            "whole source-filter phrase must be consumed, got leftover {leftover:?}"
+        );
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(
+            tf.properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::InZone { zone: Zone::Exile })),
+            "zone clause must lower to InZone {{ Exile }}, got {:?}",
+            tf.properties
+        );
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::Counters {
+                    counters: CounterMatch::OfType(CounterType::Generic(ct)),
+                    comparator: Comparator::GE,
+                    count: QuantityExpr::Fixed { value: 1 },
+                } if ct == "takeover"
+            )),
+            "counter clause must lower to GE-1 takeover Counters prop, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// CR 122.1: the pre-existing counter-then-zone ordering still parses — the
+    /// new post-zone pass must not regress the symmetric (pre-zone) case.
+    #[test]
+    fn parse_type_phrase_counter_then_zone_suffix_still_consumes_both() {
+        let (filter, leftover) =
+            parse_type_phrase("creature card with a takeover counter on it in exile");
+        assert_eq!(leftover.trim(), "", "got leftover {leftover:?}");
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::InZone { zone: Zone::Exile })));
+        assert!(tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::Counters {
+                counters: CounterMatch::OfType(CounterType::Generic(ct)),
+                ..
+            } if ct == "takeover"
+        )));
     }
 
     /// "that has a <type> counter on it" relative clause — must lower to the


### PR DESCRIPTION
## Summary
Fixes a parser misparse affecting 1 card(s) in the Doctor Who Commander precons.

**Root cause:** UNSUPPORTED one-off: The Master, Formed Anew

## Cards corrected
- The Master, Formed Anew

## Fix
Test minimal output to isolate schema parsing.

## Files changed
- crates/engine/src/parser/oracle_target.rs

## CR references
- CR 122.1

## Verification
- `cargo fmt --all` — pass
- `./scripts/check-parser-combinators.sh <upstream/main merge-base 4e103aabc>` — pass
- `cargo clippy -p engine --all-targets -- -D warnings` — pass
- `cargo test -p engine` — pass
- `cargo run --profile tool --features cli --bin oracle-gen -- data --filter "the master, formed anew"` — pass
Cards confirmed re-parsed correctly: The Master, Formed Anew

🤖 Generated with [Claude Code](https://claude.com/claude-code)
