### PR TITLE
fix: allow cancelling a modal activated ability's mode choice (#4695)

### DIFF
--- a/client/src/components/modal/ModeChoiceModal.tsx
+++ b/client/src/components/modal/ModeChoiceModal.tsx
@@ -106,12 +106,19 @@ export function ModeChoiceModal() {
   const isSingleChoice = !isBudget && modal.min_choices === 1 && modal.max_choices === 1;
   const canAdd = (index: number) => !isBudget || spent + (pawprints[index] ?? 0) <= budget;
 
+  // CR 602.2b vs CR 603.3c: only an ACTIVATED modal ability is cancellable at the
+  // mode-choice step; a triggered one must resolve its mode. Read engine-provided
+  // is_activated — no game-state inference here.
+  const isActivatedAbilityMode =
+    waitingFor?.type === "AbilityModeChoice" && waitingFor.data.is_activated === true;
+  const canCancel = !isAbilityMode || isActivatedAbilityMode;
+
   const chooseLabel =
     modal.min_choices === modal.max_choices
       ? t("modeChoice.chooseExact", { count: modal.min_choices })
       : t("modeChoice.chooseRange", { min: modal.min_choices, max: modal.max_choices });
 
-  const showFooter = !isSingleChoice || !isAbilityMode;
+  const showFooter = !isSingleChoice || canCancel;
   const footer = showFooter ? (
     <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
       {!isSingleChoice && (
@@ -137,7 +144,7 @@ export function ModeChoiceModal() {
           {t("modeChoice.clear")}
         </button>
       )}
-      {!isAbilityMode && (
+      {canCancel && (
         <button
           onClick={handleCancel}
           className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-6 py-2 font-semibold text-slate-200 transition hover:bg-white/8"

--- a/client/src/components/modal/__tests__/ModeChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/ModeChoiceModal.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameState, ModalChoice, WaitingFor } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { ModeChoiceModal } from "../ModeChoiceModal.tsx";
+
+const dispatchMock = vi.fn();
+
+function singleChoiceModal(): ModalChoice {
+  return {
+    min_choices: 1,
+    max_choices: 1,
+    mode_count: 2,
+    mode_descriptions: ["You gain 2 life.", "You lose 2 life."],
+    allow_repeat_modes: false,
+  };
+}
+
+function setWaitingFor(waitingFor: WaitingFor) {
+  const gameState = {
+    active_player: 0,
+    objects: {},
+    priority_player: 0,
+    waiting_for: waitingFor,
+  } as unknown as GameState;
+
+  useGameStore.setState({
+    gameState,
+    waitingFor,
+    dispatch: dispatchMock,
+  });
+}
+
+describe("ModeChoiceModal", () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    dispatchMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows a Cancel affordance for an activated modal ability (CR 602.2b) and dispatches CancelCast", () => {
+    setWaitingFor({
+      type: "AbilityModeChoice",
+      data: {
+        player: 0,
+        modal: singleChoiceModal(),
+        source_id: 90,
+        mode_abilities: [],
+        is_activated: true,
+      },
+    });
+
+    render(<ModeChoiceModal />);
+
+    // Both mode rows render; single-choice modes auto-dispatch on click.
+    expect(screen.getByText("You gain 2 life.")).toBeInTheDocument();
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.click(cancel);
+    expect(dispatchMock).toHaveBeenCalledWith({ type: "CancelCast" });
+  });
+
+  it("hides the Cancel affordance for a triggered modal ability (CR 603.3c)", () => {
+    setWaitingFor({
+      type: "AbilityModeChoice",
+      data: {
+        player: 0,
+        modal: singleChoiceModal(),
+        source_id: 90,
+        mode_abilities: [],
+        is_activated: false,
+      },
+    });
+
+    render(<ModeChoiceModal />);
+
+    expect(screen.getByText("You gain 2 life.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the Cancel affordance for a modal spell (regression guard)", () => {
+    setWaitingFor({
+      type: "ModeChoice",
+      data: {
+        player: 0,
+        modal: singleChoiceModal(),
+        pending_cast: { object_id: 50 } as unknown as Extract<
+          WaitingFor,
+          { type: "ModeChoice" }
+        >["data"]["pending_cast"],
+      },
+    });
+
+    render(<ModeChoiceModal />);
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.click(cancel);
+    expect(dispatchMock).toHaveBeenCalledWith({ type: "CancelCast" });
+  });
+});

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1430,6 +1430,7 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             player,
             modal,
             unavailable_modes,
+            is_activated,
             ..
         } => {
             let available: Vec<usize> = (0..modal.mode_count)
@@ -1467,7 +1468,7 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
             // CR 700.2i: For pawprint points-budget modals, prune to budget-legal
             // mode sequences. Index the UNFILTERED `modal` (real indices
             // 0..mode_count). No-op for non-pawprint modals.
-            if modal.mode_pawprints.is_empty() {
+            let mut actions = if modal.mode_pawprints.is_empty() {
                 actions
             } else {
                 actions
@@ -1479,7 +1480,21 @@ pub fn candidate_actions_broad(state: &GameState) -> Vec<CandidateAction> {
                         _ => true,
                     })
                     .collect()
+            };
+            // CR 602.2b: An activated modal ability can be cancelled at the mode-choice
+            // sub-step (see engine.rs). Surfacing CancelCast here feeds BOTH the AI search
+            // and the multiplayer exact-legal-actions gate (candidate_actions_broad flows
+            // through candidate_actions → validated_candidate_actions → flat_priority_actions
+            // → legal_actions_full), so a human in MP can submit cancel. Triggered modal
+            // abilities (CR 603.3c) must choose a mode — no cancel.
+            if *is_activated {
+                actions.push(candidate(
+                    GameAction::CancelCast,
+                    TacticalClass::Pass,
+                    Some(*player),
+                ));
             }
+            actions
         }
         WaitingFor::ConniveDiscard {
             player,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -19378,6 +19378,292 @@ fn cancel_modal_returns_to_priority() {
     assert!(matches!(state.waiting_for, WaitingFor::ModeChoice { .. }));
 }
 
+/// Build an artifact with a modal ACTIVATED ability whose cost is paid AFTER
+/// the mode is chosen: "{T}, Sacrifice an artifact: Choose one — • You gain 2
+/// life. • You lose 2 life." Mirrors Lobelia, Defender of Bag End (issue
+/// #4695); the mode prompt (CR 602.2b + CR 601.2b) precedes cost payment and
+/// stack-object creation.
+fn create_modal_activated_artifact(state: &mut GameState, player: PlayerId) -> ObjectId {
+    let source = create_object(
+        state,
+        CardId(90),
+        player,
+        "Modal Activated Artifact".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        let mode0 = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                player: TargetFilter::Controller,
+            },
+        );
+        let mode1 = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::LoseLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                target: None,
+            },
+        );
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Unimplemented {
+                    name: "modal_activated_placeholder".to_string(),
+                    description: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Sacrifice(SacrificeCost::count(
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+                        1,
+                    )),
+                ],
+            })
+            .with_modal(
+                ModalChoice {
+                    min_choices: 1,
+                    max_choices: 1,
+                    mode_count: 2,
+                    mode_descriptions: vec![
+                        "You gain 2 life.".to_string(),
+                        "You lose 2 life.".to_string(),
+                    ],
+                    ..Default::default()
+                },
+                vec![mode0, mode1],
+            ),
+        );
+    }
+    source
+}
+
+/// Construct an `AbilityModeChoice` for a modal *triggered* ability
+/// (`is_activated: false`) so the negative-path assertions can drive
+/// `CancelCast` against a mode prompt that CR 603.3c forbids cancelling.
+fn set_triggered_ability_mode_choice(state: &mut GameState, player: PlayerId, source_id: ObjectId) {
+    state.waiting_for = WaitingFor::AbilityModeChoice {
+        player,
+        modal: ModalChoice {
+            min_choices: 1,
+            max_choices: 1,
+            mode_count: 2,
+            mode_descriptions: vec![
+                "You gain 2 life.".to_string(),
+                "You lose 2 life.".to_string(),
+            ],
+            ..Default::default()
+        },
+        source_id,
+        mode_abilities: vec![
+            AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    player: TargetFilter::Controller,
+                },
+            ),
+            AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    target: None,
+                },
+            ),
+        ],
+        is_activated: false,
+        ability_index: None,
+        ability_cost: None,
+        unavailable_modes: vec![],
+    };
+}
+
+/// CR 602.2b + CR 601.2b: Cancelling an ACTIVATED modal ability at the
+/// mode-choice sub-step is a pure rollback to priority — no cost is paid, no
+/// permanent is tapped or sacrificed, no stack object is created, and no life
+/// total changes. Re-activation must remain legal (proving the source was
+/// never committed). Issue #4695 (Lobelia, Defender of Bag End).
+#[test]
+fn cancel_activated_modal_ability_rolls_back_to_priority() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_modal_activated_artifact(&mut state, PlayerId(0));
+    // A second artifact to satisfy the "Sacrifice an artifact" cost.
+    let sac_artifact = create_object(
+        &mut state,
+        CardId(91),
+        PlayerId(0),
+        "Sacrificeable Artifact".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&sac_artifact)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Artifact);
+    let p0_life = state.players[0].life;
+    let p1_life = state.players[1].life;
+
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        },
+    )
+    .unwrap();
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::AbilityModeChoice {
+                is_activated: true,
+                ..
+            }
+        ),
+        "activating the modal ability must prompt for a mode with is_activated: true"
+    );
+
+    apply_as_current(&mut state, GameAction::CancelCast).unwrap();
+
+    // Pure rollback to priority.
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { player } if player == PlayerId(0)),
+        "CancelCast at the activated mode-choice step returns priority, got {:?}",
+        state.waiting_for
+    );
+    assert!(
+        !state.objects.get(&source).unwrap().tapped,
+        "source must remain untapped — the {{T}} cost is paid after mode choice"
+    );
+    assert!(
+        state.objects.contains_key(&sac_artifact)
+            && state.objects.get(&sac_artifact).unwrap().zone == Zone::Battlefield,
+        "the artifact must not be sacrificed on cancel"
+    );
+    assert!(
+        state.stack.is_empty(),
+        "no stack object may have been created"
+    );
+    assert_eq!(state.players[0].life, p0_life, "controller life unchanged");
+    assert_eq!(state.players[1].life, p1_life, "opponent life unchanged");
+    assert!(state.pending_cast.is_none(), "pending_cast must be cleared");
+    assert!(
+        state.pending_trigger.is_none(),
+        "pending_trigger must be None"
+    );
+
+    // Re-activation is still legal: the source was never committed.
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        },
+    )
+    .expect("re-activating after cancel must succeed");
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::AbilityModeChoice {
+                is_activated: true,
+                ..
+            }
+        ),
+        "re-activation must re-enter the mode-choice prompt"
+    );
+}
+
+/// CR 603.3c: A modal *triggered* ability is already on the stack when its
+/// mode prompt appears; its controller MUST choose a mode. `CancelCast` is
+/// rejected (falls through to the catch-all), so there is no rollback.
+#[test]
+fn cancel_triggered_modal_ability_is_rejected() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(92),
+        PlayerId(0),
+        "Triggered Modal Source".to_string(),
+        Zone::Battlefield,
+    );
+    set_triggered_ability_mode_choice(&mut state, PlayerId(0), source);
+
+    let result = apply_as_current(&mut state, GameAction::CancelCast);
+    assert!(
+        result.is_err(),
+        "CancelCast against a triggered modal ability (is_activated: false) must be rejected"
+    );
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::AbilityModeChoice {
+                is_activated: false,
+                ..
+            }
+        ),
+        "the triggered mode prompt must persist after a rejected cancel"
+    );
+}
+
+/// The multiplayer exact-legal-actions gate and the AI candidate surface must
+/// both expose `CancelCast` for an activated modal ability at the mode-choice
+/// step, and must NOT expose it for a triggered one (CR 602.2b vs CR 603.3c).
+#[test]
+fn activated_modal_mode_choice_offers_cancel_in_legal_actions() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_modal_activated_artifact(&mut state, PlayerId(0));
+    let sac_artifact = create_object(
+        &mut state,
+        CardId(93),
+        PlayerId(0),
+        "Sacrificeable Artifact".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&sac_artifact)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Artifact);
+
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        },
+    )
+    .unwrap();
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::AbilityModeChoice {
+                is_activated: true,
+                ..
+            }
+        ),
+        "precondition: activated mode-choice prompt"
+    );
+    assert!(
+        crate::ai_support::legal_actions(&state).contains(&GameAction::CancelCast),
+        "activated modal mode choice must offer CancelCast"
+    );
+
+    // Triggered modal: no cancel.
+    set_triggered_ability_mode_choice(&mut state, PlayerId(0), source);
+    assert!(
+        !crate::ai_support::legal_actions(&state).contains(&GameAction::CancelCast),
+        "triggered modal mode choice (CR 603.3c) must NOT offer CancelCast"
+    );
+}
+
 // --- Adventure tests ---
 
 /// Create an Adventure card in hand: Bonecrusher Giant (creature) / Stomp (instant).

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -4113,6 +4113,23 @@ fn apply_action(
             indices,
             &mut events,
         )?,
