### PR TITLE
[codex] Preserve trigger target prompts and mana choice snapshots

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -872,11 +872,7 @@ fn finish_pending_cost_or_cast(
             pending.activation_cost.as_ref(),
             events,
         )?;
-        return Ok(drain_deferred_triggers_after_stack_object_announcement(
-            state,
-            events,
-            waiting_for,
-        ));
+        return drain_deferred_triggers_after_stack_object_announcement(state, events, waiting_for);
     }
 
     let base_cost = pending.base_cost.clone();
@@ -908,23 +904,21 @@ fn finish_pending_cost_or_cast(
         pending.payment_mode,
         events,
     )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+    drain_deferred_triggers_after_stack_object_announcement(state, events, waiting_for)
 }
 
 pub(super) fn drain_deferred_triggers_after_stack_object_announcement(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
     waiting_for: WaitingFor,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
     if !matches!(waiting_for, WaitingFor::Priority { .. }) {
-        return waiting_for;
+        return Ok(waiting_for);
     }
-    crate::game::triggers::drain_deferred_triggers_after_stack_object_announcement(state, events)
-        .unwrap_or(waiting_for)
+    let drained = crate::game::triggers::drain_deferred_triggers_after_stack_object_announcement(
+        state, events,
+    )?;
+    Ok(drained.unwrap_or(waiting_for))
 }
 
 pub(crate) fn begin_deferred_target_selection(
@@ -3247,11 +3241,7 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
         payment_mode,
         events,
     )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+    drain_deferred_triggers_after_stack_object_announcement(state, events, waiting_for)
 }
 
 fn flash_timing_non_mana_additional_cost(
@@ -7018,11 +7008,11 @@ pub fn finalize_mana_payment(
                 pending.origin_zone,
                 events,
             )?;
-            return Ok(drain_deferred_triggers_after_stack_object_announcement(
+            return drain_deferred_triggers_after_stack_object_announcement(
                 state,
                 events,
                 waiting_for,
-            ));
+            );
         }
 
         state.pending_cast = Some(Box::new(pending_resumed));
@@ -7047,11 +7037,7 @@ pub fn finalize_mana_payment(
         pending.origin_zone,
         events,
     )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+    drain_deferred_triggers_after_stack_object_announcement(state, events, waiting_for)
 }
 
 fn stamp_convoked_creatures(
@@ -7183,11 +7169,11 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 pending.origin_zone,
                 events,
             )?;
-            return Ok(drain_deferred_triggers_after_stack_object_announcement(
+            return drain_deferred_triggers_after_stack_object_announcement(
                 state,
                 events,
                 waiting_for,
-            ));
+            );
         }
 
         state.pending_cast = Some(Box::new(pending_resumed));
@@ -7213,11 +7199,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
         Some(phyrexian_choices),
         events,
     )?;
-    Ok(drain_deferred_triggers_after_stack_object_announcement(
-        state,
-        events,
-        waiting_for,
-    ))
+    drain_deferred_triggers_after_stack_object_announcement(state, events, waiting_for)
 }
 
 /// CR 107.4f + CR 601.2f: Determine whether this cast needs to pause for per-shard

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -442,11 +442,11 @@ pub(crate) fn handle_choose_target(
                 );
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
-                return Ok(drain_deferred_triggers_after_stack_object_announcement(
+                return drain_deferred_triggers_after_stack_object_announcement(
                     state,
                     events,
                     WaitingFor::Priority { player },
-                ));
+                );
             }
 
             let cost = pending.cost.clone();

