### PR TITLE
fix(engine): don't cap attack pay-{X} at attacker count (#4226)

### DIFF
--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -78,7 +78,8 @@ pub fn resolve(
         {
             let per_x = mana_x_shard_count(mana_cost);
             let max = max_resolution_mana_x_value(state, payer, ability.source_id, mana_cost);
-            let max = trigger_event_amount(state).map_or(max, |amount| max.min(amount));
+            let max =
+                trigger_event_amount_for_x_payment(state).map_or(max, |amount| max.min(amount));
             state.waiting_for = WaitingFor::PayAmountChoice {
                 player: payer,
                 resource: PayableResource::ManaGeneric { per_x },
@@ -303,6 +304,19 @@ fn trigger_event_amount(state: &GameState) -> Option<u32> {
         .as_ref()
         .and_then(crate::game::targeting::extract_amount_from_event)
         .and_then(|amount| u32::try_from(amount.max(0)).ok())
+}
+
+/// CR 107.3i + CR 508.1m: Only event amounts that bound pay-{X} via an explicit
+/// comparator where-X clause (Well of Lost Dreams class) may cap X announcement.
+/// `AttackersDeclared` exposes attacker *count* for "that many" effects, not as
+/// a pay-{X} cap — using it capped Elenda and Azor at X=1 (#4226).
+fn trigger_event_amount_for_x_payment(state: &GameState) -> Option<u32> {
+    use crate::types::events::GameEvent;
+    let event = state.current_trigger_event.as_ref()?;
+    match event {
+        GameEvent::AttackersDeclared { .. } => None,
+        _ => trigger_event_amount(state),
+    }
 }
 
 #[cfg(test)]
@@ -1851,6 +1865,29 @@ mod tests {
     /// trigger-event-amount cap independently from the X-payable cap, so a
     /// regression that drops the event cap surfaces as max=10 here even when
     /// the basic mana check still passes.
+    #[test]
+    fn trigger_event_amount_for_x_payment_ignores_attackers_declared_count() {
+        use crate::types::events::GameEvent;
+        use crate::types::identifiers::ObjectId;
+
+        let mut state = GameState::new_two_player(42);
+        state.current_trigger_event = Some(GameEvent::AttackersDeclared {
+            attacker_ids: vec![ObjectId(99)],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        });
+        assert_eq!(
+            trigger_event_amount_for_x_payment(&state),
+            None,
+            "attack-batch attacker count must not cap pay-{{X}} (#4226)"
+        );
+        assert_eq!(
+            trigger_event_amount(&state),
+            Some(1),
+            "extract_amount_from_event still exposes attacker count for other readers"
+        );
+    }
+
     #[test]
     fn pay_x_optional_max_capped_by_event_amount_not_player_mana() {
         use crate::game::effects::resolve_ability_chain;

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -311,7 +311,6 @@ fn trigger_event_amount(state: &GameState) -> Option<u32> {
 /// `AttackersDeclared` exposes attacker *count* for "that many" effects, not as
 /// a pay-{X} cap — using it capped Elenda and Azor at X=1 (#4226).
 fn trigger_event_amount_for_x_payment(state: &GameState) -> Option<u32> {
-    use crate::types::events::GameEvent;
     let event = state.current_trigger_event.as_ref()?;
     match event {
         GameEvent::AttackersDeclared { .. } => None,
@@ -1867,9 +1866,6 @@ mod tests {
     /// the basic mana check still passes.
     #[test]
     fn trigger_event_amount_for_x_payment_ignores_attackers_declared_count() {
-        use crate::types::events::GameEvent;
-        use crate::types::identifiers::ObjectId;
-
         let mut state = GameState::new_two_player(42);
         state.current_trigger_event = Some(GameEvent::AttackersDeclared {
             attacker_ids: vec![ObjectId(99)],

--- a/crates/engine/tests/integration/issue_4226_elenda_azor_attack_pay_x.rs
+++ b/crates/engine/tests/integration/issue_4226_elenda_azor_attack_pay_x.rs
@@ -1,0 +1,96 @@
+//! Regression for GitHub issue #4226: Elenda and Azor's attack trigger must not
+//! cap pay-{X} at the number of attacking creatures.
+//!
+//! Oracle: "Whenever Elenda and Azor attacks, you may pay {X}{W}{U}{B}. If you do,
+//! draw X cards."
+//!
+//! https://github.com/phase-rs/phase/issues/4226
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const ELENDA_ATTACK: &str =
+    "Whenever Elenda and Azor attacks, you may pay {X}{W}{U}{B}. If you do, draw X cards.";
+
+fn advance_to_pay_amount_or_panic(runner: &mut engine::game::scenario::GameRunner) {
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept optional pay-{X}");
+                continue;
+            }
+            WaitingFor::PayAmountChoice { .. } => return,
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                panic!(
+                    "stack settled before PayAmountChoice; waiting_for={:?}",
+                    runner.state().waiting_for
+                );
+            }
+            _ => runner.pass_both_players(),
+        }
+    }
+    panic!(
+        "exhausted advance budget without PayAmountChoice; waiting_for={:?}",
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn issue_4226_elenda_attack_pay_x_not_capped_by_attacker_count() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let elenda = scenario
+        .add_creature(P0, "Elenda and Azor", 6, 6)
+        .from_oracle_text(ELENDA_ATTACK)
+        .id();
+    scenario.add_basic_land(P0, ManaColor::White);
+    scenario.add_basic_land(P0, ManaColor::Blue);
+    scenario.add_basic_land(P0, ManaColor::Black);
+    for _ in 0..7 {
+        scenario.add_basic_land(P0, ManaColor::White);
+    }
+    for i in 0..10 {
+        scenario.add_spell_to_library_top(P0, &format!("Library Pad {i}"), false);
+    }
+
+    let mut runner = scenario.build();
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(elenda, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare Elenda attacking");
+
+    advance_to_pay_amount_or_panic(&mut runner);
+    match &runner.state().waiting_for {
+        WaitingFor::PayAmountChoice { max, .. } => {
+            assert!(
+                *max >= 3,
+                "pay-{{X}} max must not be capped at attacker count (1); got {max} with \
+                 ten untapped lands available for {{X}}{{W}}{{U}}{{B}}"
+            );
+        }
+        other => panic!("expected PayAmountChoice after attack trigger, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::SubmitPayAmount { amount: 3 })
+        .expect("submit X=3");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before + 3,
+        "paying {{X}}{{W}}{{U}}{{B}} with X=3 must draw 3 cards"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -373,6 +373,7 @@ mod issue_4000_dominating_licid;
 mod issue_4001_frolicking_familiar_adventure_instant;
 mod issue_4050_adamaro_extremum_hand_size;
 mod issue_4124_second_little_pig;
+mod issue_4226_elenda_azor_attack_pay_x;
 mod issue_4242_lagrella_crash;
 mod issue_4243_from_the_rubble;
 mod issue_4244_temple_altisaur;


### PR DESCRIPTION
## Summary

- **Symptom:** On Elenda and Azor's attack trigger (`you may pay {X}{W}{U}{B}. If you do, draw X cards.`), the engine only allowed X=1 regardless of available mana — paying 1 and drawing 1.
- **Root cause:** Resolution-time pay-{X} capped `PayAmountChoice` max via `trigger_event_amount()`, which reads a numeric amount from the current trigger event. On attack triggers that event is `AttackersDeclared`; `extract_amount_from_event` returns **attacker count** (1 when Elenda attacks alone). That value is for "that many" quantity effects, not as a pay-{X} cap.
- **Fix:** Route pay-{X} through `trigger_event_amount_for_x_payment()`, which skips `AttackersDeclared` but still caps Well of Lost Dreams–style triggers on `LifeChanged` and other bounded events.
- **Scope:** Engine-only; parser AST was already correct (`fully_parsed`). No frontend changes.

Closes #4226 

## Changed files

| File | Change |
|------|--------|
| `crates/engine/src/game/effects/pay.rs` | `trigger_event_amount_for_x_payment()` — ignore attacker count for pay-{X} cap |
| `crates/engine/tests/integration/issue_4226_elenda_azor_attack_pay_x.rs` | Integration regression (attack → accept → X≥3 → draw 3) |
| `crates/engine/tests/integration/main.rs` | Register integration module |

## Test plan

- [x] `cargo test -p engine --test integration issue_4226`
- [x] `cargo test -p engine --lib trigger_event_amount_for_x_payment`
- [x] `cargo test -p engine --lib pay_x_optional_max_capped_by_event_amount_not_player_mana`
- [x] `cargo test -p engine --test integration well_of_lost_dreams`
- [ ] Manual: attack with Elenda and Azor, accept pay-{X}, choose X>1 with sufficient mana, draw that many cards

## Rules

- CR 107.3a — X is chosen when paying a cost that includes {X}
- CR 508.1m + CR 603.7c — `AttackersDeclared` attacker count is contextual trigger metadata for "that many" effects, not a pay-{X} announcement cap
- CR 107.3i — comparator where-X bounds (Well of Lost Dreams) still cap pay-{X} at the triggering event amount (e.g. life gained)
