### PR TITLE
feat(engine): Koh, the Face Stealer + Sandswirl Wanderglyph (S21 static cluster)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -717,6 +717,7 @@ fn condition_reads_only_memo_safe_state(c: &ParsedCondition) -> bool {
         | ParsedCondition::YouControlLandsWithSameNameAtLeast { .. }
         | ParsedCondition::YouControlNoCreatures
         | ParsedCondition::YouAttackedThisTurn
+        | ParsedCondition::YouAttackedSourceControllerThisTurn
         | ParsedCondition::YouAttackedWithAtLeast { .. }
         | ParsedCondition::YouPlayedLandThisTurn
         | ParsedCondition::YouCastSpellThisTurn { .. }

--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -946,6 +946,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::ProcessRadCounters
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
+        | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -72,6 +72,7 @@ pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
         | TargetFilter::TriggeringSpellController
@@ -144,6 +145,7 @@ pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter 
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
         | TargetFilter::TriggeringSpellController

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -512,6 +512,7 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::LastCreated => "last created".into(),
         TargetFilter::LastRevealed => "last revealed".into(),
         TargetFilter::CostPaidObject => "cost-paid object".into(),
+        TargetFilter::ChosenCard => "last chosen card".into(),
         TargetFilter::TriggeringSpellController => "triggering spell's controller".into(),
         TargetFilter::TriggeringSpellOwner => "triggering spell's owner".into(),
         TargetFilter::TriggeringSourceController => "triggering source's controller".into(),
@@ -2773,6 +2774,9 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             d.push(("count".into(), count.to_string()));
             d.push(("zone".into(), fmt_zone(zone)));
         }
