### PR TITLE
feat(engine): Heroic Defiance — gate +3/+3 on most-common-color among permanents

### DIFF
--- a/crates/engine/src/game/conditions.rs
+++ b/crates/engine/src/game/conditions.rs
@@ -177,6 +177,39 @@ pub(crate) fn eval_source_has_dealt_damage(state: &GameState, source_id: ObjectI
     state.objects_that_dealt_damage.contains(&source_id)
 }
 
+/// CR 105.2 + CR 611.3a: True when the source permanent shares a color with the
+/// most common color among all battlefield permanents — counting every color
+/// tied for most common. Backs
+/// `StaticCondition::SharesColorWithMostCommonColorAmongPermanents` (Heroic
+/// Defiance, whose static gate wraps it in `Not` for the "unless" clause).
+pub(crate) fn eval_shares_color_with_most_common_color(
+    state: &GameState,
+    source_id: ObjectId,
+) -> bool {
+    use crate::types::mana::ManaColor;
+    use std::collections::HashMap;
+
+    // CR 105.2a: only the five colors count; the histogram is over every colored
+    // battlefield permanent (the source itself included).
+    let mut counts: HashMap<ManaColor, usize> = HashMap::new();
+    for &id in crate::game::targeting::zone_object_ids(state, Zone::Battlefield).iter() {
+        if let Some(obj) = state.objects.get(&id) {
+            for color in &obj.color {
+                *counts.entry(*color).or_insert(0) += 1;
+            }
+        }
+    }
+    let Some(&max) = counts.values().max() else {
+        return false; // no colored permanent — there is no "most common color"
+    };
+    // A source color is most-common (or tied) iff its board-wide count equals the
+    // maximum; sharing any such color satisfies the predicate.
+    state
+        .objects
+        .get(&source_id)
+        .is_some_and(|source| source.color.iter().any(|c| counts.get(c) == Some(&max)))
+}
+
 /// CR 301.5 + CR 303.4: True when the source object is attached to a creature
 /// controlled by `controller`. Returns false when the source has no host, when
 /// the host is a player (Curse-style Aura), or when the host is not a creature
