### PR TITLE
fix(parser): split dual-target combat compound so both halves parse (Boros Battleshaper)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1861,6 +1861,45 @@ fn starts_remove_counter_clause_lower(s: &str) -> OracleResult<'_, ()> {
     Ok((rest, ()))
 }
 
+/// CR 601.2c + CR 508.1d + CR 509.1c: A second `"[up to] <n> target <filter>"`
+/// conjunct joined by a bare `" and "` opens its OWN target (each instance of
+/// the word "target" is a distinct target — CR 601.2c) and applies its own
+/// combat requirement — an attack/block compulsion ("attacks or blocks this
+/// combat if able", CR 508.1d/509.1c) or a combat prohibition ("can't attack or
+/// block"). Boros Battleshaper: "... up to one target creature attacks or blocks
+/// this combat if able and up to one target creature can't attack or block this
+/// combat." Without this arm the second conjunct is not recognized as a clause
+/// start (its subject is a noun phrase, not an imperative verb), so it is
+/// swallowed and only one combat half parses. The discriminator is a
+/// combat-requirement predicate (attacks/blocks/can't attack/can't block) after
+/// the `"[up to] <n> target <filter>"` subject — a genuine noun-phrase
+/// continuation ("destroy up to one target creature and up to one target
+/// artifact") has no such verb and is left un-split. The predicate search is
+/// bounded to THIS conjunct's segment (up to the next `" and "`) so a combat
+/// verb in a later conjunct cannot trigger a false split. Combat sibling of
+/// `starts_target_continuous_clause_lower`.
+fn starts_up_to_target_combat_clause_lower(s: &str) -> OracleResult<'_, ()> {
+    let (rest, _) = (
+        opt(tag::<_, _, OracleError<'_>>("up to ")),
+        nom_primitives::parse_number,
+        tag(" target "),
+    )
+        .parse(s)?;
+    // Bound the combat-predicate search to THIS conjunct segment only.
+    let segment = match take_until::<_, _, OracleError<'_>>(" and ").parse(rest) {
+        Ok((_, seg)) => seg,
+        Err(_) => rest,
+    };
+    let _ = alt((
+        value((), (take_until("can't attack"), tag("can't attack"))),
+        value((), (take_until("can't block"), tag("can't block"))),
+        value((), (take_until("attacks "), tag("attacks "))),
+        value((), (take_until("blocks "), tag("blocks "))),
+    ))
+    .parse(segment)?;
+    Ok((rest, ()))
+}
+
 /// Inner implementation operating on pre-lowercased input.
 fn starts_bare_and_clause_lower(s: &str) -> bool {
     // CR 613.1b + CR 110.2: "<player-subject> gains control of …" control-handoff
@@ -2176,6 +2215,12 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
         value((), tag::<_, _, OracleError<'_>>("may play ")),
         value((), tag("may cast ")),
     )))
