### PR TITLE
test(parser): direct-call regression for Optional_YouMay Prototype reminder exemption

### DIFF
--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -3611,6 +3611,64 @@ mod tests {
         }
     }
 
+    /// CR 117.3a + CR 702.160a: direct-call contract for `detect_optional_you_may`.
+    /// A bare "you may <verb>" optional effect with no AST representation must fire
+    /// `Optional_YouMay`, while the Prototype keyword reminder text
+    /// ("You may cast this spell with different mana cost...") is keyword reminder
+    /// text — not a resolution-time optional effect — and must stay silent. This
+    /// pins the reminder-text exemption directly: reverting that gate re-fires the
+    /// detector on every Prototype card, and dropping the final `diagnostics.push`
+    /// drops the fire case.
+    #[test]
+    fn optional_you_may_fires_on_bare_verb_and_exempts_prototype_reminder() {
+        let parsed = crate::parser::oracle::ParsedAbilities {
+            abilities: Vec::new(),
+            triggers: Vec::new(),
+            statics: Vec::new(),
+            replacements: Vec::new(),
+            extracted_keywords: Vec::new(),
+            modal: None,
+            additional_cost: None,
+            casting_restrictions: Vec::new(),
+            casting_options: Vec::new(),
+            solve_condition: None,
+            strive_cost: None,
+            parse_warnings: Vec::new(),
+        };
+
+        // Fire: an unrepresented "you may draw a card" optional effect.
+        let mut fire = Vec::new();
+        super::detect_optional_you_may(
+            "you may draw a card.",
+            "You may draw a card.",
+            &parsed,
+            &mut fire,
+        );
+        assert!(
+            fire.iter().any(|d| matches!(
+                d,
+                OracleDiagnostic::SwallowedClause { detector, .. }
+                    if detector == "Optional_YouMay"
+            )),
+            "bare 'you may <verb>' with no AST representation must fire Optional_YouMay: {fire:?}"
+        );
+
+        // Silent: Prototype keyword reminder text is not an optional effect.
+        let mut silent = Vec::new();
+        super::detect_optional_you_may(
+            "you may cast this spell with different mana cost, color, and size. \
+             it keeps its abilities and types.",
+            "(You may cast this spell with different mana cost, color, and size. \
+             It keeps its abilities and types.)",
+            &parsed,
+            &mut silent,
+        );
+        assert!(
+            silent.is_empty(),
+            "Prototype reminder text must not fire Optional_YouMay: {silent:?}"
+        );
+    }
+
     /// Walk a def tree for a `GenericEffect` granting `CastWithKeyword` (directly
     /// or via `GrantStaticAbility`) — the flash-grant shape Teferi's [+1] lowers
     /// to and the swallow-check exemption keys on.


### PR DESCRIPTION
## Summary

Adds a direct-call regression test for `detect_optional_you_may` in
`crates/engine/src/parser/swallow_check.rs`, mirroring the existing
`detect_modal_dynamic_max_dropped_*` direct-call tests.

The new test pins the detector contract at its boundary:

- A bare `"you may <verb>"` optional effect with **no** AST representation must
  fire `Optional_YouMay` (CR 117.3a).
- The **Prototype** keyword reminder text
  (`"(You may cast this spell with different mana cost, color, and size...)"`,
  CR 702.160a) must stay **silent** — it is keyword reminder text, not a
  resolution-time optional effect.

Previously this exemption was only covered indirectly through full-pipeline
`parse_named(...)` fixtures. Pinning it directly means a future parser change that
keeps those fixtures green can no longer silently weaken or invert the
reminder-text gate.

Closes #4644.

## Test plan

- [ ] `optional_you_may_fires_on_bare_verb_and_exempts_prototype_reminder` passes
      (added in `swallow_check.rs` tests).
- [ ] No behavior change — test-only addition; reuses the established
      empty-`ParsedAbilities` + `super::detect_*` direct-call pattern.
