### PR TITLE
feat(engine): CR 613 layers conformance — face-down override, timestamp assignment, granted-ability timestamps

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -425,15 +425,13 @@ pub fn attach_to(
         return None;
     }
 
-    let old_target = current_attachment_target(state, attachment_id)
-        .filter(|target| *target != TargetRef::Object(target_id));
-
-    // CR 613.7e + CR 701.3b/c: bump the attachment's timestamp when it becomes
-    // attached (first attach) or moves to a different host. A no-op re-attach to
-    // the host it's already on (CR 701.3b) issues no new timestamp. Read the
-    // UNFILTERED prior host — `old_target` above collapses both first-attach and
-    // same-host re-attach to `None`, so it cannot distinguish them.
+    // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host once. The timestamp
+    // bump (below) must distinguish first-attach (None) from a same-host re-attach
+    // (Some(host)); `old_target` collapses both to `None` and cannot. `old_target`
+    // is just the filtered view, so derive it from the single read rather than
+    // querying the attachment's host twice.
     let prior_host = current_attachment_target(state, attachment_id);
+    let old_target = prior_host.filter(|target| *target != TargetRef::Object(target_id));
 
     // CR 701.3a: Attaching moves attachment onto target.
     // If already attached to something, detach first. We only need to clear an
@@ -680,13 +678,12 @@ pub fn attach_to_player(
         return None;
     }
 
-    let old_target = current_attachment_target(state, attachment_id)
-        .filter(|target| *target != TargetRef::Player(target_player));
-
-    // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host so a first-attach
+    // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host once so a first-attach
     // (None) and a same-player re-attach (Some(player)) are distinguishable —
-    // `old_target` above collapses both to `None`.
+    // `old_target` collapses both to `None`. Derive the filtered view from the
+    // single read rather than querying the attachment's host twice.
     let prior_host = current_attachment_target(state, attachment_id);
