### PR TITLE
fix(parser): quote-aware choice-list splitter so nested-token abilities aren't a modal choice (#4230)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -3525,8 +3525,23 @@ fn parse_choice_list_separator(input: &str) -> nom::IResult<&str, ()> {
 /// without manual byte-offset slicing. Returns `None` unless the whole input is
 /// consumed — a trailing unmatched remainder means the text was not a clean
 /// list.
+///
+/// CR 608.2d + CR 113.3: A token-choice branch may carry a quoted granted ability
+/// whose text contains a `,`/`or` list separator — e.g. Reef Worm's nested
+/// `a 3/3 blue Fish creature token with "When this token dies, create a 6/6 blue
+/// Whale creature token with '…'"`. A double-quoted span is therefore consumed as
+/// one opaque unit so the splitter never severs a list item inside quoted ability
+/// text; otherwise the inner `, create …` is misread as additional choice branches
+/// (a single cascading token wrongly becomes a `ChooseOneOf` of distinct tokens).
+/// Single quotes are only ever nested inside double quotes here, so handling the
+/// double-quoted span alone also covers them and leaves bare apostrophes
+/// (possessives such as "owner's") untouched.
 fn split_choice_list_items(input: &str) -> Option<Vec<&str>> {
-    let item = recognize(many1(preceded(not(parse_choice_list_separator), anychar)));
+    let unit = alt((
+        recognize((tag("\""), take_until("\""), tag("\""))),
+        recognize(preceded(not(parse_choice_list_separator), anychar)),
+    ));
+    let item = recognize(many1(unit));
     let (_, items) = all_consuming(separated_list1(parse_choice_list_separator, item))
         .parse(input)
         .ok()?;
@@ -60129,6 +60144,55 @@ mod tests {
             "Claim Jumper repeats once, got {:?}",
             trigger.repeat_until
         );
+    }
+
+    /// CR 608.2d: The choice-list splitter must treat a double-quoted granted
+    /// ability as one opaque item, so a `,`/`or` inside quoted text never
+    /// fabricates extra branches. A genuine unquoted disjunction still splits.
+    #[test]
+    fn split_choice_list_items_is_quote_aware() {
+        // Quoted ability carrying an inner ", create …" is a single item.
+        let nested = "a 3/3 blue Fish creature token with \"When this token dies, create a 6/6 blue Whale creature token.\"";
+        assert_eq!(
+            split_choice_list_items(nested),
+            Some(vec![nested]),
+            "a quoted ability with an inner comma must stay one item"
+        );
+        // A real top-level disjunction still splits into its branches.
+        assert_eq!(
+            split_choice_list_items("a Food token or a Treasure token"),
+            Some(vec!["a Food token", "a Treasure token"]),
+        );
+        // A real split survives even when one branch carries a quoted ability
+        // whose text contains a separator.
+        assert_eq!(
+            split_choice_list_items(
+                "a Treasure token or a 1/1 Soldier with \"When this dies, draw a card.\""
+            ),
+            Some(vec![
+                "a Treasure token",
+                "a 1/1 Soldier with \"When this dies, draw a card.\""
+            ]),
+        );
+    }
+
+    /// CR 111.2 + CR 608.2d: Reef Worm creates a single cascading Fish token that
+    /// carries a quoted death-triggered ability; it is NOT a modal token choice.
+    /// Before the quote-aware splitter, the inner ", create …" severed the clause
+    /// into a bogus `ChooseOneOf` of Fish/Whale/Kraken. (issue #4230)
+    #[test]
+    fn reef_worm_nested_token_is_not_modal_choice() {
+        let def = parse_effect_chain(
+            "create a 3/3 blue Fish creature token with \"When this token dies, create a 6/6 blue Whale creature token with 'When this token dies, create a 9/9 blue Kraken creature token.'\"",
+            AbilityKind::Spell,
+        );
+        let Effect::Token { name, .. } = &*def.effect else {
+            panic!(
+                "Reef Worm must create one Token (not a choice), got {:?}",
+                def.effect
+            );
+        };
+        assert_eq!(name, "Fish", "outer token is the 3/3 Fish");
     }
 }
 


### PR DESCRIPTION
## Problem

Reef Worm (#4230) creates a single cascading token:

> When this creature dies, create a 3/3 blue Fish creature token with "When this token dies, create a 6/6 blue Whale creature token with 'When this token dies, create a 9/9 blue Kraken creature token.'"

The HEAD parser misread this as a **modal token choice** — `Effect::ChooseOneOf` over three distinct tokens (Fish / Whale / Kraken) — instead of one Fish token carrying a quoted death-triggered ability. At runtime that offers the player a choice of which single token to make, so the cascade never happens.

## Root cause

`try_parse_create_token_choice` uses `split_choice_list_items` to split `create A, B, or C token` into `ChooseOneOf` branches. The splitter's item combinator was **not quote-aware**: `parse_choice_list_separator` matched the `, ` *inside* the quoted granted ability (`"When this token dies, create …"`), severing one cascading token into three bogus branches (and double-emitting `create`).

## Fix

The choice-list item combinator now consumes a **double-quoted span as one opaque unit**, so a `,`/`or` inside quoted granted-ability text can never fabricate extra branches. With Reef Worm there is no separator *outside* the quotes, so the splitter yields a single item, `try_parse_create_token_choice` declines (needs ≥2), and the normal single-token-with-quoted-ability grammar parses the cascade correctly.

- Genuine **unquoted** token/counter disjunctions (`create a Food token or a Treasure token`; counter-choice lists) are unchanged — they contain no double quotes.
- A real disjunction where one branch carries a quoted ability still splits correctly (covered by test).
- Bare apostrophes (possessives like `owner's`) are untouched — only double-quoted spans are special-cased, and the nested single quotes here are always inside a double-quoted span.

CR 608.2d (choose-one token instructions) + CR 113.3 (granted abilities).

## Tests

- `split_choice_list_items_is_quote_aware` — building-block test: a quoted ability with an inner comma stays one item; genuine disjunctions still split; a mixed list (one quoted branch) splits at the real separator.
- `reef_worm_nested_token_is_not_modal_choice` — Reef Worm parses to a single `Effect::Token { name: "Fish", .. }`, not `ChooseOneOf`.

Full engine lib suite green (14227 passed, 0 failed); `clippy -D warnings` clean.

Closes #4230

🤖 Generated with [Claude Code](https://claude.com/claude-code)