### PR TITLE
fix(engine): BecomesBlocked "that creature" binds the blocked attacker, not the blocker (#4599)

### DIFF
--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -955,9 +955,22 @@ fn blocked_attacker_from_event(
     let crate::types::events::GameEvent::BlockersDeclared { assignments } = event else {
         return None;
     };
-    let mut attackers = assignments
+    // CR 509.1 + CR 608.2c: For a `Blocks` trigger ("Whenever ~ blocks a
+    // creature, … that creature") the source is the BLOCKER, so "that creature"
+    // is the attacker it was assigned to.
+    let mut blocked = assignments
         .iter()
         .filter_map(|(blocker, attacker)| (*blocker == source_id).then_some(*attacker));
+    if let Some(first) = blocked.next() {
+        return blocked.all(|attacker| attacker == first).then_some(first);
+    }
+    // CR 509.1 + CR 608.2c (issue #4599): For a `BecomesBlocked` trigger
+    // ("Whenever a Hero you control becomes blocked, put a +1/+1 counter on that
+    // Hero …" — She-Hulk, Wallbreaker) the source is the ATTACKER (the blocked
+    // creature), or an observer of it, never the blocker — so the blocker-side
+    // filter above is empty. The matcher narrows the event to the single
+    // matched `(blocker, attacker)` pair, so "that [creature]" is that attacker.
+    let mut attackers = assignments.iter().map(|(_, attacker)| *attacker);
     let first = attackers.next()?;
     attackers.all(|attacker| attacker == first).then_some(first)
 }

--- a/crates/engine/tests/she_hulk_wallbreaker_becomes_blocked_4599.rs
+++ b/crates/engine/tests/she_hulk_wallbreaker_becomes_blocked_4599.rs
@@ -1,0 +1,101 @@
+//! Runtime regression for GitHub issue #4599 — She-Hulk, Wallbreaker's
+//! "becomes blocked" trigger.
+//!
+//! Oracle (relevant clause): "Whenever a Hero you control becomes blocked, put
+//! a +1/+1 counter on that Hero for each creature blocking it."
+//!
+//! Reported bug: the trigger does not fire / no counter is applied when a Hero
+//! the controller owns becomes blocked. The parse is correct (a `BecomesBlocked`
+//! trigger with `valid_card: Hero you control`, child `PutCounter` on the
+//! blocked Hero, count = creatures blocking it), so the defect is in the runtime
+//! block-event → trigger → counter path.
+//!
+//! This drives a real combat: She-Hulk (a Hero) attacks, the opponent blocks
+//! her, and the test asserts she gains exactly one +1/+1 counter (one blocker).
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+const SHE_HULK: &str =
+    "Whenever a Hero you control becomes blocked, put a +1/+1 counter on that Hero for each creature blocking it.";
+
+#[test]
+fn she_hulk_becomes_blocked_puts_counter_on_blocked_hero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // She-Hulk is a Hero; her own "a Hero you control becomes blocked" trigger
+    // must fire when she herself is blocked.
+    let she_hulk = scenario
+        .add_creature_from_oracle(P0, "She-Hulk, Wallbreaker", 4, 4, SHE_HULK)
+        .with_subtypes(vec!["Hero"])
+        .id();
+    // Opponent blocker.
+    let blocker = scenario.add_creature(P1, "Wall", 0, 4).id();
+
+    let mut runner = scenario.build();
+
+    let mut declared = false;
+    let mut blocked = false;
+    for _ in 0..400 {
+        // Stop once She-Hulk has the counter (trigger resolved) — before combat
+        // damage muddies the picture.
+        if runner.state().objects.get(&she_hulk).is_some_and(|o| {
+            o.counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0)
+                > 0
+        }) {
+            break;
+        }
+        let acted = match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { player, .. } if player == P0 && !declared => {
+                declared = true;
+                runner.act(GameAction::DeclareAttackers {
+                    attacks: vec![(she_hulk, AttackTarget::Player(P1))],
+                    bands: vec![],
+                })
+            }
+            WaitingFor::DeclareAttackers { .. } => runner.act(GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            }),
+            WaitingFor::DeclareBlockers { .. } if !blocked => {
+                blocked = true;
+                runner.act(GameAction::DeclareBlockers {
+                    assignments: vec![(blocker, she_hulk)],
+                })
+            }
+            WaitingFor::DeclareBlockers { .. } => runner.act(GameAction::DeclareBlockers {
+                assignments: vec![],
+            }),
+            WaitingFor::Priority { .. } => runner.act(GameAction::PassPriority),
+            _ => break,
+        };
+        if acted.is_err() {
+            break;
+        }
+    }
+
+    assert!(declared, "She-Hulk must have been declared as an attacker");
+    assert!(blocked, "the opponent must have blocked She-Hulk");
+    let counters = runner
+        .state()
+        .objects
+        .get(&she_hulk)
+        .expect("She-Hulk still exists")
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        counters, 1,
+        "She-Hulk (a Hero you control) becoming blocked by one creature must put \
+         one +1/+1 counter on her",
+    );
+}


### PR DESCRIPTION
Closes #4599

## Problem

**She-Hulk, Wallbreaker** —

> Trample
> Other Heroes you control have trample.
> **Whenever a Hero you control becomes blocked, put a +1/+1 counter on that Hero for each creature blocking it.**

— never applied the counter. The trigger fired correctly, but "that Hero"
resolved to the wrong object, so the `PutCounter` effect missed She-Hulk
entirely and no counter was placed.

## Root cause

"That Hero" lowers to `TargetFilter::ParentTarget`, whose block-event
resolution goes through `blocked_attacker_from_event` in
`crates/engine/src/game/targeting.rs`.

That helper only handled the **`Blocks`** trigger shape: it filtered the
`BlockersDeclared` assignments down to the pair whose **blocker** is the trigger
source ("Whenever ~ blocks a creature, … *that creature*" → the attacker the
source blocked). For a **`BecomesBlocked`** trigger the source is the
**attacker** (the blocked Hero), or an observer of it — never the blocker — so
the blocker-side filter matched nothing and the function returned `None`.
`ParentTarget` then fell through to the unrelated event arms
(Stationed / Crewed / ZoneChanged) and was never resolved, so the counter had no
subject.

(The trigger itself fires fine — `matching_becomes_blocked_events` handles the
`valid_card` match. The defect was purely the "that Hero" target binding.)

## Fix (additive, both trigger shapes)

When the blocker-side filter is empty, fall back to the attacker carried in the
matcher-narrowed single `(blocker, attacker)` assignment — that attacker is
exactly the blocked creature "that [creature]" refers to. The `Blocks` path is
unchanged (it returns early on a blocker match), so "Whenever ~ blocks … that
creature" keeps binding the attacker it blocked.

This covers the whole `BecomesBlocked` "that [creature]" class (counters, pumps,
etc.), not just She-Hulk.

- `crates/engine/src/game/targeting.rs` — `blocked_attacker_from_event` gains
  the attacker-side fallback.
- CR 509.1 (blocked status) + CR 608.2c (resolving "that"/"it" to the
  established object) — both verified against `docs/MagicCompRules.txt`.

## Verification

- New runtime combat regression
  (`she_hulk_wallbreaker_becomes_blocked_4599`): drives a real
  attack → declare-blocker sequence and asserts a `Plus1Plus1` counter lands on
  the blocked Hero (0 before the fix → 1 after).
- Full engine lib **14159 passed / 0 failed**; 49 block-trigger integration
  tests pass; `clippy` clean.
