### PR TITLE
feat(engine): Alchemy perpetual type-change (Second Little Pig) (#4124)

### DIFF
--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -110,12 +110,12 @@ pub fn resolve(
     let target = target.clone();
 
     let ids = perpetual_target_object_ids(state, ability, &target);
-    let all_creature_types = state.all_creature_types.clone();
+    let all_creature_types = &state.all_creature_types;
 
     let mut changed = false;
     for id in ids {
         if let Some(obj) = state.objects.get_mut(&id) {
-            obj.apply_perpetual_modification(&modification, &all_creature_types);
+            obj.apply_perpetual_modification(&modification, all_creature_types);
             changed = true;
         }
     }
@@ -487,8 +487,9 @@ mod tests {
         assert_eq!(state.objects.get(&source).unwrap().base_power, None);
     }
 
-    /// CR 613.4: perpetual type-change replaces creature subtypes, sets base
-    /// P/T, grants keywords, and recomputes live characteristics after flush.
+    /// CR 613.1d + CR 613.1f + CR 613.4b: perpetual type-change replaces
+    /// creature subtypes, grants keywords, sets base P/T, and recomputes live
+    /// characteristics after flush.
     #[test]
     fn perpetual_become_updates_types_pt_and_keywords_after_layer_flush() {
         use crate::types::ability::TargetFilter;

--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -110,11 +110,12 @@ pub fn resolve(
     let target = target.clone();
 
     let ids = perpetual_target_object_ids(state, ability, &target);
+    let all_creature_types = state.all_creature_types.clone();
 
     let mut changed = false;
     for id in ids {
         if let Some(obj) = state.objects.get_mut(&id) {
-            obj.apply_perpetual_modification(&modification);
+            obj.apply_perpetual_modification(&modification, &all_creature_types);
             changed = true;
         }
     }
@@ -484,5 +485,75 @@ mod tests {
         assert_eq!(obj.base_power, Some(2));
         assert_eq!(obj.base_toughness, Some(2));
         assert_eq!(state.objects.get(&source).unwrap().base_power, None);
+    }
+
+    /// CR 613.4: perpetual type-change replaces creature subtypes, sets base
+    /// P/T, grants keywords, and recomputes live characteristics after flush.
+    #[test]
+    fn perpetual_become_updates_types_pt_and_keywords_after_layer_flush() {
+        use crate::types::ability::TargetFilter;
+        use crate::types::card_type::CoreType;
+        use crate::types::keywords::Keyword;
+
+        let mut state = GameState::new_two_player(7);
+        state.all_creature_types =
+            vec!["Pig".to_string(), "Boar".to_string(), "Spirit".to_string()];
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Second Little Pig".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Pig".to_string());
+            obj.base_card_types = obj.card_types.clone();
+            obj.base_power = Some(2);
+            obj.base_toughness = Some(2);
+        }
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::flush_layers(&mut state);
+
+        let modification = PerpetualModification::Become {
+            creature_subtypes: vec!["Boar".to_string(), "Spirit".to_string()],
+            power: 4,
+            toughness: 4,
+            keywords: vec![Keyword::Flying],
+        };
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: TargetFilter::Any,
+                modification: modification.clone(),
+            },
+            vec![TargetRef::Object(id)],
+            id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        super::resolve(&mut state, &ability, &mut events).unwrap();
+        crate::game::layers::flush_layers(&mut state);
+
+        let obj = state.objects.get(&id).unwrap();
+        assert!(obj
+            .card_types
+            .subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Boar")));
+        assert!(obj
+            .card_types
+            .subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Spirit")));
+        assert!(!obj
+            .card_types
+            .subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Pig")));
+        assert_eq!(obj.power, Some(4));
+        assert_eq!(obj.toughness, Some(4));
+        assert!(obj.has_keyword(&Keyword::Flying));
+        assert!(obj.perpetual_mods.contains(&modification));
     }
 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1037,8 +1037,10 @@ impl GameObject {
     pub fn apply_perpetual_modification(
         &mut self,
         modification: &crate::types::ability::PerpetualModification,
+        all_creature_types: &[String],
     ) {
         use crate::types::ability::PerpetualModification;
+        use crate::types::card_type::CoreType;
         match modification {
             PerpetualModification::SetBasePowerToughness { power, toughness } => {
                 // The base_* fields are the persistent baseline the layer pass
@@ -1072,6 +1074,48 @@ impl GameObject {
                     // CR 613.1: perpetual keyword grants must survive the layer
                     // pass's `keywords = base_keywords.clone()` reset — mirror
                     // base_* P/T edits and the crew-keyword test seeding pattern.
+                    if !self.base_keywords.contains(keyword) {
+                        self.base_keywords.push(keyword.clone());
+                    }
+                }
+            }
+            PerpetualModification::Become {
+                creature_subtypes,
+                power,
+                toughness,
+                keywords,
+            } => {
+                // CR 613.4: replace creature subtypes on the persistent baseline
+                // while retaining non-creature subtypes (Artifact, Aura, etc.).
+                self.sync_missing_base_characteristics();
+                if !self
+                    .base_card_types
+                    .core_types
+                    .contains(&CoreType::Creature)
+                {
+                    self.base_card_types.core_types.push(CoreType::Creature);
+                }
+                self.base_card_types.subtypes.retain(|subtype| {
+                    !all_creature_types
+                        .iter()
+                        .any(|creature_type| creature_type.eq_ignore_ascii_case(subtype))
+                });
+                for subtype in creature_subtypes {
+                    if !self
+                        .base_card_types
+                        .subtypes
+                        .iter()
+                        .any(|existing| existing.eq_ignore_ascii_case(subtype))
+                    {
+                        self.base_card_types.subtypes.push(subtype.clone());
+                    }
+                }
+                self.base_power = Some(*power);
+                self.base_toughness = Some(*toughness);
+                for keyword in keywords {
+                    if !self.keywords.contains(keyword) {
+                        self.keywords.push(keyword.clone());
+                    }
                     if !self.base_keywords.contains(keyword) {
                         self.base_keywords.push(keyword.clone());
                     }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1085,8 +1085,9 @@ impl GameObject {
                 toughness,
                 keywords,
             } => {
-                // CR 613.4: replace creature subtypes on the persistent baseline
-                // while retaining non-creature subtypes (Artifact, Aura, etc.).
+                // CR 613.1d + CR 613.1f + CR 613.4b: update the persistent
+                // type, keyword, and base-P/T baselines while retaining
+                // non-creature subtypes (Artifact, Aura, etc.).
                 self.sync_missing_base_characteristics();
                 if !self
                     .base_card_types
@@ -1113,9 +1114,6 @@ impl GameObject {
                 self.base_power = Some(*power);
                 self.base_toughness = Some(*toughness);
                 for keyword in keywords {
-                    if !self.keywords.contains(keyword) {
-                        self.keywords.push(keyword.clone());
-                    }
                     if !self.base_keywords.contains(keyword) {
                         self.base_keywords.push(keyword.clone());
                     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6272,6 +6272,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "[~/this creature] perpetually becomes a [subtypes]
+    // with base power and toughness N/N [and gains [keyword(s)]]" — persistent
+    // type change + base P/T + keyword grant (Second Little Pig).
+    if let Some(effect) = try_parse_perpetual_become(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "[~/it/this creature] perpetually become(s)/has base
     // power and toughness N/N" — the ApplyPerpetual keyword action (base P/T).
     if let Some(effect) = try_parse_perpetual_base_pt(tp) {
@@ -6420,6 +6427,93 @@ fn try_parse_intensify(tp: TextPair) -> Option<Effect> {
     tail_done(rest).then_some(Effect::Intensify {
         scope: IntensityScope::Source,
         amount,
+    })
+}
+
+/// Digital-only Alchemy: parse the self-subject perpetual type-change form —
+/// "[~ / this creature / …] perpetually become(s) a [subtypes] with base power
+/// and toughness N/N [and gains [keyword(s)]]" → [`Effect::ApplyPerpetual`]
+/// with [`PerpetualModification::Become`] (Second Little Pig).
+///
+/// Self-subjects only; referenced-object forms ("the duplicate"/"it") are
+/// deferred. The clause tail must be fully consumed so compound riders that
+/// are not modeled (e.g. Heir to Dragonfire's ", gets +3/+3") fall through to
+/// `Unimplemented` rather than being silently dropped.
+fn try_parse_perpetual_become(tp: TextPair) -> Option<Effect> {
+    use crate::parser::oracle_util::parse_subtype;
+
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    let lower = tp.lower;
+    let after_subject = [
+        "~ ",
+        "this creature ",
+        "this artifact ",
+        "this enchantment ",
+        "this permanent ",
+        "this token ",
+        "this card ",
+    ]
+    .iter()
+    .find_map(|subject| {
+        tag::<_, _, OracleError<'_>>(*subject)
+            .parse(lower)
+            .ok()
+            .map(|(rest, _)| rest)
+    })?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("perpetually ")
+        .parse(after_subject)
+        .ok()?;
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("becomes a "),
+        tag::<_, _, OracleError<'_>>("become a "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (rest, subtype_part) =
+        take_until::<_, _, OracleError<'_>>(" with base power and toughness ")
+            .parse(rest)
+            .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(" with base power and toughness ")
+        .parse(rest)
+        .ok()?;
+    let mut creature_subtypes = Vec::new();
+    let mut subtype_rest = subtype_part.trim();
+    while !subtype_rest.is_empty() {
+        let (canonical, consumed) = parse_subtype(subtype_rest)?;
+        creature_subtypes.push(canonical);
+        subtype_rest = subtype_rest[consumed..].trim_start();
+    }
+    if creature_subtypes.is_empty() {
+        return None;
+    }
+    let (rest, power) = nom_primitives::parse_number(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("/").parse(rest).ok()?;
+    let (rest, toughness) = nom_primitives::parse_number(rest).ok()?;
+    let (rest, keywords) = if let Ok((rest, _)) = alt((
+        tag::<_, _, OracleError<'_>>(" and gains "),
+        tag::<_, _, OracleError<'_>>(" and gain "),
+    ))
+    .parse(rest)
+    {
+        let (keywords, rest) = sequence::parse_keyword_grant_list(rest)?;
+        (rest, keywords)
+    } else {
+        (rest, Vec::new())
+    };
+    if !tail_done(rest) {
+        return None;
+    }
+    Some(Effect::ApplyPerpetual {
+        target: TargetFilter::Any,
+        modification: crate::types::ability::PerpetualModification::Become {
+            creature_subtypes,
+            power: power as i32,
+            toughness: toughness as i32,
+            keywords,
+        },
     })
 }
 
@@ -52201,6 +52295,42 @@ mod tests {
                 ..
             } if keywords == vec![Keyword::Flying]
         ));
+    }
+
+    #[test]
+    fn perpetual_parser_maps_become_type_change() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::keywords::Keyword;
+
+        let e = parse_effect(
+            "~ perpetually becomes a Boar Spirit with base power and toughness 4/4 and gains flying.",
+        );
+        assert!(matches!(
+            e,
+            Effect::ApplyPerpetual {
+                target: TargetFilter::Any,
+                modification: PerpetualModification::Become {
+                    creature_subtypes,
+                    power: 4,
+                    toughness: 4,
+                    keywords,
+                },
+                ..
+            } if creature_subtypes == vec!["Boar".to_string(), "Spirit".to_string()]
+                && keywords == vec![Keyword::Flying]
+        ));
+
+        let e = parse_effect("~ perpetually becomes a Dragon, gets +3/+3.");
+        assert!(
+            !matches!(
+                e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::Become { .. },
+                    ..
+                }
+            ),
+            "compound P/T riders must not parse as Become, got {e:?}"
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7904,6 +7904,17 @@ pub enum PerpetualModification {
     GrantKeywords {
         keywords: Vec<crate::types::keywords::Keyword>,
     },
+    /// "[object] perpetually becomes a [subtypes] with base power and toughness
+    /// P/T [and gains [keywords]]" — replaces creature subtypes, ensures the
+    /// card is a creature, sets base power/toughness, and grants keywords
+    /// permanently (Second Little Pig).
+    Become {
+        creature_subtypes: Vec<String>,
+        power: i32,
+        toughness: i32,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        keywords: Vec<crate::types::keywords::Keyword>,
+    },
 }
 
 /// CR 701.20e + CR 608.2c: Discriminates where `Effect::Dig` reads its

--- a/crates/engine/tests/integration/issue_4124_second_little_pig.rs
+++ b/crates/engine/tests/integration/issue_4124_second_little_pig.rs
@@ -1,0 +1,87 @@
+//! Regression for issue #4124 — Alchemy perpetual type-change (Second Little Pig).
+//!
+//! https://github.com/phase-rs/phase/issues/4124
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, PerpetualModification};
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::CardId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SECOND_LITTLE_PIG_ORACLE: &str =
+    "~ perpetually becomes a Boar Spirit with base power and toughness 4/4 and gains flying.";
+
+#[test]
+fn second_little_pig_perpetual_become_resolves_through_effect_chain() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    let card_id = CardId(runner.state().next_object_id);
+    let id = create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        "Second Little Pig".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.card_types.subtypes.push("Pig".to_string());
+        obj.base_card_types = obj.card_types.clone();
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+    }
+    runner.state_mut().all_creature_types = vec!["Pig".into(), "Boar".into(), "Spirit".into()];
+
+    let def = parse_effect_chain(SECOND_LITTLE_PIG_ORACLE, AbilityKind::Activated);
+    assert!(
+        matches!(
+            def.effect.as_ref(),
+            engine::types::ability::Effect::ApplyPerpetual {
+                modification: PerpetualModification::Become {
+                    creature_subtypes,
+                    power: 4,
+                    toughness: 4,
+                    keywords,
+                },
+                ..
+            } if creature_subtypes == &vec!["Boar".to_string(), "Spirit".to_string()]
+                && keywords == &vec![Keyword::Flying]
+        ),
+        "precondition: parsed Become modification, got {:?}",
+        def.effect,
+    );
+
+    let ability = build_resolved_from_def(&def, id, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0).unwrap();
+    engine::game::layers::flush_layers(runner.state_mut());
+
+    let obj = runner.state().objects.get(&id).unwrap();
+    assert!(obj
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case("Boar")));
+    assert!(obj
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case("Spirit")));
+    assert!(!obj
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case("Pig")));
+    assert_eq!(obj.power, Some(4));
+    assert_eq!(obj.toughness, Some(4));
+    assert!(obj.has_keyword(&Keyword::Flying));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -371,6 +371,7 @@ mod issue_3999_latchkey_faerie_prowl_etb;
 mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
+mod issue_4124_second_little_pig;
 mod issue_4242_lagrella_crash;
 mod issue_4243_from_the_rubble;
 mod issue_4244_temple_altisaur;


### PR DESCRIPTION
## Summary

Follow-up to the Alchemy **perpetually** mechanic (`Effect::ApplyPerpetual` / `PerpetualModification`, #4104). Adds the **perpetual type-change** form:

> "[~] perpetually becomes a [subtypes] with base power and toughness N/N [and gains [keyword]]"

**Second Little Pig** — `{2}{W/B}{W/B}: Second Little Pig perpetually becomes a Boar Spirit with base power and toughness 4/4 and gains flying.`

## Root cause

#4104 modeled base-P/T setting, P/T modifiers, and keyword grants, but not the combined type-change + base P/T + keyword grant pattern. Without `PerpetualModification::Become`, the Second Little Pig activated ability fell through as unimplemented.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/types/ability.rs` | `PerpetualModification::Become { creature_subtypes, power, toughness, keywords }` |
| `crates/engine/src/parser/oracle_effect/mod.rs` | `try_parse_perpetual_become` nom combinator (before bare base-P/T parser); parser unit tests |
| `crates/engine/src/game/game_object.rs` | `apply_perpetual_modification`: replace creature subtypes (CR 613.4), ensure creature, set base P/T, grant keywords |
| `crates/engine/src/game/effects/perpetual.rs` | Thread `all_creature_types` into apply; resolver unit test |
| `crates/engine/tests/integration/issue_4124_second_little_pig.rs` | End-to-end effect-chain regression |
| `crates/engine/tests/integration/main.rs` | Register integration module |

## Behavior

1. **Parser** — self-subject only (`~`, `this creature`, …). Parses subtype list until `" with base power and toughness "`, then N/N, optional `" and gains [keywords]"`. Fully consumes the clause tail — compound riders like Heir to Dragonfire's `", gets +3/+3"` do not parse as `Become`.
2. **Resolver** — records mod on `perpetual_mods`, replaces creature subtypes on `base_card_types` (keeping non-creature subtypes via `all_creature_types`), ensures `Creature` core type, sets `base_power`/`base_toughness`, grants keywords to `base_keywords`, then `mark_layers_full`.

## Test plan

- [x] `perpetual_parser_maps_become_type_change` — Boar Spirit 4/4 flying → `Become`; Dragon + gets +3/+3 negative
- [x] `perpetual_become_updates_types_pt_and_keywords_after_layer_flush` — resolver + layer flush
- [x] `second_little_pig_perpetual_become_resolves_through_effect_chain` — full chain integration
- [ ] Manual: activate Second Little Pig in Alchemy — verify Boar Spirit 4/4 flying persists across zones

## Closes

Fixes https://github.com/phase-rs/phase/issues/4124

## Deferred

- Referenced-object subjects ("the duplicate"/"its") — #4528
- Perpetual P/T modifier only ("gets +N/+M") on become clauses — #4524
- All-zones "perpetually gains [ability]" forms
