### PR TITLE
Fix #4836: Mindskinner mills opponents when combat damage is prevented

### DIFF
--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -972,6 +972,23 @@ fn shield_kind_for_rid(state: &GameState, rid: ReplacementId) -> Option<ShieldKi
         .map(|repl| repl.shield_kind)
 }
 
+/// CR 615.5 + CR 510.2: Oracle-text prevention shields carry riders in
+/// `execute`; resolving spells install `runtime_execute` instead. During a
+/// combat-damage batch, `replace_combat_damage_batch` drains `execute` riders
+/// per prevented event inline, while `fire_combat_prevention_riders` handles
+/// only `runtime_execute`.
+fn shield_has_per_event_execute_followup(state: &GameState, rid: ReplacementId) -> bool {
+    let repl = if rid.source == ObjectId(0) {
+        state.pending_damage_replacements.get(rid.index)
+    } else {
+        state
+            .objects
+            .get(&rid.source)
+            .and_then(|obj| obj.replacement_definitions.get(rid.index))
+    };
+    repl.is_some_and(|r| r.execute.is_some() && r.runtime_execute.is_none())
+}
+
 /// CR 614.9: Read back the captured chosen-object recipient stashed in the
 /// matched replacement's `redirect_target` field (set at resolution time for
 /// `DamageRedirectTarget::ChosenObjectTarget` — "to target creature").
@@ -1380,12 +1397,21 @@ fn damage_done_applier(
             // `last_effect_count` stamp are deferred to the post-batch step in
             // `combat_damage.rs` — emitting them per-source here would fragment
             // the rider's `EventContextAmount` across attackers.
-            if prevented_amount > 0 && !accumulated_in_batch {
-                events.push(GameEvent::DamagePrevented {
-                    source_id,
-                    target,
-                    amount: prevented_amount,
-                });
+            //
+            // Exception: `execute`-template shields (Mindskinner, Weeping Angel)
+            // drain per-event inside `replace_combat_damage_batch` and need the
+            // per-event prevented amount stamped here so `EventContextAmount`
+            // resolves when that inline drain runs.
+            let per_event_execute_followup =
+                accumulated_in_batch && shield_has_per_event_execute_followup(state, rid);
+            if prevented_amount > 0 && (!accumulated_in_batch || per_event_execute_followup) {
+                if !accumulated_in_batch {
+                    events.push(GameEvent::DamagePrevented {
+                        source_id,
+                        target,
+                        amount: prevented_amount,
+                    });
+                }
                 // CR 615.5: Stash the prevented amount as the chain's last effect
                 // count so a post-replacement follow-up effect (e.g. Phyrexian
                 // Hydra's "Put a -1/-1 counter on ~ for each 1 damage prevented

--- a/crates/engine/tests/integration/issue_4836_mindskinner.rs
+++ b/crates/engine/tests/integration/issue_4836_mindskinner.rs
@@ -1,0 +1,93 @@
+//! Issue #4836: The Mindskinner prevents combat damage to opponents but must
+//! also mill that many cards for each opponent.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+
+const MINDSKINNER_ORACLE: &str = "The Mindskinner can't be blocked.\n\
+If a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.";
+
+fn resolve_combat(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        match runner.waiting_for_kind() {
+            "DeclareBlockers" => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare blockers");
+            }
+            _ => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+        }
+        if runner.state().phase == Phase::PostCombatMain && runner.state().stack.is_empty() {
+            break;
+        }
+    }
+    runner.advance_until_stack_empty();
+}
+
+#[test]
+fn mindskinner_parses_prevention_with_mill_followup() {
+    let mut scenario = GameScenario::new();
+    let mindskinner = scenario
+        .add_creature_from_oracle(P0, "The Mindskinner", 10, 1, MINDSKINNER_ORACLE)
+        .id();
+    let runner = scenario.build();
+    let repl = runner
+        .state()
+        .objects
+        .get(&mindskinner)
+        .expect("Mindskinner on battlefield")
+        .replacement_definitions
+        .iter_unchecked()
+        .find(|r| r.event == ReplacementEvent::DamageDone)
+        .expect("damage prevention replacement");
+    assert!(
+        repl.execute.is_some(),
+        "Mindskinner must carry a mill follow-up on its prevention replacement"
+    );
+}
+
+#[test]
+fn mindskinner_attack_mills_opponent_for_prevented_damage() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for i in 0..15 {
+        scenario.with_library_top(P1, &[&format!("Opp Library {i}")]);
+    }
+    let mindskinner = scenario
+        .add_creature_from_oracle(P0, "The Mindskinner", 10, 1, MINDSKINNER_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    let opp_library_before = runner.state().players[1].library.len();
+    let opp_life_before = runner.life(P1);
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(mindskinner, AttackTarget::Player(P1))])
+        .expect("declare Mindskinner attacking P1");
+    resolve_combat(&mut runner);
+
+    assert_eq!(
+        runner.life(P1),
+        opp_life_before,
+        "combat damage to the opponent must be prevented"
+    );
+    assert_eq!(
+        runner.state().players[1].library.len(),
+        opp_library_before - 10,
+        "opponent must mill 10 cards (Mindskinner's power) when damage is prevented"
+    );
+    assert!(
+        runner.state().objects[&mindskinner].tapped,
+        "Mindskinner should be tapped from attacking"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -400,6 +400,7 @@ mod issue_4560_winter_soldier;
 mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
+mod issue_4836_mindskinner;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary
- Stamp `last_effect_count` for oracle-text prevention shields during combat damage batches so `EventContextAmount` resolves when their mill rider drains inline.
- Add integration tests covering The Mindskinner's attack preventing damage and milling the opponent for the prevented amount.

## Test plan
- [x] `cargo test -p engine --test integration mindskinner`
- [x] Mindskinner parse test confirms prevention replacement carries a mill follow-up
- [x] Combat integration test confirms opponent life is unchanged and library shrinks by attacker power

Fixes #4836

Made with [Cursor](https://cursor.com)