### PR TITLE
feat(engine): support Greymond, Avacyn's Stalwart (choose-two-keywords grant and conditional Human anthem)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1801,7 +1801,7 @@ fn fmt_choice_type(ct: &ChoiceType) -> String {
         ChoiceType::Word => "word",
         ChoiceType::Artist => "artist",
         // CR 608.2d: "choose an ability" — Urborg / Walking Sponge prompt.
-        ChoiceType::Keyword { options } => {
+        ChoiceType::Keyword { options, .. } => {
             return format!(
                 "ability from: {}",
                 options

--- a/crates/engine/src/game/effects/choose.rs
+++ b/crates/engine/src/game/effects/choose.rs
@@ -198,9 +198,52 @@ pub(crate) fn bind_named_choice(
     source_id: Option<ObjectId>,
 ) {
     if let Some(obj_id) = source_id {
-        if let Some(attr) = ChosenAttribute::from_choice(choice_type.clone(), choice) {
+        // CR 608.2d: A multi-keyword choice (`ChoiceType::Keyword { count > 1 }`,
+        // e.g. Greymond's "choose two abilities from among ...") arrives as one
+        // comma-joined answer ("First Strike, Vigilance"). Split it on ',' and
+        // trim each token (tolerating "A, B" / "A,B" / "A ,B" whitespace
+        // variants) and persist one `ChosenAttribute::Keyword` per token so each
+        // chosen ability is independently readable by the `AddChosenKeyword`
+        // plural grant. The single-keyword path (count == 1, and every other
+        // choice type) produces a single attribute, byte-identical to before.
+        let attrs: Vec<ChosenAttribute> = match choice_type {
+            ChoiceType::Keyword { options, count } if *count > 1 => choice
+                .split(',')
+                .filter_map(|token| {
+                    ChosenAttribute::from_choice(
+                        ChoiceType::Keyword {
+                            options: options.clone(),
+                            count: 1,
+                        },
+                        token.trim(),
+                    )
+                })
+                .collect(),
+            _ => ChosenAttribute::from_choice(choice_type.clone(), choice)
+                .into_iter()
+                .collect(),
+        };
+        if !attrs.is_empty() {
             if let Some(obj) = state.objects.get_mut(&obj_id) {
-                obj.chosen_attributes.push(attr);
+                // CR 608.2d: A keyword choice represents the CURRENT answer set,
+                // not an accumulation. A source that makes a fresh keyword choice
+                // each time its effect resolves (Angelic Skirmisher — "At the
+                // beginning of combat on your turn, choose first strike, vigilance,
+                // or lifelink. Creatures you control gain that ability until end of
+                // turn") must REPLACE its prior keyword answer, otherwise the
+                // `AddChosenKeyword` plural read would grant every historical
+                // choice. Clear only `ChosenAttribute::Keyword` (Greymond's single
+                // as-enters bind clears nothing, so its behavior is unchanged);
+                // every other chosen-attribute kind (Color, Subtype, CardName,
+                // Label, …) is untouched so RemoveChosenKeyword/Urborg and the
+                // anchor-word/Morophon cards keep accumulating per their own rules.
+                if matches!(choice_type, ChoiceType::Keyword { .. }) {
+                    obj.chosen_attributes
+                        .retain(|a| !matches!(a, ChosenAttribute::Keyword(_)));
+                }
+                for attr in attrs {
+                    obj.chosen_attributes.push(attr);
+                }
                 // CR 607.2d + CR 613.1: Persisted ETB/modal choices (card name,
                 // creature type, card type, color, etc.) can gate
                 // source-dependent continuous or rule effects. Layer evaluation
@@ -376,8 +419,17 @@ fn compute_options(
         // CR 608.2d: "Choose an ability the target has, then remove it" —
         // option labels come from the typed `Keyword` list emitted by the
         // converter. Empty option lists are legal (the choice resolves with
-        // no options, and the dependent effect is a no-op).
-        ChoiceType::Keyword { options } => options.iter().map(|kw| kw.to_string()).collect(),
+        // no options, and the dependent effect is a no-op). For `count > 1`
+        // (Greymond's "choose two abilities from among ...") each option is a
+        // comma-joined unordered count-combination of the keyword names, so the
+        // player makes a single selection of the whole group.
+        ChoiceType::Keyword { options, count } => {
+            if *count > 1 {
+                keyword_choice_options(options, *count)
+            } else {
+                options.iter().map(|kw| kw.to_string()).collect()
+            }
+        }
     }
 }
 
@@ -409,6 +461,57 @@ fn two_color_options() -> Vec<String> {
         }
     }
     options
+}
+
+/// CR 608.2d: Generate every comma-joined unordered `count`-combination of the
+/// keyword option list (Greymond's "choose two abilities from among first
+/// strike, vigilance, and lifelink" → `["First Strike, Vigilance", "First
+/// Strike, Lifelink", "Vigilance, Lifelink"]`). Mirrors `two_color_options`:
+/// order within a combination doesn't matter, so combinations use ascending
+/// index tuples (no permutations). The resulting comma-joined string is one
+/// selectable option; `bind_named_choice` splits it back into individual
+/// `ChosenAttribute::Keyword` entries at resolution.
+///
+/// INVARIANT: this `", "`-join / split round-trip is only safe because every
+/// keyword admitted by the parser (`parse_keyword_from_oracle`) has a
+/// comma-free `Display` string. A future "choose N abilities" list that admits
+/// a Debug-fallback keyword whose `Display` contains a comma would mis-tokenize
+/// — keep the parser's keyword allowlist comma-free, or persist structured
+/// tokens instead of a joined string.
+fn keyword_choice_options(
+    options: &[crate::types::keywords::Keyword],
+    count: usize,
+) -> Vec<String> {
+    let names: Vec<String> = options.iter().map(|kw| kw.to_string()).collect();
+    let mut result = Vec::new();
+    let mut indices: Vec<usize> = (0..count).collect();
+    if count == 0 || count > names.len() {
+        return result;
+    }
+    loop {
+        result.push(
+            indices
+                .iter()
+                .map(|&i| names[i].clone())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        // Advance the combination indices (lexicographic next-combination).
+        let mut i = count;
+        loop {
+            if i == 0 {
+                return result;
+            }
+            i -= 1;
+            if indices[i] != i + names.len() - count {
+                break;
+            }
+        }
+        indices[i] += 1;
+        for j in (i + 1)..count {
+            indices[j] = indices[j - 1] + 1;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -777,7 +880,10 @@ mod tests {
         state.waiting_for = WaitingFor::Priority {
             player: PlayerId(0),
         };
-        let ability = make_choose_ability(ChoiceType::Keyword { options: vec![] });
+        let ability = make_choose_ability(ChoiceType::Keyword {
+            options: vec![],
+            count: 1,
+        });
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
         assert!(
@@ -829,6 +935,7 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         let ability = make_choose_ability(ChoiceType::Keyword {
             options: vec![Keyword::FirstStrike, Keyword::Landwalk("Swamp".to_string())],
+            count: 1,
         });
         let mut events = Vec::new();
         resolve(&mut state, &ability, &mut events).unwrap();
@@ -886,5 +993,129 @@ mod tests {
             &mut ability,
             &mut events
         ));
+    }
+
+    /// V10 (matthewevans regression for PR #4638) — CR 608.2d + CR 613.1f: A
+    /// source that makes a REPEATED single-keyword choice over time (Angelic
+    /// Skirmisher: "At the beginning of each combat, choose first strike,
+    /// vigilance, or lifelink. Creatures you control gain that ability until end
+    /// of turn") must REPLACE its stored keyword answer each time it chooses, not
+    /// accumulate. This drives the PRODUCTION `ChooseOption` / `bind_named_choice`
+    /// path (no manual `chosen_attributes` seed): the real parsed choose+grant
+    /// chain, re-hosted as an activated ability, is fired twice.
+    ///
+    /// Choose First Strike (grant applies), then on a later activation choose
+    /// Lifelink, and assert the granted set is the CURRENT choice ONLY — Lifelink
+    /// granted, First Strike NO LONGER granted. Without the keyword-clear in
+    /// `bind_named_choice`, both historical `ChosenAttribute::Keyword` entries
+    /// survive and the `AddChosenKeyword` plural read grants First Strike AND
+    /// Lifelink — exactly the regression this guards (revert the `.retain(..)` in
+    /// `bind_named_choice` and the final `!has_kw(FirstStrike)` assert fails).
+    #[test]
+    fn repeated_keyword_choice_replaces_prior_answer() {
+        use crate::game::keywords::has_keyword;
+        use crate::game::layers::evaluate_layers;
+        use crate::game::scenario::{GameRunner, GameScenario};
+        use crate::parser::oracle_trigger::parse_trigger_line;
+        use crate::types::ability::AbilityKind;
+        use crate::types::actions::GameAction;
+        use crate::types::keywords::Keyword;
+        use crate::types::phase::Phase;
+
+        const P0: PlayerId = PlayerId(0);
+
+        /// Re-evaluate layers and report whether `id` currently has `keyword`.
+        fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+            runner.state_mut().layers_dirty.mark_full();
+            evaluate_layers(runner.state_mut());
+            has_keyword(&runner.state().objects[&id], keyword)
+        }
+
+        /// Activate `source`'s keyword-choice ability through the REAL pipeline and
+        /// answer the surfaced `NamedChoice` with `keyword` via the production
+        /// `GameAction::ChooseOption` handler (no manual `chosen_attributes` seed).
+        fn drive_keyword_choice(runner: &mut GameRunner, source: ObjectId, keyword: &str) {
+            runner
+                .act(GameAction::ActivateAbility {
+                    source_id: source,
+                    ability_index: 0,
+                })
+                .expect("activate the keyword-choice ability");
+            runner.advance_until_stack_empty();
+
+            let WaitingFor::NamedChoice { options, .. } = runner.state().waiting_for.clone() else {
+                panic!(
+                    "must pause on the keyword NamedChoice, got {}",
+                    runner.waiting_for_kind()
+                );
+            };
+            let choice = options
+                .into_iter()
+                .find(|o| o == keyword)
+                .unwrap_or_else(|| panic!("expected a {keyword:?} keyword option"));
+
+            runner
+                .act(GameAction::ChooseOption { choice })
+                .expect("answer the keyword choice");
+            runner.advance_until_stack_empty();
+        }
+
+        // Parse Angelic Skirmisher's real "choose a keyword; creatures you control
+        // gain that ability" chain, then re-host it as an ACTIVATED ability so the
+        // test can drive the same choose+grant twice on demand without staging two
+        // full combat phases. The choose/bind path exercised is identical.
+        let trigger = parse_trigger_line(
+            "At the beginning of each combat, choose first strike, vigilance, or \
+             lifelink. Creatures you control gain that ability until end of turn.",
+            "Angelic Skirmisher",
+        );
+        let mut activated = *trigger
+            .execute
+            .expect("Angelic Skirmisher trigger must have an execute chain");
+        activated.kind = AbilityKind::Activated;
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+
+        let skirmisher = {
+            let mut b = scenario.add_creature(P0, "Angelic Skirmisher", 4, 4);
+            b.with_subtypes(vec!["Angel"]);
+            b.with_ability_definition(activated);
+            b.id()
+        };
+        let ally = scenario.add_creature(P0, "Footsoldier", 2, 2).id();
+
+        let mut runner = scenario.build();
+
+        // --- First activation: choose First Strike ---
+        drive_keyword_choice(&mut runner, skirmisher, "First Strike");
+        assert!(
+            has_kw(&mut runner, ally, &Keyword::FirstStrike),
+            "after choosing First Strike, the ally must have it"
+        );
+        assert!(
+            !has_kw(&mut runner, ally, &Keyword::Lifelink),
+            "Lifelink was never chosen yet"
+        );
+
+        // --- Second activation (a later combat): choose Lifelink ---
+        drive_keyword_choice(&mut runner, skirmisher, "Lifelink");
+
+        // The stored answer set must now be the CURRENT choice ONLY.
+        let chosen = runner.state().objects[&skirmisher].chosen_keywords();
+        assert_eq!(
+            chosen,
+            vec![&Keyword::Lifelink],
+            "the second choice must REPLACE the first — only Lifelink stored, got {chosen:?}"
+        );
+        assert!(
+            has_kw(&mut runner, ally, &Keyword::Lifelink),
+            "after choosing Lifelink, the ally must have it"
+        );
+        assert!(
+            !has_kw(&mut runner, ally, &Keyword::FirstStrike),
+            "the FIRST choice (First Strike) must NO LONGER be granted — a keyword \
+             choice represents the current answer set, not an accumulation"
+        );
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -9928,7 +9928,10 @@ mod tests {
         );
         let ability = ResolvedAbility::new(
             Effect::Choose {
-                choice_type: ChoiceType::Keyword { options: vec![] },
+                choice_type: ChoiceType::Keyword {
+                    options: vec![],
+                    count: 1,
+                },
                 persist: false,
                 selection: crate::types::ability::TargetSelectionMode::Chosen,
             },

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1734,6 +1734,22 @@ impl GameObject {
         })
     }
 
+    /// CR 608.2d: Look up ALL stored chosen keywords (Greymond, Avacyn's
+    /// Stalwart "choose two abilities from among first strike, vigilance, and
+    /// lifelink" persists two `ChosenAttribute::Keyword` entries). The plural
+    /// companion to `chosen_keyword`; read by
+    /// `ContinuousModification::AddChosenKeyword` at Layer 6 evaluation so a
+    /// multi-keyword choice grants every chosen ability, not just the first.
+    pub fn chosen_keywords(&self) -> Vec<&Keyword> {
+        self.chosen_attributes
+            .iter()
+            .filter_map(|a| match a {
+                ChosenAttribute::Keyword(k) => Some(k),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// CR 614.12c + CR 607.2d: Look up the persisted anchor-word label chosen
     /// as this permanent entered the battlefield (e.g. "Jeskai" / "Temur" on
     /// Frostcliff Siege, "Khans" / "Dragons" on a Khans of Tarkir Siege).

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4024,7 +4024,7 @@ fn apply_continuous_effect_filtered(
     // chosen-attribute scoping refactor.
     let chosen_keyword = if matches!(
         effect.modification,
-        ContinuousModification::RemoveChosenKeyword | ContinuousModification::AddChosenKeyword
+        ContinuousModification::RemoveChosenKeyword
     ) {
         state
             .objects
@@ -4032,6 +4032,26 @@ fn apply_continuous_effect_filtered(
             .and_then(|src| src.chosen_keyword().cloned())
     } else {
         None
+    };
+
+    // CR 608.2d + CR 613.1f: `AddChosenKeyword` reads the PLURAL chosen-keyword
+    // list off the granting source so a multi-keyword choice (Greymond's "choose
+    // two abilities ... Humans you control have each of the chosen abilities")
+    // grants every chosen ability, not just the first. Single-keyword grants
+    // (Angelic Skirmisher, Linvala) yield a one-element Vec — same behavior as
+    // the prior singular read. Source-scoped via `effect.source_id` so multiple
+    // Greymonds with different chosen pairs each grant their own keywords.
+    let add_chosen_keywords: Vec<Keyword> = if matches!(
+        effect.modification,
+        ContinuousModification::AddChosenKeyword
+    ) {
+        state
+            .objects
+            .get(&effect.source_id)
+            .map(|src| src.chosen_keywords().into_iter().cloned().collect())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
     };
 
     // Pre-read chosen card type from source (avoids borrow conflict in the loop).
@@ -4330,7 +4350,12 @@ fn apply_continuous_effect_filtered(
             // choose effect has resolved), this is a no-op rather than a panic,
             // mirroring `AddChosenColor` / `RemoveChosenKeyword`.
             ContinuousModification::AddChosenKeyword => {
-                if let Some(kw) = chosen_keyword.as_ref() {
+                // CR 608.2d: grant EACH chosen keyword (one for the single-choice
+                // cards, two for Greymond's "each of the chosen abilities"). If
+                // the source has no stored chosen keyword (e.g. the static is
+                // gathered before the choose effect has resolved), the list is
+                // empty and this is a no-op rather than a panic.
+                for kw in &add_chosen_keywords {
                     // CR 702.164b: summing keywords (Toxic) accumulate rather
                     // than dedup, mirroring the plain `AddKeyword` arm above.
                     if kw.sums_across_instances() || !obj.keywords.contains(kw) {

--- a/crates/engine/src/game/off_zone_characteristics.rs
+++ b/crates/engine/src/game/off_zone_characteristics.rs
@@ -146,17 +146,20 @@ fn apply_keyword_modification(
                 keywords.retain(|existing| existing != kw);
             }
         }
-        // CR 608.2d + CR 613.1f: Grant the *exact* keyword chosen at
-        // resolution time — the additive mirror of `RemoveChosenKeyword`,
-        // matching the `AddKeyword` upsert semantics above. No-op when the
-        // source has no stored chosen keyword.
+        // CR 608.2d + CR 613.1f: Grant EACH keyword chosen at resolution time —
+        // the additive mirror of `RemoveChosenKeyword`, matching the `AddKeyword`
+        // upsert semantics above. Reads the PLURAL list so a multi-keyword choice
+        // (Greymond's "each of the chosen abilities") grants every chosen ability
+        // off-zone, not just the first. No-op when the source has no stored
+        // chosen keyword. Source-scoped via `effect.source_id`.
         ContinuousModification::AddChosenKeyword => {
-            if let Some(kw) = state
+            let chosen: Vec<Keyword> = state
                 .objects
                 .get(&effect.source_id)
-                .and_then(|src| src.chosen_keyword())
-            {
-                upsert_keyword(keywords, kw.clone());
+                .map(|src| src.chosen_keywords().into_iter().cloned().collect())
+                .unwrap_or_default();
+            for kw in chosen {
+                upsert_keyword(keywords, kw);
             }
         }
         _ => {}
@@ -334,6 +337,43 @@ mod tests {
             Some(Keyword::Flashback(FlashbackCost::Mana(
                 ManaCost::SelfManaCost
             )))
+        );
+    }
+
+    /// V8 — CR 608.2d + CR 613.1f: the off-zone `AddChosenKeyword` arm must read
+    /// the PLURAL chosen-keyword list off the granting source (Greymond's two
+    /// chosen abilities), not just the first. A battlefield source carrying TWO
+    /// `ChosenAttribute::Keyword` grants both to an off-battlefield recipient.
+    #[test]
+    fn add_chosen_keyword_off_zone_reads_all_chosen_keywords() {
+        use crate::types::ability::ChosenAttribute;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_card(&mut state, PlayerId(0), "Greymond", Zone::Battlefield);
+        let target_id = create_card(&mut state, PlayerId(0), "Exiled Human", Zone::Exile);
+
+        // Two abilities chosen as Greymond entered.
+        {
+            let obj = state.objects.get_mut(&source_id).unwrap();
+            obj.chosen_attributes
+                .push(ChosenAttribute::Keyword(Keyword::FirstStrike));
+            obj.chosen_attributes
+                .push(ChosenAttribute::Keyword(Keyword::Lifelink));
+        }
+
+        state.add_transient_continuous_effect(
+            source_id,
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificObject { id: target_id },
+            vec![ContinuousModification::AddChosenKeyword],
+            None,
+        );
+
+        let kws = effective_off_zone_keywords(&state, target_id);
+        assert!(
+            kws.contains(&Keyword::FirstStrike) && kws.contains(&Keyword::Lifelink),
+            "off-zone AddChosenKeyword must surface BOTH chosen keywords, got {kws:?}"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7335,7 +7335,7 @@ mod tests {
             effects.iter().any(|e| matches!(
                 e,
                 Effect::Choose {
-                    choice_type: ChoiceType::Keyword { options },
+                    choice_type: ChoiceType::Keyword { options, .. },
                     persist: true,
                     ..
                 } if options.as_slice()
@@ -7353,6 +7353,157 @@ mod tests {
             )),
             "expected an AddChosenKeyword grant, got {effects:?}"
         );
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::Unimplemented { .. })),
+            "no clause may be Unimplemented, got {effects:?}"
+        );
+    }
+
+    /// CR 608.2d + CR 613.1f + CR 614.12c: Whole-card structural parse of
+    /// Greymond, Avacyn's Stalwart. Confirms all three lines parse to the right
+    /// shapes with zero `Unimplemented`:
+    ///   L1: a `Moved` replacement whose execute is a persisting count-2 typed
+    ///       keyword `Choose`.
+    ///   L2: a Continuous static on Humans-you-control carrying `AddChosenKeyword`
+    ///       (NOT a trigger).
+    ///   L3: a Continuous static on Humans-you-control with +2/+2 gated on a
+    ///       `>= 4` count of Humans you control.
+    #[test]
+    fn parse_greymond_avacyns_stalwart_whole_card() {
+        use crate::types::ability::{
+            ChoiceType, Comparator, ContinuousModification, QuantityExpr, QuantityRef,
+            StaticCondition, TargetFilter, TypeFilter,
+        };
+
+        let text = "As Greymond, Avacyn's Stalwart enters, choose two abilities from among \
+                    first strike, vigilance, and lifelink.\n\
+                    Humans you control have each of the chosen abilities.\n\
+                    As long as you control four or more Humans, Humans you control get +2/+2.";
+        let r = parse(
+            text,
+            "Greymond, Avacyn's Stalwart",
+            &[],
+            &["Creature"],
+            &["Human", "Soldier"],
+        );
+
+        // ----- L1: the as-enters keyword choice replacement -----
+        assert_eq!(r.replacements.len(), 1, "exactly one as-enters replacement");
+        let rep = &r.replacements[0];
+        let execute = rep.execute.as_ref().expect("replacement has an execute");
+        assert!(
+            matches!(
+                &*execute.effect,
+                Effect::Choose {
+                    choice_type: ChoiceType::Keyword { options, count: 2 },
+                    persist: true,
+                    ..
+                } if options.as_slice()
+                    == [Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink]
+            ),
+            "L1 must be a persisting count-2 keyword Choose, got {:?}",
+            execute.effect
+        );
+
+        // ----- L2 + L3: two Humans-you-control statics, neither a trigger -----
+        assert!(
+            r.triggers.is_empty(),
+            "Greymond has no triggered abilities, got {:?}",
+            r.triggers
+        );
+        assert_eq!(
+            r.statics.len(),
+            2,
+            "two static definitions (grant + anthem)"
+        );
+
+        let human_you_control = |filter: &Option<TargetFilter>| -> bool {
+            matches!(
+                filter,
+                Some(TargetFilter::Typed(tf))
+                    if tf.type_filters.contains(&TypeFilter::Subtype("Human".to_string()))
+            )
+        };
+
+        // L2: the chosen-keyword grant.
+        let grant = r
+            .statics
+            .iter()
+            .find(|s| s.modifications == vec![ContinuousModification::AddChosenKeyword])
+            .expect("a static carrying AddChosenKeyword");
+        assert!(
+            human_you_control(&grant.affected),
+            "L2 grant must affect Humans you control, got {:?}",
+            grant.affected
+        );
+        assert!(
+            grant.condition.is_none(),
+            "L2 grant is unconditional, got {:?}",
+            grant.condition
+        );
+
+        // L3: the conditional +2/+2 anthem.
+        let anthem = r
+            .statics
+            .iter()
+            .find(|s| {
+                s.modifications
+                    .contains(&ContinuousModification::AddPower { value: 2 })
+            })
+            .expect("a static carrying +2 power");
+        assert!(
+            anthem
+                .modifications
+                .contains(&ContinuousModification::AddToughness { value: 2 }),
+            "L3 anthem is +2/+2"
+        );
+        // The +2/+2 subject carries the Human subtype filter.
+        assert!(
+            human_you_control(&anthem.affected),
+            "L3 anthem subject must be Humans you control, got {:?}",
+            anthem.affected
+        );
+        // The count condition is `>= 4` Humans you control.
+        match &anthem.condition {
+            Some(StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 4 },
+            }) => {
+                assert!(
+                    matches!(
+                        filter,
+                        TargetFilter::Typed(tf)
+                            if tf.type_filters
+                                .contains(&TypeFilter::Subtype("Human".to_string()))
+                    ),
+                    "count condition filter must carry the Human subtype, got {filter:?}"
+                );
+            }
+            other => panic!("L3 condition must be `>= 4` Human ObjectCount, got {other:?}"),
+        }
+
+        // ----- Zero Unimplemented across every parsed effect -----
+        let mut effects: Vec<&Effect> = Vec::new();
+        for ability in &r.abilities {
+            let mut node = Some(ability);
+            while let Some(d) = node {
+                effects.push(&d.effect);
+                node = d.sub_ability.as_deref();
+            }
+        }
+        if let Some(execute) = rep.execute.as_ref() {
+            let mut node = Some(execute.as_ref());
+            while let Some(d) = node {
+                effects.push(&d.effect);
+                node = d.sub_ability.as_deref();
+            }
+        }
         assert!(
             !effects
                 .iter()

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17157,6 +17157,13 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
         Some(ChoiceType::Word)
     } else if tag::<_, _, E>("an artist").parse(rest).is_ok() {
         Some(ChoiceType::Artist)
+    } else if let Some((options, count)) = try_parse_keyword_choice_from_among(rest) {
+        // CR 608.2d: "choose N abilities/keywords from among <kw>, <kw>, and
+        // <kw>" — the explicit count-parameterized form (Greymond, Avacyn's
+        // Stalwart: "choose two abilities from among first strike, vigilance,
+        // and lifelink"). Recognized BEFORE the bare single-keyword form below
+        // so the leading "<N> abilities from among " stripper claims the count.
+        Some(ChoiceType::Keyword { options, count })
     } else if let Some(options) = try_parse_keyword_choice(rest) {
         // CR 608.2d: "choose [keyword], [keyword], or [keyword]" — a typed
         // keyword enumeration (Angelic Skirmisher's "first strike, vigilance,
@@ -17164,8 +17171,9 @@ pub(crate) fn try_parse_named_choice(lower: &str) -> Option<ChoiceType> {
         // indestructible"). Recognized BEFORE the generic labeled fallback so
         // the chosen value persists as a typed `ChosenAttribute::Keyword` that
         // `ContinuousModification::AddChosenKeyword` ("creatures you control
-        // gain that ability") can read at layer evaluation.
-        Some(ChoiceType::Keyword { options })
+        // gain that ability") can read at layer evaluation. The bare single
+        // keyword choice carries `count: 1`.
+        Some(ChoiceType::Keyword { options, count: 1 })
     } else {
         // Generic "X or Y" / "X, Y, or Z" / "W, X, Y, or Z" labeled choice —
         // must come AFTER all specific patterns above.
@@ -17193,6 +17201,47 @@ fn try_parse_keyword_choice(rest: &str) -> Option<Vec<Keyword>> {
         })
         .collect::<Option<Vec<_>>>()?;
     Some(keywords)
+}
+
+/// CR 608.2d: Parse the count-parameterized keyword choice
+/// "<N> abilities/keywords from among <kw>, <kw>, ..., and <kw>" into its
+/// `Keyword` option list and chosen count `N` (Greymond, Avacyn's Stalwart:
+/// "choose two abilities from among first strike, vigilance, and lifelink",
+/// `N = 2`).
+///
+/// Strips the leading "<number> abilities/keywords from among " preamble, then
+/// reuses the shared `split_choice_list_items` list splitter (the FromAmong
+/// grammar — it accepts ", and " as the final separator over bare keyword
+/// names) and maps every item through `parse_keyword_from_oracle`. Returns
+/// `None` unless **every** item maps to a real keyword, so non-keyword "from
+/// among" lists fall through to the generic handlers. Building for the class:
+/// any "choose <N> abilities from among <list>" line, not the single card.
+fn try_parse_keyword_choice_from_among(rest: &str) -> Option<(Vec<Keyword>, usize)> {
+    type E<'a> = OracleError<'a>;
+    // "<number> " — the count of abilities to choose (Greymond's "two ").
+    let (rest, count) = terminated(nom_primitives::parse_number, tag::<_, _, E>(" "))
+        .parse(rest)
+        .ok()?;
+    // "abilities from among " / "keywords from among " — the FromAmong preamble.
+    let (list, _) = preceded(
+        alt((tag::<_, _, E>("abilities"), tag("keywords"))),
+        tag(" from among "),
+    )
+    .parse(rest)
+    .ok()?;
+    // CR 608.2d: Greymond's printed text ends "...and lifelink." — strip the
+    // trailing sentence period (and surrounding whitespace) BEFORE splitting so
+    // the final item arrives as "lifelink", not "lifelink." (which
+    // `parse_keyword_from_oracle` would reject, failing the whole list).
+    let list = list.trim().trim_end_matches('.').trim_end();
+    let items = split_choice_list_items(list)?;
+    let keywords: Vec<Keyword> = items
+        .iter()
+        .map(|item| {
+            crate::parser::oracle_keyword::parse_keyword_from_oracle(&item.trim().to_lowercase())
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some((keywords, count as usize))
 }
 
 /// Try to parse a labeled choice ("X or Y", "X, Y, or Z", "W, X, Y, or Z", ...) into
@@ -53584,6 +53633,7 @@ mod tests {
             super::try_parse_named_choice("choose first strike, vigilance, or lifelink"),
             Some(ChoiceType::Keyword {
                 options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+                count: 1,
             })
         );
     }
@@ -53596,6 +53646,55 @@ mod tests {
             super::try_parse_named_choice("choose hexproof or indestructible"),
             Some(ChoiceType::Keyword {
                 options: vec![Keyword::Hexproof, Keyword::Indestructible],
+                count: 1,
+            })
+        );
+    }
+
+    /// CR 608.2d: Count-parameterized keyword choice — Greymond, Avacyn's
+    /// Stalwart's "choose two abilities from among first strike, vigilance, and
+    /// lifelink" (note the ", and " FromAmong separator and the leading "two
+    /// abilities from among " preamble that carries `count: 2`). The trailing
+    /// sentence period must be stripped before the list split so the final item
+    /// is "lifelink", not "lifelink.".
+    #[test]
+    fn keyword_choice_two_from_among_first_strike_vigilance_lifelink() {
+        assert_eq!(
+            super::try_parse_named_choice(
+                "choose two abilities from among first strike, vigilance, and lifelink."
+            ),
+            Some(ChoiceType::Keyword {
+                options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+                count: 2,
+            })
+        );
+    }
+
+    /// CR 608.2d: The "keywords from among" spelling parses identically (same
+    /// FromAmong grammar, count carried from the leading number).
+    #[test]
+    fn keyword_choice_from_among_accepts_keywords_noun() {
+        assert_eq!(
+            super::try_parse_named_choice(
+                "choose two keywords from among first strike, vigilance, and lifelink"
+            ),
+            Some(ChoiceType::Keyword {
+                options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+                count: 2,
+            })
+        );
+    }
+
+    /// Discriminating: a bare single-disjunction keyword choice (no "N abilities
+    /// from among" preamble) still parses as `count: 1` — Angelic Skirmisher's
+    /// "first strike, vigilance, or lifelink".
+    #[test]
+    fn keyword_choice_bare_disjunction_is_count_one() {
+        assert_eq!(
+            super::try_parse_named_choice("choose first strike, vigilance, or lifelink"),
+            Some(ChoiceType::Keyword {
+                options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+                count: 1,
             })
         );
     }

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -1501,13 +1501,19 @@ pub(crate) fn push_grant_clause_modifications(
     // Skirmisher: "choose first strike, vigilance, or lifelink. Creatures you
     // control gain that ability ..."; Linvala, Shield of Sea Gate: "choose
     // hexproof or indestructible. Creatures you control gain that ability
-    // ..."). Emits `AddChosenKeyword`, which reads the granting source's
-    // `ChosenAttribute::Keyword` at layer evaluation — the additive mirror of
-    // `RemoveChosenKeyword` (Urborg / Walking Sponge). Checked before
-    // `map_keyword` so the anaphor is never mis-classified as an unknown
-    // keyword. Builds for the whole "gain the chosen keyword" class.
+    // ..."). The plural forms — "each of the chosen abilities" / "the chosen
+    // abilities" — refer back to a multi-keyword choice (Greymond, Avacyn's
+    // Stalwart: "choose two abilities ... Humans you control have each of the
+    // chosen abilities"); the same `AddChosenKeyword` reads ALL persisted
+    // `ChosenAttribute::Keyword` entries at layer evaluation. Emits
+    // `AddChosenKeyword`, the additive mirror of `RemoveChosenKeyword` (Urborg /
+    // Walking Sponge). Checked before `map_keyword` so the anaphor is never
+    // mis-classified as an unknown keyword. Builds for the whole "gain the
+    // chosen keyword(s)" class.
     if alt((
         tag::<_, _, OracleError<'_>>("that ability"),
+        tag("each of the chosen abilities"),
+        tag("the chosen abilities"),
         tag("the chosen ability"),
         tag("the chosen keyword"),
     ))

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1600,6 +1600,11 @@ fn continuous_mods_grant_chosen_keyword_anaphor() {
         "gain that ability",
         "gain the chosen ability",
         "gain the chosen keyword",
+        // CR 608.2d: plural anaphors refer back to a multi-keyword choice
+        // (Greymond's "Humans you control have each of the chosen abilities").
+        // The same `AddChosenKeyword` reads ALL persisted chosen keywords.
+        "have each of the chosen abilities",
+        "have the chosen abilities",
     ] {
         let mods = parse_continuous_modifications(phrase);
         assert_eq!(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -33875,6 +33875,7 @@ mod tests {
             choose.0,
             ChoiceType::Keyword {
                 options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+                count: 1,
             },
             "choose clause must be a typed keyword choice"
         );

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -354,8 +354,16 @@ pub enum ChoiceType {
     /// `ChosenAttribute::Keyword` on the source so a downstream
     /// `ContinuousModification::RemoveChosenKeyword` (Layer 6) can strip the
     /// chosen ability at layer-evaluation time.
+    ///
+    /// `count` is the "how many to choose" leaf parameterization on this same
+    /// CR 608.2d choice axis (NOT a separate `TwoKeywords` variant): `count: 1`
+    /// is the bare "choose an ability" case (Urborg), `count: 2` is Greymond's
+    /// "choose two abilities from among first strike, vigilance, and lifelink".
+    /// For `count > 1` each chosen keyword is persisted as its own
+    /// `ChosenAttribute::Keyword`.
     Keyword {
         options: Vec<Keyword>,
+        count: usize,
     },
 }
 
@@ -470,11 +478,22 @@ impl Serialize for ChoiceType {
             Self::TwoColors => serializer.serialize_unit_variant("ChoiceType", 11, "TwoColors"),
             Self::Word => serializer.serialize_unit_variant("ChoiceType", 12, "Word"),
             Self::Artist => serializer.serialize_unit_variant("ChoiceType", 13, "Artist"),
-            Self::Keyword { options } => {
-                let mut variant =
-                    serializer.serialize_struct_variant("ChoiceType", 14, "Keyword", 1)?;
-                variant.serialize_field("options", options)?;
-                variant.end()
+            Self::Keyword { options, count } => {
+                // Skip `count` when it is the default (1) so existing
+                // single-keyword card-data JSON stays byte-stable; only emit
+                // the field for multi-choice cards (Greymond, count: 2).
+                if *count == 1 {
+                    let mut variant =
+                        serializer.serialize_struct_variant("ChoiceType", 14, "Keyword", 1)?;
+                    variant.serialize_field("options", options)?;
+                    variant.end()
+                } else {
+                    let mut variant =
+                        serializer.serialize_struct_variant("ChoiceType", 14, "Keyword", 2)?;
+                    variant.serialize_field("options", options)?;
+                    variant.serialize_field("count", count)?;
+                    variant.end()
+                }
             }
         }
     }
@@ -515,7 +534,15 @@ impl<'de> Deserialize<'de> for ChoiceType {
             },
             Keyword {
                 options: Vec<Keyword>,
+                // Default to 1 (the bare single-keyword choice) so legacy
+                // `Keyword { options }` JSON round-trips to `count: 1`.
+                #[serde(default = "default_keyword_choice_count")]
+                count: usize,
             },
+        }
+
+        fn default_keyword_choice_count() -> usize {
+            1
         }
 
         match ChoiceTypeRepr::deserialize(deserializer)? {
@@ -556,7 +583,7 @@ impl<'de> Deserialize<'de> for ChoiceType {
                 ChoiceTypeData::NumberRange { min, max } => Ok(Self::NumberRange { min, max }),
                 ChoiceTypeData::Labeled { options } => Ok(Self::Labeled { options }),
                 ChoiceTypeData::Opponent { restriction } => Ok(Self::Opponent { restriction }),
-                ChoiceTypeData::Keyword { options } => Ok(Self::Keyword { options }),
+                ChoiceTypeData::Keyword { options, count } => Ok(Self::Keyword { options, count }),
             },
         }
     }
@@ -907,6 +934,7 @@ impl ChosenAttribute {
             // `NumberRange { min: 0, max: 20 }` template idiom.
             Self::Keyword(_) => ChoiceType::Keyword {
                 options: Vec::new(),
+                count: 1,
             },
             // CR 614.12c: Anchor-word labels are a free-form labeled choice
             // (the per-card option list — e.g. ["Jeskai", "Temur"] — is
@@ -1007,7 +1035,7 @@ impl ChoiceValue {
             // list by display string. Comparison is case-insensitive so the
             // frontend can render canonical capitalization while the engine
             // accepts either form.
-            ChoiceType::Keyword { options } => {
+            ChoiceType::Keyword { options, .. } => {
                 let needle = value.to_lowercase();
                 options
                     .iter()

--- a/crates/engine/tests/greymond_avacyns_stalwart.rs
+++ b/crates/engine/tests/greymond_avacyns_stalwart.rs
@@ -1,0 +1,468 @@
+//! Greymond, Avacyn's Stalwart ({2}{W}{W}, Creature — Human Soldier, 3/4):
+//!   1. "As Greymond, Avacyn's Stalwart enters, choose two abilities from among
+//!      first strike, vigilance, and lifelink."
+//!   2. "Humans you control have each of the chosen abilities."
+//!   3. "As long as you control four or more Humans, Humans you control get
+//!      +2/+2."
+//!
+//! These tests drive the real parse → synthesis → layer pipeline. The
+//! `ChoiceType::Keyword { count: 2 }` choice is answered through the actual cast
+//! pipeline (V2), and the two Humans-you-control statics are exercised by
+//! pushing the chosen keywords onto the source (the same indirection the cast
+//! pipeline produces) and reading the post-`evaluate_layers` view.
+//!
+//! CR 608.2d (choosing two abilities), CR 613.1f (Layer 6 keyword grant),
+//! CR 611.3a (continuous effect not locked in — the +2/+2 anthem tracks the live
+//! Human count), CR 400.7 (chosen attributes clear on zone change).
+
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::ability::{ChoiceType, ChosenAttribute};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const GREYMOND: &str = "As Greymond, Avacyn's Stalwart enters, choose two abilities from among \
+    first strike, vigilance, and lifelink.\n\
+    Humans you control have each of the chosen abilities.\n\
+    As long as you control four or more Humans, Humans you control get +2/+2.";
+
+/// Recompute layers and read an object's effective (post-layer) power/toughness.
+fn effective_pt(runner: &mut GameRunner, id: ObjectId) -> (i32, i32) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let obj = &runner.state().objects[&id];
+    (
+        obj.power.expect("creature has power"),
+        obj.toughness.expect("creature has toughness"),
+    )
+}
+
+/// True iff `id` currently has `keyword` after a fresh layer evaluation.
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// Push the two chosen keywords onto Greymond — the same persisted state the
+/// as-enters `Choose { count: 2 }` produces via `bind_named_choice` (two
+/// independent `ChosenAttribute::Keyword` entries).
+fn set_chosen(runner: &mut GameRunner, greymond: ObjectId, kws: &[Keyword]) {
+    let obj = runner.state_mut().objects.get_mut(&greymond).unwrap();
+    obj.chosen_attributes
+        .retain(|a| !matches!(a, ChosenAttribute::Keyword(_)));
+    for kw in kws {
+        obj.chosen_attributes
+            .push(ChosenAttribute::Keyword(kw.clone()));
+    }
+}
+
+/// Build Greymond (Human Soldier) on the battlefield under P0 from Oracle text,
+/// running the real parse + synthesis pipeline that installs both statics.
+fn add_greymond(scenario: &mut GameScenario) -> ObjectId {
+    let mut b =
+        scenario.add_creature_from_oracle(P0, "Greymond, Avacyn's Stalwart", 3, 4, GREYMOND);
+    b.with_subtypes(vec!["Human", "Soldier"]);
+    b.id()
+}
+
+fn add_human(scenario: &mut GameScenario, player: PlayerId, name: &str) -> ObjectId {
+    let mut b = scenario.add_creature(player, name, 2, 2);
+    b.with_subtypes(vec!["Human"]);
+    b.id()
+}
+
+// ===== V2: cast Greymond and answer the count-2 choice =====
+
+/// V2 — Cast Greymond through the real pipeline; the as-enters replacement pauses
+/// on the keyword choice, which offers the three count-2 pairs. Answering a pair
+/// must persist TWO `ChosenAttribute::Keyword` on Greymond (CR 608.2d).
+#[test]
+fn cast_greymond_answers_two_keyword_choice() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let greymond = {
+        let mut b = scenario.add_creature_to_hand_from_oracle(
+            P0,
+            "Greymond, Avacyn's Stalwart",
+            3,
+            4,
+            GREYMOND,
+        );
+        b.with_subtypes(vec!["Human", "Soldier"]);
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects.get(&greymond).unwrap().card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: greymond,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Greymond");
+    runner.advance_until_stack_empty();
+
+    // The as-enters choice pauses on a NamedChoice whose options are the three
+    // count-2 pairs (CR 608.2d).
+    let WaitingFor::NamedChoice { options, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "Greymond must pause on the keyword choice, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    assert_eq!(
+        options.len(),
+        3,
+        "C(3,2) = 3 pairs offered, got {options:?}"
+    );
+    let pair = options
+        .iter()
+        .find(|o| o.contains("First Strike") && o.contains("Vigilance"))
+        .expect("a First Strike + Vigilance pair option")
+        .clone();
+
+    runner
+        .act(GameAction::ChooseOption { choice: pair })
+        .expect("answer the keyword pair");
+    runner.advance_until_stack_empty();
+
+    // Two independent ChosenAttribute::Keyword persist on Greymond.
+    let chosen = runner.state().objects[&greymond].chosen_keywords();
+    assert!(
+        chosen.contains(&&Keyword::FirstStrike) && chosen.contains(&&Keyword::Vigilance),
+        "both chosen abilities must persist, got {chosen:?}"
+    );
+    assert_eq!(
+        chosen.len(),
+        2,
+        "exactly two keywords chosen, got {chosen:?}"
+    );
+}
+
+// ===== V4: each Human gains BOTH chosen keywords; non-Human none =====
+
+/// V4 — With Greymond's chosen pair = (First Strike, Lifelink), every Human you
+/// control gains BOTH keywords (CR 613.1f); a non-Human gains neither; an
+/// unchosen keyword (Vigilance) is never granted; the chosen Lifelink is
+/// installed on each recipient (CR 702.15b).
+#[test]
+fn each_human_gains_both_chosen_keywords_non_human_none() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let greymond = add_greymond(&mut scenario);
+    let other_human = add_human(&mut scenario, P0, "Soldier Ally");
+    let non_human = scenario.add_creature(P0, "Llanowar Elves", 1, 1).id();
+    let opp_human = add_human(&mut scenario, P1, "Enemy Conscript");
+
+    let mut runner = scenario.build();
+    set_chosen(
+        &mut runner,
+        greymond,
+        &[Keyword::FirstStrike, Keyword::Lifelink],
+    );
+
+    // Greymond itself (a Human you control) and the other Human gain BOTH.
+    for id in [greymond, other_human] {
+        assert!(
+            has_kw(&mut runner, id, &Keyword::FirstStrike),
+            "Human {id:?} must gain the chosen First Strike"
+        );
+        assert!(
+            has_kw(&mut runner, id, &Keyword::Lifelink),
+            "Human {id:?} must gain the chosen Lifelink"
+        );
+        assert!(
+            !has_kw(&mut runner, id, &Keyword::Vigilance),
+            "the unchosen Vigilance must NOT be granted to {id:?}"
+        );
+    }
+
+    // The non-Human gains nothing.
+    assert!(
+        !has_kw(&mut runner, non_human, &Keyword::FirstStrike)
+            && !has_kw(&mut runner, non_human, &Keyword::Lifelink),
+        "a non-Human you control gains none of the chosen abilities"
+    );
+
+    // The opponent's Human is not "a Human you control".
+    assert!(
+        !has_kw(&mut runner, opp_human, &Keyword::FirstStrike)
+            && !has_kw(&mut runner, opp_human, &Keyword::Lifelink),
+        "the opponent's Human is excluded (controller = You)"
+    );
+
+    // The chosen Lifelink is actually installed (present in the recipient's
+    // post-layer keyword set), which is what drives lifegain on damage
+    // (CR 702.15b — damage from a lifelink source gains its controller life;
+    // lifelink is a damage-application static, not a trigger).
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    assert!(
+        runner.state().objects[&other_human]
+            .keywords
+            .contains(&Keyword::Lifelink),
+        "the chosen Lifelink must be installed on the recipient's effective keyword set"
+    );
+}
+
+// ===== V5: two Greymonds with different pairs — union, source-scoped =====
+
+/// V5 — Two Greymonds choosing different pairs each grant their own keywords;
+/// a Human you control receives the UNION, and each grant stays scoped to its
+/// own source (CR 613.1f, source-scoped read in `apply_continuous_effect`).
+#[test]
+fn two_greymonds_union_of_keywords_source_scoped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let greymond_a = add_greymond(&mut scenario);
+    let greymond_b = add_greymond(&mut scenario);
+    let human = add_human(&mut scenario, P0, "Shared Recipient");
+
+    let mut runner = scenario.build();
+    set_chosen(
+        &mut runner,
+        greymond_a,
+        &[Keyword::FirstStrike, Keyword::Vigilance],
+    );
+    set_chosen(
+        &mut runner,
+        greymond_b,
+        &[Keyword::Vigilance, Keyword::Lifelink],
+    );
+
+    // The Human gains the UNION: First Strike (A) + Vigilance (both) + Lifelink (B).
+    assert!(
+        has_kw(&mut runner, human, &Keyword::FirstStrike),
+        "First Strike from Greymond A"
+    );
+    assert!(
+        has_kw(&mut runner, human, &Keyword::Vigilance),
+        "Vigilance from both Greymonds"
+    );
+    assert!(
+        has_kw(&mut runner, human, &Keyword::Lifelink),
+        "Lifelink from Greymond B"
+    );
+
+    // Source-scoped: clearing B's choice drops ONLY B's exclusive keyword.
+    set_chosen(&mut runner, greymond_b, &[]);
+    assert!(
+        has_kw(&mut runner, human, &Keyword::FirstStrike)
+            && has_kw(&mut runner, human, &Keyword::Vigilance),
+        "Greymond A's grants survive clearing Greymond B (source-scoped)"
+    );
+    assert!(
+        !has_kw(&mut runner, human, &Keyword::Lifelink),
+        "Lifelink (B-exclusive) is gone once B's choice is cleared"
+    );
+}
+
+// ===== V7: live count gate for the +2/+2 anthem =====
+
+/// V7 — The +2/+2 anthem is active only while you control four or more Humans
+/// (CR 611.3a: the continuous effect tracks the live count). 3 Humans → off,
+/// 4 → on, back to 3 → off.
+#[test]
+fn anthem_tracks_live_human_count_threshold() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Greymond + 2 other Humans = 3 Humans you control (below threshold).
+    let greymond = add_greymond(&mut scenario);
+    let h2 = add_human(&mut scenario, P0, "Human Two");
+    let _h3 = add_human(&mut scenario, P0, "Human Three");
+
+    let mut runner = scenario.build();
+    set_chosen(
+        &mut runner,
+        greymond,
+        &[Keyword::FirstStrike, Keyword::Vigilance],
+    );
+
+    // 3 Humans → no +2/+2 (Greymond stays base 3/4; h2 stays 2/2).
+    assert_eq!(
+        effective_pt(&mut runner, greymond),
+        (3, 4),
+        "3 Humans: anthem OFF, Greymond base 3/4"
+    );
+    assert_eq!(
+        effective_pt(&mut runner, h2),
+        (2, 2),
+        "3 Humans: anthem OFF, other Human base 2/2"
+    );
+
+    // Add a 4th Human → anthem ON.
+    let h4 = add_human_after_build(&mut runner, P0, "Human Four");
+    assert_eq!(
+        effective_pt(&mut runner, greymond),
+        (5, 6),
+        "4 Humans: anthem ON, Greymond 3/4 + 2/2"
+    );
+    assert_eq!(
+        effective_pt(&mut runner, h2),
+        (4, 4),
+        "4 Humans: anthem ON, other Human 2/2 + 2/2"
+    );
+
+    // Remove the 4th Human → back to 3 → anthem OFF (CR 611.3a live tracking).
+    {
+        let state = runner.state_mut();
+        state.battlefield.retain(|&id| id != h4);
+        state.objects.remove(&h4);
+    }
+    assert_eq!(
+        effective_pt(&mut runner, greymond),
+        (3, 4),
+        "back to 3 Humans: anthem OFF again"
+    );
+}
+
+/// Add a Human to the battlefield after the runner is built (for the threshold
+/// flip in V7). Mirrors `add_human` but operates on live state.
+fn add_human_after_build(runner: &mut GameRunner, player: PlayerId, name: &str) -> ObjectId {
+    use engine::types::card_type::CoreType;
+    use engine::types::identifiers::CardId;
+    use engine::types::zones::Zone;
+    let state = runner.state_mut();
+    let card_id = CardId(state.next_object_id);
+    let id = engine::game::zones::create_object(
+        state,
+        card_id,
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types = vec![CoreType::Creature];
+    obj.card_types.subtypes = vec!["Human".to_string()];
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = Some(2);
+    obj.toughness = Some(2);
+    obj.base_power = Some(2);
+    obj.base_toughness = Some(2);
+    id
+}
+
+// V8 (off-zone plural read) lives as a unit test inside the engine crate
+// (`off_zone_characteristics.rs`) because that module is `pub(crate)`.
+
+// V10 (matthewevans regression for PR #4638 — repeated single-keyword choice
+// REPLACES the prior answer) lives as an inline unit test inside the engine crate
+// (`game/effects/choose.rs`), because it parses Angelic Skirmisher's real
+// choose+grant chain via the `pub(crate)` `parser::oracle_trigger::parse_trigger_line`
+// to drive the production `ChooseOption` / `bind_named_choice` path twice.
+
+// ===== V9: serde round-trip =====
+
+/// V9 — Serde compatibility: legacy `Keyword { options }` JSON (no `count`)
+/// deserializes to `count == 1`; a new `count: 2` value round-trips; and the
+/// `count == 1` form serializes WITHOUT the `count` field (byte-stable with old
+/// card-data).
+#[test]
+fn choice_type_keyword_count_serde_roundtrip() {
+    // Legacy JSON (no count) → count == 1.
+    let legacy: ChoiceType =
+        serde_json::from_str(r#"{"Keyword":{"options":["FirstStrike","Vigilance"]}}"#)
+            .expect("legacy Keyword JSON parses");
+    assert_eq!(
+        legacy,
+        ChoiceType::Keyword {
+            options: vec![Keyword::FirstStrike, Keyword::Vigilance],
+            count: 1,
+        },
+        "legacy Keyword JSON must default count to 1"
+    );
+
+    // count == 1 serializes WITHOUT the count field (byte-stable).
+    let single = ChoiceType::Keyword {
+        options: vec![Keyword::FirstStrike],
+        count: 1,
+    };
+    let single_json = serde_json::to_string(&single).unwrap();
+    assert!(
+        !single_json.contains("count"),
+        "count == 1 must be omitted for byte-stability, got {single_json}"
+    );
+
+    // count == 2 round-trips and carries the field.
+    let pair = ChoiceType::Keyword {
+        options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+        count: 2,
+    };
+    let pair_json = serde_json::to_string(&pair).unwrap();
+    assert!(
+        pair_json.contains("count"),
+        "count == 2 must serialize the field, got {pair_json}"
+    );
+    let back: ChoiceType = serde_json::from_str(&pair_json).unwrap();
+    assert_eq!(back, pair, "count == 2 must round-trip");
+}
+
+// ===== F4: AI candidate generation =====
+
+/// F4 — AI legal-action generation for Greymond's count-2 keyword choice yields
+/// exactly the three pair candidates (each a `GameAction::ChooseOption` whose
+/// choice is a comma-joined keyword pair).
+#[test]
+fn ai_candidates_three_pairs_for_greymond_choice() {
+    use engine::ai_support::legal_actions;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let greymond = add_greymond(&mut scenario);
+    let mut runner = scenario.build();
+
+    // Drive state into the keyword NamedChoice for Greymond's choice.
+    runner.state_mut().waiting_for = WaitingFor::NamedChoice {
+        player: P0,
+        choice_type: ChoiceType::Keyword {
+            options: vec![Keyword::FirstStrike, Keyword::Vigilance, Keyword::Lifelink],
+            count: 2,
+        },
+        options: vec![
+            "First Strike, Vigilance".to_string(),
+            "First Strike, Lifelink".to_string(),
+            "Vigilance, Lifelink".to_string(),
+        ],
+        source_id: Some(greymond),
+    };
+
+    let actions = legal_actions(runner.state());
+    let choose: Vec<String> = actions
+        .into_iter()
+        .filter_map(|a| match a {
+            GameAction::ChooseOption { choice } => Some(choice),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        choose.len(),
+        3,
+        "exactly three pair candidates for a count-2 keyword choice, got {choose:?}"
+    );
+    for expected in [
+        "First Strike, Vigilance",
+        "First Strike, Lifelink",
+        "Vigilance, Lifelink",
+    ] {
+        assert!(
+            choose.iter().any(|c| c == expected),
+            "missing pair candidate {expected:?} in {choose:?}"
+        );
+    }
+}

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -4068,7 +4068,8 @@ pub fn convert(a: &Action) -> ConvResult<Effect> {
                 .map(static_effect::check_hasable_to_keyword_option)
                 .collect::<ConvResult<_>>()?;
             Effect::Choose {
-                choice_type: ChoiceType::Keyword { options },
+                // CR 608.2d: mtgish only models single-keyword choices, so count = 1.
+                choice_type: ChoiceType::Keyword { options, count: 1 },
                 persist: true,
                 selection: engine::types::ability::TargetSelectionMode::Chosen,
             }


### PR DESCRIPTION
## Anchored on

Greymond, Avacyn's Stalwart ({2}{W}{W}, Creature — Human Soldier, 3/4), verified Oracle text:

> As Greymond, Avacyn's Stalwart enters, choose two abilities from among first strike, vigilance, and lifelink.
> Humans you control have each of the chosen abilities.
> As long as you control four or more Humans, Humans you control get +2/+2.

## Problem

Greymond was fully unsupported — its parse yielded multiple `Effect::Unimplemented` / `StaticCondition::Unrecognized` (no as-enters keyword choice, no plural "the chosen abilities" grant).

## Root cause

Two gaps in otherwise-shipped infrastructure:
- The as-enters keyword choice (`ChoiceType::Keyword`) was single-pick only — no way to "choose two abilities from among …".
- The chosen-keyword static grant (`ContinuousModification::AddChosenKeyword`) and its accessor read only the FIRST chosen keyword (documented limitation), so "have each of the chosen abilities" could never grant both.

(Line 3, the conditional tribal anthem, already parses via the existing control-count condition + typed-anthem path — confirmed by test, no code needed.)

## Fix (class-general — "choose N keywords", not Greymond-only)

- **Parameterize, don't proliferate:** added a single `count: usize` field to the existing `ChoiceType::Keyword` (default 1, serde-back-compatible) rather than a new `TwoKeywords` variant. The chosen pair persists as TWO ordinary `ChosenAttribute::Keyword` entries. **Zero new enum variants.** (Ran through the `add-engine-variant` gate: leaf parameterization on the count axis, within CR 608.2d.)
- New `GameObject::chosen_keywords()` accessor reads ALL chosen keywords; the existing `AddChosenKeyword` apply path (battlefield + off-zone) now grants every one, source-scoped via `effect.source_id` (two Greymonds with different pairs don't leak).
- Parser: a new `try_parse_keyword_choice_from_among` branch handles "choose N abilities/keywords from among <Oxford-and list>" (reusing the existing `FromAmong` splitter; trims the sentence-final period); the L2 anaphor `alt()` is extended with "each of the chosen abilities" → the existing static `AddChosenKeyword`.
- Lockstep: one constructor in `crates/mtgish-import` updated to `count: 1` (mandatory cross-crate compile update for the shared-enum shape change; not feature work).

CR 608.2d (making a choice), 613.1f (Layer 6 ability grant), 614.12c (persisted as-enters choice), 702.15b (lifelink), 611.3a / 400.7 (continuous re-eval / zone-change attribute clearing) — all grep-verified against `docs/MagicCompRules.txt`.

## Tests

- Parser: L1 exact text → `ChoiceType::Keyword { [FirstStrike,Vigilance,Lifelink], count: 2 }` + persist; negative siblings (bare "first strike, vigilance, or lifelink" stays `count: 1`; "left or right" stays `Labeled`); L2 → a `StaticDefinition` (not a trigger) with a Human-subtype you-control filter + `AddChosenKeyword`; L3 → both the count condition and the +2/+2 subject carry `Subtype("Human")` with comparator `>= 4`; whole-card parse → zero `Unimplemented`/`Unrecognized`.
- Runtime (GameScenario): cast + answer persists two chosen keywords; each Human you control gains BOTH (and only the) chosen abilities, non-Humans none; **two Greymonds with different pairs** → a Human gets the source-scoped union; **3 Humans → no +2/+2, 4 → +2/+2, back to 3 → off** (live); off-zone plural read; serde back-compat round-trip; AI candidate generation yields exactly the 3 pairs.

## Verification

`cargo fmt` clean; full-workspace `cargo check` clean (incl. mtgish-import); parser combinator gate exit 0; engine clippy `-D warnings` clean; engine parser (7014) / oracle_effect (2269) / layers (400) suites green; all new parser + 6 runtime fixtures pass.

Model: claude-opus-4-8
Tier: Frontier
