### PR TITLE
fix(parser): set-base-P/T toughness-only axis ("change ~'s base toughness to <value>")

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -560,6 +560,19 @@ struct BasePtSetAxes {
 /// "base " on the second noun and the optional "and toughness" conjunct are each
 /// a single combinator.
 fn parse_base_pt_axes(input: &str) -> OracleResult<'_, BasePtSetAxes> {
+    // CR 208.1: "base toughness" alone (toughness-only, symmetric with the
+    // power-only axis) — Sentinel / Wall of Tombstones set base toughness without
+    // touching base power. Tried first; it cannot shadow the both-axes form,
+    // which always opens with "base power" ("base power and base toughness").
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("base toughness").parse(input) {
+        return Ok((
+            rest,
+            BasePtSetAxes {
+                set_power: false,
+                set_toughness: true,
+            },
+        ));
+    }
     let (input, _) = tag("base power").parse(input)?;
     let (input, toughness) =
         opt(alt((tag(" and base toughness"), tag(" and toughness")))).parse(input)?;
@@ -838,15 +851,18 @@ fn try_parse_subject_base_pt_set_clause_ast(
         } else {
             // Possessive: "<subject>'s base power [and toughness]" followed by the
             // copula (" to " for the transitive "change" frame, else "become[s] ").
+            // Anchor on "'s base " (not "'s base power") so the toughness-only
+            // axis ("~'s base toughness") reaches `parse_base_pt_axes`, which
+            // classifies the specific characteristic word.
             let (rest_lower, (subject_lower, axes)) = alt((
                 (
-                    take_until::<_, _, VE>("'s base power"),
+                    take_until::<_, _, VE>("'s base "),
                     tag("'s "),
                     parse_base_pt_axes,
                 )
                     .map(|(subject, _, axes)| (subject, axes)),
                 (
-                    take_until::<_, _, VE>("\u{2019}s base power"),
+                    take_until::<_, _, VE>("\u{2019}s base "),
                     tag("\u{2019}s "),
                     parse_base_pt_axes,
                 )
@@ -7455,6 +7471,29 @@ mod tests {
             )
             .is_none(),
             "non-base-P/T change clause must not match",
+        );
+    }
+
+    #[test]
+    fn change_base_toughness_only_to_dynamic() {
+        // CR 208.1: toughness-only axis (Wall of Tombstones) — "change ~'s base
+        // toughness to <dynamic>" sets ONLY base toughness, leaving base power
+        // untouched (symmetric with the power-only axis).
+        let (mods, _) = base_pt_set_mods(
+            "change ~'s base toughness to 1 plus the number of creature cards in your graveyard",
+        );
+        assert!(
+            mods.iter()
+                .any(|m| matches!(m, ContinuousModification::SetToughnessDynamic { .. })),
+            "expected SetToughnessDynamic, got {mods:?}",
+        );
+        assert!(
+            !mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::SetPower { .. }
+                    | ContinuousModification::SetPowerDynamic { .. }
+            )),
+            "toughness-only clause must not touch base power, got {mods:?}",
         );
     }
 


### PR DESCRIPTION
The base-P/T set-clause parser handled the power-only and both-axes forms ("~'s base power [and toughness] …") but not the **toughness-only** axis, so "change ~'s base toughness to <value>" fell to `Effect::Unimplemented`.

Two symmetric adjustments in `try_parse_subject_base_pt_set_clause_ast`:
- `parse_base_pt_axes` now accepts a leading "base toughness" (`set_power:false, set_toughness:true`), mirroring the existing power-only axis. Tried first; it cannot shadow the both-axes form, which always opens with "base power".
- the possessive subject capture anchors on `"'s base "` instead of `"'s base power"` so the toughness-only characteristic word reaches `parse_base_pt_axes` for classification.

The per-axis emission (`SetToughnessDynamic` only, base power untouched) and every value form (fixed / single-axis dynamic / paired referent) are reused verbatim — **no new variant**. Unlocks **Wall of Tombstones** ("change this creature's base toughness to 1 plus the number of creature cards in your graveyard") and completes the axis symmetry for the class.

Sentinel additionally needs the "blocking or blocked by ~" combat-relation target filter in its value referent — a separate gap, left for its own change.

**Tests:** toughness-only change-form test (asserts `SetToughnessDynamic` and that base power is not touched). `cargo fmt` + `clippy` + the parser combinator gate are clean; 2307 `oracle_effect` + 118 `subject`-module tests green (power/both-axes regression intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)