### PR TITLE
Fix Isochron Scepter cast of copied imprint (fixes #4792)

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -485,7 +485,7 @@ fn cast_stack_spell_copy_during_resolution(
         ability.controller,
         None,
     )
-    .map_err(|e| EffectError::InvalidParam(e))?
+    .map_err(EffectError::InvalidParam)?
     {
         return Ok(());
     }

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
     SpellStackToGraveyardReplacement, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{CastingVariant, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::zones::Zone;
@@ -333,6 +333,9 @@ pub fn resolve(
     }
 
     if driver_free_cast || immediate_graveyard_free_cast {
+        if is_stack_spell_copy(state, target_ids[0]) {
+            return cast_stack_spell_copy_during_resolution(state, ability, target_ids[0], events);
+        }
         return cast_single_target_during_resolution(
             state,
             ability,
@@ -425,6 +428,72 @@ fn effective_cast_from_zone_constraint(
             None
         }
     })
+}
+
+/// CR 707.10 + CR 608.2g: A `CopySpell` that put a spell copy onto the stack
+/// (Isochron Scepter / Spellbinder) is not yet cast. A chained `CastFromZone {
+/// ParentTarget, DuringResolution }` completes that cast without moving zones.
+fn is_stack_spell_copy(state: &GameState, object_id: ObjectId) -> bool {
+    state.objects.get(&object_id).is_some_and(|obj| {
+        obj.zone == Zone::Stack && state.stack.iter().any(|entry| entry.id == object_id)
+    })
+}
+
+/// CR 707.10 + CR 118.9: Finish casting a spell copy that `CopySpell` already
+/// placed on the stack — emit `SpellCast`, open CR 707.10c retarget selection
+/// when needed, and do not route through `initiate_cast_during_resolution`
+/// (Stack is not a castable origin zone).
+fn cast_stack_spell_copy_during_resolution(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    copy_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CastFromZone,
+        source_id: ability.source_id,
+    });
+
+    let Some(obj) = state.objects.get(&copy_id).cloned() else {
+        return Err(EffectError::InvalidParam(format!(
+            "stack spell copy {copy_id:?} not found"
+        )));
+    };
+    if obj.zone != Zone::Stack {
+        return Err(EffectError::InvalidParam(format!(
+            "ParentTarget {copy_id:?} is not a stack spell copy"
+        )));
+    }
+
+    let origin = obj.cast_from_zone.unwrap_or(Zone::Exile);
+    events.push(GameEvent::SpellCast {
+        card_id: obj.card_id,
+        controller: ability.controller,
+        object_id: copy_id,
+    });
+    crate::game::restrictions::record_spell_cast_from_zone(
+        state,
+        ability.controller,
+        &obj,
+        origin,
+        CastingVariant::Normal,
+    );
+
+    if crate::game::effects::prepare::open_copy_target_selection(
+        state,
+        copy_id,
+        ability.controller,
+        None,
+    )
+    .map_err(|e| EffectError::InvalidParam(e))?
+    {
+        return Ok(());
+    }
+
+    state.waiting_for = WaitingFor::Priority {
+        player: ability.controller,
+    };
+    Ok(())
 }
 
 /// CR 608.2g + CR 601.2a–i: Cast a single targeted card DURING the resolution of
@@ -1008,6 +1077,138 @@ mod tests {
         assert!(
             state.players.iter().all(|p| p.mana_pool.total() == 0),
             "the free cast must not require or consume mana"
+        );
+    }
+
+    /// CR 707.10 + CR 608.2g (issue #4792): Isochron Scepter copies an imprinted
+    /// instant onto the stack, then a chained `CastFromZone { ParentTarget,
+    /// DuringResolution }` completes the free cast. The copy must not be routed
+    /// through `initiate_cast_during_resolution` — Stack is not a castable zone.
+    #[test]
+    fn stack_spell_copy_parent_target_casts_without_zone_move() {
+        use std::sync::Arc;
+
+        use crate::game::effects::copy_spell;
+        use crate::types::ability::{
+            AbilityDefinition, AbilityKind, CopyRetargetPermission, QuantityExpr,
+        };
+        use crate::types::game_state::{StackEntry, StackEntryKind};
+
+        let mut state = make_test_state();
+        let scepter_id = ObjectId(5);
+        let target_creature = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(1),
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&target_creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+        }
+
+        let imprint_spell = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Any,
+                damage_source: None,
+            },
+        );
+        let imprint_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Shock".to_string(),
+            Zone::Exile,
+        );
+        state.objects.get_mut(&imprint_id).unwrap().abilities = Arc::new(vec![imprint_spell]);
+        state
+            .tracked_object_sets
+            .insert(crate::types::identifiers::TrackedSetId(0), vec![imprint_id]);
+
+        let copy_ability = ResolvedAbility::new(
+            Effect::CopySpell {
+                target: TargetFilter::TrackedSet {
+                    id: crate::types::identifiers::TrackedSetId(0),
+                },
+                retarget: CopyRetargetPermission::KeepOriginalTargets,
+                copier: None,
+                additional_modifications: vec![],
+                starting_loyalty_from_casualty_sacrifice: false,
+            },
+            vec![],
+            scepter_id,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        copy_spell::resolve(&mut state, &copy_ability, &mut events).unwrap();
+        let copy_id = state.stack.back().expect("copy on stack").id;
+
+        let cast_ability = ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::ParentTarget,
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: false,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::DuringResolution,
+                mana_spend_permission: None,
+            },
+            vec![TargetRef::Object(copy_id)],
+            scepter_id,
+            PlayerId(0),
+        );
+        resolve(&mut state, &cast_ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.objects.get(&imprint_id).map(|o| o.zone),
+            Some(Zone::Exile),
+            "imprinted card stays in exile"
+        );
+        assert_eq!(
+            state.objects.get(&copy_id).map(|o| o.zone),
+            Some(Zone::Stack),
+            "copy remains on the stack"
+        );
+        assert!(
+            events.iter().any(|event| {
+                matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == copy_id)
+            }),
+            "CastFromZone must complete the copy cast with SpellCast"
+        );
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::CopyRetarget { copy_id: cid, .. } if cid == copy_id
+            ),
+            "targeted copy must open retarget selection, got {:?}",
+            state.waiting_for
+        );
+
+        // Choose a target and finalize the cast.
+        let _ = apply_as_current(
+            &mut state,
+            GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(target_creature)),
+            },
+        )
+        .expect("choose shock target");
+        assert!(
+            state.stack.iter().any(|entry| {
+                matches!(
+                    entry,
+                    StackEntry {
+                        id,
+                        kind: StackEntryKind::Spell { .. },
+                        ..
+                    } if *id == copy_id
+                )
+            }),
+            "copy spell must remain on the stack after targeting"
         );
     }
 

