### PR TITLE
[codex] add PR review contributor analytics

### DIFF
--- a/scripts/pr-analytics
+++ b/scripts/pr-analytics
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Convenience wrapper for contributor review analytics.
+#
+# Usage:
+#   scripts/pr-analytics
+#   scripts/pr-analytics author <login>
+#   scripts/pr-analytics json
+#   scripts/pr-analytics refresh
+#   scripts/pr-analytics top 10
+#   scripts/pr-analytics -- --sort acceptance --include-open
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+args=("analytics")
+
+while (($#)); do
+  case "$1" in
+    author)
+      args+=("--author" "${2:?author requires a login}")
+      shift 2
+      ;;
+    json)
+      args+=("--format" "json")
+      shift
+      ;;
+    refresh)
+      args+=("--refresh-github")
+      shift
+      ;;
+    top)
+      args+=("--limit" "${2:?top requires a count}")
+      shift 2
+      ;;
+    --)
+      shift
+      args+=("$@")
+      break
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+exec python3 "$script_dir/pr_review.py" "${args[@]}"

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -348,12 +348,15 @@ def event_sort_key(event: dict[str, Any]) -> tuple[str, str]:
 
 
 def parse_event_datetime(value: str | None) -> datetime | None:
-    if not value:
+    if not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def filtered_events_by_days(events: list[dict[str, Any]], days: int | None) -> list[dict[str, Any]]:
@@ -765,11 +768,12 @@ def build_analytics_model(
     for event in filtered_events:
         event_type = event.get("event_type")
         login = contributor_login_for_event(event)
-        if event_type == "quality_entry" and login:
-            signals = event.get("quality", {}).get("signals", [])
-            quality = contributor_quality.setdefault(str(login), {})
-            for signal in signals:
-                add_counter(quality, str(signal))
+        if event_type == "quality_entry":
+            if login:
+                signals = event.get("quality", {}).get("signals", [])
+                quality = contributor_quality.setdefault(str(login), {})
+                for signal in signals:
+                    add_counter(quality, str(signal))
             continue
         pr = event.get("pr")
         if pr is None:
@@ -980,6 +984,9 @@ def apply_github_refresh(model: dict[str, Any], repo: str, min_prs: int, author:
             live = gh_pr_analytics_state(repo, int(pr["pr"]))
         except subprocess.CalledProcessError as exc:
             warnings.append(f"failed to refresh PR {pr['pr']}: {exc}")
+            continue
+        if not isinstance(live, dict):
+            warnings.append(f"failed to refresh PR {pr['pr']}: empty or invalid response")
             continue
         refreshed += 1
         state = str(live.get("state") or "").upper()
@@ -1636,8 +1643,7 @@ def command_analytics(args: argparse.Namespace) -> int:
         if not args.include_open:
             filter_open_prs(model, args.min_prs, args.author, True)
         model["filters"]["include_open"] = args.include_open
-    if args.limit is not None:
-        model["contributors"] = sorted_contributors(model["contributors"], args.sort, args.limit)
+    model["contributors"] = sorted_contributors(model["contributors"], args.sort, args.limit)
     if args.format == "json":
         print(json.dumps(model, indent=2, sort_keys=True))
     else:

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -20,11 +20,75 @@ import tomllib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from statistics import median
 from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_POLICY = REPO_ROOT / ".agents/pr-review-policy.toml"
+PRIVATE_OVERRIDES = "private-overrides.json"
+SUCCESS_STATES = {"accepted", "merged"}
+BLOCK_STATES = {"blocked", "changes_requested"}
+HOLD_STATES = {"held", "held_ci"}
+TERMINAL_STATES = SUCCESS_STATES | BLOCK_STATES | {"closed"}
+PR_ATTRIBUTED_EVENTS = {
+    "approval_enqueue",
+    "approved_enqueued",
+    "blocked",
+    "changes_requested",
+    "defer",
+    "deferred",
+    "fixup_push",
+    "freshness_check",
+    "hard_stop",
+    "held",
+    "held_current_changes_requested",
+    "held_mixed_fe",
+    "hold",
+    "hold_ci",
+    "hold_review",
+    "pruned",
+    "pruned_merged",
+    "prune_merged",
+    "request_changes",
+    "review",
+    "review_blocked",
+    "review_correction",
+    "review_reopened",
+    "tracker_row",
+    "update_branch",
+}
+QUALITY_SIGNAL_WEIGHTS = {
+    "wrong-seam": 14,
+    "false-green": 12,
+    "runtime-test-gap": 10,
+    "scope-contamination": 10,
+    "rebase-not-fix": 8,
+    "build-for-card": 8,
+    "fmt/clippy-slip": 5,
+    "stale-approval": 4,
+    "low-effort-risk": 8,
+    "author-created-issue-high-bar": 6,
+    "value-bar": 6,
+    "careful-watch": 4,
+}
+
+
+@dataclass(frozen=True)
+class CanonicalOutcome:
+    state: str
+    source: str
+    confidence: str
+    reason: str
+
+
+@dataclass
+class PrAccumulator:
+    pr: int
+    contributor_login: str
+    events: list[dict[str, Any]]
+    head_events: dict[str, list[dict[str, Any]]]
+    quality_signals: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -73,6 +137,21 @@ def load_policy(path: Path) -> Policy:
         return Policy({})
     with path.open("rb") as file:
         return Policy(tomllib.load(file))
+
+
+def load_private_overrides(state_dir: Path) -> dict[str, Any]:
+    path = state_dir / PRIVATE_OVERRIDES
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def frontend_review_allowed(author_login: str | None, overrides: dict[str, Any]) -> bool:
+    if not author_login:
+        return False
+    authors = overrides.get("frontend_review_authors", [])
+    normalized = {str(author).lower() for author in authors}
+    return author_login.lower() in normalized
 
 
 def json_dumps(value: Any) -> str:
@@ -264,6 +343,691 @@ def latest_events_by_pr_head(state_dir: Path) -> dict[tuple[int, str], dict[str,
     return latest
 
 
+def event_sort_key(event: dict[str, Any]) -> tuple[str, str]:
+    return (str(event.get("timestamp") or ""), str(event.get("event_id") or ""))
+
+
+def parse_event_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def filtered_events_by_days(events: list[dict[str, Any]], days: int | None) -> list[dict[str, Any]]:
+    if days is None:
+        return events
+    cutoff = datetime.now(UTC).replace(microsecond=0).timestamp() - (days * 24 * 60 * 60)
+    filtered = []
+    for event in events:
+        timestamp = parse_event_datetime(event.get("timestamp"))
+        if timestamp is not None and timestamp.timestamp() >= cutoff:
+            filtered.append(event)
+    return filtered
+
+
+def canonical_from_text(value: str | None) -> tuple[str, str] | None:
+    if not value:
+        return None
+    text = value.lower().replace("_", "-")
+    if "changes-requested" in text or "request-changes" in text or "reviewed-request-changes" in text:
+        return ("changes_requested", "negative_review")
+    if "still-blocked" in text or text == "blocked" or text.startswith("blocked-"):
+        return ("blocked", "blocked")
+    if "hard-stop" in text:
+        return ("blocked", "hard_stop")
+    if "merged" in text or "pruned-as-merged" in text or text == "pruned-merged":
+        return ("merged", "merged")
+    if "defer-fe" in text or text == "defer" or text == "deferred":
+        return ("deferred", "deferred")
+    if "ci-failed" in text:
+        return ("changes_requested", "ci_failed")
+    if "pending-ci" in text or "hold-ci" in text or text == "hold-ci":
+        return ("held_ci", "ci_pending")
+    if text.startswith("hold") or text == "held" or text.startswith("held-"):
+        return ("held", "held")
+    if "approved-enqueued" in text or "approved-labeled-enqueued" in text:
+        return ("accepted", "approved_enqueued")
+    if text in {"enqueued", "enqueue", "approve-enqueue", "approval-enqueue", "handler-enqueue"}:
+        return ("accepted", "enqueued")
+    if text == "approved" or text == "approve":
+        return ("accepted", "approved")
+    if text.startswith("approve-pending") or text.startswith("content-clean-pending"):
+        return ("held_ci", "approval_pending_ci")
+    if text == "review" or text.startswith("review-"):
+        return ("review", "review")
+    if text == "pending" or text.startswith("pending-"):
+        return ("pending", "pending")
+    if text == "closed" or text.startswith("supersede") or text.startswith("superseded"):
+        return ("closed", "closed")
+    if text in {"queued", "pruned"}:
+        return ("accepted", text)
+    return None
+
+
+def canonical_outcome(event: dict[str, Any]) -> CanonicalOutcome:
+    tracker = event.get("tracker") or {}
+    sources = [
+        ("outcome", event.get("outcome")),
+        ("action", event.get("action")),
+        ("event_type", event.get("event_type")),
+        ("tracker.verdict", tracker.get("verdict")),
+    ]
+    for source, value in sources:
+        mapped = canonical_from_text(str(value) if value is not None else None)
+        if mapped is not None:
+            state, reason = mapped
+            return CanonicalOutcome(state, source, "high", reason)
+    enqueued = str(tracker.get("enqueued") or "").lower()
+    if enqueued in {"yes", "true"}:
+        return CanonicalOutcome("accepted", "tracker.enqueued", "medium", "legacy_enqueued")
+    return CanonicalOutcome("unknown", "none", "low", "unclassified")
+
+
+def contributor_login_for_event(event: dict[str, Any]) -> str | None:
+    event_type = event.get("event_type")
+    tracker = event.get("tracker") or {}
+    quality = event.get("quality") or {}
+    if event_type == "tracker_row":
+        return tracker.get("author") or event.get("author")
+    if event_type == "quality_entry":
+        return quality.get("login") or event.get("author")
+    if event_type in PR_ATTRIBUTED_EVENTS:
+        return event.get("author")
+    return None
+
+
+def audit_event_values(events: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    counters: dict[str, dict[str, int]] = {
+        "event_type": {},
+        "action": {},
+        "outcome": {},
+        "tracker_verdict": {},
+        "tracker_enqueued": {},
+    }
+    for event in events:
+        tracker = event.get("tracker") or {}
+        for name, value in [
+            ("event_type", event.get("event_type")),
+            ("action", event.get("action")),
+            ("outcome", event.get("outcome")),
+            ("tracker_verdict", tracker.get("verdict")),
+            ("tracker_enqueued", tracker.get("enqueued")),
+        ]:
+            if value:
+                text = str(value)
+                counters[name][text] = counters[name].get(text, 0) + 1
+    return counters
+
+
+def unknown_event_values(events: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    unknowns: dict[str, dict[str, int]] = {
+        "event_type": {},
+        "action": {},
+        "outcome": {},
+        "tracker_verdict": {},
+    }
+    for event in events:
+        if canonical_outcome(event).state != "unknown":
+            continue
+        tracker = event.get("tracker") or {}
+        for name, value in [
+            ("event_type", event.get("event_type")),
+            ("action", event.get("action")),
+            ("outcome", event.get("outcome")),
+            ("tracker_verdict", tracker.get("verdict")),
+        ]:
+            if value:
+                text = str(value)
+                unknowns[name][text] = unknowns[name].get(text, 0) + 1
+    return {name: values for name, values in unknowns.items() if values}
+
+
+def head_analytics(pr: int, head_sha: str, events: list[dict[str, Any]]) -> dict[str, Any]:
+    sorted_events = sorted(events, key=event_sort_key)
+    ever_states: dict[str, int] = {}
+    terminal = CanonicalOutcome("pending", "default", "low", "no_terminal_event")
+    for event in sorted_events:
+        outcome = canonical_outcome(event)
+        ever_states[outcome.state] = ever_states.get(outcome.state, 0) + 1
+        if outcome.state in TERMINAL_STATES:
+            terminal = outcome
+        elif terminal.state not in TERMINAL_STATES and outcome.state in {
+            "held",
+            "held_ci",
+            "deferred",
+            "review",
+            "pending",
+        }:
+            terminal = outcome
+    return {
+        "pr": pr,
+        "head_sha": head_sha,
+        "events": len(sorted_events),
+        "canonical_state": terminal.state,
+        "terminal_state": terminal.state,
+        "terminal_state_source": terminal.source,
+        "terminal_state_reason": terminal.reason,
+        "ever_states": ever_states,
+        "first_seen": sorted_events[0].get("timestamp") if sorted_events else None,
+        "last_seen": sorted_events[-1].get("timestamp") if sorted_events else None,
+    }
+
+
+def no_head_analytics(pr: int, events: list[dict[str, Any]]) -> dict[str, Any]:
+    return head_analytics(pr, "", events)
+
+
+def pr_analytics(accumulator: PrAccumulator) -> dict[str, Any]:
+    head_rows = [
+        head_analytics(accumulator.pr, head_sha, events)
+        for head_sha, events in accumulator.head_events.items()
+    ]
+    no_head_events = [event for event in accumulator.events if not event.get("head_sha")]
+    if not head_rows and no_head_events:
+        head_rows.append(no_head_analytics(accumulator.pr, no_head_events))
+    head_rows.sort(key=lambda item: (item.get("last_seen") or "", item.get("head_sha") or ""))
+    latest = head_rows[-1] if head_rows else {
+        "terminal_state": "unknown",
+        "terminal_state_source": "none",
+        "terminal_state_reason": "no_events",
+        "ever_states": {},
+    }
+    all_events_for_pr = sorted(accumulator.events, key=event_sort_key)
+    ever_states: dict[str, int] = {}
+    for row in head_rows:
+        for state, count in row["ever_states"].items():
+            ever_states[state] = ever_states.get(state, 0) + count
+    observed_heads = len([head_sha for head_sha in accumulator.head_events if head_sha])
+    return {
+        "pr": accumulator.pr,
+        "contributor_login": accumulator.contributor_login,
+        "observed_heads": observed_heads,
+        "latest_head_sha": latest.get("head_sha") or None,
+        "head_states": head_rows,
+        "terminal_state": latest["terminal_state"],
+        "terminal_state_source": latest["terminal_state_source"],
+        "terminal_state_reason": latest["terminal_state_reason"],
+        "ever_states": ever_states,
+        "quality_signals": accumulator.quality_signals,
+        "first_seen": all_events_for_pr[0].get("timestamp") if all_events_for_pr else None,
+        "last_seen": all_events_for_pr[-1].get("timestamp") if all_events_for_pr else None,
+        "is_open_or_pending": latest["terminal_state"] not in TERMINAL_STATES,
+        "event_count": len(all_events_for_pr),
+    }
+
+
+def rate(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def percentile(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{round(value * 100):d}%"
+
+
+def average(values: list[int]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def confidence_for(total_prs: int, terminal_prs: int, unclassified_ratio: float, refreshed: bool) -> str:
+    if total_prs == 0 or terminal_prs < 2 or unclassified_ratio > 0.35:
+        return "low"
+    if refreshed and terminal_prs >= 8 and unclassified_ratio <= 0.10:
+        return "high"
+    if terminal_prs >= 5 and unclassified_ratio <= 0.20:
+        return "medium"
+    return "low"
+
+
+def score_label(score: int, confidence: str) -> str:
+    if confidence == "low":
+        return "Insufficient Data"
+    if score >= 90:
+        return "Excellent Signal"
+    if score >= 75:
+        return "Strong Signal"
+    if score >= 55:
+        return "Watch"
+    return "Elevated Scrutiny"
+
+
+def contributor_score(
+    success_rate: float | None,
+    block_rate: float | None,
+    avg_observed_heads: float,
+    repo_median_heads: float,
+    quality_signals: dict[str, int],
+) -> dict[str, Any]:
+    success_component = 0 if success_rate is None else round((success_rate - 0.5) * 30)
+    block_penalty = 0 if block_rate is None else round(block_rate * 30)
+    observed_head_penalty = max(0, round((avg_observed_heads - repo_median_heads) * 6))
+    signal_penalty = sum(
+        QUALITY_SIGNAL_WEIGHTS.get(signal, 5) * count
+        for signal, count in quality_signals.items()
+    )
+    clean_bonus = 5 if success_rate is not None and success_rate >= 0.85 and signal_penalty == 0 else 0
+    score = 65 + success_component - block_penalty - observed_head_penalty - signal_penalty + clean_bonus
+    score = min(100, max(0, score))
+    return {
+        "score": score,
+        "components": {
+            "baseline": 65,
+            "success_component": success_component,
+            "block_penalty": block_penalty,
+            "observed_head_penalty": observed_head_penalty,
+            "quality_signal_penalty": signal_penalty,
+            "clean_bonus": clean_bonus,
+        },
+    }
+
+
+def contributor_analytics(
+    login: str,
+    prs: list[dict[str, Any]],
+    quality_signals: dict[str, int],
+    repo_median_heads: float,
+    refreshed: bool,
+    min_prs: int,
+) -> dict[str, Any]:
+    terminal = [pr for pr in prs if pr["terminal_state"] in TERMINAL_STATES]
+    successes = [pr for pr in terminal if pr["terminal_state"] in SUCCESS_STATES]
+    blocks = [
+        pr for pr in prs
+        if any(state in pr["ever_states"] for state in BLOCK_STATES)
+    ]
+    holds = [
+        pr for pr in prs
+        if any(state in pr["ever_states"] for state in HOLD_STATES)
+    ]
+    deferred = [pr for pr in prs if pr["terminal_state"] == "deferred"]
+    observed_heads = [pr["observed_heads"] for pr in prs]
+    unknown_events = sum(pr["ever_states"].get("unknown", 0) for pr in prs)
+    total_events = sum(sum(pr["ever_states"].values()) for pr in prs)
+    unclassified_ratio = (unknown_events / total_events) if total_events else 0.0
+    success = rate(len(successes), len(terminal))
+    block = rate(len(blocks), len(prs))
+    score_data = contributor_score(
+        success,
+        block,
+        average(observed_heads),
+        repo_median_heads,
+        quality_signals,
+    )
+    confidence = confidence_for(len(prs), len(terminal), unclassified_ratio, refreshed)
+    if len(prs) < min_prs:
+        confidence = "low"
+    top_signals = sorted(
+        quality_signals.items(),
+        key=lambda item: (-item[1], item[0]),
+    )[:5]
+    return {
+        "login": login,
+        "prs": len(prs),
+        "terminal_prs": len(terminal),
+        "accepted_or_enqueued": len(successes),
+        "observed_success_rate": success,
+        "observed_heads_avg": round(average(observed_heads), 2),
+        "observed_heads_median": median(observed_heads) if observed_heads else 0,
+        "blocks": len(blocks),
+        "holds": len(holds),
+        "deferred": len(deferred),
+        "quality_signals": quality_signals,
+        "top_signals": [{"signal": signal, "count": count} for signal, count in top_signals],
+        "local_signal_score": score_data["score"],
+        "score_components": score_data["components"],
+        "confidence": confidence,
+        "score_label": score_label(score_data["score"], confidence),
+        "unclassified_ratio": round(unclassified_ratio, 3),
+        "first_seen": min((pr["first_seen"] for pr in prs if pr.get("first_seen")), default=None),
+        "last_seen": max((pr["last_seen"] for pr in prs if pr.get("last_seen")), default=None),
+        "recent_prs": sorted(prs, key=lambda pr: (pr.get("last_seen") or "", pr["pr"]))[-5:],
+    }
+
+
+def contributor_rows_from_prs(
+    prs: list[dict[str, Any]],
+    contributor_quality: dict[str, dict[str, int]],
+    repo_median_heads: float,
+    refreshed: bool,
+    min_prs: int,
+    author: str | None,
+) -> list[dict[str, Any]]:
+    contributor_prs: dict[str, list[dict[str, Any]]] = {}
+    for pr in prs:
+        contributor_prs.setdefault(pr["contributor_login"], []).append(pr)
+    contributors = []
+    for login, login_prs in contributor_prs.items():
+        contributors.append(
+            contributor_analytics(
+                login,
+                sorted(login_prs, key=lambda item: item["pr"]),
+                contributor_quality.get(login, {}),
+                repo_median_heads,
+                refreshed,
+                min_prs,
+            )
+        )
+    for login, signals in contributor_quality.items():
+        if author and login.lower() != author.lower():
+            continue
+        if login not in contributor_prs:
+            contributors.append(
+                contributor_analytics(
+                    login,
+                    [],
+                    signals,
+                    repo_median_heads,
+                    refreshed,
+                    min_prs,
+                )
+            )
+    return contributors
+
+
+def build_pr_contributor_map(events: list[dict[str, Any]]) -> dict[int, str]:
+    contributors: dict[int, str] = {}
+    for event in sorted(events, key=event_sort_key):
+        pr = event.get("pr")
+        if pr is None:
+            continue
+        login = contributor_login_for_event(event)
+        if login:
+            contributors.setdefault(int(pr), str(login))
+    return contributors
+
+
+def add_counter(target: dict[str, int], key: str, count: int = 1) -> None:
+    target[key] = target.get(key, 0) + count
+
+
+def build_analytics_model(
+    events: list[dict[str, Any]],
+    *,
+    days: int | None,
+    author: str | None,
+    min_prs: int,
+    include_open: bool,
+    refreshed: bool = False,
+) -> dict[str, Any]:
+    all_sorted_events = sorted(events, key=event_sort_key)
+    pr_contributors = build_pr_contributor_map(all_sorted_events)
+    filtered_events = filtered_events_by_days(all_sorted_events, days)
+    pr_accumulators: dict[int, PrAccumulator] = {}
+    contributor_quality: dict[str, dict[str, int]] = {}
+    for event in filtered_events:
+        event_type = event.get("event_type")
+        login = contributor_login_for_event(event)
+        if event_type == "quality_entry" and login:
+            signals = event.get("quality", {}).get("signals", [])
+            quality = contributor_quality.setdefault(str(login), {})
+            for signal in signals:
+                add_counter(quality, str(signal))
+            continue
+        pr = event.get("pr")
+        if pr is None:
+            continue
+        pr_number = int(pr)
+        contributor = login or pr_contributors.get(pr_number)
+        if contributor is None:
+            continue
+        if author and contributor.lower() != author.lower():
+            continue
+        accumulator = pr_accumulators.setdefault(
+            pr_number,
+            PrAccumulator(pr_number, contributor, [], {}, {}),
+        )
+        accumulator.events.append(event)
+        head_sha = event.get("head_sha")
+        if head_sha:
+            accumulator.head_events.setdefault(str(head_sha), []).append(event)
+    for pr_number, accumulator in pr_accumulators.items():
+        quality = contributor_quality.get(accumulator.contributor_login, {})
+        accumulator.quality_signals.update(quality)
+    prs = [pr_analytics(accumulator) for accumulator in pr_accumulators.values()]
+    if not include_open:
+        prs = [pr for pr in prs if not pr["is_open_or_pending"]]
+    observed_head_values = [pr["observed_heads"] for pr in prs if pr["observed_heads"] > 0]
+    repo_median_heads = median(observed_head_values) if observed_head_values else 0
+    contributor_signals = {
+        login: dict(signals) for login, signals in contributor_quality.items()
+        if author is None or login.lower() == author.lower()
+    }
+    contributors = contributor_rows_from_prs(
+        prs,
+        contributor_signals,
+        repo_median_heads,
+        refreshed,
+        min_prs,
+        author,
+    )
+    return {
+        "generated_at": now_iso(),
+        "mode": "github_refreshed" if refreshed else "local_observed",
+        "title": "Local Observed Review Analytics",
+        "filters": {
+            "author": author,
+            "days": days,
+            "min_prs": min_prs,
+            "include_open": include_open,
+        },
+        "repo_medians": {"observed_heads": repo_median_heads},
+        "contributors": contributors,
+        "prs": prs,
+        "quality_by_contributor": contributor_signals,
+        "unclassified_counts": unknown_event_values(filtered_events),
+        "audit_counts": audit_event_values(filtered_events),
+        "warnings": [],
+    }
+
+
+def score_bar(score: int, width: int = 12) -> str:
+    filled = round((score / 100) * width)
+    return "#" * filled + "." * (width - filled)
+
+
+def sorted_contributors(
+    contributors: list[dict[str, Any]],
+    sort_key: str,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    def confidence_rank(item: dict[str, Any]) -> int:
+        return {"high": 0, "medium": 1, "low": 2}.get(item["confidence"], 3)
+
+    if sort_key == "activity":
+        key = lambda item: (confidence_rank(item), -item["prs"], item["login"].lower())
+    elif sort_key == "acceptance":
+        key = lambda item: (
+            confidence_rank(item),
+            -(item["observed_success_rate"] or 0),
+            item["login"].lower(),
+        )
+    elif sort_key == "observed-heads":
+        key = lambda item: (
+            confidence_rank(item),
+            -item["observed_heads_avg"],
+            item["login"].lower(),
+        )
+    else:
+        key = lambda item: (
+            confidence_rank(item),
+            -item["local_signal_score"],
+            item["login"].lower(),
+        )
+    rows = sorted(contributors, key=key)
+    return rows[:limit] if limit is not None else rows
+
+
+def render_top_signals(contributor: dict[str, Any]) -> str:
+    signals = contributor.get("top_signals", [])
+    if not signals:
+        return "-"
+    return ",".join(f"{item['signal']}:{item['count']}" for item in signals[:3])
+
+
+def confidence_display(value: str) -> str:
+    return {"high": "high", "medium": "med", "low": "low"}.get(value, value[:5])
+
+
+def render_analytics_table(model: dict[str, Any], *, sort_key: str, limit: int | None) -> str:
+    rows = sorted_contributors(model["contributors"], sort_key, limit)
+    output = [
+        model["title"],
+        "Note: local observed data; use --refresh-github for authoritative merge/close state.",
+        "",
+        "Contributor           PRs Term Succ% Heads Blocks Holds Score Conf  Signal        TopSignals",
+        "-------------------- ---- ---- ----- ----- ------ ----- ----- ----- ------------- ----------------",
+    ]
+    for row in rows:
+        output.append(
+            f"{row['login'][:20]:20} "
+            f"{row['prs']:4d} "
+            f"{row['terminal_prs']:4d} "
+            f"{percentile(row['observed_success_rate']):>5} "
+            f"{row['observed_heads_avg']:5.1f} "
+            f"{row['blocks']:6d} "
+            f"{row['holds']:5d} "
+            f"{row['local_signal_score']:5d} "
+            f"{confidence_display(row['confidence']):5} "
+            f"{score_bar(row['local_signal_score']):13} "
+            f"{render_top_signals(row)}"
+        )
+    if not rows:
+        output.append("(no contributors matched)")
+    return "\n".join(output)
+
+
+def render_count_bar(label: str, value: int, max_value: int) -> str:
+    width = 24
+    filled = 0 if max_value == 0 else round((value / max_value) * width)
+    return f"{label:18} {value:4d} {'#' * filled}{'.' * (width - filled)}"
+
+
+def render_contributor_detail(model: dict[str, Any], login: str) -> str:
+    matches = [
+        contributor for contributor in model["contributors"]
+        if contributor["login"].lower() == login.lower()
+    ]
+    if not matches:
+        return f"No analytics found for {login}."
+    row = matches[0]
+    components = row["score_components"]
+    max_count = max(row["accepted_or_enqueued"], row["blocks"], row["holds"], row["deferred"], 1)
+    lines = [
+        f"{row['login']} - {model['title']}",
+        "Note: local observed data; use --refresh-github for authoritative merge/close state.",
+        "",
+        f"Local Signal Score: {row['local_signal_score']} / 100 ({row['score_label']}, confidence: {row['confidence']})",
+        f"PRs: {row['prs']}  Terminal: {row['terminal_prs']}  Observed success: {percentile(row['observed_success_rate'])}",
+        f"Observed heads avg: {row['observed_heads_avg']}  median: {row['observed_heads_median']}",
+        "",
+        "Score Components",
+    ]
+    for name, value in components.items():
+        lines.append(f"  {name:24} {value}")
+    lines.extend(
+        [
+            "",
+            "Outcomes",
+            render_count_bar("accepted/enqueued", row["accepted_or_enqueued"], max_count),
+            render_count_bar("blocks", row["blocks"], max_count),
+            render_count_bar("holds", row["holds"], max_count),
+            render_count_bar("deferred", row["deferred"], max_count),
+            "",
+            "Top Signals",
+        ]
+    )
+    if row["top_signals"]:
+        for signal in row["top_signals"]:
+            lines.append(f"  {signal['signal']}: {signal['count']}")
+    else:
+        lines.append("  -")
+    lines.append("")
+    lines.append("Recent PRs")
+    for pr in row["recent_prs"]:
+        lines.append(
+            f"  #{pr['pr']} state={pr['terminal_state']} "
+            f"heads={pr['observed_heads']} last={pr.get('last_seen') or '-'}"
+        )
+    if not row["recent_prs"]:
+        lines.append("  -")
+    return "\n".join(lines)
+
+
+def render_analytics_ascii(model: dict[str, Any], args: argparse.Namespace) -> str:
+    if args.author:
+        return render_contributor_detail(model, args.author)
+    return render_analytics_table(model, sort_key=args.sort, limit=args.limit)
+
+
+def gh_pr_analytics_state(repo: str, pr_number: int) -> dict[str, Any]:
+    fields = "number,state,author,headRefOid,reviewDecision,mergedAt,closedAt"
+    return run_json(["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", fields])
+
+
+def apply_github_refresh(model: dict[str, Any], repo: str, min_prs: int, author: str | None) -> None:
+    warnings = model.setdefault("warnings", [])
+    refreshed = 0
+    for pr in model["prs"]:
+        try:
+            live = gh_pr_analytics_state(repo, int(pr["pr"]))
+        except subprocess.CalledProcessError as exc:
+            warnings.append(f"failed to refresh PR {pr['pr']}: {exc}")
+            continue
+        refreshed += 1
+        state = str(live.get("state") or "").upper()
+        pr["github"] = {
+            "state": state,
+            "author_login": (live.get("author") or {}).get("login"),
+            "headRefOid": live.get("headRefOid"),
+            "reviewDecision": live.get("reviewDecision"),
+            "mergedAt": live.get("mergedAt"),
+            "closedAt": live.get("closedAt"),
+        }
+        if state == "MERGED":
+            pr["terminal_state"] = "merged"
+            pr["terminal_state_source"] = "github.state"
+            pr["terminal_state_reason"] = "merged"
+            pr["is_open_or_pending"] = False
+        elif state == "CLOSED":
+            pr["terminal_state"] = "closed"
+            pr["terminal_state_source"] = "github.state"
+            pr["terminal_state_reason"] = "closed"
+            pr["is_open_or_pending"] = False
+    model["mode"] = "github_refreshed"
+    model["title"] = "GitHub Refreshed Review Analytics"
+    model["github_refreshed_prs"] = refreshed
+    model["contributors"] = contributor_rows_from_prs(
+        model["prs"],
+        model.get("quality_by_contributor", {}),
+        float(model["repo_medians"]["observed_heads"]),
+        True,
+        min_prs,
+        author,
+    )
+
+
+def filter_open_prs(model: dict[str, Any], min_prs: int, author: str | None, refreshed: bool) -> None:
+    model["prs"] = [pr for pr in model["prs"] if not pr["is_open_or_pending"]]
+    observed_head_values = [pr["observed_heads"] for pr in model["prs"] if pr["observed_heads"] > 0]
+    model["repo_medians"]["observed_heads"] = median(observed_head_values) if observed_head_values else 0
+    model["contributors"] = contributor_rows_from_prs(
+        model["prs"],
+        model.get("quality_by_contributor", {}),
+        float(model["repo_medians"]["observed_heads"]),
+        refreshed,
+        min_prs,
+        author,
+    )
+
+
 def matches_any(path: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
 
@@ -399,6 +1163,7 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     local_event = packet.get("local_current_event") or {}
     local_event_type = local_event.get("event_type")
     local_outcome = local_event.get("outcome")
+    author_policy = packet.get("author_policy", {})
 
     if pr.get("state") == "MERGED":
         action = "merged_prune"
@@ -438,7 +1203,9 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif checks.get("state") in {"pending", "unknown"}:
         action = "hold_ci"
         reason = "ci_not_green"
-    elif classification.get("surface") == "frontend":
+    elif classification.get("surface") == "frontend" and not author_policy.get(
+        "frontend_review_allowed"
+    ):
         action = "defer"
         reason = "frontend_policy"
     elif local_event_type == "approved_enqueued":
@@ -470,11 +1237,22 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def make_packet(pr: dict[str, Any], policy: Policy, acting_login: str, mode: str) -> dict[str, Any]:
+def make_packet(
+    pr: dict[str, Any],
+    policy: Policy,
+    acting_login: str,
+    mode: str,
+    private_overrides: dict[str, Any],
+) -> dict[str, Any]:
     files = pr_files_from_view(pr)
     classification = classify_files(files, policy)
     checks = status_summary(pr.get("statusCheckRollup", []))
     compact_pr = compact_pr_view(pr, acting_login)
+    author_policy = {
+        "frontend_review_allowed": frontend_review_allowed(
+            compact_pr.get("author_login"), private_overrides
+        )
+    }
     packet = {
         "schema_version": 1,
         "completeness": "complete" if mode == "full" else "triage",
@@ -485,6 +1263,7 @@ def make_packet(pr: dict[str, Any], policy: Policy, acting_login: str, mode: str
         "ci": checks,
         "latest_maintainer_review_commit": latest_review_commit(pr, acting_login),
         "domain": {"rules_domain": policy.rules_domain},
+        "author_policy": author_policy,
         "policy_trace": policy_trace(classification),
     }
     packet["recommendation"] = recommend_from_packet(packet)
@@ -549,6 +1328,7 @@ def gh_queue_state(repo: str, pr_number: int) -> dict[str, Any]:
 
 def command_scan(args: argparse.Namespace) -> int:
     policy = load_policy(args.config)
+    private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
     local_events = latest_events_by_pr_head(args.state_dir)
     prs = run_json(
@@ -569,7 +1349,7 @@ def command_scan(args: argparse.Namespace) -> int:
     candidates = []
     for pr in prs:
         pr_number = int(pr["number"])
-        packet = make_packet(pr, policy, acting_login, "light")
+        packet = make_packet(pr, policy, acting_login, "light", private_overrides)
         packet["local_current_event"] = local_events.get((pr_number, pr.get("headRefOid") or ""))
         packet["recommendation"] = recommend_from_packet(packet)
         if packet["recommendation"]["reason"] in {
@@ -581,7 +1361,7 @@ def command_scan(args: argparse.Namespace) -> int:
             "dequeue_stale_for_handler",
         }:
             pr = gh_pr_view(args.repo, pr_number)
-            packet = make_packet(pr, policy, acting_login, "full")
+            packet = make_packet(pr, policy, acting_login, "full", private_overrides)
             packet["local_current_event"] = local_events.get(
                 (pr_number, pr.get("headRefOid") or "")
             )
@@ -654,9 +1434,10 @@ def command_scan(args: argparse.Namespace) -> int:
 
 def command_inspect(args: argparse.Namespace) -> int:
     policy = load_policy(args.config)
+    private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
     pr = gh_pr_view(args.repo, args.pr)
-    packet = make_packet(pr, policy, acting_login, args.mode)
+    packet = make_packet(pr, policy, acting_login, args.mode, private_overrides)
     packet["local_current_event"] = latest_events_by_pr_head(args.state_dir).get(
         (args.pr, pr.get("headRefOid") or "")
     )
@@ -667,9 +1448,10 @@ def command_inspect(args: argparse.Namespace) -> int:
 
 def command_recommend(args: argparse.Namespace) -> int:
     policy = load_policy(args.config)
+    private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
     pr = gh_pr_view(args.repo, args.pr)
-    packet = make_packet(pr, policy, acting_login, "full")
+    packet = make_packet(pr, policy, acting_login, "full", private_overrides)
     packet["local_current_event"] = latest_events_by_pr_head(args.state_dir).get(
         (args.pr, pr.get("headRefOid") or "")
     )
@@ -839,6 +1621,30 @@ def command_compact(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_analytics(args: argparse.Namespace) -> int:
+    rebuild_index(args.state_dir)
+    events = all_events(args.state_dir)
+    model = build_analytics_model(
+        events,
+        days=args.days,
+        author=args.author,
+        min_prs=args.min_prs,
+        include_open=args.include_open or args.refresh_github,
+    )
+    if args.refresh_github:
+        apply_github_refresh(model, args.repo, args.min_prs, args.author)
+        if not args.include_open:
+            filter_open_prs(model, args.min_prs, args.author, True)
+        model["filters"]["include_open"] = args.include_open
+    if args.limit is not None:
+        model["contributors"] = sorted_contributors(model["contributors"], args.sort, args.limit)
+    if args.format == "json":
+        print(json.dumps(model, indent=2, sort_keys=True))
+    else:
+        print(render_analytics_ascii(model, args))
+    return 0
+
+
 def existing_path(value: str) -> Path:
     path = Path(value).expanduser()
     if not path.exists():
@@ -898,6 +1704,22 @@ def build_parser() -> argparse.ArgumentParser:
     compact = sub.add_parser("compact")
     add_state(compact)
     compact.set_defaults(func=command_compact)
+
+    analytics = sub.add_parser("analytics")
+    add_state(analytics)
+    analytics.add_argument("--author")
+    analytics.add_argument("--days", type=int, default=None)
+    analytics.add_argument("--min-prs", type=int, default=3)
+    analytics.add_argument("--format", choices=["ascii", "json"], default="ascii")
+    analytics.add_argument(
+        "--sort",
+        choices=["score", "activity", "acceptance", "observed-heads"],
+        default="score",
+    )
+    analytics.add_argument("--limit", type=int, default=None)
+    analytics.add_argument("--include-open", action="store_true")
+    analytics.add_argument("--refresh-github", action="store_true")
+    analytics.set_defaults(func=command_analytics)
 
     rebuild = sub.add_parser("rebuild-index")
     add_state(rebuild)

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -155,6 +155,156 @@ class PrReviewTests(unittest.TestCase):
             self.assertIn("false-green", events[0]["quality"]["signals"])
             self.assertIn("runtime-test-gap", events[0]["quality"]["signals"])
 
+    def test_canonical_outcome_maps_tracker_and_unknown_values(self) -> None:
+        accepted = pr_review.canonical_outcome(
+            {"event_type": "tracker_row", "tracker": {"verdict": "ENQUEUED"}}
+        )
+        unknown = pr_review.canonical_outcome(
+            {"event_type": "custom_event", "tracker": {"verdict": "SURPRISE"}}
+        )
+
+        self.assertEqual(accepted.state, "accepted")
+        self.assertEqual(unknown.state, "unknown")
+
+    def test_analytics_uses_latest_head_terminal_state_for_success(self) -> None:
+        events = [
+            {
+                "event_type": "changes_requested",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "old-head",
+            },
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": "2026-06-28T01:00:00Z",
+                "event_id": "b",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "new-head",
+            },
+        ]
+
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=False,
+        )
+        contributor = model["contributors"][0]
+
+        self.assertEqual(contributor["accepted_or_enqueued"], 1)
+        self.assertEqual(contributor["blocks"], 1)
+        self.assertEqual(contributor["observed_success_rate"], 1.0)
+        self.assertEqual(model["prs"][0]["observed_heads"], 2)
+
+    def test_quality_entry_affects_signals_not_pr_activity(self) -> None:
+        events = [
+            {
+                "event_type": "quality_entry",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "author": "contributor",
+                "quality": {"login": "contributor", "signals": ["wrong-seam"]},
+            }
+        ]
+
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=True,
+        )
+        contributor = model["contributors"][0]
+
+        self.assertEqual(contributor["prs"], 0)
+        self.assertEqual(contributor["quality_signals"], {"wrong-seam": 1})
+        self.assertEqual(contributor["confidence"], "low")
+
+    def test_low_sample_size_gets_insufficient_data_label(self) -> None:
+        events = [
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "head",
+            }
+        ]
+
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=3,
+            include_open=False,
+        )
+        contributor = model["contributors"][0]
+
+        self.assertEqual(contributor["confidence"], "low")
+        self.assertEqual(contributor["score_label"], "Insufficient Data")
+
+    def test_ascii_renderer_uses_json_model(self) -> None:
+        events = [
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "head",
+            }
+        ]
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=False,
+        )
+        args = type("Args", (), {"author": None, "sort": "score", "limit": None})()
+
+        rendered = pr_review.render_analytics_ascii(model, args)
+
+        self.assertIn("Local Observed Review Analytics", rendered)
+        self.assertIn("contributor", rendered)
+
+    def test_filter_open_prs_recomputes_contributors_after_refresh(self) -> None:
+        events = [
+            {
+                "event_type": "hold_ci",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "head",
+            }
+        ]
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=True,
+        )
+        model["prs"][0]["terminal_state"] = "merged"
+        model["prs"][0]["is_open_or_pending"] = False
+
+        pr_review.filter_open_prs(model, min_prs=1, author=None, refreshed=True)
+
+        self.assertEqual(model["contributors"][0]["terminal_prs"], 1)
+        self.assertEqual(model["contributors"][0]["accepted_or_enqueued"], 1)
+
+    def test_wrapper_script_exists_and_is_executable(self) -> None:
+        wrapper = Path(__file__).resolve().parent / "pr-analytics"
+
+        self.assertTrue(wrapper.exists())
+        self.assertTrue(wrapper.stat().st_mode & 0o111)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import tempfile
 import unittest
+from datetime import UTC
 from pathlib import Path
 
 import pr_review
@@ -224,6 +227,42 @@ class PrReviewTests(unittest.TestCase):
         self.assertEqual(contributor["quality_signals"], {"wrong-seam": 1})
         self.assertEqual(contributor["confidence"], "low")
 
+    def test_quality_entry_without_login_does_not_attach_to_pr_activity(self) -> None:
+        events = [
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "head",
+            },
+            {
+                "event_type": "quality_entry",
+                "timestamp": "2026-06-28T01:00:00Z",
+                "event_id": "b",
+                "pr": 1,
+                "quality": {"signals": ["wrong-seam"]},
+            },
+        ]
+
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=True,
+        )
+
+        self.assertEqual(model["prs"][0]["event_count"], 1)
+        self.assertEqual(model["contributors"][0]["quality_signals"], {})
+
+    def test_parse_event_datetime_rejects_non_string_and_normalizes_naive_time(self) -> None:
+        parsed = pr_review.parse_event_datetime("2026-06-28T00:00:00")
+
+        self.assertIsNone(pr_review.parse_event_datetime(123))
+        self.assertEqual(parsed.tzinfo, UTC)
+
     def test_low_sample_size_gets_insufficient_data_label(self) -> None:
         events = [
             {
@@ -298,6 +337,86 @@ class PrReviewTests(unittest.TestCase):
 
         self.assertEqual(model["contributors"][0]["terminal_prs"], 1)
         self.assertEqual(model["contributors"][0]["accepted_or_enqueued"], 1)
+
+    def test_github_refresh_warns_on_empty_response(self) -> None:
+        events = [
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "event_id": "a",
+                "pr": 1,
+                "author": "contributor",
+                "head_sha": "head",
+            }
+        ]
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=1,
+            include_open=True,
+        )
+        original = pr_review.gh_pr_analytics_state
+        pr_review.gh_pr_analytics_state = lambda _repo, _pr_number: None
+        try:
+            pr_review.apply_github_refresh(model, "phase-rs/phase", min_prs=1, author=None)
+        finally:
+            pr_review.gh_pr_analytics_state = original
+
+        self.assertEqual(
+            model["warnings"],
+            ["failed to refresh PR 1: empty or invalid response"],
+        )
+
+    def test_command_analytics_sorts_json_without_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            state_dir = Path(temp)
+            events = [
+                {
+                    "event_type": "changes_requested",
+                    "timestamp": "2026-06-28T00:00:00Z",
+                    "event_id": "a",
+                    "pr": 1,
+                    "author": "low-score",
+                    "head_sha": "head",
+                },
+                {
+                    "event_type": "approved_enqueued",
+                    "timestamp": "2026-06-28T00:01:00Z",
+                    "event_id": "b",
+                    "pr": 2,
+                    "author": "high-score",
+                    "head_sha": "head",
+                },
+            ]
+            for event in events:
+                pr_review.append_event(state_dir, event)
+            args = type(
+                "Args",
+                (),
+                {
+                    "state_dir": state_dir,
+                    "days": None,
+                    "author": None,
+                    "min_prs": 1,
+                    "include_open": False,
+                    "refresh_github": False,
+                    "repo": "phase-rs/phase",
+                    "limit": None,
+                    "sort": "score",
+                    "format": "json",
+                },
+            )()
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                pr_review.command_analytics(args)
+            model = json.loads(output.getvalue())
+
+        self.assertEqual(
+            [contributor["login"] for contributor in model["contributors"]],
+            ["high-score", "low-score"],
+        )
 
     def test_wrapper_script_exists_and_is_executable(self) -> None:
         wrapper = Path(__file__).resolve().parent / "pr-analytics"


### PR DESCRIPTION
## Summary

Adds contributor analytics to the PR review helper:

- new `analytics` subcommand with local observed contributor metrics
- per-head, per-PR, and per-contributor aggregation
- canonical outcome mapping with unclassified legacy values surfaced in JSON
- confidence-gated `Local Signal Score` and neutral ASCII scale labels
- opt-in `--refresh-github` for authoritative merged/closed state
- executable `scripts/pr-analytics` convenience wrapper

## Why

The review loop had local durable state but no fast way to inspect contributor activity, observed review cycles, acceptance/enqueue signal, blocks/holds, or quality signals. This keeps the default view local/advisory and makes GitHub refresh explicit so local events are not presented as authoritative merge history.

## Validation

Passed in the clean PR worktree:

- `python3 pr_review_tests.py`
- `python3 -m py_compile scripts/pr_review.py scripts/pr_review_tests.py`
- `git diff --check -- scripts/pr_review.py scripts/pr_review_tests.py scripts/pr-analytics`
- `scripts/pr-analytics top 2`
- `.githooks/pre-push` through Rust/card-data stages after restoring local MTGJSON input:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --all-targets --features engine/proptest -- -D warnings`
  - `cargo check --release --bin card-data-validate`
  - `./scripts/check-parser-combinators.sh`
  - `PROPTEST_CASES=4 cargo test -p engine --features proptest parser::oracle::tests`
  - `cargo test -p phase-ai --lib`
  - oracle generation, card-data validation, coverage report, and coverage regression check
- remaining frontend hook steps after copying local `client/node_modules` into the clean worktree:
  - `(cd client && pnpm lint)` exits 0 with existing warnings
  - `(cd client && pnpm run type-check)` exits 0
