### PR TITLE
feat(engine,client): show source object for replacement-effect choices

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1118,6 +1118,16 @@ export interface PendingTriggerSummary {
   description: string;
 }
 
+// CR 616.1 / CR 614: Display payload for one replacement-effect option — an
+// ordering candidate, or one branch (accept/decline) of an optional "you may".
+// Engine-derived; the modal must NOT re-derive name/description from
+// state.objects. Optional branches share the same source_id.
+export interface ReplacementCandidateSummary {
+  source_id: ObjectId;
+  source_name: string;
+  description: string;
+}
+
 // ── WaitingFor (discriminated union with tag="type", content="data") ─────
 
 export type OpeningHandBottomReason = { type: "TinyLeadersMultiCommander" };
@@ -1186,7 +1196,7 @@ export type WaitingFor =
   | { type: "DeclareAttackers"; data: { player: PlayerId; valid_attacker_ids: ObjectId[]; valid_attack_targets?: AttackTarget[] } }
   | { type: "DeclareBlockers"; data: { player: PlayerId; valid_blocker_ids: ObjectId[]; valid_block_targets: Record<string, ObjectId[]>; block_requirements?: Record<string, number> } }
   | { type: "GameOver"; data: { winner: PlayerId | null } }
-  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidate_descriptions?: string[] } }
+  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidates?: ReplacementCandidateSummary[] } }
   | { type: "OrderTriggers"; data: { player: PlayerId; triggers: PendingTriggerSummary[] } }
   | { type: "CopyTargetChoice"; data: { player: PlayerId; source_id: ObjectId; valid_targets: ObjectId[]; max_mana_value?: number | null } }
   | { type: "ExploreChoice"; data: { player: PlayerId; source_id: ObjectId; choosable: ObjectId[]; remaining: ObjectId[]; pending_effect: unknown } }

--- a/client/src/components/modal/ReplacementModal.tsx
+++ b/client/src/components/modal/ReplacementModal.tsx
@@ -1,21 +1,36 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ReplacementCandidateSummary } from "../../adapter/types.ts";
+import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { RichLabel } from "../mana/RichLabel.tsx";
 import { DialogShell } from "./DialogShell.tsx";
 
