### PR TITLE
feat(client): board HUD polish — priority indicator badge + lands/support collapse controls

### DIFF
--- a/client/src/components/board/BattlefieldZoneOverflow.tsx
+++ b/client/src/components/board/BattlefieldZoneOverflow.tsx
@@ -9,10 +9,12 @@ import { ManaSymbol } from "../mana/ManaSymbol.tsx";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import type { ZoneCollapseMode } from "../../stores/preferencesStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import type { GroupedPermanent } from "../../viewmodel/battlefieldProps.ts";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
+import { SelectField } from "../ui/SelectField.tsx";
 import { useBoardInteractionState } from "./BoardInteractionContext.tsx";
 import { BattlefieldRow } from "./BattlefieldRow.tsx";
 import { ResizeHandle } from "../flexlayout/ResizeHandle.tsx";
@@ -26,7 +28,13 @@ interface BattlefieldZoneOverflowProps {
   side: DrawerSide;
   className?: string;
   dividerBeforeIndex?: number;
+  /** Show the per-row collapse control (auto/on/off) on the summary tile. Only
+   *  the local player's own lands/support rows opt in — the setting is a
+   *  viewer-wide preference, so a control per opponent box would be redundant. */
+  showCollapseControl?: boolean;
 }
+
+const ZONE_COLLAPSE_MODES: ZoneCollapseMode[] = ["auto", "on", "off"];
 
 const MOBILE_COLLAPSE_GROUPS = 4;
 const DESKTOP_COLLAPSE_GROUPS = 8;
