### PR TITLE
fix(parser): Tamiyo flip return-transformed binds to source, not TriggeringSource (#4543)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21482,7 +21482,45 @@ pub(crate) fn parse_effect_chain_ir(
         // *named clause*, not the trigger condition. The SelfRef prior-clause
         // test is structural over the parsed clause and its nested sub-ability
         // chain — no string heuristic.
-        if typed_trigger_subject
+        //
+        // CR 712.2 (issue #4543): the typed-subject branch covers the typed
+        // members of this class (Ajani). The transform-flip-from-exile cards
+        // (Tamiyo, Inquisitive Student: "When you draw your third card in a turn,
+        // exile Tamiyo, then return her to the battlefield transformed") have a
+        // PLAYER subject, so `typed_trigger_subject` is false and the bare "her"
+        // would default to `TriggeringSource` — but the CardDrawn event has no
+        // resolvable source, so the return fizzles and the permanent is stranded
+        // in exile. Detect that specific structural class — a prior "exile ~"
+        // (ChangeZone→Exile, SelfRef) followed by a TRANSFORMED return
+        // (ChangeZone→Battlefield, `enter_transformed`) — and bind to the source
+        // there too. The `enter_transformed` requirement keeps Cecil-style
+        // "untap ~. transform it" (ParentTarget) and plain "exile ~. return it"
+        // (Aetherling) untouched.
+        // Narrowly: only the BROKEN binding (`TriggeringSource`, which the
+        // CardDrawn/player-subject event cannot resolve — Tamiyo). Cards whose
+        // return already binds correctly (`TrackedSet`/`ParentTarget` — the
+        // saga and flip-walker classes like Azusa's Many Journeys, Jace, Vryn's
+        // Prodigy) are left untouched: they are bound by their own (working)
+        // rewrites and must not be re-pointed.
+        let exile_then_return_transformed = matches!(
+            &clause.effect,
+            Effect::ChangeZone {
+                destination: Zone::Battlefield,
+                target: TargetFilter::TriggeringSource,
+                enter_transformed: true,
+                ..
+            }
+        ) && clauses.last().is_some_and(|prev| {
+            matches!(
+                &prev.parsed.effect,
+                Effect::ChangeZone {
+                    destination: Zone::Exile,
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            )
+        });
+        if (typed_trigger_subject || exile_then_return_transformed)
             && has_anaphoric_reference(&text_lower)
             && clauses
                 .last()

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -14502,6 +14502,62 @@ mod tests {
         assert!(def.execute.is_some());
     }
 
+    /// CR 608.2c + CR 712.2 (issue #4543): Tamiyo, Inquisitive Student —
+    /// "When you draw your third card in a turn, exile Tamiyo, then return her
+    /// to the battlefield transformed under her owner's control." The exile
+    /// step targets the source (`~` → SelfRef); the "return her ... transformed"
+    /// sub-clause's bare "her" must ALSO bind to the source (SelfRef), not to
+    /// `TriggeringSource`. The trigger subject is the player ("you draw …"), so
+    /// the source has no entry in the CardDrawn event — before the fix the
+    /// return resolved to an empty target set and Tamiyo was stranded in exile.
+    /// The SelfRef-anaphor rewrite was gated on a typed trigger subject; it now
+    /// fires for player/event subjects too because the antecedent is the named
+    /// prior clause.
+    #[test]
+    fn tamiyo_flip_return_transformed_binds_to_self_ref() {
+        use crate::types::ability::Effect;
+
+        let def = parse_trigger_line(
+            "When you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.",
+            "Tamiyo, Inquisitive Student",
+        );
+        let exec = def.execute.as_deref().expect("Tamiyo trigger execute body");
+        // Exile step: source named via `~`.
+        let Effect::ChangeZone {
+            destination,
+            target,
+            ..
+        } = &*exec.effect
+        else {
+            panic!("expected exile ChangeZone head, got {:?}", exec.effect);
+        };
+        assert_eq!(*destination, Zone::Exile);
+        assert_eq!(*target, TargetFilter::SelfRef);
+        // Return step: "her" must bind to the source and enter transformed.
+        let sub = exec.sub_ability.as_deref().expect("return sub_ability");
+        let Effect::ChangeZone {
+            destination,
+            target,
+            enter_transformed,
+            ..
+        } = &*sub.effect
+        else {
+            panic!("expected return ChangeZone sub, got {:?}", sub.effect);
+        };
+        assert_eq!(*destination, Zone::Battlefield);
+        assert!(
+            *enter_transformed,
+            "return must enter transformed (CR 712.2)"
+        );
+        assert_eq!(
+            *target,
+            TargetFilter::SelfRef,
+            "the 'return her transformed' anaphor must bind to the source (SelfRef), \
+             not TriggeringSource — otherwise the CardDrawn event has no source and \
+             Tamiyo is stranded in exile"
+        );
+    }
+
     /// SHAPE TEST — issue #3299: `parse_trigger_lines` must not compound-split
     /// Syr Konrad's disjunctive zone-change condition into separate triggers.
     #[test]

--- a/crates/engine/tests/tamiyo_inquisitive_student_flip.rs
+++ b/crates/engine/tests/tamiyo_inquisitive_student_flip.rs
@@ -1,0 +1,158 @@
+//! Runtime regression for GitHub issue #4543 — Tamiyo, Inquisitive Student's
+//! "draw your third card" transform-flip trigger.
+//!
+//! Front-face Oracle: "When you draw your third card in a turn, exile Tamiyo,
+//! then return her to the battlefield transformed under her owner's control."
+//!
+//! The reported bug was runtime-visible: when the controller drew their third
+//! card, Tamiyo exiled herself but never returned — she was stranded in exile.
+//! Root cause was a parser anaphor mis-binding. Clause 1 ("exile Tamiyo")
+//! correctly names the source via `~` → `SelfRef`, but clause 2's bare "her"
+//! ("return her ... transformed") bound to `TriggeringSource`. The trigger
+//! subject is the player ("you draw ..."), so the `CardDrawn` event carries no
+//! resolvable source object — `TriggeringSource` resolved to nothing and the
+//! return moved nothing. The SelfRef-anaphor rewrite that fixes this class was
+//! previously gated on a *typed* trigger subject (Ajani's "one or more Cats
+//! die"); the fix extends it to the transform-flip-from-exile class.
+//!
+//! This drives the REAL parse → draw-event → trigger → stack → zone-change
+//! pipeline: Tamiyo is synthesized from Oracle text (so the trigger reflects
+//! current parser source, not a stored/stale card-data AST), three draws are
+//! resolved through the production `draw::resolve` seam, and the third queues
+//! and resolves the trigger. The discriminating assertion is that Tamiyo is
+//! back on the battlefield — with the fix reverted she stays in exile.
+//!
+//! CR 608.2c: "read the whole text ... apply the rules of English" — the
+//! anaphor "her" binds to the named antecedent in the preceding clause.
+//! CR 712.14a: a double-faced card put onto the battlefield transformed enters
+//! with its back face up.
+//! CR 603.2: the third-draw trigger fires only on the third draw of the turn.
+
+use engine::game::effects::draw::resolve as resolve_draw;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::game::stack::resolve_top;
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+// Only the flip trigger line is needed to exercise the bug; `~` normalization
+// keys off the card name, so "exile Tamiyo" resolves to SelfRef.
+const TAMIYO: &str = "When you draw your third card in a turn, exile Tamiyo, then return her to the battlefield transformed under her owner's control.";
+
+/// Resolve one draw for P0 through the production `draw::resolve` seam, then
+/// process the resulting triggers. The third draw queues the flip trigger.
+fn draw_one(runner: &mut GameRunner) {
+    let ability = ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+        Vec::new(),
+        ObjectId(0),
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_draw(runner.state_mut(), &ability, &mut events).expect("draw resolves");
+    process_triggers(runner.state_mut(), &events);
+}
+
+#[test]
+fn tamiyo_third_draw_returns_transformed_not_stranded_in_exile() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Tamiyo on P0's battlefield, built from Oracle text through the real parse
+    // + synthesis pipeline so the (fixed) NthDrawThisTurn trigger is installed.
+    let tamiyo = scenario
+        .add_creature_from_oracle(P0, "Tamiyo, Inquisitive Student", 0, 3, TAMIYO)
+        .id();
+
+    // Seed P0's library with cards to draw.
+    for i in 0..4 {
+        scenario.add_card_to_library_top(P0, &format!("Library Card {i}"));
+    }
+
+    let mut runner = scenario.build();
+
+    // Precondition: Tamiyo is on the battlefield, front-face (not transformed).
+    {
+        let obj = runner.state().objects.get(&tamiyo).expect("Tamiyo exists");
+        assert_eq!(
+            obj.zone,
+            Zone::Battlefield,
+            "precondition: Tamiyo on battlefield"
+        );
+        assert!(!obj.transformed, "precondition: Tamiyo starts front-face");
+    }
+
+    // First draw of the turn: the third-draw trigger must NOT fire.
+    draw_one(&mut runner);
+    assert_eq!(
+        runner.state().stack.len(),
+        0,
+        "CR 603.2: the first draw must not queue the third-draw trigger"
+    );
+    assert_eq!(
+        runner.state().objects.get(&tamiyo).unwrap().zone,
+        Zone::Battlefield,
+        "after one draw Tamiyo is untouched"
+    );
+
+    // Second draw: still must NOT fire (discriminates the n=3 gate).
+    draw_one(&mut runner);
+    assert_eq!(
+        runner.state().stack.len(),
+        0,
+        "CR 603.2: the second draw must not queue the third-draw trigger"
+    );
+
+    // Third draw: the trigger fires and goes on the stack.
+    draw_one(&mut runner);
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "the third draw fires 'when you draw your third card in a turn'"
+    );
+
+    // Resolve the triggered ability — exile Tamiyo, then return her transformed.
+    let mut events = Vec::new();
+    resolve_top(runner.state_mut(), &mut events);
+
+    // The fix's payload: Tamiyo is back on the battlefield, NOT stranded in
+    // exile. With the parser fix reverted, clause 2's "her" binds to
+    // `TriggeringSource`; the player-subject `CardDrawn` event has no source, so
+    // the return moves nothing and this assertion fails (Tamiyo stays in Exile).
+    let obj = runner
+        .state()
+        .objects
+        .get(&tamiyo)
+        .expect("Tamiyo object still exists");
+    assert_eq!(
+        obj.zone,
+        Zone::Battlefield,
+        "CR 608.2c: 'return her transformed' must bind to the source (SelfRef) \
+         named by clause 1's 'exile ~' — otherwise Tamiyo is stranded in exile, \
+         got zone {:?}",
+        obj.zone
+    );
+    // The return is the same object the exile named (CR 608.2c anaphor), not a
+    // stranded husk left in exile.
+    assert_ne!(
+        obj.zone,
+        Zone::Exile,
+        "the source must not be left in exile after the return resolves"
+    );
+    // NB: this Oracle-text-synthesized Tamiyo has no printed back face, so the
+    // `enter_transformed` flip has nothing to swap to and `obj.transformed`
+    // stays false — that AST flag (ChangeZone { enter_transformed: true }) is
+    // asserted directly by the parser-shape test
+    // `tamiyo_flip_return_transformed_binds_to_self_ref` in oracle_trigger.rs.
+    // What this runtime test discriminates is the binding bug: the return moves
+    // the source back to the battlefield instead of fizzling on an unresolvable
+    // `TriggeringSource`.
+}


