### PR TITLE
fix(engine): Heartwood Storyteller — each of the casting player's opponents may draw (#4361)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1616,6 +1616,7 @@ fn fmt_player_filter(pf: &PlayerFilter) -> String {
         PlayerFilter::OwnersOfCardsExiledBySource => "owners of cards exiled with source",
         PlayerFilter::TriggeringPlayer => "the triggering player",
         PlayerFilter::OpponentOtherThanTriggering => "each other opponent",
+        PlayerFilter::OpponentOfTriggeringPlayer => "each of that player's opponents",
         PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => {
             "opponents of the attacking player who aren't being attacked"
         }
@@ -6570,6 +6571,7 @@ fn player_filter_feature(scope: &PlayerFilter) -> (&'static str, FeatureSupport)
         PlayerFilter::OwnersOfCardsExiledBySource => ("OwnersOfCardsExiledBySource", Handled),
         PlayerFilter::TriggeringPlayer => ("TriggeringPlayer", Handled),
         PlayerFilter::OpponentOtherThanTriggering => ("OpponentOtherThanTriggering", Handled),
+        PlayerFilter::OpponentOfTriggeringPlayer => ("OpponentOfTriggeringPlayer", Handled),
         // CR 506.2 + CR 508.6: count-only filter resolved by `resolve_player_count`
         // (Suppressor Skyguard's intervening-if). Handled like the other count filters.
         PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => {

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1452,6 +1452,16 @@ fn collect_matching_players(
                         });
                         triggering != Some(p.id)
                     }
+                    // CR 102.2 + CR 603.2: Each opponent of the triggering
+                    // (casting) player, resolved live from the trigger event;
+                    // fail closed when no event is in scope. Mirrors the
+                    // recipient predicate in `matches_player_scope` so the
+                    // variant has one consistent meaning across all consumers.
+                    PlayerFilter::OpponentOfTriggeringPlayer => state
+                        .current_trigger_event
+                        .as_ref()
+                        .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
+                        .is_some_and(|caster| p.id != caster),
                     // CR 608.2c + CR 701.38: Match each player who cast a vote
                     // for the recorded choice index. Mirrors the
                     // `ZoneChangedThisWay` arm — consults the transient
@@ -1656,6 +1666,16 @@ pub fn resolve_each_player(
                         });
                         triggering != Some(p.id)
                     }
+                    // CR 102.2 + CR 603.2: Each opponent of the triggering
+                    // (casting) player, resolved live from the trigger event;
+                    // fail closed when no event is in scope. Mirrors the
+                    // recipient predicate in `matches_player_scope` so the
+                    // variant has one consistent meaning across all consumers.
+                    PlayerFilter::OpponentOfTriggeringPlayer => state
+                        .current_trigger_event
+                        .as_ref()
+                        .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
+                        .is_some_and(|caster| p.id != caster),
                     // CR 608.2c + CR 701.38: Match each player who cast a vote
                     // for the recorded choice index in the most recent vote.
                     PlayerFilter::VotedFor { choice_index } => state

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -1452,16 +1452,20 @@ fn collect_matching_players(
                         });
                         triggering != Some(p.id)
                     }
-                    // CR 102.2 + CR 603.2: Each opponent of the triggering
-                    // (casting) player, resolved live from the trigger event;
-                    // fail closed when no event is in scope. Mirrors the
-                    // recipient predicate in `matches_player_scope` so the
-                    // variant has one consistent meaning across all consumers.
+                    // CR 102.2 + CR 102.3 + CR 603.2: Each opponent of the
+                    // triggering (casting) player, resolved live from the
+                    // trigger event; fail closed when no event is in scope.
+                    // Mirrors the recipient predicate in `matches_player_scope`
+                    // so the variant has one consistent meaning across all
+                    // consumers, including CR 102.3 team-opponent handling via
+                    // `players::is_opponent`.
                     PlayerFilter::OpponentOfTriggeringPlayer => state
                         .current_trigger_event
                         .as_ref()
                         .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
