### PR TITLE
Fix duplicate Strive static parsing

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1995,6 +1995,33 @@ fn synthesize_etb_exile_ltb_return_pair(triggers: &mut [TriggerDefinition]) {
     }
 }
 
+fn parse_strive_cost_line(line: &str) -> Option<ManaCost> {
+    let stripped = strip_reminder_text(line.trim());
+    let (ability_word, effect_text) = strip_ability_word_with_name(&stripped)?;
+    if ability_word != "strive" {
+        return None;
+    }
+
+    let effect_lower = effect_text.to_lowercase();
+    let ((), rest_original) = nom_on_lower(&effect_text, &effect_lower, |i| {
+        value((), tag("this spell costs ")).parse(i)
+    })?;
+    let (cost, rest_original) = parse_mana_symbols(rest_original)?;
+    let rest_lower = rest_original.to_lowercase();
+    nom_on_lower(rest_original, &rest_lower, |i| {
+        value(
+            (),
+            all_consuming((
+                tag(" more to cast for each target beyond the first"),
+                opt(tag(".")),
+                multispace0,
+            )),
+        )
+        .parse(i)
+    })?;
+    Some(cost)
+}
+
 /// Produce an `OracleDocIr` from Oracle text — the IR-production half of the
 /// parse/lower split (Phase 49, Plan 03).
 ///