### PR DESCRIPTION
Closes #4543

## Problem

Tamiyo, Inquisitive Student — *"When you draw your third card in a turn,
exile Tamiyo, then return her to the battlefield transformed under her
owner's control."* — left Tamiyo permanently in exile. The exile step
worked; the "return her ... transformed" step moved nothing.

## Root cause

The exile clause correctly targets the source (`~` → `SelfRef`), but the
"return her" sub-clause's bare pronoun bound to `TriggeringSource`. The
trigger subject is the player (*"you draw …"*), so the source has no entry
in the `CardDrawn` event — `TriggeringSource` resolved to nothing and the
return `ChangeZone` had an empty target set.

The SelfRef-anaphor rewrite (CR 608.2c) that handles *"exile ~, then return
it"* was gated on a **typed** trigger subject (it covers Ajani, Nacatl
Pariah's *"Whenever one or more Cats die"* path). Tamiyo's player subject
makes that guard false, so the rewrite was skipped.

## Fix

Extend the rewrite to the transform-flip-from-exile class via a precise
structural predicate: a prior `ChangeZone → Exile` targeting `SelfRef`
followed by a **transformed** return (`ChangeZone → Battlefield` with
`enter_transformed`) binds the anaphor to the source regardless of subject
shape (CR 712.2).

