### PR TITLE
fix(client): make scry and surveil top-card reordering reliable

### DIFF
--- a/client/src/components/modal/cardChoice/__tests__/libraryModals.test.tsx
+++ b/client/src/components/modal/cardChoice/__tests__/libraryModals.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, ObjectId } from "../../../../adapter/types.ts";
+import { ScryModal } from "../libraryModals.tsx";
+
+const dispatchMock = vi.fn();
+const gameStoreMock = vi.hoisted(() => ({
+  state: { gameState: null as { objects: Record<number, GameObject> } | null },
+}));
+
+vi.mock("../../../../hooks/useGameDispatch.ts", () => ({
+  useGameDispatch: () => dispatchMock,
+}));
+
+vi.mock("../../../../stores/gameStore.ts", () => ({
+  useGameStore: (selector: (state: typeof gameStoreMock.state) => unknown) =>
+    selector(gameStoreMock.state),
+}));
+
+vi.mock("framer-motion", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("framer-motion")>();
+  return {
+    ...actual,
+    Reorder: {
+      Group: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+      Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    },
+  };
+});
+
+vi.mock("../../../card/CardImage.tsx", () => ({
+  CardImage: ({ cardName }: { cardName: string }) => <div>{cardName}</div>,
+}));
+
+function card(id: ObjectId, name: string): GameObject {
+  return {
+    id,
+    name,
+    transformed: false,
+    back_face: null,
+    printed_ref: null,
+    is_emblem: false,
+    emblem_source: null,
+    display_source: "Card",
+    zone: "Library",
+    tapped: false,
+  } as unknown as GameObject;
+}
+
+function setLibraryObjects() {
+  gameStoreMock.state.gameState = {
+    objects: {
+      1: card(1, "Island"),
+      2: card(2, "Mountain"),
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  dispatchMock.mockReset();
+  gameStoreMock.state.gameState = null;
+});
+
+describe("ScryModal", () => {
+  it("dispatches kept cards in the reordered top order", () => {
+    setLibraryObjects();
+    render(<ScryModal data={{ player: 0, cards: [1, 2] }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Island: Move later" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [2, 1] },
+    });
+  });
+
+  it("omits cards moved to the bottom while preserving kept top order", () => {
+    setLibraryObjects();
+    render(<ScryModal data={{ player: 0, cards: [1, 2] }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Island: Move later" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Top" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectCards",
+      data: { cards: [2] },
+    });
+  });
+});

--- a/client/src/components/modal/cardChoice/libraryModals.tsx
+++ b/client/src/components/modal/cardChoice/libraryModals.tsx
@@ -35,12 +35,25 @@ export function ReorderableTopChoice({
   reorderHint: string;
   keepTone: "emerald" | "blue";
 }) {
+  const { t } = useTranslation("game");
   const dispatch = useGameDispatch();
   const objects = useGameStore((s) => s.gameState?.objects);
   const hoverProps = useInspectHoverProps();
   const [order, setOrder] = useState<ObjectId[]>(cards);
   const [restSet, setRestSet] = useState<Set<ObjectId>>(new Set());
   const scrollRef = useHorizontalScroll<HTMLDivElement>({ drag: false });
+
+  const moveCard = useCallback((id: ObjectId, direction: -1 | 1) => {
+    setOrder((prev) => {
+      const index = prev.indexOf(id);
+      const nextIndex = index + direction;
+      if (index < 0 || nextIndex < 0 || nextIndex >= prev.length) return prev;
+
+      const next = [...prev];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+  }, []);
 
   const toggleRest = useCallback((id: ObjectId) => {
     setRestSet((prev) => {
@@ -89,49 +102,70 @@ export function ReorderableTopChoice({
           layoutScroll
           className="mx-auto flex w-max items-center gap-2 px-1 py-2 lg:gap-3"
         >
-          {order.map((id) => {
-          const obj = objects[id];
-          if (!obj) return null;
-          const isRest = restSet.has(id);
-          const position = keepOrder.indexOf(id) + 1;
-          return (
-            <Reorder.Item
-              key={id}
-              as="div"
-              value={id}
-              className="relative flex shrink-0 cursor-grab flex-col items-center gap-2 active:cursor-grabbing"
-              whileDrag={{ scale: 1.05, zIndex: 20 }}
-            >
-              <div
-                className={`relative rounded-lg ring-2 transition ${
-                  isRest ? "opacity-50 ring-red-400/70" : keepRing
-                }`}
-                {...hoverProps(id)}
+          {order.map((id, index) => {
+            const obj = objects[id];
+            if (!obj) return null;
+            const isRest = restSet.has(id);
+            const position = keepOrder.indexOf(id) + 1;
+            return (
+              <Reorder.Item
+                key={id}
+                as="div"
+                value={id}
+                className="relative flex shrink-0 cursor-grab flex-col items-center gap-2 active:cursor-grabbing"
+                whileDrag={{ scale: 1.05, zIndex: 20 }}
               >
-                <CardImage
-                  {...objectImageProps(obj)}
-                  size="normal"
-                  className={CHOICE_CARD_IMAGE_CLASS}
-                />
-                {!isRest && (
-                  <div
-                    className={`pointer-events-none absolute left-1 top-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold text-white ${keepBadge}`}
+                <div
+                  className={`relative rounded-lg ring-2 transition ${
+                    isRest ? "opacity-50 ring-red-400/70" : keepRing
+                  }`}
+                  {...hoverProps(id)}
+                >
+                  <CardImage
+                    {...objectImageProps(obj)}
+                    size="normal"
+                    className={CHOICE_CARD_IMAGE_CLASS}
+                  />
+                  {!isRest && (
+                    <div
+                      className={`pointer-events-none absolute left-1 top-1 flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold text-white ${keepBadge}`}
+                    >
+                      {position}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center justify-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => moveCard(id, -1)}
+                    disabled={index === 0}
+                    aria-label={`${obj.name}: ${t("cardChoice.buttons.moveEarlier")}`}
+                    className="rounded-full bg-slate-700/80 px-2 py-1 text-xs font-bold text-white transition hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-30"
                   >
-                    {position}
-                  </div>
-                )}
-              </div>
-              <button
-                onClick={() => toggleRest(id)}
-                className={`rounded-full px-3 py-1 text-xs font-bold text-white transition ${
-                  isRest ? "bg-red-500/80" : keepBtn
-                }`}
-              >
-                {isRest ? restLabel : keepLabel}
-              </button>
-            </Reorder.Item>
-          );
-        })}
+                    &lt;
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => toggleRest(id)}
+                    className={`rounded-full px-3 py-1 text-xs font-bold text-white transition ${
+                      isRest ? "bg-red-500/80" : keepBtn
+                    }`}
+                  >
+                    {isRest ? restLabel : keepLabel}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => moveCard(id, 1)}
+                    disabled={index === order.length - 1}
+                    aria-label={`${obj.name}: ${t("cardChoice.buttons.moveLater")}`}
+                    className="rounded-full bg-slate-700/80 px-2 py-1 text-xs font-bold text-white transition hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-30"
+                  >
+                    &gt;
+                  </button>
+                </div>
+              </Reorder.Item>
+            );
+          })}
         </Reorder.Group>
       </div>
       <p className="mt-1 shrink-0 text-center text-xs text-slate-400">{reorderHint}</p>

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Exil ({{selected}}/{{count}})",
       "discardCount": "Abwerfen ({{selected}}/{{count}})",
       "collectCount": "Sammeln ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Nach vorne bewegen",
+      "moveLater": "Nach hinten bewegen"
     },
     "ringBearer": {
       "title": "Ringträger wählen",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Zum Umsortieren ziehen · die oberste Karte wird zuerst gezogen",
+    "reorderHint": "Zum Umsortieren ziehen oder Pfeile verwenden · die oberste Karte wird zuerst gezogen",
     "scry": {
       "title": "Hellsicht",
       "subtitle_one": "Sieh dir die oberste {{count}} Karte deiner Bibliothek an",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1191,7 +1191,9 @@
       "exileCount": "Exile ({{selected}}/{{count}})",
       "discardCount": "Discard ({{selected}}/{{count}})",
       "collectCount": "Collect ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Move earlier",
+      "moveLater": "Move later"
     },
     "ringBearer": {
       "title": "Choose Ring-bearer",
@@ -1203,7 +1205,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Drag to reorder · the top card is drawn first",
+    "reorderHint": "Drag or use arrows to reorder · the top card is drawn first",
     "scry": {
       "title": "Scry",
       "subtitle_one": "Look at the top {{count}} card of your library",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Exiliar ({{selected}}/{{count}})",
       "discardCount": "Descartar ({{selected}}/{{count}})",
       "collectCount": "Recolectar ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Mover antes",
+      "moveLater": "Mover después"
     },
     "ringBearer": {
       "title": "Elegir Portador del Anillo",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Arrastra para reordenar · la primera carta se roba antes",
+    "reorderHint": "Arrastra o usa las flechas para reordenar · la primera carta se roba antes",
     "scry": {
       "title": "Adivinar",
       "subtitle_one": "Mira la {{count}} carta superior de tu biblioteca",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Exiler ({{selected}}/{{count}})",
       "discardCount": "Défausser ({{selected}}/{{count}})",
       "collectCount": "Collecter ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Déplacer plus tôt",
+      "moveLater": "Déplacer plus tard"
     },
     "ringBearer": {
       "title": "Choisir le porteur de l'Anneau",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Glissez pour réorganiser · la première carte est piochée en premier",
+    "reorderHint": "Glissez ou utilisez les flèches pour réorganiser · la première carte est piochée en premier",
     "scry": {
       "title": "Cartomancie",
       "subtitle_one": "Regardez la {{count}} carte du dessus de votre bibliothèque",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Esilia ({{selected}}/{{count}})",
       "discardCount": "Scarta ({{selected}}/{{count}})",
       "collectCount": "Raccogli ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Sposta prima",
+      "moveLater": "Sposta dopo"
     },
     "ringBearer": {
       "title": "Scegli il Portatore dell'Anello",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Trascina per riordinare · la prima carta è pescata per prima",
+    "reorderHint": "Trascina o usa le frecce per riordinare · la prima carta è pescata per prima",
     "scry": {
       "title": "Profetizzare",
       "subtitle_one": "Guarda la prima {{count}} carta del tuo grimorio",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Wygnaj ({{selected}}/{{count}})",
       "discardCount": "Odrzuć ({{selected}}/{{count}})",
       "collectCount": "Zbierz ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Przesuń wcześniej",
+      "moveLater": "Przesuń później"
     },
     "ringBearer": {
       "title": "Wybierz Nosiciela Pierścienia",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Przeciągnij, aby zmienić kolejność · karta na wierzchu jest dobierana pierwsza",
+    "reorderHint": "Przeciągnij lub użyj strzałek, aby zmienić kolejność · karta na wierzchu jest dobierana pierwsza",
     "scry": {
       "title": "Scry",
       "subtitle_one": "Spójrz na {{count}} kartę z wierzchu swojej biblioteki",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1154,7 +1154,9 @@
       "exileCount": "Exilar ({{selected}}/{{count}})",
       "discardCount": "Descartar ({{selected}}/{{count}})",
       "collectCount": "Coletar ({{total}}/{{minimum}})",
-      "labelCount": "{{label}} ({{selected}}/{{count}})"
+      "labelCount": "{{label}} ({{selected}}/{{count}})",
+      "moveEarlier": "Mover antes",
+      "moveLater": "Mover depois"
     },
     "ringBearer": {
       "title": "Escolher Portador do Anel",
@@ -1166,7 +1168,7 @@
       "labelRummage": "Discard & draw",
       "labelSkip": "Skip"
     },
-    "reorderHint": "Arraste para reordenar · a primeira carta é comprada primeiro",
+    "reorderHint": "Arraste ou use as setas para reordenar · a primeira carta é comprada primeiro",
     "scry": {
       "title": "Vidência",
       "subtitle_one": "Olhe a {{count}} carta do topo de seu grimório",


### PR DESCRIPTION
## Summary

Closes #684

The scry/surveil modal now keeps drag reorder support, separates the scroll container from the drag group, and adds explicit arrow reorder controls so players can reliably change kept-on-top order before confirming. The submitted `SelectCards` payload remains the engine-owned contract: ordered kept-on-top cards only; scry bottom / surveil graveyard cards are derived by the engine from the unkept looked-at cards.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan -> review-plan -> implement -> review-impl -> commit)
- [x] **Not** `/engine-implementer` - explain why below

If you did **not** use `/engine-implementer`, state why:

> Frontend-only change. No `crates/engine/` parser, resolver, targeting, or rules logic was changed.

## CR references

None. Existing engine scry/surveil ordering behavior already follows CR 701.22a / CR 701.25a; this PR only fixes the frontend interaction used to submit that order.

## Visual evidence

Captured from a temporary Vite visual harness that imports this PR's actual `ReorderableTopChoice` component and mocks only the game store, dispatch hook, hover hook, and card images. The recording clicks the new arrow controls, toggles a card to Bottom, confirms, and shows the dispatched `SelectCards` payload.

- [Recording: reorder -> bottom toggle -> confirm](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-reorder-flow.webm)
- [Desktop initial state](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-initial.png)
- [Desktop after arrow reorder](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-reordered.png)
- [Desktop after confirm, dispatch payload visible](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-confirmed.png)
- [Mobile viewport after arrow reorder](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-mobile.png)

![Desktop after confirm, dispatch payload visible](https://gist.githubusercontent.com/Crystora/fc21088699215f225866da294d9cf671/raw/pr-4589-confirmed.png)

## Verification

Fresh local verification on 2026-07-02:

- `corepack pnpm --dir client install --frozen-lockfile` passed
- `corepack pnpm --dir client exec vitest run src/components/modal/cardChoice/__tests__/libraryModals.test.tsx` passed: 1 file, 2 tests
- `PATH=/tmp/corepack-bin:$PATH pnpm --dir client run type-check` passed
- `corepack pnpm --dir client lint` passed: 0 errors, existing warnings only
- `PATH=/tmp/phase-tools:/tmp/corepack-bin:$PATH pnpm --dir client test -- --run` passed: 192 files passed, 4 skipped; 1695 tests passed, 18 todo
- Browser visual capture passed with Playwright Chromium using the temporary PR harness described above

Environment notes: this container had no global `pnpm` shim and no system `jq`; verification used Corepack shims under `/tmp/corepack-bin` and a temporary `jq` binary under `/tmp/phase-tools`. The browser capture also needed temporary NSS/NSPR/ALSA libraries extracted under `/tmp/phase-browser-libs` because the container lacks those shared libraries. No PR files were changed for those environment workarounds.