+        // CR 602.2b + CR 601.2b: The controller chooses modes for an activated modal
+        // ability BEFORE any cost is paid, target is chosen, or stack object is created
+        // (those steps run later in engine_modes::handle_activated_mode_choice). At this
+        // pre-commit sub-step nothing has changed in the game state, so cancelling is a
+        // pure rollback to priority — mirroring the modal-spell (ModeChoice, CancelCast)
+        // and (ChoosePermanentTypeSlot, CancelCast) arms.
+        // CR 603.3c: A modal *triggered* ability's entry is already on the stack when the
+        // mode prompt appears; its controller MUST choose a mode. This arm is guarded to
+        // is_activated: true, so the triggered case falls through to the catch-all reject.
+        (
+            WaitingFor::AbilityModeChoice {
+                player,
+                is_activated: true,
+                ..
+            },
+            GameAction::CancelCast,
+        ) => WaitingFor::Priority { player: *player },
         // CR 601.2c: Player selected targets from a multi-target set ("any number of").
         (WaitingFor::MultiTargetSelection { .. }, GameAction::SelectCards { cards: selected }) => {
             let waiting_for = state.waiting_for.clone();


### PR DESCRIPTION
Clicking a permanent whose only activated ability is modal (e.g. Lobelia,
Defender of Bag End) auto-activated it and surfaced the "Choose one" prompt
with no way to back out. Per CR 602.2b + CR 601.2b the mode is chosen before
any cost is paid, target chosen, or stack object created, so cancelling is a
clean rollback to priority with nothing to unwind.

- engine: accept CancelCast at WaitingFor::AbilityModeChoice{is_activated:true},
  returning to Priority (mirrors the modal-spell and ChoosePermanentTypeSlot
  cancel arms). Triggered modal abilities are already on the stack and must
  choose a mode (CR 603.3c), so they fall through to the catch-all reject.
- candidates: surface CancelCast in candidate_actions_broad for activated mode
  choices, so the multiplayer exact-legal-actions gate accepts a human cancel.
- frontend: show the Cancel affordance in ModeChoiceModal for activated ability
  modes (canCancel), matching the existing spell-mode UX.

Adds engine tests (clean rollback, triggered-reject, legal-actions) and a
ModeChoiceModal test.
