### PR TITLE
fix(parser): support "more cards in hand than each opponent" condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1931,6 +1931,32 @@ fn parse_hand_size_predicate(rest: &str, player: PlayerScope) -> Option<(&str, S
         ));
     }
 
+    // CR 402: "more cards in hand than each opponent" → HandSize(player) GT
+    // HandSize(Opponent{Max}). "each opponent" is universal (more than ALL of
+    // them), so the predicate is "your hand > the maximum opponent hand" — the
+    // Max aggregate, mirroring how "more life than an opponent" uses Min for its
+    // existential "an". Okina Nightwatch, Secretkeeper.
+    if let Ok((rest, _)) =
+        tag::<_, _, OracleError<'_>>("more cards in hand than each opponent").parse(rest)
+    {
+        return Some((
+            rest,
+            StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize { player },
+                },
+                comparator: Comparator::GT,
+                rhs: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Opponent {
+                            aggregate: AggregateFunction::Max,
+                        },
+                    },
+                },
+            },
+        ));
+    }
+
     // "N or more cards in hand" → HandSize GE N
     let (after_n, n) = parse_number(rest).ok()?;
     if let Ok((rest, _)) = alt((
@@ -7453,6 +7479,48 @@ mod tests {
             }
             other => {
                 panic!("expected HandSize(ScopedPlayer) GT HandSize(Controller), got {other:?}")
+            }
+        }
+    }
+
+    /// CR 402: "you have more cards in hand than each opponent" →
+    /// HandSize(Controller) GT HandSize(Opponent{Max}). "each opponent" is
+    /// universal (more than all of them), so the bar is the maximum opponent
+    /// hand — the mirror of "more life than an opponent"'s existential Min.
+    /// Okina Nightwatch, Secretkeeper.
+    #[test]
+    fn test_parse_condition_more_cards_in_hand_than_each_opponent() {
+        let (rest, c) =
+            parse_condition("as long as you have more cards in hand than each opponent").unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs,
+                comparator,
+                rhs,
+            } => {
+                assert_eq!(
+                    lhs,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Controller,
+                        },
+                    }
+                );
+                assert_eq!(comparator, Comparator::GT);
+                assert_eq!(
+                    rhs,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Opponent {
+                                aggregate: AggregateFunction::Max,
+                            },
+                        },
+                    }
+                );
+            }
+            other => {
+                panic!("expected HandSize(Controller) GT HandSize(Opponent{{Max}}), got {other:?}")
             }
         }
     }


### PR DESCRIPTION
## Anchored on

Okina Nightwatch and Secretkeeper, both carrying the static condition "As long as you have more cards in hand than each opponent, ..." (Okina gets +3/+3; Secretkeeper gets +2/+2 and has flying). The same phrasing appears on 7 cards in total.

## Problem

The condition "you have more cards in hand than each opponent" parsed to `StaticCondition::Unrecognized`, so the conditional buff on both cards never applied.

## Root cause

`parse_hand_size_predicate` (the shared hand-size comparison combinator) had a "more cards in hand than you" arm but none for "than each opponent", and no other path in `parse_inner_condition` recognized it.

## Fix

Added a single arm to `parse_hand_size_predicate` for "more cards in hand than each opponent" that yields `QuantityComparison { HandSize(controller) GT HandSize(Opponent { aggregate: Max }) }`. "Each opponent" is universal (more than all of them), so the bar is the maximum opponent hand, which is the mirror of the existing "more life than an opponent" arm using Min for its existential "an". It reuses the existing `QuantityComparison`, `QuantityRef::HandSize`, `PlayerScope::Opponent`, and `AggregateFunction` types with no new variants.

## Tests

Parser unit test: "as long as you have more cards in hand than each opponent" parses to the expected `QuantityComparison` (HandSize controller GT HandSize Opponent{Max}). Whole-card parses of Okina Nightwatch and Secretkeeper were confirmed to yield zero `Unrecognized` / `Unimplemented`.

## Verification

`cargo fmt` clean; parser combinator gate exit 0; engine clippy `-D warnings` clean; the new parser test and the existing hand-comparison suite pass.

Model: claude-opus-4-8
Tier: Frontier