+const EMPTY_CANDIDATES: ReplacementCandidateSummary[] = [];
+
+/**
+ * CR 616.1 / CR 614: Surfaced when the local player must apply an optional
+ * replacement effect ("you may") or choose the order in which multiple
+ * applicable replacements apply. The engine owns all logic and provides one
+ * {@link ReplacementCandidateSummary} per option, so each button can show the
+ * source object (or rule-based virtual replacement) creating that effect.
+ * This component only dispatches the chosen index — no re-derivation from
+ * `state.objects`.
+ */
 export function ReplacementModal() {
   const { t } = useTranslation("game");
   const waitingFor = useGameStore((s) => s.waitingFor);
   const dispatch = useGameStore((s) => s.dispatch);
+  const hoverProps = useInspectHoverProps();
 
   const isReplacementChoice = waitingFor?.type === "ReplacementChoice";
   const candidateCount = isReplacementChoice
     ? waitingFor.data.candidate_count
     : 0;
-  const candidateDescriptions: string[] = isReplacementChoice
-    ? (waitingFor.data.candidate_descriptions ?? [])
-    : [];
+  const candidates: ReplacementCandidateSummary[] = isReplacementChoice
+    ? (waitingFor.data.candidates ?? EMPTY_CANDIDATES)
+    : EMPTY_CANDIDATES;
 
   const handleChoose = useCallback(
     (index: number) => {
@@ -26,7 +41,7 @@ export function ReplacementModal() {
 
   if (!isReplacementChoice || candidateCount === 0) return null;
 
-  const candidates = Array.from({ length: candidateCount }, (_, i) => i);
+  const indices = Array.from({ length: candidateCount }, (_, i) => i);
 
   return (
     <DialogShell
@@ -38,17 +53,26 @@ export function ReplacementModal() {
     >
       <div className="px-3 py-3 lg:px-5 lg:py-5">
         <div className="flex flex-col gap-2">
-          {candidates.map((index) => {
-            const desc = candidateDescriptions[index];
+          {indices.map((index) => {
+            const candidate = candidates[index];
+            const label =
+              candidate?.description ||
+              t("replacement.candidateFallback", { number: index + 1 });
             return (
               <button
                 key={index}
                 onClick={() => handleChoose(index)}
+                {...(candidate ? hoverProps(candidate.source_id) : {})}
                 className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
               >
-                <span className="font-semibold text-white">
-                  {desc || t("replacement.candidateFallback", { number: index + 1 })}
+                <span className="block font-semibold text-white">
+                  <RichLabel text={label} size="sm" />
                 </span>
+                {candidate?.source_name && (
+                  <span className="mt-0.5 block text-xs text-white/60">
+                    {candidate.source_name}
+                  </span>
+                )}
               </button>
             );
           })}

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -2145,7 +2145,7 @@ mod tests {
         state.waiting_for = WaitingFor::ReplacementChoice {
             player: PlayerId(0),
             candidate_count: 2,
-            candidate_descriptions: Vec::new(),
+            candidates: Vec::new(),
         };
 
         assert!(cheap_reject_candidate(

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -1027,7 +1027,7 @@ mod tests {
         let WaitingFor::ReplacementChoice {
             player,
             candidate_count,
-            candidate_descriptions,
+            candidates,
         } = &state.waiting_for
         else {
             panic!(
@@ -1038,11 +1038,12 @@ mod tests {
         };
         assert_eq!(*player, PlayerId(0));
         assert_eq!(*candidate_count, 2);
+        let descriptions: Vec<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
         assert_eq!(
-            candidate_descriptions.as_slice(),
+            descriptions.as_slice(),
             &[
-                "Remove a shield counter".to_string(),
-                "Umbra armor: destroy Hyena Umbra instead".to_string(),
+                "Remove a shield counter",
+                "Umbra armor: destroy Hyena Umbra instead",
             ]
         );
         assert_eq!(

--- a/crates/engine/src/game/effects/fight.rs
+++ b/crates/engine/src/game/effects/fight.rs
@@ -750,7 +750,11 @@ mod tests {
         state.waiting_for = WaitingFor::ReplacementChoice {
             player: *player,
             candidate_count: 1,
-            candidate_descriptions: vec!["Shield".to_string()],
+            candidates: vec![crate::types::game_state::ReplacementCandidateSummary {
+                source_id: bear,
+                source_name: String::new(),
+                description: "Shield".to_string(),
+            }],
         };
 
         // Accept the replacement for bear → wolf (first direction).

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -16,7 +16,9 @@ use super::filter::{
     matches_target_filter_on_damage_record_source, FilterContext,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, PendingReplacement, WaitingFor};
+use crate::types::game_state::{
+    GameState, PendingReplacement, ReplacementCandidateSummary, WaitingFor,
+};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
 use crate::types::player::PlayerId;
@@ -295,29 +297,48 @@ pub struct ReplacementHandlerEntry {
 /// because step-end mana handlers are not attached to a single object — they
 /// are scanned per-player per-phase-transition.
 pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> WaitingFor {
-    let (candidate_count, candidate_descriptions) = state
+    // CR 616.1 / CR 614: each option carries its source object so the frontend
+    // can show which object (or rule-based virtual replacement) creates it,
+    // mirroring the `PendingTriggerSummary` payload for CR 603.3b trigger
+    // ordering. Name resolution uses the same idiom as `order_triggers_waiting`.
+    let name_of = |id: ObjectId| -> String {
+        state
+            .objects
+            .get(&id)
+            .map(|obj| obj.name.clone())
+            .unwrap_or_default()
+    };
+    let (candidate_count, candidates) = state
         .pending_replacement
         .as_ref()
         .map(|p| match &p.proposed {
             // CR 703.4q + CR 616.1: Sentinel-source dispatch. Descriptions are
             // read from the per-phase handler list rather than per-object
-            // replacement_definitions.
+            // replacement_definitions; each handler still names its source
+            // static's object.
             ProposedEvent::EmptyManaPool { .. } => {
-                let descs: Vec<String> = p
+                let cands: Vec<ReplacementCandidateSummary> = p
                     .candidates
                     .iter()
                     .filter_map(|rid| {
                         state
                             .pending_step_end_mana_handlers
                             .get(rid.index)
-                            .map(|entry| entry.description.clone())
+                            .map(|entry| ReplacementCandidateSummary {
+                                source_id: entry.source,
+                                source_name: name_of(entry.source),
+                                description: entry.description.clone(),
+                            })
                     })
                     .collect();
-                (descs.len(), descs)
+                (cands.len(), cands)
             }
             _ => {
                 let count = if p.is_optional { 2 } else { p.candidates.len() };
-                let descs: Vec<String> = if p.is_optional {
+                let cands: Vec<ReplacementCandidateSummary> = if p.is_optional {
+                    // CR 614.12a / CR 616.1: an optional "you may" is one source
+                    // shown as two branches — both carry `candidates[0].source`.
+                    let source_id = p.candidates.first().map(|rid| rid.source);
                     let (accept_desc, decline_desc) = p
                         .candidates
                         .first()
@@ -371,7 +392,20 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                             ),
                         })
                         .unwrap_or_else(|| ("Accept".to_string(), "Decline".to_string()));
-                    vec![accept_desc, decline_desc]
+                    let source_id = source_id.unwrap_or(ObjectId(0));
+                    let source_name = name_of(source_id);
+                    vec![
+                        ReplacementCandidateSummary {
+                            source_id,
+                            source_name: source_name.clone(),
+                            description: accept_desc,
+                        },
+                        ReplacementCandidateSummary {
+                            source_id,
+                            source_name,
+                            description: decline_desc,
+                        },
+                    ]
                 } else {
                     // CR 616.1 / CR 614.1c / CR 614.1d: each candidate gets an
                     // outcome-descriptive label derived from its `execute`
@@ -381,10 +415,14 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                     // lookup stays aligned.
                     p.candidates
                         .iter()
-                        .map(|rid| replacement_choice_label_for_rid(state, *rid))
+                        .map(|rid| ReplacementCandidateSummary {
+                            source_id: rid.source,
+                            source_name: name_of(rid.source),
+                            description: replacement_choice_label_for_rid(state, *rid),
+                        })
                         .collect()
                 };
-                (count, descs)
+                (count, cands)
             }
         })
         .unwrap_or((0, vec![]));
@@ -411,7 +449,7 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
     WaitingFor::ReplacementChoice {
         player,
         candidate_count,
-        candidate_descriptions,
+        candidates,
     }
 }
 
@@ -7716,7 +7754,7 @@ mod tests {
 
         let WaitingFor::ReplacementChoice {
             candidate_count,
-            candidate_descriptions,
+            candidates,
             ..
         } = replacement_choice_waiting_for(PlayerId(0), &state)
         else {
@@ -7726,18 +7764,19 @@ mod tests {
         // After `filter_map`→`map` the vec length equals `candidate_count` by
         // construction (`map` cannot drop elements); this is a weak guard —
         // the label-set assertion below is the real regression discriminator.
-        assert_eq!(candidate_descriptions.len(), 2);
-        let labels: HashSet<&str> = candidate_descriptions.iter().map(String::as_str).collect();
+        assert_eq!(candidates.len(), 2);
+        let labels: HashSet<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
         assert_eq!(
             labels,
             HashSet::from(["Enters tapped", "Enters untapped"]),
             "labels must be outcome-descriptive, not raw Oracle text"
         );
-        for label in &candidate_descriptions {
-            assert!(!label.is_empty(), "no label may be empty");
+        for candidate in &candidates {
+            assert!(!candidate.description.is_empty(), "no label may be empty");
             assert!(
-                !label.contains("Lands you control"),
-                "label must not be a raw Oracle-text blob: {label:?}"
+                !candidate.description.contains("Lands you control"),
+                "label must not be a raw Oracle-text blob: {:?}",
+                candidate.description
             );
         }
     }
@@ -7800,7 +7839,7 @@ mod tests {
 
         let WaitingFor::ReplacementChoice {
             candidate_count,
-            candidate_descriptions,
+            candidates,
             ..
         } = replacement_choice_waiting_for(PlayerId(0), &state)
         else {
@@ -7812,16 +7851,90 @@ mod tests {
         // issue_709 granted-keyword contract). Index 1 = decline: the distinct
         // outcome ("It gains haste") rather than a bare "Decline" — the reported
         // bug was that declining silently granted haste with no indication.
+        let descriptions: Vec<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
         assert_eq!(
-            candidate_descriptions,
+            descriptions,
             vec![
                 "CR 702.136a: Riot — this permanent may enter with an additional +1/+1 \
-                 counter; otherwise it gains haste."
-                    .to_string(),
-                "It gains haste".to_string(),
+                 counter; otherwise it gains haste.",
+                "It gains haste",
             ],
             "accept identifies the source (Riot); decline shows its outcome (haste), not a bare \"Decline\""
         );
+        // Both branches of an optional "you may" name the same source object —
+        // this is the source identity the frontend `ReplacementModal` surfaces.
+        assert!(
+            candidates.iter().all(|c| c.source_id == ObjectId(20)),
+            "both accept and decline must carry the source object (ObjectId(20))"
+        );
+    }
+
+    /// CR 703.4q + CR 616.1: On the step-end empty-mana path each candidate's
+    /// own `rid.source` is the `ObjectId(0)` sentinel — the real source object
+    /// lives on the handler entry (`StepEndManaScanEntry.source`). The builder
+    /// must name the handler's source, not the sentinel; this is the most
+    /// fragile source derivation in the change, and a regression back to
+    /// `rid.source` would silently ship `ObjectId(0)`/empty-name to the
+    /// `ReplacementModal` while every other test stays green.
+    #[test]
+    fn empty_mana_pool_choice_names_the_handler_source_not_the_sentinel() {
+        let mut state = GameState::new_two_player(42);
+        let source = ObjectId(50);
+        state.objects.insert(
+            source,
+            GameObject::new(
+                source,
+                CardId(1),
+                PlayerId(0),
+                "Omnath, Locus of Mana".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        state.battlefield.push_back(source);
+        state.pending_step_end_mana_handlers =
+            vec![crate::types::game_state::StepEndManaScanEntry {
+                source,
+                controller: PlayerId(0),
+                filter: None,
+                action: StepEndManaAction::Retain,
+                description: "Retain green mana".to_string(),
+            }];
+        state.pending_replacement = Some(PendingReplacement {
+            proposed: ProposedEvent::EmptyManaPool {
+                player_id: PlayerId(0),
+                units: vec![],
+                applied: HashSet::new(),
+            },
+            // The candidate's own source is the sentinel; `index` addresses the
+            // handler list above.
+            candidates: vec![ReplacementId {
+                source: ObjectId(0),
+                index: 0,
+            }],
+            depth: 0,
+            is_optional: false,
+            library_placement: None,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+
+        let WaitingFor::ReplacementChoice { candidates, .. } =
+            replacement_choice_waiting_for(PlayerId(0), &state)
+        else {
+            panic!("expected ReplacementChoice waiting_for");
+        };
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].source_id, source,
+            "candidate must name the handler's source object, not rid.source"
+        );
+        assert_ne!(
+            candidates[0].source_id,
+            ObjectId(0),
+            "must not leak the EmptyManaPool ObjectId(0) sentinel to the frontend"
+        );
+        assert_eq!(candidates[0].source_name, "Omnath, Locus of Mana");
+        assert_eq!(candidates[0].description, "Retain green mana");
     }
 
     #[test]
@@ -10495,14 +10608,14 @@ mod tests {
 
         let WaitingFor::ReplacementChoice {
             candidate_count,
-            candidate_descriptions,
+            candidates,
             ..
         } = replacement_choice_waiting_for(player, &state)
         else {
             panic!("expected ReplacementChoice waiting_for");
         };
         assert_eq!(candidate_count, 2);
-        let labels: HashSet<&str> = candidate_descriptions.iter().map(String::as_str).collect();
+        let labels: HashSet<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
         assert_eq!(
             labels,
             HashSet::from([

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2484,6 +2484,22 @@ pub struct PendingTriggerSummary {
     pub description: String,
 }
 
+/// CR 616.1 / CR 614: Display payload for one replacement-effect option — either
+/// one candidate in a CR 616.1 ordering prompt, or one branch (accept/decline)
+/// of an optional "you may" replacement. Engine-derived so the filtered state
+/// snapshot (multiplayer) and the frontend `ReplacementModal` never re-derive
+/// the source object/description from `state.objects`, exactly as
+/// [`PendingTriggerSummary`] does for CR 603.3b trigger ordering. For the
+/// optional case both branches carry the same `source_id` (one object, two
+/// outcomes); rule-based virtual replacements (shield counter, Umbra armor,
+/// Compleated, combat skip) still point at the object they act on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplacementCandidateSummary {
+    pub source_id: ObjectId,
+    pub source_name: String,
+    pub description: String,
+}
+
 /// CR 603.3b: One controller's group within an in-flight trigger ordering
 /// pass. `ordered = true` once the controller has submitted their permutation
 /// (or once the group is single-trigger and trivially in final order, or once
@@ -3084,7 +3100,7 @@ pub enum WaitingFor {
         player: PlayerId,
         candidate_count: usize,
         #[serde(default)]
-        candidate_descriptions: Vec<String>,
+        candidates: Vec<ReplacementCandidateSummary>,
     },
     /// CR 603.3b: When a player controls 2+ triggered abilities placed on the
     /// stack in the same pass, that player chooses the order. The variant is
@@ -7459,10 +7475,10 @@ pub struct PendingReplacement {
 /// and addressed by the replacement pipeline via `ReplacementId { source:
 /// ObjectId(0), index }`.
 ///
-/// `description` is the player-facing string surfaced in `WaitingFor::
-/// ReplacementChoice::candidate_descriptions` when multiple handlers apply to
-/// the same emptying event and CR 616.1 requires the affected player to choose
-/// ordering.
+/// `description` (paired with `source`) is surfaced as a
+/// `ReplacementCandidateSummary` in `WaitingFor::ReplacementChoice::candidates`
+/// when multiple handlers apply to the same emptying event and CR 616.1
+/// requires the affected player to choose ordering.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StepEndManaScanEntry {
     pub source: ObjectId,
@@ -9121,7 +9137,7 @@ mod tests {
         variants.push(Box::new(WaitingFor::ReplacementChoice {
             player: PlayerId(0),
             candidate_count: 2,
-            candidate_descriptions: vec![],
+            candidates: vec![],
         }));
         variants.push(Box::new(WaitingFor::ExploreChoice {
             player: PlayerId(0),

--- a/crates/engine/tests/integration/abundance_optional_draw_replacement.rs
+++ b/crates/engine/tests/integration/abundance_optional_draw_replacement.rs
@@ -227,19 +227,17 @@ fn abundance_decline_falls_through_to_normal_draw() {
     issue_single_draw(&mut runner);
 
     // Find the Decline option among the candidates.
-    let WaitingFor::ReplacementChoice {
-        candidate_descriptions,
-        ..
-    } = runner.state().waiting_for.clone()
+    let WaitingFor::ReplacementChoice { candidates, .. } = runner.state().waiting_for.clone()
     else {
         panic!(
             "expected ReplacementChoice, got {:?}",
             runner.state().waiting_for
         );
     };
+    let descriptions: Vec<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
     assert_eq!(
-        candidate_descriptions,
-        vec!["Accept".to_string(), "Decline".to_string()],
+        descriptions,
+        vec!["Accept", "Decline"],
         "Abundance optional replacement must surface exactly Accept/Decline"
     );
     let decline_idx = 1;

--- a/crates/engine/tests/integration/issue_3252_rhythm_of_the_wild.rs
+++ b/crates/engine/tests/integration/issue_3252_rhythm_of_the_wild.rs
@@ -45,7 +45,7 @@ fn put_library_top(runner: &mut engine::game::scenario::GameRunner, id: ObjectId
 fn assert_riot_replacement_choice(runner: &engine::game::scenario::GameRunner) {
     let WaitingFor::ReplacementChoice {
         candidate_count,
-        candidate_descriptions,
+        candidates,
         ..
     } = &runner.state().waiting_for
     else {
@@ -56,11 +56,10 @@ fn assert_riot_replacement_choice(runner: &engine::game::scenario::GameRunner) {
     };
     assert_eq!(*candidate_count, 2);
     assert!(
-        candidate_descriptions
+        candidates
             .iter()
-            .any(|description| description.contains("Riot")),
-        "replacement choice should identify Riot, got {:?}",
-        candidate_descriptions
+            .any(|candidate| candidate.description.contains("Riot")),
+        "replacement choice should identify Riot, got {candidates:?}"
     );
 }
 

--- a/crates/engine/tests/integration/issue_709_regression.rs
+++ b/crates/engine/tests/integration/issue_709_regression.rs
@@ -223,7 +223,7 @@ fn cast_zero_cost_bear_with_uncivil_unrest() -> (GameRunner, ObjectId) {
 fn assert_riot_replacement_choice(runner: &GameRunner) {
     let WaitingFor::ReplacementChoice {
         candidate_count,
-        candidate_descriptions,
+        candidates,
         ..
     } = &runner.state().waiting_for
     else {
@@ -234,11 +234,10 @@ fn assert_riot_replacement_choice(runner: &GameRunner) {
     };
     assert_eq!(*candidate_count, 2);
     assert!(
-        candidate_descriptions
+        candidates
             .iter()
-            .any(|description| description.contains("Riot")),
-        "replacement choice should identify Riot, got {:?}",
-        candidate_descriptions
+            .any(|candidate| candidate.description.contains("Riot")),
+        "replacement choice should identify Riot, got {candidates:?}"
     );
 }
 
@@ -317,7 +316,7 @@ fn cast_zero_cost_dog_with_tesak_unleash_grant() -> (GameRunner, ObjectId, Objec
 fn assert_unleash_replacement_choice(runner: &GameRunner) {
     let WaitingFor::ReplacementChoice {
         candidate_count,
-        candidate_descriptions,
+        candidates,
         ..
     } = &runner.state().waiting_for
     else {
@@ -328,11 +327,10 @@ fn assert_unleash_replacement_choice(runner: &GameRunner) {
     };
     assert_eq!(*candidate_count, 2);
     assert!(
-        candidate_descriptions
+        candidates
             .iter()
-            .any(|description| description.contains("Unleash")),
-        "replacement choice should identify Unleash, got {:?}",
-        candidate_descriptions
+            .any(|candidate| candidate.description.contains("Unleash")),
+        "replacement choice should identify Unleash, got {candidates:?}"
     );
 }
 

--- a/crates/engine/tests/integration/rules/replacement.rs
+++ b/crates/engine/tests/integration/rules/replacement.rs
@@ -33,26 +33,17 @@ fn fast_land_replacement(description: &str) -> ReplacementDefinition {
 }
 
 fn replacement_choice_index(runner: &GameRunner, description: &str) -> usize {
-    let WaitingFor::ReplacementChoice {
-        candidate_descriptions,
-        ..
-    } = &runner.state().waiting_for
-    else {
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
         panic!(
             "expected ReplacementChoice, got {:?}",
             runner.state().waiting_for
         );
     };
 
-    candidate_descriptions
+    candidates
         .iter()
-        .position(|candidate| candidate.contains(description))
-        .unwrap_or_else(|| {
-            panic!(
-                "replacement choice {description:?} not found in {:?}",
-                candidate_descriptions
-            )
-        })
+        .position(|candidate| candidate.description.contains(description))
+        .unwrap_or_else(|| panic!("replacement choice {description:?} not found in {candidates:?}"))
 }
 
 // ── Fast land integration tests ──

--- a/crates/engine/tests/mox_diamond_discard_cost_2853.rs
+++ b/crates/engine/tests/mox_diamond_discard_cost_2853.rs
@@ -125,19 +125,15 @@ fn mox_diamond_decline_routes_to_graveyard_without_discard() {
 
     enter_via_change_zone(runner.state_mut(), mox);
 
-    let WaitingFor::ReplacementChoice {
-        candidate_descriptions,
-        ..
-    } = &runner.state().waiting_for
-    else {
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
         panic!(
             "expected Mox Diamond MayCost ReplacementChoice, got {:?}",
             runner.state().waiting_for
         );
     };
-    let decline = candidate_descriptions
+    let decline = candidates
         .iter()
-        .position(|d| d.contains("Decline"))
+        .position(|c| c.description.contains("Decline"))
         .expect("decline option must be offered");
 
     runner


### PR DESCRIPTION
When a player must apply an optional "you may" replacement (CR 614) or
choose the order of multiple applicable replacements (CR 616.1), the
prompt now identifies which object (or rule-based virtual replacement)
creates each option.

`WaitingFor::ReplacementChoice` previously carried only pre-rendered
`candidate_descriptions: Vec<String>`, discarding the `ReplacementId`
source it derived them from. It now carries
`candidates: Vec<ReplacementCandidateSummary { source_id, source_name,
description }>`, mirroring the `PendingTriggerSummary` payload already used
for CR 603.3b trigger ordering — engine-derived so the multiplayer
snapshot and the frontend never re-derive source/description from
`state.objects`.

The builder resolves a source for every branch: CR 616.1 ordering
(`rid.source`), optional accept/decline (both share `candidates[0].source`),
and the step-end `EmptyManaPool` path (the handler's real `entry.source`,
not the `ObjectId(0)` sentinel that `rid.source` holds there).

`ReplacementModal` renders each option's description with the source name
and inspect-on-hover (`hoverProps`), following `TriggerOrderModal`.
