### PR TITLE
fix(parser): support 'any player controls X' static conditions

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2959,24 +2959,34 @@ fn parse_creatures_are_attacking_count_ge(input: &str) -> OracleResult<'_, Stati
 }
 
 /// CR 109.5 (you = the controller of the object the ability is on) +
-/// CR 102.2 / CR 102.3 (an opponent of that player). Parse "you control
-/// a/an/another [type]" AND "an opponent controls a/an/another [type]" →
-/// `IsPresent` whose
-/// filter carries the matched `ControllerRef` (You / Opponent).
+/// CR 102.2 / CR 102.3 (an opponent of that player) + CR 109.4 (any player).
+/// Parse "you control a/an/another [type]", "an opponent controls a/an/another
+/// [type]", and "any player controls a/an/another [type]" → `IsPresent` whose
+/// filter carries the matched `ControllerRef` (You / Opponent) or, for "any
+/// player controls", no controller restriction at all.
 ///
 /// The verb is parameterized over the controller axis: the leading verb phrase
-/// selects `ControllerRef::You` or `ControllerRef::Opponent`, and the SAME
-/// downstream parse (required article, `parse_type_phrase`, full-consume) runs
-/// for both. CR 611.3a: this is a static "as long as" gate, so the condition is
-/// re-evaluated continuously rather than locked in. CR 109.4: the injected
-/// `InZone { Battlefield }` reflects that only the battlefield (and stack) has a
-/// controller, so the presence check is battlefield-scoped.
+/// selects `Some(ControllerRef::You)`, `Some(ControllerRef::Opponent)`, or
+/// `None` (any player), and the SAME downstream parse (required article,
+/// `parse_type_phrase`, full-consume) runs for all three. CR 611.3a: this is a
+/// static "as long as" gate, so the condition is re-evaluated continuously
+/// rather than locked in. CR 109.4: the injected `InZone { Battlefield }`
+/// reflects that only the battlefield (and stack) has a controller, so the
+/// presence check is battlefield-scoped; "any player controls" leaves the
+/// controller unset so a permanent controlled by anyone qualifies.
 fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
     // Verb axis: select the controller from the leading verb phrase. The rest of
-    // the parse is identical for both branches.
+    // the parse is identical for every branch. `None` = "any player controls"
+    // (no controller restriction).
     let (rest, ctrl) = alt((
-        value(ControllerRef::You, tag("you control ")),
-        value(ControllerRef::Opponent, tag("an opponent controls ")),
+        value(Some(ControllerRef::You), tag("you control ")),
+        value(Some(ControllerRef::Opponent), tag("an opponent controls ")),
+        // CR 109.4: "any player controls X" is a battlefield-presence gate with
+        // no controller restriction — any player's matching permanent qualifies
+        // (Knight of Grace / Knight of Malice: "as long as any player controls a
+        // black/white permanent"). A `None` controller flows to the
+        // controller-less presence injection below.
+        value(None::<ControllerRef>, tag("any player controls ")),
     ))
     .parse(input)?;
     // Required article — reject bare-plural "you control creatures" (that's a
@@ -3031,7 +3041,13 @@ fn parse_you_control_a(input: &str) -> OracleResult<'_, StaticCondition> {
     } else {
         TargetFilter::Or { filters }
     };
