### PR TITLE
Fix combat roles persisting through battlefield exits (CR 506.4)

### DIFF
--- a/crates/engine/src/game/effects/remove_from_combat.rs
+++ b/crates/engine/src/game/effects/remove_from_combat.rs
@@ -54,12 +54,20 @@ pub fn remove_object_from_combat(state: &mut GameState, oid: crate::types::ident
         let attackers_before = combat.attackers.len();
         combat.attackers.retain(|a| a.object_id != oid);
         attacker_removed = combat.attackers.len() != attackers_before;
-        // Remove as blocker from all attacker assignments
+        // Drop attacker-keyed forward assignments (oid was blocking nobody as a key,
+        // but was an attacker with blockers assigned to it).
+        combat.blocker_assignments.remove(&oid);
+        // Remove as blocker from all remaining attacker assignments
         for blockers in combat.blocker_assignments.values_mut() {
             blockers.retain(|b| *b != oid);
         }
-        // Remove reverse blocker lookup
+        // Remove reverse lookup when oid was a blocker
         combat.blocker_to_attacker.remove(&oid);
+        // Prune oid from every blocker's attacker list (oid was an attacker)
+        combat.blocker_to_attacker.retain(|_, attackers| {
+            attackers.retain(|id| *id != oid);
+            !attackers.is_empty()
+        });
         // Remove any pending damage assignments for this object
         combat.damage_assignments.remove(&oid);
     }
@@ -93,17 +101,27 @@ mod tests {
             "Bear".to_string(),
             Zone::Battlefield,
         );
+        let blocker_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Blocker".to_string(),
+            Zone::Battlefield,
+        );
 