The `enter_transformed` requirement deliberately scopes the change to the
flip class. It leaves untouched:
- **Cecil, Dark Knight** — *"untap ~. … transform it"* keeps `ParentTarget`.
- **Aetherling** — plain *"exile ~. return it"* keeps its existing binding.

Both were caught as regressions by the full suite when an earlier, broader
version of this fix dropped the guard outright; the structural predicate is
the corrected, minimal-blast-radius form.

## Tests

Added `tamiyo_flip_return_transformed_binds_to_self_ref`: asserts the exile
step is `ChangeZone → Exile (SelfRef)` and the return step is
`ChangeZone → Battlefield`, `enter_transformed`, target `SelfRef`.

The identical runtime AST (`exile ~ SelfRef → return SelfRef transformed`)
is already exercised end-to-end by the existing
`ajani_nacatl_pariah_returns_transformed_when_another_cat_dies` integration
test, which drives draw/trigger/resolve and asserts the card returns
transformed as a planeswalker.

## Verification

- `cargo fmt --all` — clean
- Parser combinator gate — pass
- `cargo clippy -p engine --lib` — exit 0, no warnings
- `cargo test -p engine --lib` — **14157 passed, 0 failed**
- Rebased onto latest `main`; `behind_by: 0`, auto-mergeable (no conflicts)
