### PR TITLE
Fix For the Ancestors chosen creature-type dig filter (#4834)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1104,6 +1104,21 @@ fn retarget_chosen_card_type_to_creature_type(filter: &mut TargetFilter) {
     }
 }
 
+/// CR 608.2c: Dig/reveal continuations after "Choose a creature type" refer to
+/// creature subtypes ("cards of the chosen type", For the Ancestors). The bare
+/// "cards" base defaults to `IsChosenCardType`; realign those dig filters once
+/// the persisted choice is known to be creature-type.
+fn retarget_creature_type_choice_dig_filters(result: &mut ParsedAbilities) {
+    for ability in &mut result.abilities {
+        retarget_creature_type_choice_dig_filters_in_ability(ability);
+    }
+    for trigger in &mut result.triggers {
+        if let Some(execute) = trigger.execute.as_mut() {
+            retarget_creature_type_choice_dig_filters_in_ability(execute);
+        }
+    }
+}
+
 fn retarget_creature_type_choice_dig_filters_in_ability(def: &mut AbilityDefinition) {
     if let Effect::Dig { filter, .. } = &mut *def.effect {
         retarget_chosen_card_type_to_creature_type(filter);
@@ -1113,9 +1128,6 @@ fn retarget_creature_type_choice_dig_filters_in_ability(def: &mut AbilityDefinit
     }
 }
 
-/// CR 702.26a + CR 603.7c: Upgrade bare one-shot `PhaseOut` ETB effects that
-/// carry a host-bound re-entry rider ("Tap that creature as it phases in this
-/// way", Oubliette) into PhaseOut + CantPhaseIn + delayed PhaseIn/Tap.
 fn chosen_kind_from_card_types(types: &[String]) -> Option<ChosenSubtypeKind> {
     if types.iter().any(|card_type| card_type == "Creature") {
         Some(ChosenSubtypeKind::CreatureType)

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1053,6 +1053,7 @@ fn reconcile_self_chosen_type_statics(result: &mut ParsedAbilities, types: &[Str
                 retarget_chosen_card_type_to_creature_type(filter);
             }
         }
+        retarget_creature_type_choice_dig_filters(result);
     }
 
     let Some(chosen_kind) = persisted_kind.or_else(|| chosen_kind_from_card_types(types)) else {
@@ -1103,6 +1104,18 @@ fn retarget_chosen_card_type_to_creature_type(filter: &mut TargetFilter) {
     }
 }
 
+fn retarget_creature_type_choice_dig_filters_in_ability(def: &mut AbilityDefinition) {
+    if let Effect::Dig { filter, .. } = &mut *def.effect {
+        retarget_chosen_card_type_to_creature_type(filter);
+    }
+    if let Some(sub) = def.sub_ability.as_mut() {
+        retarget_creature_type_choice_dig_filters_in_ability(sub);
+    }
+}
+
+/// CR 702.26a + CR 603.7c: Upgrade bare one-shot `PhaseOut` ETB effects that
+/// carry a host-bound re-entry rider ("Tap that creature as it phases in this
+/// way", Oubliette) into PhaseOut + CantPhaseIn + delayed PhaseIn/Tap.
 fn chosen_kind_from_card_types(types: &[String]) -> Option<ChosenSubtypeKind> {
     if types.iter().any(|card_type| card_type == "Creature") {
         Some(ChosenSubtypeKind::CreatureType)

--- a/crates/engine/tests/for_the_ancestors_chosen_creature_type_4834.rs
+++ b/crates/engine/tests/for_the_ancestors_chosen_creature_type_4834.rs
@@ -10,7 +10,11 @@ use engine::types::zones::Zone;
 
 const FOR_THE_ANCESTORS: &str = "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G}";
 
-fn stage_creature(runner: &mut engine::game::scenario::GameRunner, id: engine::types::identifiers::ObjectId, subtype: &str) {
+fn stage_creature(
+    runner: &mut engine::game::scenario::GameRunner,
+    id: engine::types::identifiers::ObjectId,
+    subtype: &str,
+) {
     let obj = runner.state_mut().objects.get_mut(&id).unwrap();
     obj.card_types.core_types.push(CoreType::Creature);
     obj.card_types.subtypes = vec![subtype.to_string()];
@@ -38,9 +42,7 @@ fn for_the_ancestors_exposes_matching_cards_in_dig_choice() {
     stage_creature(&mut runner, elf_one, "Elf");
     stage_creature(&mut runner, elf_two, "Elf");
     stage_creature(&mut runner, non_elf, "Human");
-    runner
-        .state_mut()
-        .players[P0.0 as usize]
+    runner.state_mut().players[P0.0 as usize]
         .mana_pool
         .add(engine::types::mana::ManaUnit::new(
             engine::types::mana::ManaType::Green,
@@ -64,10 +66,26 @@ fn for_the_ancestors_exposes_matching_cards_in_dig_choice() {
                 ..
             } => {
                 assert!(
-                    !selectable_cards.is_empty(),
-                    "matching Elf cards must be selectable"
+                    selectable_cards.contains(&elf_one),
+                    "Elf One must be selectable; selectable = {selectable_cards:?}"
                 );
-                assert!(keep_count > 0, "keep_count must reflect selectable Elves");
+                assert!(
+                    selectable_cards.contains(&elf_two),
+                    "Elf Two must be selectable; selectable = {selectable_cards:?}"
+                );
+                assert!(
+                    !selectable_cards.contains(&non_elf),
+                    "Non-Elf (Human) must NOT be selectable; selectable = {selectable_cards:?}"
+                );
+                assert_eq!(
+                    selectable_cards.len(),
+                    2,
+                    "exactly the two Elf cards must be selectable; selectable = {selectable_cards:?}"
+                );
+                assert_eq!(
+                    keep_count, 2,
+                    "keep_count must reflect both selectable Elves"
+                );
                 return;
             }
             WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
@@ -103,9 +121,7 @@ fn for_the_ancestors_puts_revealed_elves_in_hand() {
     stage_creature(&mut runner, elf_one, "Elf");
     stage_creature(&mut runner, elf_two, "Elf");
     stage_creature(&mut runner, non_elf, "Human");
-    runner
-        .state_mut()
-        .players[P0.0 as usize]
+    runner.state_mut().players[P0.0 as usize]
         .mana_pool
         .add(engine::types::mana::ManaUnit::new(
             engine::types::mana::ManaType::Green,
@@ -123,21 +139,23 @@ fn for_the_ancestors_puts_revealed_elves_in_hand() {
 
     for _ in 0..24 {
         match runner.state().waiting_for.clone() {
-            WaitingFor::DigChoice { cards, .. } => {
-                let kept: Vec<_> = cards
-                    .iter()
-                    .filter(|id| {
-                        runner.state().objects[id]
-                            .card_types
-                            .subtypes
-                            .iter()
-                            .any(|s| s == "Elf")
-                    })
-                    .copied()
-                    .collect();
+            WaitingFor::DigChoice {
+                selectable_cards, ..
+            } => {
+                assert_eq!(
+                    selectable_cards.len(),
+                    2,
+                    "exactly the two Elf cards must be selectable; selectable = {selectable_cards:?}"
+                );
+                assert!(
+                    !selectable_cards.contains(&non_elf),
+                    "Human must be excluded from selectable_cards; selectable = {selectable_cards:?}"
+                );
                 runner
-                    .act(GameAction::SelectCards { cards: kept })
-                    .expect("keep all Elves");
+                    .act(GameAction::SelectCards {
+                        cards: selectable_cards.clone(),
+                    })
+                    .expect("keep all selectable Elves");
             }
             WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
             _ => {

--- a/crates/engine/tests/for_the_ancestors_chosen_creature_type_4834.rs
+++ b/crates/engine/tests/for_the_ancestors_chosen_creature_type_4834.rs
@@ -1,0 +1,153 @@
+//! Issue #4834: For the Ancestors must allow revealing cards of the chosen type.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const FOR_THE_ANCESTORS: &str = "Choose a creature type. Look at the top six cards of your library. You may reveal any number of cards of the chosen type from among them and put the revealed cards into your hand. Put the rest on the bottom of your library in a random order.\nFlashback {3}{G}";
+
+fn stage_creature(runner: &mut engine::game::scenario::GameRunner, id: engine::types::identifiers::ObjectId, subtype: &str) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.card_types.subtypes = vec![subtype.to_string()];
+    obj.base_card_types = obj.card_types.clone();
+}
+
+#[test]
+fn for_the_ancestors_exposes_matching_cards_in_dig_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let elf_one = scenario.add_card_to_library_top(P0, "Elf One");
+    let non_elf = scenario.add_card_to_library_top(P0, "Non-Elf");
+    let elf_two = scenario.add_card_to_library_top(P0, "Elf Two");
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "For the Ancestors", false, FOR_THE_ANCESTORS)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![engine::types::mana::ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    stage_creature(&mut runner, elf_one, "Elf");
+    stage_creature(&mut runner, elf_two, "Elf");
+    stage_creature(&mut runner, non_elf, "Human");
+    runner
+        .state_mut()
+        .players[P0.0 as usize]
+        .mana_pool
+        .add(engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Green,
+            spell,
+            false,
+            vec![],
+        ));
+
+    runner.cast(spell).resolve();
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Elf".to_string(),
+        })
+        .expect("choose Elf");
+
+    for _ in 0..24 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DigChoice {
+                selectable_cards,
+                keep_count,
+                ..
+            } => {
+                assert!(
+                    !selectable_cards.is_empty(),
+                    "matching Elf cards must be selectable"
+                );
+                assert!(keep_count > 0, "keep_count must reflect selectable Elves");
+                return;
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                panic!("stack emptied without presenting DigChoice");
+            }
+            _ => {
+                runner.act(GameAction::PassPriority).expect("pass");
+            }
+        }
+    }
+
+    panic!("never reached DigChoice prompt");
+}
+
+#[test]
+fn for_the_ancestors_puts_revealed_elves_in_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let elf_one = scenario.add_card_to_library_top(P0, "Elf One");
+    let non_elf = scenario.add_card_to_library_top(P0, "Non-Elf");
+    let elf_two = scenario.add_card_to_library_top(P0, "Elf Two");
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "For the Ancestors", false, FOR_THE_ANCESTORS)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![engine::types::mana::ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    stage_creature(&mut runner, elf_one, "Elf");
+    stage_creature(&mut runner, elf_two, "Elf");
+    stage_creature(&mut runner, non_elf, "Human");
+    runner
+        .state_mut()
+        .players[P0.0 as usize]
+        .mana_pool
+        .add(engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Green,
+            spell,
+            false,
+            vec![],
+        ));
+
+    runner.cast(spell).resolve();
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Elf".to_string(),
+        })
+        .expect("choose Elf");
+
+    for _ in 0..24 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DigChoice { cards, .. } => {
+                let kept: Vec<_> = cards
+                    .iter()
+                    .filter(|id| {
+                        runner.state().objects[id]
+                            .card_types
+                            .subtypes
+                            .iter()
+                            .any(|s| s == "Elf")
+                    })
+                    .copied()
+                    .collect();
+                runner
+                    .act(GameAction::SelectCards { cards: kept })
+                    .expect("keep all Elves");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {
+                runner.act(GameAction::PassPriority).expect("pass");
+            }
+        }
+    }
+
+    let zone_of = |id| runner.state().objects[&id].zone;
+    assert_eq!(zone_of(elf_one), Zone::Hand);
+    assert_eq!(zone_of(elf_two), Zone::Hand);
+    assert_eq!(zone_of(non_elf), Zone::Library);
+}


### PR DESCRIPTION
## Summary
- Retarget dig/reveal filters after a creature-type choice from `IsChosenCardType` to `IsChosenCreatureType`
- For the Ancestors now exposes matching cards in the reveal choice instead of 0/0

Fixes #4834

## Test plan
- [x] `cargo test -p engine --test for_the_ancestors_chosen_creature_type_4834`