+    let old_target = prior_host.filter(|target| *target != TargetRef::Player(target_player));
 
     // CR 701.3a: If already attached to an object, detach from that object's
     // `attachments` list. Re-attaching to a player has no symmetric cleanup —

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -428,6 +428,13 @@ pub fn attach_to(
     let old_target = current_attachment_target(state, attachment_id)
         .filter(|target| *target != TargetRef::Object(target_id));
 
+    // CR 613.7e + CR 701.3b/c: bump the attachment's timestamp when it becomes
+    // attached (first attach) or moves to a different host. A no-op re-attach to
+    // the host it's already on (CR 701.3b) issues no new timestamp. Read the
+    // UNFILTERED prior host — `old_target` above collapses both first-attach and
+    // same-host re-attach to `None`, so it cannot distinguish them.
+    let prior_host = current_attachment_target(state, attachment_id);
+
     // CR 701.3a: Attaching moves attachment onto target.
     // If already attached to something, detach first. We only need to clear an
     // Object host's `attachments` list — a Player host has no such list.
@@ -447,6 +454,15 @@ pub fn attach_to(
     // (`attach_to_player`).
     if let Some(attachment) = state.objects.get_mut(&attachment_id) {
         attachment.attached_to = Some(target_id.into());
+    }
+
+    // CR 613.7e + CR 701.3c: first attach (None) or a move to a different host
+    // bumps the timestamp; a same-host re-attach (CR 701.3b) does not.
+    if prior_host != Some(TargetRef::Object(target_id)) {
+        let ts = state.next_timestamp();
+        if let Some(attachment) = state.objects.get_mut(&attachment_id) {
+            attachment.timestamp = ts;
+        }
     }
 
     // Add to target's attachments list
@@ -667,6 +683,11 @@ pub fn attach_to_player(
     let old_target = current_attachment_target(state, attachment_id)
         .filter(|target| *target != TargetRef::Player(target_player));
 
+    // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host so a first-attach
+    // (None) and a same-player re-attach (Some(player)) are distinguishable —
+    // `old_target` above collapses both to `None`.
+    let prior_host = current_attachment_target(state, attachment_id);
+
     // CR 701.3a: If already attached to an object, detach from that object's
     // `attachments` list. Re-attaching to a player has no symmetric cleanup —
     // the previous Player host has no list to clear.
@@ -682,6 +703,15 @@ pub fn attach_to_player(
 
     if let Some(attachment) = state.objects.get_mut(&attachment_id) {
         attachment.attached_to = Some(AttachTarget::Player(target_player));
+    }
+
+    // CR 613.7e + CR 701.3c: first attach (None) or a move to a different player
+    // host bumps the timestamp; a same-player re-attach (CR 701.3b) does not.
+    if prior_host != Some(TargetRef::Player(target_player)) {
+        let ts = state.next_timestamp();
+        if let Some(attachment) = state.objects.get_mut(&attachment_id) {
+            attachment.timestamp = ts;
+        }
     }
 
     crate::game::layers::mark_layers_full(state);
@@ -931,6 +961,56 @@ mod tests {
         assert_eq!(
             state.objects.get(&creature).unwrap().attachments,
             vec![sword, shield]
+        );
+    }
+
+    /// E1: re-attaching Equipment to a DIFFERENT host issues a new timestamp on
+    /// each attach — CR 613.7e (first attach) then CR 701.3c (move to a
+    /// different host). Reverting Step 2 leaves the timestamp at 0 throughout,
+    /// so both strict-increase asserts fail.
+    #[test]
+    fn reattach_to_different_host_bumps_timestamp() {
+        let mut state = setup();
+        let sword = spawn_with_subtype(&mut state, "Sword", "Equipment");
+        let bear_a = spawn_creature(&mut state, "Bear A");
+        let bear_b = spawn_creature(&mut state, "Bear B");
+
+        let ts_initial = state.objects[&sword].timestamp;
+
+        attach_to(&mut state, sword, bear_a);
+        let ts_after_a = state.objects[&sword].timestamp;
+        assert!(
+            ts_after_a > ts_initial,
+            "first attach must issue a new timestamp (CR 613.7e)"
+        );
+
+        attach_to(&mut state, sword, bear_b);
+        let ts_after_b = state.objects[&sword].timestamp;
+        assert!(
+            ts_after_b > ts_after_a,
+            "moving to a different host must issue a new timestamp (CR 701.3c)"
+        );
+    }
+
+    /// E2: re-attaching to the SAME host issues no new timestamp — CR 701.3b
+    /// (the effect does nothing). This row discriminates the LOW-1 fix: the gate
+    /// reads the UNFILTERED prior host, so a same-host re-attach is recognized as
+    /// a no-op. Reverting to the filtered `old_target` local collapses the
+    /// same-host case to `None`, which compares unequal and would bump.
+    #[test]
+    fn reattach_to_same_host_does_not_bump_timestamp() {
+        let mut state = setup();
+        let sword = spawn_with_subtype(&mut state, "Sword", "Equipment");
+        let bear = spawn_creature(&mut state, "Bear");
+
+        attach_to(&mut state, sword, bear);
+        let ts_after_first = state.objects[&sword].timestamp;
+
+        attach_to(&mut state, sword, bear);
+        let ts_after_second = state.objects[&sword].timestamp;
+        assert_eq!(
+            ts_after_first, ts_after_second,
+            "re-attaching to the same host must not issue a new timestamp (CR 701.3b)"
         );
     }
 

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -431,6 +431,10 @@ pub fn attach_to(
     // is just the filtered view, so derive it from the single read rather than
     // querying the attachment's host twice.
     let prior_host = current_attachment_target(state, attachment_id);
+    // Discriminate the timestamp bump (below) before `filter` consumes `prior_host`:
+    // `==` borrows, `Option::filter` moves. True on first-attach (None) or a move to a
+    // different host; false only on a same-host re-attach (CR 701.3b keeps the stamp).
+    let moving_to_new_host = prior_host != Some(TargetRef::Object(target_id));
     let old_target = prior_host.filter(|target| *target != TargetRef::Object(target_id));
 
     // CR 701.3a: Attaching moves attachment onto target.
@@ -456,7 +460,7 @@ pub fn attach_to(
 
     // CR 613.7e + CR 701.3c: first attach (None) or a move to a different host
     // bumps the timestamp; a same-host re-attach (CR 701.3b) does not.
-    if prior_host != Some(TargetRef::Object(target_id)) {
+    if moving_to_new_host {
         let ts = state.next_timestamp();
         if let Some(attachment) = state.objects.get_mut(&attachment_id) {
             attachment.timestamp = ts;
@@ -683,6 +687,10 @@ pub fn attach_to_player(
     // `old_target` collapses both to `None`. Derive the filtered view from the
     // single read rather than querying the attachment's host twice.
     let prior_host = current_attachment_target(state, attachment_id);
+    // Discriminate the timestamp bump (below) before `filter` consumes `prior_host`:
+    // `==` borrows, `Option::filter` moves. True on first-attach (None) or a move to a
+    // different player; false only on a same-player re-attach (CR 701.3b keeps the stamp).
+    let moving_to_new_host = prior_host != Some(TargetRef::Player(target_player));
     let old_target = prior_host.filter(|target| *target != TargetRef::Player(target_player));
 
     // CR 701.3a: If already attached to an object, detach from that object's
@@ -704,7 +712,7 @@ pub fn attach_to_player(
 
     // CR 613.7e + CR 701.3c: first attach (None) or a move to a different player
     // host bumps the timestamp; a same-player re-attach (CR 701.3b) does not.
-    if prior_host != Some(TargetRef::Player(target_player)) {
+    if moving_to_new_host {
         let ts = state.next_timestamp();
         if let Some(attachment) = state.objects.get_mut(&attachment_id) {
             attachment.timestamp = ts;

--- a/crates/engine/src/game/effects/conjure.rs
+++ b/crates/engine/src/game/effects/conjure.rs
@@ -95,6 +95,13 @@ pub fn resolve(
                 destination,
             );
 
+            // CR 613.7d: an object receives a timestamp when it enters a zone.
+            // Stage 2 stamps battlefield entries only, so only draw one when the
+            // conjured card lands on the battlefield. Drawn before the `get_mut`
+            // borrow (`next_timestamp` takes `&mut self`).
+            let entry_timestamp =
+                (destination == Zone::Battlefield).then(|| state.next_timestamp());
+
             if let Some(obj) = state.objects.get_mut(&obj_id) {
                 // Conjured cards are real cards, not tokens.
                 obj.is_token = false;
@@ -119,7 +126,10 @@ pub fn resolve(
                     // battlefield entry — otherwise a conjured creature could attack or
                     // tap for {T} costs the turn it appears. Delegate to the single
                     // authority rather than setting flags ad hoc.
-                    obj.reset_for_battlefield_entry(state.turn_number);
+                    obj.reset_for_battlefield_entry(
+                        state.turn_number,
+                        entry_timestamp.expect("battlefield entry draws a timestamp"),
+                    );
 
                     // Apply tapped state for "onto the battlefield tapped" patterns.
                     if tapped {

--- a/crates/engine/src/game/effects/gift_delivery.rs
+++ b/crates/engine/src/game/effects/gift_delivery.rs
@@ -164,9 +164,13 @@ fn create_gift_token(
         obj.base_card_types = card_type;
     }
 
+    // CR 613.7d: the gift token enters the battlefield, so it receives a
+    // timestamp. Drawn before the `get_mut` (`next_timestamp` takes `&mut self`).
+    let entry_timestamp = state.next_timestamp();
+
     // CR 400.7 + CR 302.6 + CR 603.6a: Single authority for ETB state.
     if let Some(obj) = state.objects.get_mut(&obj_id) {
-        obj.reset_for_battlefield_entry(state.turn_number);
+        obj.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
     }
 
     crate::game::layers::mark_layers_full(state);

--- a/crates/engine/src/game/effects/incubate.rs
+++ b/crates/engine/src/game/effects/incubate.rs
@@ -44,6 +44,10 @@ pub fn resolve(
         Zone::Battlefield,
     );
 
+    // CR 613.7d: the Incubator token enters the battlefield, so it receives a
+    // timestamp. Drawn before the `get_mut` (`next_timestamp` takes `&mut self`).
+    let entry_timestamp = state.next_timestamp();
+
     if let Some(obj) = state.objects.get_mut(&obj_id) {
         obj.is_token = true;
         obj.display_source = DisplaySource::Token;
@@ -57,7 +61,7 @@ pub fn resolve(
         obj.color = vec![];
         obj.base_color = vec![];
         // CR 400.7 + CR 302.6: Single authority for ETB state.
-        obj.reset_for_battlefield_entry(state.turn_number);
+        obj.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
     }
 
     // CR 701.53a: The Incubator enters with N +1/+1 counters.

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -682,6 +682,10 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
             Zone::Battlefield,
         );
 
+        // CR 613.7d: a token enters the battlefield, so it receives a timestamp.
+        // Drawn before the `get_mut` borrow (`next_timestamp` takes `&mut self`).
+        let entry_timestamp = state.next_timestamp();
+
         if let Some(obj) = state.objects.get_mut(&obj_id) {
             // CR 111.1: Mark as token for SBA cleanup (CR 704.5d)
             obj.is_token = true;
@@ -718,7 +722,7 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
             // (summoning sickness, echo, damage, loyalty-activated flags).
             // Delegate to the single authority for summoning sickness and
             // related transient flags rather than setting them ad-hoc.
-            obj.reset_for_battlefield_entry(state.turn_number);
+            obj.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
             obj.tapped = enter_tapped.resolve(spec.tapped);
 
             // CR 113.3d + CR 613.1: Apply static abilities from the token

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -462,6 +462,10 @@ pub(crate) fn apply_copy_token_after_replacement(
             Zone::Battlefield,
         );
 
+        // CR 613.7d: a copy token enters the battlefield, so it receives a
+        // timestamp. Drawn before the `get_mut` (`next_timestamp` takes `&mut self`).
+        let entry_timestamp = state.next_timestamp();
+
         let token = state.objects.get_mut(&token_id).unwrap();
         token.is_token = true;
         token.display_source = display_source;
@@ -499,7 +503,7 @@ pub(crate) fn apply_copy_token_after_replacement(
         // CR 400.7 + CR 302.6: Single authority for ETB state. Haste granted
         // below via `extra_keywords` (Twinflame, etc.) is folded in at query
         // time by `has_summoning_sickness`.
-        token.reset_for_battlefield_entry(state.turn_number);
+        token.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
 
         // CR 707.2 + CR 702: "except it has [keyword]" — grant additional
         // keywords on top of the copied characteristics. Twinflame's haste

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1450,11 +1450,15 @@ impl GameObject {
     /// CR 400.7: Reset transient battlefield state when a permanent enters the battlefield.
     /// A permanent entering the battlefield is a new object with no memory of its previous
     /// existence. Callers that need enter_tapped=true override `tapped` after this call.
-    pub fn reset_for_battlefield_entry(&mut self, turn_number: u32) {
+    pub fn reset_for_battlefield_entry(&mut self, turn_number: u32, timestamp: u64) {
         // CR 400.7: This (re-)entry creates a new object at the same storage id.
         // Bump the incarnation so self-references captured by abilities created
         // for the previous incarnation no longer match this permanent.
         self.incarnation += 1;
+        // CR 613.7d: an object receives a timestamp when it enters a zone. Stage 2
+        // stamps battlefield entries only; all-zone entry stamping (graveyard/exile-
+        // functioning statics) is a deferred hook (see scope boundary).
+        self.timestamp = timestamp;
         self.base_controller = Some(self.owner);
         self.controller = self.owner;
         self.entered_battlefield_turn = Some(turn_number);

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1444,6 +1444,61 @@ fn derive_suspected_abilities(obj: &mut crate::game::game_object::GameObject) {
     }
 }
 
+/// CR 613.1 + CR 707.2 + CR 708.2: seed live characteristics from base_*; shared
+/// by Step-1 top-of-pass reset and the CR 613.2b Layer-1b face-down re-seed.
+///
+/// Assigns the live copiable-characteristic fields from their `base_*` baseline,
+/// exactly mirroring the Step-1 reset block field-for-field. Does NOT call
+/// `sync_missing_base_characteristics`, and does NOT touch controller, the
+/// combat-assignment flags, or `derive_suspected_abilities` — those stay inline
+/// in Step 1 (they are not part of the face-down CR 708.2a re-seed).
+fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameObject) {
+    obj.name = obj.base_name.clone();
+    obj.power = obj.base_power;
+    obj.toughness = obj.base_toughness;
+    obj.loyalty = obj.base_loyalty;
+    obj.card_types = obj.base_card_types.clone();
+    obj.mana_cost = obj.base_mana_cost.clone();
+    obj.keywords = obj.base_keywords.clone();
+    // CR 613.1: Reset live ability fields to the printed-card baseline.
+    // Post Commit 2 of Arc-share migration: both sides are `Arc<Vec<T>>`
+    // (via `Definitions<T>`-holds-`Arc`), so this reset is a refcount
+    // bump — no deep copy of ability data per layer pass per permanent.
+    // Subsequent layer effects that mutate `obj.abilities` / definitions
+    // trigger copy-on-write via `Arc::make_mut`.
+    obj.abilities = Arc::clone(&obj.base_abilities);
+    obj.trigger_definitions = Arc::clone(&obj.base_trigger_definitions).into();
+    obj.replacement_definitions = Arc::clone(&obj.base_replacement_definitions).into();
+    obj.static_definitions = Arc::clone(&obj.base_static_definitions).into();
+    obj.color = obj.base_color.clone();
+    // Reset the display-identity pointer to its baseline; the Copy layer
+    // re-applies the copied source's `printed_ref` below for objects
+    // under a copy effect, so a temporary copy's art reverts on expiry.
+    obj.printed_ref = obj.base_printed_ref.clone();
+    // Reset display routing to the object's own derived baseline so a
+    // copy effect's override (set by `CopyValues` below) reverts on
+    // expiry. Display routing is derived state, not a copiable value
+    // (CR 707.2): a true token — created by a token-making effect
+    // (CR 111.1), so carrying no printed identity — routes to the token
+    // art database; everything else (a real card, or a token-copy *of a
+    // real card*, which carries `base_printed_ref`) routes to the card
+    // database. Deriving here (rather than storing a `base_display_source`)
+    // keeps tokens in pre-existing saved states correct on load.
+    obj.display_source = if obj.is_token && obj.base_printed_ref.is_none() {
+        DisplaySource::Token
+    } else {
+        DisplaySource::Card
+    };
+    // A nontoken never has its own token-art pointer, so clear it to its
+    // baseline (`None`); a copy-of-token effect re-applies the source
+    // token's `token_image_ref` below while active. A true token keeps
+    // its own pointer (its baseline), which the copy layer overrides only
+    // while it is copying another object.
+    if !obj.is_token {
+        obj.token_image_ref = None;
+    }
+}
+
 /// Unconditional full layer evaluation (CR 613.1).
 ///
 /// Production code must NOT call this directly — go through [`flush_layers`],
@@ -1484,52 +1539,15 @@ pub fn evaluate_layers(state: &mut GameState) {
     // remains intact; they are frozen until phase-in marks layers dirty and
     // re-includes them.
     let bf_ids: Vec<ObjectId> = state.battlefield_phased_in_ids();
+    // CR 613.2b: collect face-down permanents to re-apply their CR 708.2 profile
+    // after Layer 1a.
+    let mut face_down_ids: Vec<ObjectId> = Vec::new();
     for &id in &bf_ids {
         if let Some(obj) = state.objects.get_mut(&id) {
             obj.sync_missing_base_characteristics();
-            obj.name = obj.base_name.clone();
-            obj.power = obj.base_power;
-            obj.toughness = obj.base_toughness;
-            obj.loyalty = obj.base_loyalty;
-            obj.card_types = obj.base_card_types.clone();
-            obj.mana_cost = obj.base_mana_cost.clone();
-            obj.keywords = obj.base_keywords.clone();
-            // CR 613.1: Reset live ability fields to the printed-card baseline.
-            // Post Commit 2 of Arc-share migration: both sides are `Arc<Vec<T>>`
-            // (via `Definitions<T>`-holds-`Arc`), so this reset is a refcount
-            // bump — no deep copy of ability data per layer pass per permanent.
-            // Subsequent layer effects that mutate `obj.abilities` / definitions
-            // trigger copy-on-write via `Arc::make_mut`.
-            obj.abilities = Arc::clone(&obj.base_abilities);
-            obj.trigger_definitions = Arc::clone(&obj.base_trigger_definitions).into();
-            obj.replacement_definitions = Arc::clone(&obj.base_replacement_definitions).into();
-            obj.static_definitions = Arc::clone(&obj.base_static_definitions).into();
-            obj.color = obj.base_color.clone();
-            // Reset the display-identity pointer to its baseline; the Copy layer
-            // re-applies the copied source's `printed_ref` below for objects
-            // under a copy effect, so a temporary copy's art reverts on expiry.
-            obj.printed_ref = obj.base_printed_ref.clone();
-            // Reset display routing to the object's own derived baseline so a
-            // copy effect's override (set by `CopyValues` below) reverts on
-            // expiry. Display routing is derived state, not a copiable value
-            // (CR 707.2): a true token — created by a token-making effect
-            // (CR 111.1), so carrying no printed identity — routes to the token
-            // art database; everything else (a real card, or a token-copy *of a
-            // real card*, which carries `base_printed_ref`) routes to the card
-            // database. Deriving here (rather than storing a `base_display_source`)
-            // keeps tokens in pre-existing saved states correct on load.
-            obj.display_source = if obj.is_token && obj.base_printed_ref.is_none() {
-                DisplaySource::Token
-            } else {
-                DisplaySource::Card
-            };
-            // A nontoken never has its own token-art pointer, so clear it to its
-            // baseline (`None`); a copy-of-token effect re-applies the source
-            // token's `token_image_ref` below while active. A true token keeps
-            // its own pointer (its baseline), which the copy layer overrides only
-            // while it is copying another object.
-            if !obj.is_token {
-                obj.token_image_ref = None;
+            seed_live_characteristics_from_base(obj);
+            if obj.face_down {
+                face_down_ids.push(id);
             }
             // CR 613.1b: Reset controller to the object's base controller;
             // Layer 2 re-applies continuous control-changing effects.
@@ -1591,6 +1609,18 @@ pub fn evaluate_layers(state: &mut GameState) {
         // gather so those sticker-granted statics participate in this pass
         // without broadening the non-sticker top-of-pass rebuild contract.
         crate::types::game_state::StaticSourceIndex::rebuild_from_state(state);
+    }
+
+    // CR 613.2b + CR 708.2a + CR 708.10: Layer 1b. After Layer-1a copiable effects
+    // (copy per CR 707, merge per CR 730) are applied, re-set each face-down
+    // permanent's characteristics to its CR 708.2a profile (persisted in base_*),
+    // overriding the copy/merge. A Mirrorweaved/cloned face-down permanent stays a
+    // face-down 2/2 (or its FaceDownProfile, e.g. disguise/cloak ward {2}). Scoped to
+    // the collected face-down set so the common (no face-down) case is free.
+    for &id in &face_down_ids {
+        if let Some(obj) = state.objects.get_mut(&id) {
+            seed_live_characteristics_from_base(obj);
+        }
     }
 
     // Step 3: Gather active continuous effects after layer 1 is applied.
@@ -14958,6 +14988,245 @@ mod tests {
         assert!(
             !r.has_keyword(&Keyword::Indestructible),
             "Mono-R creature must NOT gain indestructible"
+        );
+    }
+
+    // ── CR 613.2b Layer 1b: face-down characteristics override copy/merge ─────
+
+    use crate::game::effects::become_copy;
+    use crate::game::morph::apply_face_down_creature_characteristics;
+    use crate::game::printed_cards::intrinsic_copiable_values;
+    use crate::types::ability::{FaceDownProfile, ResolvedAbility, TargetRef};
+    use crate::types::keywords::WardCost;
+
+    fn make_face_down(
+        state: &mut GameState,
+        player: PlayerId,
+        profile: FaceDownProfile,
+        real_name: &str,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(0),
+            player,
+            real_name.to_string(),
+            Zone::Battlefield,
+        );
+        // Snapshot the real face BEFORE overwriting it, so the controller view
+        // can reveal the hidden card while observers see "Hidden Card".
+        let back = crate::game::printed_cards::snapshot_object_face(&state.objects[&id]);
+        let obj = state.objects.get_mut(&id).unwrap();
+        apply_face_down_creature_characteristics(obj, &profile);
+        obj.back_face = Some(back);
+        id
+    }
+
+    fn become_copy_ability(
+        target: ObjectId,
+        source: ObjectId,
+        player: PlayerId,
+    ) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::BecomeCopy {
+                target: TargetFilter::Any,
+                duration: None,
+                mana_value_limit: None,
+                additional_modifications: Vec::new(),
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            player,
+        )
+    }
+
+    // Plan test 1: Mirrorweave (BecomeCopy) onto a face-down morph must leave it a
+    // face-down 2/2 — its CR 708.2a profile overrides the Layer-1a copy at Layer 1b
+    // (CR 613.2b + CR 708.10).
+    #[test]
+    fn mirrorweave_onto_face_down_stays_2_2() {
+        let mut state = setup();
+        let player = PlayerId(0);
+        let beast = make_creature(&mut state, "Big Beast", 4, 5, player);
+        let morph = make_face_down(
+            &mut state,
+            player,
+            FaceDownProfile::vanilla_2_2(),
+            "Secret Bear",
+        );
+
+        let mut events = Vec::new();
+        become_copy::resolve(
+            &mut state,
+            &become_copy_ability(beast, morph, player),
+            &mut events,
+        )
+        .unwrap();
+        evaluate_layers(&mut state);
+
+        let m = &state.objects[&morph];
+        assert_eq!(
+            m.power,
+            Some(2),
+            "Layer 1b re-seeds the face-down 2/2 over the copy"
+        );
+        assert_eq!(m.toughness, Some(2));
+        assert_eq!(m.name, "", "a face-down permanent has no name (CR 708.2a)");
+        assert!(m.face_down);
+
+        // SIBLING: a face-up creature under the same BecomeCopy DOES become the copy.
+        let clone = make_creature(&mut state, "Plain Clone", 1, 1, player);
+        become_copy::resolve(
+            &mut state,
+            &become_copy_ability(beast, clone, player),
+            &mut events,
+        )
+        .unwrap();
+        evaluate_layers(&mut state);
+        let c = &state.objects[&clone];
+        assert_eq!(
+            c.name, "Big Beast",
+            "a face-up creature still becomes the copy"
+        );
+        assert_eq!(c.power, Some(4));
+        assert_eq!(c.toughness, Some(5));
+    }
+
+    // Plan test 2: a cloaked (ward {2}) face-down permanent that becomes a copy of
+    // a creature with no ward retains ward {2} — Layer 1b re-seeds its CR 708.2a
+    // profile (CR 708.10).
+    #[test]
+    fn cloaked_face_down_retains_ward_under_copy() {
+        let mut state = setup();
+        let player = PlayerId(0);
+        let bear = make_creature(&mut state, "Bear", 2, 2, player);
+        let cloaked = make_face_down(
+            &mut state,
+            player,
+            FaceDownProfile::cloaked_2_2(),
+            "Secret Ace",
+        );
+        let ward = Keyword::Ward(WardCost::Mana(ManaCost::generic(2)));
+
+        let mut events = Vec::new();
+        become_copy::resolve(
+            &mut state,
+            &become_copy_ability(bear, cloaked, player),
+            &mut events,
+        )
+        .unwrap();
+        evaluate_layers(&mut state);
+
+        assert!(
+            state.objects[&cloaked].keywords.contains(&ward),
+            "Layer 1b re-seeds the cloak ward {{2}} over the copy (CR 708.10)"
+        );
+        // NEGATIVE: the copy source (Bear) has no ward — the ward comes from the
+        // face-down re-seed, not the copied creature.
+        assert!(!state.objects[&bear].keywords.contains(&ward));
+    }
+
+    // Plan test 3: a raw CopyValues transient on a face-down object is overridden
+    // by Layer 1b (live == base_*); the same copy on a non-face-down object still
+    // applies (Layer 1b is a no-op when nothing is face down).
+    #[test]
+    fn layer_1b_overrides_copy_for_face_down_object() {
+        let mut state = setup();
+        let player = PlayerId(0);
+        let donor = make_creature(&mut state, "Donor", 7, 7, player);
+        let donor_values = intrinsic_copiable_values(&state.objects[&donor]);
+        let fd = make_face_down(&mut state, player, FaceDownProfile::vanilla_2_2(), "Hidden");
+
+        state.add_transient_continuous_effect(
+            fd,
+            player,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: fd },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(donor_values),
+                display_source: crate::game::game_object::DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+        evaluate_layers(&mut state);
+
+        let o = &state.objects[&fd];
+        assert_eq!(o.power, o.base_power, "Layer 1b restores live to base_*");
+        assert_eq!(o.power, Some(2));
+        assert_eq!(o.name, "");
+
+        // EMPTY-SET: a fresh state with NO face-down objects — Layer 1b is a no-op
+        // and a normal copy applies unchanged.
+        let mut state2 = setup();
+        let donor2 = make_creature(&mut state2, "Donor", 7, 7, player);
+        let donor_values2 = intrinsic_copiable_values(&state2.objects[&donor2]);
+        let plain = make_creature(&mut state2, "Plain", 1, 1, player);
+        state2.add_transient_continuous_effect(
+            plain,
+            player,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: plain },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(donor_values2),
+                display_source: crate::game::game_object::DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+        evaluate_layers(&mut state2);
+        assert_eq!(
+            state2.objects[&plain].power,
+            Some(7),
+            "non-face-down copy still applies (1b no-op)"
+        );
+        assert_eq!(state2.objects[&plain].name, "Donor");
+    }
+
+    // Plan test 7: after a Mirrorweave onto a face-down morph, an opponent sees a
+    // hidden 2/2 (not the copied identity), while the controller still sees the
+    // real back-face name. The redacted power must be the face-down 2/2, proving
+    // Layer 1b hid the copy from observers.
+    #[test]
+    fn opponent_sees_hidden_2_2_not_copied_identity() {
+        use crate::game::visibility::filter_state_for_viewer;
+
+        let mut state = setup();
+        let controller = PlayerId(0);
+        let opponent = PlayerId(1);
+        let beast = make_creature(&mut state, "Big Beast", 4, 5, controller);
+        let morph = make_face_down(
+            &mut state,
+            controller,
+            FaceDownProfile::vanilla_2_2(),
+            "Secret Bear",
+        );
+
+        let mut events = Vec::new();
+        become_copy::resolve(
+            &mut state,
+            &become_copy_ability(beast, morph, controller),
+            &mut events,
+        )
+        .unwrap();
+        evaluate_layers(&mut state);
+
+        let opp_view = filter_state_for_viewer(&state, opponent);
+        let opp = opp_view.objects.get(&morph).unwrap();
+        assert_eq!(opp.name, "Hidden Card");
+        assert_eq!(
+            opp.power,
+            Some(2),
+            "opponent sees the face-down 2/2, not the copied 4/5"
+        );
+        assert!(opp.face_down);
+
+        let ctrl_view = filter_state_for_viewer(&state, controller);
+        let ctrl = ctrl_view.objects.get(&morph).unwrap();
+        assert_eq!(
+            ctrl.name, "Secret Bear",
+            "the controller still sees the real back-face identity"
         );
     }
 }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2662,6 +2662,14 @@ pub(crate) fn active_continuous_effects_from_static_source(
     state: &GameState,
     source: &crate::game::game_object::GameObject,
 ) -> Vec<ActiveContinuousEffect> {
+    // CR 613.7n: a static ability's continuous effect inherits `source.timestamp`,
+    // which is the object's battlefield-entry timestamp drawn in `move_to_zone`
+    // (zones.rs) when the object is put onto the battlefield. When a resolving
+    // spell/ability puts an object onto the battlefield and sets its
+    // characteristics (CR 611.2e), the entry timestamp is drawn first, then that
+    // same resolution emits its characteristic-setting transient, which draws a
+    // strictly later `next_timestamp()`. So the object's own static receives the
+    // earlier relative timestamp by construction — no explicit tiebreak needed.
     active_continuous_effects_from_static_definitions(
         state,
         source.id,
@@ -2854,8 +2862,8 @@ fn expand_granted_static_effects(
         ) {
             continue;
         }
-        let recipient_controller = match state.objects.get(&recipient_id) {
-            Some(obj) => obj.controller,
+        let (recipient_controller, recipient_timestamp) = match state.objects.get(&recipient_id) {
+            Some(obj) => (obj.controller, obj.timestamp),
             None => continue,
         };
         // CR 109.5 + CR 113.7: "You" inside the granted ability refers to the
@@ -2884,9 +2892,15 @@ fn expand_granted_static_effects(
                 transient_id: None,
                 mod_index,
                 layer: modification.layer(),
-                // Inherit the host's timestamp so ordering within a layer is
-                // stable and reproducible per CR 613.7.
-                timestamp: host_timestamp,
+                // CR 613.7a (1st sentence): a granted static ability's continuous
+                // effect uses the later of the recipient's timestamp and the
+                // granting effect's (host) timestamp. Because these effects are
+                // re-synthesized every layer pass, a recipient that later receives a
+                // new timestamp (transform/face-up/re-attach) automatically
+                // re-stamps here on the next pass. The cross-grant relative-order
+                // preservation clause (multiple granted statics on one recipient) is
+                // deferred — unobservable with current cards.
+                timestamp: host_timestamp.max(recipient_timestamp),
                 modification: modification.clone(),
                 affected_filter: inner_affected.clone(),
                 condition: retained_inner_condition.clone(),
@@ -3518,6 +3532,15 @@ fn order_with_dependencies(
         }
     }
 
+    // CR 613.8c (tracking): the rule requires the order of remaining effects to be
+    // RE-EVALUATED after each effect is applied (an unapplied effect may become
+    // dependent on / independent of other unapplied effects). This is NOT
+    // implemented: the dependency graph above is computed ONCE and the Kahn pass
+    // below consumes that fixed graph without re-running `depends_on` between
+    // applications. Impact is zero today because `depends_on` is state-blind (see
+    // its doc comment) — its answers cannot change mid-pass, so compute-once equals
+    // iterative re-evaluation. This re-evaluation MUST be added if/when `depends_on`
+    // becomes state-aware (the two are coupled).
     let mut ordered = Vec::with_capacity(sorted.len());
     let mut processed = vec![false; sorted.len()];
 
@@ -3525,6 +3548,13 @@ fn order_with_dependencies(
         let Some(next) = (0..sorted.len()).find(|&idx| !processed[idx] && in_degree[idx] == 0)
         else {
             // CR 613.8b: Dependency cycle — fall back to timestamp ordering.
+            // CR 613.8b (tracking): the rule reverts ONLY the effects that are IN
+            // the dependency loop to timestamp order, leaving non-loop dependent
+            // effects ordered normally. This implementation is coarser: on ANY
+            // cycle it reverts the WHOLE layer bucket (`sorted`) to timestamp
+            // order. Deferred and unreachable today — no current card forms a
+            // dependency loop under the state-blind `depends_on` (see its doc
+            // comment), so the loop-only-vs-whole-bucket distinction is unobservable.
             return sorted.iter().map(|effect| (*effect).clone()).collect();
         };
 
@@ -3553,6 +3583,23 @@ pub(crate) fn order_active_continuous_effects(
 
 /// Check if effect `a` depends on effect `b`.
 /// If `b` changes types and `a`'s filter is type-based, `a` depends on `b`.
+///
+/// CR 613.8a (tracking): this is a SHAPE-based approximation of the rule's
+/// "depend on" relation, deliberately state-blind (note the unused `_state`). It
+/// keys off the static structure of `b`'s modification kind and `a`'s filter
+/// shape rather than asking whether applying `b` would actually change the text,
+/// existence, what-it-applies-to, or what-it-does of `a` in the current state.
+/// This makes it both over-broad (any type/ability/PT change is treated as a
+/// dependency whenever `a`'s filter merely references that axis, even if `b` can't
+/// change `a`'s membership) and under-broad (it ignores existence/value/color
+/// dependencies the rule covers). It is nonetheless correct for every current
+/// card because, being state-blind, the predicate is invariant across an apply
+/// pass, so the dependency order computed once equals the order an iterative
+/// re-evaluation would produce — i.e. it reduces to timestamp order with the same
+/// observable result. Upgrading this to a state-aware predicate REQUIRES the
+/// CR 613.8c re-evaluation fix in `order_with_dependencies` (the two are coupled):
+/// a state-aware `depends_on` would change its answers as effects are applied, so
+/// a single Kahn pass would no longer be sound.
 fn depends_on(a: &ActiveContinuousEffect, b: &ActiveContinuousEffect, _state: &GameState) -> bool {
     // CR 613.7a + CR 613.8a: A single static ability's modifications share one
     // timestamp and apply in the order written (613.7a). "Depend on" (613.8a) is a
@@ -14348,6 +14395,97 @@ mod tests {
         assert!(
             !opc.has_keyword(&Keyword::Lifelink),
             "Opponent commander no lifelink"
+        );
+    }
+
+    /// CR 613.7a (1st sentence): a granted static ability's continuous effect uses
+    /// the LATER of the host (granting effect) timestamp and the recipient's own
+    /// timestamp. This test drives the real `evaluate_layers` → `apply_layers` →
+    /// `expand_granted_static_effects` path and discriminates the fix: it is the
+    /// case where the recipient acquires a timestamp LATER than the host after the
+    /// grant is established, with a competing same-sublayer setter whose timestamp
+    /// falls strictly between them.
+    ///
+    /// Timestamps: host (grantor) = 10, competing setter = 20, recipient = 30
+    /// (re-stamped later than the host, as happens on transform/face-up/re-attach).
+    /// The host grants `SetPower {1}` to the recipient; the competing static sets
+    /// the recipient's power to 7. Both land in the SetPT (set) sublayer, so the
+    /// later timestamp wins (last-applied-wins on a value set).
+    ///
+    /// With the fix, the granted effect's timestamp is `max(10, 30) = 30 > 20`, so
+    /// it applies AFTER the competing setter and the recipient's power is 1.
+    /// REVERT-FAILING ASSERTION: `assert_eq!(recipient.power, Some(1))`. On revert
+    /// to `timestamp: host_timestamp`, the granted effect uses 10 < 20, applies
+    /// BEFORE the competing setter, and the recipient's power would be 7 — the
+    /// assertion flips.
+    #[test]
+    fn granted_static_timestamp_is_max_of_host_and_recipient() {
+        let mut state = setup();
+
+        // Recipient creature, re-stamped to a LATER timestamp (30) than the host —
+        // models a recipient that transforms / turns face up / is re-attached after
+        // the grant is established, so the recipient's timestamp exceeds the host's
+        // — the case CR 613.7a (1st sentence) "whichever is later" must resolve.
+        let recipient = make_creature(&mut state, "Recipient", 2, 2, PlayerId(0));
+        state.objects.get_mut(&recipient).unwrap().timestamp = 30;
+
+        // Host (grantor) at the EARLIEST timestamp (10). Its static grants an inner
+        // `SetPower {1}` static targeting the recipient via the GrantStaticAbility
+        // path that flows through `expand_granted_static_effects`.
+        let host = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let inner = StaticDefinition::continuous()
+                .affected(TargetFilter::SpecificObject { id: recipient })
+                .modifications(vec![ContinuousModification::SetPower { value: 1 }]);
+            let obj = state.objects.get_mut(&host).unwrap();
+            obj.timestamp = 10;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: recipient })
+                    .modifications(vec![ContinuousModification::GrantStaticAbility {
+                        definition: Box::new(inner),
+                    }]),
+            );
+        }
+
+        // Competing same-sublayer setter at the MIDDLE timestamp (20): sets the
+        // recipient's power to 7. Its timestamp falls strictly between the host (10)
+        // and the recipient (30).
+        let competing = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Competing Setter".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&competing).unwrap();
+            obj.timestamp = 20;
+            obj.static_definitions.push(
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::SpecificObject { id: recipient })
+                    .modifications(vec![ContinuousModification::SetPower { value: 7 }]),
+            );
+        }
+
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        let recipient_obj = state.objects.get(&recipient).unwrap();
+        // CR 613.7a (1st sentence): granted effect ts = max(host=10, recipient=30) =
+        // 30 > competing=20, so the granted `SetPower {1}` applies last and wins.
+        assert_eq!(
+            recipient_obj.power,
+            Some(1),
+            "granted SetPower must use max(host, recipient) timestamp (30) and win \
+             over the competing setter at ts=20; reverting to host_timestamp (10) \
+             would let the competing setter win with power=7"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5591,6 +5591,122 @@ mod tests {
         assert_eq!(bear_obj.toughness, Some(4));
     }
 
+    /// Creates an enchantment in hand whose static sets `victim`'s color. The
+    /// static is mirrored onto `base_static_definitions` so it survives the
+    /// layers reset once the enchantment enters. The returned ObjectId is
+    /// assigned at creation, BEFORE the enchantment enters the battlefield.
+    fn make_offboard_color_setter(
+        state: &mut GameState,
+        name: &str,
+        color: ManaColor,
+        victim: ObjectId,
+    ) -> ObjectId {
+        let id = create_object(state, CardId(0), PlayerId(0), name.to_string(), Zone::Hand);
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::SpecificObject { id: victim })
+            .modifications(vec![ContinuousModification::SetColor {
+                colors: vec![color],
+            }]);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.base_card_types = obj.card_types.clone();
+        Arc::make_mut(&mut obj.base_static_definitions).push(def.clone());
+        obj.static_definitions.push(def);
+        id
+    }
+
+    /// D1: two SAME-sublayer (layer 5 color-set) statics on permanents entered
+    /// in REVERSE ObjectId order through the real `move_to_zone` entry path. The
+    /// later-entering permanent's effect must win on its CR 613.7d timestamp,
+    /// NOT on the coincidental ObjectId tiebreak. Reverting the battlefield-entry
+    /// stamp (Step 1) leaves both timestamps at 0, collapsing the sort to
+    /// ObjectId order so the higher-id blue painter would win instead.
+    #[test]
+    fn entry_timestamp_orders_same_sublayer_color_set_by_chronology() {
+        let mut state = setup();
+        let bear = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+
+        // Lower ObjectId = red, higher ObjectId = blue.
+        let painter_red =
+            make_offboard_color_setter(&mut state, "Painter Red", ManaColor::Red, bear);
+        let painter_blue =
+            make_offboard_color_setter(&mut state, "Painter Blue", ManaColor::Blue, bear);
+        assert!(
+            painter_red.0 < painter_blue.0,
+            "red must have the lower ObjectId so chronology and ObjectId disagree"
+        );
+
+        // Enter in REVERSE ObjectId order: blue (higher id) first, red last.
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, painter_blue, Zone::Battlefield, &mut events);
+        crate::game::zones::move_to_zone(&mut state, painter_red, Zone::Battlefield, &mut events);
+
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects[&bear].color,
+            vec![ManaColor::Red],
+            "later-entering source must win same-sublayer color set (CR 613.7d)"
+        );
+    }
+
+    /// D1 negative sibling: entries in ObjectId order keep the higher-ObjectId
+    /// winner — chronology and ObjectId agree, so the result is unchanged.
+    #[test]
+    fn entry_timestamp_matches_objectid_order_when_aligned() {
+        let mut state = setup();
+        let bear = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+        let painter_red =
+            make_offboard_color_setter(&mut state, "Painter Red", ManaColor::Red, bear);
+        let painter_blue =
+            make_offboard_color_setter(&mut state, "Painter Blue", ManaColor::Blue, bear);
+
+        // Enter in ObjectId order: red (lower id) first, blue (higher id) last.
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, painter_red, Zone::Battlefield, &mut events);
+        crate::game::zones::move_to_zone(&mut state, painter_blue, Zone::Battlefield, &mut events);
+
+        evaluate_layers(&mut state);
+        assert_eq!(state.objects[&bear].color, vec![ManaColor::Blue]);
+    }
+
+    /// D2: a static continuous effect (CR 613.7d) and a resolution-generated
+    /// transient continuous effect (CR 613.7b) must interleave by true
+    /// timestamp. The transient blue is created FIRST (lower timestamp); the
+    /// static red permanent enters LATER (higher timestamp), so red wins.
+    /// Reverting Step 1 leaves the static permanent at timestamp 0, which sorts
+    /// BEFORE the transient (timestamp >= 1), so the transient blue would win.
+    #[test]
+    fn static_and_transient_color_interleave_by_true_timestamp() {
+        let mut state = setup();
+        let bear = make_creature(&mut state, "Bear", 2, 2, PlayerId(0));
+        let aux = make_creature(&mut state, "Aux", 1, 1, PlayerId(0));
+
+        // Transient SetColor blue created first -> lower timestamp.
+        state.add_transient_continuous_effect(
+            aux,
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: bear },
+            vec![ContinuousModification::SetColor {
+                colors: vec![ManaColor::Blue],
+            }],
+            None,
+        );
+
+        // Static SetColor red on a permanent entering later -> higher timestamp.
+        let painter_red =
+            make_offboard_color_setter(&mut state, "Painter Red", ManaColor::Red, bear);
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, painter_red, Zone::Battlefield, &mut events);
+
+        evaluate_layers(&mut state);
+        assert_eq!(
+            state.objects[&bear].color,
+            vec![ManaColor::Red],
+            "later-created static effect must win over the earlier transient (CR 613.7b/d chronology)"
+        );
+    }
+
     #[test]
     fn test_dependency_ordering_overrides_timestamp() {
         let mut state = setup();

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -25,9 +25,27 @@
 //! already-merged permanent extends its component stack, and the merged
 //! permanent's layer-1 copy effect is re-derived from the full stack each time.
 //!
-//! Deferred: copy effects targeting a merged permanent, face-down/DFC
-//! components, full CR 702.140d downstream reflexive effects, and the CR 730.3a
-//! graveyard/library arrange-order UI (a deterministic order is used).
+//! Face-down components (partial — CR 730.2e): handled now is the merged
+//! permanent's status following its topmost component (a face-down topmost keeps
+//! the survivor face down; a face-up topmost over a face-down component does NOT
+//! count as turning it face up, so no `TurnedFaceUp` event), and the suppression
+//! of a non-topmost face-down component's listed characteristics from the
+//! copiable-values union (a cloaked/disguised component's `base_keywords = [Ward]`
+//! is not inherited by a face-up merged permanent — CR 708.2a + CR 730.2e). Still
+//! deferred: CR 730.2f turn-up of a face-down merged permanent; full CR 702.140e
+//! reveal of a formerly-face-down bottom component's real abilities on a
+//! mutate-over; the split (CR 730.3) of a face-down merge survivor (the survivor's
+//! `base_*` holds the stale 2/2 face-down profile rather than the component's real
+//! card characteristics); and the extreme corner where a sticker placed on a
+//! face-down permanent is wiped by the Layer-1b re-seed (rules-correct per CR
+//! 708.2a — a face-down object has only its listed characteristics). Note:
+//! `apply_face_down` does not normalize `base_loyalty`/`base_defense`; that is
+//! pre-existing Step-1 reset behavior, faithfully preserved by the shared
+//! `seed_live_characteristics_from_base` helper.
+//!
+//! Deferred: copy effects targeting a merged permanent, DFC components, full CR
+//! 702.140d downstream reflexive effects, and the CR 730.3a graveyard/library
+//! arrange-order UI (a deterministic order is used).
 
 use std::sync::Arc;
 
@@ -128,6 +146,10 @@ pub fn merge_object_onto(
         }
     };
     let topmost_id = ordered[0];
+    // CR 730.2e: a merged permanent's face-down status follows its topmost
+    // component. Read it BEFORE any mutation so the survivor adopts the topmost
+    // component's face-down status while merged.
+    let topmost_is_face_down = state.objects.get(&topmost_id).is_some_and(|o| o.face_down);
 
     // Remove any previous mutate copy effect before deriving the new one, so a
     // re-merge where the survivor remains topmost reads the survivor's intrinsic
@@ -146,6 +168,11 @@ pub fn merge_object_onto(
         // guard can distinguish it from a Meld survivor (a two-creature mutate
         // also has `merged_components.len() == 2`).
         survivor.merge_kind = Some(crate::game::game_object::MergeKind::Mutate);
+        // CR 730.2e: the merged permanent's status follows its topmost component.
+        // When a face-down permanent becomes face up as a result of merging, other
+        // effects don't count it as turned face up, so no `GameEvent::TurnedFaceUp`
+        // is pushed here.
+        survivor.face_down = topmost_is_face_down;
     }
 
     // CR 730.2d: a merged permanent is a token only if its TOPMOST component is a
@@ -223,6 +250,15 @@ fn merged_copiable_values(
         let Some(obj) = state.objects.get(&component_id) else {
             continue;
         };
+        // CR 708.2a + CR 730.2e: a non-topmost face-down component carries no card
+        // abilities. Morph zeroes its base abilities/triggers/statics/replacements,
+        // but a cloaked/disguised component still holds `base_keywords = [Ward {2}]`;
+        // a face-up merged permanent must not inherit a buried face-down component's
+        // ward (or any other listed face-down characteristic). Skip non-topmost
+        // face-down components entirely from the copiable-values union.
+        if component_id != topmost_id && obj.face_down {
+            continue;
+        }
         let (abil, trig, stat, repl, kws): BaseSets = (
             obj.base_abilities.clone(),
             obj.base_trigger_definitions.clone(),
@@ -637,4 +673,189 @@ pub fn handle_mutate_merge_choice(
     Ok(crate::types::game_state::WaitingFor::Priority {
         player: state.active_player,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::layers::evaluate_layers;
+    use crate::game::morph::apply_face_down_creature_characteristics;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, FaceDownProfile, QuantityExpr, TargetFilter,
+    };
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::identifiers::CardId;
+    use crate::types::keywords::{Keyword, WardCost};
+    use crate::types::mana::ManaCost;
+    use crate::types::player::PlayerId;
+
+    fn make_creature(
+        state: &mut GameState,
+        card: u64,
+        player: PlayerId,
+        name: &str,
+        power: i32,
+        toughness: i32,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(card),
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.base_name = name.to_string();
+        obj.base_power = Some(power);
+        obj.base_toughness = Some(toughness);
+        obj.base_card_types = CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+        };
+        obj.power = Some(power);
+        obj.toughness = Some(toughness);
+        obj.card_types = obj.base_card_types.clone();
+        id
+    }
+
+    fn draw_n_ability(n: i32) -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: n },
+                target: TargetFilter::Controller,
+            },
+        )
+    }
+
+    fn set_base_abilities(state: &mut GameState, id: ObjectId, abilities: Vec<AbilityDefinition>) {
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.base_abilities = Arc::new(abilities.clone());
+        obj.abilities = Arc::new(abilities);
+    }
+
+    fn make_face_down(
+        state: &mut GameState,
+        player: PlayerId,
+        profile: FaceDownProfile,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(50),
+            player,
+            "Secret".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        apply_face_down_creature_characteristics(obj, &profile);
+        id
+    }
+
+    fn ward_2() -> Keyword {
+        Keyword::Ward(WardCost::Mana(ManaCost::generic(2)))
+    }
+
+    // Plan test 4: a creature mutated UNDER a face-down survivor — the survivor
+    // stays a face-down 2/2 with no abilities (topmost is the face-down survivor;
+    // CR 730.2e + CR 708.2a, Layer 1b re-seed).
+    #[test]
+    fn mutate_under_face_down_stays_face_down_2_2() {
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let survivor = make_face_down(&mut state, player, FaceDownProfile::vanilla_2_2());
+        let mutant = make_creature(&mut state, 1, player, "Mutant", 5, 5);
+        set_base_abilities(&mut state, mutant, vec![draw_n_ability(1)]);
+
+        let mut events = Vec::new();
+        merge_object_onto(&mut state, mutant, survivor, MergeSide::Bottom, &mut events);
+        evaluate_layers(&mut state);
+
+        let s = &state.objects[&survivor];
+        assert!(s.face_down, "topmost is the face-down survivor (CR 730.2e)");
+        assert_eq!(s.power, Some(2));
+        assert_eq!(s.toughness, Some(2));
+        assert!(
+            s.abilities.is_empty(),
+            "a face-down permanent has no abilities (CR 708.2a); Layer 1b drops the unioned mutant ability"
+        );
+
+        // SIBLING: mutate-under a FACE-UP host unions abilities normally.
+        let host = make_creature(&mut state, 2, player, "Host", 3, 3);
+        set_base_abilities(&mut state, host, vec![draw_n_ability(1)]);
+        let mutant2 = make_creature(&mut state, 3, player, "Mutant2", 5, 5);
+        set_base_abilities(&mut state, mutant2, vec![draw_n_ability(2)]);
+        merge_object_onto(&mut state, mutant2, host, MergeSide::Bottom, &mut events);
+        evaluate_layers(&mut state);
+        let h = &state.objects[&host];
+        assert!(!h.face_down);
+        assert_eq!(
+            h.abilities.len(),
+            2,
+            "a face-up merged permanent unions every component's abilities (CR 702.140e)"
+        );
+    }
+
+    // Plan test 5: a creature mutated OVER a cloaked face-down survivor clears the
+    // survivor's face-down status (topmost is face up — CR 730.2e), drops the
+    // buried ward (CR 708.2a + CR 730.2e), and emits NO TurnedFaceUp event.
+    #[test]
+    fn mutate_over_face_down_clears_face_down_drops_ward() {
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let survivor = make_face_down(&mut state, player, FaceDownProfile::cloaked_2_2());
+        assert!(state.objects[&survivor].base_keywords.contains(&ward_2()));
+        let mutant = make_creature(&mut state, 1, player, "Mutant", 5, 5);
+
+        let mut events = Vec::new();
+        merge_object_onto(&mut state, mutant, survivor, MergeSide::Top, &mut events);
+        evaluate_layers(&mut state);
+
+        let s = &state.objects[&survivor];
+        assert!(
+            !s.face_down,
+            "status follows the face-up topmost component (CR 730.2e)"
+        );
+        assert!(
+            !s.keywords.contains(&ward_2()),
+            "a face-up merged permanent does not inherit a buried face-down ward (CR 708.2a)"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::TurnedFaceUp { .. })),
+            "merging is not 'turned face up' (CR 730.2e) — no TurnedFaceUp event"
+        );
+    }
+
+    // Plan test 6: merged_copiable_values skips a non-topmost FACE-DOWN component's
+    // listed characteristics, but unions a non-topmost FACE-UP component's.
+    #[test]
+    fn merged_copiable_values_skips_non_topmost_face_down_component() {
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+
+        // Topmost face-up component carries Flying.
+        let top = make_creature(&mut state, 1, player, "Top", 3, 3);
+        state.objects.get_mut(&top).unwrap().base_keywords = vec![Keyword::Flying];
+        // Non-topmost cloaked face-down component carries ward {2}.
+        let buried = make_face_down(&mut state, player, FaceDownProfile::cloaked_2_2());
+
+        let (values, _, _, _) = merged_copiable_values(&state, &[top, buried], top).unwrap();
+        assert!(values.keywords.contains(&Keyword::Flying));
+        assert!(
+            !values.keywords.contains(&ward_2()),
+            "non-topmost face-down component's ward is suppressed (CR 708.2a + CR 730.2e)"
+        );
+
+        // NEGATIVE: a non-topmost FACE-UP component IS unioned.
+        let buried_up = make_creature(&mut state, 2, player, "BuriedUp", 1, 1);
+        state.objects.get_mut(&buried_up).unwrap().base_keywords = vec![Keyword::Trample];
+        let (values2, _, _, _) = merged_copiable_values(&state, &[top, buried_up], top).unwrap();
+        assert!(
+            values2.keywords.contains(&Keyword::Trample),
+            "a face-up non-topmost component's keywords are unioned (CR 702.140e)"
+        );
+    }
 }

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -818,7 +818,7 @@ mod tests {
             "status follows the face-up topmost component (CR 730.2e)"
         );
         assert!(
-            !s.keywords.contains(&ward_2()),
+            !s.keywords.contains(&ward_2()), // allow-raw-authority: asserts the exact post-merge keyword snapshot, not an off-zone-aware query
             "a face-up merged permanent does not inherit a buried face-down ward (CR 708.2a)"
         );
         assert!(
@@ -843,9 +843,9 @@ mod tests {
         let buried = make_face_down(&mut state, player, FaceDownProfile::cloaked_2_2());
 
         let (values, _, _, _) = merged_copiable_values(&state, &[top, buried], top).unwrap();
-        assert!(values.keywords.contains(&Keyword::Flying));
+        assert!(values.keywords.contains(&Keyword::Flying)); // allow-raw-authority: merged_copiable_values snapshot struct, not a GameObject
         assert!(
-            !values.keywords.contains(&ward_2()),
+            !values.keywords.contains(&ward_2()), // allow-raw-authority: merged_copiable_values snapshot struct, not a GameObject
             "non-topmost face-down component's ward is suppressed (CR 708.2a + CR 730.2e)"
         );
 
@@ -854,7 +854,7 @@ mod tests {
         state.objects.get_mut(&buried_up).unwrap().base_keywords = vec![Keyword::Trample];
         let (values2, _, _, _) = merged_copiable_values(&state, &[top, buried_up], top).unwrap();
         assert!(
-            values2.keywords.contains(&Keyword::Trample),
+            values2.keywords.contains(&Keyword::Trample), // allow-raw-authority: merged_copiable_values snapshot struct, not a GameObject
             "a face-up non-topmost component's keywords are unioned (CR 702.140e)"
         );
     }

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -276,11 +276,22 @@ pub fn turn_face_up(
         ));
     }
 
+    // CR 613.7f: a permanent receives a new timestamp when it turns face up.
+    // (Turning face DOWN in place is unreachable in the engine today — only
+    // archenemy scheme `turn_face_down` exists, which is not a permanent event —
+    // so stamping the turn-face-up path covers the reachable case.) All error
+    // early-returns above precede this, so a blocked turn-up draws no timestamp.
+    // Drawn before the `get_mut` borrow (`next_timestamp` takes `&mut self`).
+    let ts = state.next_timestamp();
+
     // Restore original characteristics
     let obj = state.objects.get_mut(&object_id).unwrap();
     obj.face_down = false;
     apply_back_face_to_object(obj, back_face);
     obj.back_face = None;
+    // Written after `apply_back_face_to_object` so the back-face application
+    // (which does not touch `timestamp`) cannot clobber the new stamp.
+    obj.timestamp = ts;
 
     crate::game::layers::mark_layers_full(state);
 
@@ -644,6 +655,41 @@ mod tests {
             })));
         assert_eq!(obj.abilities.len(), 1);
         assert_eq!(obj.color, vec![ManaColor::Green]);
+    }
+
+    /// F1: turning a permanent face up issues a new timestamp (CR 613.7f). The
+    /// error early-returns (wrong controller / not face down / off battlefield)
+    /// all precede the write, so a rejected turn-up draws no timestamp.
+    /// Reverting Step 3 leaves the timestamp unchanged across the successful
+    /// turn-up, so the strict-increase assert fails.
+    #[test]
+    fn turn_face_up_bumps_timestamp_only_on_success() {
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let id = setup_morph_creature(&mut state, player);
+        let mut events = Vec::new();
+
+        play_face_down(&mut state, player, id, &mut events).unwrap();
+        let ts_before = state.objects[&id].timestamp;
+
+        // Wrong controller: error before the write -> no timestamp drawn.
+        assert!(turn_face_up(&mut state, PlayerId(1), id, &mut events).is_err());
+        assert_eq!(
+            state.objects[&id].timestamp, ts_before,
+            "a rejected turn-up (wrong controller) must not draw a timestamp"
+        );
+
+        // Successful turn-up: new timestamp (CR 613.7f).
+        turn_face_up(&mut state, player, id, &mut events).unwrap();
+        assert!(
+            state.objects[&id].timestamp > ts_before,
+            "turning face up must issue a new timestamp (CR 613.7f)"
+        );
+
+        // Already face up: not-face-down error before the write -> no further bump.
+        let ts_after = state.objects[&id].timestamp;
+        assert!(turn_face_up(&mut state, player, id, &mut events).is_err());
+        assert_eq!(state.objects[&id].timestamp, ts_after);
     }
 
     /// CR 116.2b + CR 708.7: Karlov Watchdog — "Permanents your opponents

--- a/crates/engine/src/game/transform.rs
+++ b/crates/engine/src/game/transform.rs
@@ -54,6 +54,12 @@ pub fn transform_permanent(
         .clone()
         .ok_or_else(|| EngineError::InvalidAction("Card has no back face".to_string()))?;
 
+    // CR 613.7g: a double-faced permanent receives a new timestamp when it
+    // transforms. All blocked/no-op early-returns above (off-battlefield,
+    // CantTransform, meld, no back face) precede this, so they draw no timestamp.
+    // Drawn before the `get_mut` borrow (`next_timestamp` takes `&mut self`).
+    let ts = state.next_timestamp();
+
     let obj = state.objects.get_mut(&object_id).unwrap();
 
     if obj.transformed {
@@ -67,6 +73,10 @@ pub fn transform_permanent(
         obj.back_face = Some(current_front);
         obj.transformed = true;
     }
+    // Written after `apply_back_face_to_object` (which does not touch
+    // `timestamp`) so the single write covers both flip directions and cannot
+    // be clobbered by the back-face application.
+    obj.timestamp = ts;
 
     crate::game::layers::mark_layers_full(state);
 
@@ -193,6 +203,49 @@ mod tests {
         assert!(!obj.transformed);
         assert_eq!(obj.name, "Werewolf Front");
         assert_eq!(events.len(), 2);
+    }
+
+    /// G1: transforming a double-faced permanent issues a new timestamp on each
+    /// flip in both directions (CR 613.7g). A non-DFC permanent (no back face)
+    /// returns before the write and draws no timestamp. Reverting Step 4 leaves
+    /// the timestamp unchanged across a transform, so the strict-increase
+    /// asserts fail.
+    #[test]
+    fn transform_bumps_timestamp_each_flip_but_not_for_non_dfc() {
+        let mut state = GameState::new_two_player(42);
+        let id = setup_dfc(&mut state);
+        let mut events = Vec::new();
+
+        let ts_initial = state.objects[&id].timestamp;
+
+        transform_permanent(&mut state, id, &mut events).unwrap();
+        let ts_front_to_back = state.objects[&id].timestamp;
+        assert!(
+            ts_front_to_back > ts_initial,
+            "transforming to the back face must issue a new timestamp (CR 613.7g)"
+        );
+
+        transform_permanent(&mut state, id, &mut events).unwrap();
+        let ts_back_to_front = state.objects[&id].timestamp;
+        assert!(
+            ts_back_to_front > ts_front_to_back,
+            "transforming back to the front face must issue a new timestamp (CR 613.7g)"
+        );
+
+        // A non-DFC permanent (no back face) errors before the write -> no draw.
+        let plain = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        let plain_ts = state.objects[&plain].timestamp;
+        assert!(transform_permanent(&mut state, plain, &mut events).is_err());
+        assert_eq!(
+            state.objects[&plain].timestamp, plain_ts,
+            "a non-DFC permanent must not draw a timestamp on a failed transform"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -674,11 +674,21 @@ pub fn move_to_zone(
         state.trigger_index.remove(object_id);
     }
 
+    // CR 613.7d: an object receives a timestamp when it enters a zone. Stage 2
+    // stamps battlefield entries only, so only draw a timestamp on a battlefield
+    // entry — a graveyard/exile/hand/library move must not burn one. Computed
+    // before the `get_mut` borrow because `next_timestamp` takes `&mut self` over
+    // the whole GameState.
+    let entry_timestamp = (to == Zone::Battlefield).then(|| state.next_timestamp());
+
     let obj_mut = state.objects.get_mut(&object_id).unwrap();
     obj_mut.zone = to;
 
     if to == Zone::Battlefield {
-        obj_mut.reset_for_battlefield_entry(state.turn_number);
+        obj_mut.reset_for_battlefield_entry(
+            state.turn_number,
+            entry_timestamp.expect("battlefield entry draws a timestamp"),
+        );
         // CR 400.7: capture the entrant's incarnation AFTER the battlefield-entry
         // bump so a later leave + re-entry (same ObjectId, higher incarnation) is
         // distinguishable from the original entrant when an ETB intervening-if is

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8402,6 +8402,36 @@ mod tests {
         );
     }
 
+    /// L1 / CR 104.4b: an object's `timestamp` is layer-ordering metadata
+    /// (CR 613.7) that `objects_content_eq` deliberately omits, like
+    /// `incarnation`. Two states differing ONLY in a per-object timestamp must
+    /// confirm as a repeat — otherwise a mandatory loop that re-stamps a
+    /// permanent every iteration (a repeated transform or re-attach) would never
+    /// draw. Revert-failing: adding `timestamp` to `objects_content_eq`'s
+    /// allow-list makes the two states differ and this assertion fail.
+    #[test]
+    fn loop_states_equal_ignores_object_timestamp() {
+        let mut a = GameState::new_two_player(7);
+        let object = GameObject::new(
+            ObjectId(500),
+            CardId(1),
+            PlayerId(0),
+            "Bear".to_string(),
+            Zone::Battlefield,
+        );
+        a.objects.insert(ObjectId(500), object);
+        a.battlefield.push_back(ObjectId(500));
+
+        let mut b = a.clone();
+        let ts_a = b.objects[&ObjectId(500)].timestamp;
+        b.objects.get_mut(&ObjectId(500)).unwrap().timestamp = ts_a + 7;
+
+        assert!(
+            loop_states_equal(&a.normalize_for_loop(), &b.normalize_for_loop()),
+            "states differing only in an object's CR 613.7 timestamp must confirm as a repeat"
+        );
+    }
+
     /// CR 104.4b: pool-unit `pip_id` is a runtime/UI identity tag stamped with a
     /// unique monotonic value each time mana enters a pool. It must NOT affect
     /// game-state equality, otherwise a mandatory loop that floats mana every


### PR DESCRIPTION
Brings the CR 613 layers system to substantial conformance. Three commits, each through the full plan → review → impl → review pipeline with revert-discriminating runtime tests driving the production path.

## Commits
- **CR 613.2b** — face-down (Layer 1b) characteristics now override copy/merge (Layer 1a); a face-down permanent that becomes a copy (e.g. Mirrorweave) stays a face-down 2/2. + CR 730.2e merge `face_down` management.
- **CR 613.7d/e/f/g** — real timestamp assignment at battlefield entry / re-attach / turn-face-up / transform (was stuck at 0, collapsing layer order to the ObjectId tiebreak). Also fixes a latent CR 613.7a/b interleave: static effects carried ts=0 and sorted before every resolution-generated continuous effect regardless of chronology.
- **CR 613.7a (1st sentence)** — granted-ability continuous effects now use `max(recipient, host)` timestamp instead of the host's unconditionally. + comment-only CR 613.7n invariant and CR 613.8a/b/c deferred-gap tracking notes.

## Scope / deferrals
A full CR 613.1–613.11 conformance audit (every CR number grep-verified) accompanied this work. Everything beyond the two reachable defects fixed here is low/zero reachability and intentionally deferred with rationale: the CR 613.8 dependency engine (state-blind predicate + compute-once order are coupled and have zero impact on any current card), Layer-3 text-changing (CR 613.1c — the `Layer::Text` slot exists and orders correctly between Control and Type, but no effect type produces a text-changing continuous effect yet; Mind Bend/Glamerdye/Spectral Shift parse to `Unimplemented`. Building it needs a continuous text-substitution primitive (CR 612) that rewrites an object's text and re-feeds every downstream characteristic consumer — a separate, larger piece of work; no card in the current pool reaches it), and niche items (613.7a re-stamp clause, 613.7k sticker cascade, 613.7m APNAP simultaneity).

**Correction (an earlier draft of this section mis-stated this):** Plane, Phenomenon, Scheme, and Conspiracy ARE modeled card types (`CoreType::{Plane,Phenomenon,Scheme,Conspiracy}`), and a face-up conspiracy's command-zone static abilities already flow through the layer/trigger gather. What is unwired is their *format-specific timestamp assignment* (CR 613.7h plane/phenomenon/scheme, CR 613.7j conspiracy): these face-up command-zone objects currently inherit timestamp 0 rather than a stamp-on-face-up, a low-reach gap of the same kind fixed elsewhere in this PR (it only bites when two command-zone continuous effects compete in one layer). CR 613.7i (vanguard) is genuinely not modeled — no `Vanguard` core type exists. Player- and rule-affecting continuous effects (613.10/613.11) remain out of the `Layer` enum by design (separate subsystems, applied after object characteristics).

## Verification
fmt clean; Tilt clippy + test-engine green; loop detection unchanged (timestamp excluded from objects_content_eq like incarnation). Tests: face-down copy/merge interaction, D1/D2 entry-order, E1/E2 attach, F1 morph, G1 transform, L1 loop-invariant, granted_static_timestamp_is_max_of_host_and_recipient.