@@ -60,6 +68,7 @@ export function BattlefieldZoneOverflow({
   side,
   className,
   dividerBeforeIndex,
+  showCollapseControl = false,
 }: BattlefieldZoneOverflowProps) {
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -71,10 +80,24 @@ export function BattlefieldZoneOverflow({
     ? (compact ? MOBILE_COLLAPSE_CREATURE_GROUPS : DESKTOP_COLLAPSE_CREATURE_GROUPS)
     : (compact ? MOBILE_COLLAPSE_GROUPS : DESKTOP_COLLAPSE_GROUPS);
   const objectIds = useMemo(() => groups.flatMap((group) => group.ids), [groups]);
-  // Creatures collapse by stack count (token swarms already group); lands and
-  // support collapse by body count, preserving their established behaviour.
-  const collapseMetric = isCreatures ? groups.length : objectIds.length;
-  const collapsed = collapseMetric > threshold;
+  // Collapse by DISTINCT stack count, never body count: identical permanents
+  // already render as one grouped tile, so 7 Forests + 2 duals reads as ~3
+  // visible stacks — the space a body count of 9 implies is never actually
+  // occupied. Creatures always worked this way (token swarms); lands/support
+  // now match, so the crowding metric tracks what the player actually sees.
+  const collapseMetric = groups.length;
+  // Per-row user override (lands/support). Creatures have no preference, so they
+  // always fall through to "auto" (the threshold compare below).
+  const collapseLands = usePreferencesStore((s) => s.collapseLands);
+  const collapseSupport = usePreferencesStore((s) => s.collapseSupport);
+  const collapseMode: ZoneCollapseMode =
+    zone === "lands" ? collapseLands : zone === "support" ? collapseSupport : "auto";
+  const collapsed =
+    collapseMode === "on"
+      ? true
+      : collapseMode === "off"
+        ? false
+        : collapseMetric > threshold;
 
   useEffect(() => {
     if (!open) return;
@@ -128,6 +151,7 @@ export function BattlefieldZoneOverflow({
           groups={groups}
           objectIds={objectIds}
           zone={zone}
+          showCollapseControl={showCollapseControl}
           onOpen={() => setOpen(true)}
         />
       )}
@@ -279,10 +303,11 @@ interface ZoneSummaryTileProps {
   groups: GroupedPermanent[];
   objectIds: ObjectId[];
   zone: OverflowZone;
+  showCollapseControl: boolean;
   onOpen: () => void;
 }
 
-function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTileProps) {
+function ZoneSummaryTile({ groups, objectIds, zone, showCollapseControl, onOpen }: ZoneSummaryTileProps) {
   const { t } = useTranslation("game");
   const gameState = useGameStore((s) => s.gameState);
   // Aspect-preserving size multiplier for the collapsed overflow pill (absent ⇒
@@ -426,7 +451,7 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
     // button — scales and moves WITH the tile. (transform is visual-only, so a
     // handle outside the scaled node would stay at the unscaled corner.)
     <span
-      className="relative inline-flex"
+      className={`relative inline-flex flex-col gap-0.5 ${zone === "support" ? "items-end" : "items-start"}`}
       style={
         summaryScale !== 1
           ? {
@@ -436,6 +461,9 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
           : undefined
       }
     >
+      {showCollapseControl && (zone === "lands" || zone === "support") && (
+        <ZoneCollapseControl zone={zone} />
+      )}
       <button
         type="button"
         onClick={onOpen}
@@ -502,6 +530,35 @@ function ZoneSummaryTile({ groups, objectIds, zone, onOpen }: ZoneSummaryTilePro
         <ResizeHandle scaleKey="summaryTile" corner={zone === "support" ? "bl" : "br"} />
       )}
     </span>
+  );
+}
+
+/** Compact per-row collapse control (auto / always-on / always-off) shown above
+ *  the summary tile on the local player's own lands/support rows. A native
+ *  <select> keeps it touch-friendly and keyboard-accessible; it reads and writes
+ *  the row's own `collapse{Lands,Support}` preference, so the tile and the
+ *  Preferences-sheet segmented control stay in lockstep through one store value. */
+function ZoneCollapseControl({ zone }: { zone: "lands" | "support" }) {
+  const { t } = useTranslation("game");
+  const value = usePreferencesStore((s) => (zone === "lands" ? s.collapseLands : s.collapseSupport));
+  const setValue = usePreferencesStore((s) =>
+    zone === "lands" ? s.setCollapseLands : s.setCollapseSupport,
+  );
+  return (
+    <SelectField
+      chevronSize="sm"
+      aria-label={t("battlefieldOverflow.collapse.label")}
+      title={t("battlefieldOverflow.collapse.label")}
+      value={value}
+      onChange={(event) => setValue(event.target.value as ZoneCollapseMode)}
+      className="rounded-md border border-white/12 bg-slate-950/72 py-0.5 pl-1.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-slate-300 backdrop-blur-md hover:border-white/25 hover:text-white"
+    >
+      {ZONE_COLLAPSE_MODES.map((mode) => (
+        <option key={mode} value={mode}>
+          {t(`battlefieldOverflow.collapse.${mode}`)}
+        </option>
+      ))}
+    </SelectField>
   );
 }
 

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -279,6 +279,7 @@ export function PlayerArea({
             zone="lands"
             side="left"
             className="justify-start px-0"
+            showCollapseControl={isOwnArea}
           />
         </>
       ),
@@ -301,6 +302,7 @@ export function PlayerArea({
           side="right"
           dividerBeforeIndex={supportDividerIndex}
           className="justify-end px-0"
+          showCollapseControl={isOwnArea}
         />
       ),
     },
@@ -411,8 +413,14 @@ export function PlayerArea({
   ) : null;
 
   const landColumnExtraOverlay = landColumnExtra ? (
+    // The stack anchors at the middle-row bottom and grows upward, so at bottom-0
+    // it rides up over the lowest lands / the collapsed land tile. Drop it into
+    // the outer column's reserved `pb-8` gutter (full, non-compact only — compact
+    // height has no bottom padding to borrow) so it clears the land row.
     <div
-      className="pointer-events-none absolute bottom-0 left-2 z-30"
+      className={`pointer-events-none absolute bottom-0 left-2 z-30 ${
+        isCompactHeight ? "" : "translate-y-8"
+      }`}
       data-testid="land-column-extra"
     >
       <div className="pointer-events-auto">{landColumnExtra}</div>

--- a/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
+++ b/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
@@ -185,16 +185,28 @@ describe("BattlefieldZoneOverflow", () => {
     expect(container.querySelector('[data-grouped-ids~="9"]')).toBe(summary);
   });
 
-  it("collapses from actual object count, not visible group count", () => {
+  it("collapses by distinct stack count, not body count", () => {
+    // 7 Forests + 2 duals reads as 2 visible stacks — far under the threshold —
+    // so a big-but-uniform land row must NOT collapse into the summary tile even
+    // though its body count (9) is high. The crowding metric tracks distinct
+    // stacks (what the player actually sees), not raw object count.
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 500 });
     const groups: GroupedPermanentType[] = [
-      { name: "Forest", ids: [1, 2], count: 2, representative: {} as GroupedPermanentType["representative"] },
-      { name: "Vernal Fen", ids: [3], count: 1, representative: {} as GroupedPermanentType["representative"] },
-      { name: "Swamp", ids: [4], count: 1, representative: {} as GroupedPermanentType["representative"] },
-      { name: "Exotic Orchard", ids: [5], count: 1, representative: {} as GroupedPermanentType["representative"] },
+      { name: "Forest", ids: [1, 2, 3, 4, 5, 6, 7], count: 7, representative: {} as GroupedPermanentType["representative"] },
+      { name: "Vernal Fen", ids: [8, 9], count: 2, representative: {} as GroupedPermanentType["representative"] },
     ];
 
     renderOverflow({ groups });
+
+    expect(screen.queryByRole("button", { name: /open lands drawer/i })).toBeNull();
+  });
+
+  it("collapses once distinct stacks exceed the threshold", () => {
+    // Nine distinct single-card stacks clear the desktop threshold (8), so the
+    // row collapses into the summary tile — the aggregate-space signal the
+    // stack-count metric is meant to catch.
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1400 });
+    renderOverflow({ groups: makeGroups(9) });
 
     expect(screen.getByRole("button", { name: /open lands drawer/i })).toBeInTheDocument();
   });

--- a/client/src/components/hud/TurnStatusLine.tsx
+++ b/client/src/components/hud/TurnStatusLine.tsx
@@ -1,8 +1,10 @@
+import type { ReactNode } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
 import { useSeatColor } from "../../hooks/useSeatColor.ts";
 import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
 import { getOpponentDisplayName } from "../../stores/multiplayerStore.ts";
+import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 
 /**
  * Persistent one-line "who has priority / why" narration. Fills the gap where
@@ -38,31 +40,149 @@ export function TurnStatusLine() {
     ? "border-emerald-400/40 bg-emerald-950/70 text-emerald-50"
     : "border-white/12 bg-slate-950/75 text-slate-200";
 
+  // The pill carries WHO holds the pending decision; a small icon badge overlapping
+  // its corner carries WHAT that decision is (attack / block / target / pay / …),
+  // so the "who + what" reads at a glance without a long sentence. The badge
+  // supersedes the old leading dot — it owns the seat-color tint + attention pulse
+  // AND the reason glyph in one mark. The full sentence still lives in the
+  // hover/focus tooltip (reusing the pre-existing verbose `*Reason` strings — no new
+  // i18n keys), which only mounts when a reason exists. `group`/`relative` are
+  // required for GameplayTooltip's CSS `group-hover` + the badge's absolute anchor,
+  // so the pill can no longer be `pointer-events-none` — fine, it lives in the
+  // interactive action rail, not over the board.
+  const badgeTone = canIActNow
+    ? "border-emerald-300/50 bg-emerald-400 text-emerald-950"
+    : "border-white/20 bg-slate-900/95";
+
   return (
     <div
       role="status"
       aria-live="polite"
-      className={`pointer-events-none flex max-w-[min(22rem,calc(100vw-1.25rem))] items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium tracking-wide shadow-[0_12px_32px_rgba(15,23,42,0.45)] backdrop-blur-xl ${tone} [@media(max-height:500px)]:px-2 [@media(max-height:500px)]:py-0.5 [@media(max-height:500px)]:text-[10px]`}
+      className={`group relative flex max-w-[min(22rem,calc(100vw-1.25rem))] items-center rounded-full border px-2.5 py-1 text-[11px] font-medium tracking-wide shadow-[0_12px_32px_rgba(15,23,42,0.45)] backdrop-blur-xl ${tone} [@media(max-height:500px)]:px-2 [@media(max-height:500px)]:py-0.5 [@media(max-height:500px)]:text-[10px]`}
     >
       <span
         aria-hidden
-        className={`h-2 w-2 shrink-0 rounded-full ${canIActNow ? "bg-emerald-300" : ""} ${waitingOnOpponent ? "animate-pulse" : ""}`}
-        style={canIActNow ? undefined : { backgroundColor: waitingSeatColor }}
-      />
+        className={`pointer-events-none absolute -left-1.5 -top-1.5 z-10 flex h-4 w-4 items-center justify-center rounded-full border shadow-[0_2px_6px_rgba(0,0,0,0.45)] ${badgeTone} ${waitingOnOpponent ? "animate-pulse" : ""}`}
+        style={canIActNow ? undefined : { color: waitingSeatColor, borderColor: `${waitingSeatColor}99` }}
+      >
+        <ReasonIcon reasonKey={reason?.key} />
+      </span>
       <span className="truncate">
         {canIActNow ? (
-          reasonText
-            ? t("status.yourPriorityReason", { reason: reasonText })
-            : t("status.yourPriority")
+          t("status.yourPriority")
         ) : (
           <Trans
             t={t}
-            i18nKey={reasonText ? "status.waitingForReason" : "status.waitingFor"}
-            values={{ player: getOpponentDisplayName(waitingSeatId), reason: reasonText }}
+            i18nKey="status.waitingFor"
+            values={{ player: getOpponentDisplayName(waitingSeatId) }}
             components={{ player: <span style={{ color: waitingSeatColor }} /> }}
           />
         )}
       </span>
+      {reasonText && (
+        <GameplayTooltip className="w-56">
+          {canIActNow ? (
+            t("status.yourPriorityReason", { reason: reasonText })
+          ) : (
+            <Trans
+              t={t}
+              i18nKey="status.waitingForReason"
+              values={{ player: getOpponentDisplayName(waitingSeatId), reason: reasonText }}
+              components={{ player: <span style={{ color: waitingSeatColor }} /> }}
+            />
+          )}
+        </GameplayTooltip>
+      )}
     </div>
+  );
+}
+
+/**
+ * Glyphs for the overlap badge, keyed by the `status.reason.*` suffix. Each is a
+ * stroke-based 16-viewBox fragment (matching the app's inline-SVG convention) so
+ * it inherits the badge's `currentColor` tint. The map groups reasons that share
+ * a visual (all priority windows → hourglass; both trigger/stack decisions →
+ * layers); anything unmapped falls back to the hourglass, mirroring
+ * `waitingForReason`'s own graceful default so a new engine variant degrades to a
+ * generic "waiting" mark rather than a blank badge.
+ */
+const REASON_ICON_PATHS: Record<string, ReactNode> = {
+  // Sword — declaring attackers / combat priority.
+  declareAttackers: (
+    <>
+      <path d="M13.5 2.5 L6.5 9.5" />
+      <path d="M4 12 L7 9" />
+      <path d="M2.5 13.5 L4.2 11.8" />
+    </>
+  ),
+  // Shield — declaring blockers.
+  declareBlockers: <path d="M8 2 L13 4 V8 C13 11 8 14 8 14 C8 14 3 11 3 8 V4 Z" />,
+  // Flame — assigning combat damage.
+  assigningDamage: (
+    <path d="M8 2 C10 5 11 6.2 11 9 A3 3 0 0 1 5 9 C5 7.6 5.6 6.8 6.4 6 C6.6 7.4 7.4 7.6 8 6.8 C8.4 5.4 8 3.4 8 2 Z" />
+  ),
+  // Crosshair — choosing targets.
+  choosingTargets: (
+    <>
+      <circle cx="8" cy="8" r="4.5" />
+      <path d="M8 1 V3.5 M8 12.5 V15 M1 8 H3.5 M12.5 8 H15" />
+      <circle cx="8" cy="8" r="0.9" fill="currentColor" stroke="none" />
+    </>
+  ),
+  // Droplet — paying a cost.
+  payingCost: <path d="M8 2 C8 2 4 7 4 10 A4 4 0 0 0 12 10 C12 7 8 2 8 2 Z" />,
+  // Circular arrow — mulligan.
+  mulligan: (
+    <>
+      <path d="M12.5 6 A5 5 0 1 0 13 9.5" />
+      <path d="M12.5 2.5 V6 H9" />
+    </>
+  ),
+  // Card with a down arrow — discarding.
+  discarding: (
+    <>
+      <rect x="4.5" y="2.5" width="7" height="7.5" rx="1" />
+      <path d="M8 11.5 V14.5 M6.5 13 L8 14.5 L9.5 13" />
+    </>
+  ),
+  // Stacked layers — ordering triggers / responding to the stack.
+  orderingTriggers: (
+    <>
+      <path d="M8 2 L14 5 L8 8 L2 5 Z" />
+      <path d="M2 8 L8 11 L14 8" />
+      <path d="M2 11 L8 14 L14 11" />
+    </>
+  ),
+  // Hourglass — generic priority windows / thinking.
+  priority: (
+    <path d="M4 2 H12 M4 14 H12 M4.5 2 C4.5 5 8 7 8 8 C8 9 4.5 11 4.5 14 M11.5 2 C11.5 5 8 7 8 8 C8 9 11.5 11 11.5 14" />
+  ),
+};
+
+// Reasons that share a glyph with a canonical key above.
+REASON_ICON_PATHS.priorityCombat = REASON_ICON_PATHS.declareAttackers;
+REASON_ICON_PATHS.respondingToStack = REASON_ICON_PATHS.orderingTriggers;
+REASON_ICON_PATHS.priorityMain = REASON_ICON_PATHS.priority;
+REASON_ICON_PATHS.thinking = REASON_ICON_PATHS.priority;
+
+/** Reason glyph for the overlap badge. Strips the `status.reason.` namespace and
+ *  looks up the shared path set; unmapped or absent reasons fall back to the
+ *  generic hourglass. Purely decorative — the words live in the tooltip. */
+function ReasonIcon({ reasonKey }: { reasonKey?: string }) {
+  const name = reasonKey?.replace("status.reason.", "") ?? "";
+  const glyph = REASON_ICON_PATHS[name] ?? REASON_ICON_PATHS.priority;
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 16 16"
+      className="h-2.5 w-2.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {glyph}
+    </svg>
   );
 }

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -33,6 +33,7 @@ import type {
   CardSizePreference,
   CommandZoneDisplay,
   LogDefaultState,
+  ZoneCollapseMode,
 } from "../../stores/preferencesStore.ts";
 import type { SupportedLng } from "../../i18n/resources.ts";
 import { LanguageFlag } from "../ui/LanguageFlag.tsx";
@@ -67,6 +68,7 @@ const LANGUAGE_OPTIONS: { value: SupportedLng; label: string }[] = [
 
 const CARD_SIZES: CardSizePreference[] = ["small", "medium", "large"];
 const COMMAND_ZONE_DISPLAYS: CommandZoneDisplay[] = ["auto", "inline", "compact"];
+const ZONE_COLLAPSE_MODES: ZoneCollapseMode[] = ["auto", "on", "off"];
 const CARD_PREVIEW_MODES: CardPreviewMode[] = ["follow", "side", "shift"];
 const LOG_DEFAULTS: LogDefaultState[] = ["open", "closed"];
 const VFX_QUALITIES: VfxQuality[] = ["full", "reduced", "minimal"];
@@ -153,6 +155,8 @@ export function PreferencesModal({
   const setLanguage = usePreferencesStore((s) => s.setLanguage);
   const cardSize = usePreferencesStore((s) => s.cardSize);
   const commandZoneDisplay = usePreferencesStore((s) => s.commandZoneDisplay);
+  const collapseLands = usePreferencesStore((s) => s.collapseLands);
+  const collapseSupport = usePreferencesStore((s) => s.collapseSupport);
   const logDefaultState = usePreferencesStore((s) => s.logDefaultState);
   const spellPaymentMode = usePreferencesStore((s) => s.spellPaymentMode);
   const boardBackground = usePreferencesStore((s) => s.boardBackground);
@@ -161,6 +165,8 @@ export function PreferencesModal({
   const pacingMultipliers = usePreferencesStore((s) => s.pacingMultipliers);
   const setCardSize = usePreferencesStore((s) => s.setCardSize);
   const setCommandZoneDisplay = usePreferencesStore((s) => s.setCommandZoneDisplay);
+  const setCollapseLands = usePreferencesStore((s) => s.setCollapseLands);
+  const setCollapseSupport = usePreferencesStore((s) => s.setCollapseSupport);
   const setLogDefaultState = usePreferencesStore((s) => s.setLogDefaultState);
   const setSpellPaymentMode = usePreferencesStore((s) => s.setSpellPaymentMode);
   const setBoardBackground = usePreferencesStore((s) => s.setBoardBackground);
@@ -359,6 +365,24 @@ export function PreferencesModal({
                       value={commandZoneDisplay}
                       onChange={setCommandZoneDisplay}
                       renderLabel={(opt) => t(`gameplay.commandZoneOptions.${opt}`)}
+                    />
+                  </SettingGroup>
+
+                  <SettingGroup label={t("gameplay.collapseLands")}>
+                    <SegmentedControl
+                      options={ZONE_COLLAPSE_MODES}
+                      value={collapseLands}
+                      onChange={setCollapseLands}
+                      renderLabel={(opt) => t(`gameplay.collapseZoneOptions.${opt}`)}
+                    />
+                  </SettingGroup>
+
+                  <SettingGroup label={t("gameplay.collapseSupport")}>
+                    <SegmentedControl
+                      options={ZONE_COLLAPSE_MODES}
+                      value={collapseSupport}
+                      onChange={setCollapseSupport}
+                      renderLabel={(opt) => t(`gameplay.collapseZoneOptions.${opt}`)}
                     />
                   </SettingGroup>
 

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Reihe einklappen",
+      "auto": "Auto",
+      "on": "Immer an",
+      "off": "Immer aus"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -12,6 +12,13 @@
     "data": "Daten"
   },
   "gameplay": {
+    "collapseLands": "Lands einklappen",
+    "collapseSupport": "Support einklappen",
+    "collapseZoneOptions": {
+      "auto": "Auto",
+      "on": "Immer an",
+      "off": "Immer aus"
+    },
     "title": "Spielablauf",
     "language": "Sprache",
     "cardSize": "Kartengröße",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -152,6 +152,12 @@
       "sacrifice": "Hidden objects that can be sacrificed.",
       "selected": "Hidden objects currently selected for the active choice.",
       "target": "Hidden objects that are legal targets."
+    },
+    "collapse": {
+      "label": "Collapse row",
+      "auto": "Auto",
+      "on": "Always on",
+      "off": "Always off"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -12,6 +12,13 @@
     "data": "Data"
   },
   "gameplay": {
+    "collapseLands": "Collapse Lands",
+    "collapseSupport": "Collapse Support",
+    "collapseZoneOptions": {
+      "auto": "Auto",
+      "on": "Always on",
+      "off": "Always off"
+    },
     "title": "Gameplay",
     "language": "Language",
     "cardSize": "Card Size",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Contraer fila",
+      "auto": "Automático",
+      "on": "Siempre activado",
+      "off": "Siempre desactivado"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -12,6 +12,13 @@
     "data": "Datos"
   },
   "gameplay": {
+    "collapseLands": "Contraer Lands",
+    "collapseSupport": "Contraer Support",
+    "collapseZoneOptions": {
+      "auto": "Automático",
+      "on": "Siempre activado",
+      "off": "Siempre desactivado"
+    },
     "title": "Jugabilidad",
     "language": "Idioma",
     "cardSize": "Tamaño de las cartas",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Réduire la rangée",
+      "auto": "Auto",
+      "on": "Toujours activé",
+      "off": "Toujours désactivé"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -12,6 +12,13 @@
     "data": "Données"
   },
   "gameplay": {
+    "collapseLands": "Réduire Lands",
+    "collapseSupport": "Réduire Support",
+    "collapseZoneOptions": {
+      "auto": "Auto",
+      "on": "Toujours activé",
+      "off": "Toujours désactivé"
+    },
     "title": "Jouabilité",
     "language": "Langue",
     "cardSize": "Taille des cartes",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Comprimi riga",
+      "auto": "Auto",
+      "on": "Sempre attivo",
+      "off": "Sempre disattivato"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -12,6 +12,13 @@
     "data": "Dati"
   },
   "gameplay": {
+    "collapseLands": "Comprimi Lands",
+    "collapseSupport": "Comprimi Support",
+    "collapseZoneOptions": {
+      "auto": "Auto",
+      "on": "Sempre attivo",
+      "off": "Sempre disattivato"
+    },
     "title": "Giocabilità",
     "language": "Lingua",
     "cardSize": "Dimensione carte",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Zwiń rząd",
+      "auto": "Auto",
+      "on": "Zawsze wł.",
+      "off": "Zawsze wył."
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -12,6 +12,13 @@
     "data": "Dane"
   },
   "gameplay": {
+    "collapseLands": "Zwiń Lands",
+    "collapseSupport": "Zwiń Support",
+    "collapseZoneOptions": {
+      "auto": "Auto",
+      "on": "Zawsze wł.",
+      "off": "Zawsze wył."
+    },
     "title": "Rozgrywka",
     "language": "Język",
     "cardSize": "Rozmiar kart",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -152,6 +152,12 @@
       "target": "Hidden objects that are legal targets.",
       "choice": "Hidden objects eligible for the active board choice.",
       "sacrifice": "Hidden objects that can be sacrificed."
+    },
+    "collapse": {
+      "label": "Recolher linha",
+      "auto": "Automático",
+      "on": "Sempre ativado",
+      "off": "Sempre desativado"
     }
   },
   "permanent": {

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -12,6 +12,13 @@
     "data": "Dados"
   },
   "gameplay": {
+    "collapseLands": "Recolher Lands",
+    "collapseSupport": "Recolher Support",
+    "collapseZoneOptions": {
+      "auto": "Automático",
+      "on": "Sempre ativado",
+      "off": "Sempre desativado"
+    },
     "title": "Jogabilidade",
     "language": "Idioma",
     "cardSize": "Tamanho da Carta",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1335,10 +1335,12 @@ function GamePageContent({
         {showFlowHelpNudge && <FlowHelpNudge />}
         {showSandboxToolsNudge && <SandboxToolsNudge />}
         <CombatPhaseIndicator />
-        <TurnStatusLine />
-        {!isSpectatorMode && (
+        {isSpectatorMode ? (
+          <TurnStatusLine />
+        ) : (
           <>
             <div className="flex items-center gap-1.5">
+              <TurnStatusLine />
               <HandBadge />
               <FullControlToggle />
             </div>

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -76,6 +76,13 @@ export type BattlefieldCardDisplay = "art_crop" | "full_card";
  *  {@link useResolvedCommandZoneDisplay}, mirroring the `boardBackground`
  *  "auto-wubrg" resolve-at-use-site precedent. */
 export type CommandZoneDisplay = "compact" | "inline" | "auto";
+/** Whether a battlefield sub-row (lands / support) collapses into its summary
+ *  tile. "auto" = collapse once the row exceeds the crowding threshold (the
+ *  prior fixed behavior); "on" = always collapse into the tile; "off" = never
+ *  collapse (always show the full row). Resolved at the use-site in
+ *  {@link BattlefieldZoneOverflow}, mirroring the `commandZoneDisplay`
+ *  tri-state "auto" precedent. Lands and support each carry their own value. */
+export type ZoneCollapseMode = "auto" | "on" | "off";
 export type TapRotation = "mtga" | "classic";
 export type SpellPaymentMode = "auto" | "manual";
 /** Which screen edge the resolving-stack panel docks to (and collapses toward).
@@ -276,6 +283,8 @@ function buildDefaultPreferences(): PreferencesState {
     collapsedFolderIds: [],
     lastSeenChangelogId: undefined,
     commandZoneDisplay: "auto",
+    collapseLands: "auto",
+    collapseSupport: "auto",
     tapRotation: "mtga",
     spellPaymentMode: "auto",
     handSort: "none",
@@ -341,6 +350,10 @@ interface PreferencesState {
   lastSeenChangelogId?: number;
   /** Command-zone layout mode (inline dock / compact pile / auto-by-viewport). */
   commandZoneDisplay: CommandZoneDisplay;
+  /** Whether the lands sub-row collapses into its summary tile (auto/on/off). */
+  collapseLands: ZoneCollapseMode;
+  /** Whether the support sub-row collapses into its summary tile (auto/on/off). */
+  collapseSupport: ZoneCollapseMode;
   tapRotation: TapRotation;
   spellPaymentMode: SpellPaymentMode;
   /** Persisted sort order for the player's own hand (display-only — never
@@ -419,6 +432,8 @@ interface PreferencesActions {
   setCollapsedFolderIds: (ids: string[]) => void;
   setLastSeenChangelogId: (id: number) => void;
   setCommandZoneDisplay: (display: CommandZoneDisplay) => void;
+  setCollapseLands: (mode: ZoneCollapseMode) => void;
+  setCollapseSupport: (mode: ZoneCollapseMode) => void;
   setTapRotation: (rotation: TapRotation) => void;
   setSpellPaymentMode: (mode: SpellPaymentMode) => void;
   setHandSort: (sort: SortKey) => void;
@@ -568,6 +583,8 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       setCollapsedFolderIds: (ids) => set({ collapsedFolderIds: ids }),
       setLastSeenChangelogId: (id) => set({ lastSeenChangelogId: id }),
       setCommandZoneDisplay: (display) => set({ commandZoneDisplay: display }),
+      setCollapseLands: (mode) => set({ collapseLands: mode }),
+      setCollapseSupport: (mode) => set({ collapseSupport: mode }),
       setTapRotation: (rotation) => set({ tapRotation: rotation }),
       setSpellPaymentMode: (mode) => set({ spellPaymentMode: mode }),
       setHandSort: (sort) => set({ handSort: sort }),
@@ -728,7 +745,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 19,
+      version: 20,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -765,6 +782,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          no unread dot for entries that predate this upgrade.
       // v18 → v19: Add handSort; legacy stores default to "none" (insertion
       //          order — the prior hand behavior) via the shallow merge.
+      // v19 → v20: Add collapseLands/collapseSupport; legacy stores default to
+      //          "auto" (the prior threshold-driven collapse) via the shallow
+      //          merge, so existing users see no behavior change.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;


### PR DESCRIPTION
Turn priority indicator (lower-right action rail):
- Move onto the "Hand N" row so it no longer pushes the combat phase indicator
  up into the commander zone; spectators keep a standalone line.
- Tighten the pill to WHO holds the pending decision and add a small corner
  overlap badge carrying a per-reason glyph (attack / block / target / pay / …),
  tinted with the waiting seat's color and pulsing when waiting on an opponent.
  The full sentence stays in the GameplayTooltip (reuses existing status.*Reason
  strings — no new i18n keys). The badge supersedes the old leading dot.

Lands/support collapse:
- New per-row collapse preference (auto/on/off) with independent lands and
  support values. Exposed both as a compact dropdown on the summary tile (own
  board only) and as segmented controls in Preferences; resolved at the use-site
  so tile, sheet, and every board stay in lockstep through one store value.
- Auto-collapse now counts DISTINCT stacks, not bodies, so 7 Forests + 2 duals
  reads as ~3 visible stacks and no longer trips the overflow.
- Shift the Manual/Undo controls down into the reserved bottom gutter so they
  clear the lands / land tile instead of riding up over them.

i18n: adds battlefieldOverflow.collapse.* and gameplay.collapse* across all
7 locales (key parity verified).
