### PR TITLE
feat(engine): die-roll result-filter triggers ("whenever you roll a [N]")

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::types::ability::{
-    AbilityTag, CoinFlipResult, ControllerRef, DamageKindFilter, DestinationConstraint, EffectKind,
-    OriginConstraint, TargetFilter, TargetRef, TriggerDefinition, TypedFilter,
+    AbilityTag, CoinFlipResult, ControllerRef, DamageKindFilter, DestinationConstraint,
+    DieResultFilter, EffectKind, OriginConstraint, TargetFilter, TargetRef, TriggerDefinition,
+    TypedFilter,
 };
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
@@ -3639,11 +3640,27 @@ pub(super) fn match_rolled_die(
     state: &GameState,
 ) -> bool {
     if let GameEvent::DieRolled {
-        player_id, sides, ..
+        player_id,
+        sides,
+        result,
     } = event
     {
         if trigger.die_sides.is_some_and(|required| required != *sides) {
             return false;
+        }
+        // CR 706.2: result-face filter. CR 706.7: a planar (non-numeric) roll has
+        // result == None and never satisfies a numeric filter; a None filter is unaffected.
+        if let Some(filter) = &trigger.die_result {
+            let Some(rolled) = *result else {
+                return false;
+            };
+            let ok = match filter {
+                DieResultFilter::Exact(faces) => faces.contains(&rolled),
+                DieResultFilter::AtLeast(min) => rolled >= *min,
+            };
+            if !ok {
+                return false;
+            }
         }
         valid_player_matches(trigger, state, *player_id, source_id)
     } else {
@@ -4773,6 +4790,82 @@ mod tests {
             &trigger,
             source,
             &state,
+        ));
+    }
+
+    #[test]
+    fn rolled_die_matcher_filters_result_face() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Complaints Clerk".to_string(),
+            Zone::Battlefield,
+        );
+        let roll = |result: Option<u8>| GameEvent::DieRolled {
+            player_id: PlayerId(0),
+            sides: 6,
+            result,
+        };
+
+        // CR 706.2: Exact([1]) — fires on Some(1), not Some(2).
+        let mut exact_one =
+            make_trigger(TriggerMode::RolledDieOnce).valid_target(TargetFilter::Controller);
+        exact_one.die_result = Some(DieResultFilter::Exact(vec![1]));
+        assert!(match_rolled_die(&roll(Some(1)), &exact_one, source, &state));
+        assert!(!match_rolled_die(
+            &roll(Some(2)),
+            &exact_one,
+            source,
+            &state
+        ));
+
+        // CR 706.2: Exact([1, 2]) — fires on 1 and 2, not 3.
+        let mut exact_disj =
+            make_trigger(TriggerMode::RolledDieOnce).valid_target(TargetFilter::Controller);
+        exact_disj.die_result = Some(DieResultFilter::Exact(vec![1, 2]));
+        assert!(match_rolled_die(
+            &roll(Some(1)),
+            &exact_disj,
+            source,
+            &state
+        ));
+        assert!(match_rolled_die(
+            &roll(Some(2)),
+            &exact_disj,
+            source,
+            &state
+        ));
+        assert!(!match_rolled_die(
+            &roll(Some(3)),
+            &exact_disj,
+            source,
+            &state
+        ));
+
+        // CR 706.2: AtLeast(3) — fires on Some(3)/Some(6), not Some(2).
+        let mut at_least =
+            make_trigger(TriggerMode::RolledDieOnce).valid_target(TargetFilter::Controller);
+        at_least.die_result = Some(DieResultFilter::AtLeast(3));
+        assert!(match_rolled_die(&roll(Some(3)), &at_least, source, &state));
+        assert!(match_rolled_die(&roll(Some(6)), &at_least, source, &state));
+        assert!(!match_rolled_die(&roll(Some(2)), &at_least, source, &state));
+
+        // CR 706.7: a numeric filter never fires on a non-numeric (planar) roll
+        // whose result is None.
+        assert!(!match_rolled_die(&roll(None), &exact_one, source, &state));
+
+        // A None filter is unaffected by a None result (any face, including planar).
+        let none_filter =
+            make_trigger(TriggerMode::RolledDieOnce).valid_target(TargetFilter::Controller);
+        assert_eq!(none_filter.die_result, None);
+        assert!(match_rolled_die(&roll(None), &none_filter, source, &state));
+        assert!(match_rolled_die(
+            &roll(Some(1)),
+            &none_filter,
+            source,
+            &state
         ));
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -19756,6 +19756,63 @@ pub mod tests {
         );
     }
 
