### PR TITLE
fix(parser): delayed "sacrifice it unless you pay" rides the delayed trigger (#4369)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -4238,7 +4238,7 @@ pub(super) fn strip_temporal_suffix(text: &str) -> (&str, Option<DelayedTriggerC
 /// CR 603.7a: Strip temporal prefix indicating a delayed trigger condition.
 /// Symmetric to `strip_temporal_suffix` but handles prefix form:
 /// "At the beginning of the next end step, untap up to two lands."
-pub(super) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerCondition>) {
+pub(crate) fn strip_temporal_prefix(text: &str) -> (&str, Option<DelayedTriggerCondition>) {
     let lower = text.to_lowercase();
     if let Some((condition, rest)) = nom_on_lower(text, &lower, |i| {
         alt((

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20996,6 +20996,17 @@ pub(crate) fn parse_effect_chain_ir(
             if let Some(sub) = inner_clause.sub_ability {
                 inner_def.sub_ability = Some(sub);
             }
+            // CR 118.12a (issue #4369): a payment-unless on the delayed
+            // instruction itself ("...next end step, sacrifice it unless you pay
+            // {cost}" — Ashling, the Limitless; Satya, Aetherflux Genius) is
+            // extracted at chunk level into `unless_pay`, but it belongs to the
+            // DELAYED sacrifice, not the outer trigger. Move it onto the inner
+            // delayed def and consume it so it is not also applied to the outer
+            // CreateDelayedTrigger wrapper. The trigger-level
+            // `extract_unless_pay_modifier` declines to hoist the same clause.
+            if let Some(up) = unless_pay.take() {
+                inner_def.unless_pay = Some(up);
+            }
             apply_where_x_ability_expression(&mut inner_def, where_x_expression.as_deref());
             let delayed_effect = Effect::CreateDelayedTrigger {
                 condition: prefix_condition.clone(),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1806,6 +1806,34 @@ fn extract_unless_pay_modifier(
         return (text.to_string(), None);
     };
 
+    // CR 603.7a + CR 118.12a (issue #4369): when the "unless you pay" lives in a
+    // DELAYED-trigger sentence ("At the beginning of [the/your] next ..., sacrifice
+    // it unless you pay {cost}" — Ashling, the Limitless; Satya, Aetherflux
+    // Genius), the alternative cost belongs to that delayed sacrifice, NOT the
+    // parent trigger. Hoisting it here makes the engine demand payment when the
+    // token is created (wrong time). Decline to hoist; the per-clause path
+    // (`extract_resolution_unless_pay_modifier`, applied in `lower_effect_chain_ir`
+    // before wrapping in `CreateDelayedTrigger`) attaches the cost to the delayed
+    // trigger's inner def. Detected by reusing the canonical delayed-temporal-
+    // prefix recognizer on the start of the sentence that contains the "unless".
+    // Forward-scan past each sentence boundary preceding the "unless" (via the
+    // `split_once_on` combinator) so `enclosing` is just the sentence that
+    // directly contains it; the byte offset back into `text` preserves original
+    // case for `strip_temporal_prefix`.
+    let mut enclosing = &lower[..unless_pos];
+    while let Ok((_, (_, after))) = nom_primitives::split_once_on(enclosing, ". ") {
+        enclosing = after;
+    }
+    let unless_sentence_start = unless_pos - enclosing.len();
+    if crate::parser::oracle_effect::lower::strip_temporal_prefix(
+        text[unless_sentence_start..].trim_start(),
+    )
+    .1
+    .is_some()
+    {
+        return (text.to_string(), None);
+    }
+
     let after_unless = &lower[unless_pos + 8..];
 
     // CR 608.2c: When the primary effect is itself a discard imperative
@@ -2168,6 +2196,33 @@ pub(crate) fn parse_unless_alt_cost(after_unless: &str) -> Option<AbilityCost> {
     // "you pay N life" / "you pay N life." — life amount is bare integer.
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you pay ").parse(after_unless) {
         if let Some(cost) = parse_unless_life_cost(rest) {
+            return Some(cost);
+        }
+    }
+
+    // CR 107.14 + CR 202.3 (issue #4369): "you pay an amount of {E} equal to ..."
+    // — a dynamic energy alternative (Satya, Aetherflux Genius's delayed
+    // "sacrifice that token unless you pay an amount of {E} equal to its mana
+    // value"). Must precede the brace-run mana arm below ("an amount of" is not a
+    // mana run). Reuses the shared dynamic-energy building block.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you pay ").parse(after_unless) {
+        if let Some(amount) = super::oracle_effect::parse_dynamic_energy_unless_cost(
+            rest.trim_end_matches('.').trim(),
+        ) {
+            return Some(AbilityCost::PayEnergy { amount });
+        }
+    }
+
+    // CR 118.12 + CR 202.1: "you pay {explicit mana}" — an explicit mana cost as
+    // the alternative (issue #4369, Ashling, the Limitless's delayed "sacrifice
+    // it unless you pay {W}{U}{B}{R}{G}"). The trigger-level caller reaches its
+    // own brace-run mana arm after this function returns None, but the per-clause
+    // resolution path (`extract_resolution_unless_pay_modifier`) relies solely on
+    // this single authority, so a delayed sub-clause's mana unless is invisible
+    // without it. Placed AFTER the "N life" arm so life keeps precedence; reuses
+    // the shared `parse_unless_mana_payment` building block.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("you pay ").parse(after_unless) {
+        if let Some(cost) = parse_unless_mana_payment(rest.trim_end_matches('.').trim()) {
             return Some(cost);
         }
     }
@@ -18915,6 +18970,111 @@ mod tests {
                 "{name}: delayed exile must bind the created token (LastCreated), not the entering creature"
             );
         }
+    }
+
+    /// CR 603.7a + CR 118.12a (issue #4369): Ashling, the Limitless — "Whenever
+    /// you sacrifice a nontoken Elemental, create a token that's a copy of it.
+    /// The token gains haste until end of turn. At the beginning of your next
+    /// end step, sacrifice it unless you pay {W}{U}{B}{R}{G}." The "unless you
+    /// pay {W}{U}{B}{R}{G}" alternative cost belongs to the DELAYED end-step
+    /// sacrifice, not to the parent "Whenever you sacrifice" trigger. Before the
+    /// fix `extract_unless_pay_modifier` scanned the whole multi-sentence effect,
+    /// found the "unless" in the delayed sentence, and hoisted the cost onto the
+    /// parent trigger — so the engine demanded the 5-color payment when the token
+    /// copy was created (wrong time), letting the player keep the token without
+    /// the mana. The cost must ride the `CreateDelayedTrigger`'s inner sacrifice.
+    #[test]
+    fn ashling_delayed_end_step_unless_pay_rides_delayed_sacrifice() {
+        use crate::types::ability::{AbilityCost, Effect};
+
+        // Walk the execute chain into the CreateDelayedTrigger's inner def.
+        fn find_delayed(def: &AbilityDefinition) -> Option<&AbilityDefinition> {
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                return Some(inner);
+            }
+            def.sub_ability
+                .as_deref()
+                .and_then(find_delayed)
+                .or_else(|| def.else_ability.as_deref().and_then(find_delayed))
+        }
+
+        let def = parse_trigger_line(
+            "Whenever you sacrifice a nontoken Elemental, create a token that's a copy of it. \
+             The token gains haste until end of turn. At the beginning of your next end step, \
+             sacrifice it unless you pay {W}{U}{B}{R}{G}.",
+            "Ashling, the Limitless",
+        );
+
+        // (1) The parent sacrifice trigger must NOT carry the delayed unless-cost.
+        assert_eq!(
+            def.unless_pay, None,
+            "the delayed end-step unless-cost must not be hoisted onto the parent trigger"
+        );
+
+        // (2) The delayed trigger's inner sacrifice carries the {W}{U}{B}{R}{G} cost.
+        let exec = def
+            .execute
+            .as_deref()
+            .expect("Ashling trigger execute body");
+        let delayed = find_delayed(exec).expect("CreateDelayedTrigger in the effect chain");
+        let unless = delayed
+            .unless_pay
+            .as_ref()
+            .expect("the delayed sacrifice must carry the unless-cost");
+        match &unless.cost {
+            AbilityCost::Mana { cost } => assert_eq!(
+                cost.mana_value(),
+                5,
+                "the delayed unless-cost must be the 5-color {{W}}{{U}}{{B}}{{R}}{{G}}, got {cost:?}"
+            ),
+            other => panic!("delayed unless-cost must be AbilityCost::Mana, got {other:?}"),
+        }
+    }
+
+    /// CR 603.7a + CR 118.12a + CR 107.14 (issue #4369): Satya, Aetherflux Genius
+    /// — the energy-cost sibling of the same class: "Whenever Satya attacks, ...
+    /// At the beginning of the next end step, sacrifice that token unless you pay
+    /// an amount of {E} equal to its mana value." The dynamic-energy unless-cost
+    /// must ride the delayed sacrifice (not the parent attack trigger), exactly
+    /// like Ashling's mana cost — proving the fix is class-general across cost
+    /// types, not a one-off for Ashling.
+    #[test]
+    fn satya_delayed_end_step_energy_unless_rides_delayed_sacrifice() {
+        use crate::types::ability::{AbilityCost, Effect};
+
+        fn find_delayed(def: &AbilityDefinition) -> Option<&AbilityDefinition> {
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                return Some(inner);
+            }
+            def.sub_ability
+                .as_deref()
+                .and_then(find_delayed)
+                .or_else(|| def.else_ability.as_deref().and_then(find_delayed))
+        }
+
+        let def = parse_trigger_line(
+            "Whenever Satya attacks, create a tapped and attacking token that's a copy of up to \
+             one other target nontoken creature you control. You get {E}{E}. At the beginning of \
+             the next end step, sacrifice that token unless you pay an amount of {E} equal to its \
+             mana value.",
+            "Satya, Aetherflux Genius",
+        );
+
+        assert_eq!(
+            def.unless_pay, None,
+            "the delayed end-step energy unless-cost must not be hoisted onto the parent trigger"
+        );
+        let exec = def.execute.as_deref().expect("Satya trigger execute body");
+        let delayed = find_delayed(exec).expect("CreateDelayedTrigger in the effect chain");
+        let unless = delayed
+            .unless_pay
+            .as_ref()
+            .expect("the delayed sacrifice must carry the energy unless-cost");
+        assert!(
+            matches!(unless.cost, AbilityCost::PayEnergy { .. }),
+            "delayed unless-cost must be AbilityCost::PayEnergy, got {:?}",
+            unless.cost
+        );
     }
 
     #[test]

--- a/crates/engine/tests/ashling_delayed_sacrifice_unless_pay.rs
+++ b/crates/engine/tests/ashling_delayed_sacrifice_unless_pay.rs
@@ -1,0 +1,210 @@
+//! Runtime regression for GitHub issue #4369 — Ashling, the Limitless's delayed
+//! "sacrifice it unless you pay {W}{U}{B}{R}{G}".
+//!
+//! Front-face Oracle: "Whenever you sacrifice a nontoken Elemental, create a
+//! token that's a copy of it. ... At the beginning of your next end step,
+//! sacrifice it unless you pay {W}{U}{B}{R}{G}."
+//!
+//! The reported bug was a runtime TIMING bug, not just AST placement: the
+//! {W}{U}{B}{R}{G} alternative cost was demanded when the token COPY was created
+//! (on the parent "Whenever you sacrifice" trigger) instead of at the next end
+//! step on the delayed sacrifice. Root cause: the trigger-level
+//! `extract_unless_pay_modifier` scanned the whole multi-sentence effect, found
+//! the "unless" in the delayed end-step sentence, and hoisted the cost onto the
+//! parent trigger (CR 118.12a payment surfaced at the wrong time). The cost
+//! belongs to the `CreateDelayedTrigger`'s inner sacrifice (CR 603.7a).
+//!
+//! This drives the REAL parse → sacrifice-event → trigger → token → delayed-
+//! trigger → end-step → unless-payment pipeline. Ashling is synthesized from
+//! Oracle text (live parse, so the trigger reflects current parser source, not a
+//! stored/stale card-data AST). A nontoken Elemental is sacrificed through the
+//! production `sacrifice::resolve` seam; the parent trigger resolves and creates
+//! the token. The discriminating checkpoints are:
+//!   (1) NO `UnlessPayment` prompt surfaces when the token is created, and
+//!   (2) the `{W}{U}{B}{R}{G}` `UnlessPayment` prompt surfaces only when the
+//!       delayed trigger resolves at the next end step,
+//! and both the paid (token survives) and declined (token sacrificed) paths
+//! behave correctly.
+//!
+//! CR 603.7a: a delayed triggered ability triggers (and its cost is paid) only
+//! when its condition is met, here "at the beginning of your next end step".
+//! CR 118.12 / CR 118.12a: "unless you pay" is an alternative the controller may
+//! decline; declining lets the otherwise-effect (the sacrifice) happen.
+
+use engine::game::effects::sacrifice::resolve as resolve_sacrifice;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ASHLING: &str = "Whenever you sacrifice a nontoken Elemental, create a token that's a copy of it. The token gains haste until end of turn. At the beginning of your next end step, sacrifice it unless you pay {W}{U}{B}{R}{G}.";
+
+/// Build Ashling + a nontoken Elemental on P0's battlefield, sacrifice the
+/// Elemental through the production seam, resolve the parent trigger, and
+/// advance to the next end step where the delayed `UnlessPayment` prompt
+/// surfaces. Returns the runner (parked at the prompt) and the created token id.
+///
+/// Asserts the discriminator along the way: NO payment is demanded when the
+/// token is created (checkpoint 1).
+fn run_to_end_step_unless_prompt() -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Ashling, built from Oracle text through the real parse + synthesis
+    // pipeline so the (fixed) parent + delayed triggers are installed.
+    let ashling = scenario
+        .add_creature_from_oracle(P0, "Ashling, the Limitless", 3, 3, ASHLING)
+        .with_subtypes(vec!["Elemental"])
+        .id();
+
+    // The sacrifice victim: a nontoken Elemental under P0's control.
+    let elemental = scenario
+        .add_creature(P0, "Fire Elemental", 5, 4)
+        .with_subtypes(vec!["Elemental"])
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Sacrifice the Elemental through the production `sacrifice::resolve` seam.
+    // `SpecificObject` targets exactly the victim (Ashling is itself an
+    // Elemental, so a type filter would be ambiguous).
+    let sac = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::SpecificObject { id: elemental },
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 0,
+        },
+        vec![TargetRef::Object(elemental)],
+        ashling,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_sacrifice(runner.state_mut(), &sac, &mut events).expect("sacrifice resolves");
+    process_triggers(runner.state_mut(), &events);
+
+    // The parent "Whenever you sacrifice a nontoken Elemental" trigger is queued.
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "sacrificing a nontoken Elemental must fire Ashling's parent trigger"
+    );
+
+    // Resolve the parent trigger: it creates the token copy and installs the
+    // delayed end-step sacrifice trigger.
+    runner.advance_until_stack_empty();
+
+    // CHECKPOINT 1 (the discriminator): the {W}{U}{B}{R}{G} cost must NOT be
+    // demanded now, at token creation. Before the fix the cost was hoisted onto
+    // this parent trigger and `WaitingFor::UnlessPayment` surfaced here.
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "CR 603.7a: no payment may be demanded when the token is created — the \
+         unless-cost belongs to the delayed end-step sacrifice; got {:?}",
+        runner.state().waiting_for
+    );
+
+    // The parent trigger produced a token copy and installed the delayed trigger.
+    let token = runner
+        .state()
+        .objects
+        .values()
+        .find(|o| o.controller == P0 && o.zone == Zone::Battlefield && o.is_token)
+        .map(|o| o.id)
+        .expect("the parent trigger must create a token copy of the sacrificed Elemental");
+    assert!(
+        !runner.state().delayed_triggers.is_empty(),
+        "the delayed end-step 'sacrifice it unless you pay' trigger must be installed"
+    );
+
+    // Advance toward the next end step. Cross combat by declaring no attackers
+    // (the harness surfaces `WaitingFor::DeclareAttackers` as a turn-based action
+    // that plain priority passes cannot answer), then advance to the end step and
+    // resolve the now-firing delayed trigger off the stack — it surfaces the
+    // unless-payment prompt (CHECKPOINT 2).
+    runner.advance_to_combat();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("declare no attackers to cross combat");
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    // CHECKPOINT 2: the prompt is Ashling's controller paying at the end step.
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player: P0, .. }
+        ),
+        "the {{W}}{{U}}{{B}}{{R}}{{G}} unless-cost must be offered to P0 when the \
+         delayed trigger resolves; got {:?}",
+        runner.state().waiting_for
+    );
+    assert_eq!(
+        runner.state().phase,
+        Phase::End,
+        "the cost is offered at the next end step (CR 603.7a)"
+    );
+
+    (runner, token)
+}
+
+/// Declining the {W}{U}{B}{R}{G} payment sacrifices the token (CR 118.12a).
+#[test]
+fn ashling_delayed_unless_pay_declined_sacrifices_token() {
+    let (mut runner, token) = run_to_end_step_unless_prompt();
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("declining the unless-cost must be accepted");
+    runner.advance_until_stack_empty();
+
+    // The token is sacrificed — no longer on the battlefield (a token in the
+    // graveyard ceases to exist as a state-based action, CR 704.5d).
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&token)
+            .is_none_or(|o| o.zone != Zone::Battlefield),
+        "declining the {{W}}{{U}}{{B}}{{R}}{{G}} cost must sacrifice the token"
+    );
+}
+
+/// Paying the {W}{U}{B}{R}{G} keeps the token on the battlefield (CR 118.12).
+#[test]
+fn ashling_delayed_unless_pay_paid_keeps_token() {
+    let (mut runner, token) = run_to_end_step_unless_prompt();
+
+    // Fund P0's pool with one of each color to pay {W}{U}{B}{R}{G}.
+    for color in [
+        ManaType::White,
+        ManaType::Blue,
+        ManaType::Black,
+        ManaType::Red,
+        ManaType::Green,
+    ] {
+        runner
+            .state_mut()
+            .add_mana_to_pool(P0, ManaUnit::new(color, ObjectId(0), false, vec![]));
+    }
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("paying the unless-cost must be accepted");
+    runner.advance_until_stack_empty();
+
+    // The token survives — the alternative cost was paid, so the sacrifice does
+    // not happen.
+    assert_eq!(
+        runner.state().objects.get(&token).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "paying the {{W}}{{U}}{{B}}{{R}}{{G}} cost must keep the token on the battlefield"
+    );
+}


