### PR TITLE
fix(parser): keep another leg-local in singular X or Y disjunctions (closes #4513)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -1306,10 +1306,18 @@ pub(super) fn parse_targeted_action_ast(
                 min_count,
             });
         }
-        let (count, after_count) = super::super::oracle_util::parse_count_expr(rest).unwrap_or((
-            crate::types::ability::QuantityExpr::Fixed { value: 1 },
-            rest,
-        ));
+        // Use the exclusion-aware sibling so a source-exclusion "another"
+        // ("sacrifice another creature or land") is reported as a typed
+        // `CountWord::SourceExclusion` instead of being silently consumed as a
+        // bare count of 1. `parse_count_expr` discards the word's identity, so
+        // without this the parsed target never regains `FilterProp::Another`
+        // and the source could sacrifice itself (Morkrut Necropod, #4513).
+        let (count, after_count, count_word) =
+            super::super::oracle_util::parse_count_expr_with_exclusion(rest).unwrap_or((
+                crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                rest,
+                super::super::oracle_util::CountWord::Plain,
+            ));
         let (target_text, _) = super::strip_optional_target_prefix(after_count.trim_start());
         // Strip the "of their choice" / "of your choice" confirmation suffix —
         // CR 701.16b makes player choice the default, so the phrase is a no-op