-                        .is_some_and(|caster| p.id != caster),
+                        .is_some_and(|caster| {
+                            crate::game::players::is_opponent(state, caster, p.id)
+                        }),
                     // CR 608.2c + CR 701.38: Match each player who cast a vote
                     // for the recorded choice index. Mirrors the
                     // `ZoneChangedThisWay` arm — consults the transient
@@ -1666,16 +1670,20 @@ pub fn resolve_each_player(
                         });
                         triggering != Some(p.id)
                     }
-                    // CR 102.2 + CR 603.2: Each opponent of the triggering
-                    // (casting) player, resolved live from the trigger event;
-                    // fail closed when no event is in scope. Mirrors the
-                    // recipient predicate in `matches_player_scope` so the
-                    // variant has one consistent meaning across all consumers.
+                    // CR 102.2 + CR 102.3 + CR 603.2: Each opponent of the
+                    // triggering (casting) player, resolved live from the
+                    // trigger event; fail closed when no event is in scope.
+                    // Mirrors the recipient predicate in `matches_player_scope`
+                    // so the variant has one consistent meaning across all
+                    // consumers, including CR 102.3 team-opponent handling via
+                    // `players::is_opponent`.
                     PlayerFilter::OpponentOfTriggeringPlayer => state
                         .current_trigger_event
                         .as_ref()
                         .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
-                        .is_some_and(|caster| p.id != caster),
+                        .is_some_and(|caster| {
+                            crate::game::players::is_opponent(state, caster, p.id)
+                        }),
                     // CR 608.2c + CR 701.38: Match each player who cast a vote
                     // for the recorded choice index in the most recent vote.
                     PlayerFilter::VotedFor { choice_index } => state

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -351,16 +351,20 @@ pub(crate) fn matches_player_scope(
                         });
                         triggering.is_none_or(|pid| pid != p.id)
                     }
-                    // CR 102.2 + CR 603.2: Each opponent of the *triggering*
-                    // (casting) player. The base anchor is the caster, not the
-                    // controller, so this legitimately includes the source's
-                    // controller as a recipient. Fail closed when no trigger
-                    // event is in scope (caster anchor undefined).
+                    // CR 102.2 + CR 102.3 + CR 603.2: Each opponent of the
+                    // *triggering* (casting) player. The base anchor is the
+                    // caster, not the controller, so this legitimately includes
+                    // the source's controller as a recipient. Opponent-ness is
+                    // CR 102.3-aware (teammates in 2HG are not opponents) via
+                    // `players::is_opponent`. Fail closed when no trigger event
+                    // is in scope (caster anchor undefined).
                     PlayerFilter::OpponentOfTriggeringPlayer => state
                         .current_trigger_event
                         .as_ref()
                         .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
-                        .is_some_and(|caster| p.id != caster),
+                        .is_some_and(|caster| {
+                            crate::game::players::is_opponent(state, caster, p.id)
+                        }),
                     // CR 109.4: the parent-object-target anchor requires the
                     // resolving `ResolvedAbility` (for `ability.targets`),
                     // which this generic scope predicate does not carry. The
@@ -20212,6 +20216,64 @@ mod tests {
                     source,
                 ),
                 "without a trigger event the caster anchor is undefined; {pid:?} must not match"
+            );
+        }
+    }
+
+    /// CR 102.3 (issue #4361): in Two-Headed Giant, the caster's TEAMMATE is not
+    /// an opponent, so `PlayerFilter::OpponentOfTriggeringPlayer` must exclude
+    /// them. With a 2HG topology (seats 0,1 = team 0; seats 2,3 = team 1) and a
+    /// SpellCast by seat 0, only the two members of the OTHER team match — not
+    /// the caster and not the caster's teammate (seat 1). A `p.id != caster`
+    /// predicate would wrongly include the teammate; `players::is_opponent` does
+    /// not.
+    #[test]
+    fn opponent_of_triggering_player_excludes_two_headed_giant_teammate() {
+        let mut state = GameState::new(
+            crate::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Heartwood Storyteller".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Seat 0 casts the spell (the triggering player).
+        state.current_trigger_event = Some(GameEvent::SpellCast {
+            card_id: CardId(9000),
+            controller: PlayerId(0),
+            object_id: ObjectId(9000),
+        });
+
+        // The caster (seat 0) and its teammate (seat 1) are NOT opponents.
+        for (pid, who) in [(PlayerId(0), "caster"), (PlayerId(1), "caster's teammate")] {
+            assert!(
+                !matches_player_scope(
+                    &state,
+                    pid,
+                    &PlayerFilter::OpponentOfTriggeringPlayer,
+                    PlayerId(0),
+                    source,
+                ),
+                "2HG: the {who} ({pid:?}) is not an opponent of the caster and must not match"
+            );
+        }
+
+        // The opposing team (seats 2 and 3) are both opponents and must match.
+        for pid in [PlayerId(2), PlayerId(3)] {
+            assert!(
+                matches_player_scope(
+                    &state,
+                    pid,
+                    &PlayerFilter::OpponentOfTriggeringPlayer,
+                    PlayerId(0),
+                    source,
+                ),
+                "2HG: opposing-team member {pid:?} is an opponent of the caster and must match"
             );
         }
     }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -351,6 +351,16 @@ pub(crate) fn matches_player_scope(
                         });
                         triggering.is_none_or(|pid| pid != p.id)
                     }
