### PR TITLE
fix(parser): Phase-triggered token-copier's delayed "sacrifice it" binds the created token, not the source (#4601)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2754,7 +2754,13 @@ pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
         }
         | Effect::Pump { target, .. }
         | Effect::Attach { target, .. }
-        | Effect::ChangeZone { target, .. } => {
+        | Effect::ChangeZone { target, .. }
+        // CR 603.7c + CR 608.2c (issue #4601 review): a delayed cleanup that
+        // puts the temporary token on top/bottom of a library ("… put it on the
+        // bottom of its owner's library at the beginning of the next end step")
+        // lowers its bare-"it" to `ParentTarget`/`TriggeringSource` just like the
+        // other move/cleanup forms — rebind to the created token.
+        | Effect::PutAtLibraryPosition { target, .. } => {
             // CR 603.7c + CR 608.2c: inside an ETB-triggered token-copier (e.g.
             // Flameshadow Conjuring / Inalla: "create a token that's a copy of
             // that creature. … Exile it at the beginning of the next end step"),
@@ -2789,15 +2795,20 @@ pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
 ///
 /// Scope is deliberately limited to the **destructive cleanup** effects that
 /// remove/move the temporary token (`Sacrifice`/`Destroy`/`Bounce`/
-/// `ChangeZone`). `Pump`/`Attach`/`SetTapState` are excluded: there a delayed
-/// `SelfRef` ("~ gets +1/+1 until end of turn") more plausibly means the
-/// source, so leaving it as `SelfRef` is correct.
+/// `ChangeZone`/`PutAtLibraryPosition`). `Pump`/`Attach`/`SetTapState` are
+/// excluded: there a delayed `SelfRef` ("~ gets +1/+1 until end of turn") more
+/// plausibly means the source, so leaving it as `SelfRef` is correct.
 fn rewrite_delayed_cleanup_self_ref_to_last_created(effect: &mut Effect) {
     match effect {
         Effect::Sacrifice { target, .. }
         | Effect::Destroy { target, .. }
         | Effect::Bounce { target, .. }
         | Effect::ChangeZone { target, .. }
+        // CR 603.7c (issue #4601 review): a delayed cleanup that puts the
+        // temporary token on top/bottom of a library ("… put it on the bottom
+        // of its owner's library at the beginning of the next end step") has the
+        // same "it" anaphor — bind it to the created token, not the source.
+        | Effect::PutAtLibraryPosition { target, .. }
             if matches!(target, TargetFilter::SelfRef) =>
         {
             *target = TargetFilter::LastCreated;

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2552,6 +2552,13 @@ fn rewrite_populated_anaphor_in_effect(effect: &mut Effect) {
     // effect for any nested anaphors.
     if let Effect::CreateDelayedTrigger { effect: inner, .. } = effect {
         rewrite_parent_target_to_last_created(&mut inner.effect);
+        // CR 603.7c + CR 608.2c (issue #4601): a PHASE-triggered token-copier
+        // (Mishra, Eminent One — "At the beginning of combat on your turn,
+        // create a token …, Sacrifice it at the beginning of the next end step")
+        // has no triggering object, so the bare-"it" delayed cleanup lowers to
+        // `SelfRef` (the source) rather than `ParentTarget`/`TriggeringSource`.
+        // In this gated post-token scope the antecedent is the created token.
+        rewrite_delayed_cleanup_self_ref_to_last_created(&mut inner.effect);
         rewrite_populated_anaphor_in_effect(&mut inner.effect);
     }
 
@@ -2765,6 +2772,35 @@ pub(super) fn rewrite_parent_target_to_last_created(effect: &mut Effect) {
             ) {
                 *target = TargetFilter::LastCreated;
             }
+        }
+        _ => {}
+    }
+}
+
+/// CR 603.7c + CR 608.2c (issue #4601): the `SelfRef` companion to
+/// [`rewrite_parent_target_to_last_created`], for the inner effect of a
+/// `CreateDelayedTrigger` in the gated post-token-creator scope. A PHASE-
+/// triggered token-copier ("At the beginning of combat on your turn, create a
+/// token …, Sacrifice it at the beginning of the next end step" — Mishra,
+/// Eminent One) has no triggering object, so the imperative parser lowers the
+/// bare-"it" delayed cleanup to `SelfRef` (the source) instead of
+/// `ParentTarget`/`TriggeringSource`. The antecedent is still the just-created
+/// token, so rebind to `LastCreated`.
+///
+/// Scope is deliberately limited to the **destructive cleanup** effects that
+/// remove/move the temporary token (`Sacrifice`/`Destroy`/`Bounce`/
+/// `ChangeZone`). `Pump`/`Attach`/`SetTapState` are excluded: there a delayed
+/// `SelfRef` ("~ gets +1/+1 until end of turn") more plausibly means the
+/// source, so leaving it as `SelfRef` is correct.
+fn rewrite_delayed_cleanup_self_ref_to_last_created(effect: &mut Effect) {
+    match effect {
+        Effect::Sacrifice { target, .. }
+        | Effect::Destroy { target, .. }
+        | Effect::Bounce { target, .. }
+        | Effect::ChangeZone { target, .. }
+            if matches!(target, TargetFilter::SelfRef) =>
+        {
+            *target = TargetFilter::LastCreated;
         }
         _ => {}
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -19171,6 +19171,48 @@ mod tests {
         );
     }
 
+    /// CR 608.2c + CR 603.7c (issue #4601): a PHASE-triggered token-copier —
+    /// Mishra, Eminent One: "At the beginning of combat on your turn, create a
+    /// token that's a copy of target noncreature artifact you control, … It
+    /// gains haste until end of turn. Sacrifice it at the beginning of the next
+    /// end step." Unlike the ETB copiers above, a Phase trigger has no
+    /// triggering object, so the bare-"it" in "Sacrifice it" lowers to `SelfRef`
+    /// (the source — Mishra) rather than `TriggeringSource`. The antecedent is
+    /// still the newly created TOKEN, so the delayed sacrifice must bind
+    /// `LastCreated` — otherwise Mishra sacrifices ITSELF at the end step.
+    #[test]
+    fn phase_trigger_token_copier_sacrifice_anaphor_binds_created_token() {
+        fn collect<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&def.effect);
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                collect(inner, out);
+            }
+            if let Some(sub) = def.sub_ability.as_deref() {
+                collect(sub, out);
+            }
+            if let Some(els) = def.else_ability.as_deref() {
+                collect(els, out);
+            }
+        }
+        let def = parse_trigger_line(
+            "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is Mishra's Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
+            "Mishra, Eminent One",
+        );
+        let exec = def.execute.as_ref().expect("execute must be Some");
+        let mut effs = Vec::new();
+        collect(exec, &mut effs);
+        let sac_target = effs.iter().find_map(|e| match e {
+            Effect::Sacrifice { target, .. } => Some(target.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            sac_target,
+            Some(TargetFilter::LastCreated),
+            "the delayed 'Sacrifice it' must bind the created token (LastCreated), not \
+             Mishra itself (SelfRef) — otherwise Mishra sacrifices itself at the end step",
+        );
+    }
+
     #[test]
     fn flicker_enters_trigger_keeps_chosen_target_anaphor() {
         // CR 608.2c: "When ~ enters, you may exile another target permanent you

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -19213,6 +19213,47 @@ mod tests {
         );
     }
 
+    /// CR 603.7c + CR 608.2c (issue #4601 review): the same Phase-triggered
+    /// token-copier anaphor, but with a LIBRARY-POSITION cleanup instead of a
+    /// sacrifice — "… create a token that's a copy of target creature you
+    /// control. It gains haste until end of turn. Put it on the bottom of its
+    /// owner's library at the beginning of the next end step." A Phase trigger
+    /// has no triggering object, so the bare-"it" in the delayed "Put it …"
+    /// lowers to `SelfRef`; `Effect::PutAtLibraryPosition` is a token-cleanup
+    /// move just like the sacrifice form, so it must rebind to `LastCreated`.
+    #[test]
+    fn phase_trigger_token_copier_library_cleanup_anaphor_binds_created_token() {
+        fn collect<'a>(def: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+            out.push(&def.effect);
+            if let Effect::CreateDelayedTrigger { effect: inner, .. } = &*def.effect {
+                collect(inner, out);
+            }
+            if let Some(sub) = def.sub_ability.as_deref() {
+                collect(sub, out);
+            }
+            if let Some(els) = def.else_ability.as_deref() {
+                collect(els, out);
+            }
+        }
+        let def = parse_trigger_line(
+            "At the beginning of combat on your turn, create a token that's a copy of target creature you control. It gains haste until end of turn. Put it on the bottom of its owner's library at the beginning of the next end step.",
+            "Test Phase Library Copier",
+        );
+        let exec = def.execute.as_ref().expect("execute must be Some");
+        let mut effs = Vec::new();
+        collect(exec, &mut effs);
+        let lib_target = effs.iter().find_map(|e| match e {
+            Effect::PutAtLibraryPosition { target, .. } => Some(target.clone()),
+            _ => None,
+        });
+        assert_eq!(
+            lib_target,
+            Some(TargetFilter::LastCreated),
+            "the delayed 'Put it on the bottom of its owner's library' must bind the \
+             created token (LastCreated), not the source (SelfRef)",
+        );
+    }
+
     #[test]
     fn flicker_enters_trigger_keeps_chosen_target_anaphor() {
         // CR 608.2c: "When ~ enters, you may exile another target permanent you


### PR DESCRIPTION
Closes #4601

## Problem

**Mishra, Eminent One** —

> At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is Mishra's Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. **Sacrifice it at the beginning of the next end step.**

— sacrificed **Mishra itself** at the next end step instead of the token it created, and popped a "graveyard or command zone" prompt for the legendary commander. The temporary copy (the intended victim) was left on the battlefield.

## Root cause

The delayed "Sacrifice it" is a bare-pronoun anaphor whose antecedent is the just-created token. The populate-anaphor repair pass (`resolve_populated_token_anaphors` → `rewrite_populated_anaphor_in_effect`, in `parser/oracle_effect/lower.rs`) already rebinds that pronoun to `TargetFilter::LastCreated` — but only for the `ParentTarget` and `TriggeringSource` defaults, which is what an **ETB-triggered** token-copier produces (Flameshadow Conjuring, Inalla, Archmage Ritualist: "Whenever a creature enters … Exile it at the beginning of the next end step").

Mishra fires off a **Phase trigger** ("At the beginning of combat on your turn, …"), which has *no* triggering object. The imperative parser therefore lowers the bare "it" to `TargetFilter::SelfRef` (the source) — a case the rewrite never touched. So the delayed sacrifice stayed bound to Mishra (`SelfRef`) instead of the token (`LastCreated`).

## Fix (parser-only, class-general)

In the `CreateDelayedTrigger` arm of `rewrite_populated_anaphor_in_effect` — already gated on a preceding token-creating effect — also rebind a `SelfRef` cleanup target to `LastCreated`, via a new `rewrite_delayed_cleanup_self_ref_to_last_created` (the `SelfRef` companion to the existing `rewrite_parent_target_to_last_created`, mirroring the established `rewrite_oneshot_selfref_to_chosen` precedent).

Scope is deliberately limited to the **destructive cleanup** effects that remove/move the temporary token — `Sacrifice` / `Destroy` / `Bounce` / `ChangeZone`. `Pump` / `Attach` / `SetTapState` are intentionally excluded: there a delayed `SelfRef` ("~ gets +1/+1 until end of turn") more plausibly means the source, so it is left untouched.

This covers the Phase-triggered temporary-token class (Mishra, Eminent One and siblings), not just the one card.

CR 603.7c (delayed triggered ability) + CR 608.2c (read the whole text; resolve the anaphor) — both verified against `docs/MagicCompRules.txt`.

The separate legendary-token-sacrifice concern from #4444 is out of scope for this PR.

## Testing

- New parser regression `phase_trigger_token_copier_sacrifice_anaphor_binds_created_token` (modeled on the existing `etb_token_copier_exile_anaphor_binds_created_token`), asserting the delayed sacrifice binds `LastCreated`. Verified it **fails on `main`** (`Some(SelfRef)`) before the change and passes after.
- Full engine suite: **14157 passed / 0 failed**.
- `clippy` clean; `cargo fmt` clean; parser-combinator / engine-authority / test-card-data-load / skill-doc gates all pass.

Diff: 2 files, +78 (fix + regression test).
