### PR TITLE
fix(engine): delayed zone-change effects no-op on objects that ceased to exist (#3883)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -778,6 +778,19 @@ pub(crate) fn process_one_zone_move(
     obj_id: ObjectId,
     events: &mut Vec<GameEvent>,
 ) -> ZoneMoveResult {
+    // CR 400.7 + CR 111.7: An object that has already left the game (a token
+    // that ceased to exist via CR 704.5d, or any other object removed from
+    // `state.objects` since this effect snapshotted it as a target) cannot
+    // undergo a further zone change — skip silently rather than falling
+    // through to `move_to_zone`, which assumes the object is live and panics
+    // otherwise. A delayed trigger that snapshots `TargetFilter::LastCreated`
+    // (e.g. Kari Zev, Skyship Raider's "exile that token at end of combat")
+    // is the common path here: the token dies in combat before the delayed
+    // trigger fires.
+    if !state.objects.contains_key(&obj_id) {
+        return ZoneMoveResult::Done;
+    }
+
     // CR 114.5: Emblems cannot be moved between zones.
     if state.objects.get(&obj_id).is_some_and(|o| o.is_emblem) {
         return ZoneMoveResult::Done;

--- a/crates/engine/tests/integration/issue_3883_kari_zev_ragavan.rs
+++ b/crates/engine/tests/integration/issue_3883_kari_zev_ragavan.rs
@@ -94,3 +94,64 @@ fn kari_zev_attack_creates_ragavan_tapped_and_attacking() {
         "Ragavan must enter attacking; attackers={attacking:?}"
     );
 }
+
+/// Regression for the Discord follow-up on #3883: if the Ragavan token is
+/// blocked and killed in combat, resolving the delayed "exile that token at
+/// end of combat" trigger must not crash. The token ceases to exist (CR
+/// 704.5d) as a state-based action before the delayed trigger fires, so by
+/// the time `ChangeZone` runs, `state.objects` no longer has an entry for it.
+#[test]
+fn kari_zev_ragavan_dying_in_combat_does_not_crash_delayed_exile() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let kari = scenario
+        .add_creature_from_oracle(P0, "Kari Zev, Skyship Raider", 1, 3, KARI_ZEV_ORACLE)
+        .id();
+    let blocker = scenario
+        .add_creature_from_oracle(P1, "P1 Bear", 2, 2, "")
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(kari, AttackTarget::Player(P1))])
+        .expect("declare Kari Zev attacking P1");
+
+    resolve_attack_trigger(&mut runner);
+
+    let tokens = ragavan_tokens(&runner);
+    assert_eq!(
+        tokens.len(),
+        1,
+        "Kari Zev must create exactly one Ragavan token"
+    );
+    let ragavan = tokens[0];
+
+    // CR 508.2: the active player gets priority after the attack trigger
+    // resolves — pass through it to reach the declare-blockers step.
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+
+    runner
+        .declare_blockers(&[(blocker, ragavan)])
+        .expect("declare blocker on Ragavan");
+
+    let _ = runner.combat_damage();
+
+    // The 2/2 blocker deals lethal combat damage to the 2/1 Ragavan; the SBA
+    // check removes the dead token from `state.objects` entirely (CR 704.5d)
+    // before the delayed exile trigger gets a chance to fire.
+    assert!(
+        !runner.state().objects.contains_key(&ragavan),
+        "Ragavan must have died and ceased to exist before its delayed exile fires"
+    );
+
+    // Drive the delayed "exile that token at end of combat" trigger to
+    // resolution. Before the fix, this panicked inside `move_to_zone`
+    // (`.expect("object exists")`) because the token had already ceased to
+    // exist. It must now resolve as a silent no-op.
+    runner.advance_until_stack_empty();
+}


### PR DESCRIPTION
## Summary
- Fixes #3883: resolving Kari Zev, Skyship Raider's delayed "exile that token at end of combat" trigger crashed the engine if the created Ragavan token was blocked and killed before the trigger fired.
- Root cause: the delayed trigger snapshots the token's `ObjectId` at creation. Once the token dies, CR 704.5d removes it from `state.objects` entirely (tokens that leave the battlefield cease to exist). The zone-move pipeline then hit a bare `.expect("object exists")` panic in `move_to_zone` ([`zones.rs:598`](crates/engine/src/game/zones.rs#L598)).
- `process_one_zone_move` in `crates/engine/src/game/effects/change_zone.rs` now treats a target object that's no longer in `state.objects` as a silent no-op (CR 400.7: a zone change can't happen to an object that's left the game). This covers any delayed or queued zone-change effect with a stale snapshot target, not just this card.

## Test plan
- [x] Added `kari_zev_ragavan_dying_in_combat_does_not_crash_delayed_exile` in `crates/engine/tests/integration/issue_3883_kari_zev_ragavan.rs`, which declares Kari Zev as an attacker, lets the attack trigger create Ragavan, blocks and kills Ragavan in combat, then drives the delayed exile trigger to resolution.
- [x] Verified the new test reproduces the exact reported panic (`zones.rs:598:45 "object exists"`) when the fix is reverted.
- [x] `cargo test -p engine --test integration issue_3883` passes with the fix in place (both the pre-existing token-creation test and the new crash regression test).
- [x] `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)