-    let combined = inject_controller(combined, ctrl);
+    let combined = match ctrl {
+        Some(ctrl) => inject_controller(combined, ctrl),
+        // CR 109.4: "any player controls" — battlefield presence with any
+        // controller; inject the battlefield scope but no controller filter, so
+        // a permanent controlled by ANY player satisfies the gate.
+        None => inject_battlefield_presence(combined),
+    };
     let consumed = input.len() - remainder.len();
     Ok((
         &input[consumed..],
@@ -3274,10 +3290,15 @@ fn parse_filter_have_total_property(input: &str) -> OracleResult<'_, StaticCondi
 /// Inject a controller (CR 109.5 You / CR 102.2 Opponent) into a TargetFilter
 /// produced by `parse_type_phrase`, and ensure the filter is battlefield-scoped
 /// (CR 109.4: only the battlefield and stack have a controller).
-pub(crate) fn inject_controller(filter: TargetFilter, ctrl: ControllerRef) -> TargetFilter {
+/// CR 109.4: Add `InZone { Battlefield }` to a Typed filter (and each `Or`/`And`
+/// leg) if absent, WITHOUT constraining the controller. Used for "any player
+/// controls X" presence gates, where any player's matching permanent qualifies
+/// (Knight of Grace / Knight of Malice). Only the battlefield (and stack) has a
+/// controller, so the presence check is battlefield-scoped; leaving the
+/// controller unset matches an object regardless of who controls it.
+pub(crate) fn inject_battlefield_presence(filter: TargetFilter) -> TargetFilter {
     match filter {
         TargetFilter::Typed(mut tf) => {
-            tf.controller = Some(ctrl);
             if !tf
                 .properties
                 .iter()
@@ -3288,6 +3309,29 @@ pub(crate) fn inject_controller(filter: TargetFilter, ctrl: ControllerRef) -> Ta
                 });
             }
             TargetFilter::Typed(tf)
+        }
+        TargetFilter::Or { filters } => TargetFilter::Or {
+            filters: filters
+                .into_iter()
+                .map(inject_battlefield_presence)
+                .collect(),
+        },
+        TargetFilter::And { filters } => TargetFilter::And {
+            filters: filters
+                .into_iter()
+                .map(inject_battlefield_presence)
+                .collect(),
+        },
+        other => other,
+    }
+}
+
+pub(crate) fn inject_controller(filter: TargetFilter, ctrl: ControllerRef) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(mut tf) => {
+            tf.controller = Some(ctrl);
+            // Share the battlefield-presence injection (CR 109.4).
+            inject_battlefield_presence(TargetFilter::Typed(tf))
         }
         // CR 109.5: Words like 'you' or 'your' on an object refer to the object's controller.
         TargetFilter::Or { filters } => TargetFilter::Or {
@@ -7720,6 +7764,42 @@ mod tests {
         let tf = typed_presence(&c);
         assert_eq!(tf.controller, Some(ControllerRef::Opponent));
         assert_has_color(tf, ManaColor::Red);
+    }
+
+    /// CR 109.4: "any player controls a <type>" → `IsPresent` with NO controller
+    /// restriction (any player's permanent qualifies), still battlefield-scoped.
+    /// Knight of Grace / Knight of Malice ("as long as any player controls a
+    /// black/white permanent").
+    #[test]
+    fn test_any_player_controls_a_black_permanent() {
+        let (rest, c) = parse_inner_condition("any player controls a black permanent").unwrap();
+        assert_eq!(rest, "");
+        let tf = typed_presence(&c);
+        assert_eq!(
+            tf.controller, None,
+            "'any player controls' must leave the controller unset (any controller)"
+        );
+        assert!(
+            tf.properties.iter().any(|p| matches!(
+                p,
+                FilterProp::InZone {
+                    zone: Zone::Battlefield
+                }
+            )),
+            "presence must stay battlefield-scoped, got {:?}",
+            tf.properties
+        );
+        assert_has_color(tf, ManaColor::Black);
+    }
+
+    /// The required-article guard applies to the new "any player" arm too:
+    /// bare-plural "any player controls creatures" is a count, not a presence gate.
+    #[test]
+    fn test_any_player_controls_bare_plural_rejected() {
+        assert!(
+            parse_you_control_a("any player controls creatures").is_err(),
+            "bare-plural 'any player controls creatures' must be rejected"
+        );
     }
 
     /// GUARD (scope containment): "an opponent controls no creatures" is owned by


### PR DESCRIPTION
## Anchored on

Knight of Grace (verified Oracle text):

> First strike, hexproof from black
> Knight of Grace gets +1/+0 as long as any player controls a black permanent.

Knight of Malice:

> First strike, hexproof from white
> Knight of Malice gets +1/+0 as long as any player controls a white permanent.

## Problem

"as long as any player controls a [type]" static conditions parsed to `StaticCondition::Unrecognized`, so the conditional P/T buff never applied. Reproduced via `parse_inner_condition`: "you control a black permanent" and "an opponent controls a black permanent" both lower to `IsPresent`, but "any player controls a black permanent" yielded `Unrecognized` (likewise "an artifact", "a Forest", etc.).

## Root cause

`parse_you_control_a` (`crates/engine/src/parser/oracle_nom/condition.rs`) dispatched the control subject over only two arms: `you control ` → `ControllerRef::You` and `an opponent controls ` → `ControllerRef::Opponent`. "any player controls" had no arm and fell through to `Unrecognized`.

## Fix (class-general)

- The verb dispatch now yields `Option<ControllerRef>` and gains an `any player controls ` arm → `None`. Per CLAUDE.md, `Option<ControllerRef>` is the idiomatic way to express "any controller" rather than introducing a sentinel variant.
- For the `None` case, the filter gets battlefield presence with no controller, via a new `inject_battlefield_presence` helper that `inject_controller` now shares (the `InZone { Battlefield }` logic is no longer duplicated). At runtime a Typed filter with `controller: None` applies no controller restriction (`game/filter.rs`: `controller_ref_player` is consulted only for `Some(_)`), so a permanent controlled by ANY player satisfies the gate — exactly "any player controls".
- Covers the whole class: Knight of Grace, Knight of Malice, and any "as long as any player controls X" condition. The `you control` / `an opponent controls` / `you control no` siblings are byte-for-byte unchanged (regression-pinned).

CR 109.4 (only battlefield/stack objects have a controller, so presence is battlefield-scoped) + CR 611.3a (continuous "as long as" re-evaluation).

## Tests

- "any player controls a black permanent" → `IsPresent` with `controller: None` + `InZone { Battlefield }` + black color.
- Required-article guard: bare-plural "any player controls creatures" still rejected (a count, not a presence gate).
- Existing "you control a" / "an opponent controls a red permanent" parses unchanged.

## Verification

`cargo fmt` clean; parser combinator gate exit 0; full engine parser suite green (incl. 960 control-condition tests); `oracle_effect` suite green; clippy clean. The coverage parse-diff confirms "any player controls X" now lowers to `IsPresent` instead of `Unrecognized`.

Model: claude-opus-4-8
Tier: Frontier
