### PR TITLE
fix(parser): support 'your opponents control no [type]' static condition

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2756,6 +2756,8 @@ pub(crate) fn parse_control_conditions(input: &str) -> OracleResult<'_, StaticCo
         parse_you_control_no,
         // "no opponent controls a/an [type]" → Not(IsPresent { Opponent })
         parse_no_opponent_controls_a,
+        // "your opponents control no [type]" → Not(IsPresent { Opponent })
+        parse_your_opponents_control_no,
         // CR 702: "a creature you control has <keyword>" — subject-first
         // presence check (Odric, Lunarch Marshal). Grouped into the control
         // family so the parent dispatcher's `alt` arity stays within bounds.
@@ -3227,6 +3229,36 @@ fn parse_no_opponent_controls_a(input: &str) -> OracleResult<'_, StaticCondition
     // Require an article — reject the bare-plural count form ("no opponent
     // controls creatures") exactly as the affirmative control arms do.
     let (rest, _) = parse_article(rest)?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    // CR 109.4: battlefield-scoped presence controlled by an opponent.
+    let filter = inject_controller(filter, ControllerRef::Opponent);
+    let consumed = input.len() - remainder.len();
+    Ok((
+        &input[consumed..],
+        StaticCondition::Not {
+            condition: Box::new(StaticCondition::IsPresent {
+                filter: Some(filter),
+            }),
+        },
+    ))
+}
+
+/// Parse "your opponents control no [type]" → Not(IsPresent { Opponent }).
+///
+/// The collective-opponents bare-plural form (no article) of
+/// `parse_no_opponent_controls_a`; mirrors `parse_you_control_no` with the
+/// opponent controller axis. "your opponents control no creatures" means no
+/// opponent controls any creature, identical to "no opponent controls a
+/// creature". Chevill, Bane of Monsters (permanents); Erebos's Titan,
+/// Kezzerdrix (creatures).
+fn parse_your_opponents_control_no(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = tag("your opponents control no ").parse(input)?;
     let (filter, remainder) = parse_type_phrase(rest);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -7998,6 +8030,26 @@ mod tests {
                 zone: Zone::Battlefield
             }
         )));
+    }
+
+    /// CR 109.4: "your opponents control no <type>" → `Not(IsPresent { Opponent })`.
+    /// Plural-opponent sibling of "no opponent controls a <type>". Erebos's Titan,
+    /// Kezzerdrix (creatures); Chevill, Bane of Monsters (permanents).
+    #[test]
+    fn test_your_opponents_control_no_creatures() {
+        let (rest, c) = parse_inner_condition("your opponents control no creatures").unwrap();
+        assert_eq!(rest, "");
+        let tf = typed_presence_under_not(&c);
+        assert_eq!(tf.controller, Some(ControllerRef::Opponent));
+        assert!(tf.type_filters.contains(&TypeFilter::Creature));
+
+        // Chevill's "no permanents" variant parses through the same arm.
+        let (rest, c) = parse_inner_condition("your opponents control no permanents").unwrap();
+        assert_eq!(rest, "");
+        assert!(
+            matches!(c, StaticCondition::Not { .. }),
+            "expected Not(IsPresent), got {c:?}"
+        );
     }
 
     /// Kavu Runner / Skittish Kavu: "... as long as no opponent controls a white


### PR DESCRIPTION
## Anchored on

Erebos's Titan — "As long as your opponents control no creatures, this creature has indestructible." The static condition "your opponents control no [type]" had no parser support.

## Problem

"your opponents control no creatures" parsed to `StaticCondition::Unrecognized`, so Erebos's Titan's conditional indestructible never applied.

## Root cause

The control-condition dispatcher already had "you control no [type]" (`parse_you_control_no`) and "no opponent controls a/an [type]" (`parse_no_opponent_controls_a`, #4629), but no arm for the collective-opponents bare-plural form "your opponents control no [type]".

## Fix

Added `parse_your_opponents_control_no`, mirroring `parse_you_control_no` with the opponent controller axis: "your opponents control no [type]" → `Not(IsPresent { inject_controller(filter, Opponent) })`. It reuses `parse_type_phrase` (creatures / permanents / color-disjunctions) and is identical in meaning to "no opponent controls a creature" (#4629). No new types.

CR 109.4 (battlefield-scoped presence controlled by an opponent), matching the sibling arm.

## Tests

`parse_inner_condition("your opponents control no creatures")` → `Not(IsPresent)` with controller `Opponent` + `Creature` type; the "no permanents" variant (Chevill) parses through the same arm. Whole-card parse of Erebos's Titan confirmed: the indestructible static's condition is now `Not(IsPresent)`, no `Unrecognized`.

## Scope

This covers the static "as long as your opponents control no [type]" form (Erebos's Titan). The `if` / `when your opponents control no [type]` trigger-intervening forms (Chevill, Kezzerdrix, Penregon Besieged) route through a separate condition path and are not addressed here.

## Verification

`cargo fmt` clean; parser combinator gate exit 0; engine clippy `-D warnings` clean; the new test and the condition suite pass.

Model: claude-opus-4-8
Tier: Frontier
