### PR TITLE
Fix Light-Paws searched Aura attach target (#4824)

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -83,20 +83,26 @@ fn resolve_forward_result_search_attach_host(
                     TargetRef::Player(id) => AttachTarget::Player(id),
                 })
         }
-        TargetFilter::Player => targets.iter().find_map(|target| match target {
-            TargetRef::Player(id) => Some(AttachTarget::Player(*id)),
-            _ => None,
-        }),
+        TargetFilter::Player => targets
+            .iter()
+            .filter_map(|target| match target {
+                TargetRef::Player(id) => Some(AttachTarget::Player(*id)),
+                _ => None,
+            })
+            .next(),
         TargetFilter::Typed(tf)
             if tf
                 .type_filters
                 .iter()
                 .any(|f| matches!(f, TypeFilter::Creature)) =>
         {
-            targets.iter().find_map(|target| match target {
-                TargetRef::Object(id) => Some(AttachTarget::Object(*id)),
-                _ => None,
-            })
+            targets
+                .iter()
+                .filter_map(|target| match target {
+                    TargetRef::Object(id) => Some(AttachTarget::Object(*id)),
+                    _ => None,
+                })
+                .next()
         }
         // Typed "target creature/player" hosts (Arachnus Spinner, Curse tutors)
         // resolve from the ability's chosen targets carried through search.

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -1,10 +1,11 @@
 use rand::Rng;
 
