### PR TITLE
feat(engine): Alchemy perpetual self-cost modification (perpetually gains "this spell costs {N} less/more to cast")

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -21517,6 +21517,423 @@ mod tests {
         }
     }
 
+    /// Apply an Alchemy "perpetually gains \"This spell costs {N} less/more to
+    /// cast\"" grant to `spell_id` through the REAL resolution path
+    /// (`parse_effect_chain` → `build_resolved_from_def` → `resolve_ability_chain`),
+    /// exactly as the `ApplyPerpetual` effect runs in production. Returns nothing;
+    /// the synthetic self-spell `ModifyCost` static is injected onto the object.
+    fn grant_perpetual_cost_mod(state: &mut GameState, spell_id: ObjectId, oracle: &str) {
+        use crate::game::ability_utils::build_resolved_from_def;
+        use crate::game::effects::resolve_ability_chain;
+        use crate::types::ability::AbilityKind;
+        let def = parse_effect_chain(oracle, AbilityKind::Activated);
+        let ability = build_resolved_from_def(&def, spell_id, PlayerId(0));
+        let mut events = Vec::new();
+        resolve_ability_chain(state, &ability, &mut events, 0).unwrap();
+    }
+
+    /// Build a generic {N}-cost sorcery in hand for the perpetual-cost tests.
+    fn create_generic_sorcery_in_hand(
+        state: &mut GameState,
+        card_id: u64,
+        name: &str,
+        generic: u32,
+    ) -> ObjectId {
+        let obj_id = create_object(
+            state,
+            CardId(card_id),
+            PlayerId(0),
+            name.to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Sorcery);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic,
+        };
+        obj_id
+    }
+
+    fn self_cost_generic(state: &GameState, spell_id: ObjectId) -> u32 {
+        let mut mana_cost = state.objects.get(&spell_id).unwrap().mana_cost.clone();
+        apply_self_spell_cost_modifiers(state, PlayerId(0), spell_id, &mut mana_cost);
+        match mana_cost {
+            ManaCost::Cost { generic, .. } => generic,
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
+    /// Reduce: a {4}-cost card granted `Reduce {2}` casts for {2}; without the
+    /// grant the same card costs {4} (revert).
+    #[test]
+    fn perpetual_cost_reduce_lowers_self_cast_cost() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_generic_sorcery_in_hand(&mut state, 4_001, "Reduce Test", 4);
+
+        // Revert baseline: no grant → full {4}.
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            4,
+            "ungranted cost is {{4}}"
+        );
+
+        grant_perpetual_cost_mod(
+            &mut state,
+            spell,
+            "~ perpetually gains \"This spell costs {2} less to cast\".",
+        );
+        // CR 601.2f: {4} − {2} = {2}.
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            2,
+            "Reduce {{2}} lowers {{4}} to {{2}}"
+        );
+    }
+
+    /// Raise: a {4}-cost card granted `Raise {2}` casts for {6}.
+    #[test]
+    fn perpetual_cost_raise_increases_self_cast_cost() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_generic_sorcery_in_hand(&mut state, 4_002, "Raise Test", 4);
+
+        grant_perpetual_cost_mod(
+            &mut state,
+            spell,
+            "~ perpetually gains \"This spell costs {2} more to cast\".",
+        );
+        // CR 601.2f: {4} + {2} = {6}.
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            6,
+            "Raise {{2}} raises {{4}} to {{6}}"
+        );
+    }
+
+    /// Floor: a {1}-cost card granted `Reduce {3}` floors at {0} (not negative).
+    #[test]
+    fn perpetual_cost_reduce_floors_at_zero() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_generic_sorcery_in_hand(&mut state, 4_003, "Floor Test", 1);
+
+        grant_perpetual_cost_mod(
+            &mut state,
+            spell,
+            "~ perpetually gains \"This spell costs {3} less to cast\".",
+        );
+        // CR 601.2f: a cost reduction cannot reduce generic mana below {0}.
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            0,
+            "Reduce {{3}} on {{1}} floors at {{0}}, not negative"
+        );
+    }
+
+    /// Persists across a zone change: the perpetual cost reduction survives a
+    /// hand → library → hand round-trip (the static lives in
+    /// `self_spell_cost_mod_active_zones`, which includes Library and Hand). This
+    /// is the perpetual-claim discriminator — a transient-only injection would
+    /// fail it.
+    #[test]
+    fn perpetual_cost_reduce_persists_across_zone_change() {
+        let mut state = setup_game_at_main_phase();
+        let spell = create_generic_sorcery_in_hand(&mut state, 4_004, "Persist Test", 4);
+
+        grant_perpetual_cost_mod(
+            &mut state,
+            spell,
+            "~ perpetually gains \"This spell costs {2} less to cast\".",
+        );
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            2,
+            "reduced to {{2}} in hand"
+        );
+
+        // Move hand → library → hand. The perpetual record and the injected
+        // static must both survive (no zone reset clears base/live statics here).
+        let mut events = Vec::new();
+        zones::move_to_zone(&mut state, spell, Zone::Library, &mut events);
+        zones::move_to_zone(&mut state, spell, Zone::Hand, &mut events);
+
+        // The perpetual modification is still recorded on the object.
+        assert!(
+            state
+                .objects
+                .get(&spell)
+                .unwrap()
+                .perpetual_mods
+                .iter()
+                .any(|m| matches!(
+                    m,
+                    crate::types::ability::PerpetualModification::ModifyCost { .. }
+                )),
+            "perpetual ModifyCost record must persist across the zone change"
+        );
+        // And the cost is still reduced after the round-trip.
+        assert_eq!(
+            self_cost_generic(&state, spell),
+            2,
+            "cost still reduced to {{2}} after hand→library→hand"
+        );
+    }
+
+    /// Multi-authority net: two grants on one card stack. `Reduce {2}` + `Raise
+    /// {1}` on a {3} base nets {2} (raise-before-reduce ordering), and a floor
+    /// case `Reduce {3}` + `Raise {2}` on a {1} base floors at {0}.
+    #[test]
+    fn perpetual_cost_multiple_grants_stack_and_floor() {
+        let mut state = setup_game_at_main_phase();
+
+        // Net case: {3} base, Reduce {2} + Raise {1} → {2}.
+        let net = create_generic_sorcery_in_hand(&mut state, 4_005, "Net Test", 3);
+        grant_perpetual_cost_mod(
+            &mut state,
+            net,
+            "~ perpetually gains \"This spell costs {2} less to cast\".",
+        );
+        grant_perpetual_cost_mod(
+            &mut state,
+            net,
+            "~ perpetually gains \"This spell costs {1} more to cast\".",
+        );
+        // CR 601.2f: raises apply before reductions: {3} + {1} − {2} = {2}.
+        assert_eq!(
+            self_cost_generic(&state, net),
+            2,
+            "Reduce {{2}} + Raise {{1}} on {{3}} nets {{2}}"
+        );
+
+        // Floor case: {1} base, Reduce {3} + Raise {2} → {0}.
+        let floor = create_generic_sorcery_in_hand(&mut state, 4_006, "Net Floor Test", 1);
+        grant_perpetual_cost_mod(
+            &mut state,
+            floor,
+            "~ perpetually gains \"This spell costs {3} less to cast\".",
+        );
+        grant_perpetual_cost_mod(
+            &mut state,
+            floor,
+            "~ perpetually gains \"This spell costs {2} more to cast\".",
+        );
+        // CR 601.2f: {1} + {2} − {3} = {0}, floored (not negative).
+        assert_eq!(
+            self_cost_generic(&state, floor),
+            0,
+            "Reduce {{3}} + Raise {{2}} on {{1}} floors at {{0}}"
+        );
+    }
+
+    /// End-to-end through the real cast pipeline: a {4}-cost card granted `Reduce
+    /// {2}`, funded with exactly {2} in pool, commits to the stack and resolves —
+    /// proving the reduced cost is actually PAYABLE from the pool (not merely a
+    /// computed number). A transient-only or unapplied injection would leave the
+    /// pool short and the cast would fail to commit.
+    #[test]
+    fn perpetual_cost_reduce_payable_through_cast_pipeline() {
+        use crate::game::scenario::GameRunner;
+
+        let mut state = setup_game_at_main_phase();
+        let spell = create_generic_sorcery_in_hand(&mut state, 4_007, "Pipeline Test", 4);
+        grant_perpetual_cost_mod(
+            &mut state,
+            spell,
+            "~ perpetually gains \"This spell costs {2} less to cast\".",
+        );
+        // Fund exactly the reduced cost: {2} generic (two colorless).
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
+
+        let mut runner = GameRunner::from_state(state);
+        let outcome = runner.cast(spell).resolve();
+
+        // CR 608.2n: a resolved sorcery goes to its owner's graveyard. Reaching
+        // the graveyard (not staying stranded in hand) proves the {2} pool
+        // covered the reduced cost and the spell actually committed + resolved —
+        // i.e. the reduction applied on the real payment path, not just to the
+        // computed cost. (Were the full {4} still required, the {2} pool could
+        // not pay it and the spell would remain in hand.)
+        outcome.assert_zone(&[spell], Zone::Graveyard);
+    }
+
+    /// Build a {N}-generic creature in `owner`'s hand for the mass-hand tests.
+    fn create_generic_creature_in_hand(
+        state: &mut GameState,
+        card_id: u64,
+        owner: PlayerId,
+        name: &str,
+        generic: u32,
+    ) -> ObjectId {
+        let obj_id = create_object(state, CardId(card_id), owner, name.to_string(), Zone::Hand);
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic,
+        };
+        obj_id
+    }
+
+    /// Build a basic-land card in `owner`'s hand — the negative control; the
+    /// mass-hand cost grant's filter excludes Land.
+    fn create_land_in_hand(
+        state: &mut GameState,
+        card_id: u64,
+        owner: PlayerId,
+        name: &str,
+    ) -> ObjectId {
+        let obj_id = create_object(state, CardId(card_id), owner, name.to_string(), Zone::Hand);
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        obj_id
+    }
+
+    fn self_cost_generic_for(state: &GameState, player: PlayerId, spell_id: ObjectId) -> u32 {
+        let mut mana_cost = state.objects.get(&spell_id).unwrap().mana_cost.clone();
+        apply_self_spell_cost_modifiers(state, player, spell_id, &mut mana_cost);
+        match mana_cost {
+            ManaCost::Cost { generic, .. } => generic,
+            other => panic!("expected ManaCost::Cost, got {other:?}"),
+        }
+    }
+
+    /// Resolve `ApplyPerpetual { cards_in_hand_filter(Creature, You),
+    /// ModifyCost{Reduce,{1}} }` through the REAL perpetual resolver and assert
+    /// the per-card outcome: the matching Creature hand card's self-cast cost
+    /// drops by {1}, the Land (filtered out) is unchanged, and an OPPONENT's
+    /// Creature (controller-scope mismatch) is unchanged.
+    #[test]
+    fn perpetual_mass_hand_cost_reduces_only_matching_cards() {
+        use crate::game::effects::perpetual;
+        use crate::parser::oracle_effect::cards_in_hand_filter;
+        use crate::types::ability::{PerpetualModification, ResolvedAbility};
+        use crate::types::statics::CostModifyMode;
+
+        let mut state = setup_game_at_main_phase();
+        let creature = create_generic_creature_in_hand(&mut state, 5_001, PlayerId(0), "Bear", 4);
+        let land = create_land_in_hand(&mut state, 5_002, PlayerId(0), "Forest");
+        // Controller-scope sibling: a Creature in the OPPONENT's hand.
+        let opp_creature =
+            create_generic_creature_in_hand(&mut state, 5_003, PlayerId(1), "Opp Bear", 4);
+
+        // Revert baseline: BEFORE resolve, all three are at their printed cost.
+        assert_eq!(self_cost_generic_for(&state, PlayerId(0), creature), 4);
+        assert_eq!(self_cost_generic_for(&state, PlayerId(1), opp_creature), 4);
+
+        // A P0-controlled source anchors `ControllerRef::You` for the filter.
+        let source = create_object(
+            &mut state,
+            CardId(5_000),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: cards_in_hand_filter(TypeFilter::Creature, Some(ControllerRef::You)),
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount: ManaCost::generic(1),
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        perpetual::resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 601.2f: the matching Creature hand card drops {1} ({4} → {3}).
+        assert_eq!(
+            self_cost_generic_for(&state, PlayerId(0), creature),
+            3,
+            "the matching Creature hand card should drop by {{1}}"
+        );
+        // The Land is excluded by the filter — no cost mod recorded.
+        assert!(
+            !state
+                .objects
+                .get(&land)
+                .unwrap()
+                .perpetual_mods
+                .iter()
+                .any(|m| matches!(m, PerpetualModification::ModifyCost { .. })),
+            "the Land must not receive the cost mod"
+        );
+        // Controller-scope: the OPPONENT's Creature is NOT reduced (filter is You).
+        assert_eq!(
+            self_cost_generic_for(&state, PlayerId(1), opp_creature),
+            4,
+            "an opponent's hand Creature must not be reduced by a 'your hand' grant"
+        );
+    }
+
+    /// Fearsome Whelp's SINGULAR + `each` subtype form, resolved through the REAL
+    /// perpetual resolver: a Dragon card and a non-Dragon card in P0's hand;
+    /// resolve `ApplyPerpetual { cards_in_hand_filter(Subtype("Dragon"), You),
+    /// ModifyCost{Reduce,{1}} }`; the Dragon card's self-cast cost drops by {1}
+    /// and the non-Dragon's is unchanged.
+    #[test]
+    fn perpetual_mass_hand_each_dragon_reduces_only_dragons() {
+        use crate::game::effects::perpetual;
+        use crate::parser::oracle_effect::cards_in_hand_filter;
+        use crate::types::ability::{PerpetualModification, ResolvedAbility};
+        use crate::types::statics::CostModifyMode;
+
+        let mut state = setup_game_at_main_phase();
+        // A Dragon creature card and a non-Dragon (Bear) creature card in hand.
+        let dragon = create_generic_creature_in_hand(&mut state, 6_001, PlayerId(0), "Whelp", 5);
+        state
+            .objects
+            .get_mut(&dragon)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Dragon".to_string());
+        let bear = create_generic_creature_in_hand(&mut state, 6_002, PlayerId(0), "Bear", 3);
+
+        // Revert baseline: BEFORE resolve, both at printed cost.
+        assert_eq!(self_cost_generic_for(&state, PlayerId(0), dragon), 5);
+        assert_eq!(self_cost_generic_for(&state, PlayerId(0), bear), 3);
+
+        let source = create_object(
+            &mut state,
+            CardId(6_000),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ApplyPerpetual {
+                target: cards_in_hand_filter(
+                    TypeFilter::Subtype("Dragon".to_string()),
+                    Some(ControllerRef::You),
+                ),
+                modification: PerpetualModification::ModifyCost {
+                    mode: CostModifyMode::Reduce,
+                    amount: ManaCost::generic(1),
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        perpetual::resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 601.2f: only the Dragon card drops {1} ({5} → {4}); the Bear is
+        // untouched (subtype filter excludes it).
+        assert_eq!(
+            self_cost_generic_for(&state, PlayerId(0), dragon),
+            4,
+            "the Dragon hand card should drop by {{1}}"
+        );
+        assert_eq!(
+            self_cost_generic_for(&state, PlayerId(0), bear),
+            3,
+            "a non-Dragon hand card must be unchanged"
+        );
+    }
+
     fn create_black_sorcery_with_keywords(
         state: &mut GameState,
         card_id: u64,

--- a/crates/engine/src/game/effects/perpetual.rs
+++ b/crates/engine/src/game/effects/perpetual.rs
@@ -85,6 +85,22 @@ fn perpetual_target_object_ids(
         }
     }
 
+    // Mass perpetual over a non-battlefield zone (CR 601.2f hand-card cost grants:
+    // "[type] cards in [your/that player's] hand perpetually gain …"). When the
+    // filter pins an `InZone` other than the battlefield, enumerate that zone and
+    // keep every object matching the filter — NOT a single declared target and
+    // NOT the source fallback (the grant edits a set of cards, possibly empty, in
+    // a hidden zone). Mirrors `layers::apply_continuous_effect_filtered`.
+    if let Some(zone) = target.extract_in_zone() {
+        if zone != crate::types::zones::Zone::Battlefield {
+            let ctx = crate::game::filter::FilterContext::from_source(state, ability.source_id);
+            return crate::game::targeting::zone_object_ids(state, zone)
+                .into_iter()
+                .filter(|&id| crate::game::filter::matches_target_filter(state, id, target, &ctx))
+                .collect();
+        }
+    }
+
     if ids.is_empty() {
         ids.push(ability.source_id);
     }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1119,6 +1119,32 @@ impl GameObject {
                     }
                 }
             }
+            PerpetualModification::ModifyCost { mode, amount } => {
+                // CR 601.2f: realize the perpetual self-cost modifier as a
+                // synthetic self-spell `ModifyCost` static. The self-spell cost collector
+                // reads LIVE `static_definitions` (casting.rs `collect_self_spell_cost_modifiers`)
+                // and the hand-zone layer pass re-syncs only `keywords` from base
+                // (layers.rs) — so push to BOTH live and base, mirroring the GrantKeywords
+                // arm (keywords + base_keywords): the live copy makes it visible to a
+                // from-hand cast immediately; the base copy survives the battlefield layer
+                // reset (`static_definitions = base.clone()`). `apply_perpetual_modification`
+                // runs once per `ApplyPerpetual` resolution (single caller, effects/perpetual.rs)
+                // so there is no double-injection; multiple distinct grants intentionally stack.
+                use crate::types::ability::TargetFilter;
+                use crate::types::statics::StaticMode;
+                self.sync_missing_base_characteristics();
+                let synthetic =
+                    crate::types::ability::StaticDefinition::new(StaticMode::ModifyCost {
+                        mode: *mode,
+                        amount: amount.clone(),
+                        spell_filter: None,
+                        dynamic_count: None,
+                    })
+                    .affected(TargetFilter::SelfRef)
+                    .active_zones(crate::types::zones::self_spell_cost_mod_active_zones());
+                self.static_definitions.push(synthetic.clone());
+                Arc::make_mut(&mut self.base_static_definitions).push(synthetic);
+            }
         }
         self.perpetual_mods.push(modification.clone());
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -5777,6 +5777,17 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
+    // Digital-only Alchemy (CR 601.2f + CR 611.2c): "[type] cards in [your/that
+    // player's] hand perpetually gain \"This spell costs {N} less/more to
+    // cast\"" — a latched self-spell cost modifier applied to each matching hand
+    // card (Blooming Cactusfolk, Charged Conjuration, Fearsome Whelp,
+    // Fountainport Charmer). Disjoint from the singular random-card arm above
+    // (plural "cards"/"gain" vs "card"/"gains") and from the self-subject arms
+    // (which require a "~"/"this …"/"that …" prefix).
+    if let Some(effect) = try_parse_typed_cards_in_hand_perpetual_gain_cost(tp) {
+        return parsed_clause(effect);
+    }
+
     if let Some(clause) = try_parse_gain_energy(tp, ctx) {
         return clause;
     }
@@ -6319,6 +6330,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    // Digital-only Alchemy: "[~/that X] perpetually gains \"This spell costs {N}
+    // less/more to cast\"" — persistent self-spell cost modifier (CR 601.2f).
+    // Tried before the keyword grant: disjoint (this requires a quoted body, the
+    // keyword grant a bare keyword list), but the quote guard keeps it explicit.
+    if let Some(effect) = try_parse_perpetual_modify_cost(tp) {
+        return parsed_clause(effect);
+    }
+
     // Digital-only Alchemy: "[~/that X] perpetually gains [keyword(s)]" — persistent
     // keyword grant (Monoist Gravliner station trigger).
     if let Some(effect) = try_parse_perpetual_grant_keywords(tp) {
@@ -6684,15 +6703,20 @@ fn try_parse_perpetual_modify_pt(tp: TextPair) -> Option<Effect> {
     })
 }
 
