### PR TITLE
feat(client): surface who holds priority and why we're waiting

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -401,22 +401,29 @@ export function ActionButton() {
                 {t("actionButton.companionToHand")}
               </button>
             )}
-            <button
-              disabled={blocked}
-              onClick={() => dispatchAction({ type: "PassPriority" })}
-              aria-describedby={priorityTooltipId}
-              className={gameButtonClass({
-                tone: "emerald",
-                size: "md",
-                disabled: blocked,
-                className: `${primaryButtonClass} group relative`,
-              })}
-            >
-              {idle ? t("actionButton.waiting") : advanceLabel}
-              <GameplayTooltip id={priorityTooltipId}>
-                {t("actionButton.priorityTooltip")}
-              </GameplayTooltip>
-            </button>
+            {/* In idle (no priority), the "who/why" narration lives in
+                TurnStatusLine — rendering a disabled "Waiting" button here too
+                would duplicate it (and an empty/relabeled disabled control is
+                worse for screen readers). So show the actionable button only
+                when the local player actually has the priority window. */}
+            {!idle && (
+              <button
+                disabled={blocked}
+                onClick={() => dispatchAction({ type: "PassPriority" })}
+                aria-describedby={priorityTooltipId}
+                className={gameButtonClass({
+                  tone: "emerald",
+                  size: "md",
+                  disabled: blocked,
+                  className: `${primaryButtonClass} group relative`,
+                })}
+              >
+                {advanceLabel}
+                <GameplayTooltip id={priorityTooltipId}>
+                  {t("actionButton.priorityTooltip")}
+                </GameplayTooltip>
+              </button>
+            )}
             <button
               disabled={blocked}
               onClick={() => dispatchAction({ type: "SetAutoPass", data: { mode: { type: "UntilEndOfTurn" } } })}

--- a/client/src/components/hud/HudPlate.tsx
+++ b/client/src/components/hud/HudPlate.tsx
@@ -34,6 +34,11 @@ interface HudPlateProps {
    *  by both `PlayerHud` and `OpponentHud`; absence means the plate never
    *  participates in debug highlighting. */
   playerId?: PlayerId;
+  /** Decision authority (orthogonal to `active`/turn): this seat is the one the
+   *  game is currently waiting on to make a choice. Renders a small pulsing
+   *  corner marker so "we're waiting on this player" is legible independently
+   *  of whose turn it is. Decorative — narration lives in `TurnStatusLine`. */
+  hasPendingDecision?: boolean;
   density?: "default" | "compact";
 }
 
@@ -75,6 +80,7 @@ export function HudPlate({
   underAttack = false,
   avatarUrl,
   playerId,
+  hasPendingDecision = false,
   density = "default",
 }: HudPlateProps) {
   const { t } = useTranslation("game");
@@ -134,6 +140,12 @@ export function HudPlate({
         <div
           aria-hidden
           className="pointer-events-none absolute -inset-1 z-30 rounded-2xl ring-4 ring-fuchsia-400 shadow-[0_0_22px_6px_rgba(232,121,249,0.7),inset_0_0_18px_4px_rgba(232,121,249,0.45)] animate-pulse"
+        />
+      )}
+      {hasPendingDecision && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -right-1 -top-1 z-30 h-2.5 w-2.5 rounded-full bg-amber-300 ring-2 ring-amber-200/50 shadow-[0_0_8px_2px_rgba(251,191,36,0.7)] animate-pulse"
         />
       )}
       <div className="absolute inset-[1px] rounded-[16px] bg-gradient-to-b from-white/8 via-transparent to-black/10" />

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
 import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
@@ -239,6 +240,9 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
   const disconnectedPlayers = useMultiplayerStore((s) => s.disconnectedPlayers);
   const connectionStatus = useMultiplayerStore((s) => s.connectionStatus);
   const isOnline = connectionStatus !== "disconnected";
+  // Seat the game is currently waiting on (semantic actor). Drives the
+  // decision marker on opponent plates, distinct from the turn ring.
+  const { waitingSeatId } = useTurnStatus();
 
   const primaryOpponentId =
     liveOpponents[0] ?? allOpponents[0] ?? (playerId === 0 ? 1 : 0);