+use crate::game::game_object::AttachTarget;
 use crate::game::zones;
 use crate::types::ability::{
     ControllerRef, Duration, Effect, EffectError, EffectKind, FilterProp, LibraryPosition,
     QuantityExpr, ResolvedAbility, TargetChoiceTiming, TargetFilter, TargetRef,
-    TargetSelectionMode, TypedFilter,
+    TargetSelectionMode, TypeFilter, TypedFilter,
 };
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
@@ -14,6 +15,116 @@ use crate::types::game_state::{GameState, PendingCounterPostAction, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::{EtbTapState, Zone};
+
+/// CR 303.4f + CR 701.23a: Search effects that put an Aura onto the battlefield
+/// "attached to ~" (Light-Paws) or "attached to that/enchanted player" (Curse
+/// tutors) carry a `forward_result` Attach sub. Pre-resolve the host so the
+/// zone pipeline attaches on entry instead of surfacing a host-choice prompt.
+fn forward_result_search_attach_host(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> Option<AttachTarget> {
+    if let Some(host) = state.search_continuation_attach_host {
+        return Some(host);
+    }
+    resolve_forward_result_search_attach_host(state, ability)
+}
+
+fn forward_result_attach_host_targets(ability: &ResolvedAbility) -> &[TargetRef] {
+    // CR 601.2c: Deferred search put-steps assign the attach-host target onto
+    // the `forward_result` Attach sub, not the ChangeZone head that carries
+    // `forward_result = true`. Read the sub's targets when present.
+    if let Some(sub) = ability.sub_ability.as_ref() {
+        if matches!(sub.effect, Effect::Attach { .. }) && !sub.targets.is_empty() {
+            return &sub.targets;
+        }
+    }
+    &ability.targets
+}
+
+fn resolve_forward_result_search_attach_host(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> Option<AttachTarget> {
+    if !ability.forward_result {
+        return None;
+    }
+    let sub = ability.sub_ability.as_ref()?;
+    let Effect::Attach { attachment, target } = &sub.effect else {
+        return None;
+    };
+    if !matches!(attachment, TargetFilter::SelfRef) {
+        return None;
+    }
+    let targets = forward_result_attach_host_targets(ability);
+    match target {
+        TargetFilter::SelfRef => Some(AttachTarget::Object(ability.source_id)),
+        TargetFilter::ParentTarget => targets.first().map(|target| match target {
+            TargetRef::Object(id) => AttachTarget::Object(*id),
+            TargetRef::Player(id) => AttachTarget::Player(*id),
+        }),
+        TargetFilter::Any => {
+            let source = state.objects.get(&ability.source_id)?;
+            if source
+                .card_types
+                .subtypes
+                .iter()
+                .any(|subtype| subtype == "Aura")
+            {
+                source.attached_to
+            } else {
+                Some(AttachTarget::Object(ability.source_id))
+            }
+        }
+        TargetFilter::TriggeringSource | TargetFilter::AttachedTo => {
+            crate::game::targeting::resolve_event_context_target(state, target, ability.source_id)
+                .map(|target| match target {
+                    TargetRef::Object(id) => AttachTarget::Object(id),
+                    TargetRef::Player(id) => AttachTarget::Player(id),
+                })
+        }
+        TargetFilter::Player => targets.iter().find_map(|target| match target {
+            TargetRef::Player(id) => Some(AttachTarget::Player(*id)),
+            _ => None,
+        }),
+        TargetFilter::Typed(tf)
+            if tf
+                .type_filters
+                .iter()
+                .any(|f| matches!(f, TypeFilter::Creature)) =>
+        {
+            targets.iter().find_map(|target| match target {
+                TargetRef::Object(id) => Some(AttachTarget::Object(*id)),
+                _ => None,
+            })
+        }
+        // Typed "target creature/player" hosts (Arachnus Spinner, Curse tutors)
+        // resolve from the ability's chosen targets carried through search.
+        _ => targets
+            .iter()
+            .map(|target| match target {
+                TargetRef::Object(id) => AttachTarget::Object(*id),
+                TargetRef::Player(id) => AttachTarget::Player(*id),
+            })
+            .next(),
+    }
+}
+
+/// CR 303.4f: Resolve the attach host for a search continuation using the
+/// chain's current target provenance (before found-card ids replace them).
+pub(crate) fn resolve_search_continuation_attach_host(
+    state: &GameState,
+    chain: &ResolvedAbility,
+) -> Option<AttachTarget> {
+    let mut cursor = Some(chain);
+    while let Some(ability) = cursor {
+        if let Some(host) = resolve_forward_result_search_attach_host(state, ability) {
+            return Some(host);
+        }
+        cursor = ability.sub_ability.as_deref();
+    }
+    None
+}
 
 /// CR 701.24a: Shuffle a player's library using the game's seeded RNG.
 /// Reusable helper for auto-shuffle after zone moves to Library.
@@ -503,6 +614,7 @@ pub fn resolve(
                 face_down_profile.as_ref(),
                 track_exiled_by_source,
                 None,
+                None,
                 events,
             ) {
                 ZoneMoveResult::Done => {
@@ -584,6 +696,7 @@ pub fn resolve(
                 &per_obj_enter_counters,
                 face_down_profile.as_ref(),
                 track_exiled_by_source,
+                None,
                 None,
                 events,
             ) {
@@ -685,6 +798,7 @@ pub fn resolve(
         face_down_profile: face_down_profile.clone(),
         library_placement: None,
         enters_modified_if: effect_enters_modified_if,
+        enter_attached_to: forward_result_search_attach_host(state, ability),
     };
     let _ = owner_library; // routing handled by move_to_zone (CR 400.7)
 
@@ -786,6 +900,7 @@ pub fn resolve(
                         // CR 614.12: preserve the moved-object type gate across a
                         // further as-enters / replacement pause.
                         enters_modified_if: ctx.enters_modified_if.clone(),
+                        enter_attached_to: ctx.enter_attached_to,
                         effect_kind: EffectKind::from(&ability.effect),
                     });
                 return Ok(());
@@ -825,6 +940,7 @@ pub fn resolve(
                         // CR 614.12: preserve the moved-object type gate across a
                         // further as-enters / replacement pause.
                         enters_modified_if: ctx.enters_modified_if.clone(),
+                        enter_attached_to: ctx.enter_attached_to,
                         effect_kind: EffectKind::from(&ability.effect),
                     });
                 // CR 608.2c: this object is paused mid-move on a replacement choice
@@ -965,6 +1081,8 @@ pub(crate) struct ChangeZoneIterationCtx {
     /// unconditionally. Carried so the gate survives the `EffectZoneChoice`
     /// pick pause and is evaluated per chosen object in `process_one_zone_move`.
     pub enters_modified_if: Option<TargetFilter>,
+    /// CR 303.4f: Pre-resolved Aura host for search/tutor "enters attached" wiring.
+    pub enter_attached_to: Option<AttachTarget>,
 }
 
 /// CR 614.12 + CR 614.12a: Resolve the effective enter-modifiers for one moved
@@ -1074,6 +1192,7 @@ pub(crate) fn process_one_zone_move(
         ctx.face_down_profile.as_ref(),
         ctx.track_exiled_by_source,
         ctx.library_placement.clone(),
+        ctx.enter_attached_to,
         events,
     );
 
@@ -1410,6 +1529,7 @@ pub fn resolve_all(
             face_down_profile.as_ref(),
             track_exiled_by_source,
             effect_library_position.clone(),
+            None,
             events,
         ) {
             ZoneMoveResult::Done => {
@@ -1476,6 +1596,7 @@ pub fn resolve_all(
                         library_placement: effect_library_position.clone(),
                         // CR 614.12: mass zone moves carry no moved-object type gate.
                         enters_modified_if: None,
+                        enter_attached_to: None,
                         effect_kind: EffectKind::from(&ability.effect),
                     });
                 // CR 608.2c: record the replacement-paused member as in-flight (with
@@ -1525,6 +1646,7 @@ pub fn resolve_all(
                         library_placement: effect_library_position.clone(),
                         // CR 614.12: mass zone moves carry no moved-object type gate.
                         enters_modified_if: None,
+                        enter_attached_to: None,
                         effect_kind: EffectKind::from(&ability.effect),
                     });
                 return Ok(());
@@ -3318,6 +3440,7 @@ mod tests {
             None,
             false,
             None,
+            None,
             &mut events,
         );
         assert!(matches!(result, ZoneMoveResult::Done));
@@ -5067,6 +5190,7 @@ mod tests {
                 face_down_profile: None,
                 library_placement: None,
                 enters_modified_if: None,
+                enter_attached_to: None,
                 effect_kind: EffectKind::ChangeZone,
             });
         state.resolving_stack_entry = Some(StackEntry {

--- a/crates/engine/src/game/effects/end_phase.rs
+++ b/crates/engine/src/game/effects/end_phase.rs
@@ -43,6 +43,7 @@ pub(super) fn exile_nonresolving_stack_objects(
                 None,
                 false,
                 None,
+                None,
                 events,
             ) {
                 ZoneMoveResult::Done => {}

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -104,6 +104,7 @@ pub fn resolve(
             None,
             track_exiled_by_source,
             None,
+            None,
             events,
         ) {
             super::change_zone::ZoneMoveResult::Done => {}

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -688,9 +688,15 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
     // re-pausing on a further per-target replacement choice.
     if !waits_for_resolution_choice(&state.waiting_for) {
         if let Some(cont) = state.pending_continuation.take() {
-            let PendingContinuation { chain, parent_kind } = cont;
+            let PendingContinuation {
+                chain,
+                parent_kind,
+                search_attach_host,
+            } = cont;
+            state.search_continuation_attach_host = search_attach_host;
             let source_id = chain.source_id;
             let _ = resolve_ability_chain(state, &chain, events, 1);
+            state.search_continuation_attach_host = None;
             if let Some(kind) = parent_kind {
                 events.push(GameEvent::EffectResolved { kind, source_id });
             }
@@ -854,6 +860,7 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
             face_down_profile,
             library_placement,
             enters_modified_if,
+            enter_attached_to,
             effect_kind,
         } = pending;
         // CR 608.2c: the object that paused this iteration on a replacement CHOICE
@@ -918,6 +925,7 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
                 // resume ctx so a resumed member is still gated on its type
                 // (Summoner's Grimoire), matching the synchronous move path.
                 enters_modified_if: enters_modified_if.clone(),
+                enter_attached_to,
             };
             let before_zone = state.objects.get(obj_id).map(|object| object.zone);
             match crate::game::effects::change_zone::process_one_zone_move(
@@ -970,6 +978,7 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
                             // CR 614.12: preserve the moved-object type gate
                             // across a further pause.
                             enters_modified_if: ctx.enters_modified_if.clone(),
+                            enter_attached_to: ctx.enter_attached_to,
                             effect_kind,
                         });
                     paused = true;
@@ -1000,6 +1009,7 @@ fn drain_pending_change_zone_iteration(state: &mut GameState, events: &mut Vec<G
                             // CR 614.12: preserve the moved-object type gate
                             // across a further pause.
                             enters_modified_if: ctx.enters_modified_if.clone(),
+                            enter_attached_to: ctx.enter_attached_to,
                             effect_kind,
                         });
                     // CR 608.2c: a further member paused mid-move on a replacement
@@ -1194,11 +1204,16 @@ pub(crate) fn append_to_pending_continuation(
 
 fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbility) {
     if let Some(existing) = state.pending_continuation.take() {
-        let PendingContinuation { chain, parent_kind } = existing;
+        let PendingContinuation {
+            chain,
+            parent_kind,
+            search_attach_host,
+        } = existing;
         super::ability_utils::append_to_sub_chain(&mut head, *chain);
         state.pending_continuation = Some(PendingContinuation {
             chain: Box::new(head),
             parent_kind,
+            search_attach_host,
         });
     } else {
         state.pending_continuation = Some(PendingContinuation::new(Box::new(head)));

--- a/crates/engine/src/game/effects/prepare.rs
+++ b/crates/engine/src/game/effects/prepare.rs
@@ -595,6 +595,7 @@ mod tests {
             None,
             false,
             None,
+            None,
             &mut events,
         );
 

--- a/crates/engine/src/game/effects/search_outside_game.rs
+++ b/crates/engine/src/game/effects/search_outside_game.rs
@@ -179,6 +179,7 @@ pub(crate) fn put_face_up_exile_into(
         library_placement: None,
         // CR 614.12: search-from-outside carries no moved-object type gate.
         enters_modified_if: None,
+        enter_attached_to: None,
     };
     Ok(change_zone::process_one_zone_move(
         state, &ctx, object_id, events,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2199,7 +2199,13 @@ pub(super) fn handle_resolution_choice(
                     .exiled_from_hand_this_resolution
                     .saturating_add(hand_exiles);
             }
-            if let Some(cont) = state.pending_continuation.as_mut() {
+            if let Some(mut cont) = state.pending_continuation.take() {
+                cont.search_attach_host =
+                    effects::change_zone::resolve_search_continuation_attach_host(
+                        state,
+                        &cont.chain,
+                    );
+                state.search_continuation_attach_host = cont.search_attach_host;
                 let mut continuation_targets: Vec<_> =
                     chosen.iter().map(|&id| TargetRef::Object(id)).collect();
                 // CR 701.23a + CR 701.24a: When the searcher is not the caster
@@ -2213,6 +2219,7 @@ pub(super) fn handle_resolution_choice(
                 }
                 cont.chain.targets = continuation_targets.clone();
                 propagate_targets_through_search_shuffle(&mut cont.chain, &continuation_targets);
+                state.pending_continuation = Some(cont);
             }
             effects::drain_pending_continuation(state, events);
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -3159,6 +3166,7 @@ pub(super) fn handle_resolution_choice(
                             // across the `EffectZoneChoice` round-trip against each
                             // chosen object (Summoner's Grimoire).
                             enters_modified_if: enters_modified_if.clone(),
+                            enter_attached_to: None,
                         };
                         match effects::change_zone::process_one_zone_move(
                             state, &ctx, *card_id, events,
@@ -3198,6 +3206,7 @@ pub(super) fn handle_resolution_choice(
                                         // CR 614.12: preserve the moved-object type
                                         // gate across a further as-enters pause.
                                         enters_modified_if: ctx.enters_modified_if.clone(),
+                                        enter_attached_to: None,
                                         effect_kind,
                                     });
                                 return Ok(action_result_outcome(
@@ -3235,6 +3244,7 @@ pub(super) fn handle_resolution_choice(
                                         // CR 614.12: preserve the moved-object type
                                         // gate across a further as-enters pause.
                                         enters_modified_if: ctx.enters_modified_if.clone(),
+                                        enter_attached_to: None,
                                         effect_kind,
                                     });
                                 state.waiting_for =
@@ -3439,6 +3449,7 @@ pub(super) fn handle_resolution_choice(
                         // CR 614.12: cost-payment exile carries no enter-modifier
                         // gate; thread the (None) round-trip value for consistency.
                         enters_modified_if: enters_modified_if.clone(),
+                        enter_attached_to: None,
                     };
                     let events_before_effect = events.len();
                     let chosen_ids: Vec<_> = chosen.to_vec();
@@ -3477,6 +3488,7 @@ pub(super) fn handle_resolution_choice(
                                         // CR 614.12: preserve the moved-object type
                                         // gate across a further as-enters pause.
                                         enters_modified_if: ctx.enters_modified_if.clone(),
+                                        enter_attached_to: None,
                                         effect_kind,
                                     });
                                 state.waiting_for =
@@ -3511,6 +3523,7 @@ pub(super) fn handle_resolution_choice(
                                         // CR 614.12: preserve the moved-object type
                                         // gate across a further as-enters pause.
                                         enters_modified_if: ctx.enters_modified_if.clone(),
+                                        enter_attached_to: None,
                                         effect_kind,
                                     });
                                 state.waiting_for =

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -17461,6 +17461,7 @@ pub mod tests {
             None,  // face_down_profile
             false, // track_exiled_by_source
             None,  // library_placement
+            None,  // enter_attached_to
             &mut events,
         );
 

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -806,6 +806,7 @@ pub(crate) fn move_object(
         req.mods.face_down_profile.as_ref(),
         track_exiled_by_source,
         None,
+        None,
         events,
     )
 }
@@ -1963,6 +1964,7 @@ pub(crate) fn execute_zone_move(
     face_down_profile: Option<&crate::types::ability::FaceDownProfile>,
     track_exiled_by_source: bool,
     library_placement: Option<LibraryPosition>,
+    enter_attached_to: Option<AttachTarget>,
     events: &mut Vec<GameEvent>,
 ) -> ZoneMoveResult {
     let mut proposed = ProposedEvent::zone_change(obj_id, from_zone, dest_zone, Some(source_id));
@@ -2017,6 +2019,16 @@ pub(crate) fn execute_zone_move(
         } = proposed
         {
             *fdp = Some(Box::new(profile.clone()));
+        }
+    }
+
+    if let Some(attach_to) = enter_attached_to {
+        if let ProposedEvent::ZoneChange {
+            attach_to: ref mut at,
+            ..
+        } = proposed
+        {
+            *at = Some(attach_to);
         }
     }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -33,6 +33,99 @@ use crate::types::mana::ManaCost;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
+/// CR 303.4f: Parse the host of "put it onto the battlefield attached to X"
+/// inside a library-search compound.
+fn parse_search_attach_host_ref(input: &str) -> OracleResult<'_, TargetFilter> {
+    alt((
+        value(
+            TargetFilter::SelfRef,
+            alt((
+                tag("~"),
+                tag("this creature"),
+                tag("this permanent"),
+                tag("this artifact"),
+            )),
+        ),
+        value(
+            TargetFilter::ParentTarget,
+            alt((
+                tag("that enchanted creature"),
+                tag("that enchanted permanent"),
+                tag("enchanted player"),
+                tag("that player"),
+                tag("that creature"),
+                tag("that permanent"),
+                tag("that token"),
+                tag("that card"),
+                tag("the creature"),
+                tag("the permanent"),
+                tag("the token"),
+            )),
+        ),
+        parse_search_attach_host_target,
+    ))
+    .parse(input)
+}
+
+fn parse_search_attach_host_target(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (filter, remainder) = parse_target(input);
+    if remainder.trim().is_empty() {
+        Ok((remainder, filter))
+    } else {
+        Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )))
+    }
+}
+
+fn parse_search_attach_host_phrase_comma(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (rest, phrase) = take_until(",")(input)?;
+    let (rest, _) = tag(",")(rest)?;
+    let (_, filter) = parse_search_attach_host_ref(phrase.trim())?;
+    Ok((rest, filter))
+}
+
+fn parse_search_attach_host_phrase_then(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (rest, phrase) = take_until(" then ")(input)?;
+    let (rest, _) = tag(" then ")(rest)?;
+    let (_, filter) = parse_search_attach_host_ref(phrase.trim())?;
+    Ok((rest, filter))
+}
+
+fn parse_search_attach_host_phrase_period(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (rest, phrase) = take_until(".")(input)?;
+    let (rest, _) = tag(".")(rest)?;
+    let (_, filter) = parse_search_attach_host_ref(phrase.trim())?;
+    Ok((rest, filter))
+}
+
+fn parse_search_attach_host_phrase_eof(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (_, filter) = all_consuming(parse_search_attach_host_ref).parse(input)?;
+    Ok(("", filter))
+}
+
+fn parse_search_attach_host_phrase(input: &str) -> OracleResult<'_, TargetFilter> {
+    alt((
+        parse_search_attach_host_phrase_comma,
+        parse_search_attach_host_phrase_then,
+        parse_search_attach_host_phrase_period,
+        parse_search_attach_host_phrase_eof,
+    ))
+    .parse(input)
+}
+
+fn parse_search_attach_host(text: &str) -> Option<TargetFilter> {
+    let lower = text.to_ascii_lowercase();
+    nom_on_lower(text, &lower, |input| {
+        let (input, _) = take_until("attached to").parse(input)?;
+        let (input, _) = tag("attached to ").parse(input)?;
+        let (input, filter) = parse_search_attach_host_phrase(input)?;
+        Ok((input, filter))
+    })
+    .map(|(filter, _)| filter)
+}
+
 /// CR 608.2c + CR 701.23i: Strip a leading player-subject from a search-result
 /// continuation chunk so the absorption matcher sees the bare verb form. Used
 /// by the SearchDestination follow-up absorber to handle iterated-search
@@ -3170,7 +3263,7 @@ pub(super) fn apply_clause_continuation(
             enter_tapped,
             enters_under,
             reveal,
-            attach_to_source,
+            attach_host,
         } => {
             // CR 701.23a: A multi-zone tutor ("graveyard, hand, and/or library")
             // finds the card in any searched zone, so the put-step must move it
@@ -3218,14 +3311,13 @@ pub(super) fn apply_clause_continuation(
                     enters_modified_if: None,
                 },
             );
-            // CR 303.4f: "attached to [source]" — forward the moved card to an Attach sub_ability
-            if attach_to_source {
+            if let Some(host) = attach_host {
                 change_zone.forward_result = true;
                 change_zone.sub_ability = Some(Box::new(AbilityDefinition::new(
                     kind,
                     Effect::Attach {
                         attachment: TargetFilter::SelfRef,
-                        target: TargetFilter::Any,
+                        target: host,
                     },
                 )));
             }
@@ -4392,8 +4484,13 @@ pub(super) fn parse_intrinsic_continuation_ast(
                 return None;
             }
             let lower = text.to_lowercase();
-            let attach_to_source = nom_primitives::scan_contains(&full_lower, "attached to")
-                || nom_primitives::scan_contains(&lower, "attached to");
+            let attach_host = if nom_primitives::scan_contains(&full_lower, "attached to")
+                || nom_primitives::scan_contains(&lower, "attached to")
+            {
+                parse_search_attach_host(&full_lower).or(Some(TargetFilter::Any))
+            } else {
+                None
+            };
             // CR 701.23a + CR 701.18a: Scan "onto the battlefield tapped" across
             // the whole sentence (full_lower) so the destination compound's
             // "enters tapped" modifier is detected even when the put-step is
@@ -4439,7 +4536,7 @@ pub(super) fn parse_intrinsic_continuation_ast(
                 enters_under: nom_primitives::scan_contains(&full_lower, "under your control")
                     .then_some(ControllerRef::You),
                 reveal,
-                attach_to_source,
+                attach_host,
             })
         }
         _ => None,
@@ -10971,6 +11068,35 @@ mod tests {
                 })
             ),
             "expected bare of-them DigFromAmong, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn search_attach_host_that_creature_is_parent_target() {