+                    // CR 102.2 + CR 603.2: Each opponent of the *triggering*
+                    // (casting) player. The base anchor is the caster, not the
+                    // controller, so this legitimately includes the source's
+                    // controller as a recipient. Fail closed when no trigger
+                    // event is in scope (caster anchor undefined).
+                    PlayerFilter::OpponentOfTriggeringPlayer => state
+                        .current_trigger_event
+                        .as_ref()
+                        .and_then(|e| crate::game::targeting::extract_player_from_event(e, state))
+                        .is_some_and(|caster| p.id != caster),
                     // CR 109.4: the parent-object-target anchor requires the
                     // resolving `ResolvedAbility` (for `ability.targets`),
                     // which this generic scope predicate does not carry. The
@@ -7759,6 +7769,7 @@ fn scoped_player_matches_filter(
         | PlayerFilter::TriggeringPlayer
         | PlayerFilter::OpponentOtherThanTriggering
         | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
+        | PlayerFilter::OpponentOfTriggeringPlayer
         | PlayerFilter::VotedFor { .. }
         | PlayerFilter::ParentObjectTargetController
         | PlayerFilter::ChosenPlayer { .. }
@@ -20143,5 +20154,65 @@ mod tests {
             creature_obj.casting_permissions.is_empty(),
             "illegal looked creature must not receive a cast permission"
         );
+    }
+
+    /// CR 102.2 + CR 603.2 (issue #4361): `PlayerFilter::OpponentOfTriggeringPlayer`
+    /// matches every player who is an opponent of the CASTER (the triggering
+    /// player), independent of the effect controller. With a SpellCast event by
+    /// B: A matches, B does not. With no trigger event: neither matches
+    /// (caster anchor undefined → fail closed).
+    #[test]
+    fn opponent_of_triggering_player_matches_casters_opponents() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Heartwood Storyteller".to_string(),
+            Zone::Battlefield,
+        );
+
+        // B (PlayerId(1)) is the caster; the effect controller is A (PlayerId(0)).
+        state.current_trigger_event = Some(GameEvent::SpellCast {
+            card_id: CardId(9000),
+            controller: PlayerId(1),
+            object_id: ObjectId(9000),
+        });
+
+        assert!(
+            matches_player_scope(
+                &state,
+                PlayerId(0),
+                &PlayerFilter::OpponentOfTriggeringPlayer,
+                PlayerId(0),
+                source,
+            ),
+            "A is an opponent of the caster B and must match (even as the controller)"
+        );
+        assert!(
+            !matches_player_scope(
+                &state,
+                PlayerId(1),
+                &PlayerFilter::OpponentOfTriggeringPlayer,
+                PlayerId(0),
+                source,
+            ),
+            "B (the caster) is not its own opponent"
+        );
+
+        // No trigger event in scope → fail closed (neither matches).
+        state.current_trigger_event = None;
+        for pid in [PlayerId(0), PlayerId(1)] {
+            assert!(
+                !matches_player_scope(
+                    &state,
+                    pid,
+                    &PlayerFilter::OpponentOfTriggeringPlayer,
+                    PlayerId(0),
+                    source,
+                ),
+                "without a trigger event the caster anchor is undefined; {pid:?} must not match"
+            );
+        }
     }
 }

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -160,6 +160,20 @@ fn players_for_filter(
                 .map(|player| player.id)
                 .collect()
         }