-/// Digital-only Alchemy: parse "perpetually gains [keyword(s)]" —
-/// [`PerpetualModification::GrantKeywords`] (Monoist Gravliner).
-fn try_parse_perpetual_grant_keywords(tp: TextPair) -> Option<Effect> {
-    fn tail_done(tail: &str) -> bool {
-        tail.is_empty() || tail == "."
-    }
-
-    let lower = tp.lower;
-
+/// Shared self-subject prefix for the perpetual self-grant arms
+/// (`try_parse_perpetual_grant_keywords`, `try_parse_perpetual_modify_cost`).
+///
+/// Strips `<subject> perpetually gain(s) ` and reports which target the grant
+/// resolves against:
+/// - the anaphoric `"that <type> perpetually gains ..."` form back-references the
+///   parent target ([`TargetFilter::ParentTarget`]);
+/// - the self forms (`~`, `this creature/artifact/…`) target the source itself
+///   ([`TargetFilter::Any`], resolved to the source by the perpetual resolver).
+///
+/// Returns the remainder after `gain(s) ` plus the resolved target; the caller
+/// parses the grant body.
+fn parse_perpetual_self_subject(lower: &str) -> Option<(&str, TargetFilter)> {
+    // Anaphoric back-reference: "that <type> perpetually gains ...".
     if let Ok((after_that, _)) = tag::<_, _, OracleError<'_>>("that ").parse(lower) {
         let (rest, _) = take_until::<_, _, OracleError<'_>>("perpetually ")
             .parse(after_that)
@@ -6706,11 +6730,7 @@ fn try_parse_perpetual_grant_keywords(tp: TextPair) -> Option<Effect> {
         ))
         .parse(rest)
         .ok()?;
-        let (keywords, rest) = sequence::parse_keyword_grant_list(rest)?;
-        return tail_done(rest).then_some(Effect::ApplyPerpetual {
-            target: TargetFilter::ParentTarget,
-            modification: crate::types::ability::PerpetualModification::GrantKeywords { keywords },
-        });
+        return Some((rest, TargetFilter::ParentTarget));
     }
 
     let after_subject = [
@@ -6738,10 +6758,228 @@ fn try_parse_perpetual_grant_keywords(tp: TextPair) -> Option<Effect> {
     ))
     .parse(rest)
     .ok()?;