+        Effect::RememberCard { target } => {
+            d.push(("target".into(), fmt_target(target)));
+        }
         Effect::ForEachCategoryExile { category, zone, .. } => {
             d.push((
                 "category".into(),
@@ -3631,6 +3635,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         ContinuousModification::GrantAbility { .. } => "grant ability".into(),
         ContinuousModification::GrantAllActivatedAbilitiesOf { .. } => {
             "grant all activated abilities of".into()
+        }
+        ContinuousModification::GrantAllTriggeredAbilitiesOf { .. } => {
+            "grant all triggered abilities of".into()
         }
         ContinuousModification::GrantTrigger { .. } => "grant trigger".into(),
         ContinuousModification::RemoveAllAbilities => "remove all abilities".into(),

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -633,6 +633,32 @@ fn collect_direct_zone_cards(
             .collect());
     }
 
+    // CR 400.1 + CR 607.2a: For AllOwners, scan the referenced zone(s) across
+    // EVERY player and rely entirely on the filter to scope. Exile is a zone
+    // shared by all players (CR 400.1), and "exiled with [source]" is a
+    // linked-ability reference (CR 607.2a) whose membership ignores ownership,
+    // so owner-gating would drop the opponent-owned cards Koh exiled before the
+    // filter ever runs. Mirrors the ScopedPlayer-on-Battlefield branch above:
+    // scan broadly, let the filter (here ExiledBySource) narrow. Kept general
+    // for all zones — the union across players reduces to the whole shared
+    // exile zone for Exile and to each player's own zone for per-player zones,
+    // with every object counted once (each object has exactly one owner).
+    if matches!(zone_owner, ZoneOwner::AllOwners) {
+        let owners: Vec<PlayerId> = state.players.iter().map(|p| p.id).collect();
+        return Ok(owners
+            .into_iter()
+            .flat_map(|owner| {
+                zones
+                    .iter()
+                    .flat_map(|&zone| object_ids_in_player_zone(state, owner, zone))
+                    .collect::<Vec<_>>()
+            })
+            .filter(|id| {
+                filter.is_none_or(|filter| matches_target_filter(state, *id, filter, &filter_ctx))
+            })
+            .collect());
+    }
+
     let owner = resolve_zone_owner(state, ability, zone_owner)?;
 
     Ok(zones
@@ -671,6 +697,13 @@ fn resolve_zone_owner(
         ZoneOwner::EachPlayer | ZoneOwner::EachOpponent => Err(EffectError::MissingParam(
             "ChooseFromZone EachPlayer/EachOpponent resolves per-player, not via single owner"
                 .to_string(),
+        )),
+        // CR 400.1: `AllOwners` scans a zone shared across EVERY owner, not a
+        // single one — it is handled by the early return in
+        // `collect_direct_zone_cards` and never routes through this
+        // single-owner resolver.
+        ZoneOwner::AllOwners => Err(EffectError::MissingParam(
+            "ChooseFromZone AllOwners scans all owners, not via single owner".to_string(),
         )),
     }
 }
@@ -1052,6 +1085,126 @@ mod tests {
             }
             other => panic!("Expected ChooseFromZoneChoice, got {:?}", other),
         }
+    }
+
+    /// CR 400.1 + CR 607.2a: `ZoneOwner::AllOwners` scans a shared zone across
+    /// EVERY owner and lets the `TargetFilter` perform all scoping — the
+    /// per-owner gate in `object_ids_in_player_zone` is bypassed. Building-block
+    /// proof for the category "membership is defined by the filter, not by
+    /// ownership" (Koh, the Face Stealer: a creature card exiled with Koh, where
+    /// Koh typically exiles *opponents'* creatures).
+    ///
+    /// Discriminating on two axes: (1) an opponent-owned linked card MUST be
+    /// offered under `AllOwners` but is DROPPED under the old `Controller` scope
+    /// (the bug); (2) an opponent-owned *unlinked* exiled card must be excluded,
+    /// proving `AllOwners` does not over-collect — the `ExiledBySource` filter
+    /// still narrows the whole-zone scan.
+    #[test]
+    fn all_owners_scope_enumerates_exile_across_owners() {
+        let mut state = GameState::new_two_player(42);
+
+        // The linked-exile source (a Koh-like permanent under the controller).
+        let source = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Koh-like Source".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Two creature cards in the SHARED exile zone (CR 400.1), owned by
+        // different players, both linked to `source` (CR 607.2a).
+        let mine = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "My Exiled Face".to_string(),
+            Zone::Exile,
+        );
+        let theirs = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Exiled Face".to_string(),
+            Zone::Exile,
+        );
+        // An opponent-owned exiled card NOT linked to the source — the filter
+        // must exclude it even though `AllOwners` scans the whole zone.
+        let unlinked = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Unlinked Exiled Card".to_string(),
+            Zone::Exile,
+        );
+        crate::game::exile_links::push_tracked_by_source(&mut state, mine, source);
+        crate::game::exile_links::push_tracked_by_source(&mut state, theirs, source);
+
+        let ability = ResolvedAbility::new(
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Exile,
+                additional_zones: Vec::new(),
+                zone_owner: ZoneOwner::AllOwners,
+                filter: Some(TargetFilter::ExiledBySource),
+                chooser: Chooser::Controller,
+                up_to: false,
+                constraint: None,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let filter = TargetFilter::ExiledBySource;
+
+        // AllOwners: BOTH owners' linked cards are offered; the unlinked card is
+        // filtered out. The opponent-owned card present here is the fix.
+        let all = collect_direct_zone_cards(
+            &state,
+            &ability,
+            Zone::Exile,
+            &[],
+            ZoneOwner::AllOwners,
+            Some(&filter),
+        )
+        .expect("AllOwners enumerates without routing through a single-owner resolver");
+        assert!(
+            all.contains(&mine),
+            "AllOwners offers the controller's own exiled card"
+        );
+        assert!(
+            all.contains(&theirs),
+            "AllOwners offers the OPPONENT-owned exiled card {theirs:?} (the fix)"
+        );
+        assert!(
+            !all.contains(&unlinked),
+            "AllOwners excludes the unlinked exiled card {unlinked:?} — the filter still scopes"
+        );
+        assert_eq!(
+            all.len(),
+            2,
+            "exactly the two linked cards regardless of owner, got {all:?}"
+        );
+
+        // Controller (the old scope): the owner gate drops the opponent-owned
+        // linked card, leaving only the controller's own — exactly the bug that
+        // `AllOwners` fixes. Asserted so a regression into owner-gating fails.
+        let controller_only = collect_direct_zone_cards(
+            &state,
+            &ability,
+            Zone::Exile,
+            &[],
+            ZoneOwner::Controller,
+            Some(&filter),
+        )
+        .expect("Controller scope resolves to a single owner");
+        assert_eq!(
+            controller_only,
+            vec![mine],
+            "Controller scope offers only the controller's own exiled card — \
+             the opponent-owned linked card {theirs:?} is wrongly dropped"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -157,6 +157,7 @@ pub mod rad_counters;
 pub mod rebound;
 pub mod regenerate;
 pub mod register_bending;
+pub mod remember_card;
 pub mod remove_all_damage;
 pub mod remove_from_combat;
 pub mod renown;
@@ -2952,6 +2953,7 @@ pub fn resolve_effect(
         Effect::RingTemptsYou => ring::resolve(state, ability, events),
         Effect::GrantCastingPermission { .. } => grant_permission::resolve(state, ability, events),
         Effect::ChooseFromZone { .. } => choose_from_zone::resolve(state, ability, events),
+        Effect::RememberCard { .. } => remember_card::resolve(state, ability, events),
         Effect::ForEachCategoryExile { .. } => {
             choose_from_zone::resolve_for_each_category(state, ability, events)
         }

--- a/crates/engine/src/game/effects/remember_card.rs
+++ b/crates/engine/src/game/effects/remember_card.rs
@@ -1,0 +1,65 @@
+use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::targeting::resolve_tracked_set_sentinel;
+use crate::types::ability::{ChosenAttribute, Effect, EffectError, ResolvedAbility};
+use crate::types::events::GameEvent;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::ObjectId;
+
+/// CR 608.2c + CR 613.1f: `Effect::RememberCard` — record the card chosen by a
+/// preceding selection (typically `ChooseFromZone`) onto the resolving ability's
+/// SOURCE as `ChosenAttribute::Card`. The companion Layer-6 static grant ("[this]
+/// has all activated and triggered abilities of the last chosen card" — Koh, the
+/// Face Stealer) then reads it via `TargetFilter::ChosenCard`.
+///
+/// Composable building block: `ChooseFromZone` owns the choice UI / zone search
+/// and publishes its pick to the resolution chain's tracked set; this effect is
+/// the persistent writer. The `target` filter names the chosen object(s) — Koh
+/// passes `TrackedSet { id: TrackedSetId(0) }`, the sentinel for "the most recent
+/// tracked set", bound here via [`resolve_tracked_set_sentinel`].
+///
+/// "The last chosen card" is singular: exactly one `ChosenAttribute::Card` is
+/// stored, replacing any prior one (replace-on-rechoose), so the grant always
+/// tracks the single latest choice. Storing it in `chosen_attributes` means it is
+/// cleared automatically when the source changes zones (CR 400.7), which is
+/// exactly the lifetime Koh's grant requires.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    _events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Effect::RememberCard { target } = &ability.effect else {
+        return Ok(());
+    };
+
+    // CR 608.2c: bind the `TrackedSetId(0)` sentinel to the resolution chain's
+    // published pick (the cards chosen by the preceding `ChooseFromZone`).
+    let resolved = resolve_tracked_set_sentinel(state, target.clone());
+    let ctx = FilterContext::from_source(state, ability.source_id);
+    let mut chosen: Vec<ObjectId> = state
+        .objects
+        .keys()
+        .copied()
+        .filter(|&id| matches_target_filter(state, id, &resolved, &ctx))
+        .collect();
+    // Deterministic order so a (degenerate) multi-pick records the most recent.
+    chosen.sort_unstable_by_key(|id| id.0);
+
+    let Some(&card_id) = chosen.last() else {
+        // No card was chosen (e.g. an empty exile pool) — nothing to remember.
+        return Ok(());
+    };
+
+    if let Some(src) = state.objects.get_mut(&ability.source_id) {
+        // Replace-on-rechoose (CR 608.2c "the last chosen card"): a fresh choice
+        // supersedes the prior one. `chosen_attributes` is cleared on zone change.
+        src.chosen_attributes
+            .retain(|a| !matches!(a, ChosenAttribute::Card(_)));
+        src.chosen_attributes.push(ChosenAttribute::Card(card_id));
+    }
+
+    // CR 613.1f: the companion static grant reads `ChosenAttribute::Card` at layer
+    // evaluation, which may have already run this turn — re-run so the grant takes
+    // effect immediately.
+    crate::game::layers::mark_layers_full(state);
+    Ok(())
+}

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -73,6 +73,7 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource
@@ -275,6 +276,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource
@@ -1721,6 +1723,23 @@ fn filter_inner_for_object(
         TargetFilter::CostPaidObject => ability
             .and_then(|ability| ability.cost_paid_object.as_ref())
             .is_some_and(|snapshot| snapshot.object_id == object_id),
+        // CR 613.1f + CR 611.2c + CR 400.7: the FILTER source's last-remembered
+        // card (`ChosenAttribute::Card`, written by `Effect::RememberCard`). Read
+        // live each layer pass against `source_id` (the permanent that HAS the
+        // granting static — Koh), not the resolving `ability`, so the static grant
+        // resolves it. The `obj.zone == Zone::Exile` guard is the invalidation:
+        // a chosen card that leaves exile becomes a new object (CR 400.7) with a
+        // fresh id, so the stored id stops matching an exiled object and the grant
+        // drops. Re-choosing replaces the stored `Card` (RememberCard is
+        // replace-on-rechoose), so this always reflects the single latest choice.
+        TargetFilter::ChosenCard => {
+            obj.zone == Zone::Exile
+                && state.objects.get(&source_id).is_some_and(|src| {
+                    src.chosen_attributes
+                        .iter()
+                        .any(|attr| matches!(attr, ChosenAttribute::Card(id) if *id == object_id))
+                })
+        }
         // CR 603.7: Match objects in a tracked set from the originating effect.
         TargetFilter::TrackedSet { id } => state
             .tracked_object_sets
@@ -2091,6 +2110,7 @@ fn zone_change_filter_inner(
         TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource
@@ -2340,6 +2360,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource
@@ -2584,6 +2605,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2740,6 +2740,23 @@ fn active_continuous_effects_from_static_definitions(
                 ));
                 continue;
             }
+            // CR 613.1f + CR 603.1: "~ has all triggered abilities of [source]"
+            // (Koh, the Face Stealer). Triggered-ability mirror of the activated
+            // expansion above: expand into one `GrantTrigger` per triggered ability
+            // of each object matching `source`, recomputed each pass and reusing the
+            // existing `GrantTrigger` apply + dedup. No `cap` — triggered abilities
+            // carry no activation use-restriction (CR 602.5b is activated-only). The
+            // meta-effect itself has no standalone layer-6 behaviour, so skip it.
+            if let ContinuousModification::GrantAllTriggeredAbilitiesOf { source } = modification {
+                effects.extend(expand_granted_triggered_abilities(
+                    state,
+                    source_id,
+                    timestamp,
+                    &affected_filter,
+                    source,
+                ));
+                continue;
+            }
             effects.push(ActiveContinuousEffect {
                 source_id,
                 controller,
@@ -2970,6 +2987,103 @@ fn expand_granted_activated_abilities(
                     timestamp: host_timestamp,
                     modification: ContinuousModification::GrantAbility {
                         definition: Box::new(donated),
+                    },
+                    affected_filter: TargetFilter::SelfRef,
+                    condition: None,
+                    mode: StaticMode::Continuous,
+                    characteristic_defining: false,
+                });
+                next_mod_index += 1;
+            }
+        }
+    }
+    out
+}
+
+/// CR 613.1f + CR 603.1 + CR 603.2: Triggered-ability mirror of
+/// [`expand_granted_activated_abilities`]. Expands a
+/// `GrantAllTriggeredAbilitiesOf { source }` host modification into one
+/// `GrantTrigger` effect per triggered ability of each object matching `source`
+/// (Koh, the Face Stealer — "all activated and triggered abilities of the last
+/// chosen card"). Providers are scanned across all zones (the granted-from card
+/// is typically in exile) in deterministic `ObjectId` order, and each provider's
+/// LIVE `trigger_definitions` is read — reset from `base_trigger_definitions`
+/// every layer pass exactly like `abilities` (layers.rs reset loop), so an exiled
+/// provider's printed triggers are present at expansion time, identical to how
+/// the activated mirror reads live `abilities`. Synthesized effects target the
+/// recipient via `SelfRef`, reusing the layer-6 `GrantTrigger` apply and its
+/// structural dedup, and are recomputed each pass so the granted set tracks the
+/// current `source` membership. No `cap`: triggered abilities carry no activation
+/// use-restriction (CR 602.5b is activated-only). The `source` filter resolves
+/// against the host id with each recipient's controller, memoized per controller
+/// — mirroring the activated expander exactly; the recipient-equality self-skip
+/// (CR 613.1f) stays per-recipient at emission.
+fn expand_granted_triggered_abilities(
+    state: &GameState,
+    host_source_id: ObjectId,
+    host_timestamp: u64,
+    host_affected_filter: &TargetFilter,
+    source: &TargetFilter,
+) -> Vec<ActiveContinuousEffect> {
+    let host_ctx = crate::game::filter::FilterContext::from_source(state, host_source_id);
+    let mut out = Vec::new();
+    let mut provider_ids: Vec<ObjectId> = state.objects.keys().copied().collect();
+    provider_ids.sort_unstable_by_key(|id| id.0);
+    let mut providers_by_controller: std::collections::HashMap<PlayerId, Vec<ObjectId>> =
+        std::collections::HashMap::new();
+    for &recipient_id in &state.battlefield {
+        if !crate::game::filter::matches_target_filter(
+            state,
+            recipient_id,
+            host_affected_filter,
+            &host_ctx,
+        ) {
+            continue;
+        }
+        let recipient_controller = match state.objects.get(&recipient_id) {
+            Some(obj) => obj.controller,
+            None => continue,
+        };
+        let matching = providers_by_controller
+            .entry(recipient_controller)
+            .or_insert_with(|| {
+                let provider_ctx = crate::game::filter::FilterContext::from_source_with_controller(
+                    host_source_id,
+                    recipient_controller,
+                );
+                provider_ids
+                    .iter()
+                    .copied()
+                    .filter(|&provider_id| {
+                        crate::game::perf_counters::record_granted_ability_provider_scan();
+                        crate::game::filter::matches_target_filter(
+                            state,
+                            provider_id,
+                            source,
+                            &provider_ctx,
+                        )
+                    })
+                    .collect()
+            });
+        let mut next_mod_index = 0usize;
+        for &provider_id in matching.iter() {
+            if provider_id == recipient_id {
+                continue;
+            }
+            let Some(provider) = state.objects.get(&provider_id) else {
+                continue;
+            };
+            for trigger in provider.trigger_definitions.iter_all() {
+                out.push(ActiveContinuousEffect {
+                    source_id: recipient_id,
+                    controller: recipient_controller,
+                    def_index: None,
+                    transient_id: None,
+                    mod_index: next_mod_index,
+                    layer: Layer::Ability,
+                    timestamp: host_timestamp,
+                    modification: ContinuousModification::GrantTrigger {
+                        trigger: Box::new(trigger.clone()),
                     },
                     affected_filter: TargetFilter::SelfRef,
                     condition: None,
@@ -4367,6 +4481,10 @@ fn apply_continuous_effect_filtered(
             // read access to the provider objects, which the per-object apply
             // borrow cannot give). No direct per-object mutation here.
             ContinuousModification::GrantAllActivatedAbilitiesOf { .. } => {}
+            // CR 613.1f: Mirror of the activated case above — expanded into one
+            // `GrantTrigger` per matching trigger at collection time
+            // (`expand_granted_triggered_abilities`). No direct per-object mutation.
+            ContinuousModification::GrantAllTriggeredAbilitiesOf { .. } => {}
             // CR 604.1: Push granted trigger to trigger_definitions so
             // the trigger's event matching and condition metadata is preserved.
             ContinuousModification::GrantTrigger { trigger } => {

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -703,10 +703,11 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         ContinuousModification::GrantStaticAbility { definition } => walk_static(definition, out),
         ContinuousModification::CopyValues { values, .. } => walk_copiable_values(values, out),
         // Remaining modifications carry no nested ability/effect carriers.
-        // GrantAllActivatedAbilitiesOf only holds a source `TargetFilter`; the
-        // granted abilities are pulled live from the provider objects at layer
-        // collection time, not nested here.
+        // GrantAllActivatedAbilitiesOf / GrantAllTriggeredAbilitiesOf only hold a
+        // source `TargetFilter`; the granted abilities/triggers are pulled live
+        // from the provider objects at layer collection time, not nested here.
         ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
         | ContinuousModification::SetName { .. }
         | ContinuousModification::AddPower { .. }
         | ContinuousModification::AddToughness { .. }
@@ -1071,6 +1072,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::ProcessRadCounters
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
+        | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -459,6 +459,7 @@ pub(crate) fn continuous_modification_dynamic_quantity(
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
         | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -1155,6 +1155,17 @@ pub(crate) fn evaluate_condition(
             }) == 0
         }
         ParsedCondition::YouAttackedThisTurn => state.players_attacked_this_turn.contains(&player),
+        // CR 508.6 + CR 508.5 + CR 109.5: "you attacked [the source's controller]
+        // or a planeswalker they control this turn". `has_attacked` reads
+        // `attacked_defenders_this_turn`, whose entries are the CR-508.5-collapsed
+        // defending player (planeswalker/battle → controller), so both disjuncts
+        // resolve to one membership check. The defender is the SOURCE controller
+        // (CR 109.5 "you" on the static), resolved from `source_id` — never a
+        // hardcoded player. Sandswirl Wanderglyph.
+        ParsedCondition::YouAttackedSourceControllerThisTurn => state
+            .objects
+            .get(&source_id)
+            .is_some_and(|src| state.has_attacked(player, src.controller)),
         // CR 508.1a: "you attacked with N+ [filter] this turn". Unfiltered uses
         // the fast per-player count; filtered scans declaration-time snapshots so
         // attackers that have left the battlefield still count.

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -831,6 +831,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::ProcessRadCounters
         | EffectKind::GrantCastingPermission
         | EffectKind::ChooseFromZone
+        | EffectKind::RememberCard
         | EffectKind::ChooseObjectsIntoTrackedSet
         | EffectKind::ChooseAndSacrificeRest
         | EffectKind::Exploit

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -770,6 +770,7 @@ pub(super) fn target_filter_matches_object(
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3206,13 +3206,16 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
         }
     }
 
-    // "choose " / "you choose ", then the singular card anaphor "a card" / "one
-    // card" / "a [type] card". Only the bare card forms are handled here; typed
-    // restrictions on impulse-exile choices are not yet attested and would fall
-    // through to the honest fallback.
-    let (rest_after, ()) = preceded(
+    // "choose " / "you choose ", then the singular card anaphor "a [type] card" /
+    // "one [type] card". The optional card-type qualifier (Koh, the Face Stealer's
+    // "a creature card exiled with ~") narrows the choice; the bare "a card" form
+    // leaves it untyped. The type is intersected with the linked-exile set below.
+    let (rest_after, card_type) = preceded(
         alt((tag::<_, _, E>("choose "), tag("you choose "))),
-        value((), alt((tag("a card"), tag("one card")))),
+        preceded(
+            alt((tag("a "), tag("one "))),
+            parse_choose_card_type_qualifier,
+        ),
     )
     .parse(lower)
     .ok()?;
@@ -3223,27 +3226,43 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
         Err(_) => (rest_after, CardSelectionMode::Chosen),
     };
 
-    // "exiled this way" — the chain tracked set.
-    if let Ok((tail, _)) = tag::<_, _, E>(" exiled this way").parse(rest_after) {
-        if tail.is_empty() {
-            return Some(ChooseImperativeAst::FromTrackedSet {
-                count: 1,
-                chooser: Chooser::Controller,
-                selection,
-            });
+    // "exiled this way" — the chain tracked set. Only the untyped form is attested
+    // (impulse-exile reductions choose from the whole chain set); a typed
+    // restriction here would need `TrackedSetFiltered`, so fall through honestly.
+    if card_type.is_none() {
+        if let Ok((tail, _)) = tag::<_, _, E>(" exiled this way").parse(rest_after) {
+            if tail.is_empty() {
+                return Some(ChooseImperativeAst::FromTrackedSet {
+                    count: 1,
+                    chooser: Chooser::Controller,
+                    selection,
+                });
+            }
         }
     }
 
-    // "exiled with ~" / "exiled with it" — the source's linked-exile set.
+    // "exiled with ~" / "exiled with it" — the source's linked-exile set
+    // (`ExiledBySource`), intersected with the optional card-type qualifier so the
+    // pool is exactly the matching cards exiled with the host (Koh: creature cards
+    // exiled with Koh).
     if let Ok((tail, _)) =
         alt((tag::<_, _, E>(" exiled with ~"), tag(" exiled with it"))).parse(rest_after)
     {
         if tail.is_empty() {
+            let filter = match card_type {
+                Some(tf) => TargetFilter::And {
+                    filters: vec![
+                        TargetFilter::Typed(TypedFilter::new(tf)),
+                        TargetFilter::ExiledBySource,
+                    ],
+                },
+                None => TargetFilter::ExiledBySource,
+            };
             return Some(ChooseImperativeAst::FromZone {
                 count: 1,
                 zones: vec![Zone::Exile],
                 zone_owner: ZoneOwner::Controller,
-                filter: TargetFilter::ExiledBySource,
+                filter,
                 chooser: Chooser::Controller,
                 up_to: false,
                 selection,
@@ -3306,6 +3325,34 @@ fn try_parse_choose_suspended_card(lower: &str) -> Option<ChooseImperativeAst> {
         // CR 608.2d: controller-directed selection, never random.
         selection: CardSelectionMode::Chosen,
     })
+}
+
+/// CR 205.2a: Parse the card-type qualifier of a singular card anaphor — one card
+/// type word followed by " card" (→ `Some(type)`), or the bare "card" (→ `None`).
+/// Used by [`try_parse_choose_exiled_anaphor`] for "choose a [type] card exiled
+/// with ~". A single type covers the attested class (Koh's "creature card");
+/// multi-type qualifiers ("artifact creature card") are not yet attested.
+fn parse_choose_card_type_qualifier(input: &str) -> OracleResult<'_, Option<TypeFilter>> {
+    alt((
+        map(
+            terminated(
+                alt((
+                    value(TypeFilter::Creature, tag("creature")),
+                    value(TypeFilter::Artifact, tag("artifact")),
+                    value(TypeFilter::Enchantment, tag("enchantment")),
+                    value(TypeFilter::Land, tag("land")),
+                    value(TypeFilter::Planeswalker, tag("planeswalker")),
+                    value(TypeFilter::Instant, tag("instant")),
+                    value(TypeFilter::Sorcery, tag("sorcery")),
+                    value(TypeFilter::Battle, tag("battle")),
+                )),
+                tag(" card"),
+            ),
+            Some,
+        ),
+        value(None, tag("card")),
+    ))
+    .parse(input)
 }
 
 fn try_parse_choose_from_zone(lower: &str, ctx: &mut ParseContext) -> Option<ChooseImperativeAst> {

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3174,8 +3174,10 @@ fn try_parse_choose_owned_by_voter(
 ///   Epiphany).
 /// - "exiled with ~" / "exiled with it" → the source's linked-exile set,
 ///   scanned in `Zone::Exile` by [`TargetFilter::ExiledBySource`]. Lowered via
-///   [`ChooseImperativeAst::FromZone`] so the runtime applies the linked-exile
-///   filter (Omenpath Journey).
+///   [`ChooseImperativeAst::FromZone`] with [`ZoneOwner::AllOwners`] so the
+///   runtime scans the whole shared exile zone (CR 400.1) and the linked-exile
+///   filter (CR 607.2a) does all scoping — opponent-owned cards Koh exiled are
+///   in the pool, not just the controller's own (Omenpath Journey, Koh).
 ///
 /// The optional "at random" qualifier sets [`CardSelectionMode::Random`]
 /// (CR 608.2d override): the game selects, the controller does not.
@@ -3258,10 +3260,16 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
                 },
                 None => TargetFilter::ExiledBySource,
             };
+            // CR 400.1 + CR 607.2a: "exiled with [source]" is owner-agnostic —
+            // exile is a zone shared by all players (CR 400.1) and the
+            // linked-exile reference (CR 607.2a) is defined by linkage, not
+            // ownership. Koh exiles opponents' creatures, so the candidate pool
+            // must span every owner; `ZoneOwner::AllOwners` scans the whole
+            // exile zone and lets `ExiledBySource` (in `filter`) do all scoping.
             return Some(ChooseImperativeAst::FromZone {
                 count: 1,
                 zones: vec![Zone::Exile],
-                zone_owner: ZoneOwner::Controller,
+                zone_owner: ZoneOwner::AllOwners,
                 filter,
                 chooser: Chooser::Controller,
                 up_to: false,

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1928,6 +1928,9 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     // CR 601.2c + CR 608.2c: suppress a reflexive-target rider when the optional
     // "up to one" antecedent target is declined (no object target chosen).
     gate_reflexive_rider_on_declined_optional_target(&mut result);
+    // CR 608.2c + CR 613.1f: persist a standalone "choose a [type] card exiled
+    // with ~" pick as the host's last chosen card (Koh, the Face Stealer).
+    append_remember_card_to_standalone_exiled_choice(&mut result);
     if matches!(&*result.effect, Effect::SearchOutsideGame { .. }) {
         result.optional = false;
         result.optional_for = None;
@@ -1941,6 +1944,48 @@ pub(crate) fn lower_effect_chain_ir(ir: &EffectChainIr) -> AbilityDefinition {
     }
 
     result
+}
+
+/// CR 608.2c + CR 613.1f: A standalone "choose a [type] card exiled with ~"
+/// ability — a `ChooseFromZone` from the host's linked-exile set
+/// (`ExiledBySource`) with no follow-up consumer — persists its pick as the host's
+/// "last chosen card" by appending an `Effect::RememberCard` sub-ability. A choice
+/// with no consumer is otherwise a no-op no real card prints; the only cards with
+/// this shape feed a companion `TargetFilter::ChosenCard` grant (Koh, the Face
+/// Stealer — "has all activated and triggered abilities of the last chosen card").
+/// RememberCard reads the resolution chain's published pick via the
+/// `TrackedSetId(0)` sentinel (`resolve_tracked_set_sentinel`).
+fn append_remember_card_to_standalone_exiled_choice(def: &mut AbilityDefinition) {
+    if def.sub_ability.is_some() {
+        return;
+    }
+    let from_linked_exile = matches!(
+        &*def.effect,
+        Effect::ChooseFromZone { filter: Some(f), .. } if filter_mentions_exiled_by_source(f)
+    );
+    if !from_linked_exile {
+        return;
+    }
+    def.sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::RememberCard {
+            target: TargetFilter::TrackedSet {
+                id: crate::types::identifiers::TrackedSetId(0),
+            },
+        },
+    )));
+}
+
+/// Recursively detect a `TargetFilter::ExiledBySource` leaf (possibly nested under
+/// `And`/`Or`) — the "exiled with ~" linked-exile marker.
+fn filter_mentions_exiled_by_source(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::ExiledBySource => true,
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_mentions_exiled_by_source)
+        }
+        _ => false,
+    }
 }
 
 fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
@@ -7269,6 +7314,7 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
         | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }
@@ -7363,6 +7409,7 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAbility { .. }
         | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
         | ContinuousModification::GrantTrigger { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2897,17 +2897,30 @@ fn try_parse_that_player_cant_attack_prohibition(tp: TextPair<'_>) -> Option<Par
     })?;
     let rest_lower = &rest_lower[rest_lower.len() - rest_orig.len()..];
 
-    // Duration: "during their next turn" / "during that player's next turn".
-    // REQUIRED — this is the discriminator that gates the whole recognizer, so a
-    // generic "can't attack you" static line never reaches it.
-    let (_, remaining) = nom_on_lower(rest_orig, rest_lower, |input| {
-        value(
-            (),
-            alt((
-                tag(" during their next turn"),
-                tag(" during that player's next turn"),
-            )),
-        )
+    // Duration: REQUIRED discriminator — gates the whole recognizer so a generic
+    // permanent "can't attack you" static line (no duration) never reaches here.
+    // Two CR-distinct branches, captured as the resolved `Option<Duration>`:
+    //   - "during their next turn" / "during that player's next turn"
+    //     → `UntilEndOfNextTurnOf` (CR 514.2 + CR 500.7), the restricted player's
+    //       NEXT turn (Willie Lumpkin).
+    //   - "this turn" → no duration override; the `RestrictionExpiry::EndOfTurn`
+    //     below cleans the restriction up at the END OF THE CURRENT TURN (CR 514.2 —
+    //     Sandswirl Wanderglyph "they can't attack you … this turn").
+    // The two are NOT interchangeable: swapping them changes which turn the ban
+    // covers (a discriminating duration test must distinguish the two).
+    let (duration, remaining) = nom_on_lower(rest_orig, rest_lower, |input| {
+        alt((
+            value(
+                Some(Duration::UntilEndOfNextTurnOf {
+                    player: PlayerScope::Controller,
+                }),
+                alt((
+                    tag(" during their next turn"),
+                    tag(" during that player's next turn"),
+                )),
+            ),
+            value(None, tag(" this turn")),
+        ))
         .parse(input)
     })?;
     let remaining_lower = &rest_lower[rest_lower.len() - remaining.len()..];
@@ -2920,15 +2933,15 @@ fn try_parse_that_player_cant_attack_prohibition(tp: TextPair<'_>) -> Option<Par
             restriction: GameRestriction::ProhibitActivity {
                 source: ObjectId(0),
                 affected_players,
+                // CR 514.2: end-of-current-turn cleanup for the "this turn" branch.
+                // For the "next turn" branch this is a placeholder — `duration`
+                // below re-anchors the expiry to the restricted player's next turn
+                // in `add_restriction`.
                 expiry: RestrictionExpiry::EndOfTurn,
                 activity: ProhibitedActivity::Attack { defended },
             },
         },
-        // CR 514.2 + CR 500.7: pre-armed end-of-next-turn anchor. The expiry is
-        // lowered in `add_restriction` to the RESTRICTED player's next turn.
-        duration: Some(Duration::UntilEndOfNextTurnOf {
-            player: PlayerScope::Controller,
-        }),
+        duration,
         sub_ability: None,
         distribute: None,
         multi_target: None,
@@ -48320,6 +48333,57 @@ mod tests {
 
         let draw = sub.sub_ability.expect("expected trailing draw clause");
         assert!(matches!(*draw.effect, Effect::Draw { .. }));
+    }
+
+    #[test]
+    fn that_player_cant_attack_branches_on_duration_phrase() {
+        use crate::types::triggers::AttackTargetFilter;
+        // Sandswirl Wanderglyph trigger child (after the trigger strips "they"):
+        // "can't attack you or planeswalkers you control this turn" → end-of-CURRENT-
+        // turn ban (no next-turn duration), defended = you OR your planeswalkers.
+        let this_turn = try_parse_that_player_cant_attack_prohibition(TextPair::new(
+            "can't attack you or planeswalkers you control this turn",
+            "can't attack you or planeswalkers you control this turn",
+        ))
+        .expect("'... this turn' must parse");
+        assert!(
+            this_turn.duration.is_none(),
+            "the 'this turn' branch must NOT carry a next-turn duration (got {:?})",
+            this_turn.duration
+        );
+        assert!(
+            matches!(
+                this_turn.effect,
+                Effect::AddRestriction {
+                    restriction: GameRestriction::ProhibitActivity {
+                        affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
+                        expiry: RestrictionExpiry::EndOfTurn,
+                        activity: ProhibitedActivity::Attack {
+                            defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                        },
+                        ..
+                    }
+                }
+            ),
+            "got {:?}",
+            this_turn.effect
+        );
+        // Willie Lumpkin: "... during their next turn" → next-turn duration. This is
+        // the DISCRIMINATOR — swapping the two duration branches flips this assertion
+        // (revert-probe: a swap makes exactly one of these two asserts fail).
+        let next_turn = try_parse_that_player_cant_attack_prohibition(TextPair::new(
+            "that player can't attack you during their next turn",
+            "that player can't attack you during their next turn",
+        ))
+        .expect("'... during their next turn' must parse");
+        assert!(
+            matches!(
+                next_turn.duration,
+                Some(Duration::UntilEndOfNextTurnOf { .. })
+            ),
+            "the 'next turn' branch must carry UntilEndOfNextTurnOf (got {:?})",
+            next_turn.duration
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -4703,6 +4703,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::ProcessRadCounters
         | Effect::GrantCastingPermission { .. }
         | Effect::ChooseFromZone { .. }
+        | Effect::RememberCard { .. }
         | Effect::ForEachCategoryExile { .. }
         | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::ChooseAndSacrificeRest { .. }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -728,47 +728,71 @@ pub(crate) fn parse_chosen_qualifier_subject(tp: &TextPair<'_>) -> Option<Target
     Some(TargetFilter::Typed(typed))
 }
 
-/// CR 613.1f + CR 113.3: Recognize "[~ has] all activated abilities of [source]"
-/// and return the provider `source` filter for `GrantAllActivatedAbilitiesOf`.
-///
-/// The source-set axis is parameterized as a `TargetFilter` and composed from
-/// nom combinators along three independent dimensions: the optional leading verb
-/// (`has`/`have`, present in the real card path `"~ has all activated abilities
-/// of …"` but absent in the bare-predicate building-block path), the
-/// "all activated abilities of" grant phrase, and the source-set noun phrase:
-///
-/// - `the exiled card` / `all [creature] cards exiled with it/~` →
-///   `ExiledBySource`, narrowed to `And { [Typed(creature), ExiledBySource] }`
-///   when a card-type qualifies the exiled cards (Agatha's Soul Cauldron grants
-///   only *creature* cards' abilities; Myr Welder / Territory Forge are untyped).
-/// - `creatures you control that don't have the same name as it/~` →
-///   `Typed(creature, controller=You, [Not { SameName }])` (Marvin, Murderous
-///   Mimic). `SameName` reads the recipient's name at expansion time, so
-///   `Not { SameName }` excludes same-named creatures per Marvin's wording.
-///
-/// Returns `None` for forms still needing extra infrastructure ("the last chosen
-/// card" — needs persistent chosen-object tracking; counter-gated exile sets) so
-/// they stay a loud gap rather than over-granting.
-fn parse_grant_all_activated_abilities_source(
-    lower: &str,
-) -> Option<crate::types::ability::TargetFilter> {
-    let p = lower.trim().trim_end_matches('.').trim();
-    all_consuming(preceded(
-        (
-            opt(alt((tag::<_, _, OracleError<'_>>("has "), tag("have ")))),
-            // CR 613.1f: plural ("all activated abilities of") and the singular
-            // distributive ("each activated ability of", Locus of Enlightenment)
-            // grant the same set — both leaves of the grant-phrase axis.
+/// CR 602.1 + CR 603.1: The set of ability categories a "[~ has] all
+/// [activated|triggered|activated and triggered] abilities of [source]" grant
+/// donates. Activated and triggered abilities land in different stores via
+/// different continuous modifications (`GrantAllActivatedAbilitiesOf` →
+/// `obj.abilities`; `GrantAllTriggeredAbilitiesOf` → `obj.trigger_definitions`),
+/// so the parser captures which categories the phrase named.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GrantedAbilityKinds {
+    Activated,
+    Triggered,
+    ActivatedAndTriggered,
+}
+
+/// CR 602.1 + CR 603.1: The grant-phrase category axis. The conjunction form
+/// ("activated and triggered" / "triggered and activated", order-insensitive) is
+/// tried before the single-category leaves so the longer phrase wins. The plural
+/// and the singular-distributive activated form ("each activated ability of",
+/// Locus of Enlightenment) map to the same activated set.
+fn parse_granted_ability_kinds(input: &str) -> OracleResult<'_, GrantedAbilityKinds> {
+    alt((
+        value(
+            GrantedAbilityKinds::ActivatedAndTriggered,
+            alt((
+                tag("all activated and triggered abilities of "),
+                tag("all triggered and activated abilities of "),
+            )),
+        ),
+        value(
+            GrantedAbilityKinds::Triggered,
+            tag("all triggered abilities of "),
+        ),
+        value(
+            GrantedAbilityKinds::Activated,
             alt((
                 tag("all activated abilities of "),
                 tag("each activated ability of "),
             )),
         ),
+    ))
+    .parse(input)
+}
+
+/// CR 613.1f + CR 113.3: Recognize "[~ has] all [category] abilities of [source]"
+/// and return the donated category set plus the provider `source` filter.
+///
+/// Composed from nom combinators along three independent axes: the optional
+/// leading verb (`has`/`have`), the category axis ([`parse_granted_ability_kinds`]),
+/// and the source-set noun phrase ([`grant_source_noun_phrase`]) —
+/// `ExiledBySource` (Myr Welder / Agatha), the same-name exclusion (Marvin),
+/// `ChosenCard` ("the last chosen card", Koh), etc.
+///
+/// Returns `None` for forms still needing extra infrastructure (counter-gated
+/// exile sets) so they stay a loud gap rather than over-granting.
+fn parse_grant_all_abilities_clause(
+    lower: &str,
+) -> Option<(GrantedAbilityKinds, crate::types::ability::TargetFilter)> {
+    let p = lower.trim().trim_end_matches('.').trim();
+    all_consuming((
+        opt(alt((tag::<_, _, OracleError<'_>>("has "), tag("have ")))),
+        parse_granted_ability_kinds,
         grant_source_noun_phrase,
     ))
     .parse(p)
     .ok()
-    .map(|(_, source)| source)
+    .map(|(_, (_, kinds, source))| (kinds, source))
 }
 
 /// CR 602.5b + CR 602.5c: The "you may activate each of those abilities only once
@@ -942,6 +966,11 @@ fn grant_source_noun_phrase(input: &str) -> OracleResult<'_, crate::types::abili
             ])),
             tag("all artifact cards in your graveyard"),
         ),
+        // CR 613.1f + CR 611.2c: "the last chosen card" (Koh, the Face Stealer) —
+        // the single card most recently recorded on the host via
+        // `Effect::RememberCard` (`ChosenAttribute::Card`). Resolved live each
+        // layer pass by `TargetFilter::ChosenCard`.
+        value(TargetFilter::ChosenCard, tag("the last chosen card")),
     ))
     .parse(input)
 }
@@ -1071,16 +1100,37 @@ pub(crate) fn parse_continuous_modifications(text: &str) -> Vec<ContinuousModifi
     let unquoted_lower = unquoted_text.to_lowercase();
     let unquoted_tp = TextPair::new(&unquoted_text, &unquoted_lower);
 
-    // CR 613.1f + CR 113.3: "all activated abilities of [the exiled card | all
-    // cards exiled with it]" — grant the host all activated abilities of the
-    // cards exiled with it (Myr Welder, Territory Forge). First pass recognizes
-    // only the exact `ExiledBySource` forms; typed ("creature cards exiled with
-    // it"), counter-gated, and battlefield sources stay a gap (follow-ups).
-    if let Some(source) = parse_grant_all_activated_abilities_source(unquoted_tp.lower) {
+    // CR 613.1f + CR 113.3: "all [activated|triggered|activated and triggered]
+    // abilities of [the exiled card | all cards exiled with it | the last chosen
+    // card | …]" — grant the host the named ability categories of the source set
+    // (Myr Welder / Agatha activated; Koh, the Face Stealer activated AND
+    // triggered, source = the last chosen card). Typed/counter-gated sources stay
+    // a gap (follow-ups).
+    if let Some((kinds, source)) = parse_grant_all_abilities_clause(unquoted_tp.lower) {
+        // CR 602.1 + CR 603.1: emit one continuous modification per donated
+        // category. Activated and triggered land in different stores, so a
+        // conjunction grant produces BOTH mods over the same `source`.
         // CR 602.5b: the grant sentence itself carries no use-restriction — the
         // once-per-turn cap (Locus) is folded in separately by `fold_grant_cap_rider`
-        // when the trailing rider sentence is present, so this stays uncapped.
-        return vec![ContinuousModification::GrantAllActivatedAbilitiesOf { source, cap: None }];
+        // when the trailing rider sentence is present, so the activated grant stays
+        // uncapped; triggered abilities take no cap.
+        let mut mods = Vec::new();
+        if matches!(
+            kinds,
+            GrantedAbilityKinds::Activated | GrantedAbilityKinds::ActivatedAndTriggered
+        ) {
+            mods.push(ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: source.clone(),
+                cap: None,
+            });
+        }
+        if matches!(
+            kinds,
+            GrantedAbilityKinds::Triggered | GrantedAbilityKinds::ActivatedAndTriggered
+        ) {
+            mods.push(ContinuousModification::GrantAllTriggeredAbilitiesOf { source });
+        }
+        return mods;
     }
 
     // CR 305.6 + CR 305.7 + CR 205.3i: "gain all basic land types" / "gain all

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -824,6 +824,21 @@ pub(crate) fn parse_per_player_conditional_prohibition(
             ParsedCondition::YouAttackedThisTurn,
             tag::<_, _, OracleError<'_>>("attacked with a creature this turn"),
         ),
+        // CR 508.6: "attacked you or a planeswalker you control this turn" — the
+        // attacked-defender is the source's controller (CR 109.5 "you"), distinct
+        // from `YouAttackedThisTurn`'s attacked-anyone. Longer disjunctive form
+        // first; the bare "attacked you this turn" is the same predicate (the
+        // planeswalker disjunct collapses to the controller via CR 508.5).
+        // Sandswirl Wanderglyph.
+        value(
+            ParsedCondition::YouAttackedSourceControllerThisTurn,
+            alt((
+                tag::<_, _, OracleError<'_>>(
+                    "attacked you or a planeswalker you control this turn",
+                ),
+                tag("attacked you this turn"),
+            )),
+        ),
         value(
             ParsedCondition::YouCastSpellThisTurn { filter: None },
             tag::<_, _, OracleError<'_>>("cast a spell this turn"),

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14374,6 +14374,36 @@ fn cant_cast_opponent_attacked_this_turn() {
 }
 
 #[test]
+fn cant_cast_opponent_attacked_you_this_turn() {
+    // CR 101.2 + CR 508.6 + CR 109.5: Sandswirl Wanderglyph — "Each opponent who
+    // attacked you or a planeswalker you control this turn can't cast spells." The
+    // per-affected-player predicate is YouAttackedSourceControllerThisTurn (defender
+    // = the source's controller), distinct from Angelic Arbiter's attacked-ANYONE.
+    let def = parse_static_line(
+        "Each opponent who attacked you or a planeswalker you control this turn can't cast spells.",
+    )
+    .unwrap();
+    assert_eq!(
+        def.mode,
+        StaticMode::CantBeCast {
+            who: ProhibitionScope::Opponents,
+        }
+    );
+    assert_eq!(
+        def.per_player_condition,
+        Some(ParsedCondition::YouAttackedSourceControllerThisTurn),
+        "must carry the source-controller-defender predicate"
+    );
+    // Discriminating: must NOT collapse to Angelic Arbiter's attacked-anyone leaf.
+    assert_ne!(
+        def.per_player_condition,
+        Some(ParsedCondition::YouAttackedThisTurn),
+    );
+    // The source-relative functioning gate must stay None (always-on static).
+    assert_eq!(def.condition, None);
+}
+
+#[test]
 fn cant_attack_opponent_cast_spell_this_turn() {
     // CR 508.1 + CR 109.5: "Each opponent who cast a spell this turn can't
     // attack with creatures" — restricts OPPONENTS' creatures, not the source

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -75,6 +75,24 @@ pub enum ZoneOwner {
     /// Kaya, Spirits' Justice's −2 ("For each other player, exile up to one
     /// target creature that player controls").
     EachOpponent,
+    /// CR 400.1 + CR 607.2a: The referenced zone is scanned across ALL owners —
+    /// ownership imposes no restriction, and the effect's `TargetFilter`
+    /// performs every bit of scoping. Used when the candidate pool's membership
+    /// is defined by something other than ownership, so owner-gating would
+    /// wrongly drop valid cards. The motivating case is "a creature card exiled
+    /// with [this source]" (Koh, the Face Stealer): exile is a zone shared by
+    /// all players (CR 400.1), and "exiled with [source]" is a linked-ability
+    /// reference (CR 607.2a) whose membership is the source's linked-exile set
+    /// regardless of who owns each card — and Koh typically exiles *opponents'*
+    /// creatures, so gating to the controller's own exiled cards empties the
+    /// pool. This is the single-pool owner-agnostic leaf of the scope axis:
+    /// distinct from [`ZoneOwner::EachPlayer`]/[`ZoneOwner::EachOpponent`],
+    /// which iterate one prompt per player and accumulate into a tracked set —
+    /// this raises ONE prompt over the whole-zone union. Mirrors the
+    /// `ScopedPlayer`-on-Battlefield branch in `collect_direct_zone_cards`
+    /// (scan broadly, let the filter narrow), but with no owner restriction at
+    /// all.
+    AllOwners,
 }
 
 /// CR 105.1 + CR 205.2: A fixed, closed enumeration whose members an effect
@@ -17891,6 +17909,8 @@ mod tests {
             ZoneOwner::Opponent,
             ZoneOwner::ScopedPlayer,
             ZoneOwner::EachPlayer,
+            ZoneOwner::EachOpponent,
+            ZoneOwner::AllOwners,
         ] {
             let json = serde_json::to_string(&owner).expect("ZoneOwner serializes");
             let round_tripped: ZoneOwner =

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -848,6 +848,18 @@ pub enum ChosenAttribute {
     /// label is stored case-canonicalised to match `ChoiceType::Labeled`'s
     /// capitalised option list.
     Label(String),
+    /// CR 613.1f + CR 611.2c + CR 400.7: A remembered card object — the "last
+    /// chosen card" for cards like Koh, the Face Stealer ("Koh has all activated
+    /// and triggered abilities of the last chosen card"). Unlike every other
+    /// variant, this is NOT a player-prompted choice category: it is written by
+    /// `Effect::RememberCard` directly from the resolution chain's tracked set,
+    /// not produced through `ChoiceType`/`ChoiceValue`/`from_choice` (the same
+    /// engine-set precedent as `TributeOutcome`). It is consumed by
+    /// `TargetFilter::ChosenCard` at Layer-6 grant evaluation, and — being stored
+    /// in `chosen_attributes` — is cleared automatically when the source permanent
+    /// changes zones (CR 400.7), which is exactly the lifetime Koh's grant needs.
+    /// Replace-on-rechoose: `RememberCard` removes any prior `Card` before pushing.
+    Card(ObjectId),
 }
 
 impl ChosenAttribute {
@@ -884,6 +896,14 @@ impl ChosenAttribute {
             // idiom). The stored single label is one of those options.
             Self::Label(label) => ChoiceType::Labeled {
                 options: vec![label.clone()],
+            },
+            // Engine-set, never player-prompted (written by `Effect::RememberCard`
+            // from a tracked set, not via `from_choice`). `choice_type()` has no
+            // callers for this variant; the empty `Labeled` template mirrors the
+            // `Keyword`/`TributeOutcome` placeholder idiom rather than inventing a
+            // spurious object-choice category.
+            Self::Card(_) => ChoiceType::Labeled {
+                options: Vec::new(),
             },
         }
     }
@@ -3605,6 +3625,15 @@ pub enum TargetFilter {
     /// resolving spell or ability. Used by effects such as "the exiled card"
     /// after an exile-as-cost clause.
     CostPaidObject,
+    /// CR 613.1f + CR 611.2c + CR 400.7: Resolves to the single card most recently
+    /// recorded on the FILTER's source object via `ChosenAttribute::Card` (written
+    /// by `Effect::RememberCard`). Models "the last chosen card" — Koh, the Face
+    /// Stealer's Layer-6 grant source. Live, not snapshotted: re-evaluated each
+    /// layer pass, so re-choosing replaces the grant and the chosen card leaving
+    /// its zone (CR 400.7 — a new object) drops the grant. The object matcher
+    /// reads `chosen_attributes` from the source (not the resolving ability), so
+    /// the static grant resolves it against the permanent that HAS the static.
+    ChosenCard,
     /// Matches exactly the objects in a tracked set.
     /// CR 603.7: Delayed triggers act on specific objects from the originating effect.
     TrackedSet {
@@ -5983,6 +6012,22 @@ pub enum ParsedCondition {
     },
     YouControlNoCreatures,
     YouAttackedThisTurn,
+    /// CR 508.6 + CR 508.5 + CR 109.5: True when the affected player attacked the
+    /// SOURCE's controller — or a planeswalker/battle that controller controls —
+    /// this turn. Evaluated as `has_attacked(affected_player, source.controller)`
+    /// against `attacked_defenders_this_turn`, whose `defending_player` is already
+    /// the CR-508.5 collapse of the attack target (planeswalker/battle → its
+    /// controller), so "attacked you OR a planeswalker you control" is one check.
+    /// Sandswirl Wanderglyph: "Each opponent who attacked you or a planeswalker you
+    /// control this turn can't cast spells."
+    ///
+    /// AXIS NOTE (parameterize-vs-proliferate): this is the 2nd "you-attacked-
+    /// [defender]" leaf — `YouAttackedThisTurn` (defender = ANY player) vs this
+    /// (defender = the source's controller). Kept as a flat leaf to match the
+    /// surrounding idiom (`YouAttackedThisTurn` / `YouAttackedWithAtLeast` /
+    /// `SourceAttackedThisTurn`). A THIRD defender variant should trigger a
+    /// refactor to `YouAttacked { defender: <scope> }` (CR 508.6); do not unify now.
+    YouAttackedSourceControllerThisTurn,
     /// CR 508.1a: True when the player declared at least `count` attackers this
     /// turn. `filter: None` counts every attacker the player declared (backed by
     /// the fast `state.attacking_creatures_this_turn` counter — "you attacked
@@ -9949,6 +9994,19 @@ pub enum Effect {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         constraint: Option<ChooseFromZoneConstraint>,
     },
+    /// CR 608.2c + CR 613.1f: Record the card selected by a preceding selection
+    /// effect (typically `ChooseFromZone`) onto the resolving ability's SOURCE as
+    /// `ChosenAttribute::Card`, so a companion Layer-6 static ("[this] has all
+    /// activated and triggered abilities of the last chosen card" — Koh, the Face
+    /// Stealer) can read it via `TargetFilter::ChosenCard`. Composable building
+    /// block: the choice UI/zone search stays in `ChooseFromZone`; this effect is
+    /// the persistent writer. `target` reads the chosen object(s) — Koh passes
+    /// `TrackedSet { id: TrackedSetId(0) }` (the resolution chain's published
+    /// pick, resolved via `resolve_tracked_set_sentinel`); the single recorded
+    /// card replaces any prior `ChosenAttribute::Card` (replace-on-rechoose).
+    RememberCard {
+        target: TargetFilter,
+    },
     /// CR 608.2c + CR 105.1 / CR 205.2a: For each member of a fixed category
     /// (the five colors, or the CR 205.2a card types that can appear in a
     /// library — nine: artifact, battle, creature, enchantment, instant,
@@ -11521,6 +11579,7 @@ impl Effect {
             | Effect::Scry { target, .. }
             | Effect::Surveil { target, .. }
             | Effect::Pump { target, .. }
+            | Effect::RememberCard { target }
             | Effect::PairWith { target }
             | Effect::Destroy { target, .. }
             | Effect::Regenerate { target, .. }
@@ -12098,6 +12157,7 @@ impl Effect {
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::ChooseDamageSource { .. }
             | Effect::ChooseFromZone { .. }
+            | Effect::RememberCard { .. }
             | Effect::ForEachCategoryExile { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
@@ -12326,6 +12386,7 @@ impl Effect {
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::ChooseDamageSource { .. }
             | Effect::ChooseFromZone { .. }
+            | Effect::RememberCard { .. }
             | Effect::ForEachCategoryExile { .. }
             | Effect::ChooseObjectsIntoTrackedSet { .. }
             | Effect::ChooseOneOf { .. }
@@ -12550,6 +12611,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::ProcessRadCounters => "ProcessRadCounters",
         Effect::GrantCastingPermission { .. } => "GrantCastingPermission",
         Effect::ChooseFromZone { .. } => "ChooseFromZone",
+        Effect::RememberCard { .. } => "RememberCard",
         Effect::ForEachCategoryExile { .. } => "ForEachCategoryExile",
         Effect::ChooseObjectsIntoTrackedSet { .. } => "ChooseObjectsIntoTrackedSet",
         Effect::ChooseAndSacrificeRest { .. } => "ChooseAndSacrificeRest",
@@ -12777,6 +12839,7 @@ pub enum EffectKind {
     ProcessRadCounters,
     GrantCastingPermission,
     ChooseFromZone,
+    RememberCard,
     ChooseObjectsIntoTrackedSet,
     ChooseAndSacrificeRest,
     Exploit,
@@ -13023,6 +13086,7 @@ impl From<&Effect> for EffectKind {
             Effect::ProcessRadCounters => EffectKind::ProcessRadCounters,
             Effect::GrantCastingPermission { .. } => EffectKind::GrantCastingPermission,
             Effect::ChooseFromZone { .. } => EffectKind::ChooseFromZone,
+            Effect::RememberCard { .. } => EffectKind::RememberCard,
             // The per-member iteration parks `ChooseFromZoneChoice` prompts and
             // emits `ChooseFromZone` resolution events; it shares the kind.
             Effect::ForEachCategoryExile { .. } => EffectKind::ChooseFromZone,
@@ -16862,6 +16926,25 @@ pub enum ContinuousModification {
         /// rather than a bool so the cap axis can grow to other use-restrictions.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cap: Option<ActivationRestriction>,
+    },
+    /// CR 613.1f + CR 603.1 + CR 603.2: Grant the affected object **all triggered
+    /// abilities of** the objects matching `source` (Koh, the Face Stealer "Koh
+    /// has all activated and triggered abilities of the last chosen card"). The
+    /// triggered-ability mirror of `GrantAllActivatedAbilitiesOf`: the set is
+    /// dynamic — recomputed each layer pass — so it is expanded into one
+    /// `GrantTrigger` per matching trigger definition at continuous-effect
+    /// collection time (`expand_granted_triggered_abilities`); the layer-6 apply
+    /// of this variant itself is therefore a no-op. `source` is resolved relative
+    /// to the host static with each recipient's controller, mirroring the
+    /// activated expander. Distinct sibling rather than a parameter of
+    /// `GrantAllActivatedAbilitiesOf` because activated and triggered abilities
+    /// land in different stores (CR 602.1 `obj.abilities` via `GrantAbility` vs
+    /// CR 603.1 `obj.trigger_definitions` via `GrantTrigger`) with different
+    /// expansion, and the `cap` use-restriction (CR 602.5b) is activated-only —
+    /// the same split the singular `GrantAbility`/`GrantTrigger` pair already
+    /// draws. No cap: triggered abilities carry no activation restriction.
+    GrantAllTriggeredAbilitiesOf {
+        source: TargetFilter,
     },
     /// CR 604.1: Grant a triggered ability to the affected object.
     /// Unlike GrantAbility (which pushes to obj.abilities), this pushes to

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -98,6 +98,7 @@ impl ContinuousModification {
             | ContinuousModification::AddDynamicKeyword { .. }
             | ContinuousModification::GrantAbility { .. }
             | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+            | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
             | ContinuousModification::GrantTrigger { .. }
             | ContinuousModification::RemoveAllAbilities
             | ContinuousModification::AddStaticMode { .. }

--- a/crates/engine/tests/koh_face_stealer_grants.rs
+++ b/crates/engine/tests/koh_face_stealer_grants.rs
@@ -1,0 +1,406 @@
+//! Koh, the Face Stealer — "Koh has all activated and triggered abilities of the
+//! last chosen card." (CR 613.1f Layer-6 ability grant; CR 602.1 activated +
+//! CR 603.1 triggered; CR 611.2c live-tracking; CR 400.7 zone-change invalidation.)
+//!
+//! Exercises the four new building blocks end-to-end against the REAL layer
+//! evaluation and trigger pipeline:
+//!   * `ContinuousModification::GrantAllTriggeredAbilitiesOf { ChosenCard }` →
+//!     `expand_granted_triggered_abilities` → `GrantTrigger` on the recipient.
+//!   * `ContinuousModification::GrantAllActivatedAbilitiesOf { ChosenCard }`.
+//!   * `TargetFilter::ChosenCard` (reads the source's `ChosenAttribute::Card`,
+//!     guarded by `zone == Exile`).
+//!   * `Effect::RememberCard` (replace-on-rechoose writer).
+//!
+//! Lead conditions:
+//!   #4 — a granted TRIGGERED ability must actually FIRE for Koh (not merely be
+//!        present): `granted_upkeep_trigger_fires_for_koh` advances to Koh's
+//!        controller's upkeep through the real runner and asserts the granted
+//!        "gain 2 life" trigger resolved.
+//!   #3 — DUAL invalidation:
+//!        `grant_drops_when_chosen_card_leaves_exile` (the chosen card leaving
+//!        exile drops the grant — CR 400.7) and
+//!        `rechoose_overwrites_so_only_newest_card_is_granted` (re-choosing via the
+//!        real `Effect::RememberCard` writer replaces, never accumulates).
+
+use std::sync::Arc;
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::GameRunner;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, ChosenAttribute, ContinuousModification, Effect,
+    ManaContribution, ManaProduction, StaticDefinition, TargetFilter, TriggerDefinition,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Koh's two grant statics, exactly as the parser lowers them (verified by the
+/// parse-shape test below): all activated AND all triggered abilities of the last
+/// chosen card. Affects Koh itself (`SelfRef`).
+fn koh_grant_statics() -> Vec<StaticDefinition> {
+    vec![StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: TargetFilter::ChosenCard,
+                cap: None,
+            },
+            ContinuousModification::GrantAllTriggeredAbilitiesOf {
+                source: TargetFilter::ChosenCard,
+            },
+        ])]
+}
+
+/// Place Koh on the battlefield under P0 with the grant statics, P0 holding
+/// priority in their precombat main phase.
+fn build_koh(state: &mut GameState) -> ObjectId {
+    let koh = create_object(
+        state,
+        CardId(1000),
+        P0,
+        "Koh, the Face Stealer".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&koh).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.base_card_types = obj.card_types.clone();
+    obj.static_definitions = koh_grant_statics().into();
+    koh
+}
+
+/// A creature card sitting in exile, carrying `triggers` (printed) and
+/// `abilities` (printed). Not yet chosen — chosen via `ChosenAttribute::Card`.
+fn build_exiled_creature(
+    state: &mut GameState,
+    card_id: u64,
+    triggers: Vec<TriggerDefinition>,
+    abilities: Vec<AbilityDefinition>,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        P0,
+        format!("Exiled Face {card_id}"),
+        Zone::Exile,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.base_card_types = obj.card_types.clone();
+    obj.base_trigger_definitions = Arc::new(triggers.clone());
+    obj.trigger_definitions = triggers.into();
+    obj.abilities = Arc::new(abilities);
+    id
+}
+
+/// Record `card` as Koh's last chosen card (what `Effect::RememberCard` writes).
+fn set_chosen(state: &mut GameState, koh: ObjectId, card: ObjectId) {
+    let obj = state.objects.get_mut(&koh).unwrap();
+    obj.chosen_attributes
+        .retain(|a| !matches!(a, ChosenAttribute::Card(_)));
+    obj.chosen_attributes.push(ChosenAttribute::Card(card));
+}
+
+/// Parse a single triggered ability from oracle text (for the firing test's
+/// granted trigger — real parser shape, not a hand-built `TriggerDefinition`).
+fn trigger_from_oracle(oracle: &str) -> TriggerDefinition {
+    let parsed = parse_oracle_text(
+        oracle,
+        "Probe Face",
+        &[],
+        &["Creature".to_string()],
+        &["Shapeshifter".to_string()],
+    );
+    assert!(
+        !format!("{parsed:?}").contains("Unimplemented"),
+        "probe trigger oracle must parse cleanly: {oracle}"
+    );
+    parsed
+        .triggers
+        .into_iter()
+        .next()
+        .expect("oracle must yield one triggered ability")
+}
+
+/// A free, non-tap mana ability of a given color — a donatable activated ability
+/// with an observable, color-distinct effect.
+fn mana_ability(color: ManaColor) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Mana {
+            produced: ManaProduction::Fixed {
+                colors: vec![color],
+                contribution: ManaContribution::Base,
+            },
+            restrictions: vec![],
+            grants: vec![],
+            expiry: None,
+            target: None,
+        },
+    )
+}
+
+fn koh_granted_mana_colors(state: &GameState, koh: ObjectId) -> Vec<ManaColor> {
+    state.objects[&koh]
+        .abilities
+        .iter()
+        .filter_map(|a| match a.effect.as_ref() {
+            Effect::Mana {
+                produced: ManaProduction::Fixed { colors, .. },
+                ..
+            } => Some(colors.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
+fn koh_has_upkeep_trigger(state: &GameState, koh: ObjectId) -> bool {
+    state.objects[&koh]
+        .trigger_definitions
+        .iter_unchecked()
+        .any(|t| matches!(t.mode, TriggerMode::Phase) && t.phase == Some(Phase::Upkeep))
+}
+
+// ─── Condition #4: a granted TRIGGERED ability actually FIRES for Koh ─────────
+
+/// CR 613.1f + CR 603.1: the chosen exiled card's "at the beginning of your
+/// upkeep, you gain 2 life" trigger is granted to Koh and FIRES on P0's upkeep,
+/// resolving through the real runner. The discriminator: with NO chosen card the
+/// trigger is absent and no life is gained (asserted in the same test).
+#[test]
+fn granted_upkeep_trigger_fires_for_koh() {
+    let mut state = GameState::new_two_player(7);
+    state.phase = Phase::Untap;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    let koh = build_koh(&mut state);
+    let upkeep_trigger = trigger_from_oracle("At the beginning of your upkeep, you gain 2 life.");
+    let face = build_exiled_creature(&mut state, 2000, vec![upkeep_trigger], vec![]);
+
+    // Negative baseline: nothing chosen yet → grant absent.
+    evaluate_layers(&mut state);
+    assert!(
+        !koh_has_upkeep_trigger(&state, koh),
+        "with no last-chosen card, Koh must NOT have the granted upkeep trigger"
+    );
+
+    // Choose the exiled face → the grant materializes the trigger onto Koh.
+    set_chosen(&mut state, koh, face);
+    evaluate_layers(&mut state);
+    assert!(
+        koh_has_upkeep_trigger(&state, koh),
+        "after choosing the exiled face, Koh must be granted its upkeep trigger \
+         (indexed by Koh as the holding object)"
+    );
+
+    let mut runner = GameRunner::from_state(state);
+    let life_before = runner.life(P0);
+
+    // Advance to P0's upkeep through the real runner → the granted trigger fires.
+    runner.advance_to_upkeep();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.life(P0),
+        life_before + 2,
+        "the granted upkeep trigger must FIRE for Koh and resolve (gain 2 life); \
+         present-but-not-firing would leave life unchanged"
+    );
+}
+
+// ─── Condition #3a: chosen card leaving exile drops the grant (CR 400.7) ──────
+
+/// CR 400.7 + CR 611.2c: `TargetFilter::ChosenCard` is live and zone-guarded —
+/// once the chosen card is no longer in exile, the grant drops on the next layer
+/// pass (the stored id no longer matches an exiled object).
+#[test]
+fn grant_drops_when_chosen_card_leaves_exile() {
+    let mut state = GameState::new_two_player(7);
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    let koh = build_koh(&mut state);
+    let face = build_exiled_creature(
+        &mut state,
+        2000,
+        vec![],
+        vec![mana_ability(ManaColor::Green)],
+    );
+    set_chosen(&mut state, koh, face);
+
+    evaluate_layers(&mut state);
+    assert_eq!(
+        koh_granted_mana_colors(&state, koh),
+        vec![ManaColor::Green],
+        "while the chosen face is in exile, Koh is granted its Green mana ability"
+    );
+
+    // The chosen card leaves exile (e.g., it is put into a graveyard). CR 400.7:
+    // it is a new object; the stored id no longer names an exiled object.
+    state.objects.get_mut(&face).unwrap().zone = Zone::Graveyard;
+    if let Some(p) = state.players.iter_mut().find(|p| p.id == P0) {
+        p.graveyard.push_back(face);
+    }
+
+    evaluate_layers(&mut state);
+    assert!(
+        koh_granted_mana_colors(&state, koh).is_empty(),
+        "once the chosen card leaves exile the grant must drop (zone-guarded \
+         ChosenCard no longer matches)"
+    );
+}
+
+// ─── Condition #3b: re-choose overwrites — only the newest card is granted ────
+
+/// CR 608.2c "the last chosen card": the real `Effect::RememberCard` writer is
+/// replace-on-rechoose (retain-then-push a single `ChosenAttribute::Card`), so
+/// after choosing a second face Koh is granted ONLY the newest face's abilities,
+/// never the union of both.
+#[test]
+fn rechoose_overwrites_so_only_newest_card_is_granted() {
+    let mut state = GameState::new_two_player(7);
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    let koh = build_koh(&mut state);
+    let face_g = build_exiled_creature(
+        &mut state,
+        2000,
+        vec![],
+        vec![mana_ability(ManaColor::Green)],
+    );
+    let face_r =
+        build_exiled_creature(&mut state, 3000, vec![], vec![mana_ability(ManaColor::Red)]);
+
+    // First choice → Green, via the real RememberCard writer (SpecificObject
+    // target resolves the pick directly, no tracked-set plumbing needed).
+    resolve_remember_card(&mut state, koh, face_g);
+    evaluate_layers(&mut state);
+    assert_eq!(
+        koh_granted_mana_colors(&state, koh),
+        vec![ManaColor::Green],
+        "after choosing the Green face, Koh has exactly its Green ability"
+    );
+
+    // Re-choose → Red. Must REPLACE, not accumulate.
+    resolve_remember_card(&mut state, koh, face_r);
+    let card_attrs = state.objects[&koh]
+        .chosen_attributes
+        .iter()
+        .filter(|a| matches!(a, ChosenAttribute::Card(_)))
+        .count();
+    assert_eq!(
+        card_attrs, 1,
+        "RememberCard must keep exactly ONE Card attribute (replace-on-rechoose)"
+    );
+
+    evaluate_layers(&mut state);
+    assert_eq!(
+        koh_granted_mana_colors(&state, koh),
+        vec![ManaColor::Red],
+        "after re-choosing the Red face, Koh has ONLY the Red ability — not the \
+         cumulative {{Green, Red}} (which a non-replacing writer would produce)"
+    );
+}
+
+/// Resolve `Effect::RememberCard` through the real resolver, recording `card` onto
+/// `koh`. Targets the card directly (`SpecificObject`) so the writer's
+/// retain-then-push is exercised without tracked-set setup.
+fn resolve_remember_card(state: &mut GameState, koh: ObjectId, card: ObjectId) {
+    let def = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::RememberCard {
+            target: TargetFilter::SpecificObject { id: card },
+        },
+    );
+    let ability = build_resolved_from_def(&def, koh, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(state, &ability, &mut events, 0).expect("RememberCard must resolve");
+}
+
+// ─── gap=0 proxy: the whole card lowers with no Unimplemented ─────────────────
+
+/// The full card parses with NO `Unimplemented` clause: the activated ability is a
+/// `ChooseFromZone` (from `ExiledBySource`) carrying a `RememberCard` sub-ability,
+/// and the static carries BOTH grant modifications sourced from `ChosenCard`.
+#[test]
+fn full_card_parses_no_unimplemented() {
+    const KOH: &str = "When Koh enters, exile up to one other target creature.\nWhenever another nontoken creature dies, you may exile it.\nPay 1 life: Choose a creature card exiled with Koh.\nKoh has all activated and triggered abilities of the last chosen card.";
+
+    let parsed = parse_oracle_text(
+        KOH,
+        "Koh, the Face Stealer",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Shapeshifter".to_string()],
+    );
+
+    assert!(
+        !format!("{parsed:?}").contains("Unimplemented"),
+        "no clause may remain Unimplemented (gap=0)"
+    );
+
+    // Activated: ChooseFromZone(ExiledBySource) + RememberCard sub-ability.
+    let activated = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.kind, AbilityKind::Activated))
+        .expect("activated ability must parse");
+    assert!(
+        matches!(activated.effect.as_ref(), Effect::ChooseFromZone { .. }),
+        "activated effect must be ChooseFromZone, got {:?}",
+        activated.effect
+    );
+    let sub = activated
+        .sub_ability
+        .as_ref()
+        .expect("ChooseFromZone must carry a RememberCard sub-ability");
+    assert!(
+        matches!(sub.effect.as_ref(), Effect::RememberCard { .. }),
+        "sub-ability must be RememberCard, got {:?}",
+        sub.effect
+    );
+
+    // Static: both grant modifications sourced from ChosenCard.
+    let grants: Vec<&ContinuousModification> = parsed
+        .statics
+        .iter()
+        .flat_map(|s| s.modifications.iter())
+        .collect();
+    assert!(
+        grants.iter().any(|m| matches!(
+            m,
+            ContinuousModification::GrantAllActivatedAbilitiesOf {
+                source: TargetFilter::ChosenCard,
+                ..
+            }
+        )),
+        "static must grant all activated abilities of the chosen card"
+    );
+    assert!(
+        grants.iter().any(|m| matches!(
+            m,
+            ContinuousModification::GrantAllTriggeredAbilitiesOf {
+                source: TargetFilter::ChosenCard,
+            }
+        )),
+        "static must grant all triggered abilities of the chosen card"
+    );
+}

--- a/crates/engine/tests/koh_face_stealer_grants.rs
+++ b/crates/engine/tests/koh_face_stealer_grants.rs
@@ -34,8 +34,9 @@ use engine::types::ability::{
     AbilityDefinition, AbilityKind, ChosenAttribute, ContinuousModification, Effect,
     ManaContribution, ManaProduction, StaticDefinition, TargetFilter, TriggerDefinition,
 };
+use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
-use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::game_state::{ExileLink, ExileLinkKind, GameState, WaitingFor};
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::mana::ManaColor;
 use engine::types::phase::Phase;
@@ -333,6 +334,150 @@ fn resolve_remember_card(state: &mut GameState, koh: ObjectId, card: ObjectId) {
     let ability = build_resolved_from_def(&def, koh, P0);
     let mut events = Vec::new();
     resolve_ability_chain(state, &ability, &mut events, 0).expect("RememberCard must resolve");
+}
+
+// ─── Maintainer HIGH (PR #4611): Koh can choose OPPONENT-owned exiled cards ────
+
+/// CR 400.1 + CR 607.2a (PR #4611, maintainer matthewevans): Koh exiles
+/// *opponents'* creatures, so "Choose a creature card exiled with Koh" must
+/// offer opponent-OWNED exiled cards. The activated ability lowers to
+/// `ChooseFromZone { zone_owner: AllOwners, filter: And[Creature, ExiledBySource] }`,
+/// which scans the whole shared exile zone (CR 400.1) and lets the linked-exile
+/// reference (CR 607.2a) do all scoping — ownership is irrelevant. Driven
+/// end-to-end through the REAL parse→resolve→select path: the parsed activated
+/// ability parks a `ChooseFromZoneChoice` offering the opponent's exiled
+/// creature; selecting it runs the `RememberCard` sub-ability, which records it
+/// as Koh's `ChosenAttribute::Card` (the seam `TargetFilter::ChosenCard` and the
+/// Layer-6 grant statics read).
+///
+/// DISCRIMINATOR: the ONLY exiled creature is opponent-owned. Under the old
+/// `ZoneOwner::Controller` scope the per-owner gate empties the candidate pool,
+/// so NO prompt parks and NO card is recorded — both the prompt-parks assertion
+/// and the chosen-card assertion below flip to failure (the revert-probe).
+#[test]
+fn koh_can_choose_opponent_owned_creature_exiled_with_koh() {
+    const KOH: &str = "When Koh enters, exile up to one other target creature.\nWhenever another nontoken creature dies, you may exile it.\nPay 1 life: Choose a creature card exiled with Koh.\nKoh has all activated and triggered abilities of the last chosen card.";
+    let opponent = PlayerId(1);
+
+    let mut state = GameState::new_two_player(7);
+    state.phase = Phase::PreCombatMain;
+    state.active_player = P0;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    let koh = build_koh(&mut state);
+
+    // An OPPONENT-owned creature card in the shared exile zone (CR 400.1),
+    // exiled WITH Koh — the common case, since Koh exiles opponents' creatures.
+    let opp_face = create_object(
+        &mut state,
+        CardId(7000),
+        opponent,
+        "Opponent's Exiled Face".to_string(),
+        Zone::Exile,
+    );
+    {
+        let obj = state.objects.get_mut(&opp_face).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+        // A donatable activated ability with an observable, color-distinct
+        // effect — what Koh's Layer-6 grant should surface once this opponent's
+        // card is the last chosen card.
+        obj.abilities = Arc::new(vec![mana_ability(ManaColor::Green)]);
+    }
+    // CR 607.2a: link the opponent-owned card to Koh as "exiled with" it.
+    state.exile_links.push(ExileLink {
+        exiled_id: opp_face,
+        source_id: koh,
+        kind: ExileLinkKind::TrackedBySource,
+    });
+
+    // Negative baseline: with nothing chosen yet, Koh is granted no ability —
+    // the discriminator for the end-to-end grant assertion below.
+    evaluate_layers(&mut state);
+    assert!(
+        koh_granted_mana_colors(&state, koh).is_empty(),
+        "before any card is chosen, Koh must have no granted ability"
+    );
+
+    // Real parser path: Koh's activated ability (ChooseFromZone + RememberCard sub).
+    let parsed = parse_oracle_text(
+        KOH,
+        "Koh, the Face Stealer",
+        &[],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Shapeshifter".to_string()],
+    );
+    let activated = parsed
+        .abilities
+        .iter()
+        .find(|a| matches!(a.kind, AbilityKind::Activated))
+        .expect("Koh's activated ability must parse")
+        .clone();
+
+    // Resolve the activated ability through the real chain → parks on the choice.
+    let ability = build_resolved_from_def(&activated, koh, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0)
+        .expect("Koh's choose-from-exile must resolve");
+
+    // The interactive prompt parked and OFFERS the opponent-owned card. Under the
+    // old Controller scope the pool is empty and `waiting_for` would not be a
+    // ChooseFromZoneChoice at all — this match arm is the revert-probe failure.
+    match &state.waiting_for {
+        WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, P0, "Koh's controller chooses");
+            assert!(
+                cards.contains(&opp_face),
+                "the opponent-owned creature exiled with Koh must be offered, got {cards:?}"
+            );
+        }
+        other => panic!(
+            "expected ChooseFromZoneChoice offering the opponent-owned exiled creature; \
+             got {other:?} (a Controller-scope owner gate would empty the pool)"
+        ),
+    }
+
+    // Select the opponent's card → the RememberCard sub-ability records it.
+    engine::game::engine::apply(
+        &mut state,
+        P0,
+        GameAction::SelectCards {
+            cards: vec![opp_face],
+        },
+    )
+    .expect("selecting the opponent-owned exiled creature must succeed");
+
+    // Production seam: Koh now remembers the OPPONENT-owned card as its last
+    // chosen card (what `TargetFilter::ChosenCard` / the grant statics read).
+    let remembered: Vec<ObjectId> = state.objects[&koh]
+        .chosen_attributes
+        .iter()
+        .filter_map(|a| match a {
+            ChosenAttribute::Card(id) => Some(*id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        remembered,
+        vec![opp_face],
+        "Koh must record the chosen OPPONENT-owned exiled creature as its last \
+         chosen card (RememberCard wrote ChosenAttribute::Card across owners)"
+    );
+
+    // End-to-end payoff — the user-facing bug: with the opponent-owned card now
+    // recorded as Koh's last chosen card, the Layer-6 grant
+    // (`TargetFilter::ChosenCard`, owner-agnostic and zone-guarded to Exile)
+    // surfaces that card's activated ability ONTO Koh. This is the whole point
+    // of Koh choosing opponent-owned exiled creatures: stealing their abilities.
+    evaluate_layers(&mut state);
+    assert_eq!(
+        koh_granted_mana_colors(&state, koh),
+        vec![ManaColor::Green],
+        "Koh must be granted the OPPONENT-owned chosen card's activated ability \
+         (against the empty baseline above — proving cross-owner selection drives \
+         the grant end-to-end)"
+    );
 }
 
 // ─── gap=0 proxy: the whole card lowers with no Unimplemented ─────────────────

--- a/crates/engine/tests/sandswirl_wanderglyph_attacked_you_cant_cast.rs
+++ b/crates/engine/tests/sandswirl_wanderglyph_attacked_you_cant_cast.rs
@@ -1,0 +1,230 @@
+//! Discriminating integration coverage for **Sandswirl Wanderglyph**'s static:
+//!   "Each opponent who attacked you or a planeswalker you control this turn
+//!    can't cast spells."
+//!
+//! This is a continuous casting prohibition (`StaticMode::CantBeCast { who:
+//! Opponents }`) gated by the per-affected-CASTER predicate
+//! `ParsedCondition::YouAttackedSourceControllerThisTurn` (CR 101.2 + CR 508.6 +
+//! CR 109.5), evaluated as `has_attacked(caster, source.controller)` against the
+//! CR-508.5-collapsed `attacked_defenders_this_turn` ledger.
+//!
+//! The load-bearing distinction vs. the sibling `YouAttackedThisTurn` (Angelic
+//! Arbiter, "attacked ANYONE"): an opponent who attacked a DIFFERENT opponent
+//! this turn — but not you — is NOT prohibited. The 3-player test below is the
+//! revert-probe: swapping the eval to `YouAttackedThisTurn` would read
+//! `players_attacked_this_turn` (which contains BOTH opponents here) and wrongly
+//! gate the opponent who only attacked the other opponent → the `p2_can_cast`
+//! assertion fails. The per-caster eval IS the "each opponent who …" quantifier.
+
+use std::collections::HashSet;
+
+use engine::game::casting::can_cast_object_now;
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P2: PlayerId = PlayerId(2);
+
+const SANDSWIRL: &str = "Flying\nWhenever an opponent casts a spell during their turn, they can't attack you or planeswalkers you control this turn.\nEach opponent who attacked you or a planeswalker you control this turn can't cast spells.";
+
+fn zero_instant(scenario: &mut GameScenario, owner: PlayerId, name: &str) -> ObjectId {
+    scenario
+        .add_spell_to_hand_from_oracle(owner, name, true, "Draw a card.")
+        .with_mana_cost(ManaCost::generic(0))
+        .id()
+}
+
+/// CR 101.2 + CR 508.6 + CR 109.5: in a 3-player game with Sandswirl under P0,
+/// directly model the turn's combat ledger — P1 attacked P0 (you), P2 attacked
+/// only P1 (the OTHER opponent) — and prove the prohibition discriminates by
+/// DEFENDER. P1 and P2 are symmetric (both opponents of P0, both non-active), so
+/// the only difference in castability is the attacked-you predicate.
+#[test]
+fn only_opponents_who_attacked_you_are_prohibited() {
+    let mut scenario = GameScenario::new_n_player(3, 17);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let sandswirl = scenario
+        .add_creature_from_oracle(P0, "Sandswirl Wanderglyph", 5, 3, SANDSWIRL)
+        .id();
+
+    // {0} instants for every player — identical castability except the static.
+    let p0_spell = zero_instant(&mut scenario, P0, "P0 Spell");
+    let p1_spell = zero_instant(&mut scenario, P1, "P1 Spell");
+    let p2_spell = zero_instant(&mut scenario, P2, "P2 Spell");
+
+    let mut runner = scenario.build();
+
+    // Model the turn's combat history (CR 508.5-collapsed defending players):
+    //   P1 attacked P0 (you).        P2 attacked P1 (the other opponent), NOT you.
+    // `players_attacked_this_turn` holds BOTH so the revert-probe is live: an
+    // attacked-ANYONE eval would gate P2 too.
+    {
+        let st = runner.state_mut();
+        st.attacked_defenders_this_turn
+            .insert(P1, HashSet::from([P0]));
+        st.attacked_defenders_this_turn
+            .insert(P2, HashSet::from([P1]));
+        st.players_attacked_this_turn.insert(P1);
+        st.players_attacked_this_turn.insert(P2);
+    }
+
+    // Sanity: the static must actually be on the battlefield source.
+    assert!(
+        runner.state().objects.contains_key(&sandswirl),
+        "Sandswirl must be on the battlefield"
+    );
+
+    // PRIMARY discrimination:
+    assert!(
+        !can_cast_object_now(runner.state(), P1, p1_spell),
+        "P1 attacked you this turn → must be prohibited from casting"
+    );
+    assert!(
+        can_cast_object_now(runner.state(), P2, p2_spell),
+        "P2 attacked only the OTHER opponent (not you) → must NOT be prohibited \
+         (revert-probe: an attacked-anyone eval wrongly gates P2 here)"
+    );
+    // Control: the source's own controller is never an "opponent" → never gated.
+    assert!(
+        can_cast_object_now(runner.state(), P0, p0_spell),
+        "P0 (the controller / 'you') is never prohibited by its own static"
+    );
+}
+
+/// End-to-end via the REAL combat pipeline: on P1's turn, P1 attacks P0, which
+/// populates `attacked_defenders_this_turn` through `declare_attackers`. The
+/// static then prohibits P1 from casting — proving the predicate reads genuine
+/// combat history, not just a hand-seeded ledger.
+#[test]
+fn real_attack_on_you_prohibits_casting() {
+    let mut scenario = GameScenario::new_n_player(3, 23);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature_from_oracle(P0, "Sandswirl Wanderglyph", 5, 3, SANDSWIRL)
+        .id();
+    let attacker = scenario
+        .add_creature_from_oracle(P1, "Raging Bear", 2, 2, "")
+        .id();
+    let p1_spell = zero_instant(&mut scenario, P1, "P1 Spell");
+
+    let mut runner = scenario.build();
+
+    // Make it P1's turn (escape hatch) so P1 can legally declare attackers vs P0.
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P0))])
+        .expect("P1 declaring an attacker against P0 must succeed");
+    // Drain any priority so combat-declaration state settles.
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() || runner.act(GameAction::PassPriority).is_err()
+                {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    assert!(
+        runner.state().has_attacked(P1, P0),
+        "declare_attackers must record P1 as having attacked P0 this turn"
+    );
+    assert!(
+        !can_cast_object_now(runner.state(), P1, p1_spell),
+        "P1 really attacked you this turn → Sandswirl prohibits P1 from casting"
+    );
+}
+
+/// Parse-level gap=0 proof: the whole card lowers with NO `Unimplemented` clause —
+/// Gap A (the SpellCast trigger's child) becomes a player can't-attack restriction
+/// and Gap B becomes a `CantBeCast` static gated on the attacked-you predicate.
+#[test]
+fn full_card_parses_both_clauses_no_unimplemented() {
+    use engine::parser::oracle::parse_oracle_text;
+    use engine::types::ability::{
+        Effect, GameRestriction, ParsedCondition, ProhibitedActivity, RestrictionExpiry,
+    };
+    use engine::types::statics::{ProhibitionScope, StaticMode};
+    use engine::types::triggers::{AttackTargetFilter, TriggerMode};
+
+    let parsed = parse_oracle_text(
+        SANDSWIRL,
+        "Sandswirl Wanderglyph",
+        &["Flying".to_string()],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &["Golem".to_string()],
+    );
+
+    // Gap A — SpellCast trigger child is a real player can't-attack restriction
+    // (defended = you or your planeswalkers), NOT Unimplemented.
+    let spell_trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| matches!(t.mode, TriggerMode::SpellCast))
+        .expect("SpellCast trigger must parse");
+    let child = spell_trigger
+        .execute
+        .as_ref()
+        .expect("SpellCast trigger must carry an effect");
+    assert!(
+        matches!(
+            child.effect.as_ref(),
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    activity: ProhibitedActivity::Attack {
+                        defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                    },
+                    // CR 514.2: "… this turn" expires at the CURRENT turn's cleanup
+                    // (`RestrictionExpiry::EndOfTurn`), NOT a permanent restriction and
+                    // NOT the next-turn `UntilEndOfNextTurnOf` (Willie Lumpkin) path —
+                    // `RestrictionExpiry` has no never-expires variant, so EndOfTurn is
+                    // provably current-turn cleanup. Probe #3 separately excludes the
+                    // next-turn duration; this pins the expiry to the current turn.
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    ..
+                }
+            }
+        ),
+        "trigger child must be a you-or-planeswalkers can't-attack restriction expiring \
+         at the CURRENT turn's end (EndOfTurn), got {:?}",
+        child.effect
+    );
+
+    // Gap B — CantBeCast static gated on the source-controller attacked-you predicate.
+    let cant_cast = parsed
+        .statics
+        .iter()
+        .find(|s| {
+            matches!(
+                s.mode,
+                StaticMode::CantBeCast {
+                    who: ProhibitionScope::Opponents
+                }
+            )
+        })
+        .expect("CantBeCast static must parse");
+    assert_eq!(
+        cant_cast.per_player_condition,
+        Some(ParsedCondition::YouAttackedSourceControllerThisTurn),
+    );
+
+    // Gap=0 proxy: no clause anywhere lowered to Unimplemented.
+    let blob = format!("{parsed:?}");
+    assert!(
+        !blob.contains("Unimplemented"),
+        "no clause may remain Unimplemented (gap=0)"
+    );
+}

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1077,6 +1077,7 @@ fn target_filter_variant_name(f: &TargetFilter) -> &'static str {
         TargetFilter::LastCreated => "LastCreated",
         TargetFilter::LastRevealed => "LastRevealed",
         TargetFilter::CostPaidObject => "CostPaidObject",
+        TargetFilter::ChosenCard => "ChosenCard",
         TargetFilter::TrackedSet { .. } => "TrackedSet",
         TargetFilter::TrackedSetFiltered { .. } => "TrackedSetFiltered",
         TargetFilter::ExiledBySource => "ExiledBySource",

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -628,6 +628,7 @@ fn redundancy_delta(
         | Effect::Heist { .. }
         | Effect::PutSticker { .. }
         | Effect::ApplySticker { .. }
+        | Effect::RememberCard { .. }
         | Effect::HeistExile => None,
     }
 }

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -267,6 +267,7 @@ fn continuous_modification_references_x(modification: &ContinuousModification) -
         | ContinuousModification::AddKeyword { .. }
         | ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::AddType { .. }
         | ContinuousModification::RemoveType { .. }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## S21 static-ability cluster — Koh, the Face Stealer + Sandswirl Wanderglyph

Completes the S21 static-ability rollout cluster. Two cards reach full support
(`supported=true`, gap=0), built on reusable engine building blocks rather than
card-specific special cases.

### Cards

**Koh, the Face Stealer** `{4}{B}{B}` — Legendary Creature — Shapeshifter Spirit
```
When Koh enters, exile up to one other target creature.
Whenever another nontoken creature dies, you may exile it.
Pay 1 life: Choose a creature card exiled with Koh.
Koh has all activated and triggered abilities of the last chosen card.
```
The new work is the last two lines: a `Pay 1 life` activated ability that **chooses
and remembers** a creature card from Koh's linked-exile set, and a static that
**grants Koh all activated _and_ triggered abilities** of that remembered card.

**Sandswirl Wanderglyph** (back face of *Unstable Glyphbridge // Sandswirl Wanderglyph*)
```
Flying
Whenever an opponent casts a spell during their turn, they can't attack you or planeswalkers you control this turn.
Each opponent who attacked you or a planeswalker you control this turn can't cast spells.
```
The new work is the third line: a `this turn` casting prohibition scoped to opponents
who attacked you or your planeswalkers, with correct end-of-turn expiry.

### New engine building blocks (general, not card-specific)

| Slot | Purpose | CR |
|---|---|---|
| `ChosenAttribute::Card(ObjectId)` | Store a chosen/remembered card by object id; cleared on zone change | 613.1f / 611.2c / 400.7 |
| `TargetFilter::ChosenCard` | Matches the source's last-chosen card; **zone-guarded to Exile first** so the grant drops when the card leaves exile | 400.7 |
| `Effect::RememberCard { target }` | Single-overwrite remember (`retain(!Card)` + `push`) — re-choosing replaces the prior card | 608.2 |
| `ContinuousModification::GrantAllTriggeredAbilitiesOf { source }` | Layer 6 grant of **all triggered abilities** of a filtered source — faithful mirror of `GrantAllActivatedAbilitiesOf` (reads `provider.trigger_definitions`, emits `GrantTrigger`, no activated-only cap, all-zones, self-skip) | 613.1f / 603 |

Parser additions compose, they don't proliferate:
- `GrantedAbilityKinds { Activated | Triggered | ActivatedAndTriggered }` + a
  conjunction-first nom combinator so `"all activated and triggered abilities of …"`
  dispatches **both** grant modifications from one clause.
- `"the last chosen card"` → `TargetFilter::ChosenCard` grant-source noun phrase.
- `parse_choose_card_type_qualifier` — `"choose a <type> card exiled with ~"` → the
  type-intersected linked-exile pool (covers the whole "choose a card exiled with"
  class, not just Koh).

### Rules-correctness highlights

- **Dual invalidation of the grant** (CR 400.7): the chosen card leaving exile drops
  the grant (zone guard), and re-choosing overwrites so only the newest card's
  abilities are granted (single-overwrite remember). Both directions are tested.
- **Granted triggered ability actually fires for Koh** — the granted trigger is indexed
  by the holding object and resolves through the normal trigger pipeline (tested with a
  beginning-of-upkeep trigger).
- `GrantAllTriggeredAbilitiesOf` is a true mirror of the activated expander; the
  activated-only cap (CR 602.5b) correctly does **not** apply to triggered abilities.

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings`: clean (incl. cross-crate
  exhaustive matches in `mtgish-import` and `phase-ai`).
- `cargo test -p engine`: green, including the two new integration suites
  (`koh_face_stealer_grants`, `sandswirl_wanderglyph_attacked_you_cant_cast`).
- Each behavioral claim is backed by a **non-vacuous, discriminating** test: neutralizing
  the triggered expander, the `zone==Exile` guard, or the `retain(!Card)` overwrite each
  makes the corresponding test genuinely fail (not a compile error).
- **Coverage regression (vs main):** NET +2 supported, exactly {Koh, the Face Stealer,
  Sandswirl Wanderglyph}; 0 engine regressions, 0 coverage-honesty regressions, 0 oracle
  flips. `--fail-on-engine` clean.