+    // CR 601.2c + CR 508.1d/509.1c: a fresh "[up to] <n> target <filter>"
+    // conjunct + combat-requirement predicate opens its own target and combat
+    // compulsion/prohibition (Boros Battleshaper). Trailing `.or()` arm
+    // (mirroring `starts_target_continuous_clause_lower`) so the `alt(...)`
+    // cluster stays under nom's 21-arm limit.
+    .or(value((), starts_up_to_target_combat_clause_lower))
     .parse(s)
     .is_ok();
     if has_verb_prefix {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1879,12 +1879,25 @@ fn starts_remove_counter_clause_lower(s: &str) -> OracleResult<'_, ()> {
 /// verb in a later conjunct cannot trigger a false split. Combat sibling of
 /// `starts_target_continuous_clause_lower`.
 fn starts_up_to_target_combat_clause_lower(s: &str) -> OracleResult<'_, ()> {
-    let (rest, _) = (
-        opt(tag::<_, _, OracleError<'_>>("up to ")),
-        nom_primitives::parse_number,
-        tag(" target "),
-    )
-        .parse(s)?;
+    // Subject accepts both the counted "[up to] <n> target <filter>" form and the
+    // bare "target <filter>" form — CR 601.2c: every "target" opens its own
+    // target, numbered or not. An unnumbered second conjunct ("… and target
+    // creature can't block this combat") therefore splits identically to the
+    // counted Boros shape; the combat-requirement predicate below stays the
+    // discriminator, so a bare-`target` noun-phrase continuation with no combat
+    // verb is still left un-split.
+    let (rest, _) = alt((
+        value(
+            (),
+            (
+                opt(tag::<_, _, OracleError<'_>>("up to ")),
+                nom_primitives::parse_number,
+                tag(" target "),
+            ),
+        ),
+        value((), tag::<_, _, OracleError<'_>>("target ")),
+    ))
+    .parse(s)?;
     // Bound the combat-predicate search to THIS conjunct segment only.
     let segment = match take_until::<_, _, OracleError<'_>>(" and ").parse(rest) {
         Ok((_, seg)) => seg,

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -732,17 +732,88 @@ fn boros_battleshaper_dual_target_combat_compound_splits_both_halves() {
     let must_attack = format!("{:?}", StaticMode::MustAttack);
     let must_block = format!("{:?}", StaticMode::MustBlock);
     assert!(
-        modes.iter().any(|m| *m == must_attack),
+        modes.contains(&must_attack),
         "force half should grant MustAttack; modes = {modes:?}"
     );
     assert!(
-        modes.iter().any(|m| *m == must_block),
+        modes.contains(&must_block),
         "force half should grant MustBlock; modes = {modes:?}"
     );
-    // Prohibition half → can't attack or block (CantAttack + CantBlock).
+    // Prohibition half → can't attack or block (CantAttack + CantBlock). Assert
+    // BOTH so a regression to half-parsed output ("can't attack" only) is caught.
     assert!(
         modes.iter().any(|m| m == "CantAttack"),
         "prohibition half should grant CantAttack; modes = {modes:?}"
+    );
+    assert!(
+        modes.iter().any(|m| m == "CantBlock"),
+        "prohibition half should grant CantBlock; modes = {modes:?}"
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "no clause should be swallowed; warnings = {:?}",
+        parsed.parse_warnings
+    );
+}
+
+/// CR 601.2c + CR 508.1d + CR 509.1c: the same dual-target combat compound in
+/// its UNNUMBERED form — bare `"target creature …"` on both conjuncts, with no
+/// `"up to <n>"` count. matthewevans/gemini review: the splitter must model the
+/// whole target-combat clause class, not just the counted Boros shape, so an
+/// unnumbered second conjunct ("… and target creature can't attack or block …")
+/// is a fresh independently-targeted clause and both halves must parse. This is
+/// the Boros text with "up to one" stripped, exercising the optional-number
+/// subject arm of `starts_up_to_target_combat_clause_lower`.
+#[test]
+fn dual_target_combat_compound_splits_both_halves_unnumbered() {
+    use crate::types::statics::StaticMode;
+
+    let parsed = parse_oracle_text(
+        "At the beginning of each combat, target creature attacks or blocks this combat if able and target creature can't attack or block this combat.",
+        "Unnumbered Dual-Target Combat",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+
+    assert_eq!(parsed.triggers.len(), 1, "expected one combat trigger");
+    let exec = parsed.triggers[0]
+        .execute
+        .as_deref()
+        .expect("beginning-of-combat trigger should carry an execute body");
+
+    fn collect_modes(v: &serde_json::Value, out: &mut Vec<String>) {
+        match v {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(a) => a.iter().for_each(|x| collect_modes(x, out)),
+            serde_json::Value::Object(o) => o.iter().for_each(|(k, x)| {
+                out.push(k.clone());
+                collect_modes(x, out);
+            }),
+            _ => {}
+        }
+    }
+    let json = serde_json::to_value(exec).expect("effect should serialize");
+    let mut modes = Vec::new();
+    collect_modes(&json, &mut modes);
+
+    let must_attack = format!("{:?}", StaticMode::MustAttack);
+    let must_block = format!("{:?}", StaticMode::MustBlock);
+    assert!(
+        modes.contains(&must_attack),
+        "force half should grant MustAttack; modes = {modes:?}"
+    );
+    assert!(
+        modes.contains(&must_block),
+        "force half should grant MustBlock; modes = {modes:?}"
+    );
+    assert!(
+        modes.iter().any(|m| m == "CantAttack"),
+        "prohibition half should grant CantAttack; modes = {modes:?}"
+    );
+    assert!(
+        modes.iter().any(|m| m == "CantBlock"),
+        "prohibition half should grant CantBlock; modes = {modes:?}"
     );
     assert!(
         parsed.parse_warnings.is_empty(),

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -683,6 +683,74 @@ fn stensian_class_builds_whenever_event_this_combat_delayed_trigger() {
     );
 }
 
+/// CR 601.2c + CR 508.1d + CR 509.1c: A dual-target combat compound —
+/// "up to one target creature [combat compulsion] and up to one target creature
+/// [combat prohibition]" — must split into two independently-targeted conjuncts
+/// so BOTH combat requirements parse (Boros Battleshaper). Regression for the
+/// clause-splitter `starts_up_to_target_combat_clause_lower` arm: before the
+/// fix the bare-`and` splitter left the RHS noun-phrase subject un-split, the
+/// leading-conditional detector swallowed the "if able" force half, and only
+/// the CantAttack prohibition survived.
+#[test]
+fn boros_battleshaper_dual_target_combat_compound_splits_both_halves() {
+    use crate::types::statics::StaticMode;
+
+    let parsed = parse_oracle_text(
+        "At the beginning of each combat, up to one target creature attacks or blocks this combat if able and up to one target creature can't attack or block this combat.",
+        "Boros Battleshaper",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+
+    assert_eq!(parsed.triggers.len(), 1, "expected one combat trigger");
+    let exec = parsed.triggers[0]
+        .execute
+        .as_deref()
+        .expect("beginning-of-combat trigger should carry an execute body");
+
+    // Walk the serialized effect tree and collect every StaticMode name that
+    // appears, without hardcoding the nested sequence shape. Unit StaticMode
+    // variants serialize as bare JSON strings; data-carrying ones as object
+    // keys — searching both covers the whole family.
+    fn collect_modes(v: &serde_json::Value, out: &mut Vec<String>) {
+        match v {
+            serde_json::Value::String(s) => out.push(s.clone()),
+            serde_json::Value::Array(a) => a.iter().for_each(|x| collect_modes(x, out)),
+            serde_json::Value::Object(o) => o.iter().for_each(|(k, x)| {
+                out.push(k.clone());
+                collect_modes(x, out);
+            }),
+            _ => {}
+        }
+    }
+    let json = serde_json::to_value(exec).expect("effect should serialize");
+    let mut modes = Vec::new();
+    collect_modes(&json, &mut modes);
+
+    // Force half → attack/block compulsion (CR 508.1d/509.1c).
+    let must_attack = format!("{:?}", StaticMode::MustAttack);
+    let must_block = format!("{:?}", StaticMode::MustBlock);
+    assert!(
+        modes.iter().any(|m| *m == must_attack),
+        "force half should grant MustAttack; modes = {modes:?}"
+    );
+    assert!(
+        modes.iter().any(|m| *m == must_block),
+        "force half should grant MustBlock; modes = {modes:?}"
+    );
+    // Prohibition half → can't attack or block (CantAttack + CantBlock).
+    assert!(
+        modes.iter().any(|m| m == "CantAttack"),
+        "prohibition half should grant CantAttack; modes = {modes:?}"
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "no clause should be swallowed; warnings = {:?}",
+        parsed.parse_warnings
+    );
+}
+
 /// CR 701.15a: A self-referential possessive (`~'s power`) inside a target
 /// filter must not put the clause splitter into quote mode and thereby
 /// swallow a later sentence boundary (a text-structure concern with no


### PR DESCRIPTION
## Problem

Boros Battleshaper only applies the can't-attack/block half of its trigger.

Oracle: *"At the beginning of each combat, up to one target creature attacks or blocks this combat if able **and** up to one target creature can't attack or block this combat."*

The force half (attack/block compulsion) is silently dropped — the parser produces only the `CantAttack`/`CantBlock` prohibition, with a `SwallowedClause { detector: "Condition_If" }` warning on the "… if able and …" span.

## Root cause

The bare-`" and "` clause splitter (`starts_bare_and_clause_lower`) only treats a conjunct as a fresh clause when its RHS begins with an **imperative verb**. Here the second conjunct begins with the noun-phrase subject *"up to one target creature"*, so the compound is left un-split. The leading-conditional detector then swallows the *"… if able"* force clause, leaving only the prohibition half.

Both halves already parse **perfectly on their own** — the gap is purely the compound split.

## Fix

Add `starts_up_to_target_combat_clause_lower`, a combat sibling of the existing `starts_target_continuous_clause_lower`:

- A `"[up to] <n> target <filter>"` subject followed by a **combat-requirement predicate** (attacks/blocks, or can't attack/block) is a fresh, independently-targeted clause — each instance of "target" opens its own target (CR 601.2c) and carries its own combat compulsion (CR 508.1d / CR 509.1c) or prohibition.
- The predicate search is **bounded to the conjunct segment** (up to the next `" and "`) so a combat verb in a later conjunct can't trigger a false split.
- A genuine shared-verb compound target (*"destroy up to one target creature and up to one target artifact"*) has no such predicate → left un-split (verified).

This is a general building block for the *"up to one target creature [combat requirement] and up to one target creature [combat requirement]"* class, not a one-card special case.

## Verification

- New regression test `boros_battleshaper_dual_target_combat_compound_splits_both_halves` asserts the trigger produces `MustAttack` + `MustBlock` (force half) **and** `CantAttack` (prohibition half) with zero parse warnings.
- Full `parser::oracle_effect` suite green (2310 passed).
- Parser combinator gate (`check-parser-combinators.sh`) and `cargo clippy -p engine` clean.
- Regression-checked: single-target *"can't attack or block this combat"* and shared-verb compound targets are unaffected.

Closes #4797

🤖 Generated with [Claude Code](https://claude.com/claude-code)