### PR TITLE
infra: serve data files from data.phase-rs.dev instead of pub-*.r2.dev

### DIFF
--- a/.claude/skills/bug-coverage-classifier/SKILL.md
+++ b/.claude/skills/bug-coverage-classifier/SKILL.md
@@ -27,7 +27,7 @@ Spend your effort on `supported_aspect_defect`. That is where bugs actually live
 ### 1. Look up the card
 
 ```bash
-curl -s "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/preview/coverage-data.json" \
+curl -s "https://data.phase-rs.dev/preview/coverage-data.json" \
   | jq --arg n "<card_name>" '.cards[] | select(.card_name == $n) | {oracle_text, supported, parse_details}'
 ```
 

--- a/.claude/workflows/contribute-card.js
+++ b/.claude/workflows/contribute-card.js
@@ -17,7 +17,7 @@ export const meta = {
 const TIER = 'Frontier'
 
 // Published coverage endpoint (AI-CONTRIBUTOR.md §3).
-const COVERAGE_URL = 'https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging/coverage-data.json'
+const COVERAGE_URL = 'https://data.phase-rs.dev/staging/coverage-data.json'
 
 // This per-card pipeline embodies the /engine-implementer contract: /engine-planner ->
 // /review-engine-plan (looped) -> engine-implementation-executor -> /review-impl (looped until

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -44,7 +44,7 @@ cargo run --profile tool --bin coverage-report -- "$tmpdir/data" --all > "$tmpdi
 
 echo "  [cards] coverage regression check"
 ./scripts/coverage-regression-check.sh \
-  "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/preview/coverage-data.json" \
+  "https://data.phase-rs.dev/preview/coverage-data.json" \
   "$tmpdir/coverage-data.json" \
   --fail-on-engine
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
         continue-on-error: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           ./scripts/coverage-regression-check.sh \
-            "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/preview/coverage-data.json" \
+            "https://data.phase-rs.dev/preview/coverage-data.json" \
             data/coverage-data.json \
             --fail-on-engine
 
@@ -295,7 +295,7 @@ jobs:
             exit 0
           fi
           echo "$PR_NUMBER" > pr-number.txt
-          URL="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/parse-baselines/coverage-data-${BASE_HASH}.json"
+          URL="https://data.phase-rs.dev/parse-baselines/coverage-data-${BASE_HASH}.json"
           if curl -fsSL --retry 3 --retry-delay 2 "$URL" -o coverage-base.json; then
             cargo run --profile tool --features cli --bin coverage-parse-diff -- \
               coverage-base.json data/coverage-data.json \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,7 +216,7 @@ jobs:
         env:
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
         run: |
-          BASE="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging"
+          BASE="https://data.phase-rs.dev/staging"
           fail=0
           check() {
             local f="$1"
@@ -355,9 +355,9 @@ jobs:
           # the directory holding every shared JSON; CARD_DATA_URL is pinned to
           # the content-addressed copy so the WASM bundle is locked to the exact
           # card-data it was built against (filename from the card-data job).
-          DATA_BASE_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging"
-          CARD_DATA_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging/${{ needs.card-data.outputs.card_data_filename }}"
-          AUDIO_BASE_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/audio"
+          DATA_BASE_URL: "https://data.phase-rs.dev/staging"
+          CARD_DATA_URL: "https://data.phase-rs.dev/staging/${{ needs.card-data.outputs.card_data_filename }}"
+          AUDIO_BASE_URL: "https://data.phase-rs.dev/audio"
           # Cloud-sync config. The anon/publishable key is client-safe (RLS is the
           # access control), so it's baked into the bundle. Empty (secret unset) →
           # cloud sync stays disabled and the app falls back to file backup.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,9 +346,9 @@ jobs:
           # Standardized data URL config — see vite.config.ts. DATA_BASE_URL is
           # the directory holding every shared JSON. CARD_DATA_URL pins the
           # WASM bundle to its content-addressed card-data forever.
-          DATA_BASE_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev"
-          CARD_DATA_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/${{ steps.card-data-hash.outputs.filename }}"
-          AUDIO_BASE_URL: "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/audio"
+          DATA_BASE_URL: "https://data.phase-rs.dev"
+          CARD_DATA_URL: "https://data.phase-rs.dev/${{ steps.card-data-hash.outputs.filename }}"
+          AUDIO_BASE_URL: "https://data.phase-rs.dev/audio"
           # Tagged production release: surfaces the "try the preview build" CTA
           # on the menu (see __IS_RELEASE_BUILD__ in vite.config.ts). The staging
           # deploy (deploy.yml) deliberately omits this so it never self-links.
@@ -402,7 +402,7 @@ jobs:
         env:
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
         run: |
-          BASE="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev"
+          BASE="https://data.phase-rs.dev"
           fail=0
           check() {
             local f="$1"

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@
 
 <!-- coverage-badges:start -->
 <p align="center">
-  <img alt="Card Coverage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fcoverage.json">
-  <img alt="Keywords" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fkeywords.json">
-  <img alt="Cards" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fcards.json">
+  <img alt="Card Coverage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fcoverage.json">
+  <img alt="Keywords" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fkeywords.json">
+  <img alt="Cards" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fcards.json">
   <br/>
-  <img alt="Pauper" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-pauper.json">
-  <img alt="Pioneer" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-pioneer.json">
-  <img alt="Modern" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-modern.json">
-  <img alt="Standard" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-standard.json">
-  <img alt="Legacy" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-legacy.json">
-  <img alt="Vintage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-vintage.json">
-  <img alt="Commander" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fpub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev%2Fbadges%2Fformat-commander.json">
+  <img alt="Pauper" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-pauper.json">
+  <img alt="Pioneer" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-pioneer.json">
+  <img alt="Modern" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-modern.json">
+  <img alt="Standard" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-standard.json">
+  <img alt="Legacy" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-legacy.json">
+  <img alt="Vintage" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-vintage.json">
+  <img alt="Commander" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdata.phase-rs.dev%2Fbadges%2Fformat-commander.json">
 </p>
 <!-- coverage-badges:end -->
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.scryfall.io https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev; media-src 'self' https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss: https://*.scryfall.io https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev; font-src 'self' data:; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.scryfall.io https://data.phase-rs.dev; media-src 'self' https://data.phase-rs.dev; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss: https://*.scryfall.io https://data.phase-rs.dev; font-src 'self' data:; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -221,7 +221,7 @@ export default defineConfig(({ mode }) => ({
             },
           },
           {
-            urlPattern: /^https:\/\/pub-fc5b5c2c6e774356ae3e730bb0326394\.r2\.dev\/audio\//,
+            urlPattern: /^https:\/\/data\.phase-rs\.dev\/audio\//,
             handler: "CacheFirst",
             options: {
               cacheName: "audio-r2",

--- a/docs/AI-CONTRIBUTOR.md
+++ b/docs/AI-CONTRIBUTOR.md
@@ -165,7 +165,7 @@ Skip this section entirely on the Non-developer track — CI runs everything `--
 **If the human did not name a card**, fetch the latest coverage data directly from the published R2 endpoint (no local `cargo coverage` needed):
 
 ```
-WebFetch: https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging/coverage-data.json
+WebFetch: https://data.phase-rs.dev/staging/coverage-data.json
 ```
 
 From the JSON, select a card where:
@@ -389,7 +389,7 @@ Steps:
    git fetch upstream main; git checkout main &&
    git merge --ff-only upstream/main && git push origin main
 2. If I named a card, use it. Otherwise WebFetch
-   https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev/staging/coverage-data.json
+   https://data.phase-rs.dev/staging/coverage-data.json
    and pick a card with supported==false and small gap_count.
 3. git checkout -b card/<slug> upstream/main  (cut the branch from CURRENT
    upstream/main, not stale fork main; if the branch already exists locally or

--- a/scripts/card-bot/config.ts
+++ b/scripts/card-bot/config.ts
@@ -19,7 +19,7 @@ export function isBuild(value: string): value is Build {
 
 /** Public R2 base, overridable for self-host / testing. No trailing slash. */
 const R2_BASE = (
-  Bun.env.CARD_BOT_R2_BASE ?? "https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev"
+  Bun.env.CARD_BOT_R2_BASE ?? "https://data.phase-rs.dev"
 ).replace(/\/+$/, "");
 
 /** Per-build path prefix under the R2 base. */

--- a/scripts/deploy-cf.sh
+++ b/scripts/deploy-cf.sh
@@ -10,7 +10,7 @@ command -v brotli >/dev/null || { echo "ERROR: brotli required (brew install bro
 
 PROJECT_NAME="${1:-phase-rs}"
 R2_BUCKET="phase-rs-data"
-R2_PUBLIC="https://pub-fc5b5c2c6e774356ae3e730bb0326394.r2.dev"
+R2_PUBLIC="https://data.phase-rs.dev"
 
 export CARD_DATA_URL="${CARD_DATA_URL:-$R2_PUBLIC/card-data.json}"
 export COVERAGE_DATA_URL="${COVERAGE_DATA_URL:-$R2_PUBLIC/coverage-data.json}"


### PR DESCRIPTION
The r2.dev public-bucket domain is heavily abused for phishing and sits
on ISP/DNS blocklists (Malwarebytes, South Korean ISPs, mainland China,
family-safe DNS filters), causing 'Card database not loaded' failures
for affected users. It is also rate-limited by Cloudflare and bypasses
the CDN edge cache entirely.

Switch every reference to the data.phase-rs.dev custom domain attached
to the same phase-rs-data bucket: full edge caching (verified MISS->HIT
with content-encoding: br intact), no rate limits, reputable hostname.
Bucket paths are unchanged; this is a pure host swap plus the
host-anchored service-worker audio cache pattern and Tauri CSP.

The r2.dev managed domain stays enabled until deployed bundles pinning
the old URL age out.