@@ -253,5 +286,44 @@ mod tests {
 
         assert!(eval_source_is_tapped_on_battlefield(&state, id));
         assert!(eval_source_is_tapped(&state, id));
+    }
+
+    /// CR 105.2 + CR 611.3a (Heroic Defiance): the most-common-color predicate is
+    /// true only when a source color's board-wide count equals the maximum, and a
+    /// color tied for most common still counts.
+    #[test]
+    fn shares_most_common_color_handles_majority_and_ties() {
+        use crate::types::mana::ManaColor;
+
+        let mut state = GameState::new_two_player(42);
+        let mk = |state: &mut GameState, cid: u64, colors: Vec<ManaColor>| {
+            let id = create_object(
+                &mut *state,
+                CardId(cid),
+                PlayerId(0),
+                "P".to_string(),
+                Zone::Battlefield,
+            );
+            state.objects.get_mut(&id).unwrap().color = colors;
+            id
+        };
+
+        let white = mk(&mut state, 1, vec![ManaColor::White]);
+        mk(&mut state, 2, vec![ManaColor::White]);
+        let red = mk(&mut state, 3, vec![ManaColor::Red]);
+
+        // White is strictly most common (2 vs 1): a white source shares it; a
+        // red-only source does not.
+        assert!(eval_shares_color_with_most_common_color(&state, white));
+        assert!(!eval_shares_color_with_most_common_color(&state, red));
+
+        // Add a second red → White 2 / Red 2. CR 611.3a counts every tied color,
+        // so the red source now shares a most-common color.
+        mk(&mut state, 4, vec![ManaColor::Red]);
+        assert!(eval_shares_color_with_most_common_color(&state, red));
+
+        // A colorless source never shares a color, even at a tie.
+        let colorless = mk(&mut state, 5, vec![]);
+        assert!(!eval_shares_color_with_most_common_color(&state, colorless));
     }
 }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3559,6 +3559,9 @@ fn fmt_static_condition(cond: &StaticCondition) -> String {
         SC::UnlessPay { .. } => "unless a cost is paid".into(),
         SC::Unrecognized { .. } => "unrecognized".into(),
         SC::DuringYourTurn => "during your turn".into(),
+        SC::SharesColorWithMostCommonColorAmongPermanents => {
+            "shares a color with the most common color among all permanents".into()
+        }
         SC::SourceEnteredThisTurn => "source entered this turn".into(),
         SC::SourceHasDealtDamage => "source has dealt damage".into(),
         SC::WasCast { zone } => match zone {
@@ -6581,6 +6584,9 @@ fn static_condition_feature(cond: &StaticCondition) -> (&'static str, FeatureSup
         StaticCondition::ClassLevelGE { .. } => ("ClassLevelGE", Handled),
         StaticCondition::DuringYourTurn => ("DuringYourTurn", Handled),
         StaticCondition::DayNightIs { .. } => ("DayNightIs", Handled),
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => {
+            ("SharesColorWithMostCommonColorAmongPermanents", Handled)
+        }
         StaticCondition::SourceEnteredThisTurn => ("SourceEnteredThisTurn", Handled),
         StaticCondition::SourceHasDealtDamage => ("SourceHasDealtDamage", Handled),
         StaticCondition::WasCast { .. } => ("WasCast", Handled),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -666,6 +666,12 @@ fn condition_uses_recipient_context(condition: &StaticCondition) -> bool {
         StaticCondition::Not { condition } => condition_uses_recipient_context(condition),
         StaticCondition::RecipientHasCounters { .. } => true,
         StaticCondition::RecipientMatchesFilter { .. } => true,
+        // CR 105.2 + CR 611.3a: "Enchanted creature gets +3/+3 unless IT shares a
+        // color…" — the color check is on the recipient (the enchanted creature),
+        // not the Aura source, so it must route through the recipient-eval path.
+        // Like `RecipientAttackingOwnerTarget`, the `Not` wrapper above recurses,
+        // so the positive inner condition is what reports `true` here.
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => true,
         // CR 509.1b + CR 506.2: the attacking creature (recipient) is the subject
         // of the owner-attack check, so this MUST route through the recipient-eval
         // path. The `Not` wrapper above already recurses, so the positive inner
@@ -1110,9 +1116,11 @@ fn evaluate_condition_with_context(
         StaticCondition::SpellCastWithVariantThisTurn { variant } => {
             crate::game::restrictions::spell_cast_with_variant_this_turn(state, variant)
         }
-        // CR 400.7: True when the source permanent entered the battlefield this turn.
+        // CR 105.2 + CR 611.3a: the subject is the recipient (the enchanted
+        // creature, "it"), not the Aura source; fall back to the source only when
+        // evaluated without a recipient (the source gate defers to per-recipient).
         StaticCondition::SharesColorWithMostCommonColorAmongPermanents => {
-            eval_shares_color_with_most_common_color(state, source_id)
+            eval_shares_color_with_most_common_color(state, recipient_id.unwrap_or(source_id))
         }
         StaticCondition::SourceEnteredThisTurn => eval_source_entered_this_turn(state, source_id),
         // CR 120.3 + CR 120.6 + CR 702.11b: True once the source has actually dealt

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -6,8 +6,9 @@ use crate::game::arithmetic::saturating_pt_add;
 use crate::game::conditions::{
     counter_condition_matches, eval_chosen_label_is, eval_class_level_ge, eval_has_city_blessing,
     eval_is_initiative, eval_is_monarch, eval_no_monarch, eval_recipient_attacking_owner_target,
-    eval_source_entered_this_turn, eval_source_has_dealt_damage, eval_source_in_zone,
-    eval_source_is_attacking, eval_source_is_tapped_on_battlefield,
+    eval_shares_color_with_most_common_color, eval_source_entered_this_turn,
+    eval_source_has_dealt_damage, eval_source_in_zone, eval_source_is_attacking,
+    eval_source_is_tapped_on_battlefield,
 };
 use crate::game::devotion::count_devotion;
 use crate::game::filter::{matches_target_filter, FilterContext};
@@ -718,6 +719,8 @@ fn static_condition_uses_object_population(condition: &StaticCondition) -> bool 
         // Devotion is a sum of mana symbols across permanents you control — pure
         // board composition.
         StaticCondition::DevotionGE { .. } => true,
+        // Reads the color histogram over every battlefield permanent.
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => true,
         // "you control [filter]" / "a [filter] is on the battlefield" — membership
         // is battlefield population. `IsPresent` has no zone field (always a
         // battlefield-presence check), so it is unconditionally population
@@ -856,6 +859,8 @@ fn entered_object_perturbs_static_condition(
         // Commander presence — conservatively perturb (a commander entering can
         // flip it; not worth a precise commander membership test here).
         StaticCondition::ControlsCommander { .. } => true,
+        // A colored permanent entering can shift the most-common-color histogram.
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => true,
         StaticCondition::And { conditions } | StaticCondition::Or { conditions } => conditions
             .iter()
             .any(|c| entered_object_perturbs_static_condition(state, entered_id, ctx, c)),
@@ -1106,6 +1111,9 @@ fn evaluate_condition_with_context(
             crate::game::restrictions::spell_cast_with_variant_this_turn(state, variant)
         }
         // CR 400.7: True when the source permanent entered the battlefield this turn.
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => {
+            eval_shares_color_with_most_common_color(state, source_id)
+        }
         StaticCondition::SourceEnteredThisTurn => eval_source_entered_this_turn(state, source_id),
         // CR 120.3 + CR 120.6 + CR 702.11b: True once the source has actually dealt
         // damage since entering the battlefield (sticky). The "hasn't dealt damage

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -510,6 +510,7 @@ pub(crate) fn static_condition_uses_unspent_mana(condition: &StaticCondition) ->
         }
         StaticCondition::Not { condition } => static_condition_uses_unspent_mana(condition),
         StaticCondition::DevotionGE { .. }
+        | StaticCondition::SharesColorWithMostCommonColorAmongPermanents
         | StaticCondition::IsPresent { .. }
         | StaticCondition::ChosenColorIs { .. }
         | StaticCondition::ChosenLabelIs { .. }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -3265,6 +3265,7 @@ pub(crate) fn static_condition_to_ability_condition(
         StaticCondition::DayNightIs { state } => {
             Some(AbilityCondition::DayNightIs { state: *state })
         }
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => None,
         StaticCondition::SourceEnteredThisTurn => None,
         StaticCondition::WasCast { .. } => None,
         StaticCondition::IsPresent { filter } => {

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -787,7 +787,16 @@ pub(crate) fn parse_enchanted_equipped_predicate(
     // is NEVER split. ---
     {
         let mut defs = Vec::new();
-        if let Some(def) = parse_continuous_gets_has(predicate, affected.clone(), description) {
+        // CR 611.3a: parse the grant from the unless/as-long-as-stripped body and
+        // attach any trailing `suffix_condition` (Heroic Defiance: "gets +3/+3
+        // unless it shares a color with the most common color among all
+        // permanents"), rather than parsing the whole predicate and dropping it.
+        if let Some(mut def) =
+            parse_continuous_gets_has(body_tp.original, affected.clone(), description)
+        {
+            if let Some(condition) = &suffix_condition {
+                def.condition = Some(condition.clone());
+            }
             defs.push(def);
         }
         // CR 509.1c: "<grant> and must be blocked by <filter> if able"

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -683,7 +683,17 @@ pub(crate) fn parse_enchanted_equipped_predicate(
     }
 
     // CR 509.1b: "can't be blocked" on enchanted/equipped creature
-    let (body_tp, suffix_condition) = if let Some((body_tp, _)) = pred_tp.split_around(" unless ") {
+    //
+    // Only peel a trailing static-grant " unless " rider (Heroic Defiance:
+    // "gets +3/+3 unless it shares a color…") when the split point sits OUTSIDE a
+    // quoted/granted ability. A granted ability's own inner "unless" (e.g. Sunken
+    // Field's "Counter target spell unless its controller pays {1}") must stay
+    // with the quoted text — the body has balanced double quotes iff the split is
+    // outside any "...".
+    let unless_split = pred_tp
+        .split_around(" unless ")
+        .filter(|(body, _)| body.original.chars().filter(|&c| c == '"').count() % 2 == 0);
+    let (body_tp, suffix_condition) = if let Some((body_tp, _)) = unless_split {
         (
             body_tp,
             super::shared::parse_unless_static_condition(&pred_tp),

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1516,6 +1516,12 @@ pub(crate) fn parse_static_condition(text: &str) -> Option<StaticCondition> {
         return Some(condition);
     }
 
+    // "it shares a color with the most common color among all permanents
+    // [or a color tied for most common]" (Heroic Defiance)
+    if let Some(condition) = parse_shares_most_common_color_condition(tp.lower) {
+        return Some(condition);
+    }
+
     // "the chosen color is [color]"
     if let Some(color_name) = nom_tag_lower(tp.lower, tp.lower, "the chosen color is ") {
         let trimmed = color_name.trim().trim_end_matches('.');
@@ -1741,6 +1747,15 @@ pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticC
     if let Ok((_, condition)) = nom_condition::parse_unless_condition(&lower) {
         return Some(condition);
     }
+    // CR 611.3a: "gets +X/+X unless <condition>" applies the grant precisely when
+    // <condition> is false — fall back to the shared static-condition parser and
+    // negate, so a recognized inner condition (e.g. Heroic Defiance's most-common-
+    // color check) gates the grant instead of being swallowed as Unrecognized.
+    if let Some(condition) = parse_static_condition(original) {
+        return Some(StaticCondition::Not {
+            condition: Box::new(condition),
+        });
+    }
     // Preserve the Oracle unless rider in the AST so swallow/coverage see a
     // `condition` slot even when the inner clause is not yet decomposed.
     Some(StaticCondition::Not {
@@ -1917,6 +1932,28 @@ pub(crate) fn parse_color_list(text: &str) -> Option<Vec<crate::types::mana::Man
     }
 
     None
+}
+
+/// CR 105.2 + CR 611.3a: "it shares a color with the most common color among all
+/// permanents[ or a color tied for most common]" (Heroic Defiance) →
+/// `SharesColorWithMostCommonColorAmongPermanents`. The optional "or a color tied
+/// for most common" tail is redundant — the runtime predicate already treats
+/// every color at the maximum count as most-common — so both phrasings map to the
+/// same condition.
+pub(crate) fn parse_shares_most_common_color_condition(lower: &str) -> Option<StaticCondition> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>(
+        "it shares a color with the most common color among all permanents",
+    )
+    .parse(lower)
+    .ok()?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(
+        " or a color tied for most common",
+    ))
+    .parse(rest)
+    .ok()?;
+    rest.trim()
+        .is_empty()
+        .then_some(StaticCondition::SharesColorWithMostCommonColorAmongPermanents)
 }
 
 /// CR 611.3a: "[N] or more [type] are on the battlefield" → a count

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -21369,3 +21369,32 @@ fn heroic_defiance_pt_grant_gated_on_most_common_color() {
         "the +3/+3 must be gated on Not(shares-most-common-color)"
     );
 }
+
+/// CR 509.1b (#4590 review): a granted ability's OWN inner "unless" must stay
+/// inside the quoted ability — the attached-subject grant parser must not lift it
+/// onto the static grant as a condition. Coral Net grants a triggered ability
+/// whose text contains "…unless you discard a card."; the static must surface a
+/// `GrantTrigger` with no spurious `condition`.
+#[test]
+fn granted_ability_inner_unless_stays_inside_quoted_ability() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature has \"At the beginning of your upkeep, sacrifice this \
+         creature unless you discard a card.\"",
+    );
+    let grant = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::Continuous)
+        .expect("a continuous granted-ability static");
+    assert!(
+        grant
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::GrantTrigger { .. })),
+        "the granted triggered ability must survive intact, got {:?}",
+        grant.modifications
+    );
+    assert_eq!(
+        grant.condition, None,
+        "the granted ability's inner `unless` must NOT become a static-grant condition"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -21331,3 +21331,41 @@ fn draw_from_bottom_singular_opponents() {
         }
     );
 }
+
+/// CR 611.3a (Heroic Defiance): an Aura's "Enchanted creature gets +3/+3 unless
+/// <condition>" grant must parse the P/T bonus AND attach the negated condition
+/// — the grant applies precisely when the condition is false. Here the condition
+/// is the most-common-color predicate, so the gate is
+/// `Not(SharesColorWithMostCommonColorAmongPermanents)`.
+#[test]
+fn heroic_defiance_pt_grant_gated_on_most_common_color() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +3/+3 unless it shares a color with the most common \
+         color among all permanents or a color tied for most common.",
+    );
+    let grant = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::Continuous)
+        .expect("a continuous P/T grant");
+    assert!(
+        grant
+            .modifications
+            .contains(&ContinuousModification::AddPower { value: 3 }),
+        "grant must add +3 power, got {:?}",
+        grant.modifications
+    );
+    assert!(
+        grant
+            .modifications
+            .contains(&ContinuousModification::AddToughness { value: 3 }),
+        "grant must add +3 toughness, got {:?}",
+        grant.modifications
+    );
+    assert_eq!(
+        grant.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::SharesColorWithMostCommonColorAmongPermanents),
+        }),
+        "the +3/+3 must be gated on Not(shares-most-common-color)"
+    );
+}

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3019,6 +3019,7 @@ pub(crate) fn static_condition_to_trigger_condition(
             player: PlayerFilter::Controller,
         }),
         StaticCondition::DayNightIs { .. } => None,
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => None,
 
         // CR 608.2c: Quantity comparisons map 1:1 (same fields). The only
         // asymmetry is the `Another` → `OtherThanTriggerObject` substitution

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5642,6 +5642,12 @@ pub enum StaticCondition {
         text: String,
     },
     DuringYourTurn,
