### PR TITLE
Fix optional retarget parser misparse

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21729,6 +21729,8 @@ pub(crate) fn parse_effect_chain_ir(
         }
         let (is_optional, opponent_may_scope, implicit_player_scope, text) =
             strip_optional_effect_prefix(&text);
+        let retained_you_may_retarget_optional =
+            !is_optional && starts_with_you_may_choose_new_targets(&text);
         let (unless_same_name_condition, text) = if is_optional {
             if let Some((stripped, unless_cond)) =
                 crate::parser::oracle_effect::conditions::strip_unless_shares_name_with_other_exiled_this_way(
@@ -22472,6 +22474,16 @@ pub(crate) fn parse_effect_chain_ir(
             Effect::ChooseFromZone { zone, .. } => Some(*zone),
             _ => None,
         };
+        // CR 608.2d + CR 115.7d: The chunk loop intentionally keeps the full
+        // `you may choose new targets ...` surface form so the retarget parser
+        // can distinguish true ChangeTargets clauses from copy-retarget riders.
+        // Once that full-surface clause has actually parsed as ChangeTargets,
+        // carry the retained "you may" modal onto the ability.
+        if retained_you_may_retarget_optional
+            && matches!(clause.effect, Effect::ChangeTargets { .. })
+        {
+            clause.optional = true;
+        }
         if let Some(target) = &for_each_reference_target {
             bind_search_library_for_each_antecedent(&mut clause.effect, target, &text_no_qty_lower);
         }
@@ -24681,6 +24693,24 @@ fn constrain_filter_to_stack(filter: TargetFilter) -> TargetFilter {
 /// - "you may choose new targets for [spell phrase]" → scope: `All` (CR 115.7d)
 ///
 /// An optional trailing "to [target phrase]" sets `forced_to`.
+fn starts_with_you_may_choose_new_targets(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    nom_on_lower(text, &lower, |input| {
+        value(
+            (),
+            (
+                tag::<_, _, OracleError<'_>>("you may "),
+                alt((
+                    tag("choose new targets for "),
+                    tag("choose new target for "),
+                )),
+            ),
+        )
+        .parse(input)
+    })
+    .is_some()
+}
+
 fn try_parse_change_targets(lower: &str) -> Option<Effect> {
     type E<'a> = OracleError<'a>;
 
@@ -24691,8 +24721,8 @@ fn try_parse_change_targets(lower: &str) -> Option<Effect> {
         ),
         value(RetargetScope::Single, tag("change a target of ")),
         value(RetargetScope::All, tag("you may choose new targets for ")),
-        // Peeled form when `strip_optional_effect_prefix` correctly declined to
-        // strip a specialized "you may choose new targets" retarget clause.
+        // Peeled form for call sites that have already recorded the governing
+        // "you may" modal before dispatching the retarget body.
         value(RetargetScope::All, tag("choose new targets for ")),
     ))
     .parse(lower)

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -3220,6 +3220,10 @@ fn deflecting_swat_choose_new_targets_for_spell_or_ability() {
     );
     assert_eq!(r.abilities.len(), 1, "abilities={:?}", r.abilities);
     assert!(
+        r.abilities[0].optional,
+        "CR 608.2d: 'you may choose new targets' must stay optional"
+    );
+    assert!(
         matches!(
             r.abilities[0].effect.as_ref(),
             Effect::ChangeTargets {
@@ -3240,6 +3244,49 @@ fn deflecting_swat_choose_new_targets_for_spell_or_ability() {
         panic!("expected Or(StackSpell, StackAbility), got {target:?}");
     };
     assert!(filters.contains(&TargetFilter::StackSpell));
+}
+
+#[test]
+fn speedball_choose_new_targets_trigger_rider_is_optional() {
+    use crate::types::ability::AbilityDefinition;
+    use crate::types::game_state::RetargetScope;
+
+    fn contains_optional_retarget(def: &AbilityDefinition) -> bool {
+        (matches!(
+            def.effect.as_ref(),
+            Effect::ChangeTargets {
+                scope: RetargetScope::All,
+                ..
+            }
+        ) && def.optional)
+            || def
+                .sub_ability
+                .as_deref()
+                .is_some_and(contains_optional_retarget)
+            || def
+                .else_ability
+                .as_deref()
+                .is_some_and(contains_optional_retarget)
+    }
+
+    let r = parse(
+        "Whenever a player casts a spell that targets Speedball, he gets +2/+2 until end of turn. \
+         You may choose new targets for that spell.",
+        "Speedball, New Warrior",
+        &[],
+        &["Creature"],
+        &["Human", "Hero"],
+    );
+
+    assert_eq!(r.triggers.len(), 1, "triggers={:#?}", r.triggers);
+    let exec = r.triggers[0]
+        .execute
+        .as_ref()
+        .expect("Speedball trigger must have an execute ability");
+    assert!(
+        contains_optional_retarget(exec),
+        "trigger body must include optional ChangeTargets rider, got {exec:#?}"
+    );
 }
 
 /// Issue #1990 — Spellskite must parse to forced-self `ChangeTargets` so the

--- a/crates/engine/tests/integration/issue_2938_deflecting_swat.rs
+++ b/crates/engine/tests/integration/issue_2938_deflecting_swat.rs
@@ -1,11 +1,10 @@
 //! Issue #2938 — Deflecting Swat must offer a retarget step for the targeted
 //! spell or ability (CR 115.7d), not silently resolve as a no-op `TargetOnly`.
 //!
-//! Root cause: `strip_optional_effect_prefix` in the effect-chain chunk loop
-//! stripped the leading "you may " from "you may choose new targets for …"
-//! without consulting the specialized-phrase blocklist that `peel_clause` uses.
-//! The peeled remainder failed `try_parse_change_targets` and fell through to
-//! the generic `choose` imperative, producing `TargetOnly { ParentTarget }`.
+//! Root cause: the effect-chain chunk loop must retain the full "you may choose
+//! new targets for ..." surface form so the retarget parser can distinguish true
+//! retarget effects from copy-retarget riders, then carry that retained "you
+//! may" modal onto the parsed `ChangeTargets` ability.
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
@@ -82,8 +81,8 @@ fn deflecting_swat_parses_change_targets_not_target_only() {
         }
     ));
     assert!(
-        !parsed.abilities[0].optional,
-        "retarget is mandatory once Deflecting Swat resolves; optional=false"
+        parsed.abilities[0].optional,
+        "CR 608.2d: 'you may choose new targets' must be optional at resolution"
     );
 
     let Effect::ChangeTargets { target, .. } = parsed.abilities[0].effect.as_ref() else {
@@ -151,6 +150,18 @@ fn deflecting_swat_retargets_opponent_spell_on_stack() {
     });
 
     runner.cast(swat).target_objects(&[bolt_id]).commit();
+
+    pass_priority_until(&mut runner, |waiting| {
+        matches!(waiting, WaitingFor::OptionalEffectChoice { .. })
+    });
+
+    let WaitingFor::OptionalEffectChoice { player, .. } = &runner.state().waiting_for else {
+        unreachable!();
+    };
+    assert_eq!(*player, P0);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept Deflecting Swat retarget choice");
 
     pass_priority_until(&mut runner, |waiting| {
         matches!(waiting, WaitingFor::RetargetChoice { .. })

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -2,9 +2,9 @@
 
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
-- **Canonical root causes:** 38
-- **Distinct cards implicated:** 4890
-- **Total card appearances across root causes:** 4924 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Canonical root causes:** 37
+- **Distinct cards implicated:** 4887
+- **Total card appearances across root causes:** 4921 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -49,7 +49,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 35 | Duplicate / spurious effect or modification emitted | 7 | oracle parser — dedupe search-result continuations and guard against phantom effect nodes |
 | 36 | 'Unless'-payment / escape-cost clause dropped | 6 | oracle parser — attach unless_pay cost / alternative-action branch to the gated effect |
 | 37 | Cost-reduction static spell_filter / condition dropped | 4 | oracle_static.rs ModifyCost — capture spell_filter and gating condition |
-| 38 | 'You may' optionality dropped (mandatory instead of optional) | 3 | oracle parser — set optional:true when 'you may' governs the effect |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
 
@@ -5380,19 +5379,5 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Dragonfire Blade
 - Progenitor's Icon
 - Visions of Ruin
-
-</details>
-
-### 38. 'You may' optionality dropped (mandatory instead of optional)  (3 cards)
-
-**Signature.** An effect's optional flag is false where Oracle 'you may' makes resolution optional.
-
-**Fix hint.** oracle parser — set optional:true when 'you may' governs the effect
-
-<details><summary>Cards</summary>
-
-- Decoy Gambit
-- Deflecting Swat
-- Speedball, New Warrior
 
 </details>


### PR DESCRIPTION
## Summary

- preserve the full `you may choose new targets ...` surface form for retarget parsing, then propagate the retained modal onto parsed `ChangeTargets`
- add parser/runtime regressions for Deflecting Swat and Speedball, including the actual `OptionalEffectChoice` prompt
- remove the fixed optionality root cause from `docs/parser-misparse-backlog.md`

## Parsed Diff Audit

Full before/after `oracle-gen` exports changed only `ChangeTargets.optional: false -> true` for the expected retarget cards:

- Aethersnatch
- Commandeer
- Deflecting Swat
- Insidious Will
- Invert Polarity
- Perplexing Chimera
- Redirect
- Speedball, New Warrior
- Tempt with Mayhem
- Wild Ricochet
- Wyll's Reversal

`Decoy Gambit` was stale in the backlog: the current parse was already correct and unchanged in the before/after export.

## Verification

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `cargo test -p engine --lib choose_new_targets -- --nocapture`
- `cargo test -p engine --test integration deflecting_swat -- --nocapture`
- regenerated before/after card-data exports with `oracle-gen` and audited changed card keys plus retarget nodes