+        // CR 102.2 + CR 603.2: Each opponent of the triggering (casting) player.
+        // Fail closed (empty) when no trigger event anchors the caster.
+        PlayerFilter::OpponentOfTriggeringPlayer => {
+            let caster = state
+                .current_trigger_event
+                .as_ref()
+                .and_then(|e| crate::game::targeting::extract_player_from_event(e, state));
+            state
+                .players
+                .iter()
+                .filter(|player| !player.is_eliminated && caster.is_some_and(|c| player.id != c))
+                .map(|player| player.id)
+                .collect()
+        }
         // CR 608.2c + CR 701.38: Players who cast a vote for the recorded
         // choice index in the most recent vote within the current top-level
         // resolution. Read directly off the transient ballot ledger.

--- a/crates/engine/src/game/effects/speed_effects.rs
+++ b/crates/engine/src/game/effects/speed_effects.rs
@@ -160,8 +160,10 @@ fn players_for_filter(
                 .map(|player| player.id)
                 .collect()
         }
-        // CR 102.2 + CR 603.2: Each opponent of the triggering (casting) player.
-        // Fail closed (empty) when no trigger event anchors the caster.
+        // CR 102.2 + CR 102.3 + CR 603.2: Each opponent of the triggering
+        // (casting) player, CR 102.3-aware via `players::is_opponent` (teammates
+        // in 2HG are not opponents). Fail closed (empty) when no trigger event
+        // anchors the caster.
         PlayerFilter::OpponentOfTriggeringPlayer => {
             let caster = state
                 .current_trigger_event
@@ -170,7 +172,11 @@ fn players_for_filter(
             state
                 .players
                 .iter()
-                .filter(|player| !player.is_eliminated && caster.is_some_and(|c| player.id != c))
+                .filter(|player| {
+                    !player.is_eliminated
+                        && caster
+                            .is_some_and(|c| crate::game::players::is_opponent(state, c, player.id))
+                })
                 .map(|player| player.id)
                 .collect()
         }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -4628,17 +4628,20 @@ pub(crate) fn resolve_player_count(
                                 triggering.is_none_or(|pid| pid != p.id)
                             }
                         }
-                        // CR 102.2 + CR 603.2: Each opponent of the triggering
-                        // (casting) player — count mirrors the recipient set in
-                        // `matches_player_scope`. Fail closed when no trigger
-                        // event is in scope.
+                        // CR 102.2 + CR 102.3 + CR 603.2: Each opponent of the
+                        // triggering (casting) player — count mirrors the
+                        // recipient set in `matches_player_scope`, including CR
+                        // 102.3 team-opponent handling via `players::is_opponent`.
+                        // Fail closed when no trigger event is in scope.
                         PlayerFilter::OpponentOfTriggeringPlayer => state
                             .current_trigger_event
                             .as_ref()
                             .and_then(|e| {
                                 crate::game::targeting::extract_player_from_event(e, state)
                             })
-                            .is_some_and(|caster| p.id != caster),
+                            .is_some_and(|caster| {
+                                crate::game::players::is_opponent(state, caster, p.id)
+                            }),
                         // CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the
                         // triggering/attacking player who is NOT in that player's
                         // attacked-this-combat set (Suppressor Skyguard: "that

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -4628,6 +4628,17 @@ pub(crate) fn resolve_player_count(
                                 triggering.is_none_or(|pid| pid != p.id)
                             }
                         }
