### PR TITLE
fix(parser): "target <filter>'s controller/owner <verb>s it" declares its object target

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -7180,6 +7180,84 @@ mod tests {
         assert_eq!(counter_step.targets, vec![TargetRef::Object(artifact)]);
     }
 
+    /// CR 608.2c + CR 115.1: Arcum Dagsson / #4678 — "Target artifact creature's
+    /// controller sacrifices it. …". The ability must SURFACE a required target
+    /// slot for the artifact creature (before the fix it compiled to a targetless
+    /// `Sacrifice{ParentTarget}` and activated with no target). Only artifact
+    /// creatures are legal; a plain creature is not.
+    #[test]
+    fn build_target_slots_target_controller_sacrifices_it_requires_object_target() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Arcum Dagsson".to_string(),
+            Zone::Battlefield,
+        );
+        // Opponent-controlled artifact creature (a legal target).
+        let art_creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Ornithopter".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let types = &mut state.objects.get_mut(&art_creature).unwrap().card_types;
+            types.core_types.push(CoreType::Artifact);
+            types.core_types.push(CoreType::Creature);
+        }
+        // A plain (non-artifact) creature — must NOT be a legal target.
+        let plain_creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&plain_creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "{T}: Target artifact creature's controller sacrifices it. That player may search their library for a noncreature artifact card, put it onto the battlefield, then shuffle.",
+            "Arcum Dagsson",
+            &[],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Artificer".to_string()],
+        );
+        let def = parsed.abilities.first().expect("activated ability parsed");
+        let ability = build_resolved_from_def(def, source, PlayerId(0));
+
+        let slots = build_target_slots(&state, &ability).unwrap();
+        assert_eq!(
+            slots.len(),
+            1,
+            "exactly one object target slot for the artifact creature, got {slots:?}",
+        );
+        assert!(
+            !slots[0].optional,
+            "the artifact-creature target is required"
+        );
+        assert!(
+            slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(art_creature)),
+            "the opponent's artifact creature must be a legal target",
+        );
+        assert!(
+            !slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(plain_creature)),
+            "a non-artifact creature must NOT be a legal target",
+        );
+    }
+
     /// CR 109.4 + CR 707.2: "target opponent creates a token that's a copy of
     /// it" — Wedding Ring's shape. `CopyTokenOf` with a context-ref copy source
     /// (`ParentTarget`) and a `Typed{Opponent}` owner must surface exactly one

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14613,6 +14613,39 @@ fn lower_subject_predicate_ast(
                 });
             }
             let mut clause = lower_imperative_clause(&text, ctx);