--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -2,6 +2,7 @@ use crate::game::combat::{AttackTarget, CombatState, DamageAssignment, DamageTar
 use crate::game::effects::deal_damage::{
     apply_damage_after_replacement, pre_replacement_damage_gate, DamageContext, DamageResult,
 };
+use crate::game::engine::EngineError;
 use crate::game::game_object::GameObject;
 use crate::game::replacement;
 use crate::game::sba;
@@ -38,11 +39,11 @@ fn combat_damage_amount(obj: &GameObject) -> u32 {
 /// 2. Run SBAs (destroy lethal-damage creatures → ZoneChanged events).
 /// 3. Process triggers from SBA-generated events (e.g., dies triggers from graveyard scan).
 /// 4. Repeat SBA/trigger cycle until stable (no new SBAs, no new triggers).
-fn process_combat_damage_triggers(
+fn try_process_combat_damage_triggers(
     state: &mut GameState,
     damage_events: &[GameEvent],
     all_events: &mut Vec<GameEvent>,
-) {
+) -> Result<(), EngineError> {
     // Step 1: Collect triggers from damage events while creatures are still alive.
     // CR 603.2: Triggers fire at the moment the event occurs — process_triggers
     // scans state.battlefield, so this must run before SBAs remove dying objects.
@@ -53,7 +54,7 @@ fn process_combat_damage_triggers(
     // processing (dies triggers). Repeat until no new SBAs and no new triggers.
     loop {
         let events_before = all_events.len();
-        sba::check_state_based_actions(state, all_events);
+        sba::try_check_state_based_actions(state, all_events)?;
 
         // If SBAs generated new events, process triggers for those events.
         if all_events.len() > events_before {
@@ -63,6 +64,7 @@ fn process_combat_damage_triggers(
             break;
         }
     }
+    Ok(())
 }
 
 /// Resolve combat damage with first strike / double strike support (CR 510.1).
@@ -76,11 +78,20 @@ pub fn resolve_combat_damage(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> Option<WaitingFor> {
-    let combat = state.combat.as_ref()?.clone();
+    try_resolve_combat_damage(state, events).expect("combat damage resolution failed")
+}
+
+pub fn try_resolve_combat_damage(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<WaitingFor>, EngineError> {
+    let Some(combat) = state.combat.as_ref().cloned() else {
+        return Ok(None);
+    };
 
     // Guard: regular damage already applied (re-entry from triggers during regular step).
     if combat.regular_damage_done {
-        return None;
+        return Ok(None);
     }
 
     let has_first_or_double = combat.attackers.iter().any(|a| {
@@ -100,7 +111,7 @@ pub fn resolve_combat_damage(
     // --- First strike sub-step ---
     if has_first_or_double && !combat.first_strike_done {
         if let Some(waiting) = collect_damage_assignments(state, SubStep::FirstStrike) {
-            return Some(waiting);
+            return Ok(Some(waiting));
         }
         // All first-strike assignments collected — apply simultaneously (CR 510.2).
         let pending = take_pending_damage(state);
@@ -119,7 +130,7 @@ pub fn resolve_combat_damage(
         }
 
         // CR 510.4: SBAs and triggers run between first-strike and regular damage sub-steps.
-        process_combat_damage_triggers(state, &damage_events, events);
+        try_process_combat_damage_triggers(state, &damage_events, events)?;
 
         // CR 510.4 + CR 603.3b: if the first-strike sub-step produced a same-
         // controller trigger-ordering prompt, surface it now — before the regular
@@ -129,7 +140,7 @@ pub fn resolve_combat_damage(
         // in priority.rs, which re-enters this function once the order is submitted
         // and the resulting triggers resolve.
         if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-            return Some(state.waiting_for.clone());
+            return Ok(Some(state.waiting_for.clone()));
         }
 
         // CR 510.3 + CR 510.3a + CR 510.4: The first-strike combat-damage step is a
@@ -149,15 +160,15 @@ pub fn resolve_combat_damage(
             // turns.rs, this returns mid-step after the first-strike substep, so we explicitly
             // clear any stale passes before the CR 510.3 priority window (harmless if already clear).
             crate::game::priority::reset_priority(state);
-            return Some(WaitingFor::Priority {
+            return Ok(Some(WaitingFor::Priority {
                 player: state.active_player,
-            });
+            }));
         }
     }
 
     // --- Regular damage sub-step ---
     if let Some(waiting) = collect_damage_assignments(state, SubStep::Regular) {
-        return Some(waiting);
+        return Ok(Some(waiting));
     }
     // All regular assignments collected — apply simultaneously (CR 510.2).
     let pending = take_pending_damage(state);
@@ -169,8 +180,8 @@ pub fn resolve_combat_damage(
         c.damage_step_index = None;
     }
 
-    process_combat_damage_triggers(state, &damage_events, events);
-    None
+    try_process_combat_damage_triggers(state, &damage_events, events)?;
+    Ok(None)
 }
 
 /// Which sub-step of combat damage we're collecting assignments for.

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -195,6 +195,7 @@ fn drain_spell_copied_observer_triggers(
             crate::game::triggers::drain_deferred_triggers_after_stack_object_announcement(
                 state, events,
             )
+            .map_err(|e| EffectError::InvalidParam(e.to_string()))?
         {
             state.waiting_for = wf;
         }

--- a/crates/engine/src/game/effects/end_combat_phase.rs
+++ b/crates/engine/src/game/effects/end_combat_phase.rs
@@ -38,7 +38,8 @@ pub fn resolve(
 
     // CR 724.2c: Check state-based actions. No player gets priority and no
     // triggered abilities are put on the stack as part of this step.
-    crate::game::sba::check_state_based_actions(state, events);
+    crate::game::sba::try_check_state_based_actions(state, events)
+        .map_err(|err| EffectError::InvalidParam(err.to_string()))?;
 
     // CR 724.2d: Remove everything from combat, expire "until end of combat"
     // effects, and skip straight to the postcombat main phase (CR 724.2e skips

--- a/crates/engine/src/game/effects/end_the_turn.rs
+++ b/crates/engine/src/game/effects/end_the_turn.rs
@@ -25,7 +25,8 @@ pub fn resolve(
 
     // CR 724.1c: Check state-based actions. No player gets priority and no
     // triggered abilities are put on the stack as part of this step.
-    crate::game::sba::check_state_based_actions(state, events);
+    crate::game::sba::try_check_state_based_actions(state, events)
+        .map_err(|err| EffectError::InvalidParam(err.to_string()))?;
 
     // CR 724.1d: Remove all creatures and planeswalkers from combat. Clearing
     // the combat state is the engine's idiom for ending combat (see the

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -185,7 +185,7 @@ pub fn handle_choose_mana_effect(
 
     state.waiting_for = WaitingFor::Priority { player: recipient };
     state.priority_player = recipient;
-    super::drain_pending_continuation(state, events);
+    super::try_drain_pending_continuation(state, events)?;
     Ok(state.waiting_for.clone())
 }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5,6 +5,7 @@ use crate::game::conditions::{
     eval_has_city_blessing, eval_is_initiative, eval_is_monarch, eval_source_entered_this_turn,
     eval_source_is_tapped,
 };
+use crate::game::engine::EngineError;
 use crate::game::filter;
 use crate::game::speed::has_max_speed;
 use crate::types::ability::{
@@ -468,16 +469,25 @@ pub(crate) fn mark_pending_continuation_parent(state: &mut GameState, kind: Effe
 /// All `pending_continuation.take()` sites should use this helper rather
 /// than rolling their own `take + resolve_ability_chain`, so the parent
 /// event is never silently dropped.
+#[cfg(test)]
 pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    try_drain_pending_continuation(state, events)
+        .expect("pending continuation drain target selection failed");
+}
+
+pub(crate) fn try_drain_pending_continuation(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     counters::drain_pending_counter_moves(state, events);
     counters::drain_pending_counter_additions(state, events);
     if waits_for_resolution_choice(&state.waiting_for) {
-        return;
+        return Ok(());
     }
     if let Some(cont) = state.pending_continuation.take() {
         let PendingContinuation { chain, parent_kind } = cont;
         let source_id = chain.source_id;
-        let _ = resolve_ability_chain(state, &chain, events, 1);
+        resolve_ability_chain(state, &chain, events, 1).map_err(effect_error_to_engine)?;
         if let Some(kind) = parent_kind {
             events.push(GameEvent::EffectResolved { kind, source_id });
         }
@@ -489,14 +499,14 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
     // the outer loop must not advance until the inner ChangeZone completes
     // and emits its `EffectResolved` event.
     if !waits_for_resolution_choice(&state.waiting_for) {
-        drain_pending_change_zone_iteration(state, events);
+        drain_pending_change_zone_iteration(state, events)?;
     }
     // CR 609.3 + CR 109.5: After the per-iteration chain drains, drive any
     // remaining `repeat_for` iterations. Each resumed iteration may itself
     // pause and re-stash via the loop in `resolve_ability_chain`, producing a
     // chain of resumed iterations until the loop completes.
     if !waits_for_resolution_choice(&state.waiting_for) {
-        drain_pending_repeat_iteration(state, events);
+        drain_pending_repeat_iteration(state, events)?;
     }
     if !waits_for_resolution_choice(&state.waiting_for) {
         choose_one_of::resume_pending(state, events);
@@ -509,17 +519,23 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
         && state.pending_continuation.is_none()
         && state.pending_repeat_iteration.is_none()
     {
-        drain_pending_repeat_until(state);
+        drain_pending_repeat_until(state)?;
     }
+
+    Ok(())
+}
+
+fn effect_error_to_engine(err: EffectError) -> EngineError {
+    EngineError::InvalidAction(format!("ability resolution failed: {err}"))
 }
 
 /// CR 608.2c + CR 107.1c: Resume a "repeat this process" loop that paused when
 /// an iteration's process entered an interactive `WaitingFor` state. Called by
 /// `drain_pending_continuation` once the iteration's choice (and any chained
 /// continuation) has fully drained.
-fn drain_pending_repeat_until(state: &mut GameState) {
+fn drain_pending_repeat_until(state: &mut GameState) -> Result<(), EngineError> {
     let Some(pending) = state.pending_repeat_until.take() else {
-        return;
+        return Ok(());
     };
     let crate::types::game_state::PendingRepeatUntil { ability } = pending;
     match &ability.repeat_until {
@@ -541,13 +557,15 @@ fn drain_pending_repeat_until(state: &mut GameState) {
                 *stop_on_put_to_hand,
                 *stop_on_duplicate_exiled_names,
             ) {
-                return;
+                return Ok(());
             }
             let mut events = Vec::new();
-            let _ = resolve_ability_chain(state, &ability, &mut events, 1);
+            resolve_ability_chain(state, &ability, &mut events, 1)
+                .map_err(effect_error_to_engine)?;
         }
         None => {}
     }
+    Ok(())
 }
 
 /// CR 608.2c + CR 107.1c: Stop predicates for `RepeatContinuation::UntilStopConditions`.
@@ -584,7 +602,10 @@ fn should_stop_repeat_until(
 /// remaining objects through `process_one_zone_move`; re-stashes and breaks on
 /// a further pause; emits the trailing `EffectResolved` event when the loop
 /// completes.
-fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<GameEvent>) {
+fn drain_pending_change_zone_iteration(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     while let Some(pending) = state.pending_change_zone_iteration.take() {
         let crate::types::game_state::PendingChangeZoneIteration {
             remaining,
@@ -763,11 +784,17 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
             .collect();
         if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
             crate::game::triggers::collect_triggers_into_deferred(state, &trigger_events);
-            crate::game::triggers::drain_deferred_trigger_queue(state, events);
+            if let Some(waiting_for) =
+                crate::game::triggers::drain_deferred_trigger_queue(state, events)?
+            {
+                state.waiting_for = waiting_for;
+                return Ok(());
+            }
         } else {
             crate::game::triggers::collect_triggers_into_deferred(state, &trigger_events);
         }
     }
+    Ok(())
 }
 
 /// CR 609.3 + CR 109.5: Resume a paused `repeat_for` loop. Each iteration
@@ -777,7 +804,10 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
 /// iteration also completes synchronously, this function drives them all
 /// in-line so the loop only pauses again when an inner effect actually
 /// transitions to a player-choice state.
-fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEvent>) {
+fn drain_pending_repeat_iteration(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     while let Some(pending) = state.pending_repeat_iteration.take() {
         let crate::types::game_state::PendingRepeatIteration {
             ability,
@@ -822,7 +852,8 @@ fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEv
             // that the depth==0 prelude in `resolve_ability_chain` would
             // otherwise reset. The resumed iteration is logically continuing the
             // outer chain, not starting a fresh top-level resolution.
-            let _ = resolve_ability_chain(state, iter_effective, events, 1);
+            resolve_ability_chain(state, iter_effective, events, 1)
+                .map_err(effect_error_to_engine)?;
             // CR 609.3: Iteration may transition to a player-choice state OR
             // synchronously install a `pending_continuation` (e.g. when the
             // sub_ability chain wires itself for later drain). Either signals
@@ -858,6 +889,7 @@ fn drain_pending_repeat_iteration(state: &mut GameState, events: &mut Vec<GameEv
             break;
         }
     }
+    Ok(())
 }
 
 pub(crate) fn append_to_pending_continuation(
@@ -1298,7 +1330,9 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::SearchChoice { .. }
             | WaitingFor::SearchPartitionChoice { .. }
             | WaitingFor::OutsideGameChoice { .. }
+            | WaitingFor::OrderTriggers { .. }
             | WaitingFor::TriggerTargetSelection { .. }
+            | WaitingFor::AbilityModeChoice { .. }
             | WaitingFor::NamedChoice { .. }
             | WaitingFor::DamageSourceChoice { .. }
             | WaitingFor::MultiTargetSelection { .. }
@@ -4973,9 +5007,9 @@ fn resolve_chain_body(
                     // (chain-local state clearing, resolution counter) does not
                     // re-run mid-loop — this iteration continues the current
                     // resolution, mirroring the drain-path resume at depth 1.
-                    let _ = resolve_ability_chain(state, iter_effective, events, depth.max(1));
+                    resolve_ability_chain(state, iter_effective, events, depth.max(1))?;
                 } else {
-                    let _ = resolve_effect(state, iter_effective, events);
+                    resolve_effect(state, iter_effective, events)?;
                 }
                 // CR 609.3 + CR 109.5: When the inner effect enters an
                 // interactive WaitingFor (e.g. SearchChoice), stash the
@@ -12029,7 +12063,8 @@ mod tests {
         });
 
         let mut events = Vec::new();
-        super::drain_pending_repeat_iteration(&mut state, &mut events);
+        super::drain_pending_repeat_iteration(&mut state, &mut events)
+            .expect("repeat iteration drain");
 
         // Iteration 1 ran: parent Draw fired (1 card), then the
         // ConditionInstead sub stashed its else_ability into

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -1,5 +1,6 @@
 use rand::seq::SliceRandom;
 
+use crate::game::engine::EngineError;
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 use crate::types::ability::{
@@ -269,7 +270,9 @@ pub fn resolve(
     if let Some(hit) = hit_card {
         clear_markers.push(hit);
     }
-    match move_rest_then(state, &revealed_misses, rest_destination, None, events) {
+    match move_rest_then(state, &revealed_misses, rest_destination, None, events)
+        .map_err(|err| EffectError::InvalidParam(err.to_string()))?
+    {
         zone_pipeline::BatchMoveResult::Done => {}
         zone_pipeline::BatchMoveResult::NeedsChoice => {
             zone_pipeline::defer_completion_on_pause(
@@ -357,7 +360,7 @@ pub(crate) fn move_rest_then(
     rest_destination: Zone,
     completion: Option<BatchCompletion>,
     events: &mut Vec<GameEvent>,
-) -> zone_pipeline::BatchMoveResult {
+) -> Result<zone_pipeline::BatchMoveResult, EngineError> {
     match rest_destination {
         Zone::Library => {
             // Random-order bottom placement is the effect instruction; CR 701.20a

--- a/crates/engine/src/game/effects/win_lose.rs
+++ b/crates/engine/src/game/effects/win_lose.rs
@@ -3,7 +3,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
 use super::resolve_player_for_context_ref;
-use crate::game::elimination::eliminate_player;
+use crate::game::elimination::try_eliminate_player;
 use crate::game::players;
 use crate::game::static_abilities::player_has_cant_win;
 
@@ -65,7 +65,8 @@ pub fn resolve_lose(
 
     for pid in players_to_eliminate {
         // CR 104.3e: A player who loses the game leaves the game.
-        eliminate_player(state, pid, events);
+        try_eliminate_player(state, pid, events)
+            .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
     }
 
     events.push(GameEvent::EffectResolved {
@@ -129,7 +130,8 @@ pub fn resolve_win(
         .collect();
 
     for pid in opponents {
-        eliminate_player(state, pid, events);
+        try_eliminate_player(state, pid, events)
+            .map_err(|e| EffectError::InvalidParam(e.to_string()))?;
     }
 
     events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -6,6 +6,7 @@ use crate::types::match_config::MatchPhase;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
+use super::engine::EngineError;
 use super::players;
 
 /// Eliminate a player from the game per CR 800.4.
@@ -17,7 +18,15 @@ use super::players;
 /// - For team-based formats (2HG): also eliminates all teammates
 /// - Checks if the game is over (1 or fewer living players/teams remain)
 pub fn eliminate_player(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
-    eliminate_players_simultaneously(state, &[player], events);
+    try_eliminate_player(state, player, events).expect("player elimination cleanup failed");
+}
+
+pub fn try_eliminate_player(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
+    try_eliminate_players_simultaneously(state, &[player], events)
 }
 
 /// CR 704.3 + CR 104.4a: Eliminate a set of players who lost in the SAME
@@ -34,6 +43,15 @@ pub fn eliminate_players_simultaneously(
     players_to_eliminate: &[PlayerId],
     events: &mut Vec<GameEvent>,
 ) {
+    try_eliminate_players_simultaneously(state, players_to_eliminate, events)
+        .expect("simultaneous player elimination cleanup failed");
+}
+
+pub fn try_eliminate_players_simultaneously(
+    state: &mut GameState,
+    players_to_eliminate: &[PlayerId],
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     let mut eliminated_any = false;
 
     for &player in players_to_eliminate {
@@ -56,7 +74,7 @@ pub fn eliminate_players_simultaneously(
     }
 
     if !eliminated_any {
-        return;
+        return Ok(());
     }
 
     // CR 704.3 + CR 104.4a: a SINGLE game-over check after all simultaneous
@@ -73,7 +91,7 @@ pub fn eliminate_players_simultaneously(
         // CR 103.5: For simultaneous mulligan states, prune eliminated players
         // from the pending list. If the list becomes empty, advance the flow
         // by emitting MulliganStarted-equivalent transition state.
-        prune_mulligan_pending(state, events);
+        prune_mulligan_pending(state, events)?;
 
         // CR 603.3b + CR 800.4a: Resolve any in-flight trigger-ordering pass
         // around the elimination — drop triggers controlled by eliminated
@@ -88,13 +106,18 @@ pub fn eliminate_players_simultaneously(
             }
         }
     }
+
+    Ok(())
 }
 
 /// CR 103.5 + CR 800.4a: Prune eliminated players from in-flight mulligan
 /// pending lists. If pruning empties the decision phase, transition to the
 /// bottoms phase (or finish mulligans). If it empties the bottoms phase,
 /// finish mulligans directly.
-fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
+fn prune_mulligan_pending(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     // CR 800.4a: Drop any final-mulligan-count entries for players who have
     // been eliminated. Symmetric with the pending-list pruning below so
     // enter_bottom_phase never sees stale entries for dead players.
@@ -122,7 +145,7 @@ fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
                 .filter(|e| players::is_alive(state, e.player))
                 .collect();
             if alive.is_empty() {
-                state.waiting_for = super::mulligan::enter_bottom_phase_public(state, events);
+                state.waiting_for = super::mulligan::try_enter_bottom_phase_public(state, events)?;
             } else {
                 state.waiting_for = WaitingFor::MulliganDecision {
                     pending: alive,
@@ -138,7 +161,7 @@ fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
             if alive.is_empty() {
                 state.final_mulligan_counts.clear();
                 state.prepaid_mulligan_bottoms.clear();
-                state.waiting_for = super::mulligan::finish_mulligans_public(state, events);
+                state.waiting_for = super::mulligan::try_finish_mulligans_public(state, events)?;
             } else {
                 state.waiting_for = WaitingFor::MulliganBottomCards { pending: alive };
             }
@@ -159,6 +182,8 @@ fn prune_mulligan_pending(state: &mut GameState, events: &mut Vec<GameEvent>) {
         }
         _ => {}
     }
+
+    Ok(())
 }
 
 /// CR 603.3b + CR 800.4a: Resolve an in-flight trigger-ordering pass when one

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -153,11 +153,11 @@ pub fn apply(
     state.die_result_this_resolution = None;
     check_actor_authorization(state, actor, &action)?;
     let mut result = apply_action(state, actor, action)?;
-    reconcile_terminal_result(state, &mut result);
+    reconcile_terminal_result(state, &mut result)?;
     bump_state_revision(state);
     sync_waiting_for(state, &result.waiting_for);
     run_auto_pass_loop(state, &mut result);
-    reconcile_terminal_result(state, &mut result);
+    reconcile_terminal_result(state, &mut result)?;
     // Debug "infinite mana" (CR 500.5 suppressed for flagged players): restore any
     // pool that a spend during this action depleted, before public state is
     // finalized and the next affordability probe runs. No-op when none flagged.
@@ -173,7 +173,10 @@ pub fn apply(
     Ok(result)
 }
 
-fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
+fn reconcile_terminal_result(
+    state: &mut GameState,
+    result: &mut ActionResult,
+) -> Result<(), EngineError> {
     // Safety net (fixes #962): If a player-loss SBA would eliminate a player,
     // run SBAs now. CR 704.3 normally checks SBAs when a player would receive
     // priority, but skipping them here can leave the engine waiting on a dead
@@ -183,7 +186,7 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
     // exception as the real player-loss SBA checks, and stays narrower than the
     // full SBA loop to avoid unrelated mid-resolution SBA prompts.
     if sba::has_pending_player_loss_sba(state) {
-        sba::check_state_based_actions(state, &mut result.events);
+        sba::try_check_state_based_actions(state, &mut result.events)?;
         // SBA may have advanced waiting_for (e.g., GameOver, or Priority for
         // the next living player). Sync the result.
         result.waiting_for = state.waiting_for.clone();
@@ -194,6 +197,7 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
         match_flow::handle_game_over_transition(state);
         result.waiting_for = state.waiting_for.clone();
     }
+    Ok(())
 }
 
 fn remember_public_reveals(state: &mut GameState, events: &[GameEvent]) {
@@ -285,7 +289,7 @@ pub(super) fn resume_pending_continuation_if_priority(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        effects::drain_pending_continuation(state, events);
+        effects::try_drain_pending_continuation(state, events)?;
     }
     Ok(())
 }
@@ -369,7 +373,7 @@ fn pass_priority_once_with_pipeline(
     // submitter (the controller), which would mis-count consecutive passes and
     // soft-lock the game.
     let current_seat = turn_control::priority_seat(state);
-    let wf = priority::handle_priority_pass(current_seat, state, events);
+    let wf = priority::handle_priority_pass(current_seat, state, events)?;
     sync_waiting_for(state, &wf);
 
     // CR 608.2 + CR 117.4: Drain any pending continuation queued during the
@@ -379,7 +383,7 @@ fn pass_priority_once_with_pipeline(
     // until an unrelated action, by which point referenced stack objects may
     // have left the stack.
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        effects::drain_pending_continuation(state, events);
+        effects::try_drain_pending_continuation(state, events)?;
     }
 
     let skip_triggers =
@@ -1284,16 +1288,16 @@ fn finalize_copy_retarget(
     // CR 707.10c + CR 603.2: Copy observers (Magecraft) must drain only after
     // the copy's targets are finalized, not while `CopyRetarget` is still open.
     if let Some(wf) =
-        triggers::drain_deferred_triggers_after_stack_object_announcement(state, events)
+        triggers::drain_deferred_triggers_after_stack_object_announcement(state, events)?
     {
         state.waiting_for = wf;
         state.priority_player = player;
-        effects::drain_pending_continuation(state, events);
+        effects::try_drain_pending_continuation(state, events)?;
         return Ok(());
     }
     state.waiting_for = WaitingFor::Priority { player };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    effects::try_drain_pending_continuation(state, events)?;
     Ok(())
 }
 
@@ -1418,7 +1422,7 @@ fn apply_action(
     // owned it (see `eliminate_player`).
     if let GameAction::Concede { player_id } = action {
         let mut events = Vec::new();
-        super::elimination::eliminate_player(state, player_id, &mut events);
+        super::elimination::try_eliminate_player(state, player_id, &mut events)?;
         return Ok(ActionResult {
             events,
             waiting_for: state.waiting_for.clone(),
@@ -2604,7 +2608,7 @@ fn apply_action(
             });
             state.waiting_for = WaitingFor::Priority { player: *player };
             state.priority_player = *player;
-            effects::drain_pending_continuation(state, &mut events);
+            effects::try_drain_pending_continuation(state, &mut events)?;
             state.waiting_for.clone()
         }
         (
@@ -3356,13 +3360,11 @@ fn apply_action(
             // with bumped count if they mulliganed, or retained with the
             // same count if they used Serum Powder) or advances to the next
             // phase when the pending set is empty.
-            mulligan::handle_mulligan_decision(state, actor, choice, &mut events)
-                .map_err(EngineError::InvalidAction)?
+            mulligan::handle_mulligan_decision(state, actor, choice, &mut events)?
         }
         (WaitingFor::MulliganBottomCards { .. }, GameAction::SelectCards { cards }) => {
             // CR 103.5: `actor` is already authorized as a member of `pending`.
-            mulligan::handle_mulligan_bottom(state, actor, cards, &mut events)
-                .map_err(EngineError::InvalidAction)?
+            mulligan::handle_mulligan_bottom(state, actor, cards, &mut events)?
         }
         (WaitingFor::OpeningHandBottomCards { .. }, GameAction::SelectCards { cards }) => {
             // TL:R 906.6a/e: `actor` is already authorized as a member of
@@ -3423,7 +3425,7 @@ fn apply_action(
                 let skipped: std::collections::HashSet<ObjectId> = declined.into_iter().collect();
                 turns::execute_untap_with_choices(state, &mut events, &skipped);
                 turns::advance_phase(state, &mut events);
-                turns::auto_advance(state, &mut events)
+                turns::try_auto_advance(state, &mut events)?
             }
         }
         // CR 508.1g + CR 701.43d: the active player decides whether to pay the
@@ -3613,9 +3615,12 @@ fn apply_action(
                     // CR 616.1 case, but the aura-host resume is the ONLY drain
                     // site for an `NeedsAuraAttachmentChoice` pause.
                     if state.pending_batch_deliveries.is_some() {
-                        super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
+                        super::zone_pipeline::drain_pending_batch_deliveries(
+                            state,
+                            &mut events,
+                        )?;
                     }
-                    effects::drain_pending_continuation(state, &mut events);
+                    effects::try_drain_pending_continuation(state, &mut events)?;
                     return Ok(ActionResult {
                         events,
                         waiting_for: state.waiting_for.clone(),
@@ -3651,9 +3656,9 @@ fn apply_action(
             // CR 603.10a + CR 616.1: drain a deferred batch completion parked
             // behind this aura-attachment pause (see the sibling path above).
             if state.pending_batch_deliveries.is_some() {
-                super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
+                super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events)?;
             }
-            effects::drain_pending_continuation(state, &mut events);
+            effects::try_drain_pending_continuation(state, &mut events)?;
             state.waiting_for.clone()
         }
         (
@@ -4317,7 +4322,7 @@ fn apply_action(
             });
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
-            effects::drain_pending_continuation(state, &mut events);
+            effects::try_drain_pending_continuation(state, &mut events)?;
             state.waiting_for.clone()
         }
         // CR 701.56a: Time travel — player selected objects for the current phase
@@ -4365,7 +4370,7 @@ fn apply_action(
                     });
                     state.waiting_for = WaitingFor::Priority { player: p };
                     state.priority_player = p;
-                    effects::drain_pending_continuation(state, &mut events);
+                    effects::try_drain_pending_continuation(state, &mut events)?;
                     state.waiting_for.clone()
                 }
             } else {
@@ -4375,7 +4380,7 @@ fn apply_action(
                 });
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                effects::try_drain_pending_continuation(state, &mut events)?;
                 state.waiting_for.clone()
             }
         }
@@ -4433,7 +4438,7 @@ fn apply_action(
             let previous_trigger_match_count = state.current_trigger_match_count;
             state.current_trigger_event = pending_event;
             state.current_trigger_match_count = state.pending_optional_trigger_match_count.take();
-            effects::drain_pending_continuation(state, &mut events);
+            effects::try_drain_pending_continuation(state, &mut events)?;
             state.current_trigger_event = previous_trigger_event;
             state.current_trigger_match_count = previous_trigger_match_count;
             state.waiting_for.clone()
@@ -4673,7 +4678,7 @@ fn apply_action(
                     "deferred-trigger drain entered with construction still active",
                 );
                 if let Some(waiting_for) =
-                    triggers::drain_deferred_trigger_queue(state, &mut events)
+                    triggers::drain_deferred_trigger_queue(state, &mut events)?
                 {
                     waiting_for
                 } else {
@@ -4683,7 +4688,7 @@ fn apply_action(
                 // Resolution-time distribution continuation path.
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                effects::try_drain_pending_continuation(state, &mut events)?;
                 state.waiting_for.clone()
             }
         }
@@ -4712,7 +4717,7 @@ fn apply_action(
             state.priority_player = p;
             effects::counters::drain_pending_counter_moves(state, &mut events);
             if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                effects::drain_pending_continuation(state, &mut events);
+                effects::try_drain_pending_continuation(state, &mut events)?;
             }
             state.waiting_for.clone()
         }
@@ -4909,7 +4914,7 @@ fn apply_retarget(
     });
     state.waiting_for = WaitingFor::Priority { player };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    effects::try_drain_pending_continuation(state, events)?;
     Ok(state.waiting_for.clone())
 }
 
@@ -6600,7 +6605,15 @@ pub fn start_game_skip_mulligan(state: &mut GameState) -> ActionResult {
 
 /// CR 607.2a + CR 406.6: Check if any exile-return sources have left the battlefield.
 /// If so, move the exiled cards back — linked abilities track which cards were exiled by the source.
+#[cfg(test)]
 pub(super) fn check_exile_returns(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    try_check_exile_returns(state, events).expect("exile return check cannot fail")
+}
+
+pub(super) fn try_check_exile_returns(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     let mut to_return: Vec<crate::types::game_state::ExileLink> = Vec::new();
 
     for event in events.iter() {
@@ -6626,7 +6639,7 @@ pub(super) fn check_exile_returns(state: &mut GameState, events: &mut Vec<GameEv
     }
 
     if to_return.is_empty() {
-        return;
+        return Ok(());
     }
 
     // CR 610.3 + CR 614.6: Return each exiled card to its previous zone through
@@ -6705,7 +6718,7 @@ pub(super) fn check_exile_returns(state: &mut GameState, events: &mut Vec<GameEv
                 reqs,
                 Some(completion),
                 events,
-            ),
+            )?,
             super::zone_pipeline::BatchMoveResult::NeedsChoice
         ) {
             // CR 616.1 / CR 303.4f: this group paused; its tail + cleanup are
@@ -6714,9 +6727,10 @@ pub(super) fn check_exile_returns(state: &mut GameState, events: &mut Vec<GameEv
             // links of any unprocessed group remain in `exile_links` until their
             // (now-gone) source re-checks — acceptable, as multi-destination
             // returns from one source-leaves event do not occur in the pool.
-            return;
+            return Ok(());
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -6886,7 +6900,7 @@ mod tests {
             log_entries: Vec::new(),
         };
 
-        reconcile_terminal_result(&mut state, &mut result);
+        reconcile_terminal_result(&mut state, &mut result).expect("terminal reconcile");
 
         assert_eq!(state.waiting_for, original_waiting_for);
         assert_eq!(result.waiting_for, original_waiting_for);
@@ -6913,7 +6927,7 @@ mod tests {
             log_entries: Vec::new(),
         };
 
-        reconcile_terminal_result(&mut state, &mut result);
+        reconcile_terminal_result(&mut state, &mut result).expect("terminal reconcile");
 
         // CR 704.5a: An unprotected player at 0 life loses before the engine
         // keeps waiting for that player's non-priority discard choice.

--- a/crates/engine/src/game/engine_combat.rs
+++ b/crates/engine/src/game/engine_combat.rs
@@ -301,7 +301,7 @@ pub(super) fn finish_declare_attackers(
         state.combat = None;
         super::layers::prune_end_of_combat_effects(state);
         turns::advance_phase(state, events);
-        Ok(turns::auto_advance(state, events))
+        turns::try_auto_advance(state, events)
     } else {
         priority::reset_priority(state);
         Ok(WaitingFor::Priority {
@@ -553,7 +553,7 @@ pub(super) fn handle_assign_combat_damage(
             combat.damage_step_index = Some(combat.damage_step_index.unwrap_or(0) + 1);
         }
 
-        if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
+        if let Some(waiting_for) = super::combat_damage::try_resolve_combat_damage(state, events)? {
             return Ok(waiting_for);
         }
 
@@ -697,7 +697,7 @@ pub(super) fn handle_assign_combat_damage(
         combat.damage_step_index = Some(combat.damage_step_index.unwrap_or(0) + 1);
     }
 
-    if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
+    if let Some(waiting_for) = super::combat_damage::try_resolve_combat_damage(state, events)? {
         return Ok(waiting_for);
     }
 
@@ -767,7 +767,7 @@ pub(super) fn handle_assign_blocker_damage(
         combat.damage_assignments.insert(blocker_id, recorded);
     }
 
-    if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
+    if let Some(waiting_for) = super::combat_damage::try_resolve_combat_damage(state, events)? {
         return Ok(waiting_for);
     }
 
@@ -812,7 +812,7 @@ pub(super) fn handle_empty_attackers(
     state.combat = None;
     super::layers::prune_end_of_combat_effects(state);
     turns::advance_phase(state, events);
-    Ok(turns::auto_advance(state, events))
+    turns::try_auto_advance(state, events)
 }
 
 pub(super) fn handle_empty_blockers(

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -47,7 +47,7 @@ pub fn apply_debug_action(
             }
             crate::game::zone_pipeline::move_object(state, req, events);
             if simulate {
-                super::sba::check_state_based_actions(state, events);
+                super::sba::try_check_state_based_actions(state, events)?;
                 super::triggers::process_triggers(state, events);
             }
             crate::game::layers::mark_layers_full(state);
@@ -98,7 +98,7 @@ pub fn apply_debug_action(
             {
                 super::sacrifice::SacrificeOutcome::Complete => {
                     super::triggers::process_triggers(state, events); // CR 603: dies/LTB triggers
-                    super::sba::check_state_based_actions(state, events); // CR 704
+                    super::sba::try_check_state_based_actions(state, events)?; // CR 704
                 }
                 super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(player) => {
                     state.waiting_for =
@@ -396,7 +396,7 @@ pub fn apply_debug_action(
         }
 
         DebugAction::RunStateBasedActions => {
-            super::sba::check_state_based_actions(state, events);
+            super::sba::try_check_state_based_actions(state, events)?;
             super::triggers::process_triggers(state, events);
         }
 
@@ -473,7 +473,8 @@ pub fn apply_debug_action(
                     // `MoveToZone { simulate: false }`.
                     if run_etb {
                         super::triggers::process_triggers(state, events); // CR 603: Process triggers
-                        super::sba::check_state_based_actions(state, events); // CR 704: Check SBAs
+                        super::sba::try_check_state_based_actions(state, events)?;
+                        // CR 704: Check SBAs
                     }
                 }
                 super::replacement::ReplacementResult::Prevented => {}
@@ -505,7 +506,7 @@ pub fn apply_debug_action(
             super::effects::token_copy::resolve(state, &ability, events)
                 .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
             super::triggers::process_triggers(state, events);
-            super::sba::check_state_based_actions(state, events);
+            super::sba::try_check_state_based_actions(state, events)?;
         }
     }
 

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -417,9 +417,9 @@ fn handle_triggered_mode_choice(
             // already drains the deferred-trigger queue and surfaces the next
             // WaitingFor if a sibling trigger needs input; use that result
             // instead of falling through to Priority below.
-            return Ok(engine_stack::finalize_trigger_target_selection(
+            return engine_stack::finalize_trigger_target_selection(
                 state, trigger, resolved, events,
-            ));
+            );
         } else {
             // CR 601.2c + CR 603.3d: Mode chosen but target choice still
             // outstanding. The entry is already on the stack (pushed at modal
@@ -481,7 +481,7 @@ fn handle_triggered_mode_choice(
             "deferred-trigger drain entered with construction still active",
         );
         if let Some(waiting_for) =
-            triggers::drain_deferred_triggers_after_trigger_construction(state, events)
+            triggers::drain_deferred_triggers_after_trigger_construction(state, events)?
         {
             return Ok(waiting_for);
         }

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -63,7 +63,7 @@ pub(super) fn handle_optional_effect_choice(
     if state.resolving_begin_game_abilities
         && matches!(state.waiting_for, WaitingFor::Priority { .. })
     {
-        return Ok(super::mulligan::resume_begin_game_abilities(state, events));
+        return super::mulligan::try_resume_begin_game_abilities(state, events);
     }
     Ok(state.waiting_for.clone())
 }

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -1,7 +1,7 @@
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 
-use super::engine::{begin_pending_trigger_target_selection, check_exile_returns, EngineError};
+use super::engine::{begin_pending_trigger_target_selection, try_check_exile_returns, EngineError};
 use super::match_flow;
 use super::players;
 use super::sba;
@@ -80,7 +80,7 @@ pub(super) fn run_post_action_pipeline_from(
     // in those states would clobber the open prompt (same failure mode as #2420).
     while matches!(state.waiting_for, WaitingFor::Priority { .. }) {
         let events_before = events.len();
-        sba::check_state_based_actions(state, events);
+        sba::try_check_state_based_actions(state, events)?;
         if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
             break;
         }
@@ -112,7 +112,7 @@ pub(super) fn run_post_action_pipeline_from(
     if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && !state.deferred_triggers.is_empty()
     {
-        if let Some(wf) = triggers::drain_deferred_trigger_queue(state, events) {
+        if let Some(wf) = triggers::drain_deferred_trigger_queue(state, events)? {
             state.waiting_for = wf;
         }
     }
@@ -132,7 +132,7 @@ pub(super) fn run_post_action_pipeline_from(
         }
     }
 
-    check_exile_returns(state, events);
+    try_check_exile_returns(state, events)?;
 
     let delayed_events = triggers::check_delayed_triggers(state, events);
     events.extend(delayed_events);

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -521,7 +521,7 @@ pub(super) fn handle_replacement_choice(
             if matches!(waiting_for, WaitingFor::Priority { .. })
                 && state.pending_batch_deliveries.is_some()
             {
-                crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events);
+                crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events)?;
                 if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
                     waiting_for = state.waiting_for.clone();
                 }
@@ -545,7 +545,7 @@ pub(super) fn handle_replacement_choice(
                 // paused on this replacement choice (issue #535). The drain
                 // helper covers both: it runs the continuation chain (if any)
                 // then the ChangeZone iteration drain hook.
-                effects::drain_pending_continuation(state, events);
+                effects::try_drain_pending_continuation(state, events)?;
                 // CR 616.1e: The continuation may itself pause on another replacement
                 // (e.g., the second direction of fight damage hitting the same shield),
                 // in which case it sets `state.waiting_for` to the next ReplacementChoice.
@@ -577,7 +577,7 @@ pub(super) fn handle_replacement_choice(
                     // is set). Resume only when that bail happened — not when
                     // `advance_phase` alone paused the drain (unit tests).
                     state.deferred_step_trigger_resume = None;
-                    waiting_for = super::turns::auto_advance(state, events);
+                    waiting_for = super::turns::try_auto_advance(state, events)?;
                 } else {
                     state.deferred_step_trigger_resume = None;
                 }
@@ -629,7 +629,7 @@ pub(super) fn handle_replacement_choice(
                 };
                 effects::counters::drain_pending_counter_moves(state, events);
                 if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                    effects::drain_pending_continuation(state, events);
+                    effects::try_drain_pending_continuation(state, events)?;
                 }
                 return Ok(state.waiting_for.clone());
             }
@@ -646,7 +646,7 @@ pub(super) fn handle_replacement_choice(
                 state.waiting_for = WaitingFor::Priority {
                     player: state.active_player,
                 };
-                crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events);
+                crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events)?;
                 return Ok(state.waiting_for.clone());
             }
             // CR 608.3e: If the ETB was prevented during spell resolution,
@@ -816,7 +816,7 @@ pub(super) fn replay_deferred_entry_events(
         let delayed_events = super::triggers::check_delayed_triggers(state, &deferred);
         events.extend(delayed_events);
     }
-    effects::drain_pending_continuation(state, events);
+    effects::try_drain_pending_continuation(state, events)?;
     // CR 113.2c + CR 603.3b + CR 707.10: `process_triggers` above may have
     // paused on an interactive replayed ETB trigger fired by the realized
     // entry. When it pauses it sets `state.pending_trigger` for the active

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -42,7 +42,7 @@ fn batch_or_drain_observer_triggers(
     events: &mut Vec<GameEvent>,
     event_slice_start: usize,
     event_slice_end: usize,
-) -> Option<ResolutionChoiceOutcome> {
+) -> Result<Option<ResolutionChoiceOutcome>, EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
         // B1: this action settled. Merge this slice's observer triggers into
         // the parked queue before draining — otherwise the last segment's
@@ -54,12 +54,12 @@ fn batch_or_drain_observer_triggers(
             .cloned()
             .collect();
         super::triggers::collect_triggers_into_deferred(state, &trigger_events);
-        if let Some(wf) = super::triggers::drain_deferred_trigger_queue(state, events) {
-            return Some(ResolutionChoiceOutcome::WaitingFor(wf));
+        if let Some(wf) = super::triggers::drain_deferred_trigger_queue(state, events)? {
+            return Ok(Some(ResolutionChoiceOutcome::WaitingFor(wf)));
         }
-        Some(ResolutionChoiceOutcome::WaitingForWithInlineTriggers(
+        Ok(Some(ResolutionChoiceOutcome::WaitingForWithInlineTriggers(
             state.waiting_for.clone(),
-        ))
+        )))
     } else {
         // B2: paused — `run_post_action_pipeline` will not scan this action.
         // Park this move's observer triggers for a later settle.
@@ -69,7 +69,7 @@ fn batch_or_drain_observer_triggers(
             .cloned()
             .collect();
         super::triggers::collect_triggers_into_deferred(state, &trigger_events);
-        None
+        Ok(None)
     }
 }
 
@@ -343,7 +343,9 @@ pub(super) fn handle_resolution_choice(
             for &card_id in &bottom_cards {
                 player_state.library.push_back(card_id);
             }
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::CoinFlipKeepChoice {
@@ -385,7 +387,7 @@ pub(super) fn handle_resolution_choice(
             // whole flip effect completed — drain back to Priority.
             let wf = match next {
                 Some(wf) => wf,
-                None => finish_with_continuation(state, player, events),
+                None => try_finish_with_continuation(state, player, events)?,
             };
             ResolutionChoiceOutcome::WaitingFor(wf)
         }
@@ -449,10 +451,10 @@ pub(super) fn handle_resolution_choice(
                 reqs,
                 Some(completion),
                 events,
-            ) {
+            )? {
                 crate::game::zone_pipeline::BatchMoveResult::Done => {
                     // `move_objects_simultaneously_then` already ran the
-                    // completion (reveal-marker cleanup + `finish_with_continuation`).
+                    // completion (reveal-marker cleanup + `try_finish_with_continuation`).
                     ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
                 }
                 crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
@@ -515,7 +517,9 @@ pub(super) fn handle_resolution_choice(
                     }
                 }
 
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         // CR 701.20a + CR 608.2c: "You may put that card onto the battlefield" —
@@ -653,9 +657,9 @@ pub(super) fn handle_resolution_choice(
                     emit_reveal_until_resolved: None,
                 }),
                 events,
-            ) {
+            )? {
                 crate::game::zone_pipeline::BatchMoveResult::Done => {
-                    // The completion ran inline (`finish_with_continuation`), so
+                    // The completion ran inline (`try_finish_with_continuation`), so
                     // `state.waiting_for` is the post-drain priority/continuation
                     // state.
                     ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -686,7 +690,9 @@ pub(super) fn handle_resolution_choice(
                 ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
             } else {
                 // CR 107.1c: declining ends the loop; drain any trailing chain.
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         (
@@ -737,7 +743,9 @@ pub(super) fn handle_resolution_choice(
                 all_to_bottom.push(hit_card);
                 crate::game::effects::cascade::shuffle_to_bottom(state, &all_to_bottom, events);
 
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         (
@@ -778,7 +786,9 @@ pub(super) fn handle_resolution_choice(
                 all_to_bottom.push(hit_card);
                 crate::game::effects::cascade::shuffle_to_bottom(state, &all_to_bottom, events);
 
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         // CR 608.2g + CR 601.2 + CR 202.3: Invoke Calamity's free-cast window —
@@ -807,7 +817,7 @@ pub(super) fn handle_resolution_choice(
                 // CR 601.2: "Up to N" — the controller may stop early. Finish the
                 // window and run the continuation (Exile ~).
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
-                    finish_with_continuation(state, player, events),
+                    try_finish_with_continuation(state, player, events)?,
                 ));
             };
             // CR 608.2c: Validate the choice against the offered candidate set.
@@ -910,14 +920,18 @@ pub(super) fn handle_resolution_choice(
                 kind: EffectKind::Learn,
                 source_id: ObjectId(0),
             });
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::TopOrBottomChoice { player, object_id },
             GameAction::ChooseTopOrBottom { top },
         ) => {
             zones::move_to_library_position(state, object_id, top, events);
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         // CR 107.1c + CR 107.14: Commit the chosen amount for a "pay any amount
         // of X" prompt. Deducts the resource, emits the matching resource event,
@@ -1001,7 +1015,7 @@ pub(super) fn handle_resolution_choice(
                     cont.chain.set_chosen_x_recursive(total);
                 }
             }
-            let mut waiting_for = finish_with_continuation(state, player, events);
+            let mut waiting_for = try_finish_with_continuation(state, player, events)?;
             if let WaitingFor::PayAmountChoice {
                 accumulated: next_accumulated,
                 ..
@@ -1034,7 +1048,9 @@ pub(super) fn handle_resolution_choice(
                 player,
             );
             let _ = effects::populate::create_token_copy(state, token_id, &dummy_ability, events);
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::ClashChooseOpponent {
@@ -1059,7 +1075,7 @@ pub(super) fn handle_resolution_choice(
             // sub_ability here and hand priority back to the clashing player.
             if !matches!(state.waiting_for, WaitingFor::ClashCardPlacement { .. }) {
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                effects::try_drain_pending_continuation(state, events)?;
             }
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -1080,7 +1096,9 @@ pub(super) fn handle_resolution_choice(
                 };
                 ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
             } else {
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         // CR 701.38: Tally a vote, then either advance to the same voter's
@@ -1184,9 +1202,9 @@ pub(super) fn handle_resolution_choice(
                     &new_ballots,
                     events,
                 );
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
                     state, controller, events,
-                ))
+                )?)
             }
         }
         // CR 700.3 + CR 700.3a + CR 101.4: Subject submits their partition;
@@ -1299,7 +1317,9 @@ pub(super) fn handle_resolution_choice(
                 };
                 ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
             } else {
-                ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+                ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                    state, player, events,
+                )?)
             }
         }
         (
@@ -1382,7 +1402,7 @@ pub(super) fn handle_resolution_choice(
                     // On a mid-pile CR 616.1 ordering pause, defer the
                     // priority/continuation drain (a cleanup-only `RevealRestPile`
                     // completion: empty pile, no markers/publish, just
-                    // `finish_with_continuation`) so it runs once the pile lands,
+                    // `try_finish_with_continuation`) so it runs once the pile lands,
                     // and surface the parked prompt instead of draining over it.
                     let reqs: Vec<_> = unkept
                         .iter()
@@ -1415,7 +1435,7 @@ pub(super) fn handle_resolution_choice(
                     }
                 }
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
-                    finish_with_continuation(state, player, events),
+                    try_finish_with_continuation(state, player, events)?,
                 ));
             }
             if let Some(kept_zone) = kept_destination {
@@ -1512,7 +1532,9 @@ pub(super) fn handle_resolution_choice(
                 cont.chain.targets = kept.iter().map(|&id| TargetRef::Object(id)).collect();
                 cont.chain.context.optional_effect_performed = !kept.is_empty();
             }
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::SurveilChoice { player, cards },
@@ -1562,7 +1584,7 @@ pub(super) fn handle_resolution_choice(
                 reqs,
                 Some(completion),
                 events,
-            );
+            )?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1585,7 +1607,7 @@ pub(super) fn handle_resolution_choice(
                 }
                 set_priority(state, player);
                 if decline_runs_continuation {
-                    effects::drain_pending_continuation(state, events);
+                    effects::try_drain_pending_continuation(state, events)?;
                 } else {
                     state.pending_continuation = None;
                 }
@@ -1636,7 +1658,7 @@ pub(super) fn handle_resolution_choice(
                     cont.chain.context.optional_effect_performed = true;
                 }
             }
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1737,7 +1759,7 @@ pub(super) fn handle_resolution_choice(
                 // the primary destination and the rest is empty. No second prompt.
                 apply_search_partition(state, &chosen, &[], &split, source_id, player, events)?;
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                effects::try_drain_pending_continuation(state, events)?;
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
                     state.waiting_for.clone(),
                 ));
@@ -1759,7 +1781,7 @@ pub(super) fn handle_resolution_choice(
                 cont.chain.targets = continuation_targets.clone();
                 propagate_targets_through_search_shuffle(&mut cont.chain, &continuation_targets);
             }
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1814,7 +1836,7 @@ pub(super) fn handle_resolution_choice(
                 events,
             )?;
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -1963,7 +1985,9 @@ pub(super) fn handle_resolution_choice(
             if let Some(cont) = state.pending_continuation.as_mut() {
                 cont.chain.targets = chosen_ids.iter().map(|&id| TargetRef::Object(id)).collect();
             }
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::ChooseFromZoneChoice {
@@ -2039,7 +2063,7 @@ pub(super) fn handle_resolution_choice(
                     }
                 }
             }
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -2105,7 +2129,7 @@ pub(super) fn handle_resolution_choice(
             // slots). Required so a `repeat_for: DistinctCounterKindsAmong` loop
             // paused on `ChooseOneOfBranch` advances past the first counter kind to
             // prompt for each remaining kind (Bribe Taker).
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -2136,9 +2160,9 @@ pub(super) fn handle_resolution_choice(
             }
 
             turns::advance_phase(state, events);
-            return Ok(ResolutionChoiceOutcome::WaitingFor(turns::auto_advance(
-                state, events,
-            )));
+            return Ok(ResolutionChoiceOutcome::WaitingFor(
+                turns::try_auto_advance(state, events)?,
+            ));
         }
         (
             WaitingFor::ConniveDiscard {
@@ -2189,7 +2213,9 @@ pub(super) fn handle_resolution_choice(
                 kind: EffectKind::Connive,
                 source_id,
             });
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::DiscardChoice {
@@ -2342,13 +2368,13 @@ pub(super) fn handle_resolution_choice(
                     events,
                     events_before_effect,
                     events_after_move,
-                ) {
+                )? {
                     return Ok(outcome);
                 }
                 return Ok(ResolutionChoiceOutcome::WaitingFor(waiting_for));
             }
 
-            let waiting_for = finish_with_continuation(state, player, events);
+            let waiting_for = try_finish_with_continuation(state, player, events)?;
 
             // CR 603.2c: each opponent's discard is a separate occurrence of a
             // `Discarded`-mode trigger event. The resolution-choice dispatch
@@ -2361,7 +2387,7 @@ pub(super) fn handle_resolution_choice(
                 events,
                 events_before_effect,
                 events_after_move,
-            ) {
+            )? {
                 return Ok(outcome);
             }
             ResolutionChoiceOutcome::WaitingFor(waiting_for)
@@ -2798,7 +2824,7 @@ pub(super) fn handle_resolution_choice(
                     events,
                     events_before_effect,
                     events_after_move,
-                ) {
+                )? {
                     return Ok(outcome);
                 }
             }
@@ -2979,7 +3005,7 @@ pub(super) fn handle_resolution_choice(
                     state.waiting_for.clone(),
                 ));
             } else {
-                effects::drain_pending_continuation(state, events);
+                effects::try_drain_pending_continuation(state, events)?;
             }
             state.last_named_choice = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -3007,7 +3033,9 @@ pub(super) fn handle_resolution_choice(
                 events,
             )
             .map_err(|e| EngineError::InvalidAction(format!("spellbook draft: {e:?}")))?;
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::DamageSourceChoice {
@@ -3028,7 +3056,7 @@ pub(super) fn handle_resolution_choice(
                 source_filter,
             });
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            effects::try_drain_pending_continuation(state, events)?;
             state.last_chosen_damage_source = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -3043,7 +3071,9 @@ pub(super) fn handle_resolution_choice(
             }
             state.ring_bearer.insert(player, Some(target));
             crate::game::layers::mark_layers_full(state);
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (WaitingFor::ChooseDungeon { player, options }, GameAction::ChooseDungeon { dungeon }) => {
             if !options.contains(&dungeon) {
@@ -3060,9 +3090,12 @@ pub(super) fn handle_resolution_choice(
             // CR 603.2 + CR 309.4c: RoomEntered from the chosen dungeon must dispatch
             // card triggers such as "Whenever you venture into the dungeon" (issue #1297).
             // The resolution-choice path does not run `run_post_action_pipeline`.
-            if let Some(outcome) =
-                batch_or_drain_observer_triggers(state, events, events_before_venture, events.len())
-            {
+            if let Some(outcome) = batch_or_drain_observer_triggers(
+                state,
+                events,
+                events_before_venture,
+                events.len(),
+            )? {
                 return Ok(outcome);
             }
             if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
@@ -3070,7 +3103,9 @@ pub(super) fn handle_resolution_choice(
                     state.waiting_for.clone(),
                 ));
             }
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::ChooseDungeonRoom {
@@ -3092,9 +3127,12 @@ pub(super) fn handle_resolution_choice(
             {
                 state.waiting_for = waiting_for.clone();
             }
-            if let Some(outcome) =
-                batch_or_drain_observer_triggers(state, events, events_before_venture, events.len())
-            {
+            if let Some(outcome) = batch_or_drain_observer_triggers(
+                state,
+                events,
+                events_before_venture,
+                events.len(),
+            )? {
                 return Ok(outcome);
             }
             if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
@@ -3102,7 +3140,9 @@ pub(super) fn handle_resolution_choice(
                     state.waiting_for.clone(),
                 ));
             }
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (
             WaitingFor::SpecializeColor {
@@ -3120,7 +3160,9 @@ pub(super) fn handle_resolution_choice(
             effects::specialize::handle_choose_specialize_color(
                 state, player, object_id, &options, color, events,
             )?;
-            ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
+            ResolutionChoiceOutcome::WaitingFor(try_finish_with_continuation(
+                state, player, events,
+            )?)
         }
         (WaitingFor::ChooseLegend { candidates, .. }, GameAction::ChooseLegend { keep }) => {
             if !candidates.contains(&keep) {
@@ -3369,7 +3411,8 @@ pub(super) fn handle_resolution_choice(
                 // B2 (paused) batches this action's sacrifice events for a
                 // later drain.
                 if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                    if let Some(wf) = super::triggers::drain_deferred_trigger_queue(state, events) {
+                    if let Some(wf) = super::triggers::drain_deferred_trigger_queue(state, events)?
+                    {
                         return Ok(ResolutionChoiceOutcome::WaitingFor(wf));
                     }
                 } else {
@@ -3502,14 +3545,14 @@ fn pop_first_pile_result(
     (first, completed)
 }
 
-fn finish_with_continuation(
+fn try_finish_with_continuation(
     state: &mut GameState,
     player: crate::types::player::PlayerId,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
     set_priority(state, player);
-    effects::drain_pending_continuation(state, events);
-    state.waiting_for.clone()
+    effects::try_drain_pending_continuation(state, events)?;
+    Ok(state.waiting_for.clone())
 }
 
 /// CR 701.25a / manifest dread: run the post-loop cleanup a rest-pile batch
@@ -3522,18 +3565,18 @@ pub(crate) fn run_batch_completion(
     state: &mut GameState,
     completion: crate::types::game_state::BatchCompletion,
     events: &mut Vec<GameEvent>,
-) {
+) -> Result<(), EngineError> {
     use crate::types::game_state::BatchCompletion;
     match completion {
         BatchCompletion::SurveilKeepOnTop { player, top_cards } => {
             surveil_keep_on_top(state, player, &top_cards);
-            finish_with_continuation(state, player, events);
+            try_finish_with_continuation(state, player, events)?;
         }
         BatchCompletion::ManifestDreadCleanup { player, revealed } => {
             for card_id in &revealed {
                 state.revealed_cards.remove(card_id);
             }
-            finish_with_continuation(state, player, events);
+            try_finish_with_continuation(state, player, events)?;
         }
         // CR 701.20b: The kept card's battlefield entry paused (aura host pick /
         // replacement ordering). Now that it has resolved, move the unkept rest
@@ -3575,9 +3618,9 @@ pub(crate) fn run_batch_completion(
                     rest_destination,
                     Some(cleanup),
                     events,
-                ) {
+                )? {
                     crate::game::zone_pipeline::BatchMoveResult::Done
-                    | crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => return,
+                    | crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => return Ok(()),
                 }
             }
             for card_id in &clear_markers {
@@ -3596,7 +3639,7 @@ pub(crate) fn run_batch_completion(
                     source_id,
                 });
             }
-            finish_with_continuation(state, player, events);
+            try_finish_with_continuation(state, player, events)?;
         }
         // CR 610.3: the exile-until-leaves return pile has fully landed (after a
         // returned creature's as-enters / aura-host pause resolved). Drop the
@@ -3649,6 +3692,7 @@ pub(crate) fn run_batch_completion(
             }
         }
     }
+    Ok(())
 }
 
 /// CR 701.25a: place the kept surveil cards on top of the player's library in

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -20,7 +20,7 @@ pub(super) fn finalize_trigger_target_selection(
     trigger: PendingTrigger,
     ability: ResolvedAbility,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
     let assigned_targets = flatten_targets_in_chain(&ability);
     casting::emit_targeting_events(
         state,
@@ -53,12 +53,12 @@ pub(super) fn finalize_trigger_target_selection(
                 state.pending_trigger = Some(trigger);
                 state.priority_passes.clear();
                 state.priority_pass_count = 0;
-                return WaitingFor::DistributeAmong {
+                return Ok(WaitingFor::DistributeAmong {
                     player: controller,
                     total,
                     targets: assigned_targets,
                     unit,
-                };
+                });
             }
         }
     }
@@ -81,11 +81,11 @@ pub(super) fn finalize_trigger_target_selection(
         "deferred-trigger drain entered with construction still active",
     );
     if let Some(waiting_for) =
-        triggers::drain_deferred_triggers_after_trigger_construction(state, events)
+        triggers::drain_deferred_triggers_after_trigger_construction(state, events)?
     {
-        return waiting_for;
+        return Ok(waiting_for);
     }
-    WaitingFor::Priority { player: controller }
+    Ok(WaitingFor::Priority { player: controller })
 }
 
 /// CR 706.2 + CR 603.12: Re-stamp the pending trigger's carried die-roll
@@ -150,9 +150,7 @@ pub(super) fn handle_trigger_target_selection_select_targets(
         .take()
         .ok_or_else(|| EngineError::InvalidAction("No pending trigger".to_string()))?;
 
-    Ok(finalize_trigger_target_selection(
-        state, trigger, ability, events,
-    ))
+    finalize_trigger_target_selection(state, trigger, ability, events)
 }
 
 pub(super) fn handle_trigger_target_selection_choose_target(
@@ -271,9 +269,7 @@ pub(super) fn handle_trigger_target_selection_choose_target(
                 .take()
                 .ok_or_else(|| EngineError::InvalidAction("No pending trigger".to_string()))?;
 
-            Ok(finalize_trigger_target_selection(
-                state, trigger, ability, events,
-            ))
+            finalize_trigger_target_selection(state, trigger, ability, events)
         }
     }
 }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -186,6 +186,9 @@ pub fn resolve_mana_ability(
     events: &mut Vec<GameEvent>,
     color_override: Option<ProductionOverride>,
 ) -> Result<(), EngineError> {
+    let source_could_produce_two_or_more_colors =
+        mana_sources::source_could_produce_two_or_more_colors(state, source_id, player);
+
     // Pay the full ability cost (tap, sacrifice, etc.)
     pay_mana_ability_cost(state, source_id, player, &ability_def.cost, events)?;
 
@@ -200,6 +203,7 @@ pub fn resolve_mana_ability(
         ability_def,
         events,
         color_override,
+        source_could_produce_two_or_more_colors,
         None,
     );
     Ok(())
@@ -219,6 +223,7 @@ fn produce_mana_from_ability(
     ability_def: &AbilityDefinition,
     events: &mut Vec<GameEvent>,
     color_override: Option<ProductionOverride>,
+    source_could_produce_two_or_more_colors: bool,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
 ) {
     // CR 117.1 + CR 202.3: Build a transient `ResolvedAbility` carrying the
@@ -262,8 +267,6 @@ fn produce_mana_from_ability(
                     ),
                 };
                 let concrete = resolve_restrictions(restrictions, state, source_id);
-                let source_could_produce_two_or_more_colors =
-                    mana_sources::source_could_produce_two_or_more_colors(state, source_id, player);
                 (
                     mana,
                     concrete,
@@ -393,6 +396,16 @@ pub fn activate_mana_ability(
         .objects
         .get(&source_id)
         .ok_or_else(|| EngineError::InvalidAction("Mana ability source not found".to_string()))?;
+    let activation_ability = source
+        .abilities
+        .get(ability_index)
+        .cloned()
+        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))?;
+    if &activation_ability != ability_def {
+        return Err(EngineError::InvalidAction(
+            "Mana ability definition does not match source".to_string(),
+        ));
+    }
     // CR 702.26b: Phased-out permanents are treated as though they do not
     // exist, so they cannot activate abilities.
     if source.is_phased_out_permanent() {
@@ -403,7 +416,9 @@ pub fn activate_mana_ability(
     if source.controller != player {
         return Err(EngineError::NotYourPriority);
     }
-    let required_zone = ability_def.activation_zone.unwrap_or(Zone::Battlefield);
+    let required_zone = activation_ability
+        .activation_zone
+        .unwrap_or(Zone::Battlefield);
     if source.zone != required_zone {
         return Err(EngineError::InvalidAction(format!(
             "Object is not in the correct zone (expected {:?})",
@@ -417,12 +432,17 @@ pub fn activate_mana_ability(
     // applies on the non-mana path, so City of Solitude (CantActivateDuring with
     // exemption: None) and any future CantBeActivated with exemption: None block
     // mana activations as the rules require.
-    if super::casting::is_blocked_by_cant_be_activated(state, player, source_id, ability_def) {
+    if super::casting::is_blocked_by_cant_be_activated(
+        state,
+        player,
+        source_id,
+        &activation_ability,
+    ) {
         return Err(EngineError::ActionNotAllowed(
             "Activated abilities of this permanent can't be activated (CR 602.5)".to_string(),
         ));
     }
-    if super::casting::is_blocked_by_cant_activate_during(state, player, ability_def) {
+    if super::casting::is_blocked_by_cant_activate_during(state, player, &activation_ability) {
         return Err(EngineError::ActionNotAllowed(
             "Activated abilities can't be activated during this turn (CR 602.5 + CR 117.1b)"
                 .to_string(),
@@ -433,26 +453,26 @@ pub fn activate_mana_ability(
         player,
         source_id,
         ability_index,
-        &ability_def.activation_restrictions,
+        &activation_ability.activation_restrictions,
     )?;
+
+    // CR 602.2a + CR 605.3b: capture the activated mana ability's text and
+    // source-quality facts before costs can tap, sacrifice, exile, or otherwise
+    // make the live source unavailable during immediate resolution.
+    let source_could_produce_two_or_more_colors =
+        mana_sources::source_could_produce_two_or_more_colors(state, source_id, player);
 
     advance_mana_ability_activation(
         state,
-        PendingManaAbility {
+        PendingManaAbility::new(
             player,
             source_id,
             ability_index,
-            color_override,
+            &activation_ability,
+            source_could_produce_two_or_more_colors,
             resume,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        },
+            color_override,
+        ),
         events,
     )
 }
@@ -672,12 +692,9 @@ pub fn handle_choose_mana_color(
         }
     };
 
-    let ability_def = state
-        .objects
-        .get(&pending.source_id)
-        .and_then(|obj| obj.abilities.get(pending.ability_index))
-        .cloned()
-        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))?;
+    let ability_def = ability_def_for_pending_activation(state, pending)?;
+    let source_could_produce_two_or_more_colors =
+        source_quality_for_pending_activation(state, pending);
 
     produce_mana_from_ability(
         state,
@@ -686,6 +703,7 @@ pub fn handle_choose_mana_color(
         &ability_def,
         events,
         Some(override_value),
+        source_could_produce_two_or_more_colors,
         pending.cost_paid_object.clone(),
     );
     complete_mana_ability_activation(
@@ -697,6 +715,35 @@ pub fn handle_choose_mana_color(
     );
 
     Ok(resume_waiting_for(pending.player, pending.resume.clone()))
+}
+
+fn ability_def_for_pending_activation(
+    state: &GameState,
+    pending: &PendingManaAbility,
+) -> Result<AbilityDefinition, EngineError> {
+    if let Some(snapshot) = &pending.activation_snapshot {
+        return Ok(snapshot.ability.clone());
+    }
+    state
+        .objects
+        .get(&pending.source_id)
+        .and_then(|obj| obj.abilities.get(pending.ability_index))
+        .cloned()
+        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))
+}
+
+fn source_quality_for_pending_activation(state: &GameState, pending: &PendingManaAbility) -> bool {
+    pending
+        .activation_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.source_could_produce_two_or_more_colors)
+        .unwrap_or_else(|| {
+            mana_sources::source_could_produce_two_or_more_colors(
+                state,
+                pending.source_id,
+                pending.player,
+            )
+        })
 }
 
 /// CR 605.3a: Bulk-activate the controller's other identical, choice-free mana
@@ -734,14 +781,7 @@ pub(crate) fn batch_activate_mana_siblings(
     // The originally-activated source's mana ability is the shape every sibling
     // was selected to match. Re-resolve each sibling's matching ability index
     // (a sibling may carry unrelated abilities too).
-    let reference_def = state
-        .objects
-        .get(&pending.source_id)
-        .and_then(|obj| obj.abilities.get(pending.ability_index))
-        .cloned()
-        .ok_or_else(|| {
-            EngineError::InvalidAction("Mana ability source no longer exists".to_string())
-        })?;
+    let reference_def = ability_def_for_pending_activation(state, pending)?;
 
     for &sibling_id in pending.batch_siblings.iter().take(extra) {
         let Some((index, def)) = state.objects.get(&sibling_id).and_then(|obj| {
@@ -1046,12 +1086,7 @@ pub(super) fn advance_mana_ability_activation(
     mut pending: PendingManaAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    let ability_def = state
-        .objects
-        .get(&pending.source_id)
-        .and_then(|obj| obj.abilities.get(pending.ability_index))
-        .cloned()
-        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))?;
+    let ability_def = ability_def_for_pending_activation(state, &pending)?;
 
     if pending.chosen_discards.is_empty() {
         if let Some((count, cards)) =
@@ -1285,6 +1320,8 @@ pub(super) fn advance_mana_ability_activation(
         }
     }
 
+    let source_could_produce_two_or_more_colors =
+        source_quality_for_pending_activation(state, &pending);
     resolve_mana_ability_with_selected_choices(
         state,
         pending.source_id,
@@ -1298,6 +1335,7 @@ pub(super) fn advance_mana_ability_activation(
         &pending.chosen_sacrificed_battlefield,
         pending.chosen_mana_payment.as_deref(),
         pending.chosen_counter_count,
+        source_could_produce_two_or_more_colors,
         pending.cost_paid_object,
     )?;
     complete_mana_ability_activation(
@@ -1349,6 +1387,7 @@ fn resolve_mana_ability_with_selected_choices(
     sacrificed_battlefield: &[ObjectId],
     chosen_hybrid_payment: Option<&[ManaType]>,
     chosen_counter_count: Option<u32>,
+    source_could_produce_two_or_more_colors: bool,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
 ) -> Result<(), EngineError> {
     let mut chosen = tapped_creatures.iter().copied();
@@ -1432,12 +1471,13 @@ fn resolve_mana_ability_with_selected_choices(
     // ability's cost includes the `{T}` symbol.
     let tapped = mana_sources::has_tap_component(&ability_def.cost);
     for &mana_type in &produced_mana {
-        mana_payment::produce_mana_with_attributes(
+        mana_payment::produce_mana_with_attributes_from_source_quality(
             state,
             source_id,
             mana_type,
             player,
             tapped,
+            source_could_produce_two_or_more_colors,
             &restrictions,
             &grants,
             expiry,
@@ -2737,6 +2777,29 @@ mod tests {
         .cost(AbilityCost::Tap)
     }
 
+    fn two_color_self_sacrificing_mana_ability() -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyOneColor {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    color_options: vec![ManaColor::Red, ManaColor::Green],
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Tap,
+                AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+            ],
+        })
+    }
+
     fn gemstone_caverns_mana_ability() -> AbilityDefinition {
         let replacement = AbilityDefinition::new(
             AbilityKind::Activated,
@@ -2794,6 +2857,46 @@ mod tests {
             ManaChoiceContext::ManaAbility(pending) => pending,
             other => panic!("expected mana ability context, got {other:?}"),
         }
+    }
+
+    fn pending_mana_ability_from_state(
+        state: &GameState,
+        player: PlayerId,
+        source_id: ObjectId,
+        ability_index: usize,
+        color_override: Option<ProductionOverride>,
+    ) -> PendingManaAbility {
+        let ability = state
+            .objects
+            .get(&source_id)
+            .and_then(|obj| obj.abilities.get(ability_index))
+            .expect("test source should carry the mana ability");
+        PendingManaAbility::new(
+            player,
+            source_id,
+            ability_index,
+            ability,
+            mana_sources::source_could_produce_two_or_more_colors(state, source_id, player),
+            ManaAbilityResume::Priority,
+            color_override,
+        )
+    }
+
+    fn pending_mana_ability_with_def(
+        player: PlayerId,
+        source_id: ObjectId,
+        ability: &AbilityDefinition,
+        color_override: Option<ProductionOverride>,
+    ) -> PendingManaAbility {
+        PendingManaAbility::new(
+            player,
+            source_id,
+            0,
+            ability,
+            false,
+            ManaAbilityResume::Priority,
+            color_override,
+        )
     }
 
     #[test]
@@ -5160,23 +5263,9 @@ mod tests {
             color_options: vec![ManaColor::Red, ManaColor::Green],
             contribution: ManaContribution::Base,
         });
-        Arc::make_mut(&mut obj.abilities).push(ability);
+        Arc::make_mut(&mut obj.abilities).push(ability.clone());
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: source,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(PlayerId(0), source, &ability, None);
         let prompt = ManaChoicePrompt::SingleColor {
             options: vec![ManaType::Red, ManaType::Green],
         };
@@ -5208,6 +5297,244 @@ mod tests {
     }
 
     #[test]
+    fn self_sacrificing_two_color_mana_choice_uses_activation_snapshot() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(9100),
+            PlayerId(0),
+            "Two-Color Spawn".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = two_color_self_sacrificing_mana_ability();
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.is_token = true;
+        Arc::make_mut(&mut obj.abilities).push(ability.clone());
+
+        let mut events = Vec::new();
+        let waiting = activate_mana_ability(
+            &mut state,
+            source,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .expect("activation should pay the self-sacrifice cost and ask for color");
+
+        let (prompt, pending) = match waiting {
+            WaitingFor::ChooseManaColor {
+                choice, context, ..
+            } => (choice, expect_mana_ability_context(context)),
+            other => panic!("expected ChooseManaColor, got {other:?}"),
+        };
+        assert_eq!(state.objects.get(&source).unwrap().zone, Zone::Graveyard);
+        Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).clear();
+
+        handle_choose_mana_color(
+            &mut state,
+            &pending,
+            &prompt,
+            ManaChoice::SingleColor(ManaType::Green),
+            &mut events,
+        )
+        .expect("snapshot should resolve after the live source ability is gone");
+
+        let produced = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .find(|unit| unit.source_id == source && unit.color == ManaType::Green)
+            .expect("chosen green mana should be produced");
+        assert!(
+            produced.source_could_produce_two_or_more_colors,
+            "mana must retain activation-time two-color source quality"
+        );
+    }
+
+    #[test]
+    fn self_sacrificing_banana_choice_survives_serialized_prompt_and_gains_life() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(9102),
+            PlayerId(0),
+            "Banana".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = two_color_self_sacrificing_mana_ability();
+        ability.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                player: TargetFilter::Controller,
+            },
+        )));
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.is_token = true;
+        Arc::make_mut(&mut obj.abilities).push(ability);
+
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::ActivateAbility {
+                source_id: source,
+                ability_index: 0,
+            },
+        )
+        .expect("Banana token mana ability should activate into a color prompt");
+
+        assert_eq!(state.objects.get(&source).unwrap().zone, Zone::Graveyard);
+        Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).clear();
+        let serialized_prompt = serde_json::to_value(&state.waiting_for).unwrap();
+        state.waiting_for = serde_json::from_value(serialized_prompt).unwrap();
+
+        crate::game::engine::apply_as_current(
+            &mut state,
+            crate::types::actions::GameAction::ChooseManaColor {
+                choice: ManaChoice::SingleColor(ManaType::Green),
+                count: 1,
+            },
+        )
+        .expect("serialized snapshot should resolve after the live ability is gone");
+
+        let produced = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .find(|unit| unit.source_id == source && unit.color == ManaType::Green)
+            .expect("chosen green mana should be produced");
+        assert!(produced.source_could_produce_two_or_more_colors);
+        assert_eq!(state.players[0].life, 22, "Banana life rider resolved");
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::Priority {
+                player: PlayerId(0)
+            }
+        ));
+    }
+
+    #[test]
+    fn mana_ability_resume_uses_snapshot_after_intermediate_mana_payment() {
+        let mut state = GameState::new_two_player(42);
+        let (ruins, ability) = setup_sunken_ruins(&mut state);
+        seed_pool_with(&mut state, PlayerId(0), ManaType::Blue, 1);
+        seed_pool_with(&mut state, PlayerId(0), ManaType::Black, 1);
+
+        let mut events = Vec::new();
+        let waiting = activate_mana_ability(
+            &mut state,
+            ruins,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .expect("hybrid sub-cost should require a payment choice");
+
+        let (options, pending) = match waiting {
+            WaitingFor::PayManaAbilityMana {
+                options,
+                pending_mana_ability,
+                ..
+            } => (options, pending_mana_ability),
+            other => panic!("expected PayManaAbilityMana, got {other:?}"),
+        };
+        Arc::make_mut(&mut state.objects.get_mut(&ruins).unwrap().abilities).clear();
+
+        let waiting = handle_pay_mana_ability_mana(
+            &mut state,
+            &options,
+            &pending,
+            &[ManaType::Blue],
+            &mut events,
+        )
+        .expect("snapshot should carry the ability through the intermediate payment");
+        let (prompt, pending) = match waiting {
+            WaitingFor::ChooseManaColor {
+                choice, context, ..
+            } => (choice, expect_mana_ability_context(context)),
+            other => panic!("expected ChooseManaColor after payment, got {other:?}"),
+        };
+
+        handle_choose_mana_color(
+            &mut state,
+            &pending,
+            &prompt,
+            ManaChoice::Combination(vec![ManaType::Blue, ManaType::Black]),
+            &mut events,
+        )
+        .expect("snapshot should resolve the output choice after live ability removal");
+
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Blue), 1);
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Black), 2);
+        assert!(state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .filter(|unit| unit.source_id == ruins)
+            .all(|unit| unit.source_could_produce_two_or_more_colors));
+    }
+
+    #[test]
+    fn direct_mana_resolution_preserves_source_quality_after_self_sacrifice() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(9101),
+            PlayerId(0),
+            "Direct Two-Color Spawn".to_string(),
+            Zone::Battlefield,
+        );
+        let ability = two_color_self_sacrificing_mana_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability.clone());
+
+        let mut events = Vec::new();
+        resolve_mana_ability(
+            &mut state,
+            source,
+            PlayerId(0),
+            &ability,
+            &mut events,
+            Some(ProductionOverride::SingleColor(ManaType::Red)),
+        )
+        .expect("direct mana resolution should survive self-sacrifice");
+
+        let produced = state.players[0]
+            .mana_pool
+            .mana
+            .iter()
+            .find(|unit| unit.source_id == source && unit.color == ManaType::Red)
+            .expect("red mana should be produced");
+        assert!(produced.source_could_produce_two_or_more_colors);
+    }
+
+    #[test]
+    fn pending_mana_ability_deserializes_without_activation_snapshot() {
+        let ability = two_color_self_sacrificing_mana_ability();
+        let pending = PendingManaAbility::new(
+            PlayerId(0),
+            ObjectId(10),
+            0,
+            &ability,
+            true,
+            ManaAbilityResume::Priority,
+            None,
+        );
+        let mut payload = serde_json::to_value(&pending).unwrap();
+        payload
+            .as_object_mut()
+            .unwrap()
+            .remove("activation_snapshot");
+
+        let decoded: PendingManaAbility = serde_json::from_value(payload).unwrap();
+        assert!(decoded.activation_snapshot.is_none());
+    }
+
+    #[test]
     fn handle_choose_mana_color_resolves_pain_land_damage_for_each_color() {
         for chosen in [ManaType::Green, ManaType::White] {
             let mut state = GameState::new_two_player(42);
@@ -5222,23 +5549,10 @@ mod tests {
             obj.card_types
                 .core_types
                 .push(crate::types::card_type::CoreType::Land);
-            Arc::make_mut(&mut obj.abilities).push(brushland_colored_ability());
+            let ability = brushland_colored_ability();
+            Arc::make_mut(&mut obj.abilities).push(ability.clone());
 
-            let pending = PendingManaAbility {
-                player: PlayerId(0),
-                source_id: source,
-                ability_index: 0,
-                color_override: None,
-                resume: ManaAbilityResume::Priority,
-                chosen_tappers: Vec::new(),
-                chosen_discards: Vec::new(),
-                chosen_mana_payment: None,
-                chosen_counter_count: None,
-                chosen_exiled: Vec::new(),
-                chosen_sacrificed_battlefield: Vec::new(),
-                cost_paid_object: None,
-                batch_siblings: Vec::new(),
-            };
+            let pending = pending_mana_ability_with_def(PlayerId(0), source, &ability, None);
             let prompt = ManaChoicePrompt::SingleColor {
                 options: vec![ManaType::Green, ManaType::White],
             };
@@ -5450,23 +5764,10 @@ mod tests {
         obj.card_types
             .core_types
             .push(crate::types::card_type::CoreType::Land);
-        Arc::make_mut(&mut obj.abilities).push(sunken_ruins_colored_ability());
+        let ability = sunken_ruins_colored_ability();
+        Arc::make_mut(&mut obj.abilities).push(ability.clone());
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: ruins,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(PlayerId(0), ruins, &ability, None);
         let prompt = ManaChoicePrompt::Combination {
             options: vec![
                 vec![ManaType::Blue, ManaType::Blue],
@@ -5551,23 +5852,10 @@ mod tests {
         obj.card_types
             .core_types
             .push(crate::types::card_type::CoreType::Land);
-        Arc::make_mut(&mut obj.abilities).push(sunken_ruins_colored_ability());
+        let ability = sunken_ruins_colored_ability();
+        Arc::make_mut(&mut obj.abilities).push(ability.clone());
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: ruins,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(PlayerId(0), ruins, &ability, None);
         let prompt = ManaChoicePrompt::Combination {
             options: vec![
                 vec![ManaType::Blue, ManaType::Blue],
@@ -6452,21 +6740,7 @@ mod tests {
         // Handler rejects a payment vector not present in `options`.
         let mut state = GameState::new_two_player(42);
         let (ruins, _ability) = setup_sunken_ruins(&mut state);
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: ruins,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_from_state(&state, PlayerId(0), ruins, 0, None);
         let options = vec![vec![ManaType::Blue], vec![ManaType::Black]];
         let mut events = Vec::new();
         let result = handle_pay_mana_ability_mana(
@@ -6819,21 +7093,7 @@ mod tests {
             .push(crate::types::card_type::CoreType::Land);
         Arc::make_mut(&mut obj.abilities).push(brushland_colored_ability());
 
-        let pending = PendingManaAbility {
-            player: PlayerId(1),
-            source_id: brushland,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_from_state(&state, PlayerId(1), brushland, 0, None);
         let prompt = ManaChoicePrompt::SingleColor {
             options: vec![ManaType::Green, ManaType::White],
         };
@@ -7377,21 +7637,8 @@ mod tests {
             "Second graveyard card".to_string(),
             Zone::Graveyard,
         );
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: source,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let ability = make_titans_nest_ability();
+        let pending = pending_mana_ability_with_def(PlayerId(0), source, &ability, None);
 
         let result = handle_exile_for_mana_ability(
             &mut state,
@@ -7418,7 +7665,7 @@ mod tests {
             Zone::Battlefield,
         );
         let ability = make_phyrexian_altar_ability();
-        Arc::make_mut(&mut state.objects.get_mut(&altar).unwrap().abilities).push(ability);
+        Arc::make_mut(&mut state.objects.get_mut(&altar).unwrap().abilities).push(ability.clone());
 
         let creature = spawn_creature_with_cost(
             &mut state,
@@ -7445,21 +7692,12 @@ mod tests {
                 },
             }));
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: altar,
-            ability_index: 0,
-            color_override: Some(ProductionOverride::SingleColor(ManaType::Black)),
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(
+            PlayerId(0),
+            altar,
+            &ability,
+            Some(ProductionOverride::SingleColor(ManaType::Black)),
+        );
 
         let result = handle_sacrifice_for_mana_ability(
             &mut state,
@@ -7556,8 +7794,8 @@ mod tests {
             Zone::Battlefield,
         );
         // Stash the food-chain ability so the dispatch can find it by index.
-        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities)
-            .push(make_food_chain_ability());
+        let ability = make_food_chain_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities).push(ability.clone());
 
         // 3-MV creature: cost {2}{G}.
         let three_cost = ManaCost::Cost {
@@ -7568,21 +7806,12 @@ mod tests {
             spawn_creature_with_cost(&mut state, PlayerId(0), "Grizzly Bears", three_cost);
 
         // Player picks the creature to exile via the resume handler.
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: chain,
-            ability_index: 0,
-            color_override: Some(ProductionOverride::SingleColor(ManaType::Green)),
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(
+            PlayerId(0),
+            chain,
+            &ability,
+            Some(ProductionOverride::SingleColor(ManaType::Green)),
+        );
         let mut events = Vec::new();
         let _ = handle_exile_for_mana_ability(
             &mut state,
@@ -7619,8 +7848,8 @@ mod tests {
             "Food Chain".to_string(),
             Zone::Battlefield,
         );
-        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities)
-            .push(make_food_chain_ability());
+        let ability = make_food_chain_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities).push(ability.clone());
 
         // 0-MV creature (Memnite-style): no shards, no generic.
         let zero_cost = ManaCost::Cost {
@@ -7629,21 +7858,12 @@ mod tests {
         };
         let creature = spawn_creature_with_cost(&mut state, PlayerId(0), "Memnite", zero_cost);
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: chain,
-            ability_index: 0,
-            color_override: Some(ProductionOverride::SingleColor(ManaType::Red)),
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(
+            PlayerId(0),
+            chain,
+            &ability,
+            Some(ProductionOverride::SingleColor(ManaType::Red)),
+        );
         let mut events = Vec::new();
         let _ = handle_exile_for_mana_ability(
             &mut state,
@@ -7771,8 +7991,8 @@ mod tests {
             "Food Chain".to_string(),
             Zone::Battlefield,
         );
-        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities)
-            .push(make_food_chain_ability());
+        let ability = make_food_chain_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&chain).unwrap().abilities).push(ability.clone());
 
         let three_cost = ManaCost::Cost {
             shards: vec![ManaCostShard::Green],
@@ -7781,21 +8001,12 @@ mod tests {
         let creature =
             spawn_creature_with_cost(&mut state, PlayerId(0), "Grizzly Bears", three_cost);
 
-        let pending = PendingManaAbility {
-            player: PlayerId(0),
-            source_id: chain,
-            ability_index: 0,
-            color_override: Some(ProductionOverride::SingleColor(ManaType::Green)),
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        };
+        let pending = pending_mana_ability_with_def(
+            PlayerId(0),
+            chain,
+            &ability,
+            Some(ProductionOverride::SingleColor(ManaType::Green)),
+        );
         let mut events = Vec::new();
         let _ = handle_exile_for_mana_ability(
             &mut state,

--- a/crates/engine/src/game/mulligan.rs
+++ b/crates/engine/src/game/mulligan.rs
@@ -12,6 +12,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
+use super::engine::EngineError;
 use super::turns;
 
 /// CR 103.5: A player's starting hand size is normally seven cards.
@@ -177,20 +178,27 @@ pub fn handle_mulligan_decision(
     player: PlayerId,
     choice: MulliganChoice,
     events: &mut Vec<GameEvent>,
-) -> Result<WaitingFor, String> {
+) -> Result<WaitingFor, EngineError> {
     let free_first = free_first_mulligan(state);
 
     // Snapshot the current pending list (we own a clone because the engine
     // borrows `state.waiting_for` immutably during match dispatch).
     let WaitingFor::MulliganDecision { pending, .. } = &state.waiting_for else {
-        return Err("handle_mulligan_decision called outside MulliganDecision".to_string());
+        return Err(EngineError::InvalidAction(
+            "handle_mulligan_decision called outside MulliganDecision".to_string(),
+        ));
     };
     let mut pending = pending.clone();
 
     let idx = pending
         .iter()
         .position(|e| e.player == player)
-        .ok_or_else(|| format!("Player {:?} is not in the mulligan pending set", player))?;
+        .ok_or_else(|| {
+            EngineError::InvalidAction(format!(
+                "Player {:?} is not in the mulligan pending set",
+                player
+            ))
+        })?;
     let current_count = pending[idx].mulligan_count;
 
     match choice {
@@ -223,12 +231,13 @@ pub fn handle_mulligan_decision(
             // object is in the actor's hand and is named "Serum Powder"
             // (CR 201.2 — name match is exact), then exile the entire hand
             // and redraw the same number of cards. Mulligan count unchanged.
-            handle_serum_powder(state, player, object_id, events)?;
+            handle_serum_powder(state, player, object_id, events)
+                .map_err(EngineError::InvalidAction)?;
             // Player remains in `pending` with the same mulligan_count.
         }
     }
 
-    Ok(advance_after_decision(state, pending, free_first, events))
+    advance_after_decision(state, pending, free_first, events)
 }
 
 /// CR 103.5b + Serum Powder Oracle text: "Any time you could mulligan and this
@@ -316,23 +325,23 @@ fn advance_after_decision(
     pending: Vec<MulliganDecisionEntry>,
     free_first: bool,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
     if !pending.is_empty() {
-        return WaitingFor::MulliganDecision {
+        return Ok(WaitingFor::MulliganDecision {
             pending,
             free_first_mulligan: free_first,
-        };
+        });
     }
 
     // All players have locked in their hands. Build the bottoms-phase pending
     // list from each player's final mulligan count.
-    enter_bottom_phase(state, events)
+    try_enter_bottom_phase(state, events)
 }
 
-/// CR 103.5: Enter the bottoms phase. Each player who took at least one
-/// counted mulligan (after free-first discount) must put N cards on the
-/// bottom of their library. Players choose simultaneously.
-fn enter_bottom_phase(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
+fn try_enter_bottom_phase(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     let free_first = free_first_mulligan(state);
     let pending: Vec<MulliganBottomEntry> = state
         .seat_order
@@ -366,9 +375,9 @@ fn enter_bottom_phase(state: &mut GameState, events: &mut Vec<GameEvent>) -> Wai
     if pending.is_empty() {
         state.final_mulligan_counts.clear();
         state.prepaid_mulligan_bottoms.clear();
-        finish_mulligans(state, events)
+        try_finish_mulligans(state, events)
     } else {
-        WaitingFor::MulliganBottomCards { pending }
+        Ok(WaitingFor::MulliganBottomCards { pending })
     }
 }
 
@@ -428,19 +437,27 @@ pub fn handle_mulligan_bottom(
     player: PlayerId,
     cards: Vec<ObjectId>,
     events: &mut Vec<GameEvent>,
-) -> Result<WaitingFor, String> {
+) -> Result<WaitingFor, EngineError> {
     let WaitingFor::MulliganBottomCards { pending } = &state.waiting_for else {
-        return Err("handle_mulligan_bottom called outside MulliganBottomCards".to_string());
+        return Err(EngineError::InvalidAction(
+            "handle_mulligan_bottom called outside MulliganBottomCards".to_string(),
+        ));
     };
     let mut pending = pending.clone();
 
     let idx = pending
         .iter()
         .position(|e| e.player == player)
-        .ok_or_else(|| format!("Player {:?} is not in the bottoms pending set", player))?;
+        .ok_or_else(|| {
+            EngineError::InvalidAction(format!(
+                "Player {:?} is not in the bottoms pending set",
+                player
+            ))
+        })?;
     let expected_count = pending[idx].count;
 
-    validate_bottom_selection(state, player, &cards, expected_count)?;
+    validate_bottom_selection(state, player, &cards, expected_count)
+        .map_err(EngineError::InvalidAction)?;
 
     // CR 103.5: pregame bottoming — route to the library bottom through the
     // pipeline's library-placement arm under the `PregameProcedure` exempt
@@ -456,7 +473,7 @@ pub fn handle_mulligan_bottom(
     if pending.is_empty() {
         state.final_mulligan_counts.clear();
         state.prepaid_mulligan_bottoms.clear();
-        Ok(finish_mulligans(state, events))
+        try_finish_mulligans(state, events)
     } else {
         Ok(WaitingFor::MulliganBottomCards { pending })
     }
@@ -528,24 +545,32 @@ pub fn resume_begin_game_abilities(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> WaitingFor {
+    try_resume_begin_game_abilities(state, events)
+        .expect("begin-game ability resume phase trigger prompt construction failed")
+}
+
+pub(super) fn try_resume_begin_game_abilities(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     while let Some(pending) = state.pending_begin_game_abilities.pop() {
-        let _ = resolve_ability_chain(state, &pending.ability, events, 0);
+        resolve_ability_chain(state, &pending.ability, events, 0).map_err(|err| {
+            EngineError::InvalidAction(format!("begin-game ability resolution failed: {err}"))
+        })?;
         if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-            return state.waiting_for.clone();
+            return Ok(state.waiting_for.clone());
         }
     }
 
     state.resolving_begin_game_abilities = false;
-    turns::auto_advance(state, events)
+    turns::try_auto_advance(state, events)
 }
 
-/// CR 103.5 + CR 800.4a: Re-entry point for elimination cleanup — drives the
-/// flow to the bottoms phase as if the decision phase had ended naturally.
-pub(crate) fn enter_bottom_phase_public(
+pub(crate) fn try_enter_bottom_phase_public(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
-    enter_bottom_phase(state, events)
+) -> Result<WaitingFor, EngineError> {
+    try_enter_bottom_phase(state, events)
 }
 
 /// TL:R 906.6a: Re-entry point after pruning an opening-hand bottom prompt.
@@ -553,20 +578,20 @@ pub(crate) fn enter_normal_mulligan_public(state: &GameState) -> WaitingFor {
     normal_mulligan_decision(state)
 }
 
-/// CR 103.5 + CR 800.4a: Re-entry point for elimination cleanup — drives the
-/// flow to game start as if all bottoms had been submitted.
-pub(crate) fn finish_mulligans_public(
+pub(crate) fn try_finish_mulligans_public(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
-    finish_mulligans(state, events)
+) -> Result<WaitingFor, EngineError> {
+    try_finish_mulligans(state, events)
 }
 
-/// All players have kept. Start the game properly.
-fn finish_mulligans(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
+fn try_finish_mulligans(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     queue_begin_game_abilities(state);
     state.resolving_begin_game_abilities = true;
-    resume_begin_game_abilities(state, events)
+    try_resume_begin_game_abilities(state, events)
 }
 
 fn shuffle_hand_into_library(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
@@ -670,7 +695,7 @@ mod tests {
         player: PlayerId,
         object_id: ObjectId,
         events: &mut Vec<GameEvent>,
-    ) -> Result<WaitingFor, String> {
+    ) -> Result<WaitingFor, EngineError> {
         let wf = handle_mulligan_decision(
             state,
             player,
@@ -686,7 +711,7 @@ mod tests {
         player: PlayerId,
         cards: Vec<ObjectId>,
         events: &mut Vec<GameEvent>,
-    ) -> Result<WaitingFor, String> {
+    ) -> Result<WaitingFor, EngineError> {
         let wf = handle_mulligan_bottom(state, player, cards, events)?;
         state.waiting_for = wf.clone();
         Ok(wf)

--- a/crates/engine/src/game/priority.rs
+++ b/crates/engine/src/game/priority.rs
@@ -2,6 +2,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{AutoPassMode, GameState, WaitingFor};
 use crate::types::player::PlayerId;
 
+use super::engine::EngineError;
 use super::players;
 use super::turns;
 
@@ -24,7 +25,7 @@ pub fn handle_priority_pass(
     current_seat: PlayerId,
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
     // Record this seat's pass (CR 117.4).
     state.priority_passes.insert(current_seat);
 
@@ -59,11 +60,11 @@ pub fn handle_priority_pass(
                     .as_ref()
                     .is_some_and(|c| !c.regular_damage_done);
             if combat_damage_incomplete {
-                turns::auto_advance(state, events)
+                Ok(turns::try_auto_advance(state, events)?)
             } else {
                 // CR 117.4: Empty stack — advance to next phase.
                 turns::advance_phase(state, events);
-                turns::auto_advance(state, events)
+                Ok(turns::try_auto_advance(state, events)?)
             }
         } else {
             // CR 117.4: Non-empty stack — resolve the next object. A batch-safe
@@ -86,11 +87,11 @@ pub fn handle_priority_pass(
             // request player interaction.
             if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
                 reset_priority(state);
-                WaitingFor::Priority {
+                Ok(WaitingFor::Priority {
                     player: state.active_player,
-                }
+                })
             } else {
-                state.waiting_for.clone()
+                Ok(state.waiting_for.clone())
             }
         }
     } else {
@@ -103,7 +104,7 @@ pub fn handle_priority_pass(
 
         events.push(GameEvent::PriorityPassed { player_id: next });
 
-        WaitingFor::Priority { player: next }
+        Ok(WaitingFor::Priority { player: next })
     }
 }
 
@@ -182,7 +183,8 @@ mod tests {
         let mut state = setup();
         let mut events = Vec::new();
 
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         assert!(matches!(
             result,
@@ -202,7 +204,8 @@ mod tests {
         state.priority_player = PlayerId(1);
 
         let mut events = Vec::new();
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // Should advance past combat to PostCombatMain
         assert!(matches!(result, WaitingFor::Priority { .. }));
@@ -246,7 +249,8 @@ mod tests {
             .push(crate::types::card_type::CoreType::Instant);
 
         let mut events = Vec::new();
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         assert!(matches!(
             result,
@@ -279,7 +283,8 @@ mod tests {
         let mut state = setup_three_player();
         let mut events = Vec::new();
 
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // P0 passes, priority goes to P1
         assert!(matches!(
@@ -298,9 +303,11 @@ mod tests {
         let mut events = Vec::new();
 
         // P0 passes
-        handle_priority_pass(state.priority_player, &mut state, &mut events);
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
         // P1 passes
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // Still not all 3 have passed, priority goes to P2
         assert!(matches!(
@@ -318,11 +325,14 @@ mod tests {
         let mut events = Vec::new();
 
         // P0 passes
-        handle_priority_pass(state.priority_player, &mut state, &mut events);
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
         // P1 passes
-        handle_priority_pass(state.priority_player, &mut state, &mut events);
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
         // P2 passes - all 3 have passed
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // Should advance phase (empty stack)
         assert!(matches!(result, WaitingFor::Priority { .. }));
@@ -351,7 +361,8 @@ mod tests {
         let mut events = Vec::new();
 
         // P0 passes
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // Should skip P1 and go to P2
         assert!(matches!(
@@ -371,9 +382,11 @@ mod tests {
         let mut events = Vec::new();
 
         // P0 passes -> P2
-        handle_priority_pass(state.priority_player, &mut state, &mut events);
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
         // P2 passes -> both living players passed
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // Should advance phase (2 living players both passed)
         assert!(matches!(result, WaitingFor::Priority { .. }));
@@ -392,7 +405,8 @@ mod tests {
         let mut events = Vec::new();
 
         // P0 (active team member) passes
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // In APNAP order with P0 active: P0, P1 (teammate), P2, P3
         // Next should be P1 (teammate on active team)
@@ -415,10 +429,14 @@ mod tests {
         let mut events = Vec::new();
 
         // All 4 pass in APNAP order
-        handle_priority_pass(state.priority_player, &mut state, &mut events); // P0
-        handle_priority_pass(state.priority_player, &mut state, &mut events); // P1
-        handle_priority_pass(state.priority_player, &mut state, &mut events); // P2
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events); // P3
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass"); // P0
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass"); // P1
+        handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass"); // P2
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass"); // P3
 
         // All passed, should advance
         assert!(matches!(result, WaitingFor::Priority { .. }));
@@ -485,7 +503,8 @@ mod tests {
         });
 
         let mut events = Vec::new();
-        let result = handle_priority_pass(state.priority_player, &mut state, &mut events);
+        let result = handle_priority_pass(state.priority_player, &mut state, &mut events)
+            .expect("priority pass");
 
         // RevealHand should set RevealChoice, and priority pass should preserve it
         assert!(

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -16,6 +16,7 @@ use crate::types::proposed_event::ProposedEvent;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
+use super::engine::EngineError;
 use super::speed::{controls_start_your_engines, set_speed};
 use super::zones;
 
@@ -24,6 +25,13 @@ const MAX_SBA_ITERATIONS: u32 = 9;
 /// CR 704.3: Run state-based actions in a fixpoint loop until no more actions are performed,
 /// capped at MAX_SBA_ITERATIONS.
 pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    try_check_state_based_actions(state, events).expect("state-based action check failed");
+}
+
+pub fn try_check_state_based_actions(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     // CR 604.2: Re-evaluate layers so computed P/T reflects current static abilities.
     if state.layers_dirty.is_dirty() {
         // Snapshot P/T before layer re-evaluation for delta logging.
@@ -82,11 +90,11 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
             for &loser in &losers {
                 events.push(GameEvent::PlayerLost { player_id: loser });
             }
-            super::elimination::eliminate_players_simultaneously(state, &losers, events);
+            super::elimination::try_eliminate_players_simultaneously(state, &losers, events)?;
 
             // If the game ended (a sole winner or a CR 104.4a draw), stop now.
             if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-                return;
+                return Ok(());
             }
         }
 
@@ -95,7 +103,7 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
         // ask the player, similar to the legend rule.
         check_commander_zone_return(state);
         if matches!(state.waiting_for, WaitingFor::CommanderZoneChoice { .. }) {
-            return;
+            return Ok(());
         }
 
         // CR 704.5f: A creature with toughness 0 or less is put into its owner's graveyard.
@@ -106,7 +114,7 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
 
         // CR 614.3 / CR 701.19b: If a regeneration replacement choice is pending, pause SBA evaluation.
         if state.pending_replacement.is_some() {
-            return;
+            return Ok(());
         }
 
         // CR 704.5j: If a player controls two or more legendary permanents with the same name,
@@ -177,6 +185,8 @@ pub fn check_state_based_actions(state: &mut GameState, events: &mut Vec<GameEve
             break;
         }
     }
+
+    Ok(())
 }
 
 /// CR 704.5z + CR 702.179a: If a player controls a permanent with start your engines!

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -14,7 +14,7 @@ use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
     DelayedTrigger, DistributionUnit, GameState, MayTriggerOrigin, StackEntry, StackEntryKind,
-    TargetSelectionConstraint,
+    TargetSelectionConstraint, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::WardCost;
@@ -31,6 +31,7 @@ use super::conditions::{
     eval_is_initiative, eval_is_monarch, eval_no_monarch, eval_source_entered_this_turn,
     eval_source_in_zone, eval_source_is_attacking, eval_source_is_tapped,
 };
+use super::engine::EngineError;
 use super::filter::{
     matches_target_filter, matches_target_filter_on_damage_record_source,
     spell_record_matches_filter, FilterContext,
@@ -3700,9 +3701,9 @@ pub(crate) fn should_drain_deferred_triggers_now(state: &GameState) -> bool {
 pub(crate) fn drain_deferred_trigger_queue(
     state: &mut GameState,
     events_out: &mut Vec<GameEvent>,
-) -> Option<crate::types::game_state::WaitingFor> {
+) -> Result<Option<WaitingFor>, EngineError> {
     if !should_drain_deferred_triggers_now(state) {
-        return None;
+        return Ok(None);
     }
 
     drain_deferred_trigger_queue_unchecked(state, events_out)
@@ -3717,9 +3718,9 @@ pub(crate) fn drain_deferred_trigger_queue(
 pub(crate) fn drain_deferred_triggers_after_stack_object_announcement(
     state: &mut GameState,
     events_out: &mut Vec<GameEvent>,
-) -> Option<crate::types::game_state::WaitingFor> {
+) -> Result<Option<WaitingFor>, EngineError> {
     if !can_drain_deferred_triggers(state, true) {
-        return None;
+        return Ok(None);
     }
 
     drain_deferred_trigger_queue_unchecked(state, events_out)
@@ -3735,7 +3736,7 @@ pub(crate) fn drain_deferred_triggers_after_stack_object_announcement(
 pub(crate) fn drain_deferred_triggers_after_trigger_construction(
     state: &mut GameState,
     events_out: &mut Vec<GameEvent>,
-) -> Option<crate::types::game_state::WaitingFor> {
+) -> Result<Option<WaitingFor>, EngineError> {
     if state.resolving_stack_entry.is_some() {
         drain_deferred_trigger_queue(state, events_out)
     } else {
@@ -3746,13 +3747,13 @@ pub(crate) fn drain_deferred_triggers_after_trigger_construction(
 fn drain_deferred_trigger_queue_unchecked(
     state: &mut GameState,
     events_out: &mut Vec<GameEvent>,
-) -> Option<crate::types::game_state::WaitingFor> {
+) -> Result<Option<WaitingFor>, EngineError> {
     let pending = std::mem::take(&mut state.deferred_triggers);
     match begin_trigger_ordering(state, pending) {
         TriggerOrderingDisposition::PromptForChoice(wf) => {
             let wf = *wf;
             state.waiting_for = wf.clone();
-            Some(wf)
+            Ok(Some(wf))
         }
         TriggerOrderingDisposition::NoChoiceNeeded(pending) => {
             dispatch_deferred_triggers_in_order(state, pending, events_out)
@@ -3766,7 +3767,7 @@ fn dispatch_deferred_triggers_in_order(
     state: &mut GameState,
     pending: Vec<PendingTriggerContext>,
     events_out: &mut Vec<GameEvent>,
-) -> Option<crate::types::game_state::WaitingFor> {
+) -> Result<Option<WaitingFor>, EngineError> {
     let mut iter = pending.into_iter();
     while let Some(trigger_context) = iter.next() {
         if dispatch_pending_trigger_context(state, trigger_context, events_out) {
@@ -3775,14 +3776,12 @@ fn dispatch_deferred_triggers_in_order(
                 state.waiting_for,
                 crate::types::game_state::WaitingFor::DistributeAmong { .. }
             ) {
-                return Some(state.waiting_for.clone());
+                return Ok(Some(state.waiting_for.clone()));
             }
-            return super::engine::begin_pending_trigger_target_selection(state)
-                .ok()
-                .flatten();
+            return super::engine::begin_pending_trigger_target_selection(state);
         }
     }
-    None
+    Ok(None)
 }
 
 /// CR 603.2d: Apply trigger doubling from `StaticMode::DoubleTriggers`
@@ -15716,7 +15715,9 @@ pub mod tests {
             "continuation in flight — must not drain deferred triggers yet"
         );
         assert!(
-            drain_deferred_trigger_queue(&mut state, &mut events).is_none(),
+            drain_deferred_trigger_queue(&mut state, &mut events)
+                .expect("guarded deferred drain should not fail")
+                .is_none(),
             "drain must be a no-op while pending_continuation is set"
         );
         assert_eq!(state.deferred_triggers.len(), 2);
@@ -15734,6 +15735,7 @@ pub mod tests {
         let mut events = Vec::new();
 
         let wf = drain_deferred_trigger_queue(&mut state, &mut events)
+            .expect("deferred trigger drain should not fail")
             .expect("two same-controller deferred triggers require ordering");
         assert!(
             matches!(wf, WaitingFor::OrderTriggers { .. }),

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -18,6 +18,7 @@ use crate::types::zones::Zone;
 use super::combat;
 use super::combat_damage;
 use super::day_night;
+use super::engine::EngineError;
 use super::turn_control;
 use super::zones;
 
@@ -1417,7 +1418,9 @@ fn add_lore_counters_to_sagas(state: &mut GameState, events: &mut Vec<GameEvent>
 ///   - an active trigger prompt (`TriggerTargetSelection`, etc.) when
 ///     `pending_trigger` / `deferred_triggers` still hold unresolved work (CR
 ///     603.3). The caller MUST surface this prompt instead of granting priority.
-fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
+fn process_phase_triggers(
+    state: &mut GameState,
+) -> Result<(bool, Option<WaitingFor>), EngineError> {
     let phase_event = [GameEvent::PhaseChanged { phase: state.phase }];
     let stack_before = state.stack.len();
     let waiting_before = state.waiting_for.clone();
@@ -1433,9 +1436,28 @@ fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
     // longer blindly implies `waiting_for == OrderTriggers`, which is exactly why
     // the prior `.then(|| clone)` idiom was unsafe.
     let order_triggers_prompt = super::triggers::build_next_order_triggers_prompt_public(state);
-    let active_trigger_prompt = (order_triggers_prompt.is_none()
-        && (state.pending_trigger.is_some() || !state.deferred_triggers.is_empty()))
-    .then(|| state.waiting_for.clone());
+    let active_trigger_prompt = if order_triggers_prompt.is_none()
+        && (state.pending_trigger.is_some() || !state.deferred_triggers.is_empty())
+    {
+        if state.pending_trigger.is_some()
+            && !matches!(
+                state.waiting_for,
+                WaitingFor::TriggerTargetSelection { .. } | WaitingFor::DistributeAmong { .. }
+            )
+        {
+            match super::engine::begin_pending_trigger_target_selection(state)? {
+                Some(wf) => {
+                    state.waiting_for = wf.clone();
+                    Some(wf)
+                }
+                None => None,
+            }
+        } else {
+            Some(state.waiting_for.clone())
+        }
+    } else {
+        None
+    };
     // CR 117.5 + CR 118.12a: Unless-pay and other inline resolution prompts arm
     // `waiting_for` without `pending_trigger` after the trigger has reached the
     // stack and begun resolving. Surface any non-priority prompt
@@ -1458,13 +1480,20 @@ fn process_phase_triggers(state: &mut GameState) -> (bool, Option<WaitingFor>) {
         || state.pending_trigger.is_some()
         || !state.deferred_triggers.is_empty()
         || prompt.is_some();
-    (fired, prompt)
+    Ok((fired, prompt))
 }
 
 pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> WaitingFor {
+    try_auto_advance(state, events).expect("auto-advance phase trigger prompt construction failed")
+}
+
+pub(super) fn try_auto_advance(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     loop {
         if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-            return state.waiting_for.clone();
+            return Ok(state.waiting_for.clone());
         }
         // CR 703.4q + CR 616.1: A step-end empty-mana drain paused on a
         // player's CR 616.1 choice. Surface the prompt so the engine round-
@@ -1472,7 +1501,7 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
         // via the `EmptyManaPool` arm of `handle_replacement_choice`.
         if state.pending_phase_transition_progress.is_some() {
             state.deferred_step_trigger_resume = Some(state.phase);
-            return state.waiting_for.clone();
+            return Ok(state.waiting_for.clone());
         }
 
         // CR 800.4: If the active player has been eliminated, skip their
@@ -1490,11 +1519,11 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 if !should_skip_step_now(state, Phase::Untap) {
                     let candidates = untap_choice_candidates(state, state.active_player);
                     if !candidates.is_empty() {
-                        return WaitingFor::UntapChoice {
+                        return Ok(WaitingFor::UntapChoice {
                             player: state.active_player,
                             candidates,
                             chosen_not_to_untap: Vec::new(),
-                        };
+                        });
                     }
                     execute_untap(state, events);
                 }
@@ -1511,18 +1540,18 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // applied before trigger conditions like "if you have the city's blessing"
                 // are evaluated (Twilight Prophet #1375).
                 let waiting_before_sba = state.waiting_for.clone();
-                super::sba::check_state_based_actions(state, events);
+                super::sba::try_check_state_based_actions(state, events)?;
                 if state.waiting_for != waiting_before_sba
                     && !matches!(state.waiting_for, WaitingFor::Priority { .. })
                 {
-                    return state.waiting_for.clone();
+                    return Ok(state.waiting_for.clone());
                 }
                 // CR 503.1a: "At the beginning of [your] upkeep" triggers fire here.
                 // CR 603.3b: 2+ same-controller upkeep triggers (multiple suspended
                 // cards, two Howling Mines) require an ordering choice that must be
                 // surfaced before priority — see `process_phase_triggers`.
-                if let (_, Some(prompt)) = process_phase_triggers(state) {
-                    return prompt;
+                if let (_, Some(prompt)) = process_phase_triggers(state)? {
+                    return Ok(prompt);
                 }
                 // CR 503.2 + CR 117.1c: The active player ALWAYS receives priority
                 // during the upkeep step, regardless of whether triggers fired.
@@ -1530,9 +1559,9 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // user's `phase_stops` / full-control preferences) is decided by
                 // `run_auto_pass_loop` and the frontend, not by skipping the step
                 // here. Mirrors the pattern in PreCombatMain and DeclareBlockers.
-                return WaitingFor::Priority {
+                return Ok(WaitingFor::Priority {
                     player: state.active_player,
-                };
+                });
             }
             Phase::Draw => {
                 // CR 103.8: The starting player skips their first-turn draw
@@ -1549,26 +1578,26 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     continue;
                 }
                 if let Some(wf) = execute_draw(state, events) {
-                    return wf;
+                    return Ok(wf);
                 }
                 // CR 504.2: "At the beginning of [your] draw step" triggers fire here.
                 // CR 603.3b: surface a same-controller ordering prompt before priority.
-                if let (_, Some(prompt)) = process_phase_triggers(state) {
-                    return prompt;
+                if let (_, Some(prompt)) = process_phase_triggers(state)? {
+                    return Ok(prompt);
                 }
                 // CR 504.3 + CR 117.1c: The active player ALWAYS receives priority
                 // during the draw step (after the turn-based draw and any triggers).
                 // See the Upkeep arm above for the rationale — same pattern.
-                return WaitingFor::Priority {
+                return Ok(WaitingFor::Priority {
                     player: state.active_player,
-                };
+                });
             }
             Phase::PreCombatMain | Phase::PostCombatMain => {
                 // CR 714.3b: As the precombat main phase begins, add a lore counter
                 // to each Saga the active player controls (turn-based action).
                 if state.phase == Phase::PreCombatMain {
                     if !add_lore_counters_to_sagas(state, events) {
-                        return state.waiting_for.clone();
+                        return Ok(state.waiting_for.clone());
                     }
                     super::attractions::perform_roll_to_visit_turn_based_action(state, events);
                     // CR 702.xxx: Paradigm (Strixhaven) — turn-based action at
@@ -1580,37 +1609,37 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     // publishes SOS CR update.
                     let active = state.active_player;
                     if super::effects::paradigm::enqueue_offer_if_any(state, active) {
-                        return state.waiting_for.clone();
+                        return Ok(state.waiting_for.clone());
                     }
                 }
                 // CR 603.2b + CR 603.3: beginning-of-main-phase triggers are
                 // put on the stack before the active player receives priority.
                 // CR 603.3b: surface a same-controller ordering prompt first.
-                if let (_, Some(prompt)) = process_phase_triggers(state) {
-                    return prompt;
+                if let (_, Some(prompt)) = process_phase_triggers(state)? {
+                    return Ok(prompt);
                 }
                 // CR 505.6: The active player receives priority during a main phase.
-                return WaitingFor::Priority {
+                return Ok(WaitingFor::Priority {
                     player: state.active_player,
-                };
+                });
             }
             Phase::BeginCombat => {
                 // CR 507.1: "At the beginning of combat" triggers fire here.
                 // Process triggers regardless of attackers — CR 507.1 says the step
                 // happens unconditionally; trigger conditions (e.g., ControlCount)
                 // are checked by the trigger system, not by skipping the step.
-                let (triggers_fired, ordering_prompt) = process_phase_triggers(state);
+                let (triggers_fired, ordering_prompt) = process_phase_triggers(state)?;
                 if triggers_fired {
                     state.combat = Some(crate::game::combat::CombatState::default());
                     // CR 603.3b: surface a same-controller ordering prompt before
                     // priority; combat state is set first so it exists when the
                     // ordered begin-combat triggers later resolve.
                     if let Some(prompt) = ordering_prompt {
-                        return prompt;
+                        return Ok(prompt);
                     }
-                    return WaitingFor::Priority {
+                    return Ok(WaitingFor::Priority {
                         player: state.active_player,
-                    };
+                    });
                 }
                 if combat::has_potential_attackers(state) {
                     state.combat = Some(crate::game::combat::CombatState::default());
@@ -1629,11 +1658,11 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // CR 508.1: Active player declares attackers as a turn-based action.
                 let valid_attacker_ids = super::combat::get_valid_attacker_ids(state);
                 let valid_attack_targets = super::combat::get_valid_attack_targets(state);
-                return WaitingFor::DeclareAttackers {
+                return Ok(WaitingFor::DeclareAttackers {
                     player: state.active_player,
                     valid_attacker_ids,
                     valid_attack_targets,
-                };
+                });
             }
             Phase::DeclareBlockers => {
                 // CR 509.1: Defending player declares blockers as a turn-based action.
@@ -1657,12 +1686,12 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     let valid_blocker_ids: Vec<_> = valid_block_targets.keys().copied().collect();
                     let block_requirements =
                         super::combat::block_requirements_for_player(state, defending);
-                    return WaitingFor::DeclareBlockers {
+                    return Ok(WaitingFor::DeclareBlockers {
                         player: defending,
                         valid_blocker_ids,
                         valid_block_targets,
                         block_requirements,
-                    };
+                    });
                 } else {
                     // CR 508.8: Declare blockers and combat damage steps are skipped if no attackers.
                     state.phase = Phase::EndCombat;
@@ -1681,9 +1710,9 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 super::layers::flush_layers(state);
                 // CR 510.1 / CR 510.2: Combat damage assigned and dealt as a turn-based action.
                 // resolve_combat_damage may pause for interactive assignment (2+ blockers).
-                if let Some(waiting) = combat_damage::resolve_combat_damage(state, events) {
+                if let Some(waiting) = combat_damage::try_resolve_combat_damage(state, events)? {
                     state.waiting_for = waiting.clone();
-                    return waiting;
+                    return Ok(waiting);
                 }
                 // CR 603.3b: combat-damage triggers ran inside resolve_combat_damage
                 // (process_combat_damage_triggers -> process_triggers). If 2+ triggers
@@ -1700,25 +1729,25 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // regular-step case, where resolve_combat_damage returns None but set
                 // `waiting_for` to the OrderTriggers prompt internally.
                 if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-                    return state.waiting_for.clone();
+                    return Ok(state.waiting_for.clone());
                 }
                 // CR 704.3 / CR 800.4: SBAs may have ended the game during combat damage.
                 if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-                    return state.waiting_for.clone();
+                    return Ok(state.waiting_for.clone());
                 }
                 // If triggers were placed on the stack (DamageReceived, dies, etc.),
                 // grant priority so they can resolve before advancing.
                 if !state.stack.is_empty() {
-                    return WaitingFor::Priority {
+                    return Ok(WaitingFor::Priority {
                         player: state.active_player,
-                    };
+                    });
                 }
                 advance_phase(state, events);
                 // Continue to EndCombat
             }
             Phase::EndCombat => {
                 // CR 511.1: "At end of combat" triggers fire here.
-                let (triggers_fired, ordering_prompt) = process_phase_triggers(state);
+                let (triggers_fired, ordering_prompt) = process_phase_triggers(state)?;
                 // CR 511.3: At end of combat, all creatures are removed from combat.
                 state.combat = None;
                 super::layers::prune_end_of_combat_effects(state);
@@ -1732,11 +1761,11 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 if triggers_fired {
                     // CR 603.3b: surface a same-controller ordering prompt before priority.
                     if let Some(prompt) = ordering_prompt {
-                        return prompt;
+                        return Ok(prompt);
                     }
-                    return WaitingFor::Priority {
+                    return Ok(WaitingFor::Priority {
                         player: state.active_player,
-                    };
+                    });
                 }
                 advance_phase(state, events);
                 // Continue to PostCombatMain
@@ -1758,17 +1787,17 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                 // CR 513.1: End step — active player receives priority.
                 // CR 513.1a: "At the beginning of [your] end step" triggers fire here.
                 // CR 603.3b: surface a same-controller ordering prompt before priority.
-                if let (_, Some(prompt)) = process_phase_triggers(state) {
-                    return prompt;
+                if let (_, Some(prompt)) = process_phase_triggers(state)? {
+                    return Ok(prompt);
                 }
-                return WaitingFor::Priority {
+                return Ok(WaitingFor::Priority {
                     player: state.active_player,
-                };
+                });
             }
             Phase::Cleanup => {
                 // CR 514: Cleanup step — discard to hand size (CR 514.1), remove damage and expire effects (CR 514.2).
                 if let Some(waiting) = execute_cleanup(state, events) {
-                    return waiting;
+                    return Ok(waiting);
                 }
                 advance_phase(state, events);
                 // advance_phase handles start_next_turn when wrapping Cleanup -> Untap
@@ -1782,6 +1811,7 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
 mod tests {
     use super::*;
     use crate::game::zones::create_object;
+    use crate::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
     use crate::types::card_type::Supertype;
     use crate::types::identifiers::CardId;
     use crate::types::player::PlayerId;
@@ -1791,6 +1821,72 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         state.turn_number = 1;
         state
+    }
+
+    #[test]
+    fn process_phase_triggers_clears_pending_trigger_without_returning_stale_priority_prompt() {
+        let mut state = setup();
+        state.phase = Phase::Upkeep;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let source_id = ObjectId(99);
+        let pending = crate::game::triggers::PendingTrigger {
+            source_id,
+            controller: PlayerId(0),
+            condition: None,
+            ability: ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                source_id,
+                PlayerId(0),
+            ),
+            timestamp: 1,
+            target_constraints: Vec::new(),
+            distribute: None,
+            trigger_event: None,
+            modal: None,
+            mode_abilities: Vec::new(),
+            description: Some("No target upkeep trigger".to_string()),
+            may_trigger_origin: None,
+            subject_match_count: None,
+            die_result: None,
+        };
+        let pending_for_state = pending.clone();
+        let stack_before = state.stack.len();
+        let mut setup_events = Vec::new();
+        let entry_id = crate::game::triggers::push_pending_trigger_to_stack(
+            &mut state,
+            pending,
+            &mut setup_events,
+        );
+        state.pending_trigger = Some(pending_for_state);
+        state.pending_trigger_entry = Some(entry_id);
+
+        let (fired, prompt) =
+            process_phase_triggers(&mut state).expect("phase trigger processing must succeed");
+
+        assert!(
+            !fired,
+            "a cleaned-up pending trigger with no prompt must not count as active trigger work"
+        );
+        assert!(
+            prompt.is_none(),
+            "stale priority must not be returned as an active phase-trigger prompt"
+        );
+        assert!(state.pending_trigger.is_none());
+        assert!(state.pending_trigger_entry.is_none());
+        assert_eq!(
+            state.stack.len(),
+            stack_before,
+            "defensive cleanup must pop the in-construction stack entry"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -764,21 +764,27 @@ mod tests {
         player: PlayerId,
         source_id: ObjectId,
     ) -> Box<PendingManaAbility> {
-        Box::new(PendingManaAbility {
+        let ability = crate::types::ability::AbilityDefinition::new(
+            crate::types::ability::AbilityKind::Activated,
+            Effect::Mana {
+                produced: crate::types::ability::ManaProduction::Colorless {
+                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        );
+        Box::new(PendingManaAbility::new(
             player,
             source_id,
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        })
+            0,
+            &ability,
+            false,
+            ManaAbilityResume::Priority,
+            None,
+        ))
     }
 
     #[test]

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -35,6 +35,7 @@ use crate::types::proposed_event::{ProposedEvent, ReplacementId};
 use crate::types::zones::{EtbTapState, Zone};
 
 use crate::game::effects::change_zone::shuffle_library;
+use crate::game::engine::EngineError;
 use crate::game::game_object::AttachTarget;
 use crate::types::ability::FaceDownProfile;
 
@@ -832,6 +833,7 @@ pub(crate) fn move_objects_simultaneously(
     events: &mut Vec<GameEvent>,
 ) -> BatchMoveResult {
     move_objects_simultaneously_then(state, reqs, None, events)
+        .expect("batch move without completion cannot fail")
 }
 
 /// CR 603.10a + CR 616.1: As [`move_objects_simultaneously`], but runs a typed
@@ -848,7 +850,7 @@ pub(crate) fn move_objects_simultaneously_then(
     reqs: Vec<ZoneMoveRequest>,
     completion: Option<BatchCompletion>,
     events: &mut Vec<GameEvent>,
-) -> BatchMoveResult {
+) -> Result<BatchMoveResult, EngineError> {
     let ids: Vec<ObjectId> = reqs.iter().map(|r| r.object_id).collect();
     let destination = reqs.first().map(|r| r.to);
     match deliver_batch(state, reqs, &ids, events) {
@@ -856,9 +858,9 @@ pub(crate) fn move_objects_simultaneously_then(
             // Synchronous completion (the common single-redirect path): run the
             // cleanup now.
             if let Some(completion) = completion {
-                run_batch_completion(state, completion, events);
+                run_batch_completion(state, completion, events)?;
             }
-            BatchMoveResult::Done
+            Ok(BatchMoveResult::Done)
         }
         BatchMoveResult::NeedsChoice => {
             // Paused mid-pile. `deliver_batch` stashed the undelivered tail when
@@ -872,7 +874,7 @@ pub(crate) fn move_objects_simultaneously_then(
                 ensure_batch_record(state, destination.unwrap_or(Zone::Graveyard)).completion =
                     Some(completion);
             }
-            BatchMoveResult::NeedsChoice
+            Ok(BatchMoveResult::NeedsChoice)
         }
     }
 }
@@ -885,8 +887,8 @@ fn run_batch_completion(
     state: &mut GameState,
     completion: BatchCompletion,
     events: &mut Vec<GameEvent>,
-) {
-    crate::game::engine_resolution_choices::run_batch_completion(state, completion, events);
+) -> Result<(), EngineError> {
+    crate::game::engine_resolution_choices::run_batch_completion(state, completion, events)
 }
 
 /// CR 303.4f / CR 616.1 + CR 603.10a: Hang a [`BatchCompletion`] off the current
@@ -1045,7 +1047,10 @@ fn stash_batch_tail(state: &mut GameState, tail: Vec<ZoneMoveRequest>, destinati
 /// `mill_double_redirect_choice_continuation` (two sequential parks, no
 /// completion) and `surveil_rest_pile_redirect_continuation` (two sequential
 /// parks WITH a completion that must fire once after the second park drains).
-pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut Vec<GameEvent>) {
+pub(crate) fn drain_pending_batch_deliveries(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     if let Some(pending) = state.pending_batch_deliveries.take() {
         let completion = pending.completion;
         let ids = pending.remaining.clone();
@@ -1075,7 +1080,7 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
                 // when `deliver_batch` did NOT re-park, so the completion fires at
                 // most once per batch.
                 if let Some(completion) = completion {
-                    run_batch_completion(state, completion, events);
+                    run_batch_completion(state, completion, events)?;
                 }
             }
             BatchMoveResult::NeedsChoice => {
@@ -1090,6 +1095,7 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
             }
         }
     }
+    Ok(())
 }
 
 /// Deliver an event that already passed the replacement consult. Only callable

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1768,11 +1768,30 @@ pub enum ManaChoiceContext {
     ResolvingEffect(Box<ResolvedAbility>),
 }
 
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManaAbilityActivationSnapshot {
+    pub ability: AbilityDefinition,
+    pub source_could_produce_two_or_more_colors: bool,
+}
+
+impl std::fmt::Debug for ManaAbilityActivationSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ManaAbilityActivationSnapshot")
+            .field(
+                "source_could_produce_two_or_more_colors",
+                &self.source_could_produce_two_or_more_colors,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingManaAbility {
     pub player: PlayerId,
     pub source_id: ObjectId,
     pub ability_index: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activation_snapshot: Option<ManaAbilityActivationSnapshot>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color_override: Option<ProductionOverride>,
     pub resume: ManaAbilityResume,
@@ -1819,6 +1838,38 @@ pub struct PendingManaAbility {
     /// every non-batchable activation (the default).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub batch_siblings: Vec<ObjectId>,
+}
+
+impl PendingManaAbility {
+    pub fn new(
+        player: PlayerId,
+        source_id: ObjectId,
+        ability_index: usize,
+        ability: &AbilityDefinition,
+        source_could_produce_two_or_more_colors: bool,
+        resume: ManaAbilityResume,
+        color_override: Option<ProductionOverride>,
+    ) -> Self {
+        Self {
+            player,
+            source_id,
+            ability_index,
+            activation_snapshot: Some(ManaAbilityActivationSnapshot {
+                ability: ability.clone(),
+                source_could_produce_two_or_more_colors,
+            }),
+            color_override,
+            resume,
+            chosen_tappers: Vec::new(),
+            chosen_discards: Vec::new(),
+            chosen_mana_payment: None,
+            chosen_counter_count: None,
+            chosen_exiled: Vec::new(),
+            chosen_sacrificed_battlefield: Vec::new(),
+            cost_paid_object: None,
+            batch_siblings: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -8011,21 +8062,26 @@ mod tests {
             count: 1,
             min_count: 0,
             resume: CostResume::ManaAbility {
-                mana_ability: Box::new(PendingManaAbility {
-                    player: PlayerId(0),
-                    source_id: ObjectId(1),
-                    ability_index: 0,
-                    color_override: None,
-                    resume: ManaAbilityResume::Priority,
-                    chosen_tappers: Vec::new(),
-                    chosen_discards: Vec::new(),
-                    chosen_mana_payment: None,
-                    chosen_counter_count: None,
-                    chosen_exiled: Vec::new(),
-                    chosen_sacrificed_battlefield: Vec::new(),
-                    cost_paid_object: None,
-                    batch_siblings: Vec::new(),
-                }),
+                mana_ability: Box::new(PendingManaAbility::new(
+                    PlayerId(0),
+                    ObjectId(1),
+                    0,
+                    &AbilityDefinition::new(
+                        crate::types::ability::AbilityKind::Activated,
+                        crate::types::ability::Effect::Mana {
+                            produced: crate::types::ability::ManaProduction::Colorless {
+                                count: QuantityExpr::Fixed { value: 1 },
+                            },
+                            restrictions: vec![],
+                            grants: vec![],
+                            expiry: None,
+                            target: None,
+                        },
+                    ),
+                    false,
+                    ManaAbilityResume::Priority,
+                    None,
+                )),
             },
         };
         assert!(!tap_mana.has_pending_cast());

--- a/crates/engine/tests/sheoldred_whispering_one_upkeep_770.rs
+++ b/crates/engine/tests/sheoldred_whispering_one_upkeep_770.rs
@@ -1,0 +1,70 @@
+//! Regression coverage for issue #770.
+//!
+//! The reported symptom was that upkeep triggers, including Sheoldred,
+//! Whispering One's graveyard-return trigger, did not activate. This drives the
+//! real Oracle-to-runtime trigger path and requires an interactive target
+//! selection so a one-target auto path cannot mask the bug.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SHEOLDRED_ORACLE: &str =
+    "At the beginning of your upkeep, return target creature card from your graveyard to the battlefield.";
+
+#[test]
+fn sheoldred_whispering_one_upkeep_returns_chosen_creature_from_graveyard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    scenario.add_creature_from_oracle(P0, "Sheoldred, Whispering One", 6, 6, SHEOLDRED_ORACLE);
+    let returned_id = scenario
+        .add_creature_to_graveyard(P0, "Returned Creature", 2, 2)
+        .id();
+    let left_id = scenario
+        .add_creature_to_graveyard(P0, "Left Creature", 3, 3)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.advance_to_upkeep();
+
+    match &runner.state().waiting_for {
+        WaitingFor::TriggerTargetSelection {
+            player,
+            target_slots,
+            ..
+        } => {
+            assert_eq!(*player, P0);
+            assert_eq!(runner.state().active_player, P0);
+            assert_eq!(runner.state().phase, Phase::Upkeep);
+
+            let legal_targets = &target_slots
+                .first()
+                .expect("Sheoldred trigger must have a target slot")
+                .legal_targets;
+            assert!(
+                legal_targets.contains(&TargetRef::Object(returned_id)),
+                "first slot must include the returned creature card"
+            );
+            assert!(
+                legal_targets.contains(&TargetRef::Object(left_id)),
+                "first slot must include the other legal graveyard creature card"
+            );
+        }
+        other => {
+            panic!("expected TriggerTargetSelection for Sheoldred upkeep trigger, got {other:?}")
+        }
+    }
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(returned_id)),
+        })
+        .expect("choosing a legal graveyard creature target must succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(runner.state().objects[&returned_id].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&left_id].zone, Zone::Graveyard);
+}

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1689,21 +1689,27 @@ mod tests {
     }
 
     fn dummy_pending_mana_ability() -> Box<PendingManaAbility> {
-        Box::new(PendingManaAbility {
-            player: PlayerId(0),
-            source_id: ObjectId(1),
-            ability_index: 0,
-            color_override: None,
-            resume: ManaAbilityResume::Priority,
-            chosen_tappers: Vec::new(),
-            chosen_discards: Vec::new(),
-            chosen_mana_payment: None,
-            chosen_counter_count: None,
-            chosen_exiled: Vec::new(),
-            chosen_sacrificed_battlefield: Vec::new(),
-            cost_paid_object: None,
-            batch_siblings: Vec::new(),
-        })
+        let ability = engine::types::ability::AbilityDefinition::new(
+            engine::types::ability::AbilityKind::Activated,
+            Effect::Mana {
+                produced: engine::types::ability::ManaProduction::Colorless {
+                    count: engine::types::ability::QuantityExpr::Fixed { value: 1 },
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        );
+        Box::new(PendingManaAbility::new(
+            PlayerId(0),
+            ObjectId(1),
+            0,
+            &ability,
+            false,
+            ManaAbilityResume::Priority,
+            None,
+        ))
     }
 
     fn prompt_for(waiting_for: WaitingFor) -> Result<AgentPrompt> {


### PR DESCRIPTION
## Summary
Preserves two local commits that were present on this checkout's `main` but are not patch-equivalent to current `origin/main`:

- `ec58a9b5a` Fix phase trigger target prompts
- `628942a1d` Fix mana ability color choice snapshots

## Why
While cleaning the worktree, the staged workflow changes were stale relative to current `origin/main` and would have reverted newer upstream workflow/CI changes, so those were discarded. These two local commits were not present in current main according to `git cherry -v origin/main main`, so they were moved to this branch instead of being lost.

## Validation
Not run during cleanup. This PR is draft for review and validation before merge.