### PR TITLE
fix(engine): hold priority for mana on opponent's turn (CR 117.1d, #4388)

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -796,6 +796,15 @@ pub fn auto_pass_recommended(state: &GameState, actions: &[GameAction]) -> bool 
         _ => return false,
     };
 
+    // CR 117.1d (issue #4388): On an opponent's turn the priority player may
+    // activate their own mana abilities (Gaea's Cradle, Itlimoc, basic lands).
+    // Those actions live only in `legal_actions_by_object`, not the flat list
+    // consumed here — without this guard auto-pass fires through the window
+    // before the frontend can offer a tap.
+    if state.active_player != player && !activatable_object_mana_actions(state).is_empty() {
+        return false;
+    }
+
     if auto_passes_initial_priority_by_default(state) {
         return true;
     }
@@ -2495,6 +2504,73 @@ mod tests {
             !super::auto_pass_recommended(&state, &flat),
             "Issue #544: auto-pass must not fire from flat legal_actions alone \
              when grouped sacrifice-for-mana is available"
+        );
+    }
+
+    /// Issue #4388: Gaea's Cradle / Itlimoc / basic-land mana on an opponent's
+    /// turn must not be skipped by auto-pass (CR 117.1d).
+    #[test]
+    fn auto_pass_holds_priority_for_grouped_mana_on_opponents_turn() {
+        use crate::game::zones::create_object;
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction,
+        };
+        use crate::types::card_type::CoreType;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaColor;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        state.phase = crate::types::phase::Phase::PreCombatMain;
+        state.active_player = PlayerId(1);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let land = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&land).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![ManaColor::Green],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+        }
+
+        let flat = super::flat_priority_actions(&state);
+        assert!(
+            !super::auto_pass_recommended(&state, &flat),
+            "auto-pass must hold priority on opponent's turn when grouped mana is available"
+        );
+
+        // Control: on the active player's own turn, standalone mana still auto-passes.
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        assert!(
+            super::auto_pass_recommended(&state, &flat),
+            "auto-pass should still fire on your turn when only mana is available"
         );
     }
 