@@ -1372,6 +1380,44 @@ pub(super) fn parse_targeted_action_ast(
         // sacrifice a non-Demon creature" must restrict the prompt to the
         // actor's permanents — sacrificing requires controlling the permanent.
         apply_actor_default(&mut target, ctx);
+        // Re-apply the source exclusion the count word stripped. The count
+        // grammar consumes "another " as a bare count of 1, discarding the
+        // exclusion, so the filter built from the remainder ("creature or land")
+        // carries no `FilterProp::Another` and would let the source sacrifice
+        // itself (Morkrut Necropod, #4513).
+        //
+        // Apply the exclusion to EVERY leg of an `Or` disjunction. "Another"
+        // means "not this source permanent"; it is required on any leg the
+        // source's type could match and is harmless (vacuous) on legs it cannot
+        // (a land is never the source creature). Marking only the first leg, or
+        // only same-type legs, leaves a self-sacrifice hole for a source that
+        // matches a non-first leg — e.g. Mukotai Soulripper, an artifact
+        // creature, in "sacrifice another creature or artifact".
+        //
+        // Single-type "sacrifice another <type>" exclusion is deliberately NOT
+        // applied here: it reduces a single-eligible mandatory sacrifice (e.g.
+        // Disciple of Bolas) to one option, routing it through the
+        // auto-sacrifice fast-path, which mis-resolves a follow-on "that
+        // creature's power" reference — a separate, pre-existing engine bug for
+        // its own fix.
+        //
+        // No CR annotation here: this is parser-grammar scoping of the word
+        // "another"; the exclusion itself is CR-annotated at the filter layer
+        // (`game/filter.rs` `FilterProp::Another`).
+        if matches!(
+            count_word,
+            super::super::oracle_util::CountWord::SourceExclusion
+        ) {
+            if let TargetFilter::Or { filters } = &mut target {
+                for leg in filters.iter_mut() {
+                    if let TargetFilter::Typed(typed) = leg {
+                        if !typed.properties.contains(&FilterProp::Another) {
+                            typed.properties.push(FilterProp::Another);
+                        }
+                    }
+                }
+            }
+        }
         return Some(TargetedImperativeAst::Sacrifice {
             target,
             count,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -34670,7 +34670,7 @@ mod snapshot_tests {
         assert_eq!(*target, TargetFilter::TriggeringSource);
     }
 
-    // CR 109.4 + CR 701.21a: Morkrut Necropod's
+    // CR 701.21a: Morkrut Necropod's
     // "Whenever ~ attacks or blocks, sacrifice another creature or land" — the
     // source-exclusion "another" must land `FilterProp::Another` on the CREATURE
     // leg only. A creature is never a land, so distributing the exclusion to the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -34337,6 +34337,59 @@ mod snapshot_tests {
         assert_eq!(*target, TargetFilter::TriggeringSource);
     }
 
+    // CR 109.4 + CR 701.21a: Morkrut Necropod's
+    // "Whenever ~ attacks or blocks, sacrifice another creature or land" — the
+    // source-exclusion "another" must land `FilterProp::Another` on the CREATURE
+    // leg only. A creature is never a land, so distributing the exclusion to the
+    // land leg is meaningless; more importantly, WITHOUT the exclusion on the
+    // creature leg the source could sacrifice ITSELF, a functional bug (#4513).
+    // Parsed end-to-end through the production trigger entry to lock in that the
+    // sacrifice imperative re-applies the exclusion the count word consumed.
+    #[test]
+    fn morkrut_necropod_sacrifice_another_creature_or_land_trigger() {
+        let def = parse_trigger_line(
+            "Whenever Morkrut Necropod attacks or blocks, sacrifice another creature or land.",
+            "Morkrut Necropod",
+        );
+        let execute = def.execute.as_deref().expect("trigger has execute");
+        let Effect::Sacrifice { target, .. } = execute.effect.as_ref() else {
+            panic!("expected Sacrifice, got {:?}", execute.effect);
+        };
+        let TargetFilter::Or { filters } = target else {
+            panic!("expected an Or target for 'creature or land', got {target:?}");
+        };
+        assert_eq!(filters.len(), 2, "expected two legs, got {filters:?}");
+        // Leg 0: creature — the source-exclusion MUST be present.
+        let TargetFilter::Typed(creature_leg) = &filters[0] else {
+            panic!("expected a typed creature leg, got {:?}", filters[0]);
+        };
+        assert!(
+            creature_leg.type_filters.contains(&TypeFilter::Creature),
+            "first leg should be the creature leg, got {creature_leg:?}"
+        );
+        assert!(
+            creature_leg.properties.contains(&FilterProp::Another),
+            "creature leg must carry FilterProp::Another so the source can't \
+             sacrifice itself (#4513), got {creature_leg:?}"
+        );
+        // Leg 1: land — the source-exclusion is present here too. "Another" is
+        // applied to every leg: it is vacuous on the land leg (a creature source
+        // is never a land) but the uniform rule is what keeps a source that
+        // matches a non-first leg (e.g. an artifact creature in "creature or
+        // artifact") from sacrificing itself.
+        let TargetFilter::Typed(land_leg) = &filters[1] else {
+            panic!("expected a typed land leg, got {:?}", filters[1]);
+        };
+        assert!(
+            land_leg.type_filters.contains(&TypeFilter::Land),
+            "second leg should be the land leg, got {land_leg:?}"
+        );
+        assert!(
+            land_leg.properties.contains(&FilterProp::Another),
+            "land leg should carry FilterProp::Another (vacuous but uniform), got {land_leg:?}"
+        );
+    }
+
     // CR 701.3d: shorter form "becomes unattached" (future-proofing)
     #[test]
     fn trigger_becomes_unattached_short_form() {

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -591,13 +591,12 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
 ///
 /// The numeric value of a count is the same whether the text said "a", "an",
 /// "1", "any", or "another" — all yield `QuantityExpr::Fixed { value: 1 }`. But
-/// "another" is not merely a quantity: it is the source-exclusion qualifier (CR
-/// 109.4 + CR 701.21a — the ability's own permanent is excluded from
-/// the matched population). Callers that build a target from the remainder need
-/// to re-apply that exclusion (`FilterProp::Another`) to the parsed filter, and
-/// they must distinguish the exclusion word from an ordinary article without
-/// re-matching the raw string at the call site (CLAUDE.md forbids stringly-typed
-/// dispatch). This enum is that typed signal.
+/// "another" is not merely a quantity: it is the source-exclusion qualifier.
+/// Callers that build a target from the remainder need to re-apply that
+/// exclusion (`FilterProp::Another`) to the parsed filter, and they must
+/// distinguish the exclusion word from an ordinary article without re-matching
+/// the raw string at the call site (CLAUDE.md forbids stringly-typed dispatch).
+/// This enum is that typed signal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CountWord {
     /// The count word was the source-exclusion "another" — the consuming caller
@@ -625,8 +624,8 @@ pub(crate) fn parse_count_expr_with_exclusion(
 ) -> Option<(QuantityExpr, &str, CountWord)> {
     let text = text.trim_start();
     let lower = text.to_lowercase();
-    // CR 109.4 + CR 701.21a: source-exclusion "another " — implicit
-    // count of 1 that ALSO excludes the ability source from the matched set.
+    // Source-exclusion "another " — implicit count of 1 that ALSO excludes
+    // the ability source from the matched set.
     // Detected here as a typed `CountWord::SourceExclusion` so the caller can
     // re-apply `FilterProp::Another` without re-matching the string.
     if let Some(((), rest)) = super::oracle_nom::bridge::nom_on_lower(text, &lower, |i| {

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -587,6 +587,65 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
     Some((QuantityExpr::Fixed { value: base }, rest))
 }
 
+/// Typed signal distinguishing which count-word `parse_count_expr` consumed.
+///
+/// The numeric value of a count is the same whether the text said "a", "an",
+/// "1", "any", or "another" — all yield `QuantityExpr::Fixed { value: 1 }`. But
+/// "another" is not merely a quantity: it is the source-exclusion qualifier (CR
+/// 109.4 + CR 701.21a — the ability's own permanent is excluded from
+/// the matched population). Callers that build a target from the remainder need
+/// to re-apply that exclusion (`FilterProp::Another`) to the parsed filter, and
+/// they must distinguish the exclusion word from an ordinary article without
+/// re-matching the raw string at the call site (CLAUDE.md forbids stringly-typed
+/// dispatch). This enum is that typed signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CountWord {
+    /// The count word was the source-exclusion "another" — the consuming caller
+    /// must re-apply `FilterProp::Another` to the target it builds.
+    SourceExclusion,
+    /// Any other count form (article "a"/"an", a digit/word number, "X", "any",
+    /// a fraction, an arithmetic offset, etc.) — no source exclusion implied.
+    Plain,
+}
+
+/// Sibling of [`parse_count_expr`] that additionally reports, via a typed
+/// [`CountWord`], whether the consumed count word was the source-exclusion
+/// "another" (as opposed to "a"/"an"/a number/"X"/"any"/a fraction).
+///
+/// Used by the sacrifice imperative path, where "sacrifice another creature or
+/// land" must re-apply `FilterProp::Another` to the parsed target so the source
+/// can't sacrifice itself (Morkrut Necropod, #4513). It dispatches the
+/// source-exclusion "another " via a nom `tag()` BEFORE delegating to
+/// `parse_count_expr` for every other count form, so the numeric result is
+/// identical to `parse_count_expr` and the only addition is the typed word
+/// signal. The remainder shape (leading whitespace trimmed) matches
+/// `parse_count_expr` exactly.
+pub(crate) fn parse_count_expr_with_exclusion(
+    text: &str,
+) -> Option<(QuantityExpr, &str, CountWord)> {
+    let text = text.trim_start();
+    let lower = text.to_lowercase();
+    // CR 109.4 + CR 701.21a: source-exclusion "another " — implicit
+    // count of 1 that ALSO excludes the ability source from the matched set.
+    // Detected here as a typed `CountWord::SourceExclusion` so the caller can
+    // re-apply `FilterProp::Another` without re-matching the string.
+    if let Some(((), rest)) = super::oracle_nom::bridge::nom_on_lower(text, &lower, |i| {
+        nom::combinator::value(
+            (),
+            nom::bytes::complete::tag::<_, _, OracleError<'_>>("another "),
+        )
+        .parse(i)
+    }) {
+        return Some((
+            QuantityExpr::Fixed { value: 1 },
+            rest.trim_start(),
+            CountWord::SourceExclusion,
+        ));
+    }
+    let (expr, rest) = parse_count_expr(text)?;
+    Some((expr, rest, CountWord::Plain))
+}
+
 /// CR 107.3a: Strip a trailing "[, ]where x is " binder clause from the
 /// (already-lowercased) text following a bare `X`, returning the lowercase
 /// description that defines the variable. Shared by every count-position

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -470,6 +470,7 @@ mod mindblade_render_warrior_intervening_if_2867;
 mod mjolnir_hammer_double_damage;
 mod mogg_war_marshal_echo_dies_trigger;
 mod morbid_curiosity_cost_paid_mana_value_draw;
+mod morkrut_ashaya_self_sacrifice;
 mod morophon_chosen_type_1653;
 mod mr_foxglove_defending_hand_minus_yours_draw;
 mod ms_marvel_power_exceeds_base;

--- a/crates/engine/tests/integration/morkrut_ashaya_self_sacrifice.rs
+++ b/crates/engine/tests/integration/morkrut_ashaya_self_sacrifice.rs
@@ -1,0 +1,183 @@
+//! Regression for issue #4513 (PR #4597) — Morkrut Necropod must never be
+//! offered as a sacrifice to its own "sacrifice another creature or land"
+//! trigger, even when a type-changing static makes it a Land.
+//!
+//! Morkrut Necropod reads: "Whenever Morkrut Necropod attacks or blocks,
+//! sacrifice another creature or land." The parser builds the sacrifice target
+//! as `Or { [Typed(creature), Typed(land)] }`. The word "another" is a runtime
+//! IDENTITY exclusion (`FilterProp::Another` → `object_id != source.id`, see
+//! `game/filter.rs`), NOT a type exclusion — it removes the *source permanent*
+//! from the legal set regardless of what types that permanent currently has.
+//!
+//! The maintainer's (matthewevans) scenario: Ashaya, Soul of the Wild makes
+//! "Nontoken creatures you control are Forest lands in addition to their other
+//! types." Under Ashaya, Morkrut is simultaneously a Creature AND a Land, so it
+//! matches the *land* leg of its own disjunctive trigger. An earlier fix put
+//! `FilterProp::Another` on only the first (creature) leg of the `Or`; that
+//! left the land leg without source-exclusion, so Morkrut-as-Land slipped
+//! through and could be offered as a sacrifice to its own trigger. PR #4597
+//! re-applies `Another` to EVERY leg of the `Or`, closing the hole.
+//!
+//! This test drives the real production path — declare Morkrut as an attacker,
+//! let its attacks trigger resolve — and asserts that the Sacrifice
+//! `EffectZoneChoice` excludes Morkrut (identity exclusion holds on the land
+//! leg too) while still offering the other eligible permanent (so the
+//! assertion is meaningful, not vacuously passing on an empty/absent choice).
+//!
+//! Why it would FAIL under the old single-leg behavior: with `Another` only on
+//! the creature leg, Ashaya turns Morkrut into a Land, so it satisfies the
+//! land leg — which carries no identity exclusion — and its id would appear in
+//! the offered `cards`. The all-legs fix is exactly what removes it.
+//!
+//! CR 701.21a: To sacrifice a permanent, its controller moves it from the
+//! battlefield to its owner's graveyard; a player can only sacrifice a
+//! permanent they control. Morkrut's controller is the one choosing here, so
+//! the legal set is its own permanents minus (by "another") Morkrut itself.
+//!
+//! https://github.com/phase-rs/phase/issues/4513
+
+use engine::types::ability::EffectKind;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+
+use super::rules::{AttackTarget, GameRunner, GameScenario, P0, P1};
+
+/// Morkrut Necropod's combat trigger (Eldritch Moon). The "attacks or blocks"
+/// trigger fires on declaration; "another creature or land" is the disjunctive
+/// sacrifice target whose identity exclusion this test guards.
+const MORKRUT_NECROPOD: &str =
+    "Whenever Morkrut Necropod attacks or blocks, sacrifice another creature or land.";
+
+/// Ashaya's "Nontoken creatures you control are Forest lands" static (shared
+/// with `ashaya_nontoken_lands.rs`). The first line (a CDA) is included for
+/// fidelity to the real card; only the type-changing line matters here.
+const ASHAYA: &str = "Ashaya, Soul of the Wild's power and toughness are each \
+equal to the number of lands you control.\nNontoken creatures you control are \
+Forest lands in addition to their other types.";
+
+/// Drive from `DeclareAttackers` (Morkrut already declared) through trigger
+/// ordering and priority until the mandatory Sacrifice `EffectZoneChoice`
+/// surfaces, then stop. Returns the offered `cards` set for inspection.
+///
+/// The sacrifice is mandatory and has more than one eligible permanent (the
+/// other creature qualifies on both legs under Ashaya, and Morkrut is excluded
+/// by "another"), so the resolver surfaces an `EffectZoneChoice` rather than
+/// auto-sacrificing (see `game/effects/sacrifice.rs`).
+fn drive_to_sacrifice_choice(runner: &mut GameRunner) -> Vec<engine::types::identifiers::ObjectId> {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::EffectZoneChoice {
+                effect_kind: EffectKind::Sacrifice,
+                cards,
+                ..
+            } => return cards,
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(engine::types::actions::GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(engine::types::actions::GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .ok();
+            }
+            _ => {
+                if runner
+                    .act(engine::types::actions::GameAction::PassPriority)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+    panic!(
+        "Morkrut's attack trigger never surfaced a Sacrifice EffectZoneChoice; \
+         waiting_for = {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// Under Ashaya, Morkrut Necropod is itself a creature-Land and so matches the
+/// land leg of its own "sacrifice another creature or land" trigger. PR #4597
+/// applies the `another` identity exclusion to BOTH legs of the disjunction, so
+/// Morkrut is not offered to its own trigger; the other eligible permanent is.
+#[test]
+fn morkrut_under_ashaya_is_not_offered_to_its_own_sacrifice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    // Morkrut Necropod: a fat attacker carrying the self-sacrifice trigger.
+    let morkrut = scenario
+        .add_creature_from_oracle(P0, "Morkrut Necropod", 4, 5, MORKRUT_NECROPOD)
+        .id();
+
+    // Ashaya makes every nontoken creature P0 controls a Forest land in
+    // addition to its other types — including Morkrut and Grizzly Bears.
+    scenario
+        .add_creature_from_oracle(P0, "Ashaya, Soul of the Wild", 0, 0, ASHAYA)
+        .id();
+
+    // A second nontoken creature so the mandatory sacrifice has a legal target
+    // other than Morkrut. Under Ashaya it is a Creature AND a Land, so it
+    // qualifies on both legs of the disjunction.
+    let bears = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    // Pass priority so SBAs run and the layer system recomputes: Morkrut and
+    // Grizzly Bears become creature-Lands under Ashaya.
+    runner
+        .act(engine::types::actions::GameAction::PassPriority)
+        .ok();
+
+    // Sanity: Ashaya's static actually made Morkrut a Land (the whole premise).
+    // If this regressed, the land leg would not match Morkrut and the test
+    // would pass vacuously — so we assert it explicitly.
+    assert!(
+        runner.state().objects[&morkrut]
+            .card_types
+            .core_types
+            .contains(&CoreType::Land),
+        "premise broken: Ashaya must make Morkrut a Land, got {:?}",
+        runner.state().objects[&morkrut].card_types.core_types
+    );
+    assert!(
+        runner.state().objects[&bears]
+            .card_types
+            .core_types
+            .contains(&CoreType::Land),
+        "premise broken: Ashaya must make Grizzly Bears a Land, got {:?}",
+        runner.state().objects[&bears].card_types.core_types
+    );
+
+    // Production path: advance to the declare-attackers step (CR 508) and
+    // declare Morkrut as an attacker so its "attacks" trigger fires.
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(morkrut, AttackTarget::Player(P1))])
+        .expect("Morkrut should be a legal attacker");
+
+    // Resolve the attacks trigger until the Sacrifice choice surfaces.
+    let offered = drive_to_sacrifice_choice(&mut runner);
+
+    // CR 701.21a + `FilterProp::Another` (identity): Morkrut is the source of
+    // its own trigger; "another" excludes it on BOTH the creature and land legs
+    // even though Ashaya made it a Land. PR #4597 guards exactly this.
+    assert!(
+        !offered.contains(&morkrut),
+        "Morkrut must NOT be offered as a sacrifice to its own trigger even as a \
+         creature-Land under Ashaya (#4513); offered = {offered:?}"
+    );
+
+    // The choice must be genuinely non-empty: the other eligible permanent is
+    // offered, so the exclusion above is a meaningful assertion, not a vacuous
+    // pass on an empty/absent set.
+    assert!(
+        offered.contains(&bears),
+        "the other eligible creature-Land must be offered (choice must be \
+         non-empty); offered = {offered:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Morkrut Necropod's "sacrifice another creature or land" (#4513) parsed its sacrifice target with no source-exclusion on either leg, so the source could sacrifice ITSELF. The sacrifice-count grammar consumes "another " as a bare count of 1 and discards the exclusion, so the filter built from the remainder ("creature or land") never carried `FilterProp::Another`.

## Fix

- New typed signal `CountWord { SourceExclusion, Plain }` plus a sibling combinator `parse_count_expr_with_exclusion` in `oracle_util.rs`. The central `parse_count_expr` and its ~50 callers are untouched (no ripple).
- In the sacrifice imperative branch, when the count word was the source-exclusion "another", re-apply `FilterProp::Another` to every leg of an `Or` target. "Another" means "not this source permanent": it is required on any leg the source's type could match and is harmless (vacuous) on legs it cannot (a land is never the source creature). Marking only some legs would leave a self-sacrifice hole for a source that matches a non-first leg — e.g. Mukotai Soulripper, an artifact creature, in "sacrifice another creature or artifact".

## Scope

Single-type "sacrifice another `<type>`" (e.g. Disciple of Bolas) source-exclusion is intentionally left for a follow-up: applying it reduces a single-eligible mandatory sacrifice to one option, which routes it through the engine's auto-sacrifice fast-path, where a follow-on "that creature's power" reference is mis-resolved — a separate, pre-existing engine bug outside this parser change.

## Tests

- End-to-end Morkrut trigger test (`parse_trigger_line` to `Effect::Sacrifice` target): asserts `FilterProp::Another` on both the creature and land legs.
- Production-path integration regression: Morkrut made a creature-Land by Ashaya, Soul of the Wild, then attacks, asserting the source is NOT offered to its own "sacrifice another creature or land" trigger while the other eligible permanent still is. This guards the identity-vs-type case (a type-changing effect making the source match a non-first leg) that a per-leg-type exclusion would miss.

## Verification

`cargo fmt` clean; parser combinator gate exit 0; engine parser and `oracle_effect` suites green; clippy clean. The card-data parse-diff confirms the change is confined to "sacrifice another X or Y" disjunction cards (Morkrut Necropod, Mukotai Soulripper, the "creature or artifact" group, etc.), each now correctly excluding its own source on every leg.

Closes #4513

Model: claude-opus-4-8
Tier: Frontier