@@ -2190,21 +2217,9 @@ pub(crate) fn parse_oracle_ir(
     // Strive lines have the form: "Strive — This spell costs {X} more to cast for each
     // target beyond the first." — extract the per-target surcharge cost.
     for raw in &lines {
-        let stripped = strip_reminder_text(raw.trim());
-        if let Some(effect_text) = strip_ability_word(&stripped) {
-            let effect_lower = effect_text.to_lowercase();
-            if let Some(((), rest_original)) = nom_on_lower(&effect_text, &effect_lower, |i| {
-                value((), tag("this spell costs ")).parse(i)
-            }) {
-                if let Some((mana_part, _)) =
-                    rest_original.split_once(" more to cast for each target beyond the first")
-                {
-                    if let Some((cost, _)) = parse_mana_symbols(mana_part) {
-                        result.strive_cost = Some(cost);
-                        break;
-                    }
-                }
-            }
+        if let Some(cost) = parse_strive_cost_line(raw) {
+            result.strive_cost = Some(cost);
+            break;
         }
     }
 
@@ -3175,6 +3190,10 @@ pub(crate) fn parse_oracle_ir(
             std::borrow::Cow::Borrowed(lower.as_str())
         };
         if is_static_pattern(&static_classify_view) {
+            if result.strive_cost.is_some() && parse_strive_cost_line(&line).is_some() {
+                i += 1;
+                continue;
+            }
             // CR 614.1c / CR 707.9: Lines that are both static-shaped (e.g.
             // trailing "doesn't untap during…" from a reflexive "When you do"
             // clause) and a copy-replacement ("enter as a copy of") must route
@@ -3439,16 +3458,9 @@ pub(crate) fn parse_oracle_ir(
         // Priority 8c-strive: Skip strive lines (cost already extracted in pre-parse above).
         // Must run before Priority 9 (spell imperative catch-all) which would otherwise
         // consume the entire "Strive — This spell costs..." line as an unimplemented ability.
-        if result.strive_cost.is_some() {
-            if let Some(effect_text) = strip_ability_word(&line) {
-                let effect_lower = effect_text.to_lowercase();
-                if lower_starts_with(&effect_lower, "this spell costs ")
-                    && effect_lower.contains("more to cast for each target beyond the first")
-                {
-                    i += 1;
-                    continue;
-                }
-            }
+        if result.strive_cost.is_some() && parse_strive_cost_line(&line).is_some() {
+            i += 1;
+            continue;
         }
 
         // CR 601.3: "Cast this spell only [condition]" — applies to any card type, not just instants/sorceries.

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -11924,6 +11924,16 @@ fn strive_line_consumed_not_reparsed() {
         !has_strive_ability,
         "strive line should be consumed, not produce an ability"
     );
+    assert!(
+        r.statics.is_empty(),
+        "strive line should be consumed, not produce a static: {:#?}",
+        r.statics
+    );
+    assert!(
+        r.parse_warnings.is_empty(),
+        "strive cost should satisfy swallow detection without fake statics: {:?}",
+        r.parse_warnings
+    );
 }
 
 /// CR 207.2c (Strive) + CR 115.1d ("any number of") + CR 707.2 (CopyTokenOf) +

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -1540,10 +1540,10 @@ fn detect_dynamic_qty(
         // `Effect::ProliferateTarget`. The counter-kind iteration is intrinsic to
         // the proliferate operation, not a swallowed `QuantityExpr` count.
         "\"type\":\"ProliferateTarget\"",
-        // CR 702.122: Strive — "this spell costs {N} more for each target
+        // CR 207.2c + CR 601.2f: Strive — "this spell costs {N} more for each target
         // beyond the first" is captured on the top-level `Card` as
         // `strive_cost: Some(ManaCost)`, not inside an ability tree.
-        "\"strive_cost\":{",
+        "\"striveCost\":{",
         // CR 702.139 / CR 702.41: Affinity / Improvise / Convoke style
         // built-in cost mods — captured as `keywords` entries with cost
         // payload, not as in-AST quantity expressions.

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -2,9 +2,9 @@
 
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
-- **Canonical root causes:** 37
-- **Distinct cards implicated:** 4887
-- **Total card appearances across root causes:** 4921 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Canonical root causes:** 36
+- **Distinct cards implicated:** 4876
+- **Total card appearances across root causes:** 4910 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -43,12 +43,11 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 29 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 30 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
 | 31 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
-| 32 | Strive surcharge double-emitted as spurious ModifyCost static | 11 | oracle_static.rs — suppress Strive lines from static cost-modifier dispatch |
-| 33 | 'another'/'other' self-exclusion FilterProp dropped | 10 | oracle_target.rs — re-inject FilterProp::Another after 'another'/'other' is consumed |
-| 34 | Other / uncategorized misparse | 7 | manual triage |
-| 35 | Duplicate / spurious effect or modification emitted | 7 | oracle parser — dedupe search-result continuations and guard against phantom effect nodes |
-| 36 | 'Unless'-payment / escape-cost clause dropped | 6 | oracle parser — attach unless_pay cost / alternative-action branch to the gated effect |
-| 37 | Cost-reduction static spell_filter / condition dropped | 4 | oracle_static.rs ModifyCost — capture spell_filter and gating condition |
+| 32 | 'another'/'other' self-exclusion FilterProp dropped | 10 | oracle_target.rs — re-inject FilterProp::Another after 'another'/'other' is consumed |
+| 33 | Other / uncategorized misparse | 7 | manual triage |
+| 34 | Duplicate / spurious effect or modification emitted | 7 | oracle parser — dedupe search-result continuations and guard against phantom effect nodes |
+| 35 | 'Unless'-payment / escape-cost clause dropped | 6 | oracle parser — attach unless_pay cost / alternative-action branch to the gated effect |
+| 36 | Cost-reduction static spell_filter / condition dropped | 4 | oracle_static.rs ModifyCost — capture spell_filter and gating condition |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
 
@@ -5271,29 +5270,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 32. Strive surcharge double-emitted as spurious ModifyCost static  (11 cards)
-
-**Signature.** Strive line captured in strive_cost but also classified by the static cost-modifier parser, producing a duplicate ModifyCost{empty ObjectCount}.
-
-**Fix hint.** oracle_static.rs — suppress Strive lines from static cost-modifier dispatch
-
-<details><summary>Cards</summary>
-
-- Aerial Formation
-- Consign to Dust
-- Eternal Dominion
-- Fertilid
-- Harness by Force
-- Kiora's Dismissal
-- Launch the Fleet
-- Phalanx Formation
-- Setessan Tactics
-- Silence the Believers
-- Twinflame
-
-</details>
-
-### 33. 'another'/'other' self-exclusion FilterProp dropped  (10 cards)
+### 32. 'another'/'other' self-exclusion FilterProp dropped  (10 cards)
 
 **Signature.** Target/sacrifice filter omits FilterProp::Another; the 'another'/'other' qualifier excluding the source object is not propagated.
 
@@ -5314,7 +5291,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 34. Other / uncategorized misparse  (7 cards)
+### 33. Other / uncategorized misparse  (7 cards)
 
 **Signature.** Cluster did not match a canonical signature class.
 
@@ -5332,7 +5309,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 35. Duplicate / spurious effect or modification emitted  (7 cards)
+### 34. Duplicate / spurious effect or modification emitted  (7 cards)
 
 **Signature.** A single Oracle instruction is lowered to two effects (double ChangeZone after search, duplicate modification) or a phantom node with no Oracle basis is injected.
 
@@ -5350,7 +5327,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 36. 'Unless'-payment / escape-cost clause dropped  (6 cards)
+### 35. 'Unless'-payment / escape-cost clause dropped  (6 cards)
 
 **Signature.** An 'unless its controller pays/sacrifices/discards' alternative is modeled unconditionally; the unless_pay cost or sacrifice-alternative branch is absent.
 
@@ -5367,7 +5344,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 37. Cost-reduction static spell_filter / condition dropped  (4 cards)
+### 36. Cost-reduction static spell_filter / condition dropped  (4 cards)
 
 **Signature.** ModifyCost emitted with spell_filter and/or condition null; the reduction applies to all spells or unconditionally, dropping the type/subtype/state gate.
 


### PR DESCRIPTION
Root cause 32 was caused by Strive cost lines being parsed into strive_cost and then later falling through the static cost-modifier classifier, creating a duplicate ModifyCost static.

Factor the Strive line recognizer through nom, guard the static-priority dispatch with it, and teach the swallow detector to recognize the camelCase striveCost field so removing the fake static does not create a coverage warning.

Parsed-output verification: exact before/after card-data diff changes only 20 Strive cards; each removes the duplicate Strive static_abilities entry, preserves strive_cost, and has zero parse_warnings. Removed the stale/fixed root cause from docs/parser-misparse-backlog.md.

Verification: cargo fmt --all; ./scripts/check-parser-combinators.sh; git diff --check; cargo test -p engine --lib strive -- --nocapture.
