### PR TITLE
Add Cabal Stronghold play-land regression test (fixes #515)

### DIFF
--- a/crates/engine/tests/integration/issue_515_cabal_stronghold_play_land.rs
+++ b/crates/engine/tests/integration/issue_515_cabal_stronghold_play_land.rs
@@ -1,0 +1,39 @@
+//! Issue #515: Playing Cabal Stronghold must not surface a spurious optional effect.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const CABAL_STRONGHOLD_ORACLE: &str =
+    "{T}: Add {C}.\n{3}, {T}: Add {B} for each basic Swamp you control.";
+
+#[test]
+fn cabal_stronghold_play_land_no_optional_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let land = scenario
+        .add_land_to_hand(P0, "Cabal Stronghold")
+        .from_oracle_text(CABAL_STRONGHOLD_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    let card_id = runner.state().objects[&land].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land,
+            card_id,
+        })
+        .expect("play land");
+
+    assert_eq!(runner.state().objects[&land].zone, Zone::Battlefield);
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "playing Cabal Stronghold must not prompt OptionalEffectChoice, got {:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -404,6 +404,7 @@ mod issue_4829_zenith_chronicler;
 mod issue_4830_orvar_land_copy;
 mod issue_4835_intimidation_tactics;
 mod issue_4836_mindskinner;
+mod issue_515_cabal_stronghold_play_land;
 mod issue_536_six_grants_retrace;
 mod issue_541_endurance_graveyard_to_bottom;
 mod issue_544_krark_clan_ironworks_auto_pass;


### PR DESCRIPTION
## Summary
- Add an integration test confirming Cabal Stronghold does not prompt `OptionalEffectChoice` when played as a land.

## Test plan
- [x] `cargo test -p engine --test integration issue_515`
- [x] `cargo fmt --all`


Made with [Cursor](https://cursor.com)