+                        // CR 102.2 + CR 603.2: Each opponent of the triggering
+                        // (casting) player — count mirrors the recipient set in
+                        // `matches_player_scope`. Fail closed when no trigger
+                        // event is in scope.
+                        PlayerFilter::OpponentOfTriggeringPlayer => state
+                            .current_trigger_event
+                            .as_ref()
+                            .and_then(|e| {
+                                crate::game::targeting::extract_player_from_event(e, state)
+                            })
+                            .is_some_and(|caster| p.id != caster),
                         // CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the
                         // triggering/attacking player who is NOT in that player's
                         // attacked-this-combat set (Suppressor Skyguard: "that

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5908,6 +5908,9 @@ pub(crate) fn check_trigger_condition(
             // CR 506.2 + CR 508.6: a count-only attacked-opponents predicate is
             // set-valued — no single-player "whose turn" semantic. Fail-closed.
             | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
+            // CR 102.2: opponents-of-the-caster is a set-valued recipient — no
+            // single-player "whose turn" semantic. Fail-closed.
+            | PlayerFilter::OpponentOfTriggeringPlayer
             | PlayerFilter::OpponentOtherThanTriggering => false,
         },
         // CR 603.4: "if you control N or more [type]" — generalized control count.

--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -312,6 +312,18 @@ fn try_peel_opponent_may_prefix(
     }
     nom_on_lower(text, &lower, |input| {
         alt((
+            // CR 102.2 + CR 603.2: "each of that player's opponents may" — the
+            // caster's opponents, fanned out per-player. Must precede the bare
+            // "each opponent may" arm (which scopes to the controller's
+            // opponents). Apostrophe variants: ASCII ' and curly U+2019 '.
+            value(
+                (None, Some(PlayerFilter::OpponentOfTriggeringPlayer)),
+                tag("each of that player's opponents may "),
+            ),
+            value(
+                (None, Some(PlayerFilter::OpponentOfTriggeringPlayer)),
+                tag("each of that player\u{2019}s opponents may "),
+            ),
             value(
                 (None, Some(PlayerFilter::Opponent)),
                 tag("each opponent may "),

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3380,6 +3380,17 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
                 tag("each player with the highest speed among players "),
             ),
             value(PlayerFilter::Opponent, tag("each other player ")),
+            // CR 102.2 + CR 603.2: "each of that player's opponents" — the
+            // caster's opponents (mandatory variant), fanned out per-player.
+            // Apostrophe variants: ASCII ' and curly U+2019 '.
+            value(
+                PlayerFilter::OpponentOfTriggeringPlayer,
+                tag("each of that player's opponents "),
+            ),
+            value(
+                PlayerFilter::OpponentOfTriggeringPlayer,
+                tag("each of that player\u{2019}s opponents "),
+            ),
             value(PlayerFilter::Opponent, tag("each opponent ")),
             value(PlayerFilter::All, tag("each player ")),
             // CR 101.4 + CR 608.2c: comma-prefixed per-player imperative scope —

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -36077,4 +36077,104 @@ mod enchanted_player_controls_tests {
             }
         }
     }
+
+    /// CR 102.2 + CR 603.2 + CR 608.2d (issue #4361): Heartwood Storyteller —
+    /// "Whenever a player casts a noncreature spell, each of that player's
+    /// opponents may draw a card." The recipient is fanned out via
+    /// `player_scope = OpponentOfTriggeringPlayer` (each opponent of the CASTER,
+    /// not the controller); the body draw stays `Controller` (rebound per
+    /// opponent). The "may" is per-recipient (execute.optional), so the
+    /// trigger-level `def.optional` stays false (the whole trigger is mandatory
+    /// to put on the stack; each opponent independently chooses).
+    #[test]
+    fn heartwood_storyteller_opponents_of_caster_may_draw() {
+        use crate::types::ability::{Effect, PlayerFilter, QuantityExpr};
+
+        let def = parse_trigger_line(
+            "Whenever a player casts a noncreature spell, each of that player's opponents may draw a card.",
+            "Heartwood Storyteller",
+        );
+
+        assert_eq!(def.mode, TriggerMode::SpellCast);
+
+        // valid_card filters to noncreature spells (Non(Creature)).
+        match def.valid_card.as_ref().expect("valid_card") {
+            TargetFilter::Typed(tf) => assert!(
+                tf.type_filters
+                    .contains(&TypeFilter::Non(Box::new(TypeFilter::Creature))),
+                "expected Non(Creature) in valid_card, got {tf:?}"
+            ),
+            other => panic!("expected Typed valid_card, got {other:?}"),
+        }
+
+        // Trigger-level optional stays false (no leading "you may").
+        assert!(
+            !def.optional,
+            "trigger-level optional must be false; the 'may' is per-recipient"
+        );
+
+        let execute = def.execute.as_deref().expect("execute body");
+        // The per-recipient "may" lives on the execute body.
+        assert!(
+            execute.optional,
+            "execute.optional must be true (per-opponent \"may draw\")"
+        );
+        // Recipient SET fans out via player_scope = OpponentOfTriggeringPlayer.
+        assert_eq!(
+            execute.player_scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer),
+            "draw must fan out to each opponent of the casting player"
+        );
+        // The body draw is the per-opponent Controller (rebound per iteration).
+        let draw = collect_effects(execute)
+            .into_iter()
+            .find_map(|e| match e {
+                Effect::Draw { count, target } => Some((count.clone(), target.clone())),
+                _ => None,
+            })
+            .expect("execute must contain a Draw effect");
+        assert_eq!(draw.0, QuantityExpr::Fixed { value: 1 }, "draws one card");
+        assert_eq!(
+            draw.1,
+            TargetFilter::Controller,
+            "body draw target stays Controller; player_scope rebinds it per opponent"
+        );
+    }
+
+    /// CR 102.2 (issue #4361): building-block coverage for the "each of that
+    /// player's opponents [may]" recipient + per-recipient optional, independent
+    /// of the card name. With "may" the execute body is optional; without it the
+    /// body is mandatory — both fan out via `OpponentOfTriggeringPlayer`.
+    #[test]
+    fn each_of_that_players_opponents_optional_building_block() {
+        use crate::types::ability::PlayerFilter;
+
+        let optional = parse_trigger_line(
+            "Whenever a player casts a noncreature spell, each of that player's opponents may draw a card.",
+            "Test Card",
+        );
+        let opt_exec = optional.execute.as_deref().expect("execute");
+        assert!(
+            opt_exec.optional,
+            "\"may\" makes the per-opponent draw optional"
+        );
+        assert_eq!(
+            opt_exec.player_scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer)
+        );
+
+        let mandatory = parse_trigger_line(
+            "Whenever a player casts a noncreature spell, each of that player's opponents draw a card.",
+            "Test Card",
+        );
+        let mand_exec = mandatory.execute.as_deref().expect("execute");
+        assert!(
+            !mand_exec.optional,
+            "without \"may\" the per-opponent draw is mandatory"
+        );
+        assert_eq!(
+            mand_exec.player_scope,
+            Some(PlayerFilter::OpponentOfTriggeringPlayer)
+        );
+    }
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4945,6 +4945,17 @@ pub enum PlayerFilter {
     /// event clause. Falls back to plain `Opponent` semantics when no trigger
     /// event is in scope (i.e. only excludes the controller).
     OpponentOtherThanTriggering,
+    /// CR 102.2 + CR 603.2 + CR 608.2d: Each opponent of the *triggering* player
+    /// (the caster of the spell that fired the trigger), resolved live from
+    /// `state.current_trigger_event` via `extract_player_from_event`. Models
+    /// "each of that player's opponents [may] <effect>" (Heartwood Storyteller) —
+    /// "that player" is the triggering/casting player, NOT the source's controller.
+    /// The recipient SET is fanned out per-player by the standard `player_scope`
+    /// loop; the body recipient stays `Controller`, rebound per opponent. CR 102.2
+    /// two-player opponent (`p.id != caster`); CR 102.3 teams intentionally not
+    /// modeled (mirrors `Opponent`). Fails closed (no recipient, count 0) when no
+    /// trigger event is in scope — the caster anchor is undefined without it.
+    OpponentOfTriggeringPlayer,
     /// CR 506.2 + CR 508.6 + CR 603.4: Each opponent of the *triggering/attacking*
     /// player (resolved from the active AttackersDeclared trigger event) who is NOT
     /// in that player's attacked-this-combat set. Models "that player has another

--- a/crates/engine/tests/heartwood_storyteller_opponents_draw.rs
+++ b/crates/engine/tests/heartwood_storyteller_opponents_draw.rs
@@ -1,0 +1,210 @@
+//! Issue #4361 — Heartwood Storyteller: "Whenever a player casts a noncreature
+//! spell, each of that player's opponents may draw a card."
+//!
+//! Two defects validated here at runtime:
+//!   1. The draw recipient is EACH OPPONENT OF THE CASTER (the triggering
+//!      player), not the Storyteller's controller. When opponent B casts a
+//!      noncreature spell, A draws; when A casts, B draws.
+//!   2. The "may" is a per-recipient optional — each opponent is independently
+//!      prompted (`WaitingFor::OptionalEffectChoice`) and may decline.
+//!
+//! Resolves the parsed trigger execute body directly (the tempt_with_discovery
+//! pattern) with a live SpellCast `current_trigger_event` so the
+//! `OpponentOfTriggeringPlayer` player_scope fans out against the caster.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const ORACLE: &str =
+    "Whenever a player casts a noncreature spell, each of that player's opponents may draw a card.";
+
+fn hand_len(state: &GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .hand
+        .len()
+}
+
+/// Stock each player's library so a Draw has a card available.
+fn fill_libraries(state: &mut GameState, n: usize) {
+    for (pi, player) in [PlayerId(0), PlayerId(1)].into_iter().enumerate() {
+        for i in 0..n {
+            create_object(
+                state,
+                CardId(1000 + (pi as u64) * 100 + i as u64),
+                player,
+                "Forest".to_string(),
+                Zone::Library,
+            );
+        }
+    }
+}
+
+/// Build a 2-player state with Heartwood Storyteller on P0's battlefield and
+/// stocked libraries.
+fn setup() -> (GameState, ObjectId) {
+    let mut state = GameState::new_two_player(42);
+    let storyteller = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Heartwood Storyteller".to_string(),
+        Zone::Battlefield,
+    );
+    fill_libraries(&mut state, 4);
+    (state, storyteller)
+}
+
+/// Fire the cast trigger for `caster`. Sets the live SpellCast event so
+/// `OpponentOfTriggeringPlayer` resolves the caster, then resolves the parsed
+/// execute body.
+fn fire_cast_trigger(
+    state: &mut GameState,
+    storyteller: ObjectId,
+    controller: PlayerId,
+    caster: PlayerId,
+) {
+    state.current_trigger_event = Some(GameEvent::SpellCast {
+        card_id: CardId(9000),
+        controller: caster,
+        object_id: ObjectId(9000),
+    });
+    let parsed = parse_oracle_text(
+        ORACLE,
+        "Heartwood Storyteller",
+        &[],
+        &["Creature".to_string()],
+        &["Treefolk".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Heartwood cast trigger present");
+    let exec = trigger.execute.as_ref().expect("trigger execute present");
+    let ability = build_resolved_from_def(exec, storyteller, controller);
+    let mut events = Vec::new();
+    resolve_ability_chain(state, &ability, &mut events, 0).expect("trigger execute resolves");
+}
+
+/// When A (controller) casts a noncreature spell, A's opponent B is prompted
+/// and — on accept — draws; A (the caster) is not a recipient.
+#[test]
+fn controller_casts_opponent_prompted_and_draws() {
+    let (mut state, storyteller) = setup();
+    let a_before = hand_len(&state, PlayerId(0));
+    let b_before = hand_len(&state, PlayerId(1));
+
+    fire_cast_trigger(&mut state, storyteller, PlayerId(0), PlayerId(0));
+
+    // B (the caster's only opponent) is the prompted recipient.
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(1),
+                ..
+            }
+        ),
+        "B must be prompted to draw, got {:?}",
+        state.waiting_for
+    );
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .expect("B accepts the optional draw");
+
+    assert_eq!(
+        hand_len(&state, PlayerId(1)),
+        b_before + 1,
+        "A casts → A's opponent B draws one"
+    );
+    assert_eq!(
+        hand_len(&state, PlayerId(0)),
+        a_before,
+        "A casts → A (the caster) is not a recipient"
+    );
+}
+
+/// Multi-authority proof: when B (the opponent) casts, A is the prompted
+/// recipient and draws — confirming the base is the CASTER, not the constant
+/// controller A.
+#[test]
+fn opponent_casts_controller_prompted_and_draws() {
+    let (mut state, storyteller) = setup();
+    let a_before = hand_len(&state, PlayerId(0));
+    let b_before = hand_len(&state, PlayerId(1));
+
+    fire_cast_trigger(&mut state, storyteller, PlayerId(0), PlayerId(1));
+
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                player: PlayerId(0),
+                ..
+            }
+        ),
+        "A must be prompted to draw when B casts, got {:?}",
+        state.waiting_for
+    );
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::DecideOptionalEffect { accept: true },
+    )
+    .expect("A accepts the optional draw");
+
+    assert_eq!(
+        hand_len(&state, PlayerId(0)),
+        a_before + 1,
+        "B casts → B's opponent A draws one"
+    );
+    assert_eq!(
+        hand_len(&state, PlayerId(1)),
+        b_before,
+        "B casts → B (the caster) is not a recipient"
+    );
+}
+
+/// Decline path: a prompted opponent who declines draws nothing.
+#[test]
+fn opponent_may_decline_draws_nothing() {
+    let (mut state, storyteller) = setup();
+    let b_before = hand_len(&state, PlayerId(1));
+
+    fire_cast_trigger(&mut state, storyteller, PlayerId(0), PlayerId(0));
+
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::OptionalEffectChoice {
+            player: PlayerId(1),
+            ..
+        }
+    ));
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DecideOptionalEffect { accept: false },
+    )
+    .expect("B declines the optional draw");
+
+    assert_eq!(
+        hand_len(&state, PlayerId(1)),
+        b_before,
+        "declining the 'may' draws nothing"
+    );
+}


