### PR TITLE
fix(parser): controller-scoped "you lost life this turn" intervening-if condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4309,6 +4309,10 @@ fn parse_life_history_condition(input: &str) -> OracleResult<'_, StaticCondition
         parse_player_lost_life_this_turn,
         // "you gained life this turn" / "you gained N or more life this turn"
         parse_you_gained_life_this_turn,
+        // "you lost life this turn" / "you lost N or more life this turn" — the
+        // controller-scoped mirror of the gained sibling (was the only missing
+        // subject in the gained/lost × you/opponent/player matrix).
+        parse_you_lost_life_this_turn,
     ))
     .parse(input)
 }
@@ -4919,6 +4923,46 @@ fn parse_you_gained_life_this_turn(input: &str) -> OracleResult<'_, StaticCondit
         rest,
         make_quantity_ge(
             QuantityRef::LifeGainedThisTurn {
+                player: PlayerScope::Controller,
+            },
+            1,
+        ),
+    ))
+}
+
+/// CR 119.3 + CR 603.4: Parse "you lost [N or more] life this turn".
+///
+/// Controller-scoped mirror of `parse_you_gained_life_this_turn`. The opponent
+/// and any-player subjects already parse (`parse_opponent_lost_life_this_turn`,
+/// `parse_player_lost_life_this_turn`) and the controller *gained* subject
+/// parses too — only "you lost …" was missing, so phase-trigger intervening-ifs
+/// such as The Book of Vile Darkness ("if you lost 2 or more life this turn,
+/// create a 2/2 black Zombie") silently dropped their condition. Resolves via
+/// the existing `LifeLostThisTurn { Controller }` QuantityRef — no new variants.
+fn parse_you_lost_life_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = alt((tag("you lost "), tag("you've lost "))).parse(input)?;
+    // Try "N or more life this turn".
+    if let Ok((after_n, n)) = parse_number(rest) {
+        let after_n = after_n.trim_start();
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("or more life this turn").parse(after_n)
+        {
+            return Ok((
+                rest,
+                make_quantity_ge(
+                    QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                    n,
+                ),
+            ));
+        }
+    }
+    // "life this turn" (minimum 1).
+    let (rest, _) = tag("life this turn").parse(rest)?;
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::LifeLostThisTurn {
                 player: PlayerScope::Controller,
             },
             1,

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -17661,6 +17661,55 @@ mod tests {
         );
     }
 
+    /// CR 119.3 + CR 603.4: The Book of Vile Darkness — the controller-scoped
+    /// "you lost N or more life this turn" intervening-if mirrors the gained
+    /// sibling. Previously the condition was silently dropped (left `None`).
+    #[test]
+    fn trigger_if_you_lost_2_or_more_life() {
+        let def = parse_trigger_line(
+            "At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.",
+            "The Book of Vile Darkness",
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 2 },
+            })
+        );
+        assert!(
+            def.execute.is_some(),
+            "execute must be Some — token creation effect after the condition was dropped"
+        );
+    }
+
+    /// "if you lost life this turn" (no minimum) → controller LifeLostThisTurn ≥ 1.
+    #[test]
+    fn trigger_if_you_lost_life_this_turn_no_minimum() {
+        let def = parse_trigger_line(
+            "At the beginning of your end step, if you lost life this turn, draw a card.",
+            "Test Lost Life",
+        );
+        assert_eq!(
+            def.condition,
+            Some(TriggerCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeLostThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            })
+        );
+        assert!(def.execute.is_some(), "execute must be Some");
+    }
+
     #[test]
     fn trigger_ocelot_pride_copy_each_entered_token_not_source() {
         let def = parse_trigger_line(


### PR DESCRIPTION
## Problem

The gained/lost-life intervening-if condition matrix was missing exactly one subject: the controller-scoped **"you lost [N or more] life this turn"**. Opponent (`parse_opponent_lost_life_this_turn`) and any-player (`parse_player_lost_life_this_turn`) "lost life" parsed, and the controller *gained* sibling parsed too — but `"you lost ..."` silently dropped its condition (left `None`).

As a result, phase-trigger intervening-ifs such as **The Book of Vile Darkness** lost **both** the gate and their effect:

> At the beginning of your end step, if you lost 2 or more life this turn, create a 2/2 black Zombie creature token.

## Fix

Add `parse_you_lost_life_this_turn` as the exact mirror of `parse_you_gained_life_this_turn`, wired into `parse_life_history_condition`. It resolves via the existing `QuantityRef::LifeLostThisTurn { player: Controller }` — **no new variants**. Handles both `"you lost N or more life this turn"` (≥ N) and the bare `"you lost life this turn"` (≥ 1) forms, plus the `"you've lost ..."` contraction.

CR 119.3 (life-total changes) + CR 603.4 (intervening-if).

## Tests

Two inline parser regressions in `oracle_trigger.rs`:
- `trigger_if_you_lost_2_or_more_life` — The Book of Vile Darkness; asserts condition `LifeLostThisTurn{Controller} ≥ 2` **and** `execute.is_some()` (the dropped effect).
- `trigger_if_you_lost_life_this_turn_no_minimum` — bare form → `≥ 1`.

Both pass; engine compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)