+    /// CR 706.2: A "Whenever you roll a 1" trigger (Complaints Clerk) fires
+    /// when the controller rolls a 1 and does NOT fire on any other face. Drives
+    /// `process_triggers` with a synthetic `DieRolled` event so the result face
+    /// is deterministic; asserts the trigger reaches the stack (or pending target
+    /// selection) only for the matching face. Tests the trigger firing — not the
+    /// token-creation effect.
+    #[test]
+    fn roll_a_one_trigger_fires_only_on_face_one() {
+        let parsed = crate::parser::oracle_trigger::parse_trigger_line(
+            "Whenever you roll a 1, create a 1/1 white Clown Robot artifact creature token.",
+            "Complaints Clerk",
+        );
+        assert_eq!(parsed.mode, TriggerMode::RolledDieOnce);
+
+        let run_case = |rolled: u8| -> bool {
+            let mut state = setup();
+            state.active_player = PlayerId(0);
+
+            let clerk = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Complaints Clerk".to_string(),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&clerk)
+                .unwrap()
+                .trigger_definitions
+                .push(parsed.clone());
+
+            let events = vec![GameEvent::DieRolled {
+                player_id: PlayerId(0),
+                sides: 6,
+                result: Some(rolled),
+            }];
+            process_triggers(&mut state, &events);
+
+            let on_stack = state.stack.iter().any(|entry| {
+                entry.source_id == clerk
+                    && matches!(entry.kind, StackEntryKind::TriggeredAbility { .. })
+            });
+            let pending = state
+                .pending_trigger
+                .as_ref()
+                .is_some_and(|p| p.source_id == clerk);
+            on_stack || pending
+        };
+
+        assert!(run_case(1), "rolling a 1 must fire the roll-a-1 trigger");
+        assert!(
+            !run_case(2),
+            "rolling a 2 must NOT fire the roll-a-1 trigger"
+        );
+    }
+
     #[test]
     fn arcane_adaptation_vampire_type_change_is_visible_to_etb_trigger_matching() {
         let mut state = setup();

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -38,9 +38,9 @@ use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AttachmentKind,
     AttackersDeclaredCountSubject, CastManaObjectScope, CastManaSpentMetric, CastVariantPaid,
     CoinFlipResult, Comparator, ControllerRef, CounterTriggerFilter, DamageKindFilter,
-    DestinationConstraint, Effect, FilterProp, ObjectScope, OriginConstraint, ParsedCondition,
-    PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
-    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition,
+    DestinationConstraint, DieResultFilter, Effect, FilterProp, ObjectScope, OriginConstraint,
+    ParsedCondition, PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
+    RenownSubject, SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, StaticCondition,
     TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
     TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
@@ -9109,7 +9109,7 @@ fn try_parse_die_roll_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefini
     .ok()?;
 
     let (rest, valid_target) = parse_die_roll_actor(rest).ok()?;
-    let (rest, (mode, batched, die_sides)) = parse_die_roll_object(rest).ok()?;
+    let (rest, (mode, batched, die_sides, die_result)) = parse_die_roll_object(rest).ok()?;
     if !rest.is_empty() {
         return None;
     }
@@ -9119,6 +9119,7 @@ fn try_parse_die_roll_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefini
     def.valid_target = Some(valid_target);
     def.batched = batched;
     def.die_sides = die_sides;
+    def.die_result = die_result;
     Some((mode, def))
 }
 
@@ -9134,16 +9135,62 @@ fn parse_die_roll_actor(input: &str) -> OracleResult<'_, TargetFilter> {
     .parse(input)
 }
 