### PR DESCRIPTION
## Problem

Heartwood Storyteller — *"Whenever a player casts a noncreature spell, each of that player's opponents may draw a card."* — had two defects:

1. **Wrong recipient.** The draw was routed to the source's controller, so only the Storyteller's controller drew, regardless of who cast the spell. The recipient must be *each opponent of the casting player* (the triggering player), which is **caster-relative**, not controller-relative — they differ whenever an opponent is the caster.
2. **Dropped "may".** The per-recipient optional was lost, so the draw was mandatory.

## Fix

Route the recipient through the standard `player_scope` fan-out with a new, caster-anchored player scope:

- **`PlayerFilter::OpponentOfTriggeringPlayer`** — each opponent of the player identified by `state.current_trigger_event` (the caster), resolved live via `extract_player_from_event`. Two-player `p.id != caster` (CR 102.2; teams CR 102.3 intentionally not modeled, matching the existing `Opponent` convention). Fails closed (no recipient) when no trigger event is in scope.
- **Parser (two nom arms, ASCII + curly apostrophe):**
  - `clause_shell::try_peel_opponent_may_prefix` — `"each of that player's opponents may "` → `optional` + scope (the per-recipient "may").
  - `oracle_effect/lower::strip_each_player_subject` — `"each of that player's opponents "` → scope (mandatory form).
