### PR TITLE
fix(parser): dynamic-power "can't be blocked by" restriction (Kraken of the Straits)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -480,11 +480,6 @@ fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
 fn parse_power_threshold_block_restriction(text: &str) -> Option<StaticDefinition> {
     // allow-noncombinator: split on the fixed clause anchor, not parsing dispatch.
     let (filter_text, after) = text.split_once(" can't block ")?;
-    // The blocker subject must be power-qualified — a bare "creatures … can't
-    // block this creature" is a different (unconditional) shape handled elsewhere.
-    if !filter_text.to_lowercase().contains("with power") {
-        return None;
-    }
     // CR 509.1b: the restriction is on blocking the SOURCE ("this creature"/"~").
     let after = after.trim().trim_end_matches('.').trim().to_lowercase();
     if after != "this creature" && after != "~" {
@@ -493,7 +488,10 @@ fn parse_power_threshold_block_restriction(text: &str) -> Option<StaticDefinitio
     // Reuse the shared filter grammar so the power comparison + dynamic threshold
     // ("less than the number of Islands you control") lower through one authority.
     let (filter, remainder) = parse_target(filter_text.trim());
-    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+    if !remainder.trim().is_empty()
+        || matches!(filter, TargetFilter::Any)
+        || !target_filter_has_power_comparison(&filter)
+    {
         return None;
     }
     Some(
@@ -501,6 +499,31 @@ fn parse_power_threshold_block_restriction(text: &str) -> Option<StaticDefinitio
             .affected(TargetFilter::SelfRef)
             .description(text.to_string()),
     )
+}
+
+fn target_filter_has_power_comparison(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(filter_prop_has_power_comparison),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(target_filter_has_power_comparison)
+        }
+        TargetFilter::Not { filter } => target_filter_has_power_comparison(filter),
+        _ => false,
+    }
+}
+
+fn filter_prop_has_power_comparison(prop: &FilterProp) -> bool {
+    match prop {
+        FilterProp::PtComparison {
+            stat: PtStat::Power,
+            ..
+        } => true,
+        FilterProp::AnyOf { props } => props.iter().any(filter_prop_has_power_comparison),
+        _ => false,
+    }
 }
 
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -466,6 +466,43 @@ fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
     .and_then(|(_, condition)| condition)
 }
 
+/// CR 509.1b: "Creatures with power <comparison> <quantity> can't
+/// block this creature." — a can't-be-blocked-by restriction whose blocker
+/// filter gates on a power threshold that may be DYNAMIC (Kraken of the Straits:
+/// "Creatures with power less than the number of Islands you control can't block
+/// this creature."). Sibling of `parse_source_power_block_restriction` (which
+/// fixes the threshold to `~'s power` and targets `creatures you control`); this
+/// arm accepts any `parse_target` power-comparison filter — including a dynamic
+/// `ObjectCount` threshold — and targets the source itself. Without it the
+/// subject-first "creatures with power … can't block this creature" wording
+/// mis-dispatches to a bare `CantBlock { SelfRef }` (source can't block), which
+/// is the inverse of the intended restriction.
+fn parse_power_threshold_block_restriction(text: &str) -> Option<StaticDefinition> {
+    // allow-noncombinator: split on the fixed clause anchor, not parsing dispatch.
+    let (filter_text, after) = text.split_once(" can't block ")?;
+    // The blocker subject must be power-qualified — a bare "creatures … can't
+    // block this creature" is a different (unconditional) shape handled elsewhere.
+    if !filter_text.to_lowercase().contains("with power") {
+        return None;
+    }
+    // CR 509.1b: the restriction is on blocking the SOURCE ("this creature"/"~").
+    let after = after.trim().trim_end_matches('.').trim().to_lowercase();
+    if after != "this creature" && after != "~" {
+        return None;
+    }
+    // Reuse the shared filter grammar so the power comparison + dynamic threshold
+    // ("less than the number of Islands you control") lower through one authority.
+    let (filter, remainder) = parse_target(filter_text.trim());
+    if !remainder.trim().is_empty() || matches!(filter, TargetFilter::Any) {
+        return None;
+    }
+    Some(
+        StaticDefinition::new(StaticMode::CantBeBlockedBy { filter })
+            .affected(TargetFilter::SelfRef)
+            .description(text.to_string()),
+    )
+}
+
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by
 /// either `" as long as <condition>"` (continuous) or `" if <condition>"` (state
 /// gate) — e.g. Rock Jockey: "You can't play lands if this creature was cast