-fn parse_die_roll_object(input: &str) -> OracleResult<'_, (TriggerMode, bool, Option<u8>)> {
+fn parse_die_roll_object(
+    input: &str,
+) -> OracleResult<'_, (TriggerMode, bool, Option<u8>, Option<DieResultFilter>)> {
     alt((
         value(
-            (TriggerMode::RolledDie, true, None),
+            (TriggerMode::RolledDie, true, None, None),
             tag("one or more dice"),
         ),
-        value((TriggerMode::RolledDieOnce, false, Some(20)), tag("a d20")),
-        value((TriggerMode::RolledDieOnce, false, None), tag("a die")),
+        value(
+            (TriggerMode::RolledDieOnce, false, Some(20), None),
+            tag("a d20"),
+        ),
+        value(
+            (TriggerMode::RolledDieOnce, false, None, None),
+            tag("a die"),
+        ),
+        // CR 706.2: "a [result]" — single face, disjunction, or GE threshold.
+        // Placed after the literal "a d20"/"a die" arms; `parse_number` declines
+        // on the leading "d" of "d20"/"die", so those arms always win their text.
+        map(parse_die_roll_result, |filter| {
+            (TriggerMode::RolledDieOnce, false, None, Some(filter))
+        }),
     ))
     .parse(input)
+}
+
+/// CR 706.2: "Whenever you roll a [result]" — the rolled-face filter. Tries the
+/// GE threshold ("N or higher"/"N or more") before the disjunction ("N or M")
+/// so the shared "or" keyword is never mis-claimed by the disjunction arm, then
+/// falls back to a single exact face. `u8::try_from` guards the d100 ceiling and
+/// declines (via `oracle_err`) on any face that overflows a single byte.
+fn parse_die_roll_result(input: &str) -> OracleResult<'_, DieResultFilter> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("a ").parse(input)?;
+    let (rest, first_raw) = nom_primitives::parse_number.parse(rest)?;
+    let first = u8::try_from(first_raw).map_err(|_| oracle_err(input))?;
+
+    // GE threshold special case: "N or higher" / "N or more" → AtLeast(N).
+    if let Ok((rest, _)) =
+        alt((tag::<_, _, OracleError<'_>>(" or higher"), tag(" or more"))).parse(rest)
+    {
+        return Ok((rest, DieResultFilter::AtLeast(first)));
+    }
+
+    // Disjunction: "N or M" → Exact([N, M]).
+    if let Ok((rest, second_raw)) = preceded(
+        tag::<_, _, OracleError<'_>>(" or "),
+        nom_primitives::parse_number,
+    )
+    .parse(rest)
+    {
+        let second = u8::try_from(second_raw).map_err(|_| oracle_err(input))?;
+        return Ok((rest, DieResultFilter::Exact(vec![first, second])));
+    }
+
+    // Single exact face: "N" → Exact([N]).
+    Ok((rest, DieResultFilter::Exact(vec![first])))
 }
 
 /// CR 120.1 + CR 120.3 + CR 603.2: "Whenever a source [you control] deals
@@ -24922,6 +24969,70 @@ mod tests {
         assert_eq!(def.mode, TriggerMode::RolledDieOnce);
         assert_eq!(def.valid_target, Some(TargetFilter::Controller));
         assert_eq!(def.die_sides, Some(20));
+    }
+
+    #[test]
+    fn trigger_rolled_die_result_exact_single() {
+        let def = parse_trigger_line(
+            "Whenever you roll a 1, create a Treasure token.",
+            "Complaints Clerk",
+        );
+        assert_eq!(def.mode, TriggerMode::RolledDieOnce);
+        assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+        assert_eq!(def.die_sides, None);
+        assert_eq!(def.die_result, Some(DieResultFilter::Exact(vec![1])));
+    }
+
+    #[test]
+    fn trigger_rolled_die_result_exact_disjunction() {
+        // Atomwheel Acrobats: "Whenever you roll a 1 or 2, ...".
+        let def = parse_trigger_line(
+            "Whenever you roll a 1 or 2, put that many +1/+1 counters on this creature.",
+            "Atomwheel Acrobats",
+        );
+        assert_eq!(def.mode, TriggerMode::RolledDieOnce);
+        assert_eq!(def.die_result, Some(DieResultFilter::Exact(vec![1, 2])));
+    }
+
+    #[test]
+    fn trigger_rolled_die_result_at_least_higher() {
+        // Monoxa, Midway Manager: "Whenever you roll a 3 or higher, ...".
+        let def = parse_trigger_line(
+            "Whenever you roll a 3 or higher, Monoxa gains first strike until end of turn.",
+            "Monoxa, Midway Manager",
+        );
+        assert_eq!(def.mode, TriggerMode::RolledDieOnce);
+        assert_eq!(def.die_result, Some(DieResultFilter::AtLeast(3)));
+    }
+
+    #[test]
+    fn trigger_rolled_die_result_at_least_more() {
+        // "N or more" is the alternate GE phrasing; folds to AtLeast like "N or higher".
+        let def = parse_trigger_line(
+            "Whenever you roll a 4 or more, draw a card.",
+            "Die Roll GE Phrasing",
+        );
+        assert_eq!(def.mode, TriggerMode::RolledDieOnce);
+        assert_eq!(def.die_result, Some(DieResultFilter::AtLeast(4)));
+    }
+
+    #[test]
+    fn trigger_rolled_die_no_result_filter_is_none() {
+        // Regression: the bare "a die" form classifies as RolledDieOnce with no
+        // result filter, and the batched "one or more dice" form is RolledDie.
+        let single = parse_trigger_line(
+            "Whenever you roll a die, put a +1/+1 counter on ~.",
+            "The Space Family Goblinson",
+        );
+        assert_eq!(single.mode, TriggerMode::RolledDieOnce);
+        assert_eq!(single.die_result, None);
+
+        let batch = parse_trigger_line(
+            "Whenever you roll one or more dice, put a +1/+1 counter on ~.",
+            "Vrondiss, Rage of Ancients",
+        );
+        assert_eq!(batch.mode, TriggerMode::RolledDie);
+        assert_eq!(batch.die_result, None);
     }
 
     #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -15909,6 +15909,17 @@ pub enum CoinFlipResult {
     Lost,
 }
 
