### PR TITLE
Add Dogmeat ETB mill-five regression test (fixes #218)

### DIFF
--- a/crates/engine/tests/integration/issue_218_dogmeat_mill_five.rs
+++ b/crates/engine/tests/integration/issue_218_dogmeat_mill_five.rs
@@ -1,0 +1,39 @@
+//! Issue #218: Dogmeat, Ever Loyal must mill five cards on ETB.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::phase::Phase;
+
+const DOGMEAT_ORACLE: &str = "\
+When Dogmeat enters, mill five cards, then return an Aura or Equipment card from your graveyard to your hand.\n\
+Whenever a creature you control that's enchanted or equipped attacks, create a Junk token. (It's an artifact with \"{T}, Sacrifice this token: Exile the top card of your library. You may play that card this turn. Activate only as a sorcery.\")";
+
+#[test]
+fn dogmeat_etb_mills_five_cards() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for i in 0..10 {
+        scenario.with_library_top(P0, &[&format!("Library Card {i}")]);
+    }
+
+    let dogmeat = scenario
+        .add_creature_to_hand_from_oracle(P0, "Dogmeat, Ever Loyal", 3, 3, DOGMEAT_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let library_before = runner.state().players[0].library.len();
+    let graveyard_before = runner.state().players[0].graveyard.len();
+
+    runner.cast(dogmeat).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[0].library.len(),
+        library_before - 5,
+        "Dogmeat ETB must mill exactly five cards"
+    );
+    assert_eq!(
+        runner.state().players[0].graveyard.len(),
+        graveyard_before + 5,
+        "milled cards must land in graveyard"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -203,6 +203,7 @@ mod issue_1987_bucknards_everfull_purse;
 mod issue_1996_rot_wolf_draw;
 mod issue_2011_eldrazi_temple_kozilek_cast;
 mod issue_2020_smeagol_ring_tempt;
+mod issue_218_dogmeat_mill_five;
 mod issue_2345_lavinia_no_mana_spent;
 mod issue_2348_key_to_the_vault;
 mod issue_2351_aven_interrupter;


### PR DESCRIPTION
## Summary
- Add an integration test confirming Dogmeat, Ever Loyal mills five cards on ETB.

## Test plan
- [x] `cargo test -p engine --test integration issue_218`
- [x] `cargo fmt --all`


Made with [Cursor](https://cursor.com)