+        use crate::types::ability::TypedFilter;
+        assert_eq!(
+            super::parse_search_attach_host(
+                "put it onto the battlefield attached to that creature, then shuffle"
+            ),
+            Some(TargetFilter::ParentTarget)
+        );
+        assert_eq!(
+            super::parse_search_attach_host(
+                "put it onto the battlefield attached to target creature. if you search your library this way, shuffle"
+            ),
+            Some(TargetFilter::Typed(TypedFilter::creature()))
+        );
+        assert_eq!(
+            super::parse_search_attach_host(
+                "put it onto the battlefield attached to target player, then shuffle"
+            ),
+            Some(TargetFilter::Player)
+        );
+        assert_eq!(
+            super::parse_search_attach_host(
+                "put that card onto the battlefield attached to ~, then shuffle"
+            ),
+            Some(TargetFilter::SelfRef)
         );
     }
 

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -210,9 +210,9 @@ pub(crate) enum ContinuationAst {
         enters_under: Option<ControllerRef>,
         /// CR 701.23a: When true, the searched card is revealed before it moves.
         reveal: bool,
-        /// When true, the found card enters "attached to" the search source.
-        /// Adds forward_result on the ChangeZone and chains an Attach sub_ability.
-        attach_to_source: bool,
+        /// When `Some`, the found card enters attached to this host filter.
+        /// Adds `forward_result` on the ChangeZone and chains an Attach sub_ability.
+        attach_host: Option<TargetFilter>,
     },
     RevealHandFilter {
         card_filter: Option<TargetFilter>,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -985,6 +985,9 @@ pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_kind: Option<EffectKind>,
+    /// CR 303.4f: Attach host captured before SearchChoice overwrites parent targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_attach_host: Option<AttachTarget>,
 }
 
 impl PendingContinuation {
@@ -995,6 +998,7 @@ impl PendingContinuation {
         Self {
             chain,
             parent_kind: None,
+            search_attach_host: None,
         }
     }
 
@@ -1006,6 +1010,7 @@ impl PendingContinuation {
         Self {
             chain,
             parent_kind: Some(parent_kind),
+            search_attach_host: None,
         }
     }
 }