+            // CR 608.2c + CR 109.4 + CR 115.1: "target <filter>'s controller/owner
+            // <verb>s it" (Arcum Dagsson, Mercy Killing). `parse_subject_application`
+            // records this possessive shift as `affected = ParentTargetController/
+            // Owner` WITH the targeted object carried in `subject.target` (the
+            // anaphoric "its controller" / "that creature's controller" subjects
+            // leave `target = None`, so the pair uniquely identifies the shift).
+            // Declare that object as the ability's `TargetOnly` slot so
+            // `build_target_slots` requires it and the imperative effect's
+            // `ParentTarget` anaphor ("it") — plus `ParentTargetController` in any
+            // following clause ("that player may …") — resolve against it. Mirrors
+            // the player-target ChangeZone / Explore wrapping just below.
+            if matches!(
+                subject.affected,
+                TargetFilter::ParentTargetController | TargetFilter::ParentTargetOwner
+            ) {
+                if let Some(object_target) = subject.target.clone() {
+                    let mut inner = AbilityDefinition::new(AbilityKind::Spell, clause.effect);
+                    inner.sub_ability = clause.sub_ability;
+                    inner.multi_target = clause.multi_target;
+                    return ParsedEffectClause {
+                        effect: Effect::TargetOnly {
+                            target: object_target,
+                        },
+                        duration: clause.duration,
+                        sub_ability: Some(Box::new(inner)),
+                        distribute: None,
+                        multi_target: subject.multi_target,
+                        condition: None,
+                        optional: subject.is_optional,
+                        unless_pay: None,
+                    };
+                }
+            }
             // CR 113.1a + CR 611.2: "each <type> you control gains all activated
             // abilities of target <donor>" (Grell Philosopher). The imperative
             // path lowered the verb to `GainActivatedAbilitiesOfTarget` with the

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1710,7 +1710,38 @@ pub(super) fn parse_subject_application(
         // path of "target creature that player controls becomes …" (Gornog,
         // the Red Reaper) silently bound the target to the trigger
         // controller's own creatures.
-        let (filter, _) = parse_target_with_ctx(subject, ctx);
+        let (filter, rest) = parse_target_with_ctx(subject, ctx);
+        // CR 608.2c + CR 109.4: "target <filter>'s controller/owner <verb>s it"
+        // (Arcum Dagsson, Mercy Killing) — the ability TARGETS <filter>; its
+        // controller/owner performs the verb on it ("it" = that target). Preserve
+        // <filter> as the ability's object target while shifting the acting
+        // subject to the target's controller/owner, so the imperative lowering
+        // declares a `TargetOnly{<filter>}` slot (see `lower_subject_predicate_ast`)
+        // against which `ParentTarget`/`ParentTargetController` resolve. Only the
+        // exact possessive-controller/owner suffix (nothing else) qualifies.
+        if let Ok((_, actor)) = all_consuming(alt((
+            value(
+                TargetFilter::ParentTargetController,
+                alt((
+                    tag::<_, _, OracleError<'_>>("'s controller"),
+                    tag("\u{2019}s controller"),
+                )),
+            ),
+            value(
+                TargetFilter::ParentTargetOwner,
+                alt((tag("'s owner"), tag("\u{2019}s owner"))),
+            ),
+        )))
+        .parse(rest.trim())
+        {
+            return Some(SubjectApplication {
+                affected: actor,
+                target: Some(filter),
+                multi_target: None,
+                inherits_parent: false,
+                is_optional: false,
+            });
+        }
         return subject_filter_application(filter, true);
     }
     if tag::<_, _, OracleError<'_>>("up to ")


### PR DESCRIPTION
Closes #4678.

**Bug:** "{T}: Target artifact creature's controller sacrifices it. …" (Arcum Dagsson) compiled to `Effect::Sacrifice { target: ParentTarget }` with **no selectable object-target slot** — `build_target_slots` produced zero slots, so the ability activated without targeting or sacrificing anything. Root cause: `parse_subject_application`'s "target " branch parsed the `Typed([Artifact,Creature])` filter but **discarded the "'s controller" remainder**, and the imperative "sacrifices it" lowered to a dangling `ParentTarget` anaphor. The whole **"target <filter>'s controller/owner <verb>s it"** class was broken (Mercy Killing, etc.).

**Fix (two scoped changes, no new variant):**
- `parse_subject_application` (subject.rs): when the "target " subject's remainder is exactly `"'s controller"`/`"'s owner"` (nom `all_consuming(alt(...))`), record the possessive shift as `affected = ParentTargetController/Owner` while keeping `<filter>` in `target`. Anaphoric "its controller"/"that creature's controller" subjects leave `target = None`, so the `(affected, target)` pair uniquely identifies the new shift.
- `lower_subject_predicate_ast` imperative arm (mod.rs): for that shift, wrap the imperative effect in `Effect::TargetOnly { target: <filter> }` — the **established pattern** already used for player-target ChangeZone / Explore — so `build_target_slots` requires the object target and the effect's `ParentTarget` ("it") plus a following `ParentTargetController` ("that player may …") resolve against it.

CR 608.2c + CR 109.4 + CR 115.1.

**Runtime test** (`build_target_slots`): Arcum now surfaces exactly one required target slot; the opponent's artifact creature is legal, a plain creature is not. `cargo fmt` + `clippy` + the parser combinator gate are clean; **2308 oracle_effect + 125 ability_utils + 78 targeting + 697 casting** tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)