@@ -1920,6 +1957,10 @@ pub(crate) fn parse_static_line_inner(
     }
 
     if let Some(def) = parse_source_power_block_restriction(&text) {
+        return Some(def);
+    }
+
+    if let Some(def) = parse_power_threshold_block_restriction(&text) {
         return Some(def);
     }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -376,6 +376,72 @@ fn wirecat_cant_attack_or_block_gated_on_enchantment_exists() {
     );
 }
 
+/// CR 509.1b: Kraken of the Straits — "Creatures with power less than the
+/// number of Islands you control can't block this creature." must lower to a
+/// `CantBeBlockedBy` restriction on the SOURCE whose blocker filter gates on a
+/// DYNAMIC power threshold (ObjectCount of Islands you control). Regression for
+/// the subject-first "creatures with power … can't block this creature" wording
+/// previously mis-dispatching to a bare `CantBlock { SelfRef }` (the inverse:
+/// "the source can't block") and swallowing the dynamic quantity.
+#[test]
+fn kraken_of_the_straits_dynamic_power_cant_be_blocked_by() {
+    let defs = parse_static_line_multi(
+        "Creatures with power less than the number of Islands you control can't block this creature.",
+    );
+    let def = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::CantBeBlockedBy { .. }))
+        .expect("expected a CantBeBlockedBy restriction on the source");
+    assert_eq!(
+        def.affected,
+        Some(TargetFilter::SelfRef),
+        "the restriction is on the source being blocked, got {:?}",
+        def.affected
+    );
+    let StaticMode::CantBeBlockedBy { filter } = &def.mode else {
+        unreachable!()
+    };
+    let dbg = format!("{filter:?}");
+    assert!(
+        dbg.contains("PtComparison") && dbg.contains("Power"),
+        "blocker filter must gate on power, got {dbg}"
+    );
+    assert!(
+        dbg.contains("ObjectCount") && dbg.contains("Island"),
+        "power threshold must be the DYNAMIC Islands-you-control count, got {dbg}"
+    );
+
+    // Full-card dispatch: no swallowed clause and no bogus CantBlock{SelfRef}.
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "Creatures with power less than the number of Islands you control can't block this creature.",
+        "Kraken of the Straits",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert!(
+        parsed
+            .statics
+            .iter()
+            .any(|d| matches!(d.mode, StaticMode::CantBeBlockedBy { .. })),
+        "full dispatch must produce CantBeBlockedBy, got {:?}",
+        parsed.statics.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    );
+    assert!(
+        !parsed
+            .statics
+            .iter()
+            .any(|d| d.mode == StaticMode::CantBlock),
+        "must NOT produce the inverse CantBlock, got {:?}",
+        parsed.statics.iter().map(|d| &d.mode).collect::<Vec<_>>()
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "no clause should be swallowed; warnings = {:?}",
+        parsed.parse_warnings
+    );
+}
+
 /// CR 509.1b: Brave the Sands — "Creatures you control have vigilance and can
 /// block an additional creature each combat." must decompose into BOTH the
 /// vigilance grant AND an `ExtraBlockers` grant affecting creatures you control.


### PR DESCRIPTION
Fixes a parser correctness bug on **Kraken of the Straits** — *"Creatures with power less than the number of Islands you control can't block this creature."*

## Problem
This subject-first wording misparsed to a bare `CantBlock { SelfRef }` — the **inverse** restriction (*"Kraken can't block"*) — and **swallowed** the dynamic power threshold. The card actually means *other* creatures whose power is below the number of Islands you control can't block Kraken.

## Fix
- **`oracle_static/dispatch.rs`** — add `parse_power_threshold_block_restriction` for the *"Creatures with power \<comparison\> \<quantity\> can't block this creature"* shape. It delegates the blocker filter to the shared `parse_target` grammar, so the power comparison **and** a **dynamic `ObjectCount` threshold** (`the number of Islands you control`) lower through one authority, and emits `CantBeBlockedBy { filter }` affecting the source.

Existing `parse_source_power_block_restriction` only handled the fixed *"less than ~'s power … creatures you control"* shape. Composed from existing primitives (`CantBeBlockedBy` + `parse_target`) — **no new variant**. General across the *"creatures with power \<comparison\> \<quantity\> can't block this creature"* class.

## CR
CR 509.1b (blocking restrictions: effects that say a creature can’t block).

## Verification
- Full `parser::oracle_static` suite green — **928 passed, 0 failed**.
- New regression `kraken_of_the_straits_dynamic_power_cant_be_blocked_by` asserts `CantBeBlockedBy` on the source with a `power < ObjectCount(Islands)` filter, that the inverse `CantBlock` is **not** produced, and zero swallowed clauses.
- `cargo fmt` + `cargo clippy -p engine -- -D warnings` clean.
- Regression-checked: the fixed-threshold `parse_source_power_block_restriction` shape and other block restrictions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