+/// CR 706.2: Typed result-face filter for "Whenever you roll a [result]" die-roll
+/// triggers. `Exact` covers single faces ("roll a 1") AND disjunctions ("roll a 1
+/// or 2") — a set, which no single Comparator can express; `AtLeast` is the GE
+/// threshold special case ("roll a N or higher"), folded in for ergonomics rather
+/// than reusing `(Comparator, u8)` so the valid design space stays exact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DieResultFilter {
+    Exact(Vec<u8>),
+    AtLeast(u8),
+}
+
 /// Trigger definition with typed fields. Zero params HashMap.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TriggerDefinition {
@@ -16035,6 +16046,11 @@ pub struct TriggerDefinition {
     /// When `Some(Won)`, fires only on wins; `Some(Lost)` only on losses; `None` fires on any flip.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub coin_flip_result: Option<CoinFlipResult>,
+    /// CR 706.2: result-face filter for RolledDieOnce triggers; None accepts any
+    /// face. CR 706.7: a numeric filter never fires on a non-numeric (planar) roll
+    /// (result None); a None filter is unaffected. See match_rolled_die.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub die_result: Option<DieResultFilter>,
     /// CR 603.2 + CR 106.1: Produced-mana filter for `TriggerMode::TapsForMana`
     /// triggers whose event text specifies "for {C}" / "for {G}" rather than
     /// the generic "for mana". When `Some`, the `TappedForMana` event must
@@ -16077,6 +16093,7 @@ impl TriggerDefinition {
             damage_amount: None,
             life_amount: None,
             coin_flip_result: None,
+            die_result: None,
             taps_for_mana_produced: None,
         }
     }
@@ -18820,11 +18837,40 @@ mod tests {
             damage_amount: None,
             life_amount: None,
             coin_flip_result: None,
+            die_result: None,
             taps_for_mana_produced: None,
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();
         assert_eq!(trigger, deserialized);
+    }
+
+    #[test]
+    fn die_result_filter_roundtrips_each_variant() {
+        // CR 706.2: each DieResultFilter variant survives a serde round-trip.
+        for filter in [
+            DieResultFilter::Exact(vec![1]),
+            DieResultFilter::Exact(vec![1, 2]),
+            DieResultFilter::AtLeast(3),
+        ] {
+            let json = serde_json::to_string(&filter).unwrap();
+            let deserialized: DieResultFilter = serde_json::from_str(&json).unwrap();
+            assert_eq!(filter, deserialized);
+        }
+    }
+
+    #[test]
+    fn die_result_back_compat_omitted_key_is_none() {
+        // CR 706.2: a TriggerDefinition JSON with no `die_result` key (the
+        // pre-feature serialization) deserializes to `die_result: None`.
+        let trigger = TriggerDefinition::new(TriggerMode::RolledDieOnce);
+        let json = serde_json::to_value(&trigger).unwrap();
+        assert!(
+            json.get("die_result").is_none(),
+            "None die_result must be skipped on serialize"
+        );
+        let deserialized: TriggerDefinition = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.die_result, None);
     }
 
     #[test]


