### PR TITLE
Fix #4835: Intimidation Tactics exiles chosen hand card

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -250,13 +250,12 @@ pub fn resolve(
                     .get(&parent)
                     .is_some_and(|obj| obj.zone == Zone::Hand)
                 {
-                    let tracked_filter =
-                        crate::game::targeting::resolve_tracked_set_sentinel(
-                            state,
-                            TargetFilter::TrackedSet {
-                                id: crate::types::identifiers::TrackedSetId(0),
-                            },
-                        );
+                    let tracked_filter = crate::game::targeting::resolve_tracked_set_sentinel(
+                        state,
+                        TargetFilter::TrackedSet {
+                            id: crate::types::identifiers::TrackedSetId(0),
+                        },
+                    );
                     // Dig tails (Expressive Iteration) keep looked-at cards in a
                     // tracked set with library members — "exile one of them" must
                     // not re-exile the card already put in hand. RevealHand ->

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -250,13 +250,27 @@ pub fn resolve(
                     .get(&parent)
                     .is_some_and(|obj| obj.zone == Zone::Hand)
                 {
-                    exile_tracked_set_library_only = true;
-                    effective_target_filter = crate::game::targeting::resolve_tracked_set_sentinel(
-                        state,
-                        TargetFilter::TrackedSet {
-                            id: crate::types::identifiers::TrackedSetId(0),
-                        },
-                    );
+                    let tracked_filter =
+                        crate::game::targeting::resolve_tracked_set_sentinel(
+                            state,
+                            TargetFilter::TrackedSet {
+                                id: crate::types::identifiers::TrackedSetId(0),
+                            },
+                        );
+                    // Dig tails (Expressive Iteration) keep looked-at cards in a
+                    // tracked set with library members — "exile one of them" must
+                    // not re-exile the card already put in hand. RevealHand ->
+                    // "exile that card" also binds ParentTarget in hand but has
+                    // no library members in the tracked set and must exile the
+                    // chosen hand card directly.
+                    let has_library_member = tracked_set_member_zones(state, &tracked_filter)
+                        .is_some_and(|zones| zones.contains(&Zone::Library));
+                    if has_library_member {
+                        exile_tracked_set_library_only = true;
+                        effective_target_filter = tracked_filter;
+                    } else if origin.is_none() {
+                        origin = Some(Zone::Hand);
+                    }
                 }
             }
         }

--- a/crates/engine/tests/integration/issue_4835_intimidation_tactics.rs
+++ b/crates/engine/tests/integration/issue_4835_intimidation_tactics.rs
@@ -24,14 +24,20 @@ fn reveal_hand_filter(def: &engine::types::ability::AbilityDefinition) -> Option
     }
 }
 