@@ -290,6 +294,7 @@ export function OpponentHud({ opponentName, onKickPlayer }: OpponentHudProps) {
           underAttack={isOpponentUnderAttack}
           avatarUrl={opponentAvatarUrl}
           playerId={opponentId}
+          hasPendingDecision={waitingSeatId === opponentId}
           density={compact ? "compact" : "default"}
           onClick={isValidTarget ? () => handlePlayerTarget(opponentId) : undefined}
           trailing={
@@ -546,6 +551,8 @@ function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isVa
   const isMobile = useIsMobile();
   const gameState = useGameStore((s) => s.gameState);
   const isTheirTurn = gameState?.active_player === playerId;
+  const { waitingSeatId } = useTurnStatus();
+  const isWaitingOnThem = waitingSeatId === playerId;
   const seatColor = getSeatColor(playerId, gameState?.seat_order);
   const isUnderAttack = gameState?.combat?.attackers.some(
     (a) => a.attack_target.type === "Player" && a.attack_target.data === playerId,
@@ -714,6 +721,13 @@ function OpponentTab({ playerId, isFocused, isEliminated, isTeammate: ally, isVa
 
   const statusCluster = (
     <div className="flex shrink-0 items-center gap-1">
+      {isWaitingOnThem && (
+        <span
+          aria-hidden
+          title={t("status.waitingFor", { player: label })}
+          className="h-1.5 w-1.5 rounded-full bg-amber-300 shadow-[0_0_6px_1px_rgba(251,191,36,0.7)] animate-pulse"
+        />
+      )}
       {isTheirTurn && <span className="h-1.5 w-1.5 rounded-full bg-rose-400 animate-pulse" />}
       <span className={`flex items-center gap-0.5 text-xs font-semibold tabular-nums @min-[10rem]:text-sm ${isTheirTurn ? "text-rose-200" : ally ? "text-emerald-200" : isFocused ? "text-amber-100" : "text-slate-100"}`}>
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="h-2.5 w-2.5 text-rose-400/90">

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { useSeatColor } from "../../hooks/useSeatColor.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
@@ -20,6 +21,7 @@ export function PlayerHud() {
   const { t } = useTranslation("game");
   const playerId = usePerspectivePlayerId();
   const isMyTurn = useGameStore((s) => s.gameState?.active_player === playerId);
+  const { waitingSeatId } = useTurnStatus();
   const speed = useGameStore((s) => s.gameState?.players[playerId]?.speed ?? 0);
   const poisonCounters = useGameStore((s) => s.gameState?.players[playerId]?.poison_counters ?? 0);
   const radCounters = useGameStore((s) => s.gameState?.players[playerId]?.player_counters?.Rad ?? 0);
@@ -93,6 +95,7 @@ export function PlayerHud() {
         underAttack={isUnderAttack}
         avatarUrl={avatarUrl}
         playerId={playerId}
+        hasPendingDecision={waitingSeatId === playerId}
         density={compact ? "compact" : "default"}
         onClick={isValidTarget ? handleTargetClick : undefined}
         trailing={

--- a/client/src/components/hud/TurnStatusLine.tsx
+++ b/client/src/components/hud/TurnStatusLine.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+
+import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
+import { getOpponentDisplayName } from "../../stores/multiplayerStore.ts";
+
+/**
+ * Persistent one-line "who has priority / why" narration. Fills the gap where
+ * the action rail goes quiet because the local player is waiting on someone
+ * else — the engine knows exactly who and why; this just renders it.
+ *
+ * Reads the single `useTurnStatus()` authority. Framing is driven by
+ * `canIActNow` (spectator- and turn-control-safe), never by a raw seat compare,
+ * so spectators and Mindslaver-controlled turns get correct copy. Rendered as
+ * an `aria-live` status region so the changing state is announced.
+ */
+export function TurnStatusLine() {
+  const { t } = useTranslation("game");
+  const { waitingSeatId, canIActNow, waitingOnOpponent, reason } = useTurnStatus();
+
+  // Nothing pending to narrate (between turns, mid-animation, game over).
+  if (waitingSeatId == null) return null;
+
+  const reasonText = reason ? t(reason.key, reason.params) : "";
+
+  let text: string;
+  if (canIActNow) {
+    text = reasonText
+      ? t("status.yourPriorityReason", { reason: reasonText })
+      : t("status.yourPriority");
+  } else {
+    const name = getOpponentDisplayName(waitingSeatId);
+    text = reasonText
+      ? t("status.waitingForReason", { player: name, reason: reasonText })
+      : t("status.waitingFor", { player: name });
+  }
+
+  // Your decision reads as a positive prompt; waiting on someone else reads as
+  // a muted, patient state. The dot pulses only while we wait on another seat.
+  const tone = canIActNow
+    ? "border-emerald-400/40 bg-emerald-950/70 text-emerald-50"
+    : "border-white/12 bg-slate-950/75 text-slate-200";
+  const dotTone = canIActNow ? "bg-emerald-300" : "bg-amber-300";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`pointer-events-none flex max-w-[min(22rem,calc(100vw-1.25rem))] items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium tracking-wide shadow-[0_12px_32px_rgba(15,23,42,0.45)] backdrop-blur-xl ${tone} [@media(max-height:500px)]:px-2 [@media(max-height:500px)]:py-0.5 [@media(max-height:500px)]:text-[10px]`}
+    >
+      <span
+        aria-hidden
+        className={`h-2 w-2 shrink-0 rounded-full ${dotTone} ${waitingOnOpponent ? "animate-pulse" : ""}`}
+      />
+      <span className="truncate">{text}</span>
+    </div>
+  );
+}

--- a/client/src/components/hud/__tests__/TurnStatusLine.test.tsx
+++ b/client/src/components/hud/__tests__/TurnStatusLine.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Runtime tests for TurnStatusLine — the persistent "who has priority / why"
+ * narration. Renders the real component against real i18n + Zustand stores and
+ * asserts on the user-visible English copy, so framing bugs (e.g. "Your
+ * priority" shown to a spectator) are caught at the rendered-text level.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { GameState, Phase, WaitingFor } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
+import { TurnStatusLine } from "../TurnStatusLine.tsx";
+
+function createGameState(o: { active_player?: number; phase?: Phase; stack?: GameState["stack"] } = {}): GameState {
+  return {
+    turn_number: 1,
+    active_player: o.active_player ?? 0,
+    phase: o.phase ?? "PreCombatMain",
+    players: [
+      { id: 0, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+      { id: 1, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+    ],
+    priority_player: o.active_player ?? 0,
+    objects: {},
+    next_object_id: 100,
+    battlefield: [],
+    stack: o.stack ?? [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 1,
+    seat_order: [0, 1],
+    turn_decision_controller: o.active_player ?? 0,
+    format_config: {
+      format: "Standard", starting_life: 20, min_players: 2, max_players: 2, deck_size: 60,
+      singleton: false, command_zone: false, commander_damage_threshold: null,
+      range_of_influence: null, team_based: false, uses_commander: false, allow_debug_actions: false,
+    },
+    eliminated_players: [],
+  };
+}
+
+const ONE_STACK_ENTRY = [{ object_id: 50 }] as unknown as GameState["stack"];
+
+function setup(opts: { seat: number; waitingFor: WaitingFor; state?: Parameters<typeof createGameState>[0]; spectate?: boolean }) {
+  useGameStore.setState({
+    gameMode: opts.spectate ? "spectate" : "online",
+    gameState: createGameState(opts.state),
+    waitingFor: opts.waitingFor,
+  });
+  useMultiplayerStore.setState({
+    activePlayerId: opts.seat,
+    isSpectator: opts.spectate ?? false,
+    playerNames: new Map([[1, "Sorin"]]),
+  });
+}
+
+describe("TurnStatusLine", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    useMultiplayerStore.setState({ activePlayerId: null, isSpectator: false, playerNames: new Map() });
+  });
+  afterEach(() => {
+    cleanup();
+    useGameStore.getState().reset();
+    useMultiplayerStore.setState({ activePlayerId: null, isSpectator: false, playerNames: new Map() });
+  });
+
+  it("announces the local player's own priority with the phase reason", () => {
+    setup({ seat: 0, waitingFor: { type: "Priority", data: { player: 0 } }, state: { active_player: 0 } });
+    render(<TurnStatusLine />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveTextContent("Your priority — main phase");
+    expect(region).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("names the opponent we are waiting on, with the stack reason", () => {
+    setup({
+      seat: 0,
+      waitingFor: { type: "Priority", data: { player: 1 } },
+      state: { active_player: 0, stack: ONE_STACK_ENTRY },
+    });
+    render(<TurnStatusLine />);
+    expect(screen.getByRole("status")).toHaveTextContent("Waiting for Sorin — responding to the stack");
+  });
+
+  it("never frames the decision as the spectator's own", () => {
+    setup({ seat: 0, waitingFor: { type: "Priority", data: { player: 0 } }, spectate: true });
+    render(<TurnStatusLine />);
+    const region = screen.getByRole("status");
+    expect(region).not.toHaveTextContent("Your priority");
+    expect(region).toHaveTextContent(/Waiting for/);
+  });
+
+  it("renders nothing when no decision is pending", () => {
+    setup({ seat: 0, waitingFor: { type: "GameOver", data: { winner: 0 } } });
+    render(<TurnStatusLine />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/client/src/game/__tests__/waitingForReason.test.ts
+++ b/client/src/game/__tests__/waitingForReason.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for `waitingForReason` — maps a pending decision to a localized
+ * reason key. Pure function over engine-provided facts (variant type, plus
+ * phase/stack for the priority window); it labels state, never infers it.
+ *
+ * The function reads only `waitingFor.type` (and, for `Priority`, the
+ * engine-provided `stack.length` / `phase`), so the fixtures are intentionally
+ * minimal and cast to the public types.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { GameState, Phase, WaitingFor } from "../../adapter/types";
+import { waitingForReason } from "../waitingForRegistry";
+
+function wf(type: string, data: Record<string, unknown> = {}): WaitingFor {
+  return { type, data } as unknown as WaitingFor;
+}
+
+function gs(phase: Phase, stackLen = 0): GameState {
+  return {
+    phase,
+    stack: Array.from({ length: stackLen }, (_, i) => ({ object_id: i })),
+  } as unknown as GameState;
+}
+
+describe("waitingForReason", () => {
+  it("returns null when nothing is pending or the game is over", () => {
+    expect(waitingForReason(null, null)).toBeNull();
+    expect(waitingForReason(wf("GameOver", { winner: 0 }), gs("End"))).toBeNull();
+  });
+
+  it("maps common decision variants to their reason keys", () => {
+    expect(waitingForReason(wf("DeclareAttackers"), gs("DeclareAttackers"))?.key)
+      .toBe("status.reason.declareAttackers");
+    expect(waitingForReason(wf("DeclareBlockers"), gs("DeclareBlockers"))?.key)
+      .toBe("status.reason.declareBlockers");
+    expect(waitingForReason(wf("TargetSelection"), gs("PreCombatMain"))?.key)
+      .toBe("status.reason.choosingTargets");
+    expect(waitingForReason(wf("ManaPayment"), gs("PreCombatMain"))?.key)
+      .toBe("status.reason.payingCost");
+    expect(waitingForReason(wf("MulliganDecision"), gs("Untap"))?.key)
+      .toBe("status.reason.mulligan");
+    expect(waitingForReason(wf("OrderTriggers"), gs("Upkeep"))?.key)
+      .toBe("status.reason.orderingTriggers");
+  });
+
+  it("disambiguates the Priority window by stack depth then phase", () => {
+    // Non-empty stack wins regardless of phase.
+    expect(waitingForReason(wf("Priority"), gs("PreCombatMain", 1))?.key)
+      .toBe("status.reason.respondingToStack");
+    // Empty stack: main phases.
+    expect(waitingForReason(wf("Priority"), gs("PreCombatMain"))?.key)
+      .toBe("status.reason.priorityMain");
+    expect(waitingForReason(wf("Priority"), gs("PostCombatMain"))?.key)
+      .toBe("status.reason.priorityMain");
+    // Empty stack: combat steps.
+    expect(waitingForReason(wf("Priority"), gs("DeclareBlockers"))?.key)
+      .toBe("status.reason.priorityCombat");
+    // Empty stack: other phases (e.g. upkeep) fall to the generic priority key.
+    expect(waitingForReason(wf("Priority"), gs("Upkeep"))?.key)
+      .toBe("status.reason.priority");
+  });
+
+  it("falls back to a generic reason for unmapped variants (graceful degradation)", () => {
+    // A real variant with no explicit case must not break — it degrades.
+    expect(waitingForReason(wf("ScryChoice"), gs("Upkeep"))?.key)
+      .toBe("status.reason.thinking");
+  });
+});

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -9,7 +9,7 @@
 // present in the TS WaitingFor union but absent from this set deliberately
 // surface the diagnostic modal instead of silently hanging.
 
-import type { WaitingFor } from "../adapter/types";
+import type { GameState, WaitingFor } from "../adapter/types";
 
 /**
  * CR 601.2g + CR 107.4f: WaitingFor variants resolved by the single
@@ -175,4 +175,84 @@ export function isWaitingForHandled(
 ): boolean {
   if (!waitingFor) return true;
   return HANDLED_WAITING_FOR_TYPES.has(waitingFor.type);
+}
+
+/** A localized-reason descriptor: an i18n key plus optional interpolation params. */
+export interface WaitingReason {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Map a pending decision to a human-readable *reason* (an i18n key under
+ * `status.reason.*`) describing WHY the game is waiting. This is display
+ * formatting over engine-provided facts (the `waiting_for` variant, plus
+ * `phase` / `stack` for the generic priority window) — it labels a state the
+ * engine already decided; it never infers game state.
+ *
+ * Returns `null` when there is nothing to narrate (no pending decision or the
+ * game is over). Unknown variants fall through to a generic key so a new
+ * engine `WaitingFor` variant degrades gracefully instead of breaking the
+ * build (coverage of the common variants is asserted in tests, not via a
+ * compile-time exhaustiveness check).
+ */
+export function waitingForReason(
+  waitingFor: WaitingFor | null,
+  gameState: GameState | null,
+): WaitingReason | null {
+  if (!waitingFor || waitingFor.type === "GameOver") return null;
+
+  switch (waitingFor.type) {
+    case "DeclareAttackers":
+      return { key: "status.reason.declareAttackers" };
+    case "DeclareBlockers":
+      return { key: "status.reason.declareBlockers" };
+    case "AssignCombatDamage":
+    case "AssignBlockerDamage":
+    case "DistributeAmong":
+      return { key: "status.reason.assigningDamage" };
+    case "TargetSelection":
+    case "TriggerTargetSelection":
+    case "MultiTargetSelection":
+    case "CopyRetarget":
+    case "RetargetChoice":
+      return { key: "status.reason.choosingTargets" };
+    case "ManaPayment":
+    case "PhyrexianPayment":
+    case "PayCost":
+    case "PayManaAbilityMana":
+    case "UnlessPayment":
+      return { key: "status.reason.payingCost" };
+    case "MulliganDecision":
+    case "MulliganBottomCards":
+    case "OpeningHandBottomCards":
+      return { key: "status.reason.mulligan" };
+    case "DiscardToHandSize":
+    case "DiscardChoice":
+      return { key: "status.reason.discarding" };
+    case "OrderTriggers":
+      return { key: "status.reason.orderingTriggers" };
+    case "Priority": {
+      // CR 117: the priority window. The engine-provided stack depth and phase
+      // tell us what kind of window this is — purely descriptive labeling.
+      if ((gameState?.stack.length ?? 0) > 0) {
+        return { key: "status.reason.respondingToStack" };
+      }
+      switch (gameState?.phase) {
+        case "BeginCombat":
+        case "DeclareAttackers":
+        case "DeclareBlockers":
+        case "CombatDamage":
+        case "EndCombat":
+          return { key: "status.reason.priorityCombat" };
+        case "PreCombatMain":
+        case "PostCombatMain":
+          return { key: "status.reason.priorityMain" };
+        default:
+          return { key: "status.reason.priority" };
+      }
+    }
+    default:
+      return { key: "status.reason.thinking" };
+  }
 }

--- a/client/src/hooks/__tests__/useTurnStatus.test.ts
+++ b/client/src/hooks/__tests__/useTurnStatus.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Runtime tests for `useTurnStatus` — the single source for "whose turn / who
+ * must act / why" presentation. Drives the real Zustand stores (no mocks) so
+ * the composed authorities (`waitingPlayer`, `useCanActForWaitingState`,
+ * `usePlayerId`) run exactly as in production.
+ *
+ * The load-bearing assertions are the SEPARATION cases: turn ownership
+ * (`isMyTurn`, raw seat) must stay independent of decision authority
+ * (`canIActNow`), so an opponent holding priority during my turn, and a
+ * turn-control (Mindslaver) seat, both report correctly.
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { GameState, Phase, WaitingFor } from "../../adapter/types";
+import { useGameStore } from "../../stores/gameStore";
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
+import { useTurnStatus } from "../useTurnStatus";
+
+interface Overrides {
+  active_player?: number;
+  turn_decision_controller?: number;
+  phase?: Phase;
+  stack?: GameState["stack"];
+}
+
+function createGameState(o: Overrides = {}): GameState {
+  return {
+    turn_number: 1,
+    active_player: o.active_player ?? 0,
+    phase: o.phase ?? "PreCombatMain",
+    players: [
+      { id: 0, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+      { id: 1, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+    ],
+    priority_player: o.active_player ?? 0,
+    objects: {},
+    next_object_id: 100,
+    battlefield: [],
+    stack: o.stack ?? [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: { type: "Priority", data: { player: 0 } },
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 1,
+    seat_order: [0, 1],
+    turn_decision_controller: o.turn_decision_controller ?? (o.active_player ?? 0),
+    format_config: {
+      format: "Standard",
+      starting_life: 20,
+      min_players: 2,
+      max_players: 2,
+      deck_size: 60,
+      singleton: false,
+      command_zone: false,
+      commander_damage_threshold: null,
+      range_of_influence: null,
+      team_based: false,
+      uses_commander: false,
+      allow_debug_actions: false,
+    },
+    eliminated_players: [],
+  };
+}
+
+/** A non-empty stack: one entry is enough for the `Priority` sub-branch. */
+const ONE_STACK_ENTRY = [{ object_id: 50 }] as unknown as GameState["stack"];
+
+function setup(opts: {
+  seat: number;
+  waitingFor: WaitingFor;
+  state?: Overrides;
+  spectate?: boolean;
+}) {
+  useGameStore.setState({
+    gameMode: opts.spectate ? "spectate" : "online",
+    gameState: createGameState(opts.state),
+    waitingFor: opts.waitingFor,
+  });
+  useMultiplayerStore.setState({
+    activePlayerId: opts.seat,
+    isSpectator: opts.spectate ?? false,
+  });
+}
+
+describe("useTurnStatus", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    useMultiplayerStore.setState({ activePlayerId: null, isSpectator: false });
+  });
+  afterEach(() => {
+    useGameStore.getState().reset();
+    useMultiplayerStore.setState({ activePlayerId: null, isSpectator: false });
+  });
+
+  it("my priority on an empty main-phase stack: actionable, reason is the main-phase window", () => {
+    setup({ seat: 0, waitingFor: { type: "Priority", data: { player: 0 } }, state: { active_player: 0 } });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.isMyTurn).toBe(true);
+    expect(result.current.canIActNow).toBe(true);
+    expect(result.current.waitingSeatId).toBe(0);
+    expect(result.current.waitingOnOpponent).toBe(false);
+    expect(result.current.reason?.key).toBe("status.reason.priorityMain");
+  });
+
+  it("separates turn from priority: opponent holds priority during MY turn", () => {
+    // active_player = 0 (my turn), but seat 1 holds the priority window with a
+    // spell on the stack — I am waiting on them even though it is my turn.
+    setup({
+      seat: 0,
+      waitingFor: { type: "Priority", data: { player: 1 } },
+      state: { active_player: 0, stack: ONE_STACK_ENTRY },
+    });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.isMyTurn).toBe(true); // still my turn
+    expect(result.current.canIActNow).toBe(false); // but not my decision
+    expect(result.current.waitingSeatId).toBe(1);
+    expect(result.current.waitingOnOpponent).toBe(true);
+    expect(result.current.reason?.key).toBe("status.reason.respondingToStack");
+  });
+
+  it("turn control (Mindslaver): isMyTurn is false but I am the authorized actor", () => {
+    // active_player = 1 (the victim's turn); I (seat 0) am the controller.
+    setup({
+      seat: 0,
+      waitingFor: { type: "Priority", data: { player: 1 } },
+      state: { active_player: 1, turn_decision_controller: 0 },
+    });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.isMyTurn).toBe(false); // not my turn (raw seat)
+    expect(result.current.canIActNow).toBe(true); // but I act for it
+  });
+
+  it("spectator: never frames a decision as the viewer's own", () => {
+    setup({ seat: 0, waitingFor: { type: "Priority", data: { player: 0 } }, spectate: true });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.isMyTurn).toBe(false);
+    expect(result.current.canIActNow).toBe(false);
+    expect(result.current.waitingOnOpponent).toBe(false);
+    // The seat is still resolved so the status line can name it neutrally.
+    expect(result.current.waitingSeatId).toBe(0);
+  });
+
+  it("game over: nothing pending to narrate", () => {
+    setup({ seat: 0, waitingFor: { type: "GameOver", data: { winner: 0 } } });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.waitingSeatId).toBeNull();
+    expect(result.current.reason).toBeNull();
+  });
+
+  it("resolves the semantic actor for delegated decisions (Assist helper, not caster)", () => {
+    // CR 702.132a: the chosen helper acts, not the caster. waitingPlayer routes
+    // this; useTurnStatus must surface the helper as the waiting seat.
+    setup({
+      seat: 0,
+      waitingFor: { type: "AssistPayment", data: { caster: 1, chosen: 0, max_generic: 3 } },
+      state: { active_player: 1 },
+    });
+    const { result } = renderHook(() => useTurnStatus());
+    expect(result.current.waitingSeatId).toBe(0);
+    expect(result.current.canIActNow).toBe(true);
+  });
+});

--- a/client/src/hooks/usePlayerId.ts
+++ b/client/src/hooks/usePlayerId.ts
@@ -1,4 +1,4 @@
-import type { PlayerId } from "../adapter/types";
+import type { PlayerId, WaitingFor } from "../adapter/types";
 import { PLAYER_ID, SPECTATOR_PLAYER_ID } from "../constants/game";
 import { useGameStore } from "../stores/gameStore";
 import { useMultiplayerStore } from "../stores/multiplayerStore";
@@ -32,7 +32,14 @@ export function getPlayerId(): PlayerId {
   return currentLocalPlayerId();
 }
 
-function waitingPlayer(waitingFor: ReturnType<typeof useGameStore.getState>["waitingFor"]): PlayerId | null {
+/**
+ * The seat that must act next for `waitingFor` — the *semantic* actor, which
+ * differs from the engine's `priority_player` (the re-derived authorized
+ * submitter). Resolves Vote delegation and Assist's chosen helper; otherwise
+ * the variant's `player`. Exported so display surfaces (e.g. `useTurnStatus`)
+ * read this single authority instead of cloning the logic.
+ */
+export function waitingPlayer(waitingFor: WaitingFor | null): PlayerId | null {
   if (!waitingFor || waitingFor.type === "GameOver") return null;
   // `VoteChoice.actor` names who submits the next `ChooseOption`. Classic
   // Council's-dilemma votes carry `{ type: "SubjectActs" }` so the current

--- a/client/src/hooks/useTurnStatus.ts
+++ b/client/src/hooks/useTurnStatus.ts
@@ -1,0 +1,50 @@
+import type { PlayerId } from "../adapter/types.ts";
+import { useGameStore } from "../stores/gameStore.ts";
+import { useMultiplayerStore } from "../stores/multiplayerStore.ts";
+import { waitingForReason, type WaitingReason } from "../game/waitingForRegistry.ts";
+import { useCanActForWaitingState, usePlayerId, waitingPlayer } from "./usePlayerId.ts";
+
+export interface TurnStatus {
+  /** Whose turn it is (raw `active_player`), or null before the game starts. */
+  activePlayerId: PlayerId | null;
+  /** The seat that must act next (semantic actor), or null when nothing is pending. */
+  waitingSeatId: PlayerId | null;
+  /** True when it is the local player's turn (raw seat compare; NO perspective remap). */
+  isMyTurn: boolean;
+  /** True when the local player is the authorized actor for the pending decision. */
+  canIActNow: boolean;
+  /** True when a decision is pending and the local player is not the one to make it. */
+  waitingOnOpponent: boolean;
+  /** A localized reason descriptor for the pending decision, or null. */
+  reason: WaitingReason | null;
+}
+
+/**
+ * Single source of truth for "whose turn / who must act / why" presentation.
+ *
+ * Composes the existing authorities rather than re-deriving: `waitingPlayer()`
+ * resolves the semantic actor (Vote delegation, Assist helper) and
+ * `useCanActForWaitingState()` resolves "is it mine" (spectator- and
+ * turn-control-aware). It deliberately does NOT read raw `priority_player`
+ * (the engine re-derives that to the authorized submitter) and does NOT route
+ * `isMyTurn` through `usePerspectivePlayerId()` — turn ownership is raw seat
+ * identity, kept separate from decision authority so turn-control effects
+ * (e.g. Mindslaver) never light two plates as active.
+ */
+export function useTurnStatus(): TurnStatus {
+  const gameState = useGameStore((s) => s.gameState);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const gameMode = useGameStore((s) => s.gameMode);
+  const isSpectator = useMultiplayerStore((s) => s.isSpectator);
+  const playerId = usePlayerId();
+  const canIActNow = useCanActForWaitingState();
+
+  const spectating = isSpectator || gameMode === "spectate";
+  const activePlayerId = gameState?.active_player ?? null;
+  const waitingSeatId = waitingPlayer(waitingFor);
+  const isMyTurn = !spectating && activePlayerId != null && activePlayerId === playerId;
+  const waitingOnOpponent = waitingSeatId != null && !canIActNow && !spectating;
+  const reason = waitingForReason(waitingFor, gameState ?? null);
+
+  return { activePlayerId, waitingSeatId, isMyTurn, canIActNow, waitingOnOpponent, reason };
+}

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -88,6 +88,7 @@ import { StackDisplay } from "../components/stack/StackDisplay.tsx";
 import { TargetingOverlay } from "../components/targeting/TargetingOverlay.tsx";
 import { PlayerHud } from "../components/hud/PlayerHud.tsx";
 import { OpponentHud } from "../components/hud/OpponentHud.tsx";
+import { TurnStatusLine } from "../components/hud/TurnStatusLine.tsx";
 import { GraveyardPile } from "../components/zone/GraveyardPile.tsx";
 import { LibraryPile } from "../components/zone/LibraryPile.tsx";
 import { ExilePile } from "../components/zone/ExilePile.tsx";
@@ -1334,6 +1335,7 @@ function GamePageContent({
         {showFlowHelpNudge && <FlowHelpNudge />}
         {showSandboxToolsNudge && <SandboxToolsNudge />}
         <CombatPhaseIndicator />
+        <TurnStatusLine />
         {!isSpectatorMode && (
           <>
             <div className="flex items-center gap-1.5">

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -134,6 +134,11 @@ vi.mock("../../hooks/usePlayerId", () => ({
   usePlayerId: () => 0,
   usePerspectivePlayerId: () => 0,
   useCanActForWaitingState: () => true,
+  // useTurnStatus (reached via the mounted <TurnStatusLine/>) also imports
+  // waitingPlayer from this module; the whole module is mocked, so it must be
+  // re-declared or the call throws. gameStore is mocked with waitingFor: null,
+  // for which the real waitingPlayer returns null — mirror that here.
+  waitingPlayer: () => null,
 }));
 
 vi.mock("../../hooks/useIsMobile", () => ({


### PR DESCRIPTION
Adds a persistent turn/priority indicator so players can tell who
currently holds the pending decision (distinct from whose turn it is)
and why the game is waiting on them.

- useTurnStatus: single source composing waitingPlayer() +
  useCanActForWaitingState() (no raw priority_player re-derivation)
- waitingForReason: maps the typed WaitingFor variant (+ phase/stack)
  to a localized reason key; graceful default for unmapped variants
- TurnStatusLine: aria-live status region ("Your priority - <reason>" /
  "Waiting for <player> - <reason>"), spectator-safe framing
- HudPlate: additive hasPendingDecision marker (distinct from the turn
  ring), wired in PlayerHud, the 1v1 OpponentHud plate, and OpponentTab
- ActionButton: drop the redundant disabled idle "Waiting" button so the
  narration lives only in TurnStatusLine

The status.* i18n keys and the actionButton.waiting removal already
landed on main via #4677; this commit adds the code that consumes them
(and removes the now-dangling t("actionButton.waiting") usage).

Tests: useTurnStatus, waitingForReason, TurnStatusLine (14 cases).
