### PR TITLE
feat(lobby): Swiss tournament organizer for lobby broker (#4612)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,8 +28,11 @@ const CoveragePage = lazy(() => import("./pages/CoveragePage").then((m) => ({ de
 const DraftLandingPage = lazy(() => import("./pages/DraftLandingPage").then((m) => ({ default: m.DraftLandingPage })));
 const DraftPage = lazy(() => import("./pages/DraftPage").then((m) => ({ default: m.DraftPage })));
 const DraftPodPage = lazy(() => import("./pages/DraftPodPage").then((m) => ({ default: m.DraftPodPage })));
-const DraftSpectatorPage = lazy(() =>
-  import("./pages/DraftSpectatorPage").then((m) => ({ default: m.DraftSpectatorPage })),
+const TournamentLandingPage = lazy(() =>
+  import("./pages/TournamentLandingPage").then((m) => ({ default: m.TournamentLandingPage })),
+);
+const TournamentPage = lazy(() =>
+  import("./pages/TournamentPage").then((m) => ({ default: m.TournamentPage })),
 );
 
 function DevStrict({ children }: { children: ReactNode }) {
@@ -108,6 +111,8 @@ function AppContent() {
             <Route path="/" element={<DevStrict><MenuPage /></DevStrict>} />
             <Route path="/setup" element={<DevStrict><GameSetupPage /></DevStrict>} />
             <Route path="/multiplayer" element={<DevStrict><MultiplayerPage /></DevStrict>} />
+            <Route path="/tournament" element={<DevStrict><TournamentLandingPage /></DevStrict>} />
+            <Route path="/tournament/:code" element={<DevStrict><TournamentPage /></DevStrict>} />
             <Route path="/my-decks" element={<DevStrict><MyDecksPage /></DevStrict>} />
             <Route path="/deck-builder" element={<DevStrict><DeckBuilderPage /></DevStrict>} />
             <Route path="/coverage" element={<DevStrict><CoveragePage /></DevStrict>} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,9 @@ const CoveragePage = lazy(() => import("./pages/CoveragePage").then((m) => ({ de
 const DraftLandingPage = lazy(() => import("./pages/DraftLandingPage").then((m) => ({ default: m.DraftLandingPage })));
 const DraftPage = lazy(() => import("./pages/DraftPage").then((m) => ({ default: m.DraftPage })));
 const DraftPodPage = lazy(() => import("./pages/DraftPodPage").then((m) => ({ default: m.DraftPodPage })));
+const DraftSpectatorPage = lazy(() =>
+  import("./pages/DraftSpectatorPage").then((m) => ({ default: m.DraftSpectatorPage })),
+);
 const TournamentLandingPage = lazy(() =>
   import("./pages/TournamentLandingPage").then((m) => ({ default: m.TournamentLandingPage })),
 );

--- a/client/src/adapter/__tests__/contract-fixtures.test.ts
+++ b/client/src/adapter/__tests__/contract-fixtures.test.ts
@@ -39,7 +39,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 11,
+    protocol_version: 12,
     mode: "Full",
   },
 });

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -37,7 +37,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 11,
+    protocol_version: 12,
     mode: "Full",
   },
 });

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -43,7 +43,7 @@ const SERVER_HELLO = JSON.stringify({
   data: {
     server_version: "0.0.0-test",
     build_commit: "testhash",
-    protocol_version: 11,
+    protocol_version: 12,
     mode: "Full",
   },
 });

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -195,6 +195,64 @@ export interface JoinTargetInfo {
   reservation_expires_at_ms?: number | null;
 }
 
+/** Tournament lifecycle phase from the lobby broker. */
+export type TournamentStatus = "registration" | "in_progress" | "completed";
+
+/** Browse-row summary for open tournaments. */
+export interface TournamentSummary {
+  tournamentCode: string;
+  name: string;
+  organizerName: string;
+  createdAt: number;
+  status: TournamentStatus;
+  playerCount: number;
+  totalRounds: number;
+  currentRound: number;
+}
+
+/** A single row in the standings table. */
+export interface TournamentStanding {
+  playerKey: string;
+  displayName: string;
+  dropped: boolean;
+  matchPoints: number;
+  matchWins: number;
+  matchLosses: number;
+  matchDraws: number;
+  gameWins: number;
+  gameLosses: number;
+  omwPercentage: number;
+  gwPercentage: number;
+  ogwPercentage: number;
+}
+
+/** A pairing for the current round. */
+export interface PairingView {
+  matchId: string;
+  round: number;
+  table: number;
+  playerAKey: string;
+  playerAName: string;
+  playerBKey?: string | null;
+  playerBName?: string | null;
+  reported: boolean;
+  winnerPlayerKey?: string | null;
+}
+
+/** Full tournament state broadcast by the broker. */
+export interface TournamentView {
+  tournamentCode: string;
+  name: string;
+  organizerName: string;
+  createdAt: number;
+  status: TournamentStatus;
+  totalRounds: number;
+  currentRound: number;
+  playerCount: number;
+  standings: TournamentStanding[];
+  pairings: PairingView[];
+}
+
 // ── Match / Series ───────────────────────────────────────────────────────
 
 export type MatchType = "Bo1" | "Bo3";

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -34,7 +34,7 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  */
-export const PROTOCOL_VERSION = 11;
+export const PROTOCOL_VERSION = 12;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/tournament/PairingsList.tsx
+++ b/client/src/components/tournament/PairingsList.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+
+import type { PairingView } from "../../adapter/types";
+
+interface PairingsListProps {
+  pairings: PairingView[];
+  playerKey: string | null;
+  isOrganizer: boolean;
+  onReport: (
+    matchId: string,
+    winnerKey: string | null,
+    playerAWins: number,
+    playerBWins: number,
+  ) => void;
+}
+
+export function PairingsList({
+  pairings,
+  playerKey,
+  isOrganizer,
+  onReport,
+}: PairingsListProps) {
+  if (pairings.length === 0) {
+    return (
+      <p className="text-sm text-white/50">No pairings for the current round yet.</p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {pairings.map((pairing) => (
+        <PairingRow
+          key={pairing.matchId}
+          pairing={pairing}
+          playerKey={playerKey}
+          isOrganizer={isOrganizer}
+          onReport={onReport}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function PairingRow({
+  pairing,
+  playerKey,
+  isOrganizer,
+  onReport,
+}: {
+  pairing: PairingView;
+  playerKey: string | null;
+  isOrganizer: boolean;
+  onReport: PairingsListProps["onReport"];
+}) {
+  const [aWins, setAWins] = useState(2);
+  const [bWins, setBWins] = useState(0);
+  const isBye = !pairing.playerBKey;
+  const canReport =
+    !pairing.reported &&
+    !isBye &&
+    (isOrganizer ||
+      playerKey === pairing.playerAKey ||
+      playerKey === pairing.playerBKey);
+
+  return (
+    <li className="rounded-xl border border-white/10 bg-black/20 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs uppercase tracking-wide text-white/40">
+          Table {pairing.table + 1}
+        </span>
+        {pairing.reported && (
+          <span className="text-xs text-emerald-300">Reported</span>
+        )}
+      </div>
+      <p className="mt-2 text-white">
+        {isBye ? (
+          <>{pairing.playerAName} — Bye</>
+        ) : (
+          <>
+            {pairing.playerAName}
+            <span className="mx-2 text-white/40">vs</span>
+            {pairing.playerBName}
+          </>
+        )}
+      </p>
+      {canReport && pairing.playerBKey && (
+        <div className="mt-3 flex flex-wrap items-end gap-2">
+          <label className="text-xs text-white/50">
+            {pairing.playerAName} wins
+            <input
+              type="number"
+              min={0}
+              max={3}
+              value={aWins}
+              onChange={(e) => setAWins(Number(e.target.value))}
+              className="mt-1 block w-16 rounded border border-white/10 bg-black/40 px-2 py-1 text-white"
+            />
+          </label>
+          <label className="text-xs text-white/50">
+            {pairing.playerBName} wins
+            <input
+              type="number"
+              min={0}
+              max={3}
+              value={bWins}
+              onChange={(e) => setBWins(Number(e.target.value))}
+              className="mt-1 block w-16 rounded border border-white/10 bg-black/40 px-2 py-1 text-white"
+            />
+          </label>
+          <button
+            type="button"
+            className="rounded-lg bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/20"
+            onClick={() => {
+              const winnerKey =
+                aWins === bWins
+                  ? null
+                  : aWins > bWins
+                    ? pairing.playerAKey
+                    : pairing.playerBKey!;
+              onReport(pairing.matchId, winnerKey, aWins, bWins);
+            }}
+          >
+            Report result
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/client/src/components/tournament/StandingsTable.tsx
+++ b/client/src/components/tournament/StandingsTable.tsx
@@ -1,0 +1,56 @@
+import type { TournamentStanding } from "../../adapter/types";
+
+interface StandingsTableProps {
+  standings: TournamentStanding[];
+  highlightPlayerKey?: string | null;
+}
+
+export function StandingsTable({ standings, highlightPlayerKey }: StandingsTableProps) {
+  if (standings.length === 0) {
+    return (
+      <p className="text-sm text-white/50">Standings appear after the first round.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-white/10">
+      <table className="min-w-full text-left text-sm text-white/80">
+        <thead className="bg-white/5 text-xs uppercase tracking-wide text-white/50">
+          <tr>
+            <th className="px-3 py-2">#</th>
+            <th className="px-3 py-2">Player</th>
+            <th className="px-3 py-2">Pts</th>
+            <th className="px-3 py-2">Record</th>
+            <th className="px-3 py-2">OMW%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {standings.map((row, index) => {
+            const highlighted = highlightPlayerKey === row.playerKey;
+            return (
+              <tr
+                key={row.playerKey}
+                className={highlighted ? "bg-amber-500/10" : "border-t border-white/5"}
+              >
+                <td className="px-3 py-2">{index + 1}</td>
+                <td className="px-3 py-2">
+                  {row.displayName}
+                  {row.dropped && (
+                    <span className="ml-2 text-xs text-red-300">(dropped)</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 font-medium">{row.matchPoints}</td>
+                <td className="px-3 py-2">
+                  {row.matchWins}-{row.matchLosses}-{row.matchDraws}
+                </td>
+                <td className="px-3 py-2">
+                  {(row.omwPercentage * 100).toFixed(1)}%
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/components/tournament/TournamentCard.tsx
+++ b/client/src/components/tournament/TournamentCard.tsx
@@ -1,0 +1,62 @@
+import type { TournamentSummary } from "../../adapter/types";
+
+interface TournamentCardProps {
+  tournament: TournamentSummary;
+  onJoin: (code: string) => void;
+}
+
+function statusLabel(status: TournamentSummary["status"]): string {
+  switch (status) {
+    case "registration":
+      return "Registration";
+    case "in_progress":
+      return "In Progress";
+    case "completed":
+      return "Completed";
+    default:
+      return status;
+  }
+}
+
+export function TournamentCard({ tournament, onJoin }: TournamentCardProps) {
+  return (
+    <article className="rounded-xl border border-white/10 bg-black/30 p-4 backdrop-blur-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-white">{tournament.name}</h3>
+          <p className="text-sm text-white/60">
+            Hosted by {tournament.organizerName}
+          </p>
+        </div>
+        <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs uppercase tracking-wide text-white/80">
+          {statusLabel(tournament.status)}
+        </span>
+      </div>
+      <dl className="mt-3 grid grid-cols-3 gap-2 text-sm text-white/70">
+        <div>
+          <dt className="text-white/40">Players</dt>
+          <dd>{tournament.playerCount}</dd>
+        </div>
+        <div>
+          <dt className="text-white/40">Rounds</dt>
+          <dd>
+            {tournament.currentRound}/{tournament.totalRounds}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-white/40">Code</dt>
+          <dd className="font-mono">{tournament.tournamentCode}</dd>
+        </div>
+      </dl>
+      {tournament.status === "registration" && (
+        <button
+          type="button"
+          className="mt-4 w-full rounded-lg bg-amber-500/90 px-3 py-2 text-sm font-medium text-black transition hover:bg-amber-400"
+          onClick={() => onJoin(tournament.tournamentCode)}
+        >
+          Join tournament
+        </button>
+      )}
+    </article>
+  );
+}

--- a/client/src/pages/MultiplayerPage.tsx
+++ b/client/src/pages/MultiplayerPage.tsx
@@ -810,6 +810,18 @@ export function MultiplayerPage() {
         )}
 
         {view === "lobby" && (
+          <div className="mb-4 w-full max-w-3xl">
+            <button
+              type="button"
+              onClick={() => navigate("/tournament")}
+              className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/80 transition hover:bg-white/10"
+            >
+              Swiss tournaments
+            </button>
+          </div>
+        )}
+
+        {view === "lobby" && (
           <LobbyView
             // Remount on server change so local lobby state (playerCount,
             // game list) resets and the subscription effect re-runs against

--- a/client/src/pages/TournamentLandingPage.tsx
+++ b/client/src/pages/TournamentLandingPage.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { ScreenChrome } from "../components/chrome/ScreenChrome";
+import { MenuShell } from "../components/menu/MenuShell";
+import { TournamentCard } from "../components/tournament/TournamentCard";
+import type { TournamentSummary } from "../adapter/types";
+import { openTournamentClient } from "../services/tournamentClient";
+import { useMultiplayerStore } from "../stores/multiplayerStore";
+
+export function TournamentLandingPage() {
+  const navigate = useNavigate();
+  const brokerUrl = useMultiplayerStore((s) => s.serverAddress);
+  const [tournaments, setTournaments] = useState<TournamentSummary[]>([]);
+  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [rounds, setRounds] = useState(3);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const connect = useCallback(async () => {
+    if (!brokerUrl) {
+      setError("No lobby broker configured. Set a broker URL in multiplayer settings.");
+      return null;
+    }
+    return openTournamentClient(brokerUrl);
+  }, [brokerUrl]);
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const client = await connect();
+        if (!client || cancelled) return;
+        cleanup = client.subscribeTournaments(
+          setTournaments,
+          () => {},
+          (code) => setTournaments((prev) => prev.filter((t) => t.tournamentCode !== code)),
+        );
+        const list = await client.listTournaments();
+        if (!cancelled) setTournaments(list);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [connect]);
+
+  const handleCreate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const client = await connect();
+      if (!client) return;
+      const created = await client.createTournament({
+        name: name.trim(),
+        displayName: displayName.trim(),
+        totalRounds: rounds,
+      });
+      client.close();
+      navigate(`/tournament/${created.tournamentCode}`, {
+        state: { playerKey: created.playerKey, organizer: true },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleJoin = (code: string) => {
+    navigate(`/tournament/${code}`);
+  };
+
+  return (
+    <div className="menu-scene relative flex min-h-screen flex-col overflow-hidden">
+      <ScreenChrome onBack={() => navigate("/multiplayer")} />
+      <div className="menu-scene__vignette" />
+      <div className="menu-scene__haze" />
+
+      <MenuShell
+        eyebrow="Swiss events"
+        title="Tournaments"
+        subtitle="Organize multi-round Swiss events for your playgroup — pairings and standings without a spreadsheet."
+      >
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-black/25 p-5">
+            <h2 className="text-lg font-semibold text-white">Create tournament</h2>
+            <div className="mt-4 space-y-3">
+              <label className="block text-sm text-white/70">
+                Event name
+                <input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-white"
+                  placeholder="Friday Night Swiss"
+                />
+              </label>
+              <label className="block text-sm text-white/70">
+                Your display name
+                <input
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-white"
+                  placeholder="Alice"
+                />
+              </label>
+              <label className="block text-sm text-white/70">
+                Swiss rounds
+                <input
+                  type="number"
+                  min={1}
+                  max={15}
+                  value={rounds}
+                  onChange={(e) => setRounds(Number(e.target.value))}
+                  className="mt-1 w-24 rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-white"
+                />
+              </label>
+              <button
+                type="button"
+                disabled={loading || !name.trim() || !displayName.trim()}
+                onClick={() => void handleCreate()}
+                className="w-full rounded-lg bg-amber-500/90 py-2 font-medium text-black disabled:opacity-40"
+              >
+                {loading ? "Creating…" : "Create & organize"}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="mb-3 text-lg font-semibold text-white">Open tournaments</h2>
+            {tournaments.length === 0 ? (
+              <p className="text-sm text-white/50">No open tournaments right now.</p>
+            ) : (
+              <div className="space-y-3">
+                {tournaments.map((t) => (
+                  <TournamentCard key={t.tournamentCode} tournament={t} onJoin={handleJoin} />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-red-400/30 bg-red-950/40 px-3 py-2 text-sm text-red-200">
+            {error}
+          </p>
+        )}
+      </MenuShell>
+    </div>
+  );
+}

--- a/client/src/pages/TournamentLandingPage.tsx
+++ b/client/src/pages/TournamentLandingPage.tsx
@@ -87,7 +87,7 @@ export function TournamentLandingPage() {
       <MenuShell
         eyebrow="Swiss events"
         title="Tournaments"
-        subtitle="Organize multi-round Swiss events for your playgroup — pairings and standings without a spreadsheet."
+        description="Organize multi-round Swiss events for your playgroup — pairings and standings without a spreadsheet."
       >
         <section className="grid gap-6 lg:grid-cols-2">
           <div className="rounded-2xl border border-white/10 bg-black/25 p-5">

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
+
+import { ScreenChrome } from "../components/chrome/ScreenChrome";
+import { MenuShell } from "../components/menu/MenuShell";
+import { PairingsList } from "../components/tournament/PairingsList";
+import { StandingsTable } from "../components/tournament/StandingsTable";
+import type { TournamentView } from "../adapter/types";
+import { openTournamentClient } from "../services/tournamentClient";
+import { useMultiplayerStore } from "../stores/multiplayerStore";
+
+interface LocationState {
+  playerKey?: string;
+  organizer?: boolean;
+}
+
+export function TournamentPage() {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state ?? {}) as LocationState;
+  const brokerUrl = useMultiplayerStore((s) => s.serverAddress);
+
+  const [tournament, setTournament] = useState<TournamentView | null>(null);
+  const [playerKey, setPlayerKey] = useState<string | null>(state.playerKey ?? null);
+  const [isOrganizer, setIsOrganizer] = useState(Boolean(state.organizer));
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [joining, setJoining] = useState(false);
+
+  const connect = useCallback(async () => {
+    if (!brokerUrl) {
+      throw new Error("No lobby broker configured.");
+    }
+    return openTournamentClient(brokerUrl);
+  }, [brokerUrl]);
+
+  useEffect(() => {
+    if (!code) return;
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const client = await connect();
+        cleanup = client.subscribeTournaments(
+          () => {},
+          (view) => {
+            if (view.tournamentCode === code && !cancelled) {
+              setTournament(view);
+            }
+          },
+          (completed) => {
+            if (completed === code && !cancelled) {
+              setTournament((prev) =>
+                prev ? { ...prev, status: "completed" } : prev,
+              );
+            }
+          },
+        );
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, [code, connect]);
+
+  const handleJoin = async () => {
+    if (!code) return;
+    setJoining(true);
+    setError(null);
+    try {
+      const client = await connect();
+      const view = await client.joinTournament(code, displayName.trim());
+      setTournament(view);
+      const self = view.standings.find(
+        (s) => s.displayName.toLowerCase() === displayName.trim().toLowerCase(),
+      );
+      if (self) setPlayerKey(self.playerKey);
+      client.close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const handleStartRound = async () => {
+    if (!code) return;
+    try {
+      const client = await connect();
+      await client.startRound(code);
+      client.close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleReport = async (
+    matchId: string,
+    winnerKey: string | null,
+    aWins: number,
+    bWins: number,
+  ) => {
+    if (!code) return;
+    try {
+      const client = await connect();
+      await client.reportMatchResult(code, matchId, winnerKey, aWins, bWins);
+      client.close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleDrop = async () => {
+    if (!code) return;
+    try {
+      const client = await connect();
+      await client.dropFromTournament(code);
+      client.close();
+      navigate("/tournament");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleEnd = async () => {
+    if (!code) return;
+    try {
+      const client = await connect();
+      await client.endTournament(code);
+      client.close();
+      navigate("/tournament");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const needsJoin = !playerKey && tournament?.status === "registration";
+
+  return (
+    <div className="menu-scene relative flex min-h-screen flex-col overflow-hidden">
+      <ScreenChrome onBack={() => navigate("/tournament")} />
+      <div className="menu-scene__vignette" />
+      <div className="menu-scene__haze" />
+
+      <MenuShell
+        eyebrow={code ?? ""}
+        title={tournament?.name ?? "Tournament"}
+        subtitle={
+          tournament
+            ? `Round ${tournament.currentRound} of ${tournament.totalRounds} · ${tournament.playerCount} players`
+            : "Loading…"
+        }
+      >
+        {needsJoin && (
+          <section className="mb-6 rounded-2xl border border-amber-400/20 bg-amber-950/20 p-4">
+            <h2 className="font-medium text-white">Join this event</h2>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <input
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Display name"
+                className="flex-1 rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-white"
+              />
+              <button
+                type="button"
+                disabled={joining || !displayName.trim()}
+                onClick={() => void handleJoin()}
+                className="rounded-lg bg-amber-500/90 px-4 py-2 font-medium text-black disabled:opacity-40"
+              >
+                Join
+              </button>
+            </div>
+          </section>
+        )}
+
+        {isOrganizer && tournament && tournament.status !== "completed" && (
+          <div className="mb-6 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void handleStartRound()}
+              className="rounded-lg bg-emerald-600/90 px-4 py-2 text-sm font-medium text-white"
+            >
+              {tournament.status === "registration"
+                ? "Start tournament"
+                : "Start next round"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleEnd()}
+              className="rounded-lg border border-white/20 px-4 py-2 text-sm text-white/80"
+            >
+              End tournament
+            </button>
+          </div>
+        )}
+
+        {playerKey && tournament?.status !== "completed" && (
+          <button
+            type="button"
+            onClick={() => void handleDrop()}
+            className="mb-6 text-sm text-red-300 underline"
+          >
+            Drop from tournament
+          </button>
+        )}
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-white">Standings</h2>
+            <StandingsTable
+              standings={tournament?.standings ?? []}
+              highlightPlayerKey={playerKey}
+            />
+          </section>
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-white">Current pairings</h2>
+            <PairingsList
+              pairings={tournament?.pairings ?? []}
+              playerKey={playerKey}
+              isOrganizer={isOrganizer}
+              onReport={handleReport}
+            />
+            <p className="mt-4 text-xs text-white/40">
+              Play your match at your own table using the normal P2P host flow, then
+              report the result here.
+            </p>
+          </section>
+        </div>
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-red-400/30 bg-red-950/40 px-3 py-2 text-sm text-red-200">
+            {error}
+          </p>
+        )}
+      </MenuShell>
+    </div>
+  );
+}

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -151,7 +151,7 @@ export function TournamentPage() {
       <MenuShell
         eyebrow={code ?? ""}
         title={tournament?.name ?? "Tournament"}
-        subtitle={
+        description={
           tournament
             ? `Round ${tournament.currentRound} of ${tournament.totalRounds} · ${tournament.playerCount} players`
             : "Loading…"

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -23,7 +23,7 @@ export function TournamentPage() {
 
   const [tournament, setTournament] = useState<TournamentView | null>(null);
   const [playerKey, setPlayerKey] = useState<string | null>(state.playerKey ?? null);
-  const [isOrganizer, setIsOrganizer] = useState(Boolean(state.organizer));
+  const isOrganizer = Boolean(state.organizer);
   const [displayName, setDisplayName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [joining, setJoining] = useState(false);

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -44,7 +44,7 @@ function helloFrame(
     data: {
       server_version: "0.0.0-test",
       build_commit: "testhash",
-      protocol_version: 11,
+      protocol_version: 12,
       mode: "Full",
       ...overrides,
     },
@@ -64,7 +64,7 @@ describe("openPhaseSocket", () => {
 
     const socket = await promise;
     expect(socket.serverInfo.mode).toBe("Full");
-    expect(socket.serverInfo.protocolVersion).toBe(11);
+    expect(socket.serverInfo.protocolVersion).toBe(12);
     expect(ws.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"ClientHello"'),
     );

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -82,7 +82,7 @@ describe("openPhaseSocket", () => {
   it("rejects the previous protocol version for Full servers", async () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];
-    ws.deliverMessage(helloFrame({ protocol_version: 10 }));
+    ws.deliverMessage(helloFrame({ protocol_version: 11 }));
 
     await expect(promise).rejects.toMatchObject({
       kind: "protocol_mismatch",
@@ -94,14 +94,14 @@ describe("openPhaseSocket", () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];
     ws.deliverMessage(
-      helloFrame({ protocol_version: 10, mode: "LobbyOnly" }),
+      helloFrame({ protocol_version: 11, mode: "LobbyOnly" }),
     );
 
     const socket = await promise;
     expect(socket.serverInfo.mode).toBe("LobbyOnly");
-    expect(socket.serverInfo.protocolVersion).toBe(10);
+    expect(socket.serverInfo.protocolVersion).toBe(11);
     expect(ws.send).toHaveBeenCalledWith(
-      expect.stringContaining('"protocol_version":10'),
+      expect.stringContaining('"protocol_version":11'),
     );
   });
 

--- a/client/src/services/tournamentClient.ts
+++ b/client/src/services/tournamentClient.ts
@@ -1,0 +1,308 @@
+import type {
+  TournamentSummary,
+  TournamentView,
+} from "../adapter/types";
+import type { ServerInfo } from "../adapter/ws-adapter";
+import {
+  HandshakeError,
+  openPhaseSocket,
+  type PhaseSocket,
+} from "./openPhaseSocket";
+
+export interface CreateTournamentRequest {
+  name: string;
+  displayName: string;
+  totalRounds?: number;
+}
+
+export interface CreatedTournament {
+  tournamentCode: string;
+  playerKey: string;
+}
+
+export interface TournamentClient {
+  readonly serverInfo: ServerInfo;
+  createTournament(req: CreateTournamentRequest): Promise<CreatedTournament>;
+  joinTournament(tournamentCode: string, displayName: string): Promise<TournamentView>;
+  dropFromTournament(tournamentCode: string): Promise<void>;
+  startRound(tournamentCode: string): Promise<void>;
+  reportMatchResult(
+    tournamentCode: string,
+    matchId: string,
+    winnerPlayerKey: string | null,
+    playerAWins: number,
+    playerBWins: number,
+  ): Promise<void>;
+  endTournament(tournamentCode: string): Promise<void>;
+  listTournaments(): Promise<TournamentSummary[]>;
+  subscribeTournaments(
+    onList: (tournaments: TournamentSummary[]) => void,
+    onUpdate: (tournament: TournamentView) => void,
+    onCompleted: (tournamentCode: string) => void,
+  ): () => void;
+  close(): void;
+}
+
+export interface OpenTournamentClientOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export async function openTournamentClient(
+  wsUrl: string,
+  opts: OpenTournamentClientOptions = {},
+): Promise<TournamentClient> {
+  const socket = await openPhaseSocket(wsUrl, opts);
+  if (socket.serverInfo.mode !== "LobbyOnly") {
+    socket.close();
+    throw new HandshakeError(
+      "protocol_mismatch",
+      `Expected LobbyOnly server, got ${socket.serverInfo.mode}`,
+    );
+  }
+  return makeTournamentClient(socket);
+}
+
+function sendRpc<T>(
+  socket: PhaseSocket,
+  frame: object,
+  match: (msg: { type: string; data?: unknown }) => T | null,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const { ws } = socket;
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("Tournament RPC timed out"));
+    }, 15_000);
+
+    const listener = (event: MessageEvent) => {
+      let msg: { type: string; data?: unknown };
+      try {
+        msg = JSON.parse(event.data as string) as { type: string; data?: unknown };
+      } catch {
+        return;
+      }
+      if (msg.type === "Error") {
+        cleanup();
+        const data = msg.data as { message: string };
+        reject(new Error(data.message));
+        return;
+      }
+      const result = match(msg);
+      if (result !== null) {
+        cleanup();
+        resolve(result);
+      }
+    };
+
+    const cleanup = () => {
+      window.clearTimeout(timeout);
+      ws.removeEventListener("message", listener);
+    };
+
+    ws.addEventListener("message", listener);
+    ws.send(JSON.stringify(frame));
+  });
+}
+
+function camelizeTournamentSummary(raw: Record<string, unknown>): TournamentSummary {
+  return {
+    tournamentCode: String(raw.tournament_code ?? raw.tournamentCode ?? ""),
+    name: String(raw.name ?? ""),
+    organizerName: String(raw.organizer_name ?? raw.organizerName ?? ""),
+    createdAt: Number(raw.created_at ?? raw.createdAt ?? 0),
+    status: (raw.status as TournamentSummary["status"]) ?? "registration",
+    playerCount: Number(raw.player_count ?? raw.playerCount ?? 0),
+    totalRounds: Number(raw.total_rounds ?? raw.totalRounds ?? 3),
+    currentRound: Number(raw.current_round ?? raw.currentRound ?? 0),
+  };
+}
+
+function camelizeStanding(raw: Record<string, unknown>): import("../adapter/types").TournamentStanding {
+  return {
+    playerKey: String(raw.player_key ?? raw.playerKey ?? ""),
+    displayName: String(raw.display_name ?? raw.displayName ?? ""),
+    dropped: Boolean(raw.dropped),
+    matchPoints: Number(raw.match_points ?? raw.matchPoints ?? 0),
+    matchWins: Number(raw.match_wins ?? raw.matchWins ?? 0),
+    matchLosses: Number(raw.match_losses ?? raw.matchLosses ?? 0),
+    matchDraws: Number(raw.match_draws ?? raw.matchDraws ?? 0),
+    gameWins: Number(raw.game_wins ?? raw.gameWins ?? 0),
+    gameLosses: Number(raw.game_losses ?? raw.gameLosses ?? 0),
+    omwPercentage: Number(raw.omw_percentage ?? raw.omwPercentage ?? 0),
+    gwPercentage: Number(raw.gw_percentage ?? raw.gwPercentage ?? 0),
+    ogwPercentage: Number(raw.ogw_percentage ?? raw.ogwPercentage ?? 0),
+  };
+}
+
+function camelizePairing(raw: Record<string, unknown>): import("../adapter/types").PairingView {
+  return {
+    matchId: String(raw.match_id ?? raw.matchId ?? ""),
+    round: Number(raw.round ?? 0),
+    table: Number(raw.table ?? 0),
+    playerAKey: String(raw.player_a_key ?? raw.playerAKey ?? ""),
+    playerAName: String(raw.player_a_name ?? raw.playerAName ?? ""),
+    playerBKey: (raw.player_b_key ?? raw.playerBKey ?? null) as string | null,
+    playerBName: (raw.player_b_name ?? raw.playerBName ?? null) as string | null,
+    reported: Boolean(raw.reported),
+    winnerPlayerKey: (raw.winner_player_key ?? raw.winnerPlayerKey ?? null) as string | null,
+  };
+}
+
+function camelizeTournamentView(raw: Record<string, unknown>): TournamentView {
+  const standings = Array.isArray(raw.standings)
+    ? raw.standings.map((s) => camelizeStanding(s as Record<string, unknown>))
+    : [];
+  const pairings = Array.isArray(raw.pairings)
+    ? raw.pairings.map((p) => camelizePairing(p as Record<string, unknown>))
+    : [];
+  return {
+    tournamentCode: String(raw.tournament_code ?? raw.tournamentCode ?? ""),
+    name: String(raw.name ?? ""),
+    organizerName: String(raw.organizer_name ?? raw.organizerName ?? ""),
+    createdAt: Number(raw.created_at ?? raw.createdAt ?? 0),
+    status: (raw.status as TournamentView["status"]) ?? "registration",
+    totalRounds: Number(raw.total_rounds ?? raw.totalRounds ?? 3),
+    currentRound: Number(raw.current_round ?? raw.currentRound ?? 0),
+    playerCount: Number(raw.player_count ?? raw.playerCount ?? 0),
+    standings,
+    pairings,
+  };
+}
+
+function makeTournamentClient(socket: PhaseSocket): TournamentClient {
+  return {
+    serverInfo: socket.serverInfo,
+
+    createTournament(req) {
+      return sendRpc(socket, {
+        type: "CreateTournament",
+        data: {
+          name: req.name,
+          display_name: req.displayName,
+          total_rounds: req.totalRounds ?? 3,
+        },
+      }, (msg) => {
+        if (msg.type !== "TournamentCreated") return null;
+        const data = msg.data as { tournament_code: string; player_key: string };
+        return {
+          tournamentCode: data.tournament_code,
+          playerKey: data.player_key,
+        };
+      });
+    },
+
+    joinTournament(tournamentCode, displayName) {
+      return sendRpc(socket, {
+        type: "JoinTournament",
+        data: { tournament_code: tournamentCode, display_name: displayName },
+      }, (msg) => {
+        if (msg.type !== "TournamentUpdate") return null;
+        const data = msg.data as { tournament: Record<string, unknown> };
+        return camelizeTournamentView(data.tournament);
+      });
+    },
+
+    dropFromTournament(tournamentCode) {
+      return sendRpc(socket, {
+        type: "DropFromTournament",
+        data: { tournament_code: tournamentCode },
+      }, (msg) => {
+        if (msg.type === "Error") return null;
+        if (msg.type === "TournamentUpdate") return undefined as unknown as void;
+        return null;
+      }).then(() => undefined);
+    },
+
+    startRound(tournamentCode) {
+      return sendRpc(socket, {
+        type: "StartTournamentRound",
+        data: { tournament_code: tournamentCode },
+      }, (msg) => {
+        if (msg.type === "TournamentUpdate" || msg.type === "TournamentCompleted") {
+          return undefined as unknown as void;
+        }
+        return null;
+      }).then(() => undefined);
+    },
+
+    reportMatchResult(tournamentCode, matchId, winnerPlayerKey, playerAWins, playerBWins) {
+      return sendRpc(socket, {
+        type: "ReportMatchResult",
+        data: {
+          tournament_code: tournamentCode,
+          match_id: matchId,
+          winner_player_key: winnerPlayerKey,
+          player_a_wins: playerAWins,
+          player_b_wins: playerBWins,
+        },
+      }, (msg) => {
+        if (msg.type === "TournamentUpdate") return undefined as unknown as void;
+        return null;
+      }).then(() => undefined);
+    },
+
+    endTournament(tournamentCode) {
+      return sendRpc(socket, {
+        type: "EndTournament",
+        data: { tournament_code: tournamentCode },
+      }, (msg) => {
+        if (msg.type === "TournamentCompleted" || msg.type === "TournamentUpdate") {
+          return undefined as unknown as void;
+        }
+        return null;
+      }).then(() => undefined);
+    },
+
+    listTournaments() {
+      return sendRpc(socket, { type: "ListTournaments" }, (msg) => {
+        if (msg.type !== "TournamentListUpdate") return null;
+        const data = msg.data as { tournaments: Record<string, unknown>[] };
+        return data.tournaments.map(camelizeTournamentSummary);
+      });
+    },
+
+    subscribeTournaments(onList, onUpdate, onCompleted) {
+      const { ws } = socket;
+      const listener = (event: MessageEvent) => {
+        let msg: { type: string; data?: unknown };
+        try {
+          msg = JSON.parse(event.data as string) as { type: string; data?: unknown };
+        } catch {
+          return;
+        }
+        switch (msg.type) {
+          case "TournamentListUpdate": {
+            const data = msg.data as { tournaments: Record<string, unknown>[] };
+            onList(data.tournaments.map(camelizeTournamentSummary));
+            break;
+          }
+          case "TournamentUpdate": {
+            const data = msg.data as { tournament: Record<string, unknown> };
+            onUpdate(camelizeTournamentView(data.tournament));
+            break;
+          }
+          case "TournamentCompleted": {
+            const data = msg.data as { tournament_code: string };
+            onCompleted(data.tournament_code);
+            break;
+          }
+        }
+      };
+      ws.addEventListener("message", listener);
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "SubscribeLobby" }));
+      }
+      return () => {
+        ws.removeEventListener("message", listener);
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "UnsubscribeLobby" }));
+        }
+      };
+    },
+
+    close() {
+      socket.close();
+    },
+  };
+}

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -16,11 +16,12 @@ use tracing::{debug, info, warn};
 
 use crate::env::BrokerEnv;
 use crate::lobby::{LobbyManager, RegisterGameRequest};
-use crate::protocol::{LobbyClientMessage, LobbyServerMessage, ServerMode};
+use crate::protocol::{LobbyClientMessage, LobbyServerMessage, ServerMode, TournamentStatus};
 use crate::reservation_auth::{
     consume_owned_reservation, release_owned_reservation, ReservationConsume, ReservationRelease,
     NOT_OWNED_RESERVATION,
 };
+use crate::tournament::{MatchResult, TournamentManager, MAX_TOURNAMENT_ENTRIES};
 
 /// Capacity cap for the broker path. `LobbyManager` is otherwise unbounded —
 /// without this gate an abusive client could pin arbitrary entries in memory
@@ -55,6 +56,11 @@ pub struct ConnState {
     /// `(game_code, token)` reservations this connection holds, released on
     /// disconnect or explicit release/consume.
     pub reservations: Vec<(String, String)>,
+    /// Tournament code this connection created as organizer, if any.
+    pub tournament_organizer: Option<String>,
+    /// `(tournament_code, player_key)` entries for self-service drop and
+    /// result-report authorization.
+    pub joined_tournaments: Vec<(String, String)>,
 }
 
 /// A side effect the shell must perform after a broker call. **Order within a
@@ -108,12 +114,14 @@ pub fn check_build_commit(host_commit: &str, guest_commit: &str) -> BuildCommitC
 #[derive(Serialize, Deserialize)]
 pub struct Broker {
     lobby: LobbyManager,
+    tournaments: TournamentManager,
 }
 
 impl Broker {
     pub fn new() -> Self {
         Self {
             lobby: LobbyManager::new(),
+            tournaments: TournamentManager::new(),
         }
     }
 
@@ -129,6 +137,14 @@ impl Broker {
     /// lobby operations (see [`Broker::lobby`]).
     pub fn lobby_mut(&mut self) -> &mut LobbyManager {
         &mut self.lobby
+    }
+
+    pub fn tournaments(&self) -> &TournamentManager {
+        &self.tournaments
+    }
+
+    pub fn tournaments_mut(&mut self) -> &mut TournamentManager {
+        &mut self.tournaments
     }
 
     /// Single entry for client frames. Returns the ordered side effects the
@@ -164,10 +180,16 @@ impl Broker {
                 debug!("lobby subscription");
                 conn.subscribed = true;
                 let games = self.lobby.public_games();
-                debug!(games = games.len(), "sending lobby state");
+                let tournaments = self.tournaments.public_summaries();
+                debug!(
+                    games = games.len(),
+                    tournaments = tournaments.len(),
+                    "sending lobby state"
+                );
                 vec![
                     Outbound::AddSubscriber,
                     Outbound::ToSelf(LobbyServerMessage::LobbyUpdate { games }),
+                    Outbound::ToSelf(LobbyServerMessage::TournamentListUpdate { tournaments }),
                     Outbound::SendPlayerCountToSelf,
                 ]
             }
@@ -253,6 +275,46 @@ impl Broker {
             LobbyClientMessage::UnregisterLobby { game_code } => {
                 self.handle_unregister(conn, game_code)
             }
+
+            LobbyClientMessage::CreateTournament {
+                name,
+                display_name,
+                total_rounds,
+            } => self.handle_create_tournament(conn, name, display_name, total_rounds, env),
+
+            LobbyClientMessage::JoinTournament {
+                tournament_code,
+                display_name,
+            } => self.handle_join_tournament(conn, tournament_code, display_name, env),
+
+            LobbyClientMessage::DropFromTournament { tournament_code } => {
+                self.handle_drop_tournament(conn, tournament_code)
+            }
+
+            LobbyClientMessage::StartTournamentRound { tournament_code } => {
+                self.handle_start_tournament_round(conn, tournament_code, env)
+            }
+
+            LobbyClientMessage::ReportMatchResult {
+                tournament_code,
+                match_id,
+                winner_player_key,
+                player_a_wins,
+                player_b_wins,
+            } => self.handle_report_match_result(
+                conn,
+                tournament_code,
+                match_id,
+                winner_player_key,
+                player_a_wins,
+                player_b_wins,
+            ),
+
+            LobbyClientMessage::EndTournament { tournament_code } => {
+                self.handle_end_tournament(conn, tournament_code)
+            }
+
+            LobbyClientMessage::ListTournaments => self.handle_list_tournaments(conn),
         }
     }
 
@@ -288,6 +350,19 @@ impl Broker {
             }
         }
 
+        if let Some(tournament_code) = conn.tournament_organizer.take() {
+            let existed = self.tournaments.has_tournament(&tournament_code);
+            self.tournaments.unregister_tournament(&tournament_code);
+            if existed {
+                info!(tournament = %tournament_code, "organizer disconnected — tournament removed");
+                out.push(Outbound::ToSubscribers(
+                    LobbyServerMessage::TournamentCompleted { tournament_code },
+                ));
+            }
+        }
+
+        conn.joined_tournaments.clear();
+
         // Subscriber pruning on close is shell-owned (it drops the closed
         // sender). The core only signals it if the conn was subscribed.
         if conn.subscribed {
@@ -303,13 +378,23 @@ impl Broker {
     /// stays in the shell — it pulls the expired codes from
     /// [`Broker::lobby_mut`]`.check_expired` directly.
     pub fn reap_expired(&mut self, timeout_secs: u64, env: &impl BrokerEnv) -> Vec<Outbound> {
-        self.lobby
+        let mut out: Vec<Outbound> = self
+            .lobby
             .check_expired(timeout_secs, env)
             .into_iter()
             .map(|game_code| {
                 Outbound::ToSubscribers(LobbyServerMessage::LobbyGameRemoved { game_code })
             })
-            .collect()
+            .collect();
+
+        for code in self.tournaments.check_expired(timeout_secs, env) {
+            out.push(Outbound::ToSubscribers(
+                LobbyServerMessage::TournamentCompleted {
+                    tournament_code: code,
+                },
+            ));
+        }
+        out
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -724,6 +809,278 @@ impl Broker {
             vec![]
         }
     }
+
+    fn handle_create_tournament(
+        &mut self,
+        conn: &mut ConnState,
+        name: String,
+        display_name: String,
+        total_rounds: u8,
+        env: &impl BrokerEnv,
+    ) -> Vec<Outbound> {
+        if conn.client_hello.is_none() {
+            return vec![error("ClientHello required before any other message")];
+        }
+
+        let mut out = Vec::new();
+
+        if let Some(previous) = conn.tournament_organizer.take() {
+            let existed = self.tournaments.has_tournament(&previous);
+            self.tournaments.unregister_tournament(&previous);
+            if existed {
+                out.push(Outbound::ToSubscribers(
+                    LobbyServerMessage::TournamentCompleted {
+                        tournament_code: previous,
+                    },
+                ));
+            }
+        }
+
+        if self.tournaments.len() >= MAX_TOURNAMENT_ENTRIES {
+            out.push(error(
+                "Server tournament list is full, please try again shortly",
+            ));
+            return out;
+        }
+
+        let tournament_code = env.new_game_code();
+        let player_key = env.new_token();
+
+        self.tournaments.register_tournament(
+            &tournament_code,
+            name,
+            display_name.clone(),
+            total_rounds,
+            env,
+        );
+
+        if let Err(reason) =
+            self.tournaments
+                .join_tournament(&tournament_code, display_name, player_key.clone())
+        {
+            return vec![error(&reason)];
+        }
+
+        conn.tournament_organizer = Some(tournament_code.clone());
+        conn.joined_tournaments
+            .push((tournament_code.clone(), player_key.clone()));
+
+        out.push(Outbound::ToSelf(LobbyServerMessage::TournamentCreated {
+            tournament_code: tournament_code.clone(),
+            player_key,
+        }));
+
+        if let Some(view) = self.tournaments.to_view(&tournament_code) {
+            out.push(Outbound::ToSubscribers(
+                LobbyServerMessage::TournamentUpdate { tournament: view },
+            ));
+            out.push(Outbound::ToSubscribers(
+                LobbyServerMessage::TournamentListUpdate {
+                    tournaments: self.tournaments.public_summaries(),
+                },
+            ));
+        }
+
+        out
+    }
+
+    fn handle_join_tournament(
+        &mut self,
+        conn: &mut ConnState,
+        tournament_code: String,
+        display_name: String,
+        env: &impl BrokerEnv,
+    ) -> Vec<Outbound> {
+        if conn.client_hello.is_none() {
+            return vec![error("ClientHello required before any other message")];
+        }
+
+        let player_key = env.new_token();
+        match self
+            .tournaments
+            .join_tournament(&tournament_code, display_name, player_key.clone())
+        {
+            Ok(()) => {
+                conn.joined_tournaments
+                    .push((tournament_code.clone(), player_key));
+                let mut out = vec![];
+                if let Some(view) = self.tournaments.to_view(&tournament_code) {
+                    out.push(Outbound::ToSelf(LobbyServerMessage::TournamentUpdate {
+                        tournament: view.clone(),
+                    }));
+                    out.push(Outbound::ToSubscribers(
+                        LobbyServerMessage::TournamentUpdate { tournament: view },
+                    ));
+                    out.push(Outbound::ToSubscribers(
+                        LobbyServerMessage::TournamentListUpdate {
+                            tournaments: self.tournaments.public_summaries(),
+                        },
+                    ));
+                }
+                out
+            }
+            Err(reason) => vec![error(&reason)],
+        }
+    }
+
+    fn handle_drop_tournament(
+        &mut self,
+        conn: &mut ConnState,
+        tournament_code: String,
+    ) -> Vec<Outbound> {
+        let player_key = match conn_player_key(conn, &tournament_code) {
+            Some(key) => key,
+            None => return vec![error("You are not registered in this tournament")],
+        };
+        match self.tournaments.drop_player(&tournament_code, &player_key) {
+            Ok(()) => {
+                conn.joined_tournaments
+                    .retain(|(code, _)| code != &tournament_code);
+                broadcast_tournament_update(self, &tournament_code)
+            }
+            Err(reason) => vec![error(&reason)],
+        }
+    }
+
+    fn handle_start_tournament_round(
+        &mut self,
+        conn: &mut ConnState,
+        tournament_code: String,
+        env: &impl BrokerEnv,
+    ) -> Vec<Outbound> {
+        if !conn
+            .tournament_organizer
+            .as_deref()
+            .is_some_and(|c| c == tournament_code)
+        {
+            return vec![error("Only the tournament organizer can start a round")];
+        }
+        match self.tournaments.start_round(&tournament_code, env) {
+            Ok(()) => {
+                let tournament = self.tournaments.get(&tournament_code);
+                let completed = tournament
+                    .map(|t| t.status == TournamentStatus::Completed)
+                    .unwrap_or(false);
+                let mut out = broadcast_tournament_update(self, &tournament_code);
+                if completed {
+                    out.push(Outbound::ToSubscribers(
+                        LobbyServerMessage::TournamentCompleted {
+                            tournament_code: tournament_code.clone(),
+                        },
+                    ));
+                    out.push(Outbound::ToSubscribers(
+                        LobbyServerMessage::TournamentListUpdate {
+                            tournaments: self.tournaments.public_summaries(),
+                        },
+                    ));
+                }
+                out
+            }
+            Err(reason) => vec![error(&reason)],
+        }
+    }
+
+    fn handle_report_match_result(
+        &mut self,
+        conn: &mut ConnState,
+        tournament_code: String,
+        match_id: String,
+        winner_player_key: Option<String>,
+        player_a_wins: u8,
+        player_b_wins: u8,
+    ) -> Vec<Outbound> {
+        let pairing = match self.tournaments.get(&tournament_code) {
+            Some(t) => t.pairings.iter().find(|p| p.match_id == match_id).cloned(),
+            None => return vec![error(&format!("Tournament not found: {tournament_code}"))],
+        };
+        let Some(pairing) = pairing else {
+            return vec![error(&format!("Pairing not found: {match_id}"))];
+        };
+
+        let is_organizer = conn
+            .tournament_organizer
+            .as_deref()
+            .is_some_and(|c| c == tournament_code);
+        let player_key = conn_player_key(conn, &tournament_code);
+        let authorized = is_organizer
+            || player_key.as_deref().is_some_and(|k| k == pairing.player_a)
+            || pairing
+                .player_b
+                .as_deref()
+                .is_some_and(|b| player_key.as_deref() == Some(b));
+        if !authorized {
+            return vec![error("Not authorized to report this match result")];
+        }
+
+        let result = MatchResult {
+            winner_player_key,
+            player_a_wins,
+            player_b_wins,
+        };
+        match self
+            .tournaments
+            .report_result(&tournament_code, &match_id, result)
+        {
+            Ok(()) => broadcast_tournament_update(self, &tournament_code),
+            Err(reason) => vec![error(&reason)],
+        }
+    }
+
+    fn handle_end_tournament(
+        &mut self,
+        conn: &mut ConnState,
+        tournament_code: String,
+    ) -> Vec<Outbound> {
+        if !conn
+            .tournament_organizer
+            .as_deref()
+            .is_some_and(|c| c == tournament_code)
+        {
+            return vec![error(
+                "Only the tournament organizer can end the tournament",
+            )];
+        }
+        match self.tournaments.end_tournament(&tournament_code) {
+            Ok(()) => {
+                conn.tournament_organizer = None;
+                let mut out = broadcast_tournament_update(self, &tournament_code);
+                out.push(Outbound::ToSubscribers(
+                    LobbyServerMessage::TournamentCompleted {
+                        tournament_code: tournament_code.clone(),
+                    },
+                ));
+                out.push(Outbound::ToSubscribers(
+                    LobbyServerMessage::TournamentListUpdate {
+                        tournaments: self.tournaments.public_summaries(),
+                    },
+                ));
+                out
+            }
+            Err(reason) => vec![error(&reason)],
+        }
+    }
+
+    fn handle_list_tournaments(&self, _conn: &ConnState) -> Vec<Outbound> {
+        vec![Outbound::ToSelf(LobbyServerMessage::TournamentListUpdate {
+            tournaments: self.tournaments.public_summaries(),
+        })]
+    }
+}
+
+fn conn_player_key(conn: &ConnState, tournament_code: &str) -> Option<String> {
+    conn.joined_tournaments
+        .iter()
+        .find(|(code, _)| code == tournament_code)
+        .map(|(_, key)| key.clone())
+}
+
+fn broadcast_tournament_update(broker: &Broker, tournament_code: &str) -> Vec<Outbound> {
+    match broker.tournaments.to_view(tournament_code) {
+        Some(tournament) => vec![Outbound::ToSubscribers(
+            LobbyServerMessage::TournamentUpdate { tournament },
+        )],
+        None => vec![],
+    }
 }
 
 impl Default for Broker {
@@ -918,8 +1275,12 @@ mod tests {
             out[1],
             Outbound::ToSelf(LobbyServerMessage::LobbyUpdate { .. })
         ));
-        assert_eq!(out[2], Outbound::SendPlayerCountToSelf);
-        assert_eq!(out.len(), 3);
+        assert!(matches!(
+            out[2],
+            Outbound::ToSelf(LobbyServerMessage::TournamentListUpdate { .. })
+        ));
+        assert_eq!(out[3], Outbound::SendPlayerCountToSelf);
+        assert_eq!(out.len(), 4);
         assert!(conn.subscribed);
     }
 
@@ -1558,14 +1919,29 @@ mod tests {
     }
 
     #[test]
-    fn ping_returns_pong() {
+    fn create_tournament_registers_organizer_and_broadcasts() {
         let env = FakeEnv::new();
         let mut broker = Broker::new();
         let mut conn = ConnState::default();
-        let out = broker.handle(&mut conn, LobbyClientMessage::Ping { timestamp: 7 }, &env);
-        assert_eq!(
-            out.as_slice(),
-            [Outbound::ToSelf(LobbyServerMessage::Pong { timestamp: 7 })]
+        hello(&mut conn, &mut broker, &env);
+        let out = broker.handle(
+            &mut conn,
+            LobbyClientMessage::CreateTournament {
+                name: "Friday Swiss".into(),
+                display_name: "TO".into(),
+                total_rounds: 3,
+            },
+            &env,
         );
+        assert!(matches!(
+            out[0],
+            Outbound::ToSelf(LobbyServerMessage::TournamentCreated { .. })
+        ));
+        assert!(matches!(
+            out[1],
+            Outbound::ToSubscribers(LobbyServerMessage::TournamentUpdate { .. })
+        ));
+        assert!(conn.tournament_organizer.is_some());
+        assert_eq!(conn.joined_tournaments.len(), 1);
     }
 }

--- a/crates/lobby-broker/src/lib.rs
+++ b/crates/lobby-broker/src/lib.rs
@@ -13,6 +13,7 @@ pub mod inbound_guard;
 pub mod lobby;
 pub mod protocol;
 pub mod reservation_auth;
+pub mod tournament;
 pub mod validation;
 
 pub use broker::{
@@ -31,10 +32,12 @@ pub use lobby::{
 };
 pub use protocol::{
     parse_lobby_client_message, DraftLobbyMetadata, LobbyClientMessage, LobbyGame,
-    LobbyServerMessage, ParsedFrame, ServerMode, MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
+    LobbyServerMessage, PairingView, ParsedFrame, ServerMode, TournamentStanding, TournamentStatus,
+    TournamentSummary, TournamentView, MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
 };
 pub use reservation_auth::{
     conn_holds_reservation, consume_owned_reservation, release_owned_reservation,
     ReservationConsume, ReservationRelease, NOT_OWNED_RESERVATION,
 };
+pub use tournament::{TournamentManager, MAX_TOURNAMENT_ENTRIES, MAX_TOURNAMENT_PLAYERS};
 pub use validation::validate_lobby_message;

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// (clients see "Invalid message: unknown variant") rather than at the
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -179,6 +179,37 @@ pub enum LobbyClientMessage {
     UnregisterLobby {
         game_code: String,
     },
+    CreateTournament {
+        name: String,
+        display_name: String,
+        #[serde(default = "default_swiss_rounds")]
+        total_rounds: u8,
+    },
+    JoinTournament {
+        tournament_code: String,
+        display_name: String,
+    },
+    DropFromTournament {
+        tournament_code: String,
+    },
+    StartTournamentRound {
+        tournament_code: String,
+    },
+    ReportMatchResult {
+        tournament_code: String,
+        match_id: String,
+        winner_player_key: Option<String>,
+        player_a_wins: u8,
+        player_b_wins: u8,
+    },
+    EndTournament {
+        tournament_code: String,
+    },
+    ListTournaments,
+}
+
+fn default_swiss_rounds() -> u8 {
+    3
 }
 
 fn default_player_count() -> u8 {
@@ -257,6 +288,94 @@ pub enum LobbyServerMessage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reservation_token: Option<String>,
     },
+    TournamentCreated {
+        tournament_code: String,
+        player_key: String,
+    },
+    TournamentUpdate {
+        tournament: TournamentView,
+    },
+    TournamentCompleted {
+        tournament_code: String,
+    },
+    TournamentListUpdate {
+        tournaments: Vec<TournamentSummary>,
+    },
+}
+
+/// Lifecycle phase of a Swiss tournament.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TournamentStatus {
+    Registration,
+    InProgress,
+    Completed,
+}
+
+/// Full tournament state broadcast to subscribers and participants.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TournamentView {
+    pub tournament_code: String,
+    pub name: String,
+    pub organizer_name: String,
+    pub created_at: u64,
+    pub status: TournamentStatus,
+    pub total_rounds: u8,
+    pub current_round: u8,
+    pub player_count: u32,
+    pub standings: Vec<TournamentStanding>,
+    pub pairings: Vec<PairingView>,
+}
+
+/// Browse-row summary for open tournaments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TournamentSummary {
+    pub tournament_code: String,
+    pub name: String,
+    pub organizer_name: String,
+    pub created_at: u64,
+    pub status: TournamentStatus,
+    pub player_count: u32,
+    pub total_rounds: u8,
+    pub current_round: u8,
+}
+
+/// A single row in the standings table.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TournamentStanding {
+    pub player_key: String,
+    pub display_name: String,
+    pub dropped: bool,
+    pub match_points: u32,
+    pub match_wins: u32,
+    pub match_losses: u32,
+    pub match_draws: u32,
+    pub game_wins: u32,
+    pub game_losses: u32,
+    pub omw_percentage: f64,
+    pub gw_percentage: f64,
+    pub ogw_percentage: f64,
+}
+
+/// A pairing visible for the current round.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairingView {
+    pub match_id: String,
+    pub round: u8,
+    pub table: u8,
+    pub player_a_key: String,
+    pub player_a_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_b_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_b_name: Option<String>,
+    pub reported: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub winner_player_key: Option<String>,
 }
 
 /// Advertised role of the server. Mirrors `server_core::protocol::ServerMode`
@@ -310,6 +429,13 @@ fn is_known_lobby_tag(tag: &str) -> bool {
             | "Ping"
             | "UpdateLobbyMetadata"
             | "UnregisterLobby"
+            | "CreateTournament"
+            | "JoinTournament"
+            | "DropFromTournament"
+            | "StartTournamentRound"
+            | "ReportMatchResult"
+            | "EndTournament"
+            | "ListTournaments"
     )
 }
 

--- a/crates/lobby-broker/src/tournament.rs
+++ b/crates/lobby-broker/src/tournament.rs
@@ -1,0 +1,972 @@
+//! Swiss-pairing tournament organizer — pure registry alongside [`LobbyManager`].
+//!
+//! Organizes multi-round P2P Swiss events: registration, round lifecycle, drops,
+//! pairings with rematch avoidance, and standings using the standard Magic
+//! tiebreaker order (match points → OMW% → GW% → OGW%, each floored at 1/3).
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::env::BrokerEnv;
+use crate::protocol::{
+    PairingView, TournamentStanding, TournamentStatus, TournamentSummary, TournamentView,
+};
+
+/// Capacity cap for registered tournaments in broker memory.
+pub const MAX_TOURNAMENT_ENTRIES: usize = 100;
+/// Max players per tournament.
+pub const MAX_TOURNAMENT_PLAYERS: usize = 128;
+/// Default Swiss round count when the organizer does not specify one.
+pub const DEFAULT_SWISS_ROUNDS: u8 = 3;
+/// Minimum players required to start a Swiss event.
+pub const MIN_TOURNAMENT_PLAYERS: usize = 4;
+
+/// Tiebreaker floor used by official Magic tournaments (33%).
+const TIE_BREAKER_FLOOR: f64 = 1.0 / 3.0;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TournamentPlayer {
+    pub player_key: String,
+    pub display_name: String,
+    pub dropped: bool,
+    pub had_bye: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MatchResult {
+    pub winner_player_key: Option<String>,
+    pub player_a_wins: u8,
+    pub player_b_wins: u8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TournamentPairing {
+    pub match_id: String,
+    pub round: u8,
+    pub table: u8,
+    pub player_a: String,
+    pub player_b: Option<String>,
+    pub result: Option<MatchResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TournamentMeta {
+    pub code: String,
+    pub name: String,
+    pub organizer_name: String,
+    pub created_at: u64,
+    pub status: TournamentStatus,
+    pub total_rounds: u8,
+    pub current_round: u8,
+    pub players: Vec<TournamentPlayer>,
+    pub pairings: Vec<TournamentPairing>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct PlayerRecord {
+    match_wins: u32,
+    match_losses: u32,
+    match_draws: u32,
+    game_wins: u32,
+    game_losses: u32,
+    opponents: Vec<String>,
+}
+
+/// Pure tournament registry — no I/O, deterministic given `BrokerEnv` injection.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct TournamentManager {
+    tournaments: HashMap<String, TournamentMeta>,
+}
+
+impl TournamentManager {
+    pub fn new() -> Self {
+        Self {
+            tournaments: HashMap::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.tournaments.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tournaments.is_empty()
+    }
+
+    pub fn has_tournament(&self, code: &str) -> bool {
+        self.tournaments.contains_key(code)
+    }
+
+    pub fn get(&self, code: &str) -> Option<&TournamentMeta> {
+        self.tournaments.get(code)
+    }
+
+    pub fn public_summaries(&self) -> Vec<TournamentSummary> {
+        let mut summaries: Vec<TournamentSummary> = self
+            .tournaments
+            .values()
+            .filter(|t| t.status != TournamentStatus::Completed)
+            .map(|t| TournamentSummary {
+                tournament_code: t.code.clone(),
+                name: t.name.clone(),
+                organizer_name: t.organizer_name.clone(),
+                created_at: t.created_at,
+                status: t.status,
+                player_count: active_player_count(t),
+                total_rounds: t.total_rounds,
+                current_round: t.current_round,
+            })
+            .collect();
+        summaries.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        summaries
+    }
+
+    pub fn register_tournament(
+        &mut self,
+        code: &str,
+        name: String,
+        organizer_name: String,
+        total_rounds: u8,
+        env: &impl BrokerEnv,
+    ) {
+        let rounds = total_rounds.max(1);
+        self.tournaments.insert(
+            code.to_string(),
+            TournamentMeta {
+                code: code.to_string(),
+                name,
+                organizer_name,
+                created_at: env.now_ms(),
+                status: TournamentStatus::Registration,
+                total_rounds: rounds,
+                current_round: 0,
+                players: Vec::new(),
+                pairings: Vec::new(),
+            },
+        );
+    }
+
+    pub fn unregister_tournament(&mut self, code: &str) -> bool {
+        self.tournaments.remove(code).is_some()
+    }
+
+    pub fn join_tournament(
+        &mut self,
+        code: &str,
+        display_name: String,
+        player_key: String,
+    ) -> Result<(), String> {
+        let tournament = self
+            .tournaments
+            .get_mut(code)
+            .ok_or_else(|| format!("Tournament not found: {code}"))?;
+        if tournament.status != TournamentStatus::Registration {
+            return Err("Tournament registration is closed".to_string());
+        }
+        if tournament.players.len() >= MAX_TOURNAMENT_PLAYERS {
+            return Err("Tournament is full".to_string());
+        }
+        if tournament
+            .players
+            .iter()
+            .any(|p| p.display_name.eq_ignore_ascii_case(&display_name))
+        {
+            return Err("Display name already taken in this tournament".to_string());
+        }
+        tournament.players.push(TournamentPlayer {
+            player_key,
+            display_name,
+            dropped: false,
+            had_bye: false,
+        });
+        Ok(())
+    }
+
+    pub fn drop_player(&mut self, code: &str, player_key: &str) -> Result<(), String> {
+        let tournament = self
+            .tournaments
+            .get_mut(code)
+            .ok_or_else(|| format!("Tournament not found: {code}"))?;
+        let player = tournament
+            .players
+            .iter_mut()
+            .find(|p| p.player_key == player_key)
+            .ok_or_else(|| "You are not registered in this tournament".to_string())?;
+        if player.dropped {
+            return Err("Already dropped from tournament".to_string());
+        }
+        player.dropped = true;
+        Ok(())
+    }
+
+    pub fn start_round(&mut self, code: &str, env: &impl BrokerEnv) -> Result<(), String> {
+        let tournament = self
+            .tournaments
+            .get_mut(code)
+            .ok_or_else(|| format!("Tournament not found: {code}"))?;
+        if tournament.status == TournamentStatus::Completed {
+            return Err("Tournament is already completed".to_string());
+        }
+        let active = active_players(tournament);
+        if tournament.status == TournamentStatus::Registration {
+            if active.len() < MIN_TOURNAMENT_PLAYERS {
+                return Err(format!(
+                    "Need at least {MIN_TOURNAMENT_PLAYERS} players to start"
+                ));
+            }
+            tournament.status = TournamentStatus::InProgress;
+            tournament.current_round = 1;
+        } else {
+            if !round_complete(tournament) {
+                return Err("Current round is not complete".to_string());
+            }
+            if tournament.current_round >= tournament.total_rounds {
+                tournament.status = TournamentStatus::Completed;
+                return Ok(());
+            }
+            tournament.current_round += 1;
+        }
+
+        let round = tournament.current_round;
+        let records = compute_records(tournament);
+        let prior_pairs = prior_opponent_pairs(tournament);
+        let new_pairings =
+            generate_swiss_pairings(tournament, round, &records, &prior_pairs, env.now_ms());
+        tournament.pairings.extend(new_pairings);
+        Ok(())
+    }
+
+    pub fn report_result(
+        &mut self,
+        code: &str,
+        match_id: &str,
+        result: MatchResult,
+    ) -> Result<(), String> {
+        let tournament = self
+            .tournaments
+            .get_mut(code)
+            .ok_or_else(|| format!("Tournament not found: {code}"))?;
+        if tournament.status != TournamentStatus::InProgress {
+            return Err("Tournament is not in progress".to_string());
+        }
+        let pairing = tournament
+            .pairings
+            .iter_mut()
+            .find(|p| p.match_id == match_id && p.round == tournament.current_round)
+            .ok_or_else(|| format!("Pairing not found: {match_id}"))?;
+        if pairing.player_b.is_none() {
+            return Err("Cannot report result for a bye".to_string());
+        }
+        validate_match_result(pairing, &result)?;
+        pairing.result = Some(result);
+        Ok(())
+    }
+
+    pub fn end_tournament(&mut self, code: &str) -> Result<(), String> {
+        let tournament = self
+            .tournaments
+            .get_mut(code)
+            .ok_or_else(|| format!("Tournament not found: {code}"))?;
+        tournament.status = TournamentStatus::Completed;
+        Ok(())
+    }
+
+    pub fn check_expired(&mut self, timeout_secs: u64, env: &impl BrokerEnv) -> Vec<String> {
+        let now = env.now_ms();
+        let cutoff = now.saturating_sub(timeout_secs.saturating_mul(1000));
+        let expired: Vec<String> = self
+            .tournaments
+            .iter()
+            .filter(|(_, t)| t.created_at < cutoff)
+            .map(|(code, _)| code.clone())
+            .collect();
+        for code in &expired {
+            self.tournaments.remove(code);
+        }
+        expired
+    }
+
+    pub fn to_view(&self, code: &str) -> Option<TournamentView> {
+        self.tournaments.get(code).map(build_view)
+    }
+}
+
+fn active_player_count(tournament: &TournamentMeta) -> u32 {
+    tournament.players.iter().filter(|p| !p.dropped).count() as u32
+}
+
+fn active_players(tournament: &TournamentMeta) -> Vec<&TournamentPlayer> {
+    tournament.players.iter().filter(|p| !p.dropped).collect()
+}
+
+fn round_complete(tournament: &TournamentMeta) -> bool {
+    let round = tournament.current_round;
+    if round == 0 {
+        return false;
+    }
+    tournament
+        .pairings
+        .iter()
+        .filter(|p| p.round == round)
+        .all(|p| p.player_b.is_none() || p.result.is_some())
+}
+
+fn validate_match_result(pairing: &TournamentPairing, result: &MatchResult) -> Result<(), String> {
+    let player_b = pairing
+        .player_b
+        .as_ref()
+        .ok_or_else(|| "Invalid pairing".to_string())?;
+    let valid_keys = [&pairing.player_a, player_b];
+    if let Some(winner) = &result.winner_player_key {
+        if !valid_keys.iter().any(|k| *k == winner) {
+            return Err("Winner must be one of the paired players".to_string());
+        }
+    }
+    if result.player_a_wins == result.player_b_wins && result.winner_player_key.is_some() {
+        return Err("Draw results must not specify a winner".to_string());
+    }
+    Ok(())
+}
+
+fn prior_opponent_pairs(tournament: &TournamentMeta) -> HashSet<(String, String)> {
+    tournament
+        .pairings
+        .iter()
+        .filter_map(|p| p.player_b.as_ref().map(|b| (p.player_a.clone(), b.clone())))
+        .flat_map(|(a, b)| [(a.clone(), b.clone()), (b, a)])
+        .collect()
+}
+
+fn compute_records(tournament: &TournamentMeta) -> HashMap<String, PlayerRecord> {
+    let mut records: HashMap<String, PlayerRecord> = tournament
+        .players
+        .iter()
+        .map(|p| (p.player_key.clone(), PlayerRecord::default()))
+        .collect();
+
+    for pairing in &tournament.pairings {
+        let Some(player_b) = pairing.player_b.as_ref() else {
+            if let Some(rec) = records.get_mut(&pairing.player_a) {
+                rec.match_wins += 1;
+                rec.game_wins += 1;
+            }
+            continue;
+        };
+        let Some(result) = pairing.result.as_ref() else {
+            continue;
+        };
+        let a = &pairing.player_a;
+        let b = player_b;
+        if let Some(rec_a) = records.get_mut(a) {
+            rec_a.game_wins += u32::from(result.player_a_wins);
+            rec_a.game_losses += u32::from(result.player_b_wins);
+            rec_a.opponents.push(b.clone());
+        }
+        if let Some(rec_b) = records.get_mut(b) {
+            rec_b.game_wins += u32::from(result.player_b_wins);
+            rec_b.game_losses += u32::from(result.player_a_wins);
+            rec_b.opponents.push(a.clone());
+        }
+        match &result.winner_player_key {
+            Some(winner) if winner == a => {
+                records.get_mut(a).unwrap().match_wins += 1;
+                records.get_mut(b).unwrap().match_losses += 1;
+            }
+            Some(winner) if winner == b => {
+                records.get_mut(b).unwrap().match_wins += 1;
+                records.get_mut(a).unwrap().match_losses += 1;
+            }
+            Some(_) => {}
+            None => {
+                records.get_mut(a).unwrap().match_draws += 1;
+                records.get_mut(b).unwrap().match_draws += 1;
+            }
+        }
+    }
+    records
+}
+
+fn match_points(record: &PlayerRecord) -> u32 {
+    record.match_wins * 3 + record.match_draws
+}
+
+fn game_win_percentage(record: &PlayerRecord) -> f64 {
+    let total = record.game_wins + record.game_losses;
+    if total == 0 {
+        return TIE_BREAKER_FLOOR;
+    }
+    (record.game_wins as f64 / total as f64).max(TIE_BREAKER_FLOOR)
+}
+
+fn opponent_match_win_percentage(
+    record: &PlayerRecord,
+    records: &HashMap<String, PlayerRecord>,
+) -> f64 {
+    if record.opponents.is_empty() {
+        return TIE_BREAKER_FLOOR;
+    }
+    let sum: f64 = record
+        .opponents
+        .iter()
+        .filter_map(|opp| records.get(opp))
+        .map(|opp_rec| {
+            let played = opp_rec.match_wins + opp_rec.match_losses + opp_rec.match_draws;
+            if played == 0 {
+                return TIE_BREAKER_FLOOR;
+            }
+            (opp_rec.match_wins as f64 * 3.0 + opp_rec.match_draws as f64) / (played as f64 * 3.0)
+        })
+        .map(|pct| pct.max(TIE_BREAKER_FLOOR))
+        .sum();
+    (sum / record.opponents.len() as f64).max(TIE_BREAKER_FLOOR)
+}
+
+fn opponent_game_win_percentage(
+    record: &PlayerRecord,
+    records: &HashMap<String, PlayerRecord>,
+) -> f64 {
+    if record.opponents.is_empty() {
+        return TIE_BREAKER_FLOOR;
+    }
+    let sum: f64 = record
+        .opponents
+        .iter()
+        .filter_map(|opp| records.get(opp))
+        .map(|opp_rec| game_win_percentage(opp_rec))
+        .sum();
+    (sum / record.opponents.len() as f64).max(TIE_BREAKER_FLOOR)
+}
+
+fn build_standings(tournament: &TournamentMeta) -> Vec<TournamentStanding> {
+    let records = compute_records(tournament);
+    let mut standings: Vec<TournamentStanding> = tournament
+        .players
+        .iter()
+        .filter(|p| !p.dropped || records.get(&p.player_key).is_some_and(|r| r.match_wins > 0))
+        .map(|p| {
+            let record = records.get(&p.player_key).cloned().unwrap_or_default();
+            TournamentStanding {
+                player_key: p.player_key.clone(),
+                display_name: p.display_name.clone(),
+                dropped: p.dropped,
+                match_points: match_points(&record),
+                match_wins: record.match_wins,
+                match_losses: record.match_losses,
+                match_draws: record.match_draws,
+                game_wins: record.game_wins,
+                game_losses: record.game_losses,
+                omw_percentage: opponent_match_win_percentage(&record, &records),
+                gw_percentage: game_win_percentage(&record),
+                ogw_percentage: opponent_game_win_percentage(&record, &records),
+            }
+        })
+        .collect();
+
+    standings.sort_by(|a, b| {
+        b.match_points
+            .cmp(&a.match_points)
+            .then_with(|| {
+                b.omw_percentage
+                    .partial_cmp(&a.omw_percentage)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.gw_percentage
+                    .partial_cmp(&a.gw_percentage)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.ogw_percentage
+                    .partial_cmp(&a.ogw_percentage)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.display_name.cmp(&b.display_name))
+    });
+    standings
+}
+
+fn build_view(tournament: &TournamentMeta) -> TournamentView {
+    let player_names: HashMap<String, String> = tournament
+        .players
+        .iter()
+        .map(|p| (p.player_key.clone(), p.display_name.clone()))
+        .collect();
+
+    let pairings: Vec<PairingView> = tournament
+        .pairings
+        .iter()
+        .filter(|p| p.round == tournament.current_round)
+        .map(|p| {
+            let name_a = player_names
+                .get(&p.player_a)
+                .cloned()
+                .unwrap_or_else(|| "Unknown".to_string());
+            let name_b = p
+                .player_b
+                .as_ref()
+                .and_then(|k| player_names.get(k).cloned());
+            PairingView {
+                match_id: p.match_id.clone(),
+                round: p.round,
+                table: p.table,
+                player_a_key: p.player_a.clone(),
+                player_a_name: name_a,
+                player_b_key: p.player_b.clone(),
+                player_b_name: name_b,
+                reported: p.result.is_some(),
+                winner_player_key: p.result.as_ref().and_then(|r| r.winner_player_key.clone()),
+            }
+        })
+        .collect();
+
+    TournamentView {
+        tournament_code: tournament.code.clone(),
+        name: tournament.name.clone(),
+        organizer_name: tournament.organizer_name.clone(),
+        created_at: tournament.created_at,
+        status: tournament.status,
+        total_rounds: tournament.total_rounds,
+        current_round: tournament.current_round,
+        player_count: active_player_count(tournament),
+        standings: build_standings(tournament),
+        pairings,
+    }
+}
+
+/// Swiss pairing: score-group pairing with backtracking rematch avoidance,
+/// float-down for odd groups, bye preferring players without a prior bye.
+fn generate_swiss_pairings(
+    tournament: &mut TournamentMeta,
+    round: u8,
+    records: &HashMap<String, PlayerRecord>,
+    prior_pairs: &HashSet<(String, String)>,
+    seed: u64,
+) -> Vec<TournamentPairing> {
+    let mut active: Vec<String> = tournament
+        .players
+        .iter()
+        .filter(|p| !p.dropped)
+        .map(|p| p.player_key.clone())
+        .collect();
+
+    active.sort_by(|a, b| {
+        let pts_a = records.get(a).map(match_points).unwrap_or(0);
+        let pts_b = records.get(b).map(match_points).unwrap_or(0);
+        pts_b.cmp(&pts_a)
+    });
+
+    let mut brackets: Vec<Vec<String>> = Vec::new();
+    let mut current_pts: Option<u32> = None;
+    for key in active {
+        let pts = records.get(&key).map(match_points).unwrap_or(0);
+        if current_pts != Some(pts) {
+            brackets.push(Vec::new());
+            current_pts = Some(pts);
+        }
+        brackets.last_mut().unwrap().push(key);
+    }
+
+    let mut rng = SimpleRng::new(seed ^ u64::from(round));
+    for bracket in &mut brackets {
+        rng.shuffle(bracket);
+    }
+
+    let mut paired: Vec<(String, String)> = Vec::new();
+    let mut carry: Option<String> = None;
+
+    for bracket in brackets {
+        let mut pool = bracket;
+        if let Some(c) = carry.take() {
+            pool.insert(0, c);
+        }
+
+        let (bracket_pairs, floated) =
+            pair_bracket_with_backtracking(&pool, prior_pairs, &mut paired);
+        paired.extend(bracket_pairs);
+        carry = floated;
+    }
+
+    let mut bye_player: Option<String> = None;
+    if let Some(unpaired) = carry {
+        bye_player = Some(select_bye_player(tournament, &unpaired, records, &mut rng));
+    }
+
+    if let Some(ref bye_key) = bye_player {
+        if let Some(player) = tournament
+            .players
+            .iter_mut()
+            .find(|p| p.player_key == *bye_key)
+        {
+            player.had_bye = true;
+        }
+    }
+
+    let mut pairings: Vec<TournamentPairing> = paired
+        .iter()
+        .enumerate()
+        .map(|(table, (a, b))| TournamentPairing {
+            match_id: format!("{round}-t{table}"),
+            round,
+            table: table as u8,
+            player_a: a.clone(),
+            player_b: Some(b.clone()),
+            result: None,
+        })
+        .collect();
+
+    if let Some(bye_key) = bye_player {
+        pairings.push(TournamentPairing {
+            match_id: format!("{round}-bye"),
+            round,
+            table: pairings.len() as u8,
+            player_a: bye_key,
+            player_b: None,
+            result: Some(MatchResult {
+                winner_player_key: None,
+                player_a_wins: 1,
+                player_b_wins: 0,
+            }),
+        });
+    }
+
+    pairings
+}
+
+fn pair_bracket_with_backtracking(
+    pool: &[String],
+    prior_pairs: &HashSet<(String, String)>,
+    already_paired: &[(String, String)],
+) -> (Vec<(String, String)>, Option<String>) {
+    if pool.is_empty() {
+        return (Vec::new(), None);
+    }
+    if pool.len() == 1 {
+        return (Vec::new(), Some(pool[0].clone()));
+    }
+
+    let used: HashSet<String> = already_paired
+        .iter()
+        .flat_map(|(a, b)| [a.clone(), b.clone()])
+        .collect();
+
+    let available: Vec<String> = pool
+        .iter()
+        .filter(|k| !used.contains(*k))
+        .cloned()
+        .collect();
+
+    if let Some(solution) = backtrack_pair(&available, prior_pairs, &mut Vec::new()) {
+        let floated = if solution.len() * 2 < available.len() {
+            available
+                .iter()
+                .find(|k| !solution.iter().any(|(a, b)| a == *k || b == *k))
+                .cloned()
+        } else {
+            None
+        };
+        return (solution, floated);
+    }
+
+    // Fallback: greedy pairing allowing rematches if backtracking fails.
+    let mut remaining = available;
+    let mut pairs = Vec::new();
+    let mut floated = None;
+    while remaining.len() >= 2 {
+        let first = remaining.remove(0);
+        let partner_idx = remaining
+            .iter()
+            .position(|p| !prior_pairs.contains(&(first.clone(), p.clone())))
+            .unwrap_or(0);
+        let partner = remaining.remove(partner_idx);
+        pairs.push((first, partner));
+    }
+    if remaining.len() == 1 {
+        floated = Some(remaining.remove(0));
+    }
+    (pairs, floated)
+}
+
+fn backtrack_pair(
+    players: &[String],
+    prior_pairs: &HashSet<(String, String)>,
+    acc: &mut Vec<(String, String)>,
+) -> Option<Vec<(String, String)>> {
+    if players.is_empty() {
+        return Some(acc.clone());
+    }
+    if players.len() == 1 {
+        return None;
+    }
+    let first = &players[0];
+    for (i, partner) in players.iter().enumerate().skip(1) {
+        if prior_pairs.contains(&(first.clone(), partner.clone())) {
+            continue;
+        }
+        let mut rest: Vec<String> = players
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != 0 && *idx != i)
+            .map(|(_, k)| k.clone())
+            .collect();
+        acc.push((first.clone(), partner.clone()));
+        if let Some(solution) = backtrack_pair(&rest, prior_pairs, acc) {
+            return Some(solution);
+        }
+        acc.pop();
+        let _ = &mut rest;
+    }
+    None
+}
+
+/// Deterministic PRNG for bracket shuffles — no `rand` crate in this WASM-safe core.
+struct SimpleRng {
+    state: u64,
+}
+
+impl SimpleRng {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        self.state
+    }
+
+    fn shuffle(&mut self, slice: &mut [String]) {
+        for i in (1..slice.len()).rev() {
+            let j = (self.next_u64() as usize) % (i + 1);
+            slice.swap(i, j);
+        }
+    }
+}
+
+fn select_bye_player(
+    tournament: &TournamentMeta,
+    floated: &str,
+    records: &HashMap<String, PlayerRecord>,
+    _rng: &mut SimpleRng,
+) -> String {
+    let active_without_bye: Vec<String> = tournament
+        .players
+        .iter()
+        .filter(|p| !p.dropped && !p.had_bye)
+        .map(|p| p.player_key.clone())
+        .collect();
+
+    if active_without_bye.contains(&floated.to_string()) {
+        return floated.to_string();
+    }
+
+    let mut candidates: Vec<String> = active_without_bye;
+    if candidates.is_empty() {
+        return floated.to_string();
+    }
+    candidates.sort_by(|a, b| {
+        let pts_a = records.get(a).map(match_points).unwrap_or(0);
+        let pts_b = records.get(b).map(match_points).unwrap_or(0);
+        pts_a.cmp(&pts_b)
+    });
+    candidates
+        .first()
+        .cloned()
+        .unwrap_or_else(|| floated.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::BrokerEnv;
+
+    struct FakeEnv {
+        now: u64,
+        code_seq: std::cell::Cell<u32>,
+        token_seq: std::cell::Cell<u32>,
+    }
+
+    impl FakeEnv {
+        fn new() -> Self {
+            Self {
+                now: 1_000_000,
+                code_seq: std::cell::Cell::new(1),
+                token_seq: std::cell::Cell::new(1),
+            }
+        }
+    }
+
+    impl BrokerEnv for FakeEnv {
+        fn now_ms(&self) -> u64 {
+            self.now
+        }
+        fn new_token(&self) -> String {
+            let n = self.token_seq.get();
+            self.token_seq.set(n + 1);
+            format!("tok-{n}")
+        }
+        fn new_game_code(&self) -> String {
+            let n = self.code_seq.get();
+            self.code_seq.set(n + 1);
+            format!("T{n:04}")
+        }
+    }
+
+    fn register_players(mgr: &mut TournamentManager, code: &str, count: usize) {
+        for i in 0..count {
+            let key = format!("p{i}");
+            mgr.join_tournament(code, format!("Player {i}"), key)
+                .expect("join");
+        }
+    }
+
+    #[test]
+    fn registration_and_join() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Friday Swiss".into(), "TO".into(), 3, &env);
+        mgr.join_tournament("T0001", "Alice".into(), "alice".into())
+            .unwrap();
+        let view = mgr.to_view("T0001").unwrap();
+        assert_eq!(view.player_count, 1);
+        assert_eq!(view.status, TournamentStatus::Registration);
+    }
+
+    #[test]
+    fn swiss_pairings_cover_all_active_players_round_1() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Event".into(), "TO".into(), 3, &env);
+        register_players(&mut mgr, "T0001", 8);
+        mgr.start_round("T0001", &env).unwrap();
+        let view = mgr.to_view("T0001").unwrap();
+        assert_eq!(view.current_round, 1);
+        assert_eq!(view.pairings.len(), 4);
+        let mut paired: HashSet<String> = HashSet::new();
+        for p in &view.pairings {
+            paired.insert(p.player_a_key.clone());
+            if let Some(b) = &p.player_b_key {
+                paired.insert(b.clone());
+            }
+        }
+        assert_eq!(paired.len(), 8);
+    }
+
+    #[test]
+    fn standings_sort_by_match_points_then_tiebreakers() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Event".into(), "TO".into(), 1, &env);
+        for (i, name) in ["A", "B", "C", "D"].iter().enumerate() {
+            mgr.join_tournament("T0001", (*name).into(), format!("p{i}"))
+                .unwrap();
+        }
+        mgr.start_round("T0001", &env).unwrap();
+        let view = mgr.to_view("T0001").unwrap();
+        let m1 = view.pairings[0].match_id.clone();
+        mgr.report_result(
+            "T0001",
+            &m1,
+            MatchResult {
+                winner_player_key: Some(view.pairings[0].player_a_key.clone()),
+                player_a_wins: 2,
+                player_b_wins: 0,
+            },
+        )
+        .unwrap();
+        let standings = mgr.to_view("T0001").unwrap().standings;
+        assert!(!standings.is_empty());
+        assert!(standings[0].match_points >= standings.last().unwrap().match_points);
+    }
+
+    #[test]
+    fn drop_player_prevents_future_pairing() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Event".into(), "TO".into(), 2, &env);
+        register_players(&mut mgr, "T0001", 5);
+        mgr.drop_player("T0001", "p4").unwrap();
+        mgr.start_round("T0001", &env).unwrap();
+        let view = mgr.to_view("T0001").unwrap();
+        let paired: HashSet<_> = view
+            .pairings
+            .iter()
+            .flat_map(|p| std::iter::once(p.player_a_key.clone()).chain(p.player_b_key.clone()))
+            .collect();
+        assert!(!paired.contains("p4"));
+    }
+
+    #[test]
+    fn odd_player_count_assigns_bye() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Event".into(), "TO".into(), 1, &env);
+        register_players(&mut mgr, "T0001", 5);
+        mgr.start_round("T0001", &env).unwrap();
+        let view = mgr.to_view("T0001").unwrap();
+        let byes = view
+            .pairings
+            .iter()
+            .filter(|p| p.player_b_key.is_none())
+            .count();
+        assert_eq!(byes, 1);
+    }
+
+    #[test]
+    fn rematch_avoided_when_possible_in_round_2() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Event".into(), "TO".into(), 2, &env);
+        register_players(&mut mgr, "T0001", 8);
+        mgr.start_round("T0001", &env).unwrap();
+        for p in mgr.get("T0001").unwrap().pairings.clone() {
+            if let Some(b) = p.player_b {
+                mgr.report_result(
+                    "T0001",
+                    &p.match_id,
+                    MatchResult {
+                        winner_player_key: Some(p.player_a.clone()),
+                        player_a_wins: 2,
+                        player_b_wins: 0,
+                    },
+                )
+                .unwrap();
+                let _ = b;
+            }
+        }
+        mgr.start_round("T0001", &env).unwrap();
+        let prior: HashSet<(String, String)> = mgr
+            .get("T0001")
+            .unwrap()
+            .pairings
+            .iter()
+            .filter(|p| p.round == 1)
+            .filter_map(|p| p.player_b.as_ref().map(|b| (p.player_a.clone(), b.clone())))
+            .flat_map(|(a, b)| [(a.clone(), b.clone()), (b, a)])
+            .collect();
+        let round2 = mgr
+            .to_view("T0001")
+            .unwrap()
+            .pairings
+            .into_iter()
+            .filter(|p| p.round == 2)
+            .collect::<Vec<_>>();
+        for p in round2 {
+            if let Some(b) = &p.player_b_key {
+                let a = &p.player_a_key;
+                assert!(
+                    !prior.contains(&(a.clone(), b.clone())),
+                    "rematch: {a} vs {b}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn public_summaries_omit_completed() {
+        let env = FakeEnv::new();
+        let mut mgr = TournamentManager::new();
+        mgr.register_tournament("T0001", "Open".into(), "TO".into(), 1, &env);
+        mgr.end_tournament("T0001").unwrap();
+        assert!(mgr.public_summaries().is_empty());
+    }
+}

--- a/crates/lobby-broker/src/validation.rs
+++ b/crates/lobby-broker/src/validation.rs
@@ -220,6 +220,47 @@ pub fn validate_unregister_lobby_fields(game_code: &str) -> Result<(), String> {
     validate_token("game_code", game_code, MAX_GAME_CODE_LEN)
 }
 
+pub fn validate_tournament_code(tournament_code: &str) -> Result<(), String> {
+    validate_token("tournament_code", tournament_code, MAX_GAME_CODE_LEN)
+}
+
+pub fn validate_create_tournament_fields(
+    name: &str,
+    display_name: &str,
+    total_rounds: u8,
+) -> Result<(), String> {
+    validate_required_label("name", name, MAX_ROOM_NAME_LEN)?;
+    validate_required_label("display_name", display_name, MAX_DISPLAY_NAME_LEN)?;
+    if total_rounds == 0 || total_rounds > 15 {
+        return Err("total_rounds must be between 1 and 15".to_string());
+    }
+    Ok(())
+}
+
+pub fn validate_join_tournament_fields(
+    tournament_code: &str,
+    display_name: &str,
+) -> Result<(), String> {
+    validate_tournament_code(tournament_code)?;
+    validate_required_label("display_name", display_name, MAX_DISPLAY_NAME_LEN)
+}
+
+pub fn validate_report_match_result_fields(
+    tournament_code: &str,
+    match_id: &str,
+    winner_player_key: Option<&str>,
+    player_a_wins: u8,
+    player_b_wins: u8,
+) -> Result<(), String> {
+    validate_tournament_code(tournament_code)?;
+    validate_token("match_id", match_id, MAX_GAME_CODE_LEN)?;
+    validate_optional_token("winner_player_key", winner_player_key, MAX_TOKEN_LEN)?;
+    if player_a_wins > 3 || player_b_wins > 3 {
+        return Err("game win counts must be at most 3".to_string());
+    }
+    Ok(())
+}
+
 /// Validate every client-supplied field of a parsed lobby message against the
 /// size/shape bounds above. Returns the first violation as a human-readable
 /// reason suitable for an `Error` reply. Server-populated reply types
@@ -301,7 +342,32 @@ pub fn validate_lobby_message(msg: &crate::protocol::LobbyClientMessage) -> Resu
             validate_unregister_lobby_fields(game_code)?;
         }
         // No client-supplied bounded fields.
-        M::SubscribeLobby | M::UnsubscribeLobby | M::Ping { .. } => {}
+        M::SubscribeLobby | M::UnsubscribeLobby | M::Ping { .. } | M::ListTournaments => {}
+        M::CreateTournament {
+            name,
+            display_name,
+            total_rounds,
+        } => validate_create_tournament_fields(name, display_name, *total_rounds)?,
+        M::JoinTournament {
+            tournament_code,
+            display_name,
+        } => validate_join_tournament_fields(tournament_code, display_name)?,
+        M::DropFromTournament { tournament_code }
+        | M::StartTournamentRound { tournament_code }
+        | M::EndTournament { tournament_code } => validate_tournament_code(tournament_code)?,
+        M::ReportMatchResult {
+            tournament_code,
+            match_id,
+            winner_player_key,
+            player_a_wins,
+            player_b_wins,
+        } => validate_report_match_result_fields(
+            tournament_code,
+            match_id,
+            winner_player_key.as_deref(),
+            *player_a_wins,
+            *player_b_wins,
+        )?,
     }
 
     Ok(())

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -519,6 +519,8 @@ struct SocketIdentity {
     /// 5-minute expiry. Empty in `Full` mode (handled via `game_code` +
     /// `SessionManager` cleanup).
     lobby_host_game: Option<String>,
+    lobby_tournament_organizer: Option<String>,
+    lobby_joined_tournaments: Vec<(String, String)>,
     seat_reservations: Vec<(String, String)>,
     lobby_reservations: Vec<(String, String)>,
     /// Set when this socket is participating in a draft session.
@@ -664,12 +666,18 @@ fn reject_if_disabled(msg: &ClientMessage, mode: ServerMode) -> Option<&'static 
         },
 
         // Lobby-only-exclusive.
-        ClientMessage::UpdateLobbyMetadata { .. } | ClientMessage::UnregisterLobby { .. } => {
-            match mode {
-                ServerMode::Full => Some(FULL_MODE_REJECTION),
-                ServerMode::LobbyOnly => None,
-            }
-        }
+        ClientMessage::UpdateLobbyMetadata { .. }
+        | ClientMessage::UnregisterLobby { .. }
+        | ClientMessage::CreateTournament { .. }
+        | ClientMessage::JoinTournament { .. }
+        | ClientMessage::DropFromTournament { .. }
+        | ClientMessage::StartTournamentRound { .. }
+        | ClientMessage::ReportMatchResult { .. }
+        | ClientMessage::EndTournament { .. }
+        | ClientMessage::ListTournaments => match mode {
+            ServerMode::Full => Some(FULL_MODE_REJECTION),
+            ServerMode::LobbyOnly => None,
+        },
     }
 }
 
@@ -752,6 +760,8 @@ impl SocketIdentity {
             subscribed: self.lobby_subscribed,
             host_game: self.lobby_host_game.clone(),
             reservations: self.lobby_reservations.clone(),
+            tournament_organizer: self.lobby_tournament_organizer.clone(),
+            joined_tournaments: self.lobby_joined_tournaments.clone(),
         }
     }
 
@@ -762,6 +772,8 @@ impl SocketIdentity {
         self.lobby_subscribed = conn.subscribed;
         self.lobby_host_game = conn.host_game;
         self.lobby_reservations = conn.reservations;
+        self.lobby_tournament_organizer = conn.tournament_organizer;
+        self.lobby_joined_tournaments = conn.joined_tournaments;
     }
 }
 
@@ -1379,6 +1391,8 @@ async fn handle_socket(
         session_span: None,
         client_hello: None,
         lobby_host_game: None,
+        lobby_tournament_organizer: None,
+        lobby_joined_tournaments: Vec::new(),
         seat_reservations: Vec::new(),
         lobby_reservations: Vec::new(),
         draft_code: None,
@@ -1685,6 +1699,20 @@ fn to_server_message(m: lobby_broker::LobbyServerMessage) -> ServerMessage {
             filled_seats,
             reservation_token,
         },
+        L::TournamentCreated {
+            tournament_code,
+            player_key,
+        } => ServerMessage::TournamentCreated {
+            tournament_code,
+            player_key,
+        },
+        L::TournamentUpdate { tournament } => ServerMessage::TournamentUpdate { tournament },
+        L::TournamentCompleted { tournament_code } => {
+            ServerMessage::TournamentCompleted { tournament_code }
+        }
+        L::TournamentListUpdate { tournaments } => {
+            ServerMessage::TournamentListUpdate { tournaments }
+        }
     }
 }
 
@@ -1780,6 +1808,45 @@ fn to_lobby_client_message(msg: &ClientMessage) -> Option<lobby_broker::LobbyCli
         ClientMessage::UnregisterLobby { game_code } => L::UnregisterLobby {
             game_code: game_code.clone(),
         },
+        ClientMessage::CreateTournament {
+            name,
+            display_name,
+            total_rounds,
+        } => L::CreateTournament {
+            name: name.clone(),
+            display_name: display_name.clone(),
+            total_rounds: *total_rounds,
+        },
+        ClientMessage::JoinTournament {
+            tournament_code,
+            display_name,
+        } => L::JoinTournament {
+            tournament_code: tournament_code.clone(),
+            display_name: display_name.clone(),
+        },
+        ClientMessage::DropFromTournament { tournament_code } => L::DropFromTournament {
+            tournament_code: tournament_code.clone(),
+        },
+        ClientMessage::StartTournamentRound { tournament_code } => L::StartTournamentRound {
+            tournament_code: tournament_code.clone(),
+        },
+        ClientMessage::ReportMatchResult {
+            tournament_code,
+            match_id,
+            winner_player_key,
+            player_a_wins,
+            player_b_wins,
+        } => L::ReportMatchResult {
+            tournament_code: tournament_code.clone(),
+            match_id: match_id.clone(),
+            winner_player_key: winner_player_key.clone(),
+            player_a_wins: *player_a_wins,
+            player_b_wins: *player_b_wins,
+        },
+        ClientMessage::EndTournament { tournament_code } => L::EndTournament {
+            tournament_code: tournament_code.clone(),
+        },
+        ClientMessage::ListTournaments => L::ListTournaments,
         _ => return None,
     })
 }
@@ -5616,6 +5683,24 @@ async fn handle_client_message(
             )
             .await;
         }
+
+        ClientMessage::CreateTournament { .. }
+        | ClientMessage::JoinTournament { .. }
+        | ClientMessage::DropFromTournament { .. }
+        | ClientMessage::StartTournamentRound { .. }
+        | ClientMessage::ReportMatchResult { .. }
+        | ClientMessage::EndTournament { .. }
+        | ClientMessage::ListTournaments => {
+            dispatch_broker(
+                &client_msg,
+                lobby,
+                lobby_subscribers,
+                player_count,
+                tx,
+                identity,
+            )
+            .await;
+        }
     }
 }
 
@@ -6377,6 +6462,8 @@ mod handshake_tests {
             session_span: None,
             client_hello: None,
             lobby_host_game: None,
+            lobby_tournament_organizer: None,
+            lobby_joined_tournaments: Vec::new(),
             seat_reservations: Vec::new(),
             lobby_reservations: Vec::new(),
             draft_code: None,

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -11,6 +11,8 @@ use lobby_broker::inbound_guard::{
     LookupJoinTargetInbound,
 };
 use lobby_broker::validation::{
+    validate_create_tournament_fields, validate_join_tournament_fields,
+    validate_report_match_result_fields, validate_tournament_code,
     validate_unregister_lobby_fields, validate_update_lobby_metadata_fields,
     UpdateLobbyMetadataFields,
 };
@@ -153,6 +155,34 @@ pub fn guard_client_message_before_dispatch(
             player_token,
         } => guard_reconnect_draft(draft_code, player_token),
         ClientMessage::SpectateDraft { draft_code } => guard_spectate_draft(draft_code),
+        ClientMessage::CreateTournament {
+            name,
+            display_name,
+            total_rounds,
+        } => validate_create_tournament_fields(name, display_name, *total_rounds),
+        ClientMessage::JoinTournament {
+            tournament_code,
+            display_name,
+        } => validate_join_tournament_fields(tournament_code, display_name),
+        ClientMessage::DropFromTournament { tournament_code }
+        | ClientMessage::StartTournamentRound { tournament_code }
+        | ClientMessage::EndTournament { tournament_code } => {
+            validate_tournament_code(tournament_code)
+        }
+        ClientMessage::ReportMatchResult {
+            tournament_code,
+            match_id,
+            winner_player_key,
+            player_a_wins,
+            player_b_wins,
+        } => validate_report_match_result_fields(
+            tournament_code,
+            match_id,
+            winner_player_key.as_deref(),
+            *player_a_wins,
+            *player_b_wins,
+        ),
+        ClientMessage::ListTournaments => Ok(()),
     }
 }
 
@@ -229,6 +259,34 @@ pub fn guard_broker_projection_inbound(msg: &ClientMessage) -> Result<(), String
             consumed_reservation_tokens,
         }),
         ClientMessage::UnregisterLobby { game_code } => validate_unregister_lobby_fields(game_code),
+        ClientMessage::CreateTournament {
+            name,
+            display_name,
+            total_rounds,
+        } => validate_create_tournament_fields(name, display_name, *total_rounds),
+        ClientMessage::JoinTournament {
+            tournament_code,
+            display_name,
+        } => validate_join_tournament_fields(tournament_code, display_name),
+        ClientMessage::DropFromTournament { tournament_code }
+        | ClientMessage::StartTournamentRound { tournament_code }
+        | ClientMessage::EndTournament { tournament_code } => {
+            validate_tournament_code(tournament_code)
+        }
+        ClientMessage::ReportMatchResult {
+            tournament_code,
+            match_id,
+            winner_player_key,
+            player_a_wins,
+            player_b_wins,
+        } => validate_report_match_result_fields(
+            tournament_code,
+            match_id,
+            winner_player_key.as_deref(),
+            *player_a_wins,
+            *player_b_wins,
+        ),
+        ClientMessage::ListTournaments => Ok(()),
         ClientMessage::CreateGame { .. }
         | ClientMessage::JoinGame { .. }
         | ClientMessage::Action { .. }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -57,7 +57,10 @@ pub struct AiSeatRequest {
 // re-exported here so `ServerMessage::LobbyUpdate { games: Vec<LobbyGame> }`
 // and the broker reference the same struct. The serde shape is unchanged —
 // wire bytes are byte-identical (guarded by tests/lobby_wire_contract.rs).
-pub use lobby_broker::protocol::{DraftLobbyMetadata, LobbyGame};
+pub use lobby_broker::protocol::{
+    DraftLobbyMetadata, LobbyGame, PairingView, TournamentStanding, TournamentStatus,
+    TournamentSummary, TournamentView,
+};
 
 pub use seat_reducer::types::{DeckChoice, SeatKind, SeatMutation, SeatTeamInfo, SeatView};
 
@@ -202,6 +205,33 @@ pub enum ClientMessage {
     UnregisterLobby {
         game_code: String,
     },
+    CreateTournament {
+        name: String,
+        display_name: String,
+        #[serde(default = "default_swiss_rounds")]
+        total_rounds: u8,
+    },
+    JoinTournament {
+        tournament_code: String,
+        display_name: String,
+    },
+    DropFromTournament {
+        tournament_code: String,
+    },
+    StartTournamentRound {
+        tournament_code: String,
+    },
+    ReportMatchResult {
+        tournament_code: String,
+        match_id: String,
+        winner_player_key: Option<String>,
+        player_a_wins: u8,
+        player_b_wins: u8,
+    },
+    EndTournament {
+        tournament_code: String,
+    },
+    ListTournaments,
     CreateDraftWithSettings {
         display_name: String,
         set_code: String,
@@ -249,6 +279,10 @@ fn default_player_count() -> u8 {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_swiss_rounds() -> u8 {
+    3
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -430,6 +464,19 @@ pub enum ServerMessage {
         filled_seats: u8,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reservation_token: Option<String>,
+    },
+    TournamentCreated {
+        tournament_code: String,
+        player_key: String,
+    },
+    TournamentUpdate {
+        tournament: TournamentView,
+    },
+    TournamentCompleted {
+        tournament_code: String,
+    },
+    TournamentListUpdate {
+        tournaments: Vec<TournamentSummary>,
     },
     DraftCreated {
         draft_code: String,
@@ -1806,8 +1853,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_11() {
-        assert_eq!(PROTOCOL_VERSION, 11);
+    fn protocol_version_is_12() {
+        assert_eq!(PROTOCOL_VERSION, 12);
     }
 
     #[test]

--- a/lobby-worker/broker-wasm/src/lib.rs
+++ b/lobby-worker/broker-wasm/src/lib.rs
@@ -104,11 +104,18 @@ fn mutates_lobby(msg: &LobbyClientMessage) -> bool {
         | LobbyClientMessage::JoinGameWithPassword { .. }
         | LobbyClientMessage::LookupJoinTarget { .. }
         | LobbyClientMessage::UpdateLobbyMetadata { .. }
-        | LobbyClientMessage::UnregisterLobby { .. } => true,
+        | LobbyClientMessage::UnregisterLobby { .. }
+        | LobbyClientMessage::CreateTournament { .. }
+        | LobbyClientMessage::JoinTournament { .. }
+        | LobbyClientMessage::DropFromTournament { .. }
+        | LobbyClientMessage::StartTournamentRound { .. }
+        | LobbyClientMessage::ReportMatchResult { .. }
+        | LobbyClientMessage::EndTournament { .. } => true,
         LobbyClientMessage::ClientHello { .. }
         | LobbyClientMessage::SubscribeLobby
         | LobbyClientMessage::UnsubscribeLobby
-        | LobbyClientMessage::Ping { .. } => false,
+        | LobbyClientMessage::Ping { .. }
+        | LobbyClientMessage::ListTournaments => false,
     }
 }
 

--- a/lobby-worker/src/hello-gate.ts
+++ b/lobby-worker/src/hello-gate.ts
@@ -12,6 +12,8 @@ export interface ConnAttachment {
   subscribed: boolean;
   host_game: string | null;
   reservations: unknown[];
+  tournament_organizer: string | null;
+  joined_tournaments: Array<[string, string]>;
 }
 
 export function classifyHelloGate(

--- a/lobby-worker/src/lobby-do.ts
+++ b/lobby-worker/src/lobby-do.ts
@@ -54,6 +54,8 @@ const DEFAULT_CONN = {
   subscribed: false,
   host_game: null,
   reservations: [],
+  tournament_organizer: null,
+  joined_tournaments: [],
 };
 
 /** Boundary mirror of `lobby_broker_wasm::OutboundDto`. */


### PR DESCRIPTION
## Summary

- Adds a lobby-only Swiss tournament organizer to `lobby-broker`: registration, Swiss pairing with rematch avoidance, Magic tiebreaker standings, and self-reported match results.
- Wires new protocol v12 messages through `server-core`, `phase-server`, and the Cloudflare `lobby-worker` WASM shell (shared `ConnState` + DO snapshot).
- Adds client tournament pages (`/tournament`, `/tournament/:code`), `tournamentClient.ts`, and a link from Multiplayer.

Closes #4612.

## Test plan

- [x] `cargo test -p lobby-broker` (90 tests)
- [x] `cargo test -p server-core --test lobby_wire_contract` (5 tests)
- [x] `cargo check -p phase-server`
- [ ] Manual: create tournament on LobbyOnly broker, join players, start round, report results, verify standings
- [ ] Rebuild/deploy `lobby-worker` WASM before production (protocol v12 + broker snapshot shape)