### PR TITLE
Add Role Reversal (share a permanent type)

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -825,6 +825,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                     SharedQuality::CreatureType => "creature type",
                     SharedQuality::Color => "color",
                     SharedQuality::CardType => "card type",
+                    SharedQuality::PermanentType => "permanent type",
                     SharedQuality::LandType => "land type",
                 };
                 let prefix = match relation {

--- a/crates/engine/src/game/effects/search_library.rs
+++ b/crates/engine/src/game/effects/search_library.rs
@@ -251,6 +251,20 @@ fn selection_has_distinct_quality(
                 None => false,
             })
         }
+        // CR 110.4: distinct-permanent-type check ignores non-permanent card
+        // types (Kindred/Tribal etc.), so only permanent types are inserted.
+        SharedQuality::PermanentType => {
+            let mut seen = std::collections::HashSet::new();
+            chosen.iter().all(|id| match state.objects.get(id) {
+                Some(obj) => obj
+                    .card_types
+                    .core_types
+                    .iter()
+                    .filter(|card_type| card_type.is_permanent_type())
+                    .all(|card_type| seen.insert(*card_type)),
+                None => false,
+            })
+        }
         SharedQuality::CreatureType => {
             distinct_string_sets(state, chosen, |obj| obj.card_types.subtypes.clone())
         }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4515,6 +4515,15 @@ fn shared_quality_values(
             .iter()
             .map(|card_type| format!("{card_type:?}").to_ascii_lowercase())
             .collect(),
+        // CR 110.4: only the six permanent types count; Kindred/Tribal and
+        // other non-permanent card types (CR 205.2a) are excluded, so two
+        // permanents sharing only Kindred do NOT share a permanent type.
+        SharedQuality::PermanentType => source
+            .core_types
+            .iter()
+            .filter(|card_type| card_type.is_permanent_type())
+            .map(|card_type| format!("{card_type:?}").to_ascii_lowercase())
+            .collect(),
         SharedQuality::LandType => source
             .subtypes
             .iter()
@@ -5941,6 +5950,89 @@ mod tests {
         let id = add_creature(&mut state, PlayerId(0), "Bear");
         let filter = TargetFilter::Typed(TypedFilter::permanent());
         assert!(matches_target_filter(&state, id, &filter, id));
+    }
+
+    /// CR 110.4 narrowing regression (maintainer CR on PR #4839): two objects
+    /// that share ONLY a non-permanent card type (Kindred) must NOT be treated
+    /// as sharing a permanent type. The value sets under
+    /// `SharedQuality::PermanentType` are disjoint (Kindred filtered out),
+    /// while under the old `SharedQuality::CardType` mapping they would overlap
+    /// on "kindred" — proving why "share a permanent type" cannot lower to
+    /// `CardType`.
+    #[test]
+    fn shared_permanent_type_excludes_kindred() {
+        let mut state = setup();
+
+        // Object A: Kindred Enchantment. Object B: Kindred Artifact.
+        // They share the Kindred card type but NO permanent type.
+        let a_card = CardId(state.next_object_id);
+        let a = create_object(
+            &mut state,
+            a_card,
+            PlayerId(0),
+            "A".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&a).unwrap();
+            obj.card_types.core_types = vec![CoreType::Kindred, CoreType::Enchantment];
+        }
+        let b_card = CardId(state.next_object_id);
+        let b = create_object(
+            &mut state,
+            b_card,
+            PlayerId(0),
+            "B".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&b).unwrap();
+            obj.card_types.core_types = vec![CoreType::Kindred, CoreType::Artifact];
+        }
+
+        let obj_a = state.objects.get(&a).unwrap();
+        let obj_b = state.objects.get(&b).unwrap();
+        let creature_types: &[String] = &[];
+
+        // Under PermanentType, Kindred is excluded: the value sets are the
+        // singletons {"enchantment"} and {"artifact"} and share nothing.
+        let perm_a = super::object_shared_quality_values_public(
+            obj_a,
+            &SharedQuality::PermanentType,
+            creature_types,
+        );
+        let perm_b = super::object_shared_quality_values_public(
+            obj_b,
+            &SharedQuality::PermanentType,
+            creature_types,
+        );
+        assert_eq!(perm_a, HashSet::from(["enchantment".to_string()]));
+        assert_eq!(perm_b, HashSet::from(["artifact".to_string()]));
+        assert!(
+            perm_a.is_disjoint(&perm_b),
+            "two permanents sharing only Kindred must NOT share a permanent type: {perm_a:?} vs {perm_b:?}"
+        );
+
+        // Sanity: under CardType (the old, wrong mapping) they DO overlap on
+        // "kindred", which is exactly the false positive CR 110.4 forbids.
+        let card_a = super::object_shared_quality_values_public(
+            obj_a,
+            &SharedQuality::CardType,
+            creature_types,
+        );
+        let card_b = super::object_shared_quality_values_public(
+            obj_b,
+            &SharedQuality::CardType,
+            creature_types,
+        );
+        assert!(
+            card_a.contains("kindred") && card_b.contains("kindred"),
+            "CardType mapping would (wrongly) let a shared Kindred satisfy the constraint: {card_a:?} vs {card_b:?}"
+        );
+        assert!(
+            !card_a.is_disjoint(&card_b),
+            "sanity: CardType sets overlap on kindred, proving the old mapping was over-broad"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -21729,6 +21729,48 @@ fn effect_exchange_control_quantified_two_target_creatures() {
 }
 
 #[test]
+fn effect_exchange_control_two_permanents_share_permanent_type() {
+    // Role Reversal: "Exchange control of two target permanents that share a
+    // permanent type." Quantified two-target shape whose shared-quality
+    // suffix uses "permanent type" instead of "card type" (Shifting
+    // Loyalties). CR 110.4 + CR 205.2a: permanent types are card types, so the
+    // constraint lowers to SharedQuality::CardType on both identical slots.
+    use crate::types::ability::{FilterProp, SharedQuality, SharedQualityRelation, TypeFilter};
+    let e = parse_effect("exchange control of two target permanents that share a permanent type");
+    match e {
+        Effect::ExchangeControl { target_a, target_b } => {
+            assert_eq!(
+                target_a, target_b,
+                "quantified shape: both slot filters identical"
+            );
+            let TargetFilter::Typed(ref tf) = target_a else {
+                panic!("target_a should be Typed, got {target_a:?}");
+            };
+            assert!(
+                tf.type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Permanent)),
+                "expected a Permanent type filter, got {:?}",
+                tf.type_filters
+            );
+            assert!(
+                tf.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::SharesQuality {
+                        quality: SharedQuality::CardType,
+                        relation: SharedQualityRelation::Shares,
+                        ..
+                    }
+                )),
+                "expected a shared-card-type constraint, got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("Expected ExchangeControl, got {other:?}"),
+    }
+}
+
+#[test]
 fn effect_exchange_control_compound_distinct_filters() {
     // Compound shape with per-slot legality (Political Trickery / Trade the Helm shape):
     // each slot carries its own controller-relative filter. Assert on the

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -21733,8 +21733,9 @@ fn effect_exchange_control_two_permanents_share_permanent_type() {
     // Role Reversal: "Exchange control of two target permanents that share a
     // permanent type." Quantified two-target shape whose shared-quality
     // suffix uses "permanent type" instead of "card type" (Shifting
-    // Loyalties). CR 110.4 + CR 205.2a: permanent types are card types, so the
-    // constraint lowers to SharedQuality::CardType on both identical slots.
+    // Loyalties). CR 110.4: permanent types are only a SUBSET of the card
+    // types, so the constraint lowers to the narrower
+    // SharedQuality::PermanentType on both identical slots (NOT CardType).
     use crate::types::ability::{FilterProp, SharedQuality, SharedQualityRelation, TypeFilter};
     let e = parse_effect("exchange control of two target permanents that share a permanent type");
     match e {
@@ -21757,12 +21758,12 @@ fn effect_exchange_control_two_permanents_share_permanent_type() {
                 tf.properties.iter().any(|p| matches!(
                     p,
                     FilterProp::SharesQuality {
-                        quality: SharedQuality::CardType,
+                        quality: SharedQuality::PermanentType,
                         relation: SharedQualityRelation::Shares,
                         ..
                     }
                 )),
-                "expected a shared-card-type constraint, got {:?}",
+                "expected a shared-permanent-type constraint, got {:?}",
                 tf.properties
             );
         }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5093,13 +5093,15 @@ pub(crate) fn parse_shared_quality(
         value(SharedQuality::CreatureType, tag("creature type")),
         value(SharedQuality::CardType, tag("card types")),
         value(SharedQuality::CardType, tag("card type")),
-        // CR 110.4 + CR 205.2a: The six permanent types (artifact, battle,
-        // creature, enchantment, land, planeswalker) are a subset of the card
-        // types, so for permanents "share a permanent type" is equivalent to
-        // "share a card type" and maps to the same SharedQuality::CardType
-        // (Role Reversal, Cloudstone Curio).
-        value(SharedQuality::CardType, tag("permanent types")),
-        value(SharedQuality::CardType, tag("permanent type")),
+        // CR 110.4: the six permanent types (artifact, battle, creature,
+        // enchantment, land, planeswalker) are only a SUBSET of the card types.
+        // "share a permanent type" must NOT map to SharedQuality::CardType,
+        // because CR 205.2a card types also include non-permanent types like
+        // Kindred/Tribal: two permanents sharing only Kindred would wrongly
+        // satisfy "share a permanent type". Map to the narrower
+        // SharedQuality::PermanentType instead (Role Reversal, Cloudstone Curio).
+        value(SharedQuality::PermanentType, tag("permanent types")),
+        value(SharedQuality::PermanentType, tag("permanent type")),
         value(SharedQuality::LandType, tag("land types")),
         value(SharedQuality::LandType, tag("land type")),
         value(SharedQuality::Color, tag("colors")),
@@ -11888,15 +11890,17 @@ mod tests {
     }
 
     #[test]
-    fn parse_shared_quality_permanent_type_maps_to_card_type() {
-        // CR 110.4 + CR 205.2a: for permanents, "permanent type" is a card
-        // type, so the shared-quality recognizer maps both the singular and
-        // plural forms to SharedQuality::CardType (Role Reversal wording).
+    fn parse_shared_quality_permanent_type_maps_to_permanent_type() {
+        // CR 110.4: "permanent type" names only the six permanent types, a
+        // strict subset of the card types (CR 205.2a). The recognizer maps
+        // both the singular and plural forms to SharedQuality::PermanentType
+        // (NOT CardType), so a shared non-permanent card type like Kindred
+        // cannot satisfy "share a permanent type" (Role Reversal wording).
         let (rest, q) = parse_shared_quality("permanent type").expect("singular");
-        assert_eq!(q, SharedQuality::CardType);
+        assert_eq!(q, SharedQuality::PermanentType);
         assert!(rest.is_empty(), "remainder: {rest:?}");
         let (rest, q) = parse_shared_quality("permanent types").expect("plural");
-        assert_eq!(q, SharedQuality::CardType);
+        assert_eq!(q, SharedQuality::PermanentType);
         assert!(rest.is_empty(), "remainder: {rest:?}");
     }
 
@@ -11904,7 +11908,9 @@ mod tests {
     fn that_shares_permanent_type_with_it_consumed() {
         // Cloudstone Curio: "... permanent you control that shares a permanent
         // type with it ...". The relative clause must be consumed and lowered
-        // to a SharesQuality{CardType} constraint (previously silently dropped).
+        // to a SharesQuality{PermanentType} constraint (CR 110.4 narrowing:
+        // NOT CardType, so a shared Kindred-only pairing does not match;
+        // previously the clause was silently dropped).
         let (filter, rest) = parse_type_phrase("permanent that shares a permanent type with it");
         let TargetFilter::Typed(ref tf) = filter else {
             panic!("expected Typed filter, got {filter:?}");
@@ -11912,7 +11918,7 @@ mod tests {
         assert!(tf.properties.iter().any(|p| matches!(
             p,
             FilterProp::SharesQuality {
-                quality: SharedQuality::CardType,
+                quality: SharedQuality::PermanentType,
                 relation: SharedQualityRelation::Shares,
                 ..
             }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5093,6 +5093,13 @@ pub(crate) fn parse_shared_quality(
         value(SharedQuality::CreatureType, tag("creature type")),
         value(SharedQuality::CardType, tag("card types")),
         value(SharedQuality::CardType, tag("card type")),
+        // CR 110.4 + CR 205.2a: The six permanent types (artifact, battle,
+        // creature, enchantment, land, planeswalker) are a subset of the card
+        // types, so for permanents "share a permanent type" is equivalent to
+        // "share a card type" and maps to the same SharedQuality::CardType
+        // (Role Reversal, Cloudstone Curio).
+        value(SharedQuality::CardType, tag("permanent types")),
+        value(SharedQuality::CardType, tag("permanent type")),
         value(SharedQuality::LandType, tag("land types")),
         value(SharedQuality::LandType, tag("land type")),
         value(SharedQuality::Color, tag("colors")),
@@ -11876,6 +11883,39 @@ mod tests {
                 reference: Some(reference),
                 relation: SharedQualityRelation::Shares,
             } if matches!(reference.as_ref(), TargetFilter::TrackedSet { id } if *id == TrackedSetId(0))
+        )));
+        assert!(rest.trim().is_empty(), "remainder: {rest:?}");
+    }
+
+    #[test]
+    fn parse_shared_quality_permanent_type_maps_to_card_type() {
+        // CR 110.4 + CR 205.2a: for permanents, "permanent type" is a card
+        // type, so the shared-quality recognizer maps both the singular and
+        // plural forms to SharedQuality::CardType (Role Reversal wording).
+        let (rest, q) = parse_shared_quality("permanent type").expect("singular");
+        assert_eq!(q, SharedQuality::CardType);
+        assert!(rest.is_empty(), "remainder: {rest:?}");
+        let (rest, q) = parse_shared_quality("permanent types").expect("plural");
+        assert_eq!(q, SharedQuality::CardType);
+        assert!(rest.is_empty(), "remainder: {rest:?}");
+    }
+
+    #[test]
+    fn that_shares_permanent_type_with_it_consumed() {
+        // Cloudstone Curio: "... permanent you control that shares a permanent
+        // type with it ...". The relative clause must be consumed and lowered
+        // to a SharesQuality{CardType} constraint (previously silently dropped).
+        let (filter, rest) = parse_type_phrase("permanent that shares a permanent type with it");
+        let TargetFilter::Typed(ref tf) = filter else {
+            panic!("expected Typed filter, got {filter:?}");
+        };
+        assert!(tf.properties.iter().any(|p| matches!(
+            p,
+            FilterProp::SharesQuality {
+                quality: SharedQuality::CardType,
+                relation: SharedQualityRelation::Shares,
+                ..
+            }
         )));
         assert!(rest.trim().is_empty(), "remainder: {rest:?}");
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2813,6 +2813,11 @@ pub enum SharedQuality {
     CardType,
     /// CR 205.3i + CR 305.6: land subtypes, including the five basic land types.
     LandType,
+    /// CR 110.4: the six permanent types only — artifact, battle, creature,
+    /// enchantment, land, planeswalker. Distinct from `CardType` (CR 205.2a),
+    /// which also includes non-permanent types such as Kindred/Tribal; two
+    /// permanents sharing only Kindred do NOT share a permanent type.
+    PermanentType,
 }
 
 /// Relationship required by `FilterProp::SharesQuality`.


### PR DESCRIPTION
## Summary

**Role Reversal** (WAR) — *"Exchange control of two target permanents that share a permanent type."* — parsed to `Effect::Unimplemented`. The shared-quality recognizer `parse_shared_quality()` already handled *"share a **card** type"* (Shifting Loyalties, Burglar's Plot) but not *"share a **permanent** type"*, so Role Reversal's exchange-control clause fell through.

## Change

Per **CR 110.4**, the six permanent types (artifact, battle, creature, enchantment, land, planeswalker) are a subset of the card types (**CR 205.2a**), so for permanents *"share a permanent type"* is equivalent to *"share a card type"*. Add the singular/plural `permanent type[s]` tags to `parse_shared_quality()`, mapping to the same `SharedQuality::CardType`. Role Reversal then lowers to the existing `Effect::ExchangeControl` path — no new effect, filter, or resolver behavior.

**Bonus fix:** Cloudstone Curio shares this phrasing (*"...another permanent you control that shares a permanent type with it..."*) and was **silently dropping** its shared-type constraint; it now captures it as `SharesQuality{CardType}`.

The two `"permanent type"` forms are the only shared-quality uses of the phrase corpus-wide (verified by grep); the other `"permanent type"` occurrences (choose / count / for-each) route through unrelated parsers and never reach `parse_shared_quality`.

## Tests

- `parse_shared_quality_permanent_type_maps_to_card_type` — recognizer unit test (singular + plural).
- `that_shares_permanent_type_with_it_consumed` — Cloudstone Curio return clause.
- `effect_exchange_control_two_permanents_share_permanent_type` — Role Reversal end-to-end → `ExchangeControl` with both slots carrying `SharesQuality{CardType}`.

Verified: rustfmt clean, parser-combinator (Rule Zero) gate pass, `cargo clippy -D warnings` clean, full engine suite **14493 passed; 0 failed**. Fails-before (Role Reversal → `Unimplemented`) / passes-after confirmed.