-        state.combat = Some(CombatState {
+        let mut combat = CombatState {
             attackers: vec![AttackerInfo {
                 object_id: obj_id,
                 defending_player: PlayerId(1),
                 attack_target: AttackTarget::Player(PlayerId(1)),
-                blocked: false,
+                blocked: true,
                 band_id: None,
             }],
             ..Default::default()
-        });
+        };
+        combat.blocker_assignments.insert(obj_id, vec![blocker_id]);
+        combat.blocker_to_attacker.insert(blocker_id, vec![obj_id]);
+        state.combat = Some(combat);
 
         let ability = ResolvedAbility::new(
             Effect::RemoveFromCombat {
@@ -119,6 +137,17 @@ mod tests {
 
         let combat = state.combat.as_ref().unwrap();
         assert!(combat.attackers.is_empty(), "Attacker should be removed");
+        assert!(
+            !combat.blocker_assignments.contains_key(&obj_id),
+            "Attacker-keyed block assignment must be removed"
+        );
+        assert!(
+            combat
+                .blocker_to_attacker
+                .get(&blocker_id)
+                .is_none_or(|attackers| !attackers.contains(&obj_id)),
+            "Departing attacker must be pruned from every blocker's reverse lookup"
+        );
         assert!(events.iter().any(|e| matches!(
             e,
             GameEvent::EffectResolved {

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -410,6 +410,11 @@ pub(crate) fn apply_zone_exit_cleanup(
     // Prune host-bound transient effects and clean up mana-tap tracking
     // when a permanent leaves the battlefield.
     if from == Zone::Battlefield {
+        // CR 506.4: A permanent is removed from combat when it leaves the
+        // battlefield. Combat role is snapshotted into the zone-change record
+        // (capture_combat_status) before this cleanup runs so look-back
+        // triggers still read attacking/blocking status (CR 603.10a).
+        super::effects::remove_from_combat::remove_object_from_combat(state, object_id);
         super::pairing::break_pair(state, object_id);
         crate::game::layers::mark_layers_full(state);
         // CR 400.7 + CR 702.11b: The "has dealt damage since entering" sticky flag
@@ -1517,6 +1522,86 @@ mod tests {
     /// rules say cease to exist. This test drives `move_to_zone` directly
     /// (not a shape assertion on the HashMap) and would have caught a
     /// regression in `apply_zone_exit_cleanup`'s counter-clear branch.
+    #[test]
+    fn issue_4223_combat_role_cleared_on_battlefield_exit() {
+        use crate::game::combat::{AttackTarget, AttackerInfo, CombatState};
+
+        let mut state = setup();
+        let attacker = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Strangleroot Geist".to_string(),
+            Zone::Battlefield,
+        );
+        let blocker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Blocker".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut combat = CombatState {
+            attackers: vec![AttackerInfo {
+                object_id: attacker,
+                defending_player: PlayerId(1),
+                attack_target: AttackTarget::Player(PlayerId(1)),
+                blocked: true,
+                band_id: None,
+            }],
+            ..Default::default()
+        };
+        combat.blocker_assignments.insert(attacker, vec![blocker]);
+        combat.blocker_to_attacker.insert(blocker, vec![attacker]);
+        state.combat = Some(combat);
+
+        let mut events = Vec::new();
+        // Blocker dies (e.g. combat damage) — must leave combat before Undying
+        // returns the same ObjectId to the battlefield.
+        move_to_zone(&mut state, blocker, Zone::Graveyard, &mut events);
+        let combat = state.combat.as_ref().unwrap();
+        assert!(
+            !combat.blocker_to_attacker.contains_key(&blocker),
+            "CR 506.4: blocker must be removed from combat when it leaves the battlefield"
+        );
+        assert!(
+            combat
+                .blocker_assignments
+                .get(&attacker)
+                .is_none_or(|blockers| !blockers.contains(&blocker)),
+            "dead blocker must not remain assigned to the attacker"
+        );
+
+        // Undying-style return: same ObjectId re-enters without combat role.
+        move_to_zone(&mut state, blocker, Zone::Battlefield, &mut events);
+        let combat = state.combat.as_ref().unwrap();
+        assert!(
+            !combat.blocker_to_attacker.contains_key(&blocker),
+            "returned creature must not inherit stale blocking status (issue #4223)"
+        );
+
+        // Attacker dies and returns — must not remain an attacker either.
+        move_to_zone(&mut state, attacker, Zone::Graveyard, &mut events);
+        let combat = state.combat.as_ref().unwrap();
+        assert!(
+            combat
+                .attackers
+                .iter()
+                .all(|info| info.object_id != attacker),
+            "CR 506.4: attacker must be removed from combat when it leaves the battlefield"
+        );
+        move_to_zone(&mut state, attacker, Zone::Battlefield, &mut events);
+        let combat = state.combat.as_ref().unwrap();
+        assert!(
+            combat
+                .attackers
+                .iter()
+                .all(|info| info.object_id != attacker),
+            "returned attacker must not inherit stale attacking status"
+        );
+    }
+
     #[test]
     fn counters_cease_to_exist_across_exile_and_return() {
         use crate::types::counter::CounterType;

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -1591,6 +1591,17 @@ mod tests {
                 .all(|info| info.object_id != attacker),
             "CR 506.4: attacker must be removed from combat when it leaves the battlefield"
         );
+        assert!(
+            !combat.blocker_assignments.contains_key(&attacker),
+            "CR 506.4: attacker-keyed block assignment must be removed on battlefield exit"
+        );
+        assert!(
+            combat
+                .blocker_to_attacker
+                .values()
+                .all(|attackers| !attackers.contains(&attacker)),
+            "CR 506.4: departed attacker must be pruned from every blocker's reverse lookup"
+        );
         move_to_zone(&mut state, attacker, Zone::Battlefield, &mut events);
         let combat = state.combat.as_ref().unwrap();
         assert!(
@@ -1599,6 +1610,14 @@ mod tests {
                 .iter()
                 .all(|info| info.object_id != attacker),
             "returned attacker must not inherit stale attacking status"
+        );
+        assert!(
+            !combat.blocker_assignments.contains_key(&attacker),
+            "returned attacker must not inherit stale attacker-keyed block assignment"
+        );
+        assert!(
+            !combat.blocker_to_attacker.contains_key(&attacker),
+            "returned attacker must not inherit stale blocking status via reverse lookup"
         );
     }
 


### PR DESCRIPTION
## Summary

- Clear live combat membership when a permanent leaves the battlefield during `apply_zone_exit_cleanup` (CR 506.4).
- Combat role is still snapshotted into the zone-change record before cleanup (CR 603.10a), so look-back triggers (`"if it was blocking"`, `"attacking creatures die"`, etc.) are unaffected.
- Fixes stale block/attack UI lines when the same `ObjectId` re-enters the battlefield (Undying, blink, exile-and-return) while combat is still in progress.

## Problem

Reported via Discord: attacking with Strangleroot Geist showed block assignments persisting after zone changes.

The engine already called `capture_combat_status` at zone exit but never removed the object from `combat.attackers`, `combat.blocker_assignments`, or `combat.blocker_to_attacker`. Because phase.rs reuses storage identity (`ObjectId`) across zone changes, a blocker that died and returned via Undying still appeared in `blocker_to_attacker`, and the client continued rendering block lines.

## Solution

Wire the existing `remove_object_from_combat` building block into the battlefield-exit path in `apply_zone_exit_cleanup`, after combat status has been captured in `move_to_zone` / `move_to_library_at_index`.

## Files changed

- `crates/engine/src/game/zones.rs`
  - Call `remove_object_from_combat` on battlefield exit.
  - Add regression test `issue_4223_combat_role_cleared_on_battlefield_exit`.

## Test plan

- [x] `cargo test -p engine --lib zones::tests::issue_4223_combat_role_cleared_on_battlefield_exit`
- [x] `cargo test -p engine --lib remove_from_combat::`
- [x] `cargo test -p engine --lib filter::tests::zone_change_record_combat_properties_match_snapshot`
- [ ] Manual: attack with a creature, block it, kill the blocker in combat, resolve Undying — returned creature must not show block lines
- [ ] Manual: attacker dies and returns mid-combat — must not remain in the attackers list

## Closes

- https://github.com/phase-rs/phase/issues/4223