### PR TITLE
feat(pwa): runtime-cache Scryfall images and remaining data JSONs for offline play

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -228,6 +228,70 @@ export default defineConfig(({ mode }) => ({
               expiration: { maxEntries: 50, maxAgeSeconds: 2592000 },
             },
           },
+          {
+            // Remaining data-manifest JSONs (Scryfall lookup maps, precon
+            // decks, draft pools, coverage, set metadata) — served from R2 in
+            // production, site-root in dev/Tauri; the pattern matches both.
+            // R2 serves `max-age=60, must-revalidate` with ETags, so the
+            // StaleWhileRevalidate background refresh is a 304 revalidation,
+            // not a re-download — the cached copy serves instantly and
+            // offline, mirroring the card-locale-sidecars reasoning. Without
+            // this rule the image-URL lookup layer (scryfall-data.json) is
+            // unavailable offline even when the images themselves are cached.
+            urlPattern:
+              /\/(scryfall-data|scryfall-printings|scryfall-token-images|scryfall-sets|card-names|card-data-meta|set-list|decks|draft-pools|coverage-data|coverage-summary)\.json$/,
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "data-json",
+              expiration: { maxEntries: 12, purgeOnQuotaError: true },
+            },
+          },
+          {
+            // Same-origin deck feeds fetched by the home dashboard
+            // (see src/data/feedRegistry.ts). Mutable — regenerated
+            // periodically — so StaleWhileRevalidate.
+            urlPattern: /\/feeds\/[^/]+\.json$/,
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "deck-feeds",
+              expiration: { maxEntries: 16 },
+            },
+          },
+          {
+            // Card imagery from Scryfall's CDNs. Image URLs are content-stable
+            // (upstream serves `max-age=31556952`), so CacheFirst is correct.
+            // `<img>` elements issue no-cors requests whose opaque responses
+            // Chrome pads to ~7MB each against origin quota; `fetchOptions`
+            // upgrades the SW-side fetch to CORS (Scryfall sends
+            // `access-control-allow-origin: *`), so cached entries count at
+            // true size. This cache is also the offline card-image store that
+            // an explicit "download deck for offline" prefetch warms.
+            urlPattern: /^https:\/\/(cards|backs|svgs)\.scryfall\.io\//,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "scryfall-images",
+              fetchOptions: { mode: "cors" },
+              expiration: {
+                maxEntries: 4000,
+                maxAgeSeconds: 31536000,
+                purgeOnQuotaError: true,
+              },
+            },
+          },
+          {
+            // Same-origin static imagery from public/ (battlefield art, nav
+            // icons, logos). Not in the precache manifest — the default glob
+            // only covers js/css/html — and unhashed, so StaleWhileRevalidate
+            // keeps them offline-available without pinning stale copies past
+            // a deploy.
+            urlPattern: ({ sameOrigin, request }) =>
+              sameOrigin && request.destination === "image",
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "static-images",
+              expiration: { maxEntries: 300, purgeOnQuotaError: true },
+            },
+          },
         ],
       },
     }),


### PR DESCRIPTION
Four new Workbox runtimeCaching rules:
- data-json: the 11 data-manifest JSONs (scryfall-data, printings, token
  images, decks, draft-pools, coverage, set metadata) had no rule, so the
  image-URL lookup layer was unavailable offline even when images were
  cached. SWR is cheap: R2 serves max-age=60 + ETags, so background
  refresh is a 304 revalidation.
- deck-feeds: same-origin /feeds/*.json dashboard feeds (feedRegistry.ts).
- scryfall-images: cards/backs/svgs.scryfall.io, CacheFirst (upstream
  max-age is 1 year, URLs content-stable) with fetchOptions mode:cors so
  the SW upgrades the <img> no-cors request — Scryfall sends ACAO:* —
  and cached entries are transparent instead of opaque (Chrome pads
  opaque cache entries ~7MB each against origin quota). LRU 4000 +
  purgeOnQuotaError.
- static-images: same-origin public/ imagery (battlefield art, icons,
  logos) never covered by the js/css/html precache glob.