--- a/crates/engine/tests/integration/issue_4792_isochron_scepter.rs
+++ b/crates/engine/tests/integration/issue_4792_isochron_scepter.rs
@@ -1,0 +1,119 @@
+//! Issue #4792: Isochron Scepter must allow casting the copied imprinted instant.
+
+use engine::game::rehydrate_game_from_card_db;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{ExileLink, ExileLinkKind, WaitingFor};
+use engine::types::identifiers::TrackedSetId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+
+fn fund_generic(runner: &mut GameRunner, amount: u32) {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    let pool = &mut runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == P0)
+        .unwrap()
+        .mana_pool;
+    for _ in 0..amount {
+        pool.add(ManaUnit::new(ManaType::Colorless, dummy, false, vec![]));
+    }
+}
+
+fn link_imprinted_instant(
+    runner: &mut GameRunner,
+    scepter: engine::types::identifiers::ObjectId,
+    imprint: engine::types::identifiers::ObjectId,
+) {
+    let state = runner.state_mut();
+    assert_eq!(
+        state.objects.get(&imprint).map(|o| o.zone),
+        Some(Zone::Exile),
+        "imprint candidate must start in exile"
+    );
+    state.exile_links.push(ExileLink {
+        source_id: scepter,
+        exiled_id: imprint,
+        kind: ExileLinkKind::TrackedBySource,
+    });
+    state
+        .tracked_object_sets
+        .insert(TrackedSetId(0), vec![imprint]);
+}
+
+fn drive_isochron_activation(runner: &mut GameRunner, target: engine::types::ability::TargetRef) {
+    for step in 0..80 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept optional copy/cast");
+            }
+            WaitingFor::CopyRetarget { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(target.clone()),
+                    })
+                    .expect("choose shock target");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => return,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass");
+            }
+            other if runner.state().stack.is_empty() => {
+                panic!("unexpected waiting state at step {step}: {other:?}");
+            }
+            _ => {}
+        }
+    }
+    panic!(
+        "Isochron activation did not finish: stack={:?} waiting={:?}",
+        runner.state().stack,
+        runner.state().waiting_for
+    );
+}
+
+#[test]
+fn isochron_scepter_copies_and_casts_imprinted_instant() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let scepter = scenario.add_real_card(P0, "Isochron Scepter", Zone::Battlefield, db);
+    let shock = scenario.add_real_card(P0, "Shock", Zone::Exile, db);
+
+    let mut runner = scenario.build();
+    rehydrate_game_from_card_db(runner.state_mut(), db);
+    link_imprinted_instant(&mut runner, scepter, shock);
+    fund_generic(&mut runner, 2);
+
+    let life_before = runner.state().players[1].life;
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: scepter,
+            ability_index: 0,
+        })
+        .expect("Isochron activation must be legal with imprint and mana");
+
+    drive_isochron_activation(&mut runner, engine::types::ability::TargetRef::Player(P1));
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().players[1].life < life_before,
+        "Shock copy must deal damage to the chosen creature's controller"
+    );
+    assert_eq!(
+        runner.state().objects.get(&shock).map(|o| o.zone),
+        Some(Zone::Exile),
+        "imprinted Shock stays exiled after copying"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -400,6 +400,7 @@ mod issue_4560_winter_soldier;
 mod issue_4564_captain_america_team_leader;
 mod issue_4566_jocasta;
 mod issue_4663_chosen_x_ptcomparison_targets;
+mod issue_4792_isochron_scepter;
 mod issue_4829_zenith_chronicler;
 mod issue_4830_orvar_land_copy;
 mod issue_4835_intimidation_tactics;


### PR DESCRIPTION
## Summary
- Route `CastFromZone { ParentTarget, DuringResolution }` through a stack-copy completion path when the target is already on the stack after `CopySpell`
- Emit `SpellCast`, record cast-from-zone provenance, and open copy retarget selection instead of calling `initiate_cast_during_resolution` (Stack is not a castable origin zone)
- Add integration coverage for Isochron Scepter copying and casting an imprinted Shock

## Test plan
- [x] `cargo test -p engine --lib cast_from_zone::tests::stack_spell_copy_parent_target_casts_without_zone_move`
- [x] `cargo test -p engine --test integration isochron_scepter_copies_and_casts_imprinted_instant`


Made with [Cursor](https://cursor.com)