### PR TITLE
fix: DistributeAmong stuck decision (#4689), Final Parting prompt, Bribery control

### DIFF
--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -538,6 +538,12 @@ function SearchPartitionModal({
   const tappedText = data.primary_enter_tapped
     ? t("cardChoice.searchPartition.tapped")
     : "";
+  const primaryText = t(
+    `cardChoice.searchPartition.zones.${data.primary_destination}`,
+  );
+  const restText = t(
+    `cardChoice.searchPartition.zones.${data.rest_destination}`,
+  );
 
   useEffect(() => {
     setSelectedSet(new Set());
@@ -575,6 +581,8 @@ function SearchPartitionModal({
       subtitle={t("cardChoice.searchPartition.subtitle", {
         count: data.primary_count,
         tapped: tappedText,
+        primary: primaryText,
+        rest: restText,
       })}
       footer={<ConfirmButton onClick={handleConfirm} disabled={!countValid} />}
     >

--- a/client/src/components/modal/__tests__/SearchPartitionModal.test.tsx
+++ b/client/src/components/modal/__tests__/SearchPartitionModal.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameObject, GameState, WaitingFor } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
+import { CardChoiceModal } from "../CardChoiceModal.tsx";
+
+const dispatchMock = vi.fn();
+
+vi.mock("../../../hooks/useGameDispatch.ts", () => ({
+  useGameDispatch: () => dispatchMock,
+}));
+
+function makeObject(id: number, name: string): GameObject {
+  return {
+    id,
+    card_id: id,
+    owner: 0,
+    controller: 0,
+    zone: "Library",
+    tapped: false,
+    face_down: false,
+    flipped: false,
+    transformed: false,
+    damage_marked: 0,
+    dealt_deathtouch_damage: false,
+    attached_to: null,
+    attachments: [],
+    counters: {},
+    name,
+    power: null,
+    toughness: null,
+    loyalty: null,
+    card_types: { supertypes: [], core_types: ["Instant"], subtypes: [] },
+    mana_cost: { type: "Cost", shards: [], generic: 1 },
+    keywords: [],
+    abilities: [],
+    trigger_definitions: [],
+    replacement_definitions: [],
+    static_definitions: [],
+    color: [],
+    base_power: null,
+    base_toughness: null,
+    base_keywords: [],
+    base_color: [],
+    timestamp: id,
+    entered_battlefield_turn: null,
+  };
+}
+
+function makeState(waitingFor: WaitingFor, objects: Record<string, GameObject>): GameState {
+  return {
+    turn_number: 1,
+    active_player: 0,
+    phase: "PreCombatMain",
+    players: [
+      { id: 0, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [42, 43], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+      { id: 1, life: 20, poison_counters: 0, mana_pool: { mana: [] }, library: [], hand: [], graveyard: [], has_drawn_this_turn: false, lands_played_this_turn: 0, turns_taken: 0 },
+    ],
+    priority_player: 0,
+    objects,
+    next_object_id: 100,
+    battlefield: [],
+    stack: [],
+    exile: [],
+    rng_seed: 1,
+    combat: null,
+    waiting_for: waitingFor,
+    has_pending_cast: false,
+    lands_played_this_turn: 0,
+    max_lands_per_turn: 1,
+    priority_pass_count: 0,
+    pending_replacement: null,
+    layers_dirty: false,
+    next_timestamp: 2,
+    eliminated_players: [],
+  } as unknown as GameState;
+}
+
+function setWaitingFor(waitingFor: WaitingFor, objects: Record<string, GameObject>) {
+  const state = makeState(waitingFor, objects);
+  useGameStore.setState({
+    gameMode: "online",
+    gameState: state,
+    waitingFor,
+  });
+}
+
+describe("SearchPartition modal", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    useMultiplayerStore.setState({ activePlayerId: 0 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Final Parting shape: primary goes to hand, the rest to the graveyard. The
+  // subtitle must name the REAL destinations, not the hard-coded battlefield.
+  it("names the real primary and rest destination zones", async () => {
+    setWaitingFor(
+      {
+        type: "SearchPartitionChoice",
+        data: {
+          player: 0,
+          cards: [42, 43],
+          primary_destination: "Hand",
+          primary_count: 1,
+          primary_enter_tapped: false,
+          rest_destination: "Graveyard",
+          source_id: 99,
+        },
+      } as WaitingFor,
+      { 42: makeObject(42, "Lightning Bolt"), 43: makeObject(43, "Dark Ritual") },
+    );
+
+    render(<CardChoiceModal />);
+
+    expect(await screen.findByText(/your hand/i)).toBeInTheDocument();
+    expect(await screen.findByText(/your graveyard/i)).toBeInTheDocument();
+    // Revert-failing: the pre-fix modal hard-coded "the battlefield" and never
+    // mentioned the graveyard.
+    expect(screen.queryByText(/battlefield/i)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Wähle bis zu {{count}} Karten innerhalb des Manawert-Limits"
     },
     "searchPartition": {
-      "title": "Karten für das Schlachtfeld wählen",
-      "subtitle_one": "Wähle {{count}} Karte, um sie{{tapped}} auf das Schlachtfeld zu legen; der Rest geht auf deine Hand",
-      "subtitle_other": "Wähle {{count}} Karten, um sie{{tapped}} auf das Schlachtfeld zu legen; der Rest geht auf deine Hand",
-      "tapped": " getappt"
+      "title": "Karten wählen",
+      "subtitle_one": "Wähle {{count}} Karte, um sie{{tapped}} {{primary}} zu legen; der Rest geht {{rest}}",
+      "subtitle_other": "Wähle {{count}} Karten, um sie{{tapped}} {{primary}} zu legen; der Rest geht {{rest}}",
+      "tapped": " getappt",
+      "zones": {
+        "Library": "in deine Bibliothek",
+        "Hand": "auf deine Hand",
+        "Battlefield": "auf das Schlachtfeld",
+        "Graveyard": "in deinen Friedhof",
+        "Stack": "auf den Stapel",
+        "Exile": "ins Exil",
+        "Command": "in die Kommandozone"
+      }
     },
     "outsideGame": {
       "title": "Aus dem Sideboard wählen",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1085,10 +1085,19 @@
       "subtitleManaValueUpTo_other": "Choose up to {{count}} cards within the mana value limit"
     },
     "searchPartition": {
-      "title": "Choose Cards for the Battlefield",
-      "subtitle_one": "Choose {{count}} card to put onto the battlefield{{tapped}}; the rest go to your hand",
-      "subtitle_other": "Choose {{count}} cards to put onto the battlefield{{tapped}}; the rest go to your hand",
-      "tapped": " tapped"
+      "title": "Choose Cards",
+      "subtitle_one": "Choose {{count}} card to put into {{primary}}{{tapped}}; the rest go to {{rest}}",
+      "subtitle_other": "Choose {{count}} cards to put into {{primary}}{{tapped}}; the rest go to {{rest}}",
+      "tapped": " tapped",
+      "zones": {
+        "Library": "your library",
+        "Hand": "your hand",
+        "Battlefield": "the battlefield",
+        "Graveyard": "your graveyard",
+        "Stack": "the stack",
+        "Exile": "exile",
+        "Command": "the command zone"
+      }
     },
     "outsideGame": {
       "title": "Choose From Sideboard",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Elige hasta {{count}} cartas dentro del límite de valor de maná"
     },
     "searchPartition": {
-      "title": "Elige cartas para el campo de batalla",
-      "subtitle_one": "Elige {{count}} carta para poner en el campo de batalla{{tapped}}; el resto va a tu mano",
-      "subtitle_other": "Elige {{count}} cartas para poner en el campo de batalla{{tapped}}; el resto va a tu mano",
-      "tapped": "giradas"
+      "title": "Elegir cartas",
+      "subtitle_one": "Elige {{count}} carta para poner {{primary}}{{tapped}}; el resto se pone {{rest}}",
+      "subtitle_other": "Elige {{count}} cartas para poner {{primary}}{{tapped}}; el resto se pone {{rest}}",
+      "tapped": " giradas",
+      "zones": {
+        "Library": "en tu biblioteca",
+        "Hand": "en tu mano",
+        "Battlefield": "en el campo de batalla",
+        "Graveyard": "en tu cementerio",
+        "Stack": "en la pila",
+        "Exile": "en el exilio",
+        "Command": "en la Zona de Mando"
+      }
     },
     "outsideGame": {
       "title": "Elegir del banquillo",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Choisissez jusqu'à {{count}} cartes dans la limite de valeur de mana"
     },
     "searchPartition": {
-      "title": "Choisir des cartes pour le champ de bataille",
-      "subtitle_one": "Choisissez {{count}} carte à mettre sur le champ de bataille{{tapped}} ; le reste va dans votre main",
-      "subtitle_other": "Choisissez {{count}} cartes à mettre sur le champ de bataille{{tapped}} ; le reste va dans votre main",
-      "tapped": " engagée(s)"
+      "title": "Choisir des cartes",
+      "subtitle_one": "Choisissez {{count}} carte à mettre {{primary}}{{tapped}} ; le reste va {{rest}}",
+      "subtitle_other": "Choisissez {{count}} cartes à mettre {{primary}}{{tapped}} ; le reste va {{rest}}",
+      "tapped": " engagée(s)",
+      "zones": {
+        "Library": "dans votre bibliothèque",
+        "Hand": "dans votre main",
+        "Battlefield": "sur le champ de bataille",
+        "Graveyard": "dans votre cimetière",
+        "Stack": "sur la pile",
+        "Exile": "en exil",
+        "Command": "dans la zone de commandement"
+      }
     },
     "outsideGame": {
       "title": "Choisir depuis la réserve",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Scegli fino a {{count}} carte entro il limite di valore di mana"
     },
     "searchPartition": {
-      "title": "Scegli carte per il campo di battaglia",
-      "subtitle_one": "Scegli {{count}} carta da mettere sul campo di battaglia{{tapped}}; il resto va nella tua mano",
-      "subtitle_other": "Scegli {{count}} carte da mettere sul campo di battaglia{{tapped}}; il resto va nella tua mano",
-      "tapped": " TAPpate"
+      "title": "Scegli carte",
+      "subtitle_one": "Scegli {{count}} carta da mettere {{primary}}{{tapped}}; il resto va {{rest}}",
+      "subtitle_other": "Scegli {{count}} carte da mettere {{primary}}{{tapped}}; il resto va {{rest}}",
+      "tapped": " TAPpate",
+      "zones": {
+        "Library": "nella tua biblioteca",
+        "Hand": "nella tua mano",
+        "Battlefield": "sul campo di battaglia",
+        "Graveyard": "nel tuo cimitero",
+        "Stack": "sulla pila",
+        "Exile": "in esilio",
+        "Command": "nella zona di comando"
+      }
     },
     "outsideGame": {
       "title": "Scegli dalla sideboard",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Wybierz do {{count}} kart w granicach limitu wartości many"
     },
     "searchPartition": {
-      "title": "Wybierz karty na pole bitwy",
-      "subtitle_one": "Wybierz {{count}} kartę, aby położyć na pole bitwy{{tapped}}; reszta trafia do twojej ręki",
-      "subtitle_other": "Wybierz {{count}} kart, aby położyć na pole bitwy{{tapped}}; reszta trafia do twojej ręki",
-      "tapped": " obrócone"
+      "title": "Wybierz karty",
+      "subtitle_one": "Wybierz {{count}} kartę, która trafi {{primary}}{{tapped}}; reszta trafia {{rest}}",
+      "subtitle_other": "Wybierz {{count}} kart, które trafią {{primary}}{{tapped}}; reszta trafia {{rest}}",
+      "tapped": " obrócone",
+      "zones": {
+        "Library": "do twojej biblioteki",
+        "Hand": "do twojej ręki",
+        "Battlefield": "na pole bitwy",
+        "Graveyard": "na twój cmentarz",
+        "Stack": "na stos",
+        "Exile": "na wygnanie",
+        "Command": "do strefy dowodzenia"
+      }
     },
     "outsideGame": {
       "title": "Wybierz z sideboardu",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1051,10 +1051,19 @@
       "subtitleManaValueUpTo_other": "Escolha até {{count}} cartas dentro do limite de valor de mana"
     },
     "searchPartition": {
-      "title": "Escolher Cartas para o Campo de Batalha",
-      "subtitle_one": "Escolha {{count}} carta para colocar no campo de batalha{{tapped}}; o restante vai para sua mão",
-      "subtitle_other": "Escolha {{count}} cartas para colocar no campo de batalha{{tapped}}; o restante vai para sua mão",
-      "tapped": " viradas"
+      "title": "Escolher Cartas",
+      "subtitle_one": "Escolha {{count}} carta para colocar {{primary}}{{tapped}}; o restante fica {{rest}}",
+      "subtitle_other": "Escolha {{count}} cartas para colocar {{primary}}{{tapped}}; o restante fica {{rest}}",
+      "tapped": " viradas",
+      "zones": {
+        "Library": "na sua biblioteca",
+        "Hand": "na sua mão",
+        "Battlefield": "no campo de batalha",
+        "Graveyard": "no seu cemitério",
+        "Stack": "na pilha",
+        "Exile": "no exílio",
+        "Command": "na zona de comando"
+      }
     },
     "outsideGame": {
       "title": "Escolher do Sideboard",

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -1410,6 +1410,34 @@ pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
     targets
 }
 
+/// CR 601.2d: The node whose effect divides damage/counters among its own
+/// targets. Mirrors `extract_distribution_total`, which inspects only the
+/// top-level `ability.effect`; a divided effect only reaches the
+/// `WaitingFor::DistributeAmong` sites when it is the top-level node.
+fn distributing_node(ability: &ResolvedAbility) -> Option<&ResolvedAbility> {
+    matches!(
+        ability.effect,
+        Effect::DealDamage { .. } | Effect::PutCounter { .. }
+    )
+    .then_some(ability)
+}
+
+/// CR 601.2d: The targets a division is distributed among — the distributing
+/// node's OWN targets only, excluding sibling-effect targets elsewhere in the
+/// chain (e.g. a chained "tap two target permanents"). Per-opponent fanout
+/// strips player refs (mirroring `flatten_targets_in_chain`); ordinary
+/// player-targeted divided damage keeps its player targets.
+pub fn distribution_targets(ability: &ResolvedAbility) -> Vec<TargetRef> {
+    let Some(node) = distributing_node(ability) else {
+        return Vec::new();
+    };
+    if is_per_opponent_target_fanout(node) {
+        object_targets_only(&node.targets)
+    } else {
+        node.targets.clone()
+    }
+}
+
 /// CR 608.2b: Re-validate targets on resolution — remove any that are no longer legal.
 pub fn validate_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> ResolvedAbility {
     let mut validated = ability.clone();
@@ -9061,6 +9089,119 @@ mod tests {
             },
         ));
         ability
+    }
+
+    /// CR 601.2d building-block (AST-shape) test: a division is announced only
+    /// among the distributing effect's OWN targets, never sibling-effect targets
+    /// elsewhere in the chain. `flatten_targets_in_chain` still returns the full
+    /// chain (those siblings still "become targets" per CR 601.2c), proving the
+    /// two helpers diverge.
+    #[test]
+    fn distribution_targets_excludes_sibling_chain_targets() {
+        // Top-level divided damage carries two of its own object targets; a
+        // chained "tap two target permanents" carries two unrelated targets.
+        let mut ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 3 },
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                damage_source: None,
+            },
+            vec![
+                TargetRef::Object(ObjectId(1)),
+                TargetRef::Object(ObjectId(2)),
+            ],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        ability = ability.sub_ability(ResolvedAbility::new(
+            Effect::SetTapState {
+                target: TargetFilter::Typed(TypedFilter::permanent()),
+                scope: EffectScope::Single,
+                state: TapStateChange::Tap,
+            },
+            vec![
+                TargetRef::Object(ObjectId(3)),
+                TargetRef::Object(ObjectId(4)),
+            ],
+            ObjectId(900),
+            PlayerId(0),
+        ));
+
+        let dist = distribution_targets(&ability);
+        assert_eq!(
+            dist,
+            vec![
+                TargetRef::Object(ObjectId(1)),
+                TargetRef::Object(ObjectId(2))
+            ],
+            "division scoped to the DealDamage node's own targets"
+        );
+        assert_eq!(
+            flatten_targets_in_chain(&ability).len(),
+            4,
+            "flatten still spans the whole chain (siblings became targets)"
+        );
+
+        // Ordinary player-targeted divided damage (NOT per-opponent fanout):
+        // the player target is part of the division and is kept.
+        let with_player = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Any,
+                damage_source: None,
+            },
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Object(ObjectId(5)),
+            ],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        assert_eq!(
+            distribution_targets(&with_player),
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Object(ObjectId(5)),
+            ],
+            "non-fanout divided damage keeps its player target"
+        );
+
+        // Per-opponent fanout divided damage: player refs are structural
+        // partitions, not division recipients, so they are stripped.
+        let mut fanout = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::TargetPlayer),
+                ),
+                damage_source: None,
+            },
+            vec![
+                TargetRef::Player(PlayerId(1)),
+                TargetRef::Object(ObjectId(6)),
+                TargetRef::Player(PlayerId(2)),
+                TargetRef::Object(ObjectId(7)),
+            ],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        fanout.multi_target = Some(MultiTargetSpec::bounded(
+            1,
+            QuantityExpr::Ref {
+                qty: QuantityRef::PlayerCount {
+                    filter: PlayerFilter::Opponent,
+                },
+            },
+        ));
+        assert!(is_per_opponent_target_fanout(&fanout));
+        assert_eq!(
+            distribution_targets(&fanout),
+            vec![
+                TargetRef::Object(ObjectId(6)),
+                TargetRef::Object(ObjectId(7)),
+            ],
+            "per-opponent fanout strips player partition refs from the division"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -7870,7 +7870,8 @@ pub fn finalize_mana_payment(
                 .chosen_x
                 .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
 
-            let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
+            // CR 601.2c + CR 601.2d: Divide only among the distributing effect's own targets.
+            let targets = super::ability_utils::distribution_targets(&pending.ability);
             // Store pending cast for post-distribution resumption. Use `ManaCost::NoCost`
             // since mana was already paid above — `finalize_cast` must not re-deduct.
             let mut pending_resumed = PendingCast::new(
@@ -8066,7 +8067,8 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 .chosen_x
                 .unwrap_or_else(|| total_paid.saturating_sub(non_x_cost));
 
-            let targets = super::ability_utils::flatten_targets_in_chain(&pending.ability);
+            // CR 601.2c + CR 601.2d: Divide only among the distributing effect's own targets.
+            let targets = super::ability_utils::distribution_targets(&pending.ability);
             let mut pending_resumed = PendingCast::new(
                 pending.object_id,
                 pending.card_id,

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -16,8 +16,8 @@ use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_selected_slots_in_chain,
     assign_targets_in_chain, auto_select_targets_for_ability, begin_target_selection_for_ability,
     build_chained_resolved, build_target_slots_labelled, choose_target_for_ability,
-    flatten_targets_in_chain, random_select_targets_for_ability, validate_modal_indices,
-    validate_selected_targets_for_ability, TargetSelectionAdvance,
+    distribution_targets, flatten_targets_in_chain, random_select_targets_for_ability,
+    validate_modal_indices, validate_selected_targets_for_ability, TargetSelectionAdvance,
 };
 use super::casting::{emit_targeting_events, pay_ability_cost_for_activation};
 use super::casting_costs::{
@@ -257,7 +257,10 @@ pub(crate) fn handle_select_targets(
     // For X-spells, distribution is deferred to after mana payment (engine.rs).
     if let Some(ref unit) = pending.distribute {
         if let Some(total) = extract_distribution_total(state, &ability, &ability.effect) {
-            let assigned_targets = flatten_targets_in_chain(&ability);
+            // CR 601.2c + CR 601.2d: Divide only among the distributing effect's
+            // own targets; sibling-effect targets became targets already and are
+            // not part of the division.
+            let assigned_targets = distribution_targets(&ability);
             // Store ability + targets on pending_cast for post-distribution resumption.
             let mut pending_dist = PendingCast::new(
                 pending.object_id,

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -7,7 +7,8 @@ use crate::types::player::PlayerId;
 
 use super::ability_utils::{
     assign_selected_slots_in_chain, assign_targets_in_chain, choose_target_for_ability,
-    flatten_targets_in_chain, validate_selected_targets_for_ability, TargetSelectionAdvance,
+    distribution_targets, flatten_targets_in_chain, validate_selected_targets_for_ability,
+    TargetSelectionAdvance,
 };
 use super::casting_targets::extract_distribution_total;
 use super::effects;
@@ -30,6 +31,9 @@ pub(super) fn finalize_trigger_target_selection(
         events,
     );
 
+    // CR 601.2d: Division is announced only among the distributing effect's own targets, not sibling-effect targets (which still become targets above).
+    let dist_targets = distribution_targets(&ability);
+
     let mut trigger = trigger;
     let controller = trigger.controller;
     let distribute = trigger.distribute.clone();
@@ -42,8 +46,8 @@ pub(super) fn finalize_trigger_target_selection(
         if let Some(total) =
             extract_distribution_total(state, &trigger.ability, &trigger.ability.effect)
         {
-            if assigned_targets.len() == 1 {
-                trigger.ability.distribution = Some(vec![(assigned_targets[0].clone(), total)]);
+            if dist_targets.len() == 1 {
+                trigger.ability.distribution = Some(vec![(dist_targets[0].clone(), total)]);
             } else {
                 // CR 601.2d: Distribution still outstanding. Entry is already
                 // on the stack with empty `distribution`; mutate the on-stack
@@ -55,7 +59,7 @@ pub(super) fn finalize_trigger_target_selection(
                 return WaitingFor::DistributeAmong {
                     player: controller,
                     total,
-                    targets: assigned_targets,
+                    targets: dist_targets,
                     unit,
                 };
             }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4385,8 +4385,11 @@ fn dispatch_pending_trigger_context(
                     &trigger.ability,
                     &trigger.ability.effect,
                 ) {
+                    // CR 601.2c + CR 601.2d: Divide only among the distributing
+                    // effect's own targets; sibling-effect targets became targets
+                    // in the emit above and are not part of the division.
                     let assigned_targets =
-                        super::ability_utils::flatten_targets_in_chain(&trigger.ability);
+                        super::ability_utils::distribution_targets(&trigger.ability);
                     if assigned_targets.len() == 1 {
                         trigger.ability.distribution =
                             Some(vec![(assigned_targets[0].clone(), total)]);
@@ -11174,6 +11177,121 @@ pub mod tests {
 
         assert_eq!(state.objects[&target1].damage_marked, 1);
         assert_eq!(state.objects[&target2].damage_marked, 3);
+    }
+
+    /// CR 601.2c + CR 601.2d + CR 603.3d (runtime seam test): a triggered
+    /// ability whose divided-damage node is CHAINED to a sibling "tap target
+    /// creature" effect announces its division only among the damage node's OWN
+    /// targets — the sibling target is excluded from `DistributeAmong.targets`
+    /// even though it still "becomes a target" (a `BecomesTarget` event fires
+    /// for it). Reverting the `distribution_targets` scoping regresses (a): the
+    /// sibling would leak into the division prompt.
+    #[test]
+    fn trigger_distributed_damage_scopes_distribution_to_own_targets_not_sibling() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+
+        let dmg1 = make_creature(&mut state, PlayerId(1), "Damage Target 1", 2, 10);
+        let dmg2 = make_creature(&mut state, PlayerId(1), "Damage Target 2", 2, 10);
+        let tap_target = make_creature(&mut state, PlayerId(1), "Tap Target", 2, 10);
+
+        let source = make_creature(&mut state, PlayerId(0), "Chained Source", 3, 3);
+        {
+            // Top-level divided damage among exactly two target creatures,
+            // chained to a sibling "tap target creature".
+            let mut execute = AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 4 },
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                    damage_source: None,
+                },
+            );
+            execute.multi_target = Some(MultiTargetSpec::fixed(2, 2));
+            execute.distribute = Some(DistributionUnit::Damage);
+            let execute = execute.sub_ability(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::SetTapState {
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                    scope: crate::types::ability::EffectScope::Single,
+                    state: crate::types::ability::TapStateChange::Tap,
+                },
+            ));
+
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.entered_battlefield_turn = Some(1);
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .execute(execute)
+                    .valid_card(TargetFilter::SelfRef)
+                    .destination(Zone::Battlefield),
+            );
+        }
+
+        let events = vec![zone_changed_event(
+            source,
+            Zone::Hand,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            Vec::new(),
+        )];
+        process_triggers(&mut state, &events);
+
+        let wf = crate::game::engine::begin_pending_trigger_target_selection(&mut state)
+            .expect("begin trigger target selection")
+            .expect("target selection required");
+        state.waiting_for = wf;
+
+        // Slot order is effect-first then sub_ability: [dmg0, dmg1, tap].
+        let result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SelectTargets {
+                targets: vec![
+                    TargetRef::Object(dmg1),
+                    TargetRef::Object(dmg2),
+                    TargetRef::Object(tap_target),
+                ],
+            },
+        )
+        .expect("target selection should succeed");
+
+        // (a) Division is scoped to the damage node's own targets — the sibling
+        // tap target is NOT offered as a division recipient.
+        match &result.waiting_for {
+            WaitingFor::DistributeAmong {
+                total,
+                targets,
+                unit: DistributionUnit::Damage,
+                ..
+            } => {
+                assert_eq!(*total, 4);
+                assert_eq!(
+                    targets,
+                    &vec![TargetRef::Object(dmg1), TargetRef::Object(dmg2)],
+                    "distribution offered only among the damage node's own targets"
+                );
+                assert!(
+                    !targets.contains(&TargetRef::Object(tap_target)),
+                    "sibling tap target must not leak into the division"
+                );
+            }
+            other => panic!("expected DistributeAmong, got {other:?}"),
+        }
+
+        // (b) The sibling target still became a target (CR 601.2c) — a
+        // BecomesTarget event fired for it.
+        assert!(
+            result.events.iter().any(|e| matches!(
+                e,
+                GameEvent::BecomesTarget {
+                    target: TargetRef::Object(id),
+                    ..
+                } if *id == tap_target
+            )),
+            "sibling tap target should still emit a becomes-target event"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -2875,6 +2875,69 @@ mod tests {
         }
     }
 
+    /// CR 110.2a: "put that card onto the battlefield under your control" must
+    /// thread `enters_under = Some(You)` all the way onto the chained
+    /// `Effect::ChangeZone`. Bribery routes the pre-chained path (the
+    /// `SearchLibrary` clause is `defs.last()` when the destination continuation
+    /// applies). Revert-failing: before the fix `enters_under` is `None`.
+    #[test]
+    fn search_put_onto_battlefield_under_your_control_sets_enters_under() {
+        use crate::types::ability::Effect;
+        let def = super::super::parse_effect_chain(
+            "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles.",
+            crate::types::ability::AbilityKind::Spell,
+        );
+        let enters_under = find_battlefield_change_zone_enters_under(&def)
+            .expect("chain should contain a ChangeZone to the battlefield");
+        assert_eq!(
+            enters_under,
+            Some(ControllerRef::You),
+            "under-your-control tutor must route the found card to the controller"
+        );
+        // Sanity: the search itself was recognized.
+        assert!(
+            matches!(&*def.effect, Effect::SearchLibrary { .. }),
+            "head of chain should be the SearchLibrary"
+        );
+    }
+
+    /// Negative sibling: a search-to-battlefield tutor WITHOUT "under your
+    /// control" must leave `enters_under = None` (the scan must not over-fire).
+    #[test]
+    fn search_put_onto_battlefield_without_control_clause_leaves_enters_under_none() {
+        let def = super::super::parse_effect_chain(
+            "Search your library for a creature card, put it onto the battlefield, then shuffle.",
+            crate::types::ability::AbilityKind::Spell,
+        );
+        let enters_under = find_battlefield_change_zone_enters_under(&def)
+            .expect("chain should contain a ChangeZone to the battlefield");
+        assert_eq!(
+            enters_under, None,
+            "no control clause -> default owner's control (None)"
+        );
+    }
+
+    /// Walk the `sub_ability` chain and return the `enters_under` of the first
+    /// `ChangeZone` whose destination is the battlefield.
+    fn find_battlefield_change_zone_enters_under(
+        def: &crate::types::ability::AbilityDefinition,
+    ) -> Option<Option<ControllerRef>> {
+        use crate::types::ability::Effect;
+        let mut cursor = Some(def);
+        while let Some(node) = cursor {
+            if let Effect::ChangeZone {
+                destination: Zone::Battlefield,
+                enters_under,
+                ..
+            } = &*node.effect
+            {
+                return Some(enters_under.clone());
+            }
+            cursor = node.sub_ability.as_deref();
+        }
+        None
+    }
+
     #[test]
     fn search_target_player_library() {
         let details = parse_search_library_details(

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2719,6 +2719,7 @@ pub(super) fn apply_clause_continuation(
         ContinuationAst::SearchDestination {
             destination,
             enter_tapped,
+            enters_under,
             reveal,
             attach_to_source,
         } => {
@@ -2738,7 +2739,12 @@ pub(super) fn apply_clause_continuation(
                     *existing_reveal |= reveal;
                     multi_zone_search = source_zones.iter().any(|zone| *zone != Zone::Library);
                 }
-                apply_search_destination_to_ability_chain(previous, destination, enter_tapped);
+                apply_search_destination_to_ability_chain(
+                    previous,
+                    destination,
+                    enter_tapped,
+                    enters_under.clone(),
+                );
             }
             let put_origin = if multi_zone_search {
                 None
@@ -2753,7 +2759,7 @@ pub(super) fn apply_clause_continuation(
                     target: TargetFilter::Any,
                     owner_library: false,
                     enter_transformed: false,
-                    enters_under: None,
+                    enters_under,
                     enter_tapped: crate::types::zones::EtbTapState::from_legacy_bool(enter_tapped),
                     enters_attacking: false,
                     up_to: false,
@@ -3745,6 +3751,7 @@ fn apply_search_destination_to_ability_chain(
     ability: &mut AbilityDefinition,
     destination: Zone,
     enter_tapped: bool,
+    enters_under: Option<ControllerRef>,
 ) {
     let mut cursor = Some(ability);
     while let Some(sub_ability) = cursor {
@@ -3752,12 +3759,17 @@ fn apply_search_destination_to_ability_chain(
             origin: Some(Zone::Library),
             destination: existing_destination,
             enter_tapped: existing_enter_tapped,
+            enters_under: existing_enters_under,
             ..
         } = &mut *sub_ability.effect
         {
             *existing_destination = destination;
             *existing_enter_tapped =
                 crate::types::zones::EtbTapState::from_legacy_bool(enter_tapped);
+            // CR 110.2a: only overwrite when the clause specified a controller, so a value set by an earlier clause is preserved.
+            if enters_under.is_some() {
+                *existing_enters_under = enters_under.clone();
+            }
         }
         cursor = sub_ability.sub_ability.as_deref_mut();
     }
@@ -3940,6 +3952,9 @@ pub(super) fn parse_intrinsic_continuation_ast(
             Some(ContinuationAst::SearchDestination {
                 destination: super::parse_search_destination(&full_lower),
                 enter_tapped,
+                // CR 110.2a: "... under your control" routes the found card to the ability controller.
+                enters_under: nom_primitives::scan_contains(&full_lower, "under your control")
+                    .then_some(ControllerRef::You),
                 reveal,
                 attach_to_source,
             })

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -206,6 +206,8 @@ pub(crate) enum ContinuationAst {
         destination: Zone,
         /// CR 701.23a: When true, the searched card enters the battlefield tapped.
         enter_tapped: bool,
+        /// CR 110.2a: Some(You) when the card enters "under your control"; None keeps the ChangeZone default (owner's control).
+        enters_under: Option<ControllerRef>,
         /// CR 701.23a: When true, the searched card is revealed before it moves.
         reveal: bool,
         /// When true, the found card enters "attached to" the search source.


### PR DESCRIPTION
Three related card bug fixes.

## fix(engine): scope DistributeAmong targets to the distributing chain node
Closes #4689. Magma Opus ("deal 4 damage divided among any number of targets" + "tap two target permanents") hit **"Stuck decision: DistributeAmong"**. `DistributeAmong.targets` was built from the whole ability chain (`flatten_targets_in_chain`), folding the sibling `SetTapState` targets into the damage-division set. Per CR 601.2d each division target must receive ≥1, so when the total (4) < the over-collected target count, no legal distribution existed → empty `legal_actions` → stuck.

New `distribution_targets()`/`distributing_node()` scope the division to the distributing (top-level `DealDamage`/`PutCounter`) node's **own** targets, mirroring `extract_distribution_total`. The full-chain set is **kept** for `emit_targeting_events` so sibling targets still "become targets" (CR 601.2c / 603.3d).

## fix(client): show real search-partition destination zones in all 7 locales
**Final Parting** ("put one into your hand and the other into your graveyard") displayed a prompt saying *put onto the battlefield … the rest go to your hand* — the AST and runtime routing were already correct; only the hardcoded prompt was wrong. The engine already ships `primary_destination`/`rest_destination` on the `SearchPartitionChoice` payload; the modal now renders those via a per-locale zone noun-map (`{{primary}}`/`{{rest}}`) with a genericized title, across en/es/fr/de/it/pt/pl. Display-only.

## fix(parser): set enters_under for "under your control" search tutors (Bribery)
**Bribery**'s stolen creature entered under the **opponent's** control. The "search … put that card onto the battlefield **under your control**" continuation lowered `ChangeZone` with `enters_under: None`, so CR 110.2a's default (owner's control) applied. The parser now detects "under your control" (`scan_contains` → `ControllerRef::You`) and threads `enters_under` through both continuation-apply paths. Covers the class (Bribery, Acquire, …). Inert on live cards until card-data regen.

---
Verification: clippy green · test-engine 16500 passed / 0 failed (4 new tests) · frontend type-check/lint clean · i18n parity 60/60 + new modal test · parser combinator gate green · semantic-audit clean · coverage additive. All CR annotations (110.2a, 601.2c, 601.2d, 603.3d) grep-verified.