### PR TITLE
feat(client): tint turn-status narration with the waiting seat's color

### DIFF
--- a/client/src/components/hud/TurnStatusLine.tsx
+++ b/client/src/components/hud/TurnStatusLine.tsx
@@ -1,5 +1,6 @@
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 
+import { useSeatColor } from "../../hooks/useSeatColor.ts";
 import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
 import { getOpponentDisplayName } from "../../stores/multiplayerStore.ts";
 
@@ -16,30 +17,26 @@ import { getOpponentDisplayName } from "../../stores/multiplayerStore.ts";
 export function TurnStatusLine() {
   const { t } = useTranslation("game");
   const { waitingSeatId, canIActNow, waitingOnOpponent, reason } = useTurnStatus();
+  // Hook must run unconditionally (before the early return). Resolves NEUTRAL
+  // for a null seat, which is never rendered thanks to the guard below.
+  const waitingSeatColor = useSeatColor(waitingSeatId);
 
   // Nothing pending to narrate (between turns, mid-animation, game over).
   if (waitingSeatId == null) return null;
 
   const reasonText = reason ? t(reason.key, reason.params) : "";
 
-  let text: string;
-  if (canIActNow) {
-    text = reasonText
-      ? t("status.yourPriorityReason", { reason: reasonText })
-      : t("status.yourPriority");
-  } else {
-    const name = getOpponentDisplayName(waitingSeatId);
-    text = reasonText
-      ? t("status.waitingForReason", { player: name, reason: reasonText })
-      : t("status.waitingFor", { player: name });
-  }
-
   // Your decision reads as a positive prompt; waiting on someone else reads as
-  // a muted, patient state. The dot pulses only while we wait on another seat.
+  // a muted, patient state. The pill's own border/background carries the state
+  // axis; when waiting on another seat, the dot AND the player name carry that
+  // seat's identity color (mirroring the HUD plate's dot+label convention) so
+  // "waiting for X" is visually anchored to X's plate. `animate-pulse` keeps the
+  // attention affordance regardless of hue. The name is colored inline via
+  // <Trans> so the tint stays inside the localized sentence regardless of word
+  // order — no sentence splitting, no new keys.
   const tone = canIActNow
     ? "border-emerald-400/40 bg-emerald-950/70 text-emerald-50"
     : "border-white/12 bg-slate-950/75 text-slate-200";
-  const dotTone = canIActNow ? "bg-emerald-300" : "bg-amber-300";
 
   return (
     <div
@@ -49,9 +46,23 @@ export function TurnStatusLine() {
     >
       <span
         aria-hidden
-        className={`h-2 w-2 shrink-0 rounded-full ${dotTone} ${waitingOnOpponent ? "animate-pulse" : ""}`}
+        className={`h-2 w-2 shrink-0 rounded-full ${canIActNow ? "bg-emerald-300" : ""} ${waitingOnOpponent ? "animate-pulse" : ""}`}
+        style={canIActNow ? undefined : { backgroundColor: waitingSeatColor }}
       />
-      <span className="truncate">{text}</span>
+      <span className="truncate">
+        {canIActNow ? (
+          reasonText
+            ? t("status.yourPriorityReason", { reason: reasonText })
+            : t("status.yourPriority")
+        ) : (
+          <Trans
+            t={t}
+            i18nKey={reasonText ? "status.waitingForReason" : "status.waitingFor"}
+            values={{ player: getOpponentDisplayName(waitingSeatId), reason: reasonText }}
+            components={{ player: <span style={{ color: waitingSeatColor }} /> }}
+          />
+        )}
+      </span>
     </div>
   );
 }

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1886,8 +1886,8 @@
   "status": {
     "yourPriority": "Your priority",
     "yourPriorityReason": "Your priority — {{reason}}",
-    "waitingFor": "Waiting for {{player}}",
-    "waitingForReason": "Waiting for {{player}} — {{reason}}",
+    "waitingFor": "Waiting for <player>{{player}}</player>",
+    "waitingForReason": "Waiting for <player>{{player}}</player> — {{reason}}",
     "reason": {
       "declareAttackers": "declaring attackers",
       "declareBlockers": "declaring blockers",


### PR DESCRIPTION
The priority narration pill named the waiting player as plain text and
used a fixed amber attention dot, so "Waiting for X" was not visually
tied to X's seat-colored HUD plate. Reuse the existing per-seat color
authority (useSeatColor) to tint both the dot and the player name when
waiting on another seat. The pill's border/background still carries the
game-state axis (your-priority vs waiting); the dot/name now carry the
seat-identity axis, and animate-pulse keeps the attention cue.

The name is colored inline via <Trans> with a <player> markup tag around
the placeholder, so the tint stays inside the localized sentence
regardless of word order (no sentence splitting, no new i18n keys).
