### PR TITLE
fix(engine): preserve Heal delayed draw after PreventDamage (#4826)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     ContinuousModification, CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection,
     Duration, Effect, FilterProp, GameRestriction, ModalSelectionCondition, ObjectScope,
     PlayerFilter, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
-    RestrictionExpiry, RestrictionPlayerScope, StaticCondition, StaticDefinition,
+    RestrictionExpiry, RestrictionPlayerScope, StaticCondition, StaticDefinition, SubAbilityLink,
     TapCreaturesRequirement, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
@@ -399,6 +399,11 @@ pub(crate) fn combined_spell_ability_def(
 }
 
 fn append_to_ability_def_sub_chain(ability: &mut AbilityDefinition, next: AbilityDefinition) {
+    // CR 608.2c: when the cast pipeline merges multiple top-level spell
+    // instructions (multi-line spells or fused split halves), each appended
+    // root is the next printed instruction, not a within-clause continuation.
+    let mut next = next;
+    next.sub_link = SubAbilityLink::SequentialSibling;
     let mut node = ability;
     while node.sub_ability.is_some() {
         node = node

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -38910,3 +38910,123 @@ fn without_paying_graveyard_free_cast_bypasses_paid_offer() {
         "the without_paying graveyard cast must reach the stack for free"
     );
 }
+
+#[test]
+fn combined_spell_ability_def_tags_top_level_spell_tails_sequential_sibling() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_object(
+        &mut state,
+        CardId(97_001),
+        PlayerId(0),
+        "Two-Line Spell".to_string(),
+        Zone::Hand,
+    );
+    let obj = state.objects.get_mut(&spell).unwrap();
+    obj.card_types.core_types.push(CoreType::Instant);
+    obj.base_card_types = obj.card_types.clone();
+    Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    ));
+    Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 2 },
+            player: TargetFilter::Controller,
+        },
+    ));
+
+    let combined = combined_spell_ability_def(state.objects.get(&spell).unwrap())
+        .expect("spell abilities should combine");
+    let sub = combined
+        .sub_ability
+        .as_deref()
+        .expect("second top-level spell instruction should be appended");
+    assert_eq!(
+        sub.sub_link,
+        crate::types::ability::SubAbilityLink::SequentialSibling,
+        "top-level spell instructions must resolve as independent siblings"
+    );
+}
+
+#[test]
+fn heal_draws_on_the_next_turns_upkeep() {
+    use crate::game::scenario::GameScenario;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let heal = scenario
+        .add_spell_to_hand_from_oracle(
+            PlayerId(0),
+            "Heal",
+            true,
+            "Prevent the next 1 damage that would be dealt to any target this turn.\n\
+             Draw a card at the beginning of the next turn's upkeep.",
+        )
+        .id();
+    scenario.add_spell_to_library_top(PlayerId(0), "Future Draw", true);
+
+    let mut runner = scenario.build();
+    runner.cast(heal).target_player(PlayerId(0)).resolve();
+
+    let mut guard = 0;
+    while !(runner.state().phase == Phase::Upkeep && runner.state().active_player == PlayerId(1)) {
+        guard += 1;
+        assert!(
+            guard < 80,
+            "turn progression stalled before the next turn's upkeep"
+        );
+        if !runner.state().stack.is_empty()
+            && matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+        {
+            runner
+                .act(GameAction::PassPriority)
+                .expect("priority pass to resolve stack");
+            continue;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("priority pass to advance the turn");
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare no attackers");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare no blockers");
+            }
+            other => panic!("unexpected waiting state during turn progression: {other:?}"),
+        }
+    }
+
+    while !runner.state().stack.is_empty() {
+        runner
+            .act(GameAction::PassPriority)
+            .expect("resolve delayed trigger");
+    }
+
+    let p0 = runner
+        .state()
+        .players
+        .iter()
+        .find(|player| player.id == PlayerId(0))
+        .expect("player 0 exists");
+    assert_eq!(
+        p0.hand.len(),
+        1,
+        "Heal must draw exactly one card on the next turn's upkeep"
+    );
+}


### PR DESCRIPTION
Fixes #4826.

## Summary
- tag appended top-level spell instructions as `SequentialSibling` when the cast pipeline merges a spell's printed ability list
- keep multi-line spell tails as independent instructions instead of `PreventDamage` riders
- add a direct cast-pipeline regression test for `Heal` and a classification test for combined spell abilities

## Root Cause
`combined_spell_ability_def` merged later top-level spell abilities into the first spell ability's `sub_ability` chain without retagging the appended root. That left the default `ContinuationStep` link in place.

For `Heal`, the delayed draw line was appended under `PreventDamage` as a continuation. The `PreventDamage` resolver intentionally short-circuits continuation sub-abilities because those belong to shield `runtime_execute` riders, so the delayed trigger was skipped entirely.

## Why this fix
Top-level spell abilities and fused-half roots are separate printed instructions under CR 608.2c, not within-clause continuations. Retagging the appended root as `SequentialSibling` fixes `Heal` and the broader class of multi-line spell tails after `PreventDamage` without changing real shield-rider behavior.

## Verification
- `cargo test -p engine --lib combined_spell_ability_def_tags_top_level_spell_tails_sequential_sibling -- --nocapture`
- `cargo test -p engine --lib heal_draws_on_the_next_turns_upkeep -- --nocapture`
- `cargo test -p engine --lib sequential_sibling_sub_is_not_installed_as_shield_rider -- --nocapture`