### PR TITLE
perf(ai): skip frontend display sweep in AI simulation applies (#4798)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -34,7 +34,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use crate::game::combat::AttackTarget;
-use crate::game::engine::{apply_as_current_for_legality, SimulationProbeGuard};
+use crate::game::engine::{apply_as_current_for_simulation, SimulationProbeGuard};
 use crate::game::functioning_abilities::game_functioning_statics;
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, FilterProp, ParitySource,
@@ -144,7 +144,7 @@ impl CandidateFilter for SimulationFilter {
         let _probe = SimulationProbeGuard::enter();
         // Legality-only probe (#4479): `sim` is discarded, so skip display derivation
         // (the O(N^2) mana-availability board sweep on go-wide token boards).
-        apply_as_current_for_legality(&mut sim, candidate.action.clone()).is_ok()
+        apply_as_current_for_simulation(&mut sim, candidate.action.clone()).is_ok()
     }
 }
 
@@ -258,8 +258,8 @@ impl FilterPipeline {
 /// purpose of the expensive legality simulation: every field the conservative
 /// SAFE classifiers read is captured here, while pure identity/ordering fields
 /// (`id`, `incarnation`, `timestamp`) and display-derived fields (recomputed
-/// under `PublicFinalizeMode::DeferredDisplay`, which `apply_as_current_for_legality`
-/// uses) are excluded.
+/// under `PublicFinalizeMode::DeferredDisplay`, which the legality probe's
+/// `apply_as_current_for_simulation` uses) are excluded.
 ///
 /// CR 400.7: object identity (`id`/`incarnation`) is intentionally NOT part of
 /// the fingerprint — the whole point is to collapse distinct-id, content-identical

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -179,6 +179,23 @@ pub fn apply(
     apply_action_boundary(state, actor, action, PublicFinalizeMode::Immediate)
 }
 
+/// Explicit-actor simulation apply: [`apply`] for throwaway forward-projection
+/// clones the caller never renders (the AI velocity-policy `project_to`
+/// look-ahead). Identical rules resolution to [`apply`], but in
+/// `DeferredDisplay` mode it skips `finalize_display_state` — the board-global
+/// mana-availability sweep whose frontend-only output no rules or
+/// AI-evaluation path consults. See [`apply_as_current_for_simulation`] for the
+/// actor-derived counterpart used by the search's `apply_candidate`; both keep
+/// the projected/simulated game-logic state rules-correct while removing the
+/// per-step O(battlefield) display sweep (#4798).
+pub fn apply_for_simulation(
+    state: &mut GameState,
+    actor: PlayerId,
+    action: GameAction,
+) -> Result<ActionResult, EngineError> {
+    apply_action_boundary(state, actor, action, PublicFinalizeMode::DeferredDisplay)
+}
+
 pub(super) fn apply_action_boundary(
     state: &mut GameState,
     actor: PlayerId,
@@ -428,20 +445,34 @@ pub fn apply_as_current(
     apply_as_current_with_mode(state, action, PublicFinalizeMode::Immediate)
 }
 
-/// Legality-probe variant of [`apply_as_current`] for throwaway simulation
-/// clones (the AI `SimulationFilter` oracle): the caller only reads `.is_ok()`
-/// and discards the mutated state. The Ok/Err verdict is fully decided inside
-/// `apply_action`; `finalize_display_state` only computes frontend-only hints
-/// (mana availability, devotion, summoning-sickness display) that no rules
-/// legality path consults. Applying in `DeferredDisplay` mode therefore yields
-/// the identical verdict while skipping the per-call `derive_display_state`
-/// board sweep — which on a go-wide mana board (Cryptolith Rite granting `{T}:
-/// Add` to hundreds of tokens) is an O(N^2) static scan paid once per candidate.
-pub(crate) fn apply_as_current_for_legality(
+/// Simulation-apply variant of [`apply_as_current`] for throwaway clones that
+/// are never rendered: either the caller discards the mutated state (the AI
+/// `SimulationFilter` legality oracle reads only `.is_ok()`) or it keeps the
+/// state solely to read *game-logic* fields for evaluation (the AI search
+/// rollout/expansion). `finalize_rules_state` still runs, so the result is
+/// rules-correct; only `finalize_display_state` — the board-global
+/// `derive_display_state` sweep computing frontend-only hints (mana
+/// availability `has_mana_ability`/`available_mana_pips`, devotion,
+/// summoning-sickness display) that no rules, enumeration, or AI-evaluation
+/// path consults — is skipped. On a large board this removes an
+/// O(battlefield) mana sweep from every legality probe AND every AI search
+/// node expansion; that per-node sweep, compounded across the un-timed
+/// `resolveAll` batch loop, was the AI-vs-AI "won't advance" wedge (#4798).
+pub fn apply_as_current_for_simulation(
     state: &mut GameState,
     action: GameAction,
 ) -> Result<ActionResult, EngineError> {
     apply_as_current_with_mode(state, action, PublicFinalizeMode::DeferredDisplay)
+}
+
+/// Legality-probe alias of [`apply_as_current_for_simulation`], named for the
+/// `SimulationFilter` oracle call site (which only reads `.is_ok()` and
+/// discards the clone). Both share one implementation.
+pub(crate) fn apply_as_current_for_legality(
+    state: &mut GameState,
+    action: GameAction,
+) -> Result<ActionResult, EngineError> {
+    apply_as_current_for_simulation(state, action)
 }
 
 fn apply_as_current_with_mode(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -465,16 +465,6 @@ pub fn apply_as_current_for_simulation(
     apply_as_current_with_mode(state, action, PublicFinalizeMode::DeferredDisplay)
 }
 
-/// Legality-probe alias of [`apply_as_current_for_simulation`], named for the
-/// `SimulationFilter` oracle call site (which only reads `.is_ok()` and
-/// discards the clone). Both share one implementation.
-pub(crate) fn apply_as_current_for_legality(
-    state: &mut GameState,
-    action: GameAction,
-) -> Result<ActionResult, EngineError> {
-    apply_as_current_for_simulation(state, action)
-}
-
 fn apply_as_current_with_mode(
     state: &mut GameState,
     action: GameAction,

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -402,7 +402,7 @@ fn setup_game_at_main_phase() -> GameState {
 
 /// Perf guard for go-wide mana-board slowness (turn-40 Cryptolith-Rite
 /// squirrel state). The AI `SimulationFilter` legality probe
-/// (`apply_as_current_for_legality`) discards its mutated clone and only
+/// (`apply_as_current_for_simulation`) discards its mutated clone and only
 /// reads `.is_ok()`, so it must NOT run `finalize_display_state`'s
 /// board-global mana-availability sweep — that sweep is O(N^2) on a board of
 /// hundreds of mana sources and the filter pays it once per candidate.
@@ -413,7 +413,7 @@ fn apply_for_legality_skips_display_mana_sweep() {
     let mut sim = setup_game_at_main_phase();
     sim.public_state_dirty.mana_display_dirty = true;
     crate::game::perf_counters::reset();
-    apply_as_current_for_legality(&mut sim, GameAction::PassPriority).unwrap();
+    apply_as_current_for_simulation(&mut sim, GameAction::PassPriority).unwrap();
     assert_eq!(
         crate::game::perf_counters::snapshot().mana_display_sweeps,
         0,

--- a/crates/phase-ai/src/bin/combat_priority_bench.rs
+++ b/crates/phase-ai/src/bin/combat_priority_bench.rs
@@ -103,9 +103,12 @@ fn bench(phase: Phase, n: usize, spells: usize) {
          choose={choose_dt:>9.3?} [clones={cc_cl} sweeps={cc_sw} swept={cc_swept}]",
         objs = state.objects.len(),
         bf = state.battlefield.len(),
-        ec_cl = ec.state_clone_for_legality,
-        ec_sw = ec.mana_display_sweeps,
-        ec_swept = ec.mana_display_swept_objects,
+        // `ec` accumulates across the `iters`-iteration read-path loop, so
+        // report per-decision averages to match `valid_mean` above. `cc` below
+        // is a single `choose_action` call and is already per-decision.
+        ec_cl = ec.state_clone_for_legality / iters as u64,
+        ec_sw = ec.mana_display_sweeps / iters as u64,
+        ec_swept = ec.mana_display_swept_objects / iters as u64,
         cc_cl = cc.state_clone_for_legality,
         cc_sw = cc.mana_display_sweeps,
         cc_swept = cc.mana_display_swept_objects,

--- a/crates/phase-ai/src/bin/combat_priority_bench.rs
+++ b/crates/phase-ai/src/bin/combat_priority_bench.rs
@@ -1,0 +1,124 @@
+//! Root-cause probe for issue #4798 (AI-vs-AI game "won't advance" after combat).
+//!
+//! The reporter's freeze was a wedged WASM worker inside the un-timed
+//! `resolveAll` batch loop, which repeatedly calls the AI callback. Each AI
+//! priority decision runs `flat_priority_actions` -> `validated_candidate_actions`
+//! (per-candidate `SimulationFilter` state clones) BEFORE the 1.5s search
+//! deadline even arms. This bench scales a realistic 3-player deep board and
+//! times that pre-search enumeration + one full `choose_action`, printing the
+//! perf counters each accrues, so any superlinear (O(n^2)) curve in the
+//! enumeration is visible directly (doubling N should ~2x a linear cost; ~4x
+//! flags quadratic).
+//!
+//! Build/run with a debug build in an isolated target dir (keeps Tilt's own
+//! target lock uncontended):
+//!   CARGO_TARGET_DIR=/tmp/forge-dbg cargo run \
+//!       -p phase-ai --bin combat_priority_bench
+
+use std::time::{Duration, Instant};
+
+use engine::ai_support;
+use engine::game::perf_counters;
+use engine::game::scenario::GameScenario;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
+use phase_ai::search::choose_action;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+
+/// Build a 3-player board where every seat controls `n` mana-producing lands
+/// plus a handful of creatures, the active player holds `spells` castable
+/// instants, and we sit at an empty-stack priority window in `phase`.
+fn bench(phase: Phase, n: usize, spells: usize) {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    for &p in &[P0, P1, P2] {
+        for i in 0..n {
+            let color = match i % 5 {
+                0 => ManaColor::White,
+                1 => ManaColor::Blue,
+                2 => ManaColor::Black,
+                3 => ManaColor::Red,
+                _ => ManaColor::Green,
+            };
+            scenario.add_basic_land(p, color);
+        }
+        // A few creatures per seat so combat/static/target scans have bodies.
+        for _ in 0..6 {
+            scenario.add_vanilla(p, 2, 2);
+        }
+    }
+    // Castable instants in the active player's hand => real, non-mana candidates
+    // so the low-value fast-pass cannot short-circuit.
+    for _ in 0..spells {
+        scenario.add_bolt_to_hand(P0);
+    }
+
+    let mut runner = scenario.build();
+    {
+        let s = runner.state_mut();
+        s.phase = phase;
+        s.active_player = P0;
+        s.priority_player = P0;
+        s.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    let state = runner.state();
+
+    // --- Read path only: per-candidate SimulationFilter enumeration (un-timed). ---
+    perf_counters::reset();
+    let iters = 3u32;
+    let mut raw_n = 0;
+    let mut valid_n = 0;
+    let mut valid_total = Duration::ZERO;
+    for _ in 0..iters {
+        let raw = ai_support::candidate_actions(state);
+        raw_n = raw.len();
+        let start = Instant::now();
+        let valid = ai_support::validated_candidate_actions(state);
+        valid_total += start.elapsed();
+        valid_n = valid.len();
+    }
+    let valid_mean = valid_total / iters;
+    let ec = perf_counters::snapshot();
+
+    // --- Full AI decision (fast-path + search) as the worker actually calls it. ---
+    let config =
+        create_config_for_players(AiDifficulty::Medium, Platform::Wasm, 3).into_measurement(42);
+    let mut rng = StdRng::seed_from_u64(42);
+    perf_counters::reset();
+    let start = Instant::now();
+    let _ = choose_action(state, P0, &config, &mut rng);
+    let choose_dt = start.elapsed();
+    let cc = perf_counters::snapshot();
+
+    println!(
+        "{phase:>16?} objs={objs:5} bf={bf:4} raw={raw_n:4} valid={valid_n:4} \
+         enum={valid_mean:>9.3?} [clones={ec_cl} sweeps={ec_sw} swept={ec_swept}]  \
+         choose={choose_dt:>9.3?} [clones={cc_cl} sweeps={cc_sw} swept={cc_swept}]",
+        objs = state.objects.len(),
+        bf = state.battlefield.len(),
+        ec_cl = ec.state_clone_for_legality,
+        ec_sw = ec.mana_display_sweeps,
+        ec_swept = ec.mana_display_swept_objects,
+        cc_cl = cc.state_clone_for_legality,
+        cc_sw = cc.mana_display_sweeps,
+        cc_swept = cc.mana_display_swept_objects,
+    );
+}
+
+fn main() {
+    println!("debug_assertions = {}", cfg!(debug_assertions));
+    println!("(enum = validated_candidate_actions mean; sim = enum minus raw candidate gen)\n");
+    for phase in [Phase::PostCombatMain, Phase::CombatDamage] {
+        for n in [10usize, 20, 30, 40, 60, 80] {
+            bench(phase, n, 4);
+        }
+        println!();
+    }
+}

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -594,8 +594,11 @@ impl<'a> PlannerServices<'a> {
                 .iter()
                 .all(|c| matches!(c.action, engine::types::actions::GameAction::PassPriority));
             if all_pass {
-                if apply_as_current_for_simulation(&mut sim, engine::types::actions::GameAction::PassPriority)
-                    .is_err()
+                if apply_as_current_for_simulation(
+                    &mut sim,
+                    engine::types::actions::GameAction::PassPriority,
+                )
+                .is_err()
                 {
                     break;
                 }
@@ -604,7 +607,9 @@ impl<'a> PlannerServices<'a> {
 
             // Case 2: Only one legal action — apply it (forced move)
             if ctx.candidates.len() == 1 {
-                if apply_as_current_for_simulation(&mut sim, ctx.candidates[0].action.clone()).is_err() {
+                if apply_as_current_for_simulation(&mut sim, ctx.candidates[0].action.clone())
+                    .is_err()
+                {
                     break;
                 }
                 continue;

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 use engine::ai_support::{
     build_decision_context, AiDecisionContext, CandidateAction, TacticalClass,
 };
-use engine::game::engine::apply_as_current;
+use engine::game::engine::apply_as_current_for_simulation;
 use engine::game::players;
 use engine::types::counter::{has_positive_counters, positive_counter_entries};
 use engine::types::game_state::{DayNight, GameState, WaitingFor};
@@ -459,7 +459,7 @@ impl<'a> PlannerServices<'a> {
                 _ => {
                     engine::game::perf_counters::record_state_clone_for_legality();
                     let mut sim = state.clone();
-                    apply_as_current(&mut sim, candidate.action.clone()).is_ok()
+                    apply_as_current_for_simulation(&mut sim, candidate.action.clone()).is_ok()
                 }
             })
             .collect()
@@ -594,7 +594,7 @@ impl<'a> PlannerServices<'a> {
                 .iter()
                 .all(|c| matches!(c.action, engine::types::actions::GameAction::PassPriority));
             if all_pass {
-                if apply_as_current(&mut sim, engine::types::actions::GameAction::PassPriority)
+                if apply_as_current_for_simulation(&mut sim, engine::types::actions::GameAction::PassPriority)
                     .is_err()
                 {
                     break;
@@ -604,7 +604,7 @@ impl<'a> PlannerServices<'a> {
 
             // Case 2: Only one legal action — apply it (forced move)
             if ctx.candidates.len() == 1 {
-                if apply_as_current(&mut sim, ctx.candidates[0].action.clone()).is_err() {
+                if apply_as_current_for_simulation(&mut sim, ctx.candidates[0].action.clone()).is_err() {
                     break;
                 }
                 continue;
@@ -621,7 +621,7 @@ impl<'a> PlannerServices<'a> {
                 &actions,
                 None,
             ) {
-                if apply_as_current(&mut sim, action).is_err() {
+                if apply_as_current_for_simulation(&mut sim, action).is_err() {
                     break;
                 }
                 continue;
@@ -955,7 +955,7 @@ where
 
 pub fn apply_candidate(state: &GameState, candidate: &CandidateAction) -> Option<GameState> {
     let mut sim = state.clone();
-    apply_as_current(&mut sim, candidate.action.clone()).ok()?;
+    apply_as_current_for_simulation(&mut sim, candidate.action.clone()).ok()?;
     Some(sim)
 }
 

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use engine::ai_support::legal_actions;
 use engine::game::combat::AttackTarget;
-use engine::game::engine::{apply, EngineError};
+use engine::game::engine::{apply_for_simulation, EngineError};
 use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
 use engine::types::{
     CoreType, GameAction, GameState, ObjectId, PayCostKind, Phase, PlayerId, WaitingFor,
@@ -162,7 +162,7 @@ pub fn project_to(
             choice_count += 1;
         }
 
-        apply(&mut state, actor, action).map_err(BailReason::EngineRejected)?;
+        apply_for_simulation(&mut state, actor, action).map_err(BailReason::EngineRejected)?;
 
         if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
             return Err(BailReason::GameOverDuringProjection);

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -2355,7 +2355,7 @@ fn validated_declare_attackers(
         bands: vec![],
     };
     let mut sim = state.clone();
-    if engine::game::engine::apply_as_current(&mut sim, candidate.clone()).is_ok() {
+    if engine::game::engine::apply_as_current_for_simulation(&mut sim, candidate.clone()).is_ok() {
         return candidate;
     }
     engine::ai_support::legal_actions(state)


### PR DESCRIPTION
Fixes #4798 — AI-vs-AI games wedging the engine worker ("game won't advance") on deep multiplayer boards.

## Root cause
The reporter's game was fully AI-driven (human eliminated turn 31; all remaining seats AI). The AI decision path applied throwaway simulation clones in `PublicFinalizeMode::Immediate`, which runs `finalize_display_state`'s **board-global O(battlefield) mana-availability sweep** — frontend-only state (`has_mana_ability`/`available_mana_pips`/`mana_ability_index` + summoning-sickness/unimplemented display fields) that no rules, enumeration, or AI-evaluation path reads.

It fired from three sites **per AI decision**:
- frontier/rollout `apply_candidate` (per search node),
- `validate_candidates` legality probes,
- the velocity policy's `project_to` look-ahead (**up to 256 forward steps** per decision).

Compounded across the client's **un-timed `resolveAll` batch loop**, per-decision cost scaled with board size until the WASM worker never replied. The combat-damage rules are correct — combat was merely where the spectator last saw progress. (`LARGE_BOARD_FAST_PRIORITY_OBJECTS = 1000` means #4677's fast-priority paths don't engage on a normal ~40-object deep board.)

## Fix
Route every throwaway-simulation apply through `DeferredDisplay` mode. `finalize_rules_state` still runs, so the state stays rules-correct; only the unread display sweep is skipped. Adds `apply_for_simulation` (explicit actor) and `apply_as_current_for_simulation` (actor-derived), mirroring `apply`/`apply_as_current`; `apply_as_current_for_legality` now delegates to the latter.

## Validation
- **Behavior-preserving — proven:** engine-wide, zero non-test reads of any display-derived field the sweep computes.
- **`combat_priority_bench`** (new): per-decision `mana_display_sweeps` **40 → 0**, swept-object-visits **10320 → 0** at 258 objects.
- **`cargo ai-gate`: 0 FAIL, 0 game-outcome flips.** (The lone WARN — affinity-mirror turn drift — is a 2-week/50-commit-stale baseline, not this change; baseline intentionally not refreshed.)
- clippy / test-engine / test-ai green; phase-ai 1159 tests + projection tests pass.