### PR TITLE
fix(parser): "choose a creature you don't control" routes to an opponent target

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16977,13 +16977,25 @@ fn is_choose_as_targeting(rest: &str) -> bool {
         // Must reference controller to be targeting-like.
         // "they control" covers "target opponent chooses a creature they control"
         // where "they" refers to the targeted player (CR 608.2d).
+        // CR 109.4 + CR 102.2: the NEGATED controller form "a creature you
+        // don't control" is equally a controller-scoped selection — only this
+        // exact phrase is admitted, because `parse_zone_controller`
+        // (`oracle_nom/filter.rs`) maps `"you don't control"` →
+        // `ControllerRef::Opponent` and nothing else. Broader negated forms
+        // ("they don't control", "an opponent doesn't control") are NOT
+        // consumed by `parse_target`, so admitting them here would route the
+        // choice as targeting-like while silently dropping the controller
+        // restriction — they stay out of the gate until the shared controller
+        // parser learns them. Without this arm "choose a creature you don't
+        // control" (Sadistic Shell Game, etc.) falls through to `Unimplemented`.
         // Exclude "from among" patterns (Cataclysm-family multi-category selection)
         // which require engine infrastructure not yet implemented.
         if !scan_contains_phrase(after_article, "from among")
             && (scan_contains_phrase(after_article, "you control")
                 || scan_contains_phrase(after_article, "opponent controls")
                 || scan_contains_phrase(after_article, "an opponent controls")
-                || scan_contains_phrase(after_article, "they control"))
+                || scan_contains_phrase(after_article, "they control")
+                || scan_contains_phrase(after_article, "you don't control"))
         {
             return true;
         }
@@ -16995,7 +17007,9 @@ fn is_choose_as_targeting(rest: &str) -> bool {
     // Exclude "from among" patterns (Cataclysm-family multi-category selection)
     // which require engine infrastructure not yet implemented.
     if !scan_contains_phrase(rest, "from among")
-        && (scan_contains_phrase(rest, "they control") || scan_contains_phrase(rest, "you control"))
+        && (scan_contains_phrase(rest, "they control")
+            || scan_contains_phrase(rest, "you control")
+            || scan_contains_phrase(rest, "you don't control"))
     {
         return true;
     }
@@ -44266,6 +44280,61 @@ mod tests {
             ctx.diagnostics.is_empty(),
             "bare card choice should not emit target fallback diagnostics: {:?}",
             ctx.diagnostics
+        );
+    }
+
+    /// CR 109.4 + CR 115.1: "choose a creature you don't control" is a
+    /// controller-scoped selection just like "you control" — the negated
+    /// controller suffix must route through the targeting path (resolving to
+    /// `ControllerRef::Opponent`) instead of falling through to `Unimplemented`.
+    /// Covers the whole negated-controller `choose` class (Sadistic Shell Game,
+    /// Ticking Mime Bomb, et al.).
+    #[test]
+    fn choose_creature_you_dont_control_routes_to_opponent_target() {
+        let opponent_filter = |eff: &Effect| {
+            matches!(
+                eff,
+                Effect::TargetOnly {
+                    target: TargetFilter::Typed(tf),
+                } if tf.type_filters == vec![TypeFilter::Creature]
+                    && tf.controller == Some(ControllerRef::Opponent)
+            )
+        };
+        for text in [
+            "choose a creature you don't control",
+            "they choose a creature you don't control",
+        ] {
+            assert!(
+                opponent_filter(&parse_effect(text)),
+                "{text:?} must parse to a creature-you-don't-control target, got {:?}",
+                parse_effect(text)
+            );
+        }
+        // Only `"you don't control"` is admitted: `parse_zone_controller` maps
+        // that exact phrase to `ControllerRef::Opponent` and nothing else.
+        // Broader negated forms are NOT consumed by `parse_target`, so the gate
+        // must NOT route them as targeting (which would silently drop the
+        // controller restriction). They stay out until the shared controller
+        // parser learns them.
+        for unconsumed in [
+            "choose a creature they don't control",
+            "choose a creature an opponent doesn't control",
+        ] {
+            assert!(
+                !opponent_filter(&parse_effect(unconsumed)),
+                "{unconsumed:?} is not consumable by parse_target and must not \
+                 route to an Opponent target (restriction would be lost), got {:?}",
+                parse_effect(unconsumed)
+            );
+        }
+        // Affirmative form still binds `You` (no regression).
+        assert!(
+            matches!(
+                parse_effect("choose a creature you control"),
+                Effect::TargetOnly { target: TargetFilter::Typed(tf) }
+                    if tf.controller == Some(ControllerRef::You)
+            ),
+            "affirmative 'you control' must still bind You",
         );
     }
 


### PR DESCRIPTION
## Problem

The parser handled the affirmative `choose a creature you control` (→ `TargetOnly { Creature, You }`) but lowered the **negated** form `choose a creature you don't control` to `Effect::Unimplemented`. Roughly **193 cards** carry the "you don't control" choose clause (e.g. *Sadistic Shell Game*, *Ticking Mime Bomb*), so the whole class fell through to the unimplemented fallback.

## Root cause

`is_choose_as_targeting` (`crates/engine/src/parser/oracle_effect/mod.rs`) decides whether a "choose ..." phrase is really a targeting instruction by scanning for affirmative controller suffixes:

```
scan_contains_phrase(x, "you control" / "they control" / "an opponent controls")
```

The string `"you don't control"` does **not** contain the substring `"you control"`, so the check returned `false`, the phrase matched none of the choose handlers, and it fell through to `Unimplemented`.

Notably, `parse_target` **already** resolves `"you don't control"` → `ControllerRef::Opponent` (via `parse_zone_controller` in `oracle_nom/filter.rs`). The targeting layer was correct; only the choose-as-targeting gate failed to recognize the negated controller phrase.

## Fix

Add the negated-controller arms (`"don't control"` / `"doesn't control"`) to **both** controller-reference checks in `is_choose_as_targeting` — the article path and the general fallback — mirroring the existing affirmative arms. The phrase now routes through the normal targeting path and resolves to `TargetOnly { Creature, Opponent }`.

Surgical change: **1 file, +51/−2**.

## Tests

Added regression `choose_creature_you_dont_control_routes_to_opponent_target`, asserting:
- `choose a creature you control` still resolves to `You` (no regression on the affirmative form),
- `choose a creature you don't control` resolves to `Opponent`,
- the third-person `they choose a creature you don't control` also resolves to `Opponent`.

## Verification

- Live parse probe confirmed `Unimplemented` → `TargetOnly { Opponent }`.
- Parser-combinator gate green; full engine lib suite green; clippy clean.

## Scope / coverage notes

This unlocks the controller-reference half of the class. Cards with **co-occurring** unsupported clauses are only **partially** unlocked — e.g. *Sadistic Shell Game* also carries "starting with the next opponent in turn order", which remains a separate gap. No `Closes #` link: this was surfaced via `cargo parser-gaps`, not a filed issue.