+    Some((rest, TargetFilter::Any))
+}
+
+/// Digital-only Alchemy: parse "perpetually gains [keyword(s)]" —
+/// [`PerpetualModification::GrantKeywords`] (Monoist Gravliner).
+fn try_parse_perpetual_grant_keywords(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    let (rest, target) = parse_perpetual_self_subject(tp.lower)?;
     let (keywords, rest) = sequence::parse_keyword_grant_list(rest)?;
     tail_done(rest).then_some(Effect::ApplyPerpetual {
-        target: TargetFilter::Any,
+        target,
         modification: crate::types::ability::PerpetualModification::GrantKeywords { keywords },
+    })
+}
+
+/// Shared quoted-body parser for the self-spell cost modifier: the inner text of
+/// `"this spell costs {N} less/more to cast[.,]"` → `(ManaCost, CostModifyMode)`.
+///
+/// Single authority for the quoted clause, used by BOTH the self-grant arm
+/// ([`try_parse_perpetual_modify_cost`]) and the mass-hand arm
+/// ([`try_parse_typed_cards_in_hand_perpetual_gain_cost`]). The leading `char('"')`
+/// and the consumption of the closing `char('"')` are the caller's responsibility;
+/// this combinator runs from just after the opening quote to just before the
+/// closing quote.
+///
+/// CR 601.2f: Oracle prints terminal punctuation INSIDE the quote on these grants
+/// (e.g. `"This spell costs {1} less to cast."`), so an optional trailing `.`/`,`
+/// is consumed before the closing quote is matched.
+fn parse_quoted_self_spell_cost_body(
+    inner: &str,
+) -> OracleResult<'_, (ManaCost, crate::types::statics::CostModifyMode)> {
+    let (inner, _) = alt((tag("this spell costs "), tag("this card costs "))).parse(inner)?;
+    let (inner, amount) = nom_primitives::parse_mana_cost(inner)?;
+    let (inner, mode) = alt((
+        value(crate::types::statics::CostModifyMode::Reduce, tag(" less")),
+        value(crate::types::statics::CostModifyMode::Raise, tag(" more")),
+    ))
+    .parse(inner)?;
+    let (inner, _) = tag(" to cast").parse(inner)?;
+    // CR 601.2f: terminal punctuation is printed inside the quote.
+    let (inner, _) = opt(alt((tag("."), tag(",")))).parse(inner)?;
+    Ok((inner, (amount, mode)))
+}
+
+/// Digital-only Alchemy (CR 601.2f cost change): parse
+/// "[card] perpetually gains \"This spell costs {N} less/more to cast\"" into a
+/// [`PerpetualModification::ModifyCost`]. The quoted self-spell cost modifier is
+/// realized at resolution by injecting a synthetic [`StaticMode::ModifyCost`]
+/// into the card's persistent static baseline.
+fn try_parse_perpetual_modify_cost(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    let (rest, target) = parse_perpetual_self_subject(tp.lower)?;
+
+    // Quoted body: "this spell costs {N} less/more to cast[.,]".
+    let ((amount, mode), rest) = nom_on_lower(rest, rest, |input| {
+        use nom::character::complete::char;
+        use nom::sequence::delimited;
+        delimited(char('"'), parse_quoted_self_spell_cost_body, char('"')).parse(input)
+    })?;
+
+    // Honest-red: reject any unconsumed tail (a rider clause inside or after the
+    // quote that this leaf cannot model) so it falls through to Unimplemented.
+    tail_done(rest).then_some(Effect::ApplyPerpetual {
+        target,
+        // CR 601.2f: perpetual self-spell cost modifier (digital-only "perpetually" grant).
+        modification: crate::types::ability::PerpetualModification::ModifyCost { mode, amount },
+    })
+}
+
+/// Peek the `card(s) in ` head that follows the type axis (without consuming),
+/// so the type-axis arms can confirm they sit in the "[type] card(s) in … hand"
+/// slot and leave the head for the caller's number-agreement `alt()`. Matches
+/// both the plural ("cards in") and the singular-`each` ("card in") forms.
+fn peek_card_head(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        peek(pair(alt((tag("cards "), tag("card "))), tag("in "))),
+    )
+    .parse(input)
+}
+
+/// Type-axis sub-combinator for the mass-hand perpetual arm: maps the leading
+/// type word(s) of "[type] card(s) in [your/that player's] hand" to a
+/// [`TypeFilter`], consuming the type word AND its trailing space so the caller
+/// can match the shared `card(s) ` head next. The bare-`"card(s)"` form (no
+/// leading type word) consumes nothing and yields [`TypeFilter::Card`].
+///
+/// STRICT `tag()` arms only — never a full-sentence tag — so the remainder
+/// ("card(s) in …") is matched separately and any rider after the type axis
+/// (e.g. Absorb Energy's "cards in your hand that share a card type with that
+/// spell") is left unconsumed and rejected upstream. A single subtype word
+/// (e.g. "dragon") is taken as a [`TypeFilter::Subtype`] via the dedicated
+/// subtype combinator.
+fn parse_hand_card_type_axis(input: &str) -> OracleResult<'_, TypeFilter> {
+    alt((
+        // "nonland card(s)" → Non(Land).
+        value(TypeFilter::Non(Box::new(TypeFilter::Land)), tag("nonland ")),
+        // "instant and/or sorcery card(s)" → AnyOf([Instant, Sorcery]).
+        value(
+            TypeFilter::AnyOf(vec![TypeFilter::Instant, TypeFilter::Sorcery]),
+            alt((tag("instant and sorcery "), tag("instant or sorcery "))),
+        ),
+        value(TypeFilter::Creature, tag("creature ")),
+        value(TypeFilter::Instant, tag("instant ")),
+        value(TypeFilter::Sorcery, tag("sorcery ")),
+        value(TypeFilter::Artifact, tag("artifact ")),
+        value(TypeFilter::Enchantment, tag("enchantment ")),
+        // A single subtype word (e.g. "dragon") directly preceding "card(s) in …".
+        nom_subtype_word,
+        // Bare "card(s) in …" → Card (any card); consume nothing.
+        value(TypeFilter::Card, peek_card_head),
+    ))
+    .parse(input)
+}
+
+/// Parse a single subtype word that directly precedes "card(s) in … hand"
+/// (e.g. "dragon" in "each Dragon card in your hand"). Consumes the word and its
+/// trailing space. Capitalizes the first letter so it matches the canonical
+/// subtype casing (`get_subtype`/database subtypes are PascalCase).
+fn nom_subtype_word(input: &str) -> OracleResult<'_, TypeFilter> {
+    use nom::bytes::complete::take_while1;
+    let (rest, word) = take_while1(|c: char| c.is_ascii_alphabetic()).parse(input)?;
+    // The subtype word must be the type slot directly before "card(s) in " — peek
+    // (don't consume) so the caller matches the shared `card(s) ` head.
+    let (rest, _) = pair(tag(" "), peek_card_head).parse(rest)?;
+    let mut chars = word.chars();
+    let canonical = match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => return Err(oracle_err(input)),
+    };
+    Ok((rest, TypeFilter::Subtype(canonical)))
+}
+
+/// Shared tail for the mass-hand cost arm: `"in <your/that player's> hand
+/// perpetually gain(s) \"<body>\""` → `(controller, ManaCost, CostModifyMode)`.
+///
+/// Single authority for the clause body shared by the PLURAL form ("nonland
+/// cards in your hand perpetually GAIN …") and the SINGULAR-with-`each` form
+/// ("each Dragon card in your hand perpetually GAINS …"). Number agreement on
+/// the verb is one `alt()` (`gain` / `gains`); the caller has already consumed
+/// the `card(s) ` head, so the tail begins at `in `.
+#[allow(clippy::type_complexity)]
+fn parse_in_whose_hand_perpetually_gain_body(
+    input: &str,
+) -> OracleResult<
+    '_,
+    (
+        Option<ControllerRef>,
+        ManaCost,
+        crate::types::statics::CostModifyMode,
+    ),
+> {
+    use nom::character::complete::char;
+    use nom::sequence::delimited;
+
+    let (input, _) = tag("in ").parse(input)?;
+    // Only "your hand" is modeled (controller = the spell's controller).
+    // "that player's hand" is a scoped reference to a specific player, but the
+    // hand-card filter has no scoped-player axis here — `controller: None` would
+    // mean ANY controller, so the hand-zone resolver would enumerate EVERY
+    // player's hand and wrongly modify both players' matching cards. Leave
+    // "that player's hand" honest-red (no parse → Unimplemented) until the
+    // referent is bound to a scoped player axis.
+    let (input, _) = tag("your").parse(input)?;
+    let controller = Some(ControllerRef::You);
+    let (input, _) = tag(" hand perpetually ").parse(input)?;
+    // Number agreement: plural "gain" / singular-each "gains".
+    let (input, _) = alt((tag("gains "), tag("gain "))).parse(input)?;
+    let (input, (amount, mode)) =
+        delimited(char('"'), parse_quoted_self_spell_cost_body, char('"')).parse(input)?;
+    Ok((input, (controller, amount, mode)))
+}
+
+/// Digital-only Alchemy (CR 601.2f + CR 611.2c): parse the mass-hand self-spell
+/// cost grant in BOTH printed number forms →
+/// [`Effect::ApplyPerpetual`] over a [`cards_in_hand_filter`]:
+/// - PLURAL: "[type] cards in [your/that player's] hand perpetually gain
+///   \"This spell costs {N} less/more to cast[.,]\"" (Blooming Cactusfolk,
+///   Charged Conjuration, Fountainport Charmer);
+/// - SINGULAR + `each`: "each [type] card in [your/that player's] hand
+///   perpetually gains \"…\"" (Fearsome Whelp). "each [type] card" = every
+///   matching card in hand — the same all-matching deterministic set the filter
+///   already yields.
+///
+/// STRICT nom sequencing (no `take_until`): the optional `each ` prefix, the type
+/// axis (discrete `tag()` arms), the `card(s) ` head (number-agreement `alt()`),
+/// then the shared `in <whose> hand perpetually gain(s) <body>` tail. Any
+/// unconsumed tail — a rider after the type axis (Absorb Energy's "that share a
+/// card type with that spell"), an `{X}` body the cost-body parser rejects, or a
+/// trailing clause ("…and draws a card") — returns `None` so the card falls to
+/// `Unimplemented` rather than installing a subtly-wrong effect.
+fn try_parse_typed_cards_in_hand_perpetual_gain_cost(tp: TextPair) -> Option<Effect> {
+    fn tail_done(tail: &str) -> bool {
+        tail.is_empty() || tail == "."
+    }
+
+    let ((type_filter, controller, amount, mode), rest) =
+        nom_on_lower(tp.original, tp.lower, |input| {
+            // Optional "each " distributive prefix (the singular form).
+            let (input, _) = opt(tag("each ")).parse(input)?;
+            let (input, type_filter) = parse_hand_card_type_axis(input)?;
+            // Number-agreement head: "cards " (plural) or "card " (singular-each).
+            let (input, _) = alt((tag("cards "), tag("card "))).parse(input)?;
+            let (input, (controller, amount, mode)) =
+                parse_in_whose_hand_perpetually_gain_body(input)?;
+            Ok((input, (type_filter, controller, amount, mode)))
+        })?;
+
+    // Honest-red: any unconsumed tail (a rider after the quote like
+    // "…and draws a card") means this leaf cannot faithfully model the clause —
+    // return None so it falls through to Unimplemented.
+    tail_done(rest).then_some(Effect::ApplyPerpetual {
+        // CR 601.2f + CR 611.2c: latched self-spell cost modifier applied to each
+        // matching card in the named hand.
+        target: cards_in_hand_filter(type_filter, controller),
+        modification: crate::types::ability::PerpetualModification::ModifyCost { mode, amount },
     })
 }
 