### PR DESCRIPTION
## Anchored on

The "Whenever you roll a [specific result]" die-roll triggered-ability class, which parsed to `TriggerMode::Unknown(...)`. Real forms: exact ("roll a 1"), disjunction ("roll a 1 or 2"), and threshold ("roll a 3 or higher" / "or more"). Cards: Complaints Clerk, Dee Kay (Finder of the Lost), Night Shift of the Living Dead, Monoxa (Midway Manager), Mr. House (President and CEO), Atomwheel Acrobats.

## Problem

The die-roll trigger event (`GameEvent::DieRolled`), mode (`RolledDie`/`RolledDieOnce`), and matcher (`match_rolled_die`) are all shipped, but the matcher only filtered by die **sides**, never by the rolled **result** — so result-specific triggers were unclassified and never fired.

## Fix (mirrors the shipped `coin_flip_result` pattern)

- **`DieResultFilter { Exact(Vec<u8>), AtLeast(u8) }`** — `Exact` covers a single face ("roll a 1") and disjunctions ("roll a 1 or 2"); `AtLeast` covers the GE threshold ("roll a N or higher"). A set is needed for the disjunction, so a single `(Comparator, u8)` can't express it; this is the same shape as the existing `CoinFlipResult` filter.
- **`die_result: Option<DieResultFilter>`** field on `TriggerDefinition` (`#[serde(default, skip_serializing_if = ...)]`, like `coin_flip_result`).
- **`match_rolled_die`** now reads `DieRolled.result` and applies the filter (`Exact` → result ∈ set; `AtLeast` → result >= n). Per CR 706.7, a non-numeric (planar) roll (`result: None`) never satisfies a numeric filter, while a `None` filter (e.g. existing "roll a d20") is unaffected.
- **Parser:** `parse_die_roll_result` (nom only) parses "a N" / "a N or M" / "a N or higher"/"or more", threaded through the die-roll trigger parser; reuses `RolledDieOnce` (no new mode).

No new event, no new mode. CR 706.2 (die-roll result) and CR 706.7 (planar-die exclusion).

## Scope (honest)

This classifies and fires the die-result **trigger** for the class. The trigger now fires on exactly the right rolled result. Several of the named cards have *additional* effect clauses that are pre-existing `Unimplemented`/partial gaps unrelated to this change — e.g. Monoxa's "if the roll was N or higher" escalations, Mr. House's "6+ instead" + its activated ability, Dee Kay's roll-2 "and you gain 1 life", Night Shift's roll-modifier line. Those are separate, known gaps; this PR does not claim to complete those cards' effects, only to classify the trigger correctly.

## Tests

Parser: each form → `RolledDieOnce` + correct `die_result` (`Exact([1])`, `Exact([1,2])`, `AtLeast(3)`, `AtLeast(4)`); "roll a die" / "one or more dice" still parse with `die_result: None` (no regression). Matcher (the discriminating matrix): `Exact([1])` fires on result 1 not 2; `AtLeast(3)` fires on 3/6 not 2; `Exact([1,2])` fires on 1 and 2 not 3; numeric filter does not fire on a `None` (planar) result. Runtime: a "roll a 1" trigger fires only on a rolled 1.

## Verification

`cargo fmt`/`check -p engine`/clippy `-D warnings`/parser combinator gate all clean; `cargo check -p mtgish-import` clean (no cross-crate ripple); the new parser/matcher/runtime tests pass; the existing `rolled_die` + `coin_flip` suites stay green.

Model: claude-opus-4-8
Tier: Frontier