### PR DESCRIPTION
Closes #4369

## Problem

Ashling, the Limitless — *"Whenever you sacrifice a nontoken Elemental,
create a token that's a copy of it. ... At the beginning of your next end
step, sacrifice it unless you pay {W}{U}{B}{R}{G}."* — let you keep the
token without the mana: the 5-color cost was demanded when the token was
**created** (on the sacrifice trigger), not at the next end step on the
delayed sacrifice.

## Root cause

The trigger-level `extract_unless_pay_modifier` scanned the whole
multi-sentence effect, found the "unless" in the **delayed** end-step
sentence, and hoisted the cost onto the **parent** trigger — so the
payment (CR 118.12a) surfaced at the wrong time. The cost belongs to the
`CreateDelayedTrigger`'s inner sacrifice (CR 603.7a).

## Fix (parser-only, class-general)

1. `extract_unless_pay_modifier` declines to hoist when the "unless" lives
   in a sentence that **starts with a delayed temporal prefix** (reusing the
   canonical `strip_temporal_prefix` recognizer, widened to `pub(crate)`).
2. `parse_unless_alt_cost` gains *"you pay {explicit mana}"* and *"you pay an
   amount of {E} equal to …"* arms, so the per-clause resolution path can
   extract the delayed sub-clause's cost (it previously handled only
   `SelfManaCost` / life / non-mana shapes).
3. In `parse_effect_chain_ir`'s temporal-prefix branch, the chunk-level
   `unless_pay` is moved onto the delayed **inner** def (and consumed),
   instead of the outer `CreateDelayedTrigger` wrapper.

The runtime delayed-trigger payment path already exists
(`build_resolved_from_def` preserves `unless_pay`; `effects::mod` surfaces it
at resolution).

## Tests

Covers **both** members of the class:
- `ashling_delayed_end_step_unless_pay_rides_delayed_sacrifice` — mana
  `{W}{U}{B}{R}{G}`.
- `satya_delayed_end_step_energy_unless_rides_delayed_sacrifice` — Satya,
  Aetherflux Genius's dynamic energy *"an amount of {E} equal to its mana
  value"*.

Each asserts the parent trigger carries no `unless_pay` and the delayed
inner sacrifice carries the cost.

## Verification

- `cargo fmt --all` — clean
- Parser combinator gate — pass
- `cargo clippy -p engine --lib` — exit 0, no warnings
- `cargo test -p engine --lib` — **14158 passed, 0 failed**
