### PR TITLE
Add Mercenary token summoning sickness regression test (fixes #480)

### DIFF
--- a/crates/engine/tests/integration/issue_480_mercenary_token_summoning_sickness.rs
+++ b/crates/engine/tests/integration/issue_480_mercenary_token_summoning_sickness.rs
@@ -1,0 +1,55 @@
+//! Issue #480: Mercenary tokens created this turn must have summoning sickness.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const PRICKLY_PAIR_ORACLE: &str = "\
+When this creature enters, create a 1/1 red Mercenary creature token with \"{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.\"";
+
+#[test]
+fn mercenary_token_from_prickly_pair_has_summoning_sickness() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let host = scenario.add_vanilla(P0, 2, 2);
+    let prickly = scenario
+        .add_creature_to_hand_from_oracle(P0, "Prickly Pair", 2, 2, PRICKLY_PAIR_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(prickly).resolve();
+    runner.advance_until_stack_empty();
+
+    let mercenary = runner
+        .state()
+        .objects
+        .values()
+        .find(|o| {
+            o.is_token
+                && o.zone == Zone::Battlefield
+                && o.card_types.subtypes.iter().any(|s| s == "Mercenary")
+        })
+        .expect("Prickly Pair ETB must create a Mercenary token");
+
+    assert!(
+        mercenary.summoning_sick,
+        "Mercenary token must enter with summoning sickness"
+    );
+
+    let tap_index = 0;
+
+    let err = runner
+        .act(GameAction::ActivateAbility {
+            source_id: mercenary.id,
+            ability_index: tap_index,
+        })
+        .expect_err("summoning-sick Mercenary token must not tap for its ability");
+    assert!(
+        matches!(err, engine::game::EngineError::ActionNotAllowed(_)),
+        "expected ActionNotAllowed, got {err:?}"
+    );
+
+    // Sanity: host creature without sickness can still be targeted later.
+    assert_eq!(runner.state().objects[&host].zone, Zone::Battlefield);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -400,6 +400,7 @@ mod issue_4560_winter_soldier;
 mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
+mod issue_480_mercenary_token_summoning_sickness;
 mod issue_4829_zenith_chronicler;
 mod issue_4830_orvar_land_copy;
 mod issue_4835_intimidation_tactics;


### PR DESCRIPTION
## Summary
- Add an integration test for Prickly Pair creating a Mercenary token that cannot tap for its ability on the turn it enters.
- Asserts the token has summoning sickness and that activating its `{T}` ability is rejected.

## Test plan
- [x] `cargo test -p engine --test integration issue_480`
- [x] `cargo fmt --all`


Made with [Cursor](https://cursor.com)