-fn hand_size(runner: &engine::game::scenario::GameRunner, player: engine::types::PlayerId) -> usize {
+fn hand_size(
+    runner: &engine::game::scenario::GameRunner,
+    player: engine::types::PlayerId,
+) -> usize {
     runner.state().players[player.0 as usize].hand.len()
 }
 
 #[test]
 fn intimidation_tactics_parses_exile_continuation() {
     let def = parse_effect_chain(INTIMIDATION_TACTICS, AbilityKind::Spell);
-    let sub = def.sub_ability.as_ref().expect("exile sub after RevealHand");
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("exile sub after RevealHand");
     assert!(
         matches!(
             sub.effect.as_ref(),
@@ -72,20 +78,18 @@ fn intimidation_tactics_parses_artifact_or_creature_reveal_filter() {
 fn intimidation_tactics_exiles_chosen_artifact_or_creature() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    scenario.with_mana_pool(P0, vec![engine::types::mana::ManaUnit::new(
-        engine::types::mana::ManaType::Black,
-        engine::types::identifiers::ObjectId(0),
-        false,
-        vec![],
-    )]);
+    scenario.with_mana_pool(
+        P0,
+        vec![engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Black,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
 
     let spell = scenario
-        .add_spell_to_hand_from_oracle(
-            P0,
-            "Intimidation Tactics",
-            false,
-            INTIMIDATION_TACTICS_FULL,
-        )
+        .add_spell_to_hand_from_oracle(P0, "Intimidation Tactics", false, INTIMIDATION_TACTICS_FULL)
         .id();
 
     let creature_id = scenario.add_creature_to_hand(P1, "Opp Creature", 2, 2).id();

--- a/crates/engine/tests/integration/issue_4835_intimidation_tactics.rs
+++ b/crates/engine/tests/integration/issue_4835_intimidation_tactics.rs
@@ -1,0 +1,129 @@
+//! Issue #4835: Intimidation Tactics must exile a chosen artifact or creature
+//! from the revealed opponent's hand.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect, TargetFilter, TypeFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const INTIMIDATION_TACTICS: &str =
+    "Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.";
+
+const INTIMIDATION_TACTICS_FULL: &str = "\
+Target opponent reveals their hand. You choose an artifact or creature card from it. Exile that card.\n\
+Cycling {3} ({3}, Discard this card: Draw a card.)";
+
+fn reveal_hand_filter(def: &engine::types::ability::AbilityDefinition) -> Option<&TargetFilter> {
+    match def.effect.as_ref() {
+        Effect::RevealHand { card_filter, .. } => Some(card_filter),
+        _ => def.sub_ability.as_deref().and_then(reveal_hand_filter),
+    }
+}
+
+fn hand_size(runner: &engine::game::scenario::GameRunner, player: engine::types::PlayerId) -> usize {
+    runner.state().players[player.0 as usize].hand.len()
+}
+
+#[test]
+fn intimidation_tactics_parses_exile_continuation() {
+    let def = parse_effect_chain(INTIMIDATION_TACTICS, AbilityKind::Spell);
+    let sub = def.sub_ability.as_ref().expect("exile sub after RevealHand");
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ),
+        "expected ParentTarget hand exile sub, got {:?}",
+        sub.effect
+    );
+}
+
+#[test]
+fn intimidation_tactics_parses_artifact_or_creature_reveal_filter() {
+    let def = parse_effect_chain(INTIMIDATION_TACTICS, AbilityKind::Spell);
+    let filter = reveal_hand_filter(&def).expect("RevealHand in chain");
+    assert!(
+        matches!(
+            filter,
+            TargetFilter::Or { filters }
+                if filters.len() == 2
+                    && filters.iter().any(|f| matches!(
+                        f,
+                        TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Artifact)
+                    ))
+                    && filters.iter().any(|f| matches!(
+                        f,
+                        TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)
+                    ))
+        ),
+        "expected artifact-or-creature reveal filter, got {filter:?}"
+    );
+}
+
+#[test]
+fn intimidation_tactics_exiles_chosen_artifact_or_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, vec![engine::types::mana::ManaUnit::new(
+        engine::types::mana::ManaType::Black,
+        engine::types::identifiers::ObjectId(0),
+        false,
+        vec![],
+    )]);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Intimidation Tactics",
+            false,
+            INTIMIDATION_TACTICS_FULL,
+        )
+        .id();
+
+    let creature_id = scenario.add_creature_to_hand(P1, "Opp Creature", 2, 2).id();
+    let artifact = scenario.add_card_to_hand(P1, "Opp Artifact");
+    scenario.add_card_to_hand(P1, "Opp Instant");
+
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&artifact).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.base_card_types = obj.card_types.clone();
+    }
+    let p1_hand_before = hand_size(&runner, P1);
+
+    runner.cast(spell).resolve();
+
+    let eligible = match &runner.state().waiting_for {
+        WaitingFor::RevealChoice { cards, .. } => cards.clone(),
+        other => panic!("expected RevealChoice after reveal, got {other:?}"),
+    };
+    assert_eq!(eligible.len(), 2, "artifact and creature must be choosable");
+    assert!(eligible.contains(&creature_id));
+    assert!(eligible.contains(&artifact));
+
+    let pick = creature_id;
+    runner
+        .act(GameAction::SelectCards { cards: vec![pick] })
+        .expect("choose creature to exile");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&pick].zone,
+        Zone::Exile,
+        "chosen card must be exiled"
+    );
+    assert_eq!(
+        hand_size(&runner, P1),
+        p1_hand_before - 1,
+        "opponent hand must shrink by the exiled card"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -400,6 +400,7 @@ mod issue_4560_winter_soldier;
 mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
+mod issue_4835_intimidation_tactics;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary
- Fix `ChangeZone` hand exiles after `RevealHand` choice so ParentTarget cards in hand are exiled directly instead of being misrouted through dig tracked-set logic.
- Preserve Expressive Iteration dig-tail behavior by only using tracked-set library exile when the looked-at set still has library members.
- Add integration tests for Intimidation Tactics reveal, filter, and exile flow.

## Test plan
- [x] `cargo test -p engine --test integration intimidation_tactics`
- [x] `cargo test -p engine --lib expressive_iteration_dig_chain_reaches_library_bottom_and_exile`

Fixes #4835

Made with [Cursor](https://cursor.com)