### PR TITLE
fix(engine): one-sided-fight source reuses its slot for "its power" magnitude (Bite Down #4234)

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2,8 +2,8 @@
 use crate::types::ability::TapStateChange;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, CardTypeSetSource, CastManaSpentMetric,
-    CombatRelationSubject, ControllerRef, CounterMoveSelection, Effect, EffectScope, FilterProp,
-    GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
+    CombatRelationSubject, ControllerRef, CounterMoveSelection, DamageSource, Effect, EffectScope,
+    FilterProp, GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
     MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef,
     ResolvedAbility, RestrictionPlayerScope, SpellContext, SubAbilityLink, TargetChoiceTiming,
     TargetFilter, TargetRef, TypeFilter, TypedFilter,
@@ -2013,6 +2013,7 @@ fn collect_target_slots(
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_needs_target_creature_quantity_slot(&ability.effect)
+            && !one_sided_fight_source_supplies_quantity_creature(&ability.effect)
         {
             let filter = effect_target_slot_filter(&ability.effect)
                 .expect("slot filter present when gate true");
@@ -2735,6 +2736,87 @@ fn sub_ability_inherits_parent_creature_target_only(
         && effect_player_filter_is_parent_target_anaphor(&sub.effect)
 }
 
+/// CR 115.1 + CR 115.10a + CR 608.2c: A one-sided-fight `DealDamage` ("Target
+/// creature you control deals damage equal to its power to target creature or
+/// planeswalker you don't control") reuses the parent-declared source creature
+/// (`targets[0]`) for BOTH the damage source (`damage_source: Target`) and the
+/// `Power { Target }` / `Toughness { Target }` magnitude. The amount's per-target
+/// creature-quantity slot would therefore surface a SECOND "target creature" —
+/// the bug in GH #4234, where Bite Down asked for one target too many (CR 601.2c:
+/// one slot per distinct instance of "target", and the magnitude here is NOT a
+/// distinct instance — "its power" anaphorically reuses the source).
+///
+/// Sibling of `sub_ability_inherits_parent_creature_target_only`, which handles
+/// the Swords to Plowshares GainLife rider whose ONLY slot is the redundant
+/// magnitude; here the genuine recipient slot remains, so we drop only the
+/// magnitude slot. The boost variant (Bite Down on Crime / Ambuscade) reads
+/// `Power { Anaphoric }`, which surfaces no quantity slot, so it is unaffected.
+///
+/// `damage_source: Some(Target)` is only emitted for a one-sided-fight clause
+/// whose damage-dealing object was named with "target" in an earlier clause (the
+/// subject, e.g. "Target creature you control deals…"), so that earlier slot
+/// always supplies `targets[0]`; the magnitude `Power { Target }` reads the SAME
+/// `targets[0]` and never needs a slot of its own. This is purely a function of
+/// the effect shape, so every slot-mapping site (producer, spec builder, both
+/// consumers, the minimum-count) can apply it identically and stay in lockstep
+/// (CR 700.2 slot-mapping invariant). It only ever fires when
+/// `effect_needs_target_creature_quantity_slot` is already true — i.e. the
+/// recipient filter (here `Or[Creature, Planeswalker] you don't control`) failed
+/// `effect_primary_target_supplies_creature_target`, the exact gap that left Bite
+/// Down asking for an extra target while Rabid Bite (plain creature recipient)
+/// was already correct — so it can only drop a redundant slot, never a real one.
+fn one_sided_fight_source_supplies_quantity_creature(effect: &Effect) -> bool {
+    let amount = match effect {
+        Effect::DealDamage {
+            damage_source: Some(DamageSource::Target),
+            amount,
+            ..
+        }
+        | Effect::DamageAll {
+            damage_source: Some(DamageSource::Target),
+            amount,
+            ..
+        } => amount,
+        _ => return false,
+    };
+    // CR 208.1: the magnitude reads the Target-scoped source object's P/T — the
+    // same object `damage_source: Target` reads. Recipient-scoped or fixed
+    // magnitudes keep their own slots.
+    quantity_expr_reads_target_object_pt(amount)
+}
+
+/// CR 208.1: whether a magnitude reads the Target-scoped object's power or
+/// toughness (`Power { Target }` / `Toughness { Target }`), recursing through the
+/// arithmetic wrappers `quantity_expr_target_slot_filter` already traverses.
+fn quantity_expr_reads_target_object_pt(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Ref { qty } => matches!(
+            qty,
+            QuantityRef::Power {
+                scope: ObjectScope::Target,
+            } | QuantityRef::Toughness {
+                scope: ObjectScope::Target,
+            }
+        ),
+        QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::UpTo { max: inner }
+        | QuantityExpr::Power {
+            exponent: inner, ..
+        } => quantity_expr_reads_target_object_pt(inner),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_reads_target_object_pt)
+        }
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_reads_target_object_pt(left)
+                || quantity_expr_reads_target_object_pt(right)
+        }
+        QuantityExpr::Fixed { .. } => false,
+    }
+}
+
 fn effect_player_filter_is_parent_target_anaphor(effect: &Effect) -> bool {
     match effect {
         Effect::GainLife { player, .. } => matches!(
@@ -3237,6 +3319,7 @@ fn collect_target_slot_specs(
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_needs_target_creature_quantity_slot(&ability.effect)
+            && !one_sided_fight_source_supplies_quantity_creature(&ability.effect)
         {
             let id = TargetInstanceId(*next_instance);
             *next_instance += 1;
@@ -4796,6 +4879,7 @@ fn assign_targets_recursive(
     }
     if ability.target_choice_timing == TargetChoiceTiming::Stack
         && effect_needs_target_creature_quantity_slot(&ability.effect)
+        && !one_sided_fight_source_supplies_quantity_creature(&ability.effect)
     {
         if let Some(target) = targets.get(*next_target) {
             ability.targets.push(target.clone());
@@ -5078,6 +5162,7 @@ fn assign_selected_slots_recursive(
     }
     if ability.target_choice_timing == TargetChoiceTiming::Stack
         && effect_needs_target_creature_quantity_slot(&ability.effect)
+        && !one_sided_fight_source_supplies_quantity_creature(&ability.effect)
     {
         let Some(selected_slot) = selected_slots.get(*next_slot) else {
             return Err(EngineError::InvalidAction(
@@ -5477,6 +5562,7 @@ fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usi
     let target_creature_quantity_companion = if ability.target_choice_timing
         == TargetChoiceTiming::Stack
         && effect_needs_target_creature_quantity_slot(&ability.effect)
+        && !one_sided_fight_source_supplies_quantity_creature(&ability.effect)
         && !ability.optional_targeting
     {
         1

--- a/crates/engine/tests/integration/ambuscade_one_sided_fight_anaphoric.rs
+++ b/crates/engine/tests/integration/ambuscade_one_sided_fight_anaphoric.rs
@@ -130,6 +130,47 @@ fn conditional_then_it_deals_variant_reads_boosted_power() {
 const BITE_DOWN_ON_CRIME_FIGHT: &str = "Target creature you control gets +2/+0 until end of turn. \
 It deals damage equal to its power to target creature you don't control.";
 
+/// Reproduction probe for GitHub #4234 (plain "Bite Down", the NO-BOOST
+/// variant): "Target creature you control deals damage equal to its power to
+/// target creature or planeswalker you don't control." The card legitimately
+/// targets TWO objects (CR 601.2c) — the source creature you control and the
+/// opponent's recipient — so "asks for 2 targets" is correct. The only real-bug
+/// question is whether the SOURCE wrongly takes damage too. P0's 4/4 deals 4 to
+/// the opponent's 6/6 and must take 0 itself.
+#[test]
+fn bite_down_no_boost_source_deals_power_and_takes_none() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    const BITE_DOWN_NO_BOOST: &str = "Target creature you control deals damage equal to its power \
+to target creature or planeswalker you don't control.";
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Bite Down", true, BITE_DOWN_NO_BOOST)
+        .id();
+    let own = scenario.add_creature(P0, "Biting Beast", 4, 4).id();
+    let foe = scenario.add_creature(P1, "Opposing Ogre", 6, 6).id();
+
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).target_objects(&[own, foe]).resolve();
+
+    let foe_damage = outcome.state().objects[&foe].damage_marked;
+    let own_damage = outcome.state().objects[&own].damage_marked;
+
+    assert_eq!(
+        foe_damage, 4,
+        "#4234: the source creature (power 4) must deal 4 to the opponent's \
+         creature; got {foe_damage}."
+    );
+    assert_eq!(
+        own_damage, 0,
+        "#4234: the source creature must take NO damage (it is the damage source, \
+         not a recipient); got {own_damage}. Non-zero means the source slot is \
+         being damaged as well — the reported double-damage bug."
+    );
+}
+
 #[test]
 fn bite_down_on_crime_boosted_creature_deals_its_power() {
     let mut scenario = GameScenario::new_n_player(2, 42);


### PR DESCRIPTION
Fixes #4234.

## Problem
Plain **Bite Down** ("Target creature you control deals damage equal to its power to target creature or planeswalker you don't control") asked for one target too many. The card legitimately targets two objects (the source creature you control and the opponent's recipient), but the engine surfaced a *third* redundant creature-quantity slot for the magnitude.

## Root cause
The magnitude `Power { Target }` ("its power") anaphorically reuses the source creature, which was already declared with "target" in the subject clause and supplies `targets[0]`. Per CR 601.2c it is therefore **not** a distinct instance of "target" and must not get its own slot.

## Fix
Added `one_sided_fight_source_supplies_quantity_creature`, which fires only when `damage_source: Some(Target)` and the amount reads `Power { Target }` / `Toughness { Target }` (recursing through arithmetic wrappers via `quantity_expr_reads_target_object_pt`). It is gated at all five slot-mapping sites in lockstep (CR 700.2 invariant): `collect_target_slots`, `collect_target_slot_specs`, `assign_targets_recursive`, `assign_selected_slots_recursive`, and `minimum_targets_in_chain`.

The boost variant (Bite Down on Crime / Ambuscade) reads `Power { Anaphoric }`, which surfaces no quantity slot, and is unaffected.

## Tests
- New `bite_down_no_boost_source_deals_power_and_takes_none`: source 4/4 deals 4 to opponent's 6/6 and takes 0 itself.
- Full `ambuscade_one_sided_fight_anaphoric` module + fight/bite regression sweep (12 tests) pass; `cargo clippy -p engine --lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)