### PR TITLE
fix(parser): parse Stridehangar appended Thopter token replacement

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -6164,13 +6164,12 @@ fn normalize_additional_token_descriptor(descriptor: &str) -> Option<String> {
 
 /// True when the descriptor needs a leading `"a "` before `parse_token_description`.
 /// Subtype-only specs (`"Food token"`) have no count and require an article.
-/// P/T-led specs (`"1/1 colorless Thopter …"`) also require one: without it
-/// `parse_token_count_prefix` mis-reads the leading `1` in `1/1` as a bare
-/// count and leaves `/1 …`, breaking P/T parsing (Stridehangar Automaton).
+/// P/T-led specs (`"1/1 …"`, `"10/10 …"`) also require one: without it
+/// `parse_token_count_prefix` mis-reads the leading digits before `/` as a bare
+/// count and leaves `/toughness …`, breaking P/T parsing.
 fn additional_token_descriptor_needs_leading_article(descriptor: &str) -> bool {
     let trimmed = descriptor.trim_start();
-    let bytes = trimmed.as_bytes();
-    if bytes.len() >= 2 && bytes[0].is_ascii_digit() && bytes[1] == b'/' {
+    if nom_primitives::parse_pt_value(trimmed).is_ok() {
         return true;
     }
     parse_count_expr(trimmed).is_none()
@@ -14004,7 +14003,6 @@ mod tests {
 
     /// CR 614.1a + CR 111.1: Stridehangar Automaton (#654) — artifact-token-gated
     /// "those tokens plus an additional 1/1 colorless Thopter …" replacement.
-    /// The appended spec carries explicit P/T; article injection must not run.
     #[test]
     fn parses_stridehangar_additional_thopter_token_replacement() {
         let text = "If one or more artifact tokens would be created under your control, those tokens plus an additional 1/1 colorless Thopter artifact creature token with flying are created instead.";
@@ -14035,6 +14033,25 @@ mod tests {
             "Thopter must have flying, got {:?}",
             spec.characteristics.keywords
         );
+    }
+
+    /// CR 614.1a + CR 111.1: Multi-digit P/T appended specs share the same
+    /// `"those tokens plus an additional <P/T> …"` grammar as 1/1 cards
+    /// (Stridehangar class). Article injection must recognize `10/10`, not
+    /// only single-digit power.
+    #[test]
+    fn parses_additional_token_replacement_with_multi_digit_pt_descriptor() {
+        let text = "If one or more tokens would be created under your control, those tokens plus an additional 10/10 colorless Eldrazi creature token are created instead.";
+        let def =
+            parse_replacement_line(text, "Eldrazi Spawn").expect("should parse multi-digit P/T");
+        assert_eq!(def.event, ReplacementEvent::CreateToken);
+        let spec = def
+            .additional_token_spec
+            .as_ref()
+            .expect("additional Eldrazi token spec");
+        assert_eq!(spec.characteristics.power, Some(10));
+        assert_eq!(spec.characteristics.toughness, Some(10));
+        assert_eq!(spec.characteristics.subtypes, vec!["Eldrazi".to_string()]);
     }
 
     /// CR 614.1a: The "twice that many" shape and the "those tokens plus"

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -6155,11 +6155,25 @@ fn normalize_additional_token_descriptor(descriptor: &str) -> Option<String> {
         let (_, article) = peek(opt(alt((tag::<_, _, OracleError<'_>>("a "), tag("an ")))))
             .parse(descriptor)
             .ok()?;
-        if article.is_none() {
+        if article.is_none() && additional_token_descriptor_needs_leading_article(descriptor) {
             return Some(format!("a {descriptor}"));
         }
     }
     Some(descriptor.to_string())
+}
+
+/// True when the descriptor needs a leading `"a "` before `parse_token_description`.
+/// Subtype-only specs (`"Food token"`) have no count and require an article.
+/// P/T-led specs (`"1/1 colorless Thopter …"`) also require one: without it
+/// `parse_token_count_prefix` mis-reads the leading `1` in `1/1` as a bare
+/// count and leaves `/1 …`, breaking P/T parsing (Stridehangar Automaton).
+fn additional_token_descriptor_needs_leading_article(descriptor: &str) -> bool {
+    let trimmed = descriptor.trim_start();
+    let bytes = trimmed.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_digit() && bytes[1] == b'/' {
+        return true;
+    }
+    parse_count_expr(trimmed).is_none()
 }
 
 /// CR 614.1a + CR 111.1: Parse Xorn-class subtype-gated additional-token
@@ -13986,6 +14000,41 @@ mod tests {
             .as_ref()
             .expect("additional Food token spec");
         assert_eq!(spec.characteristics.subtypes, vec!["Food".to_string()]);
+    }
+
+    /// CR 614.1a + CR 111.1: Stridehangar Automaton (#654) — artifact-token-gated
+    /// "those tokens plus an additional 1/1 colorless Thopter …" replacement.
+    /// The appended spec carries explicit P/T; article injection must not run.
+    #[test]
+    fn parses_stridehangar_additional_thopter_token_replacement() {
+        let text = "If one or more artifact tokens would be created under your control, those tokens plus an additional 1/1 colorless Thopter artifact creature token with flying are created instead.";
+        let def = parse_replacement_line(text, "Stridehangar Automaton")
+            .expect("should parse Stridehangar");
+        assert_eq!(def.event, ReplacementEvent::CreateToken);
+        assert_eq!(def.token_owner_scope, Some(ControllerRef::You));
+        assert!(
+            matches!(
+                def.condition,
+                Some(ReplacementCondition::TokenCoreTypeMatches { .. })
+            ),
+            "artifact tokens gate must be TokenCoreTypeMatches, got {:?}",
+            def.condition
+        );
+        let spec = def
+            .additional_token_spec
+            .as_ref()
+            .expect("additional Thopter token spec");
+        assert_eq!(spec.characteristics.power, Some(1));
+        assert_eq!(spec.characteristics.toughness, Some(1));
+        assert_eq!(spec.characteristics.subtypes, vec!["Thopter".to_string()]);
+        assert!(
+            spec.characteristics
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Flying)),
+            "Thopter must have flying, got {:?}",
+            spec.characteristics.keywords
+        );
     }
 
     /// CR 614.1a: The "twice that many" shape and the "those tokens plus"

--- a/crates/engine/tests/integration/issue_654_stridehangar_automaton.rs
+++ b/crates/engine/tests/integration/issue_654_stridehangar_automaton.rs
@@ -1,0 +1,97 @@
+//! GitHub issue #654 — Stridehangar Automaton must create an additional Thopter
+//! when artifact tokens would be created under your control (CR 614.1a / CR 111.1).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::card_type::CoreType;
+use engine::types::phase::Phase;
+
+const STRIDEHANGAR_REPLACEMENT: &str = "If one or more artifact tokens would be created under your control, those tokens plus an additional 1/1 colorless Thopter artifact creature token with flying are created instead.";
+const TREASURE_MAKER_ETB: &str = "When this creature enters, create a Treasure token.";
+const SQUIRREL_MAKER_ETB: &str =
+    "When this creature enters, create a 1/1 green Squirrel creature token.";
+
+fn tokens_with_subtype(runner: &engine::game::scenario::GameRunner, subtype: &str) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|o| o.is_token && o.card_types.subtypes.iter().any(|s| s == subtype))
+        })
+        .count()
+}
+
+fn artifact_tokens(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner.state().objects.get(id).is_some_and(|o| {
+                o.is_token && o.card_types.core_types.contains(&CoreType::Artifact)
+            })
+        })
+        .count()
+}
+
+#[test]
+fn stridehangar_adds_thopter_when_artifact_token_would_be_created() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_creature_from_oracle(P0, "Stridehangar Automaton", 3, 3, STRIDEHANGAR_REPLACEMENT);
+    let treasure_maker = scenario
+        .add_creature_to_hand_from_oracle(P0, "Treasure Maker", 1, 1, TREASURE_MAKER_ETB)
+        .with_mana_cost(engine::types::mana::ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    assert_eq!(artifact_tokens(&runner), 0);
+
+    runner.cast(treasure_maker).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        tokens_with_subtype(&runner, "Treasure"),
+        1,
+        "ETB must create the primary Treasure token"
+    );
+    assert_eq!(
+        tokens_with_subtype(&runner, "Thopter"),
+        1,
+        "Stridehangar replacement must append a Thopter; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        artifact_tokens(&runner),
+        2,
+        "Treasure plus appended Thopter must both be artifact tokens on the battlefield"
+    );
+}
+
+#[test]
+fn stridehangar_replacement_does_not_fire_for_non_artifact_tokens() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario.add_creature_from_oracle(P0, "Stridehangar Automaton", 3, 3, STRIDEHANGAR_REPLACEMENT);
+    let squirrel_maker = scenario
+        .add_creature_to_hand_from_oracle(P0, "Squirrel Maker", 1, 1, SQUIRREL_MAKER_ETB)
+        .with_mana_cost(engine::types::mana::ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(squirrel_maker).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(tokens_with_subtype(&runner, "Squirrel"), 1);
+    assert_eq!(
+        tokens_with_subtype(&runner, "Thopter"),
+        0,
+        "Non-artifact creature tokens must not trigger the artifact-token replacement"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -397,6 +397,7 @@ mod issue_580_solitude_evoke_prompt;
 mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_629_fractured_sanity_cycling;
+mod issue_654_stridehangar_automaton;
 mod issue_680_shalai_and_hallar_forgotten_ancient;
 mod issue_680_shalai_upkeep_move;
 mod issue_688_mind_into_matter;


### PR DESCRIPTION
## Summary

[Stridehangar Automaton](https://github.com/phase-rs/phase/issues/654) should create artifact tokens **plus** an additional 1/1 colorless Thopter artifact creature token with flying when one or more artifact tokens would be created under your control (CR 614.1a / CR 111.1). The replacement line was classified correctly but failed to parse because `normalize_additional_token_descriptor` injected a spurious leading article before P/T-prefixed specs (`"a 1/1 colorless Thopter …"`), causing `parse_token_description` to return `None` and the line to fall through as `replacement_structure` unimplemented.

## Root cause

For `"those tokens plus an additional 1/1 colorless Thopter artifact creature token with flying are created instead"`, the `"an additional "` strip left `"1/1 colorless Thopter …"`. The normalizer skipped article injection because `parse_count_expr` mis-read the leading `1` in `1/1` as a bare count — but bare `1/1 …` still breaks `parse_token_description` (count prefix consumes `1`, leaving `/1 …`). The fix prepends `"a "` for P/T-led descriptors so the count prefix consumes the article and P/T parsing sees `1/1` intact (same path as `"create a 1/1 colorless Phyrexian Mite …"`).

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/parser/oracle_replacement.rs` | `additional_token_descriptor_needs_leading_article`: prepend `"a "` for subtype-only and P/T-led appended token specs |
| `crates/engine/src/parser/oracle_replacement.rs` (tests) | `parses_stridehangar_additional_thopter_token_replacement` parser regression |
| `crates/engine/tests/integration/issue_654_stridehangar_automaton.rs` | Runtime: Treasure ETB creates Treasure + Thopter; Food ETB does not append Thopter |
| `crates/engine/tests/integration/main.rs` | Register integration module |

## Test plan

- [x] `parses_stridehangar_additional_thopter_token_replacement` — `TokenCoreTypeMatches(Artifact)` gate + `additional_token_spec` with 1/1 flying Thopter
- [x] `parses_peregrin_took_additional_food_token` — unchanged Food-token path still parses
- [x] `stridehangar_adds_thopter_when_artifact_token_would_be_created` — ETB Treasure → 1 Treasure + 1 Thopter on battlefield
- [x] `stridehangar_replacement_does_not_fire_for_non_artifact_tokens` — Squirrel creature token (non-artifact) does not append Thopter
- [ ] Manual: Stridehangar on board, create multiple artifact tokens (e.g. Treasure + Clue) — verify one Thopter per replacement event batch

## Closes

Fixes https://github.com/phase-rs/phase/issues/654
