### PR TITLE
fix(parser): parse 'choose a number' when it ends a sentence (closes #722)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17011,8 +17011,14 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
             min: n + 1,
             max: 20,
         })
-    } else if rest == "a number" || tag::<_, _, E>("a number ").parse(rest).is_ok() {
-        // Generic "choose a number" — default range 0-20
+    } else if tag::<_, _, E>("a number").parse(rest).is_ok() {
+        // Generic "choose a number" (default range 0-20). A bare-prefix `tag`,
+        // mirroring the "a color" branch above, so a sentence-ending clause such
+        // as "As ~ enters, choose a number." parses (Squall, Gunblade Duelist,
+        // #722). The previous exact/trailing-space match dropped the period and
+        // produced no choice. The bounded "a number between" / "a number greater
+        // than" forms are consumed by the earlier branches, so this arm is reached
+        // only for a bare "a number".
         Some(ChoiceType::NumberRange { min: 0, max: 20 })
     } else if alt((tag::<_, _, E>("a land type"), tag("a nonbasic land type")))
         .parse(rest)

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -10314,6 +10314,36 @@ mod tests {
     }
 
     #[test]
+    fn as_enters_choose_a_number_sentence_ending_period() {
+        // #722: "As Squall enters, choose a number." ends the sentence, so the
+        // "choose a number" clause reaches the parser as "a number." (trailing
+        // period). The as-enters-choose replacement must still be produced so the
+        // player is prompted to pick a number on ETB; the prior exact/space-only
+        // match dropped the period and yielded no choice.
+        let def = parse_replacement_line(
+            "As Squall enters, choose a number.",
+            "Squall, Gunblade Duelist",
+        )
+        .expect("choose-a-number ETB must produce a replacement");
+        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+        assert!(matches!(def.mode, ReplacementMode::Mandatory));
+        let execute = def.execute.as_ref().unwrap();
+        assert!(
+            matches!(
+                *execute.effect,
+                Effect::Choose {
+                    choice_type: ChoiceType::NumberRange { min: 0, max: 20 },
+                    persist: true,
+                    ..
+                }
+            ),
+            "expected a persisted NumberRange(0,20) choice, got {:?}",
+            execute.effect
+        );
+    }
+
+    #[test]
     fn enters_tapped_then_choose_color_composes_tap_and_choice() {
         // CR 614.1c + CR 614.1d: Thriving land text ("This land enters
         // tapped. As it enters, choose a color other than green.") must compose


### PR DESCRIPTION
## Anchored on

Squall, Gunblade Duelist (verified Oracle text):

> First strike
> As Squall enters, choose a number.
> Whenever one or more creatures attack one of your opponents, if any of those creatures have power or toughness equal to the chosen number, Squall deals damage equal to its power to defending player.

## Problem

"As Squall enters, choose a number." did not prompt the player to pick a number on ETB (#722). The as-enters-choose replacement was not produced at all.

## Root cause

`try_parse_named_choice` (`crates/engine/src/parser/oracle_effect/mod.rs`) matched the generic "choose a number" form with `rest == "a number" || tag("a number ")` — an exact match or a trailing SPACE. When the clause ends the sentence ("...choose a number."), the parser sees `"a number."` (trailing period), which matches neither, so `try_parse_named_choice` returns `None` and `parse_as_enters_choose` produces no `ReplacementDefinition`. Every sibling choice arm ("a color", "a creature type", "a card type", ...) uses a prefix `tag()` that tolerates trailing punctuation; the number arm was the lone outlier.

## Fix (class-general)

Match the generic number form with a prefix `tag("a number")`, exactly like the sibling "a color" arm. This parses "a number" followed by any boundary (a sentence-ending ".", a ",", or end of clause), so it fixes every "choose a number." card, not just Squall. The bounded "a number between" / "a number greater than" forms are still consumed by the earlier branches, so this arm is only ever reached for a bare "a number". The result is the existing `ChoiceType::NumberRange { min: 0, max: 20 }` template, unchanged.

This is parser-grammar scoping (a `tag` boundary), not game-rule logic, so it carries no new CR annotation; the as-enters-choose replacement itself is CR-annotated where it is built (`parse_as_enters_choose`, CR 614.1c).

## Scope

This addresses the reported ETB-prompt gap (#722). Squall's chosen-number *trigger* ("power or toughness equal to the chosen number") is a separate Talion-class pattern and is out of scope here.

## Verification

`cargo fmt` clean; parser combinator gate exit 0; new regression test `as_enters_choose_a_number_sentence_ending_period` (Squall's exact line → a persisted `NumberRange(0,20)` `Moved`/Battlefield replacement) passes; existing as-enters-choose and number-range tests pass; full engine parser suite green; clippy clean.

Closes #722

Model: claude-opus-4-8
Tier: Frontier