+    /// CR 105.2 + CR 611.3a: True when the source permanent shares a color with
+    /// the most common color among all permanents on the battlefield (including
+    /// any color tied for most common). Used by Heroic Defiance's "gets +3/+3
+    /// unless it shares a color with the most common color among all permanents
+    /// or a color tied for most common" (the static gate wraps this in `Not`).
+    SharesColorWithMostCommonColorAmongPermanents,
     /// CR 400.7: True when the source permanent entered the battlefield this turn.
     /// Used for "as long as this [permanent] entered this turn" conditional statics.
     SourceEnteredThisTurn,

--- a/crates/engine/tests/integration/heroic_defiance_recipient_color_4590.rs
+++ b/crates/engine/tests/integration/heroic_defiance_recipient_color_4590.rs
@@ -1,0 +1,81 @@
+//! CR 105.2 + CR 611.3a (#4590 review [HIGH]): Heroic Defiance gates its +3/+3
+//! on the ENCHANTED CREATURE's color ("…unless IT shares a color…"), not the
+//! Aura's. A red Aura on a lone white creature, with red the most common color,
+//! must still pump the creature (white does not share red) — proving the
+//! condition is recipient-scoped, not source-scoped. The earlier source-scoped
+//! evaluation read the Aura's color and would (wrongly) withhold the grant.
+
+use engine::game::derived::derive_display_state;
+use engine::game::effects::attach::attach_to;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+const HEROIC_DEFIANCE: &str = "Enchant creature\nEnchanted creature gets +3/+3 \
+     unless it shares a color with the most common color among all permanents or \
+     a color tied for most common.";
+
+fn power_toughness(
+    runner: &engine::game::scenario::GameRunner,
+    id: engine::types::identifiers::ObjectId,
+) -> (i32, i32) {
+    let obj = runner.state().objects.get(&id).expect("object present");
+    (obj.power.unwrap_or(0), obj.toughness.unwrap_or(0))
+}
+
+#[test]
+fn heroic_defiance_gates_on_enchanted_creature_color_not_aura() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The enchanted creature is the only WHITE permanent.
+    let creature = scenario.add_creature(P0, "Lone White", 1, 1).id();
+    // The Aura (Heroic Defiance) is RED — the most common color — so a
+    // source-scoped check would read the Aura's color and withhold the grant.
+    let aura = scenario
+        .add_creature(P0, "Heroic Defiance", 0, 0)
+        .from_oracle_text(HEROIC_DEFIANCE)
+        .as_enchantment()
+        .id();
+    // Two more red permanents make RED strictly most common (3 red vs 1 white).
+    let red1 = scenario.add_creature(P0, "Red One", 1, 1).id();
+    let red2 = scenario.add_creature(P0, "Red Two", 1, 1).id();
+
+    let mut runner = scenario.build();
+    {
+        let s = runner.state_mut();
+        s.objects.get_mut(&creature).unwrap().base_color = vec![ManaColor::White];
+        for id in [aura, red1, red2] {
+            s.objects.get_mut(&id).unwrap().base_color = vec![ManaColor::Red];
+        }
+    }
+    attach_to(runner.state_mut(), aura, creature);
+    evaluate_layers(runner.state_mut());
+    derive_display_state(runner.state_mut());
+
+    // White creature does NOT share the most-common color (red): the "unless" is
+    // false, so the grant applies, 1/1 -> 4/4. A source-scoped read of the red
+    // Aura would see it shares red and leave the creature at 1/1.
+    assert_eq!(
+        power_toughness(&runner, creature),
+        (4, 4),
+        "recipient-scoped: white creature doesn't share most-common red -> +3/+3"
+    );
+
+    // Recolor the creature RED: now it shares the most-common color, the "unless"
+    // is satisfied, and the grant is withheld — back to 1/1.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .base_color = vec![ManaColor::Red];
+    evaluate_layers(runner.state_mut());
+    derive_display_state(runner.state_mut());
+    assert_eq!(
+        power_toughness(&runner, creature),
+        (1, 1),
+        "recipient now shares most-common red -> grant withheld"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -126,6 +126,7 @@ mod halana_alena_partners_where_x;
 mod harrow_regression;
 mod heist_production_path_handoff;
 mod hellkite_tyrant_steal_artifacts_2906;
+mod heroic_defiance_recipient_color_4590;
 mod hunters_insight_combat_draw;
 mod inevitable_betrayal_no_mana_cost;
 mod integration_adventure;


### PR DESCRIPTION
## Summary
Implements Heroic Defiance: *"Enchanted creature gets +3/+3 unless it shares a color with the most common color among all permanents or a color tied for most common."*

Previously the Aura's `+3/+3` grant parsed but the `unless <condition>` rider was dropped, so the bonus applied unconditionally.

## Changes
- **New `StaticCondition::SharesColorWithMostCommonColorAmongPermanents`** + runtime evaluator (CR 105.2 + CR 611.3a): a source color is "most common" when its board-wide count equals the maximum, counting every color **tied** for the lead. The static gate wraps it in `Not` for the "unless" clause.
- **Parser**: recognize the most-common-color phrase in the shared static-condition parser, and fix the Aura `"+X/+X unless <condition>"` grant to parse from the unless-stripped body and attach the **negated** condition (the grant applies precisely when the condition is false).
- Wired the condition through the layers / coverage / quantity / trigger / effect exhaustive sites.

## Tests
- **Parser regression**: the `+3/+3` carries `Not(SharesColorWithMostCommonColorAmongPermanents)`.
- **Runtime regression**: covers a strict majority (source shares vs. a non-sharing source returns false), a **tie** (every tied color counts), and a colorless source.

## Verification
`cargo fmt`, `cargo clippy -p engine --lib`, and the parser-combinator gate are clean. `oracle_static` (917), `game::conditions` (4), and `game::layers` (189) suites pass. Oracle-gen confirms Heroic Defiance now emits `AddPower 3 / AddToughness 3` gated on `Not(shares-most-common-color)`.