### PR TITLE
fix(engine): bind Orvar copy source to triggering spell targets (#4830)

### DIFF
--- a/crates/engine/src/game/effects/choose_one_of.rs
+++ b/crates/engine/src/game/effects/choose_one_of.rs
@@ -411,6 +411,52 @@ mod tests {
     }
 
     #[test]
+    fn explicit_branch_descriptions_reach_waiting_for_prompt() {
+        let mut state = GameState::new_two_player(42);
+        let colorless = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .description("Colorless".to_string());
+        let white = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .description("White".to_string());
+        let ability = ResolvedAbility::new(
+            Effect::ChooseOneOf {
+                chooser: PlayerFilter::Controller,
+                branches: vec![colorless, white],
+            },
+            Vec::new(),
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::ChooseOneOfBranch {
+                branch_descriptions,
+                ..
+            } => {
+                assert_eq!(
+                    branch_descriptions,
+                    &vec!["Colorless".to_string(), "White".to_string()]
+                );
+            }
+            other => panic!("expected ChooseOneOfBranch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn chosen_player_chooser_prompts_chosen_opponent() {
         // CR 608.2c + CR 109.4: A `ChooseOneOf` whose chooser is
         // `PlayerFilter::ChosenPlayer { index: 0 }` must prompt the player

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -466,6 +466,8 @@ fn source_subtype_matches_protection_quality(source_subtype: &str, quality: &str
 
 pub fn source_matches_quality(source: &GameObject, quality: &str) -> bool {
     match quality {
+        // CR 105.2c: An object with no colors is colorless.
+        "colorless" => source.color.is_empty(),
         "monocolored" => source.color.len() == 1,
         "multicolored" => source.color.len() > 1,
         _ => false,
@@ -2327,6 +2329,51 @@ mod tests {
                     } if *ninjutsu_object_id == ninja_id && *creature_to_return == attacker_id
                 ))),
             "Ninjutsu should be grouped under the hand object for frontend playability"
+        );
+    }
+
+    #[test]
+    fn source_matches_quality_colorless_tracks_zero_color_sources() {
+        let mut colorless = make_obj();
+        let mut white = make_obj();
+        white.color.push(ManaColor::White);
+
+        assert!(
+            source_matches_quality(&colorless, "colorless"),
+            "objects with no colors must satisfy the colorless quality"
+        );
+        assert!(
+            !source_matches_quality(&white, "colorless"),
+            "colored objects must not satisfy the colorless quality"
+        );
+
+        colorless.color.push(ManaColor::Blue);
+        assert!(
+            !source_matches_quality(&colorless, "colorless"),
+            "once an object gains a color, the colorless quality must stop matching"
+        );
+    }
+
+    #[test]
+    fn protection_from_colorless_prevents_only_colorless_sources() {
+        let mut protected = make_obj();
+        protected
+            .keywords
+            .push(Keyword::Protection(ProtectionTarget::Quality(
+                "colorless".to_string(),
+            )));
+
+        let colorless_source = make_obj();
+        let mut green_source = make_obj();
+        green_source.color.push(ManaColor::Green);
+
+        assert!(
+            protection_prevents_from(&protected, &colorless_source),
+            "protection from colorless must stop a source with no colors"
+        );
+        assert!(
+            !protection_prevents_from(&protected, &green_source),
+            "protection from colorless must not stop a colored source"
         );
     }
 }

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -2400,7 +2400,7 @@ fn parse_hexproof_filter(s: &str) -> HexproofFilter {
         "black" => HexproofFilter::Color(ManaColor::Black),
         "red" => HexproofFilter::Color(ManaColor::Red),
         "green" => HexproofFilter::Color(ManaColor::Green),
-        "monocolored" | "multicolored" => HexproofFilter::Quality(lower),
+        "colorless" | "monocolored" | "multicolored" => HexproofFilter::Quality(lower),
         // CR 702.11d + CR 105.4 + CR 609.6: "that color" / "the chosen color"
         // anaphors after a preceding `Choose a color` instruction. Resolved at
         // runtime via `ChosenAttribute::Color` on the granting source. Mirrors
@@ -2431,7 +2431,7 @@ pub(crate) fn parse_protection_target(s: &str) -> ProtectionTarget {
         // `source.color.len() == 1`. Multicolored keeps its dedicated variant;
         // monocolored reuses the existing Quality variant (no new variant / no game
         // change). Mirrors parse_hexproof_filter's monocolored→Quality handling.
-        "monocolored" => ProtectionTarget::Quality("monocolored".into()),
+        "colorless" | "monocolored" => ProtectionTarget::Quality(lower),
         // CR 702.16 + CR 105.4: "the chosen color" / "the color of your choice"
         // resolve at runtime from the granting source's `ChosenAttribute::Color`.
         // "color of your choice" is the as-resolved phrasing (Mother of Runes,
@@ -3419,6 +3419,10 @@ mod tests {
             Keyword::Protection(ProtectionTarget::Color(ManaColor::Red))
         );
         assert_eq!(
+            Keyword::from_str("Protection:colorless").unwrap(),
+            Keyword::Protection(ProtectionTarget::Quality("colorless".to_string()))
+        );
+        assert_eq!(
             Keyword::from_str("Protection:from everything").unwrap(),
             Keyword::Protection(ProtectionTarget::Quality("from everything".to_string()))
         );
@@ -3485,6 +3489,33 @@ mod tests {
         assert_eq!(
             parse_protection_target("artifacts"),
             ProtectionTarget::CardType("artifacts".to_string())
+        );
+    }
+
+    /// CR 702.16a + CR 105.2c: "protection from colorless" is a color-quality
+    /// predicate (zero colors), NOT a card type. The runtime reads it through
+    /// `source_matches_quality` the same way as monocolored/multicolored.
+    #[test]
+    fn parse_protection_target_colorless_is_quality_not_card_type() {
+        assert_eq!(
+            parse_protection_target("colorless"),
+            ProtectionTarget::Quality("colorless".to_string())
+        );
+        assert_ne!(
+            parse_protection_target("colorless"),
+            ProtectionTarget::CardType("colorless".to_string())
+        );
+        assert_eq!(
+            Keyword::from_str("Protection:colorless").unwrap(),
+            Keyword::Protection(ProtectionTarget::Quality("colorless".to_string()))
+        );
+        assert_eq!(
+            parse_hexproof_filter("colorless"),
+            HexproofFilter::Quality("colorless".to_string())
+        );
+        assert_eq!(
+            Keyword::from_str("hexproof from colorless").unwrap(),
+            Keyword::HexproofFrom(HexproofFilter::Quality("colorless".to_string()))
         );
     }
 

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -2264,6 +2264,17 @@ enum ConcreteColorOrColorlessChoice {
 }
 
 impl ConcreteColorOrColorlessChoice {
+    fn description(self) -> &'static str {
+        match self {
+            Self::Color(ManaColor::White) => "White",
+            Self::Color(ManaColor::Blue) => "Blue",
+            Self::Color(ManaColor::Black) => "Black",
+            Self::Color(ManaColor::Red) => "Red",
+            Self::Color(ManaColor::Green) => "Green",
+            Self::Colorless => "Colorless",
+        }
+    }
+
     fn protection_target(self) -> engine::types::keywords::ProtectionTarget {
         match self {
             Self::Color(color) => engine::types::keywords::ProtectionTarget::Color(color),
@@ -2311,11 +2322,10 @@ fn lower_choose_color_or_colorless_sequence(
         saw_chosen_ref |=
             rewrite_color_or_colorless_choice_refs_in_effects(&mut branch_effects, concrete_choice)
                 > 0;
-        branches.push(crate::convert::build_ability_chain(
-            AbilityKind::Spell,
-            None,
-            branch_effects,
-        )?);
+        branches.push(
+            crate::convert::build_ability_chain(AbilityKind::Spell, None, branch_effects)?
+                .description(concrete_choice.description().to_string()),
+        );
     }
 
     if !saw_chosen_ref {
@@ -7190,6 +7200,11 @@ mod tests {
         assert_eq!(branches.len(), 6, "colorless + five colors");
 
         let colorless_branch = &branches[0];
+        assert_eq!(
+            colorless_branch.description.as_deref(),
+            Some("Colorless"),
+            "branch labels must preserve the concrete color choice for UI prompts"
+        );
         match colorless_branch.effect.as_ref() {
             Effect::GenericEffect {
                 static_abilities, ..
@@ -7216,6 +7231,7 @@ mod tests {
         );
 
         let white_branch = &branches[1];
+        assert_eq!(white_branch.description.as_deref(), Some("White"));
         match white_branch.effect.as_ref() {
             Effect::GenericEffect {
                 static_abilities, ..

--- a/crates/mtgish-import/src/convert/action.rs
+++ b/crates/mtgish-import/src/convert/action.rs
@@ -16,7 +16,7 @@ use engine::types::ability::{
 };
 use engine::types::counter::{parse_counter_type, CounterType as EngineCounterType};
 use engine::types::game_state::DistributionUnit;
-use engine::types::mana::ManaCost;
+use engine::types::mana::{ManaColor, ManaCost};
 use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
 use engine::types::zones::Zone;
@@ -2236,6 +2236,10 @@ fn convert_action_vec_with_bindings(
     actions: &[Action],
     inherited: &VariableBindings,
 ) -> ConvResult<Vec<Effect>> {
+    if let Some(lowered) = try_lower_choose_color_or_colorless_sequence(actions, inherited) {
+        return lowered;
+    }
+
     let mut out = Vec::with_capacity(actions.len());
     let mut bindings = inherited.clone();
     for a in actions {
@@ -2251,6 +2255,239 @@ fn convert_action_vec_with_bindings(
         }
     }
     Ok(out)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConcreteColorOrColorlessChoice {
+    Color(ManaColor),
+    Colorless,
+}
+
+impl ConcreteColorOrColorlessChoice {
+    fn protection_target(self) -> engine::types::keywords::ProtectionTarget {
+        match self {
+            Self::Color(color) => engine::types::keywords::ProtectionTarget::Color(color),
+            Self::Colorless => {
+                engine::types::keywords::ProtectionTarget::Quality("colorless".into())
+            }
+        }
+    }
+
+    fn hexproof_filter(self) -> engine::types::keywords::HexproofFilter {
+        match self {
+            Self::Color(color) => engine::types::keywords::HexproofFilter::Color(color),
+            Self::Colorless => engine::types::keywords::HexproofFilter::Quality("colorless".into()),
+        }
+    }
+}
+
+fn try_lower_choose_color_or_colorless_sequence(
+    actions: &[Action],
+    bindings: &VariableBindings,
+) -> Option<ConvResult<Vec<Effect>>> {
+    let [Action::ChooseAColorOrColorless(choice), tail @ ..] = actions else {
+        return None;
+    };
+    if tail.is_empty() {
+        return None;
+    }
+    Some(lower_choose_color_or_colorless_sequence(
+        choice, tail, bindings,
+    ))
+}
+
+fn lower_choose_color_or_colorless_sequence(
+    choice: &crate::schema::types::ChoosableColor,
+    tail: &[Action],
+    bindings: &VariableBindings,
+) -> ConvResult<Vec<Effect>> {
+    let base_effects = convert_action_vec_with_bindings(tail, bindings)?;
+    let choices = concrete_color_or_colorless_choices(choice)?;
+
+    let mut saw_chosen_ref = false;
+    let mut branches = Vec::with_capacity(choices.len());
+    for concrete_choice in choices {
+        let mut branch_effects = base_effects.clone();
+        saw_chosen_ref |=
+            rewrite_color_or_colorless_choice_refs_in_effects(&mut branch_effects, concrete_choice)
+                > 0;
+        branches.push(crate::convert::build_ability_chain(
+            AbilityKind::Spell,
+            None,
+            branch_effects,
+        )?);
+    }
+
+    if !saw_chosen_ref {
+        return Err(ConversionGap::MalformedIdiom {
+            idiom: "ActionList/ChooseAColorOrColorless",
+            path: String::new(),
+            detail: "tail actions never read the chosen color".into(),
+        });
+    }
+
+    Ok(vec![Effect::ChooseOneOf {
+        chooser: PlayerFilter::Controller,
+        branches,
+    }])
+}
+
+fn concrete_color_or_colorless_choices(
+    choice: &crate::schema::types::ChoosableColor,
+) -> ConvResult<Vec<ConcreteColorOrColorlessChoice>> {
+    let choice_type = filter_mod::choice_type_for_choosable_color(choice);
+    let ChoiceType::Color { excluded } = choice_type else {
+        return Err(ConversionGap::MalformedIdiom {
+            idiom: "Action::ChooseAColorOrColorless",
+            path: String::new(),
+            detail: format!("expected color choice, got {choice_type:?}"),
+        });
+    };
+
+    let mut out = Vec::with_capacity(ManaColor::ALL.len() + 1);
+    out.push(ConcreteColorOrColorlessChoice::Colorless);
+    out.extend(
+        ManaColor::ALL
+            .iter()
+            .copied()
+            .filter(|color| !excluded.contains(color))
+            .map(ConcreteColorOrColorlessChoice::Color),
+    );
+    Ok(out)
+}
+
+fn rewrite_color_or_colorless_choice_refs_in_effects(
+    effects: &mut [Effect],
+    concrete_choice: ConcreteColorOrColorlessChoice,
+) -> usize {
+    effects
+        .iter_mut()
+        .map(|effect| rewrite_color_or_colorless_choice_refs_in_effect(effect, concrete_choice))
+        .sum()
+}
+
+fn rewrite_color_or_colorless_choice_refs_in_effect(
+    effect: &mut Effect,
+    concrete_choice: ConcreteColorOrColorlessChoice,
+) -> usize {
+    match effect {
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => static_abilities
+            .iter_mut()
+            .map(|definition| {
+                rewrite_color_or_colorless_choice_refs_in_static_definition(
+                    definition,
+                    concrete_choice,
+                )
+            })
+            .sum(),
+        Effect::ChooseOneOf { branches, .. } => branches
+            .iter_mut()
+            .map(|branch| {
+                rewrite_color_or_colorless_choice_refs_in_ability_definition(
+                    branch,
+                    concrete_choice,
+                )
+            })
+            .sum(),
+        Effect::CreateDelayedTrigger { effect, .. } => {
+            rewrite_color_or_colorless_choice_refs_in_ability_definition(effect, concrete_choice)
+        }
+        Effect::CreateEmblem { statics, triggers } => {
+            let static_count: usize = statics
+                .iter_mut()
+                .map(|definition| {
+                    rewrite_color_or_colorless_choice_refs_in_static_definition(
+                        definition,
+                        concrete_choice,
+                    )
+                })
+                .sum();
+            let trigger_count: usize = triggers
+                .iter_mut()
+                .filter_map(|trigger| trigger.execute.as_mut())
+                .map(|execute| {
+                    rewrite_color_or_colorless_choice_refs_in_ability_definition(
+                        execute,
+                        concrete_choice,
+                    )
+                })
+                .sum();
+            static_count + trigger_count
+        }
+        _ => 0,
+    }
+}
+
+fn rewrite_color_or_colorless_choice_refs_in_ability_definition(
+    ability: &mut AbilityDefinition,
+    concrete_choice: ConcreteColorOrColorlessChoice,
+) -> usize {
+    let mut rewrites =
+        rewrite_color_or_colorless_choice_refs_in_effect(ability.effect.as_mut(), concrete_choice);
+    if let Some(sub) = ability.sub_ability.as_mut() {
+        rewrites +=
+            rewrite_color_or_colorless_choice_refs_in_ability_definition(sub, concrete_choice);
+    }
+    if let Some(otherwise) = ability.else_ability.as_mut() {
+        rewrites += rewrite_color_or_colorless_choice_refs_in_ability_definition(
+            otherwise,
+            concrete_choice,
+        );
+    }
+    rewrites
+}
+
+fn rewrite_color_or_colorless_choice_refs_in_static_definition(
+    definition: &mut StaticDefinition,
+    concrete_choice: ConcreteColorOrColorlessChoice,
+) -> usize {
+    definition
+        .modifications
+        .iter_mut()
+        .map(|modification| {
+            rewrite_color_or_colorless_choice_refs_in_modification(modification, concrete_choice)
+        })
+        .sum()
+}
+
+fn rewrite_color_or_colorless_choice_refs_in_modification(
+    modification: &mut ContinuousModification,
+    concrete_choice: ConcreteColorOrColorlessChoice,
+) -> usize {
+    match modification {
+        ContinuousModification::AddKeyword { keyword } => match keyword {
+            engine::types::keywords::Keyword::Protection(
+                engine::types::keywords::ProtectionTarget::ChosenColor,
+            ) => {
+                *keyword = engine::types::keywords::Keyword::Protection(
+                    concrete_choice.protection_target(),
+                );
+                1
+            }
+            engine::types::keywords::Keyword::HexproofFrom(
+                engine::types::keywords::HexproofFilter::ChosenColor,
+            ) => {
+                *keyword = engine::types::keywords::Keyword::HexproofFrom(
+                    concrete_choice.hexproof_filter(),
+                );
+                1
+            }
+            _ => 0,
+        },
+        ContinuousModification::GrantTrigger { trigger } => trigger
+            .execute
+            .as_mut()
+            .map(|execute| {
+                rewrite_color_or_colorless_choice_refs_in_ability_definition(
+                    execute,
+                    concrete_choice,
+                )
+            })
+            .unwrap_or(0),
+        _ => 0,
+    }
 }
 
 fn actions_are_noop(actions: &[Action]) -> bool {
@@ -6772,16 +7009,18 @@ mod tests {
     use super::*;
     use crate::convert::build_ability_from_actions;
     use crate::schema::types::{
-        CardInGraveyard, Cards, CardtypeVariable, Color, ColorList, Comparison, Condition, Cost,
-        CounterType, CreatableToken, CreatureTokenSubtypes, CreatureTokenType, DamageSources,
-        ManaSymbol, PTXValue, Permanent, Permanents, ReplacementActionWouldEnter, SubType,
+        CardInGraveyard, Cards, CardtypeVariable, ChoosableColor, Color, ColorList, Comparison,
+        Condition, Cost, CounterType, CreatableToken, CreatureTokenSubtypes, CreatureTokenType,
+        DamageSources, Expiration, LayerEffect, ManaSymbol, PTXValue, Permanent, Permanents,
+        Protectable, ProtectableColor, ReplacementActionWouldEnter, Rule, SubType,
         TokenCopyEffects, TokenFlag, PT,
     };
     use engine::types::ability::{
-        AbilityKind, ChoiceType, Comparator, ControllerRef, Effect, FilterProp, QuantityRef,
-        TargetFilter, TypeFilter, TypedFilter,
+        AbilityKind, ChoiceType, Comparator, ContinuousModification, ControllerRef, Effect,
+        FilterProp, PlayerFilter, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
     };
     use engine::types::card_type::CoreType;
+    use engine::types::keywords::{Keyword, ProtectionTarget};
     use engine::types::mana::ManaColor;
 
     // Issue #4201 follow-up — Turnabout's "choose artifact, creature, or
@@ -6927,6 +7166,68 @@ mod tests {
                 ]),),
             }
         );
+    }
+
+    #[test]
+    fn choose_a_color_or_colorless_lowers_to_concrete_choose_one_of_branches() {
+        let effects = convert_list(&Actions::ActionList(vec![
+            Action::ChooseAColorOrColorless(ChoosableColor::AnyColor),
+            Action::CreatePermanentLayerEffectUntil(
+                Box::new(Permanent::ThisPermanent),
+                vec![LayerEffect::AddAbility(vec![Rule::Protection(
+                    Protectable::FromColor(ProtectableColor::TheChosenColor),
+                )])],
+                Expiration::UntilEndOfTurn,
+            ),
+            Action::DrawACard,
+        ]))
+        .unwrap();
+
+        let [Effect::ChooseOneOf { chooser, branches }] = effects.as_slice() else {
+            panic!("expected single ChooseOneOf effect, got {effects:?}");
+        };
+        assert_eq!(*chooser, PlayerFilter::Controller);
+        assert_eq!(branches.len(), 6, "colorless + five colors");
+
+        let colorless_branch = &branches[0];
+        match colorless_branch.effect.as_ref() {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => {
+                assert!(static_abilities.iter().any(|s| s.modifications.contains(
+                    &ContinuousModification::AddKeyword {
+                        keyword: Keyword::Protection(ProtectionTarget::Quality(
+                            "colorless".to_string(),
+                        )),
+                    }
+                )));
+            }
+            other => panic!("expected colorless branch grant, got {other:?}"),
+        }
+        assert!(
+            matches!(
+                colorless_branch
+                    .sub_ability
+                    .as_ref()
+                    .map(|sub| sub.effect.as_ref()),
+                Some(Effect::Draw { .. })
+            ),
+            "branch must preserve follow-on effects"
+        );
+
+        let white_branch = &branches[1];
+        match white_branch.effect.as_ref() {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => {
+                assert!(static_abilities.iter().any(|s| s.modifications.contains(
+                    &ContinuousModification::AddKeyword {
+                        keyword: Keyword::Protection(ProtectionTarget::Color(ManaColor::White)),
+                    }
+                )));
+            }
+            other => panic!("expected white branch grant, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4830.

## Summary
- seed `ParentTarget` spell-cast / spell-copy triggers from the triggering spell's committed object targets when the trigger is pushed to the stack
- reuse a single stack-spell target helper for both trigger seeding and `TriggeringSpellTargetsFilter` checks
- strengthen Orvar integration coverage so it proves the copied token matches the targeted permanent instead of just counting creatures

## Root Cause
`CopyTokenOf { target: ParentTarget }` is the correct parse shape for Orvar, but spell-cast triggers were not inheriting the triggering spell's chosen targets at stack-push time.

When Orvar's trigger resolved, `CopyTokenOf` saw an empty `ability.targets` list and fell back to the trigger source object, so it created an Orvar copy instead of a copy of the permanent the spell had actually targeted.

## Why this fix
The trigger seam already seeds `ParentTarget` for attack batches and for event-context permanents like crew/station/saddle. Spell-cast triggers that anaphorically read the triggering spell's targets are the same class of problem and should be seeded from the stack spell's committed targets before resolution.

That fixes Orvar and the broader class of spell-target-driven `ParentTarget` trigger effects without changing copy resolution itself.

## Verification
- `cargo test -p engine --test integration issue_1341_orvar -- --nocapture`
