### PR TITLE
fix(parser): nested single-quoted token ability keeps its clause (Urza's Saga ch. II) (#4605)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -550,7 +550,7 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
     let mut chars = text.chars().peekable();
     let mut paren_depth = 0usize;
     let mut in_single_quote = false;
-    // CR 111.1 (issue #4605): a created token has the abilities defined in its
+    // CR 111.3 (issue #4605): a created token has the abilities defined in its
     // creation effect. Tracks whether the currently-open single-quoted span is a
     // genuine NESTED ability quote — the inner ability of a token/permanent
     // created inside a double-quoted granted ability (Urza's Saga:
@@ -650,7 +650,7 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
             // split here and reset the phantom single-quote state.
             // `in_double_quote` (a genuine quoted ability) still suppresses the
             // split.
-            // CR 111.1 (issue #4605): inside a genuine nested ability quote
+            // CR 111.3 (issue #4605): inside a genuine nested ability quote
             // (`single_quote_is_ability`) the `.` belongs to the quoted text
             // (`... with 'This token gets +1/+1 for each artifact you control.'`)
             // and must NOT close the clause — otherwise the span is bisected and
@@ -2474,17 +2474,17 @@ fn starts_with_damage_clause(lower: &str) -> bool {
     }
 }
 
-/// CR 111.1 (issue #4605): true when the text accumulated right before an
+/// CR 111.3 (issue #4605): true when the text accumulated right before an
 /// apostrophe ends at a phrase boundary that opens a nested quoted ability
 /// (`with '` / `and '` / `or '` / `, '`). Mirrors the opener anchors in
 /// `extract_token_static_abilities`'s single-quote pass, so a possessive
 /// (`~'s`) or contraction (`can't`) apostrophe is never treated as an
 /// ability-quote opener and a sentence-ending `.` keeps splitting normally.
 fn ends_with_single_quote_ability_anchor(current: &str) -> bool {
-    current.ends_with("with ")
-        || current.ends_with("and ")
-        || current.ends_with("or ")
-        || current.ends_with(", ")
+    // allow-noncombinator: terminal suffix probe on the incremental chunk buffer during the char scan in `split_clause_sequence`, not parsing dispatch against raw oracle text (mirrors `current_ends_with_bare_and`).
+    ["with ", "and ", "or ", ", "]
+        .iter()
+        .any(|anchor| current.ends_with(anchor))
 }
 
 pub(super) fn is_possessive_apostrophe(current: &str, next: Option<char>) -> bool {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -550,6 +550,15 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
     let mut chars = text.chars().peekable();
     let mut paren_depth = 0usize;
     let mut in_single_quote = false;
+    // CR 111.1 (issue #4605): a created token has the abilities defined in its
+    // creation effect. Tracks whether the currently-open single-quoted span is a
+    // genuine NESTED ability quote — the inner ability of a token/permanent
+    // created inside a double-quoted granted ability (Urza's Saga:
+    // `... gains "... create a token with 'X.'"`). Only an anchored opener
+    // (`with '` / `and '` / `or '` / `, '`) opens such a span; a possessive or
+    // contraction apostrophe (`~'s`, `can't`) does not. Inside a genuine ability
+    // quote a `.` is part of the quoted text, NOT a sentence boundary.
+    let mut single_quote_is_ability = false;
     let mut in_double_quote = false;
     // CR 109.5 + CR 115.1: once a compound-subject-each head ("you and" / "~ and"
     // followed by "<noun> each") is detected, keep the WHOLE distributed body
@@ -581,7 +590,16 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
                 if is_possessive_apostrophe(&current, chars.peek().copied()) {
                     current.push(ch);
                 } else {
-                    in_single_quote = !in_single_quote;
+                    if in_single_quote {
+                        in_single_quote = false;
+                        single_quote_is_ability = false;
+                    } else {
+                        in_single_quote = true;
+                        // Anchor mirrors `extract_token_static_abilities`'s
+                        // single-quote pass: only `with '` / `and '` / `or '` /
+                        // `, '` opens a genuine nested ability span.
+                        single_quote_is_ability = ends_with_single_quote_ability_anchor(&current);
+                    }
                     current.push(ch);
                 }
             }
@@ -632,8 +650,18 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
             // split here and reset the phantom single-quote state.
             // `in_double_quote` (a genuine quoted ability) still suppresses the
             // split.