@@ -1196,6 +1201,9 @@ pub struct PendingChangeZoneIteration {
     /// carry-through pattern on this same struct.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enters_modified_if: Option<crate::types::ability::TargetFilter>,
+    /// CR 303.4f: Pre-resolved Aura host carried across a paused ChangeZone loop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enter_attached_to: Option<AttachTarget>,
     pub effect_kind: crate::types::ability::EffectKind,
 }
 
@@ -7316,6 +7324,10 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_continuation: Option<PendingContinuation>,
 
+    /// CR 303.4f: Attach host captured before SearchChoice replaces parent targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_continuation_attach_host: Option<AttachTarget>,
+
     /// CR 609.3 + CR 109.5: Pending `repeat_for` iteration loop paused mid-flight
     /// because the inner effect entered an interactive `WaitingFor` state.
     /// Drained by `drain_pending_continuation` AFTER `pending_continuation`,
@@ -8641,6 +8653,7 @@ impl GameState {
             revealed_cards: HashSet::new(),
             public_revealed_cards: HashSet::new(),
             pending_continuation: None,
+            search_continuation_attach_host: None,
             pending_repeat_iteration: None,
             pending_repeated_optional_payment: None,
             pending_change_zone_iteration: None,
@@ -10690,6 +10703,7 @@ mod tests {
             library_placement: None,
             effect_kind: crate::types::ability::EffectKind::ChangeZone,
             enters_modified_if: None,
+            enter_attached_to: None,
         };
         let json = serde_json::to_string(&original).expect("serialize");
         // Modern shape must be emitted, NOT the legacy bool field.

--- a/crates/engine/tests/integration/issue_4824_light_paws_aura_attach.rs
+++ b/crates/engine/tests/integration/issue_4824_light_paws_aura_attach.rs
@@ -1,0 +1,266 @@
+//! Issue #4824: library-search put steps that attach Auras must honor the
+//! parsed attach host (SelfRef, ParentTarget, or typed target creature/player)
+//! instead of opening an Aura host-choice prompt.
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{Effect, TargetFilter, TypedFilter};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LIGHT_PAWS_ORACLE: &str =
+    "Whenever an Aura you control enters, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, then shuffle.";
+
+const TYPED_CREATURE_TUTOR_ORACLE: &str =
+    "{T}: Search your library for an Aura card, put it onto the battlefield attached to target creature, then shuffle.";
+
+const TYPED_PLAYER_TUTOR_ORACLE: &str =
+    "{T}: Search your library for a Curse card, put it onto the battlefield attached to target player, then shuffle.";
+
+fn search_attach_host_from_ability(
+    ability: &engine::types::ability::AbilityDefinition,
+) -> &TargetFilter {
+    let change_zone = ability.sub_ability.as_ref().expect("search put-step sub");
+    let attach = change_zone
+        .sub_ability
+        .as_ref()
+        .expect("attach sub")
+        .effect
+        .as_ref();
+    match attach {
+        Effect::Attach { target, .. } => target,
+        other => panic!("expected Attach sub, got {other:?}"),
+    }
+}
+
+#[test]
+fn typed_creature_tutor_oracle_search_attach_host_parses_as_creature() {
+    let parsed = parse_oracle_text(
+        TYPED_CREATURE_TUTOR_ORACLE,
+        "Aura Tutor",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let ability = parsed.abilities.first().expect("activated ability");
+    assert_eq!(
+        search_attach_host_from_ability(ability),
+        &TargetFilter::Typed(TypedFilter::creature()),
+        "typed creature attach host must parse from search continuation"
+    );
+}
+
+#[test]
+fn typed_player_tutor_oracle_search_attach_host_parses_as_player() {
+    let parsed = parse_oracle_text(
+        "{T}: Search your library for a Curse card, put it onto the battlefield attached to target player, then shuffle.",
+        "Curse Tutor",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let ability = parsed.abilities.first().expect("activated ability");
+    assert_eq!(
+        search_attach_host_from_ability(ability),
+        &TargetFilter::Player,
+        "typed player attach host must parse from search continuation"
+    );
+}
+
+#[test]
+fn light_paws_oracle_search_attach_host_parses_as_self_ref() {
+    let parsed = parse_oracle_text(
+        LIGHT_PAWS_ORACLE,
+        "Light-Paws, Emperor's Voice",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed.triggers.first().expect("trigger");
+    let execute = trigger.execute.as_ref().expect("execute");
+    let sub = execute.sub_ability.as_ref().expect("change zone sub");
+    let attach = sub
+        .sub_ability
+        .as_ref()
+        .expect("attach sub")
+        .effect
+        .as_ref();
+    match attach {
+        Effect::Attach { target, .. } => {
+            assert_eq!(
+                target,
+                &TargetFilter::SelfRef,
+                "search put-step must attach to the ability source (~)"
+            );
+        }
+        other => panic!("expected Attach sub, got {other:?}"),
+    }
+}
+
+#[test]
+fn light_paws_searched_aura_enters_attached_without_host_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let light_paws = scenario
+        .add_creature_from_oracle(P0, "Light-Paws, Emperor's Voice", 1, 2, LIGHT_PAWS_ORACLE)
+        .id();
+
+    let searched_aura = scenario
+        .add_spell_to_library_top(P0, "Search Aura Two", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let cast_aura = scenario
+        .add_spell_to_hand(P0, "Cast Aura One", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::White, ObjectId(9_998), false, vec![]),
+            ManaUnit::new(ManaType::White, ObjectId(9_999), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+
+    runner
+        .cast(cast_aura)
+        .target_object(light_paws)
+        .accept_optional()
+        .search_first_legal()
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&searched_aura].zone,
+        Zone::Battlefield,
+        "searched Aura must enter the battlefield from the library search"
+    );
+    assert_eq!(
+        runner.state().objects[&searched_aura].attached_to,
+        Some(AttachTarget::Object(light_paws)),
+        "searched Aura must attach to Light-Paws without a host-choice prompt"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReturnAsAuraTarget { .. } | WaitingFor::TargetSelection { .. }
+        ),
+        "search put must not surface an Aura host prompt, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn searched_aura_attaches_to_chosen_creature_without_host_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let tutor = scenario
+        .add_creature_from_oracle(P0, "Aura Tutor", 1, 1, TYPED_CREATURE_TUTOR_ORACLE)
+        .id();
+    let chosen_target = scenario.add_vanilla(P0, 2, 2);
+    let _decoy_host = scenario.add_vanilla(P0, 3, 3);
+
+    let searched_aura = scenario
+        .add_spell_to_library_top(P0, "Searched Aura", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner
+        .activate(tutor, 0)
+        .target_object(chosen_target)
+        .search_first_legal()
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&searched_aura].zone,
+        Zone::Battlefield,
+        "searched Aura must enter the battlefield from the library search"
+    );
+    assert_eq!(
+        runner.state().objects[&searched_aura].attached_to,
+        Some(AttachTarget::Object(chosen_target)),
+        "searched Aura must attach to the ability's chosen target creature"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReturnAsAuraTarget { .. } | WaitingFor::TargetSelection { .. }
+        ),
+        "typed creature attach host must not surface an Aura host prompt, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn searched_curse_attaches_to_chosen_player_without_host_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let tutor = scenario
+        .add_creature_from_oracle(P0, "Curse Tutor", 1, 1, TYPED_PLAYER_TUTOR_ORACLE)
+        .id();
+
+    let searched_curse = scenario
+        .add_spell_to_library_top(P0, "Searched Curse", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura", "Curse"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Player))
+        .id();
+
+    let mut runner = scenario.build();
+
+    runner
+        .activate(tutor, 0)
+        .target_player(P1)
+        .search_first_legal()
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&searched_curse].zone,
+        Zone::Battlefield,
+        "searched Curse must enter the battlefield from the library search"
+    );
+    assert_eq!(
+        runner.state().objects[&searched_curse].attached_to,
+        Some(AttachTarget::Player(P1)),
+        "searched Curse must attach to the ability's chosen target player"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReturnAsAuraTarget { .. } | WaitingFor::TargetSelection { .. }
+        ),
+        "typed player attach host must not surface an Aura host prompt when P0 is also legal, got {:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -412,6 +412,7 @@ mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
 mod issue_4786_wrenn_realmbreaker;
 mod issue_4792_isochron_scepter;
+mod issue_4824_light_paws_aura_attach;
 mod issue_4829_zenith_chronicler;
 mod issue_4830_orvar_land_copy;
 mod issue_4831_bloodthorn_flail_equip;


### PR DESCRIPTION
## Summary
- Pre-resolve Aura attach hosts for library-search put steps that chain a `forward_result` Attach sub, so Light-Paws tutors attach to the trigger source instead of opening a creature choice prompt.
- Parse search continuations like "attached to ~" / card self-reference as `TargetFilter::SelfRef` rather than `Any`.
- Add parser regression coverage for Light-Paws search attach wiring.

Fixes #4824

## Test plan
- [x] `cargo test -p engine --test integration light_paws`


Made with [Cursor](https://cursor.com)