@@ -10070,12 +10308,25 @@ fn parse_energy_gain_base(input: &str, multiplier: QuantityExpr) -> Option<Effec
     parse_energy_symbols_gain(rest, multiplier)
 }
 
-fn nonland_card_in_hand_filter(controller: Option<ControllerRef>) -> TargetFilter {
+/// "[type] cards in [your/that player's] hand" → a card-style
+/// [`TargetFilter::Typed`] carrying `type_filter` + `InZone { Hand }` + the given
+/// controller scope. Single authority for the hand-card filter shared by the
+/// random-card grant, the mass-hand perpetual cost arm, and their callers.
+pub(crate) fn cards_in_hand_filter(
+    type_filter: TypeFilter,
+    controller: Option<ControllerRef>,
+) -> TargetFilter {
     let mut filter = TypedFilter::card()
-        .with_type(TypeFilter::Non(Box::new(TypeFilter::Land)))
+        .with_type(type_filter)
         .properties(vec![FilterProp::InZone { zone: Zone::Hand }]);
     filter.controller = controller;
     TargetFilter::Typed(filter)
+}
+
+/// Thin wrapper preserving the original "nonland card in hand" filter so existing
+/// callers and tests are untouched.
+fn nonland_card_in_hand_filter(controller: Option<ControllerRef>) -> TargetFilter {
+    cards_in_hand_filter(TypeFilter::Non(Box::new(TypeFilter::Land)), controller)
 }
 
 fn try_parse_random_card_perpetual_gain_quoted_ability(
@@ -52533,6 +52784,382 @@ mod tests {
                 }
             ),
             "compound P/T riders must not parse as Become, got {e:?}"
+        );
+    }
+
+    #[test]
+    fn perpetual_parser_maps_modify_cost() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::CostModifyMode;
+
+        // Reduce: "~ perpetually gains \"This spell costs {2} less to cast\"."
+        let e = parse_effect("~ perpetually gains \"This spell costs {2} less to cast\".");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::Any,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(2)
+            ),
+            "expected Reduce generic(2), got {e:?}"
+        );
+
+        // Raise: "{1} more to cast".
+        let e = parse_effect("~ perpetually gains \"This spell costs {1} more to cast\".");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::Any,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Raise,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(1)
+            ),
+            "expected Raise generic(1), got {e:?}"
+        );
+
+        // Anaphoric "that creature ..." form back-references the parent target.
+        let e =
+            parse_effect("that creature perpetually gains \"This spell costs {2} less to cast\".");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::ParentTarget,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(2)
+            ),
+            "expected ParentTarget Reduce generic(2), got {e:?}"
+        );
+
+        // "this card costs" synonym.
+        let e = parse_effect("~ perpetually gains \"This card costs {3} less to cast\".");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                    ..
+                } if *amount == ManaCost::generic(3)
+            ),
+            "expected Reduce generic(3) via 'this card costs', got {e:?}"
+        );
+
+        // CR 601.2f: terminal PERIOD printed INSIDE the quote (the real Oracle
+        // form). Was failing before Step A's `opt(alt(("."/","))).` punctuation
+        // consume — the closing `"` would not match after the trailing period.
+        let e = parse_effect("~ perpetually gains \"This spell costs {1} less to cast.\"");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::Any,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(1)
+            ),
+            "period-inside-quote must parse as Reduce generic(1), got {e:?}"
+        );
+
+        // Comma-inside-quote variant.
+        let e = parse_effect("~ perpetually gains \"This spell costs {1} less to cast,\"");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        ..
+                    },
+                    ..
+                }
+            ),
+            "comma-inside-quote must parse as Reduce, got {e:?}"
+        );
+
+        // `more`-inside-quote-with-period variant.
+        let e = parse_effect("~ perpetually gains \"This spell costs {2} more to cast.\"");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Raise,
+                        amount,
+                    },
+                    ..
+                } if *amount == ManaCost::generic(2)
+            ),
+            "more-inside-quote-with-period must parse as Raise generic(2), got {e:?}"
+        );
+    }
+
+    /// Anaphoric "that card perpetually gains …" — the EXACT clause printed on
+    /// Paths of Tuinvale and Talion's Throneguard. Back-references the parent
+    /// target ([`TargetFilter::ParentTarget`]).
+    #[test]
+    fn perpetual_modify_cost_anaphor_that_card() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::CostModifyMode;
+
+        let e = parse_effect("that card perpetually gains \"This spell costs {1} less to cast.\"");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::ParentTarget,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(1)
+            ),
+            "'that card' anaphor must map to ParentTarget Reduce generic(1), got {e:?}"
+        );
+    }
+
+    /// Mass-hand arm: the EXACT real Oracle clauses (verified against
+    /// `data/mtgjson/AtomicCards.json`) for the four covered cards →
+    /// `ApplyPerpetual` over `cards_in_hand_filter`:
+    /// - Blooming Cactusfolk: "nonland cards in your hand perpetually gain …";
+    /// - Charged Conjuration: "instant and sorcery cards in your hand perpetually gain …";
+    /// - Fountainport Charmer: "creature cards in your hand perpetually gain …";
+    /// - Fearsome Whelp: "each Dragon card in your hand perpetually gains …"
+    ///   (the SINGULAR + `each` form).
+    ///
+    /// Plus a "that player's" controller-scope variant. Each effect clause is the
+    /// post-trigger-split remainder the parser actually receives.
+    #[test]
+    fn perpetual_mass_hand_cost_arm_parses_typed_hand_filter() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::CostModifyMode;
+
+        // Blooming Cactusfolk: "Nonland cards in your hand perpetually gain …".
+        let e = parse_effect(
+            "Nonland cards in your hand perpetually gain \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(1)
+                    && *target
+                        == cards_in_hand_filter(
+                            TypeFilter::Non(Box::new(TypeFilter::Land)),
+                            Some(ControllerRef::You),
+                        )
+            ),
+            "Blooming Cactusfolk must map to nonland-hand ApplyPerpetual, got {e:?}"
+        );
+
+        // Charged Conjuration: "Instant and sorcery cards in your hand perpetually gain …".
+        let e = parse_effect(
+            "Instant and sorcery cards in your hand perpetually gain \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target,
+                    modification: PerpetualModification::ModifyCost { mode: CostModifyMode::Reduce, .. },
+                } if *target
+                    == cards_in_hand_filter(
+                        TypeFilter::AnyOf(vec![TypeFilter::Instant, TypeFilter::Sorcery]),
+                        Some(ControllerRef::You),
+                    )
+            ),
+            "Charged Conjuration must map to instant/sorcery-hand ApplyPerpetual, got {e:?}"
+        );
+
+        // Fountainport Charmer: "creature cards in your hand perpetually gain …".
+        let e = parse_effect(
+            "creature cards in your hand perpetually gain \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual { target, .. }
+                    if *target
+                        == cards_in_hand_filter(TypeFilter::Creature, Some(ControllerRef::You))
+            ),
+            "Fountainport Charmer must map to creature-hand ApplyPerpetual, got {e:?}"
+        );
+
+        // Fearsome Whelp: the REAL SINGULAR + `each` Oracle form — "each Dragon
+        // card in your hand perpetually gains …" (singular `card`/`gains`). Must
+        // route to the SAME ApplyPerpetual over a Subtype("Dragon") hand filter
+        // as the plural forms ("each Dragon card" = every Dragon card in hand).
+        let e = parse_effect(
+            "each Dragon card in your hand perpetually gains \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target,
+                    modification: PerpetualModification::ModifyCost {
+                        mode: CostModifyMode::Reduce,
+                        amount,
+                    },
+                } if *amount == ManaCost::generic(1)
+                    && *target
+                        == cards_in_hand_filter(
+                            TypeFilter::Subtype("Dragon".to_string()),
+                            Some(ControllerRef::You),
+                        )
+            ),
+            "Fearsome Whelp's 'each Dragon card … perpetually gains' must map to \
+             Subtype(\"Dragon\")-hand ApplyPerpetual Reduce generic(1), got {e:?}"
+        );
+
+        // "that player's hand" is honest-red: `controller: None` would mean ANY
+        // controller (both players' hands), so this scoped-player form is NOT
+        // parsed — it must fall through to Unimplemented rather than apply to
+        // every player's matching cards.
+        let e = parse_effect(
+            "Nonland cards in that player's hand perpetually gain \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            !matches!(&e, Effect::ApplyPerpetual { .. }),
+            "'that player's hand' must be honest-red (not ApplyPerpetual), got {e:?}"
+        );
+    }
+
+    /// Honest-red: the mass-hand arm MUST reject clauses it cannot faithfully
+    /// model and fall through (NOT ApplyPerpetual::ModifyCost):
+    /// - Absorb Energy's "that share a card type with that spell" rider;
+    /// - an `{X}` body the cost-body parser cannot interpret;
+    /// - a trailing rider "…and draws a card";
+    /// - the "It perpetually gains …" form (subject not in the mass-arm list).
+    #[test]
+    fn perpetual_mass_hand_cost_arm_honest_red() {
+        use crate::types::ability::PerpetualModification;
+
+        fn is_modify_cost(e: &Effect) -> bool {
+            matches!(
+                e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::ModifyCost { .. },
+                    ..
+                }
+            )
+        }
+
+        // Absorb Energy: the "that share a card type with that spell" rider after
+        // the type axis is unconsumed → reject.
+        let e = parse_effect(
+            "Cards in your hand that share a card type with that spell perpetually gain \"This spell costs {1} less to cast.\"",
+        );
+        assert!(
+            !is_modify_cost(&e),
+            "Absorb Energy rider must not parse as ModifyCost, got {e:?}"
+        );
+
+        // {X} body: the cost-body parser rejects a variable amount → reject.
+        let e = parse_effect(
+            "Nonland cards in your hand perpetually gain \"This spell costs {X} less to cast.\"",
+        );
+        assert!(!is_modify_cost(&e), "{{X}} body must not parse, got {e:?}");
+
+        // Trailing rider after the quote → unconsumed tail → reject.
+        let e = parse_effect(
+            "Nonland cards in your hand perpetually gain \"This spell costs {1} less to cast\" and draws a card.",
+        );
+        assert!(
+            !is_modify_cost(&e),
+            "trailing rider must not parse as ModifyCost, got {e:?}"
+        );
+
+        // "It perpetually gains …" — the subject is not in the mass-arm class.
+        let e = parse_effect("It perpetually gains \"This spell costs {1} less to cast.\"");
+        assert!(
+            !is_modify_cost(&e),
+            "'It perpetually gains' is not a mass-hand subject, got {e:?}"
+        );
+    }
+
+    #[test]
+    fn perpetual_modify_cost_honest_red_on_unconsumed_tail() {
+        use crate::types::ability::PerpetualModification;
+
+        // An unmodeled rider inside the quote must NOT parse as ModifyCost — it
+        // must fall through (Unimplemented), not silently drop the rider.
+        let e = parse_effect(
+            "~ perpetually gains \"This spell costs {2} less to cast and draws a card\".",
+        );
+        assert!(
+            !matches!(
+                e,
+                Effect::ApplyPerpetual {
+                    modification: PerpetualModification::ModifyCost { .. },
+                    ..
+                }
+            ),
+            "unconsumed quoted tail must not parse as ModifyCost, got {e:?}"
+        );
+    }
+
+    #[test]
+    fn perpetual_modify_cost_serde_round_trip() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::mana::ManaCost;
+        use crate::types::statics::CostModifyMode;
+
+        for modification in [
+            PerpetualModification::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                amount: ManaCost::generic(2),
+            },
+            PerpetualModification::ModifyCost {
+                mode: CostModifyMode::Raise,
+                amount: ManaCost::generic(1),
+            },
+        ] {
+            let json = serde_json::to_string(&modification).unwrap();
+            let back: PerpetualModification = serde_json::from_str(&json).unwrap();
+            assert_eq!(modification, back, "round-trip mismatch for {json}");
+        }
+    }
+
+    #[test]
+    fn perpetual_gains_keyword_still_routes_to_grant_keywords() {
+        use crate::types::ability::PerpetualModification;
+        use crate::types::keywords::Keyword;
+
+        // Regression: the cost arm (tried first) must not steal the bare-keyword
+        // grant form; it requires a quoted body, so this still routes to GrantKeywords.
+        let e = parse_effect("~ perpetually gains flying.");
+        assert!(
+            matches!(
+                &e,
+                Effect::ApplyPerpetual {
+                    target: TargetFilter::Any,
+                    modification: PerpetualModification::GrantKeywords { keywords },
+                } if *keywords == vec![Keyword::Flying]
+            ),
+            "expected GrantKeywords flying, got {e:?}"
         );
     }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7998,7 +7998,8 @@ impl FaceDownProfile {
 ///
 /// Increment 1 covers base power/toughness setting; the enum is extensible to the
 /// other perpetual forms (`ModifyPowerToughness` for "perpetually gets +N/+N",
-/// `GrantAbility` for "perpetually gains ...", `Become` for type changes).
+/// `GrantAbility` for "perpetually gains ...", `Become` for type changes,
+/// `ModifyCost` for "perpetually gains \"This spell costs {N} less/more to cast\"").
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 #[serde(tag = "kind")]
 pub enum PerpetualModification {
@@ -8027,6 +8028,16 @@ pub enum PerpetualModification {
         toughness: i32,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         keywords: Vec<crate::types::keywords::Keyword>,
+    },
+    /// Digital-only Alchemy (no CR entry for "perpetually"; the cost change itself
+    /// is CR 601.2f): "[card] perpetually gains \"This spell costs {N} less/more to
+    /// cast\"" — records a permanent self-referential cast-cost modifier, realized
+    /// by injecting a synthetic self-spell `StaticMode::ModifyCost` into the card's
+    /// persistent static baseline so the existing self-spell cost collector consumes
+    /// it unchanged and it survives every layer/zone reset.
+    ModifyCost {
+        mode: crate::types::statics::CostModifyMode,
+        amount: ManaCost,
     },
 }
 


### PR DESCRIPTION
## Anchored on

The Alchemy (digital-only) "perpetual self-cost modification" class: an effect that permanently grants a card a change to its own cast cost, written as `perpetually gains "This spell costs {N} less to cast"` (~17 cards) and `perpetually gains "This spell costs {N} more to cast"` (~6 cards). ~23 cards today, plus every future card with the same grant template.

## Problem

`perpetually gains "This spell costs {N} less/more to cast"` had no engine support. The existing `PerpetualModification` enum covered base P/T, +N/+M, keyword grants, and type-change (philluiz's #4525/#4529/#4616), but no perpetual cost modifier, so these cards' grants did nothing.

## Root cause

Two layers were missing: the perpetual-modification type had no cost variant, and the perpetual-grant parser had no arm for the quoted self-cost static.

## Fix (class-general, parameterized)

- **One new leaf variant** `PerpetualModification::ModifyCost { mode: CostModifyMode, amount: ManaCost }` — direction (`Reduce`/`Raise`) and amount are parameters, not separate variants (passed the add-engine-variant gate; the axis lies within CR 601.2f). Zero other new types.
- **Parser:** a new `try_parse_perpetual_modify_cost` arm in the perpetual-grant cluster, parsing the quoted `"This spell costs {N} less/more to cast"` body with nom combinators (`delimited` + `parse_mana_cost` + `value(Reduce/Raise)`), reusing a factored-out `parse_perpetual_self_subject` helper shared with the keyword-grant arm. Honest-red `None` on any unconsumed tail.
- **Realization (reuse, not reinvent):** `apply_perpetual_modification` injects a synthetic self-spell `StaticMode::ModifyCost` static (`affected = SelfRef`, `active_zones = self_spell_cost_mod_active_zones()`) into **both** the live `static_definitions` and the persistent `base_static_definitions` — mirroring how the `GrantKeywords` arm writes both `keywords` and `base_keywords`. The live copy makes the discount visible to a from-hand cast immediately; the base copy survives the battlefield layer reset (`static_definitions = base.clone()`). `apply_perpetual_modification` runs once per `ApplyPerpetual` resolution (single caller), so there is no double-injection; distinct grants intentionally stack.
- **Consumption: no cost-calc changes.** The existing `collect_self_spell_cost_modifiers` consumes the injected static unchanged, including the raise-before-reduce ordering and the `{0}` floor.

CR 601.2f (cost determination, increase/reduction, `{0}` floor); "perpetually" is a digital-only Alchemy keyword action with no CR entry (annotated as such, matching the existing perpetual code).

## Tests

- **Runtime (real cast pipeline, `GameRunner::cast(...).resolve()`):** reduce lowers self-cast cost; raise increases it; `{0}` floor; the modifier **persists across a hand→library→hand zone change**; two grants **stack and floor** correctly; and a from-hand cast funded with **only the reduced `{2}` pool** resolves (sorcery → graveyard, CR 608.2n) — proving the reduction applies on the real payment path, not just to the computed cost.
- **Parser (the class):** reduce/raise/anaphoric forms map to `ModifyCost`; negative honest-red (unconsumed tail → `Unimplemented`); `perpetually gains flying` still routes to `GrantKeywords` (no regression).
- **serde:** additive `#[serde(tag="kind")]` round-trip.

## Verification

`cargo fmt` clean; `cargo check -p engine` clean; engine clippy `-D warnings` clean; parser combinator gate exit 0; the 6 new runtime + 3 parser tests pass; broad perpetual (25) and casting-cost (944) suites stay green. Engine-only change, no cross-crate lockstep.

Model: claude-opus-4-8
Tier: Frontier