-            '.' if paren_depth == 0 && !in_double_quote => {
+            // CR 111.1 (issue #4605): inside a genuine nested ability quote
+            // (`single_quote_is_ability`) the `.` belongs to the quoted text
+            // (`... with 'This token gets +1/+1 for each artifact you control.'`)
+            // and must NOT close the clause — otherwise the span is bisected and
+            // the token-creation effect loses its inner ability (and dispatches
+            // to the inner `Pump` instead of `Token`).
+            '.' if paren_depth == 0
+                && !in_double_quote
+                && !(in_single_quote && single_quote_is_ability) =>
+            {
                 in_single_quote = false;
+                single_quote_is_ability = false;
                 push_clause_chunk(&mut chunks, &current, Some(ClauseBoundary::Sentence));
                 current.clear();
                 compound_subject_each_sticky = false;
@@ -2444,6 +2472,19 @@ fn starts_with_damage_clause(lower: &str) -> bool {
     } else {
         false
     }
+}
+
+/// CR 111.1 (issue #4605): true when the text accumulated right before an
+/// apostrophe ends at a phrase boundary that opens a nested quoted ability
+/// (`with '` / `and '` / `or '` / `, '`). Mirrors the opener anchors in
+/// `extract_token_static_abilities`'s single-quote pass, so a possessive
+/// (`~'s`) or contraction (`can't`) apostrophe is never treated as an
+/// ability-quote opener and a sentence-ending `.` keeps splitting normally.
+fn ends_with_single_quote_ability_anchor(current: &str) -> bool {
+    current.ends_with("with ")
+        || current.ends_with("and ")
+        || current.ends_with("or ")
+        || current.ends_with(", ")
 }
 
 pub(super) fn is_possessive_apostrophe(current: &str, next: Option<char>) -> bool {

--- a/crates/engine/src/parser/oracle_saga.rs
+++ b/crates/engine/src/parser/oracle_saga.rs
@@ -512,7 +512,7 @@ mod tests {
         }
     }
 
-    /// CR 111.1 (issue #4605): Urza's Saga chapter II grants
+    /// CR 111.3 (issue #4605): Urza's Saga chapter II grants
     /// `{2}, {T}: Create a 0/0 colorless Construct artifact creature token with
     /// 'This token gets +1/+1 for each artifact you control.'`. Because the
     /// create-token clause is nested inside the double-quoted granted ability,

--- a/crates/engine/src/parser/oracle_saga.rs
+++ b/crates/engine/src/parser/oracle_saga.rs
@@ -292,7 +292,9 @@ fn promote_generic_effect_duration(effect: &mut Effect) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{ControllerRef, FilterProp, PtValue, TypeFilter};
+    use crate::types::ability::{
+        ContinuousModification, ControllerRef, FilterProp, PtValue, TypeFilter,
+    };
 
     #[test]
     fn parse_roman_numeral_range() {
@@ -508,6 +510,42 @@ mod tests {
             }
             other => panic!("expected GenericEffect, got {other:?}"),
         }
+    }
+
+    /// CR 111.1 (issue #4605): Urza's Saga chapter II grants
+    /// `{2}, {T}: Create a 0/0 colorless Construct artifact creature token with
+    /// 'This token gets +1/+1 for each artifact you control.'`. Because the
+    /// create-token clause is nested inside the double-quoted granted ability,
+    /// its inner token ability uses SINGLE quotes. The granted ability's effect
+    /// must be a token-creation effect — NOT the inner `Pump` lifted out of the
+    /// single-quoted span (which is what made activating it create no token).
+    #[test]
+    fn urzas_saga_chapter_two_granted_ability_creates_token() {
+        let lines = vec![
+            "II — This Saga gains \"{2}, {T}: Create a 0/0 colorless Construct artifact creature token with 'This token gets +1/+1 for each artifact you control.'\"",
+        ];
+        let (triggers, _etb, _consumed) = parse_saga_chapters(&lines, "Urza's Saga");
+        assert_eq!(triggers.len(), 1);
+        let exec = triggers[0].execute.as_ref().unwrap();
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*exec.effect
+        else {
+            panic!("expected GenericEffect, got {:?}", exec.effect);
+        };
+        let granted = static_abilities
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .find_map(|m| match m {
+                ContinuousModification::GrantAbility { definition } => Some(definition),
+                _ => None,
+            })
+            .expect("chapter II must grant an activated ability");
+        assert!(
+            matches!(&*granted.effect, Effect::Token { .. }),
+            "granted ability must create a token, got {:?}",
+            granted.effect
+        );
     }
 
     /// CR 514.2: Roar of the Fifth People chapter IV explicitly says "until end


### PR DESCRIPTION
Closes #4605

## Problem

**Urza's Saga** chapter II grants `{2}, {T}: Create a 0/0 colorless Construct artifact creature token with 'This token gets +1/+1 for each artifact you control.'`. Activating it created **no token** — the granted ability's effect parsed as `Pump` (artifact-count power/toughness, target Any), i.e. the inner ability lifted out of the single-quoted span, instead of a token-creation effect.

## Root cause

The clause splitter (`split_clause_sequence`) ends a clause on a sentence-period whenever it is not inside a **double**-quoted span. Its comment assumed any open single-quote could only be a possessive/contraction apostrophe — true at the top level (Oracle text uses double quotes for quoted abilities), but **not** when a token-creation clause is itself nested inside a double-quoted granted ability. There the inner token ability genuinely uses **single** quotes (`with 'This token gets +1/+1 … control.'`). The `.` inside that span bisected the clause, dropped the closing quote, and broke token dispatch.

## Fix (class-general — all nested token grants: Sagas, ability-granting cards)

Track whether the open single-quote is a genuine nested ability quote, opened only at an anchored boundary (`with '` / `and '` / `or '` / `, '`) — the same anchors `extract_token_static_abilities` already uses. A sentence-period inside such a span no longer closes the clause. Possessive/contraction apostrophes (`~'s`, `can't`) are unaffected, so the existing `"~'s … turn. Goad it."` (The Master, Mesmerist) sentence split is preserved.

CR 111.1 (a token has the abilities defined in its creation effect), verified against `docs/MagicCompRules.txt`.

## Verification

- New regression `urzas_saga_chapter_two_granted_ability_creates_token` asserts the granted ability's effect is `Effect::Token`, not `Pump` (fails before, passes after).
- Full engine lib **14181 passed / 0 failed**; clippy clean.