--- a/crates/engine/tests/integration/issue_4388_mana_on_opponents_turn.rs
+++ b/crates/engine/tests/integration/issue_4388_mana_on_opponents_turn.rs
@@ -1,0 +1,125 @@
+//! Regression for GitHub issue #4388 — Gaea's Cradle / Itlimoc activatable
+//! during the opponent's turn when the controller holds priority (CR 117.1d).
+
+use engine::ai_support::legal_actions_full;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+const GAEAS_CRADLE_ORACLE: &str = "{T}: Add {G} for each creature you control.";
+const ITLIMOC_ORACLE: &str = "{T}: Add {G} for each creature you control.";
+
+fn cradle_has_mana_action(
+    grouped: &std::collections::HashMap<engine::types::identifiers::ObjectId, Vec<GameAction>>,
+    cradle: engine::types::identifiers::ObjectId,
+) -> bool {
+    grouped.get(&cradle).is_some_and(|actions| {
+        actions.iter().any(|a| {
+            matches!(
+                a,
+                GameAction::TapLandForMana { object_id } if *object_id == cradle
+            ) || matches!(
+                a,
+                GameAction::ActivateAbility { source_id, .. } if *source_id == cradle
+            )
+        })
+    })
+}
+
+#[test]
+fn issue_4388_gaeas_cradle_offered_on_opponents_turn_with_priority() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let cradle = scenario
+        .add_creature(P0, "Gaea's Cradle", 0, 0)
+        .as_artifact()
+        .from_oracle_text(GAEAS_CRADLE_ORACLE)
+        .id();
+    let _bear = scenario.add_creature(P0, "Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+
+    let (_, _, grouped) = legal_actions_full(runner.state());
+    assert!(
+        cradle_has_mana_action(&grouped, cradle),
+        "CR 117.1d: Gaea's Cradle mana must be offered when P0 holds priority on P1's turn; grouped={grouped:?}"
+    );
+
+    runner
+        .act(match grouped.get(&cradle).and_then(|a| a.first()) {
+            Some(action) => action.clone(),
+            None => panic!("no action for cradle"),
+        })
+        .expect("activate Gaea's Cradle on opponent's turn");
+
+    assert_eq!(
+        runner.state().players[0]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "one creature should produce one green mana"
+    );
+}
+
+#[test]
+fn issue_4388_auto_pass_holds_priority_for_mana_on_opponents_turn() {
+    use engine::ai_support::{auto_pass_recommended, flat_priority_actions};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let _cradle = scenario
+        .add_creature(P0, "Gaea's Cradle", 0, 0)
+        .as_artifact()
+        .from_oracle_text(GAEAS_CRADLE_ORACLE)
+        .id();
+    let _bear = scenario.add_creature(P0, "Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+
+    let flat = flat_priority_actions(runner.state());
+    assert!(
+        !auto_pass_recommended(runner.state(), &flat),
+        "CR 117.1d: auto-pass must not fire on opponent's turn when mana is activatable (#4388)"
+    );
+}
+
+#[test]
+fn issue_4388_itlimoc_offered_on_opponents_turn_with_priority() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let itlimoc = scenario
+        .add_creature(P0, "Itlimoc, Cradle of the Sun", 0, 0)
+        .from_oracle_text(ITLIMOC_ORACLE)
+        .id();
+    let _elf = scenario.add_creature(P0, "Elf", 1, 1).id();
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+
+    let (_, _, grouped) = legal_actions_full(runner.state());
+    assert!(
+        cradle_has_mana_action(&grouped, itlimoc),
+        "CR 117.1d: Itlimoc mana must be offered when P0 holds priority on P1's turn"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -390,6 +390,7 @@ mod issue_4271_birthing_ritual_cmc_filter;
 mod issue_4272_birthing_ritual_etb_triggers;
 mod issue_4379_convoke_cancel_untap;
 mod issue_4384_airbend_stack_spell;
+mod issue_4388_mana_on_opponents_turn;
 mod issue_4420_lava_blister_unless_deal_damage;
 mod issue_4459_decoy_gambit_unless_have_you_draw;
 mod issue_4503_incremental_growth;


### PR DESCRIPTION
## Summary

- **Root cause:** `auto_pass_recommended` treated standalone mana abilities (Gaea's Cradle, Itlimoc, basic lands) as non-meaningful priority actions. On an opponent's turn, the client auto-passed through priority windows before the player could tap those lands, even though the engine already exposed the actions in `legal_actions_by_object`.
- **Fix:** When the priority player is not the active player and `activatable_object_mana_actions` is non-empty, do not recommend auto-pass (CR 117.1d).
- **Scope:** Engine-only; no parser or frontend changes. Sacrifice-for-mana (KCI, #544) behavior unchanged. Auto-pass on your own turn with only mana available is unchanged.

## Changed files

| File | Change |
|------|--------|
| `crates/engine/src/ai_support/mod.rs` | Hold priority when grouped mana is available on opponent's turn |
| `crates/engine/tests/integration/issue_4388_mana_on_opponents_turn.rs` | Integration regression (legal actions + auto-pass + activation) |
| `crates/engine/tests/integration/main.rs` | Register integration module |

## Test plan

- [x] `cargo test -p engine --test integration issue_4388`
- [x] `cargo test -p engine auto_pass_holds_priority_for_grouped_mana_on_opponents_turn`
- [x] `cargo test -p engine auto_pass_does_not_skip_sacrifice_for_mana_ability` (existing behavior preserved)
- [ ] Manual: on opponent's turn with priority, tap Gaea's Cradle / Itlimoc without Full Control enabled
- [ ] Manual: on your own main phase with only mana available, auto-pass still advances as before

## Rules

- CR 117.1d — priority player may activate their mana abilities during another player's turn
- CR 605.3a — mana abilities do not use the stack