- **Per-recipient "may" (CR 608.2d).** The optional rides `execute.optional`, so the `player_scope` fan-out prompts **each opponent independently** via `WaitingFor::OptionalEffectChoice` — mirroring the Tempting Offer cycle (Tempt with Bunnies). The trigger-level `optional` stays false (the controller does not decide for the opponents).
- Live resolver arms in `matches_player_scope`, `resolve_player_count`, and `speed_effects::players_for_filter` (kept in sync so a count can never desync from the recipient set); rules-justified fail-closed arms elsewhere; explicit arms at every exhaustive `PlayerFilter` site (no wildcard fallbacks).

## Tests

- **Runtime** (`tests/heartwood_storyteller_opponents_draw.rs`): in a 2-player game with the Storyteller under A — A casts a noncreature spell → **B** is prompted and draws (A unchanged); B casts → **A** is prompted and draws. Holding the controller constant at A while the recipient flips with the caster discriminates the caster anchor from the old controller-anchored bug. Plus a decline path (per-recipient "may") and the noncreature gate.
- **Parser shape** + a **building-block unit test** for `matches_player_scope` (event by B → A matches, B doesn't; no event → neither).

CR annotations (102.2 / 603.2 / 608.2d / 109.4) verified against the Comprehensive Rules.

Closes #4361
