### PR TITLE
fix(engine): install catalog triggers on debug preset token spawns

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2489,7 +2489,7 @@ pub(super) fn inject_resolved_token_abilities(
 /// CR 111.4 + CR 707.2a: Grant catalog `rules_text` when token creation resolved
 /// a `token_image_ref` preset whose abilities are not already covered by the
 /// predefined path (e.g. SOS Pest attack life gain).
-pub(super) fn inject_catalog_token_abilities(
+pub(crate) fn inject_catalog_token_abilities(
     state: &mut GameState,
     obj_id: crate::types::identifiers::ObjectId,
 ) {

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -485,17 +485,25 @@ pub fn apply_debug_action(
                 count: 1,
                 applied: HashSet::new(),
             };
-            let first_created_id = state.next_object_id;
             match super::replacement::replace_event(state, proposed, events) {
                 super::replacement::ReplacementResult::Execute(event) => {
                     super::effects::token::apply_create_token_after_replacement(
                         state, event, events,
                     );
+                    // CR 111.4 + CR 707.2a: Preset spawns must install catalog
+                    // `rules_text` abilities (SOS Pest attack-life trigger, etc.)
+                    // after linking the preset image ref. The apply path runs
+                    // `inject_catalog_token_abilities` during creation when
+                    // `token_image_ref` is already set; debug preset creation
+                    // deferred the ref until here, so inject + reindex now.
                     if let Some(image_ref) = preset_image_ref {
-                        for (id, obj) in state.objects.iter_mut() {
-                            if id.0 >= first_created_id {
+                        let created_ids = state.last_created_token_ids.clone();
+                        for token_id in created_ids {
+                            if let Some(obj) = state.objects.get_mut(&token_id) {
                                 obj.token_image_ref = Some(image_ref.clone());
                             }
+                            super::effects::token::inject_catalog_token_abilities(state, token_id);
+                            super::trigger_index::reindex_object_triggers(state, token_id);
                         }
                     }
                     // "Run ETB effects" unchecked: the token is still created
@@ -854,6 +862,56 @@ mod tests {
     /// `+1/+1` counters in `enter_with_counters` enters as a 2/2 because
     /// the counters apply during the same ETB replacement window that
     /// engine-driven token creation uses. CR 704.5f does not kill it.
+    /// CR 111.4 + CR 603.6a: Debug preset spawns must install catalog
+    /// `rules_text` triggers and register them in the trigger index — same as
+    /// engine-driven token creation (issue #853).
+    #[test]
+    fn debug_create_preset_token_installs_catalog_triggers() {
+        let mut state = sandbox_state();
+        let sos_pest_preset_id = "00a0801d-0212-5890-8957-3cde30f382f9";
+        let action = GameAction::Debug(DebugAction::CreateToken {
+            request: DebugTokenRequest::Preset {
+                preset_id: sos_pest_preset_id.to_string(),
+                owner: PlayerId(0),
+                enter_with_counters: Vec::new(),
+            },
+            run_etb: true,
+        });
+        let result = crate::game::engine::apply(&mut state, PlayerId(0), action)
+            .expect("debug CreateToken preset should succeed");
+
+        let token_id = result
+            .events
+            .iter()
+            .find_map(|event| match event {
+                GameEvent::TokenCreated { object_id, .. } => Some(*object_id),
+                _ => None,
+            })
+            .expect("TokenCreated event should fire");
+
+        let obj = state
+            .objects
+            .get(&token_id)
+            .expect("pest token should exist on battlefield");
+        assert_eq!(
+            obj.trigger_definitions.len(),
+            1,
+            "SOS Pest preset must install its attack-life trigger"
+        );
+        assert_eq!(
+            obj.trigger_definitions[0].mode,
+            crate::types::triggers::TriggerMode::Attacks
+        );
+        assert!(
+            state
+                .trigger_index
+                .by_key
+                .values()
+                .any(|bucket| bucket.contains(&token_id)),
+            "catalog trigger must be registered in the trigger index"
+        );
+    }
+
     #[test]
     fn debug_create_token_enters_with_counters_survives_sba() {
         let mut state = sandbox_state();


### PR DESCRIPTION
## Summary

Manual/debug token creation from the preset catalog produced tokens with the correct body and art but **without** their printed `rules_text` triggers. Reported when players manually spawned SOS **Pest** tokens (e.g. while testing Lluwen's prepared spell) — those pests did not fire "Whenever this token attacks, you gain 1 life."

Engine-driven token creation installs catalog abilities during `apply_create_token_after_replacement` via `inject_catalog_token_abilities`, which reads the preset's `rules_text` from `token_image_ref`. The debug preset path deferred setting `token_image_ref` until **after** that pipeline ran, so catalog injection was skipped and triggers never registered.

## Root cause

`DebugAction::CreateToken` with `DebugTokenRequest::Preset`:

1. Routes through the real `CreateToken` pipeline (`apply_create_token_after_replacement`).
2. During creation, `inject_resolved_token_abilities` → `inject_catalog_token_abilities` needs `obj.token_image_ref` to resolve the preset.
3. Debug code set `token_image_ref` only in a post-create loop — too late for catalog injection.
4. Trigger index was never updated with the missing definitions.

## Changes

| File | Change |
|------|--------|
| `crates/engine/src/game/engine_debug.rs` | After preset spawn: set `token_image_ref`, call `inject_catalog_token_abilities`, `reindex_object_triggers`; regression test |
| `crates/engine/src/game/effects/token.rs` | Widen `inject_catalog_token_abilities` to `pub(crate)` for debug path |

## Behavior

1. **Preset debug spawn** — unchanged create/replacement pipeline; after accept, link preset image ref on `last_created_token_ids`, inject catalog `rules_text` (triggers, statics, keywords, equip), reindex triggers.
2. **Custom debug spawn** — unchanged (no preset ref → no catalog injection).
3. **Engine-driven tokens** — unchanged (image ref resolved at create time via `find_exact_token_ref`).

## Test plan

- [x] `debug_create_preset_token_installs_catalog_triggers` — SOS Pest preset gets attack-life trigger + trigger-index registration
- [ ] Manual: debug-spawn SOS Pest preset, attack — verify life gain trigger fires
- [ ] Manual: compare debug preset Pest vs Lluwen-created Pest — same trigger behavior

## Closes

Fixes https://github.com/phase-rs/phase/issues/853

## Deferred

- Custom debug tokens with bodies matching a unique catalog entry (no preset id selected) — could fall back to body-only preset lookup
- `PartialMissingAbilities` presets whose full rules_text is not yet modeled in the catalog parser
