### PR TITLE
fix(parser): harden trailing if-gate combinator on static restrictions (#4876)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -869,6 +869,86 @@ where
     None
 }
 
+/// Like [`scan_at_word_boundaries`] but returns the **last** successful match,
+/// together with the byte offset where that match began.
+pub fn scan_last_at_word_boundaries_with_offset<'a, O, F>(
+    text: &'a str,
+    mut combinator: F,
+) -> Option<(usize, O, &'a str)>
+where
+    F: FnMut(&'a str) -> nom::IResult<&'a str, O, OracleError<'a>>,
+{
+    let mut remaining = text;
+    let mut offset = 0;
+    let mut last = None;
+    while !remaining.is_empty() {
+        if let Ok((rest, val)) = combinator(remaining) {
+            last = Some((offset, val, rest));
+        }
+        if let Some(rel) = remaining.find(' ') {
+            offset += rel + 1;
+            remaining = remaining[rel + 1..].trim_start();
+        } else {
+            break;
+        }
+    }
+    last
+}
+
+/// Like [`scan_last_at_word_boundaries_with_offset`] but only retains matches
+/// whose offset passes `accept_offset`.
+pub fn scan_last_valid_at_word_boundaries_with_offset<'a, O, F, P>(
+    text: &'a str,
+    mut combinator: F,
+    mut accept_offset: P,
+) -> Option<(usize, O, &'a str)>
+where
+    F: FnMut(&'a str) -> nom::IResult<&'a str, O, OracleError<'a>>,
+    P: FnMut(usize) -> bool,
+{
+    let mut remaining = text;
+    let mut offset = 0;
+    let mut last = None;
+    while !remaining.is_empty() {
+        if let Ok((rest, val)) = combinator(remaining) {
+            if accept_offset(offset) {
+                last = Some((offset, val, rest));
+            }
+        }
+        if let Some(rel) = remaining.find(' ') {
+            offset += rel + 1;
+            remaining = remaining[rel + 1..].trim_start();
+        } else {
+            break;
+        }
+    }
+    last
+}
+
+/// Like [`scan_at_word_boundaries`] but returns the **last** successful match.
+///
+/// Use for terminal riders ("... if <condition>", "... as long as <condition>")
+/// where an earlier `as if` phrase must not steal the gate.
+pub fn scan_last_at_word_boundaries<'a, O, F>(
+    text: &'a str,
+    mut combinator: F,
+) -> Option<(O, &'a str)>
+where
+    F: FnMut(&'a str) -> nom::IResult<&'a str, O, OracleError<'a>>,
+{
+    let mut remaining = text;
+    let mut last = None;
+    while !remaining.is_empty() {
+        if let Ok((rest, val)) = combinator(remaining) {
+            last = Some((val, rest));
+        }
+        remaining = remaining
+            .find(' ')
+            .map_or("", |i| remaining[i + 1..].trim_start());
+    }
+    last
+}
+
 /// Check whether `phrase` appears at any word boundary in `text`.
 ///
 /// More precise than `str::contains()` — matches complete phrases at word
@@ -1185,6 +1265,44 @@ mod tests {
         let result = scan_preceded("the creature enters", |i| {
             tag::<_, _, OracleError<'_>>("dies").parse(i)
         });
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_scan_last_at_word_boundaries_picks_terminal_if_gate() {
+        let (_, tail) = scan_last_at_word_boundaries(
+            "you may cast as if they had flash if you control a zombie",
+            |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+        )
+        .expect("terminal if gate");
+        assert_eq!(tail, "you control a zombie");
+    }
+
+    #[test]
+    fn test_scan_last_at_word_boundaries_with_offset_picks_terminal_if_gate() {
+        let (_, _, tail) = scan_last_at_word_boundaries_with_offset(
+            "you can't play lands as if there were no rule if ten or more lands are on the battlefield",
+            |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+        )
+        .expect("terminal if gate");
+        assert_eq!(tail, "ten or more lands are on the battlefield");
+    }
+
+    #[test]
+    fn test_scan_last_at_word_boundaries_with_offset_skips_as_if() {
+        let result = scan_last_valid_at_word_boundaries_with_offset(
+            "you can't play lands as if there were no rule",
+            |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+            |if_offset| {
+                if_offset < 3
+                    || tag::<_, _, OracleError<'_>>("as ")
+                        .parse(
+                            &"you can't play lands as if there were no rule"
+                                [if_offset - 3..if_offset],
+                        )
+                        .is_err()
+            },
+        );
         assert!(result.is_none());
     }
 

--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -1294,12 +1294,12 @@ mod tests {
             "you can't play lands as if there were no rule",
             |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
             |if_offset| {
-                if_offset < 3
+                let Some(start) = if_offset.checked_sub(3) else {
+                    return true;
+                };
+                !"you can't play lands as if there were no rule".is_char_boundary(start)
                     || tag::<_, _, OracleError<'_>>("as ")
-                        .parse(
-                            &"you can't play lands as if there were no rule"
-                                [if_offset - 3..if_offset],
-                        )
+                        .parse(&"you can't play lands as if there were no rule"[start..if_offset])
                         .is_err()
             },
         );

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -451,21 +451,6 @@ pub(crate) fn parse_damage_not_removed_during_cleanup(
     )
 }
 
-/// Split a trailing " as long as <condition>" rider off a static line, returning
-/// the condition text when present (combinator form, no string-method dispatch).
-fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
-    opt(preceded(
-        (
-            take_until::<_, _, OracleError<'_>>(" as long as "),
-            tag(" as long as "),
-        ),
-        rest,
-    ))
-    .parse(lower)
-    .ok()
-    .and_then(|(_, condition)| condition)
-}
-
 /// CR 509.1b: "Creatures with power <comparison> <quantity> can't
 /// block this creature." — a can't-be-blocked-by restriction whose blocker
 /// filter gates on a power threshold that may be DYNAMIC (Kraken of the Straits:
@@ -524,26 +509,6 @@ fn filter_prop_has_power_comparison(prop: &FilterProp) -> bool {
         FilterProp::AnyOf { props } => props.iter().any(filter_prop_has_power_comparison),
         _ => false,
     }
-}
-
-/// CR 611.3a: A static restriction may carry a trailing gate introduced by
-/// either `" as long as <condition>"` (continuous) or `" if <condition>"` (state
-/// gate) — e.g. Rock Jockey: "You can't play lands if this creature was cast
-/// this turn." Returns the condition text for `parse_static_condition`. The
-/// `as long as` form is tried first so a card carrying both keywords anchors on
-/// the continuous form; a bare `if` gate is the fallback. As with
-/// `split_trailing_as_long_as`, an unrecognized condition downstream leaves the
-/// line unsupported rather than enforcing the restriction unconditionally.
-fn split_trailing_gate_condition(lower: &str) -> Option<&str> {
-    split_trailing_as_long_as(lower).or_else(|| {
-        opt(preceded(
-            (take_until::<_, _, OracleError<'_>>(" if "), tag(" if ")),
-            rest,
-        ))
-        .parse(lower)
-        .ok()
-        .and_then(|(_, condition)| condition)
-    })
 }
 
 pub(crate) fn parse_static_line_inner(

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1948,14 +1948,21 @@ fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
     Some(tp.original.get(start..)?.trim_start())
 }
 
+/// CR 508.1c + CR 509.1b: Split the gated combat tail `<A> and can't block if <B>`
+/// after the leading `"can't attack if "` marker has been consumed.
+fn parse_dual_gated_combat_condition_tails(input: &str) -> OracleResult<'_, (&str, &str)> {
+    let (input, attack_cond) = take_until(" and can't block if ").parse(input)?;
+    let (input, _) = tag(" and can't block if ").parse(input)?;
+    let (input, block_cond) = terminated(rest, opt(tag("."))).parse(input)?;
+    Ok((input, (attack_cond, block_cond)))
+}
+
 /// CR 508.1c + CR 509.1b: Split a compound "~ can't attack if <A> and can't block
 /// if <B>" static into two gated restrictions (The Fallen Apart).
 fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &str, &str)> {
     let (input, subject) = take_until("can't attack if ").parse(input)?;
     let (input, _) = tag("can't attack if ").parse(input)?;
-    let (input, attack_cond) = take_until(" and can't block if ").parse(input)?;
-    let (input, _) = tag(" and can't block if ").parse(input)?;
-    let (input, block_cond) = terminated(rest, opt(tag("."))).parse(input)?;
+    let (input, (attack_cond, block_cond)) = parse_dual_gated_combat_condition_tails(input)?;
     Ok((input, (subject, attack_cond, block_cond)))
 }
 
@@ -2050,13 +2057,9 @@ fn try_split_grant_and_dual_gated_combat(
             Ok((i, ()))
         })?;
 
-    let (remainder, (gate_subject, attack_cond_lower, block_cond_lower)) =
-        parse_dual_gated_cant_attack_block(gates_lower).ok()?;
-    if !gate_subject.trim().is_empty()
-        || !remainder.trim().is_empty()
-        || attack_cond_lower.is_empty()
-        || block_cond_lower.is_empty()
-    {
+    let (remainder, (attack_cond_lower, block_cond_lower)) =
+        parse_dual_gated_combat_condition_tails(gates_lower).ok()?;
+    if !remainder.trim().is_empty() || attack_cond_lower.is_empty() || block_cond_lower.is_empty() {
         return None;
     }
 
@@ -2475,53 +2478,6 @@ fn exists_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondit
         StaticCondition::QuantityComparison {
             lhs: QuantityExpr::Ref {
                 qty: QuantityRef::ObjectCount { filter },
-            },
-            comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: 1 },
-        },
-    ))
-}
-
-/// CR 611.3a: "there's / there is another <type> on the battlefield" (Shauku).
-fn parse_another_on_battlefield_condition(lower: &str) -> Option<StaticCondition> {
-    another_on_battlefield_condition(lower)
-        .ok()
-        .and_then(|(rest, cond)| rest.trim().trim_end_matches('.').is_empty().then_some(cond))
-}
-
-fn another_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (input, _) = alt((tag("there's another "), tag("there is another "))).parse(input)?;
-    let (input, type_text) = take_until(" on the battlefield").parse(input)?;
-    let (input, _) = tag(" on the battlefield").parse(input)?;
-    let (filter, remainder) = parse_type_phrase(type_text.trim());
-    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
-        return Err(nom::Err::Error(OracleError::new(
-            input,
-            nom::error::ErrorKind::Fail,
-        )));
-    }
-    let TargetFilter::Typed(mut tf) = filter else {
-        return Err(nom::Err::Error(OracleError::new(
-            input,
-            nom::error::ErrorKind::Fail,
-        )));
-    };
-    // "another <type>" excludes the ability source at runtime via
-    // FilterProp::Another — not ObjectCount(type) >= 2.
-    if !tf
-        .properties
-        .iter()
-        .any(|p| matches!(p, FilterProp::Another))
-    {
-        tf.properties.push(FilterProp::Another);
-    }
-    Ok((
-        input,
-        StaticCondition::QuantityComparison {
-            lhs: QuantityExpr::Ref {
-                qty: QuantityRef::ObjectCount {
-                    filter: TargetFilter::Typed(tf),
-                },
             },
             comparator: Comparator::GE,
             rhs: QuantityExpr::Fixed { value: 1 },

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1888,14 +1888,67 @@ pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticC
     })
 }
 
+/// True when `if_space_pos` is the space before "if" in an "as if" phrase.
+fn is_as_if_boundary(lower: &str, if_space_pos: usize) -> bool {
+    if_space_pos >= 2 && lower[..if_space_pos].ends_with("as")
+}
+
+/// Split a trailing `" as long as <condition>"` rider, anchored on the last
+/// occurrence (restriction gates are terminal).
+fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
+    const MARKER: &str = " as long as ";
+    let pos = lower.rfind(MARKER)?;
+    Some(lower[pos + MARKER.len()..].trim_start())
+}
+
+/// Split a trailing `" if <condition>"` rider, skipping `as if` false positives.
+fn split_trailing_if_condition(lower: &str) -> Option<&str> {
+    const MARKER: &str = " if ";
+    let mut end = lower.len();
+    while let Some(pos) = lower[..end].rfind(MARKER) {
+        if is_as_if_boundary(lower, pos) {
+            end = pos;
+            continue;
+        }
+        return Some(lower[pos + MARKER.len()..].trim_start());
+    }
+    None
+}
+
+fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
+    const MARKER: &str = " if ";
+    let mut end = tp.lower.len();
+    while let Some(pos) = tp.lower[..end].rfind(MARKER) {
+        if is_as_if_boundary(tp.lower, pos) {
+            end = pos;
+            continue;
+        }
+        return Some(&tp.original[pos + MARKER.len()..]);
+    }
+    None
+}
+
+/// CR 611.3a: A static restriction may carry a trailing gate introduced by
+/// either `" as long as <condition>"` (continuous) or `" if <condition>"` (state
+/// gate) — e.g. Rock Jockey: "You can't play lands if this creature was cast
+/// this turn." Returns the condition text for `parse_static_condition`. The
+/// `as long as` form is tried first so a card carrying both keywords anchors on
+/// the continuous form; a bare `if` gate uses the last valid trailing "if"
+/// (not an "as if" substring). As with the `as long as` peel, an unrecognized
+/// leaves the line unsupported rather than enforcing the restriction
+/// unconditionally.
+pub(crate) fn split_trailing_gate_condition(lower: &str) -> Option<&str> {
+    split_trailing_as_long_as(lower).or_else(|| split_trailing_if_condition(lower))
+}
+
 /// CR 508.1 / CR 509.1c: Parse the trailing " if [condition]" clause of a
 /// combat-restriction static ("~ can't attack if defending player controls an
 /// untapped land"). Mirrors `parse_unless_static_condition`; delegates the
 /// condition body to `parse_static_condition` → `parse_inner_condition` (the
 /// single authority for game-state conditions).
 pub(crate) fn parse_if_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
-    let (_, if_text) = tp.split_around(" if ")?;
-    parse_static_condition(if_text.original)
+    let condition_original = split_trailing_if_condition_tp(tp)?;
+    parse_static_condition(condition_original.trim_end_matches('.'))
 }
 
 /// Result of the combat-tax nom parse.

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1111,6 +1111,14 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 508.1c + CR 509.1b + CR 611.3a: "<grant> and can't attack if <A> and
+    // can't block if <B>" (Cagemail-class pump plus gated combat drawbacks).
+    // The bare dual-gate splitter declines when the subject carries a leading
+    // grant; peel the conjunct and append both gated combat statics.
+    if let Some(defs) = try_split_grant_and_dual_gated_combat(&tp, &stripped) {
+        return defs;
+    }
+
     // Check compound must-attack/block first — may return multiple.
     if let Some(defs) = try_parse_scoped_must_attack_block(&lower, &stripped) {
         return defs;
@@ -2017,6 +2025,75 @@ fn try_parse_dual_gated_cant_attack_and_cant_block(
             .condition(block_condition)
             .description(text.to_string()),
     ])
+}
+
+/// CR 508.1c + CR 509.1b + CR 611.3a: Decompose `"<grant> and can't attack if
+/// <A> and can't block if <B>"` into the leading grant static(s) plus gated
+/// `CantAttack` and `CantBlock` companions sharing the grant's `affected`.
+///
+/// Without this split the dual-gate arm declines (the subject prefix carries the
+/// grant) and the bare `try_split_and_cant_attack` / `try_split_and_cant_block`
+/// arms decline (non-terminal gated tails), so only the pump grant is emitted.
+fn try_split_grant_and_dual_gated_combat(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    type VE<'a> = OracleError<'a>;
+
+    let (grant_lower, _matched, gates_lower) =
+        nom_primitives::scan_preceded(tp.lower, |i: &str| {
+            let (i, _) = alt((
+                tag::<_, _, VE>(" and can't attack if "),
+                tag::<_, _, VE>(" and can\u{2019}t attack if "),
+            ))
+            .parse(i)?;
+            Ok((i, ()))
+        })?;
+
+    let (remainder, (gate_subject, attack_cond_lower, block_cond_lower)) =
+        parse_dual_gated_cant_attack_block(gates_lower).ok()?;
+    if !gate_subject.trim().is_empty()
+        || !remainder.trim().is_empty()
+        || attack_cond_lower.is_empty()
+        || block_cond_lower.is_empty()
+    {
+        return None;
+    }
+
+    let grant_text = lower_subslice_to_original(tp, grant_lower.trim())?;
+    let grant_line = format!("{}.", grant_text.trim_end_matches('.'));
+    let mut defs = parse_static_line_multi(&grant_line);
+    if defs.is_empty() {
+        return None;
+    }
+
+    let affected = defs.iter().find_map(|def| def.affected.clone())?;
+
+    let attack_cond = lower_subslice_to_original(tp, attack_cond_lower)?;
+    let block_cond = lower_subslice_to_original(tp, block_cond_lower)?;
+    let (Some(attack_condition), Some(block_condition)) = (
+        parse_static_condition(attack_cond.trim()),
+        parse_static_condition(block_cond.trim()),
+    ) else {
+        return None;
+    };
+
+    for def in &mut defs {
+        def.description = Some(text.to_string());
+    }
+    defs.push(
+        StaticDefinition::new(StaticMode::CantAttack)
+            .affected(affected.clone())
+            .condition(attack_condition)
+            .description(text.to_string()),
+    );
+    defs.push(
+        StaticDefinition::new(StaticMode::CantBlock)
+            .affected(affected)
+            .condition(block_condition)
+            .description(text.to_string()),
+    );
+    Some(defs)
 }
 
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1106,6 +1106,8 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
     // CR 508.1c + CR 509.1b + CR 611.3a: "~ can't attack if <cond> and can't block
     // if <cond>" (The Fallen Apart) — each restriction carries its own trailing
     // gate; must split before the single-gate `can't block` dispatch arm.
+    // Attached-subject forms ("enchanted creature …") defer to the established
+    // subject parser — SelfRef would scope the Aura/Equipment, not the host.
     if let Some(defs) = try_parse_dual_gated_cant_attack_and_cant_block(&tp, &stripped) {
         return defs;
     }
@@ -1950,10 +1952,29 @@ fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &s
     Ok((input, (attack_cond, block_cond)))
 }
 
+/// True when a dual-gated combat line's leading subject is the static source
+/// (~ / this creature / …), not an attached-subject or scoped form.
+fn dual_gated_combat_restriction_is_self_subject(tp: &TextPair<'_>) -> bool {
+    if attached_subject_filter(tp).is_some() {
+        return false;
+    }
+    let Some(subject_end) = tp.lower.find("can't attack if ") else {
+        return false;
+    };
+    let subject = tp.lower[..subject_end].trim();
+    subject == "~"
+        || subject == "it"
+        || SELF_REF_TYPE_PHRASES.contains(&subject)
+        || SELF_REF_PARSE_ONLY_PHRASES.contains(&subject)
+}
+
 fn try_parse_dual_gated_cant_attack_and_cant_block(
     tp: &TextPair<'_>,
     text: &str,
 ) -> Option<Vec<StaticDefinition>> {
+    if !dual_gated_combat_restriction_is_self_subject(tp) {
+        return None;
+    }
     let (remainder, (attack_cond_lower, block_cond_lower)) =
         parse_dual_gated_cant_attack_block(tp.lower).ok()?;
     if !remainder.trim().trim_end_matches('.').is_empty()

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1964,19 +1964,24 @@ fn try_parse_dual_gated_cant_attack_and_cant_block(
     }
     let attack_cond = tp_slice_from_lower_substr(tp, attack_cond_lower)?;
     let block_cond = tp_slice_from_lower_substr(tp, block_cond_lower.trim_end_matches('.'))?;
-    let mut attack = StaticDefinition::new(StaticMode::CantAttack)
-        .affected(TargetFilter::SelfRef)
-        .description(text.to_string());
-    if let Some(condition) = parse_static_condition(attack_cond.trim()) {
-        attack.condition = Some(condition);
-    }
-    let mut block = StaticDefinition::new(StaticMode::CantBlock)
-        .affected(TargetFilter::SelfRef)
-        .description(text.to_string());
-    if let Some(condition) = parse_static_condition(block_cond.trim()) {
-        block.condition = Some(condition);
-    }
-    Some(vec![attack, block])
+    let (Some(attack_condition), Some(block_condition)) = (
+        parse_static_condition(attack_cond.trim()),
+        parse_static_condition(block_cond.trim()),
+    ) else {
+        // CR 508.1c + CR 509.1b: both gates must decompose — an unrecognized
+        // rider must not collapse to unconditional CantAttack / CantBlock.
+        return Some(vec![]);
+    };
+    Some(vec![
+        StaticDefinition::new(StaticMode::CantAttack)
+            .affected(TargetFilter::SelfRef)
+            .condition(attack_condition)
+            .description(text.to_string()),
+        StaticDefinition::new(StaticMode::CantBlock)
+            .affected(TargetFilter::SelfRef)
+            .condition(block_condition)
+            .description(text.to_string()),
+    ])
 }
 
 fn tp_slice_from_lower_substr<'a>(tp: &'a TextPair<'a>, lower_substr: &str) -> Option<&'a str> {

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2391,8 +2391,8 @@ fn another_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondi
             nom::error::ErrorKind::Fail,
         )));
     };
-    // CR 613.7: "another <type>" excludes the ability source — reuse
-    // FilterProp::Another rather than approximating with ObjectCount(type) >= 2.
+    // "another <type>" excludes the ability source at runtime via
+    // FilterProp::Another — not ObjectCount(type) >= 2.
     if !tf
         .properties
         .iter()

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1106,8 +1106,7 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
     // CR 508.1c + CR 509.1b + CR 611.3a: "~ can't attack if <cond> and can't block
     // if <cond>" (The Fallen Apart) — each restriction carries its own trailing
     // gate; must split before the single-gate `can't block` dispatch arm.
-    // Attached-subject forms ("enchanted creature …") defer to the established
-    // subject parser — SelfRef would scope the Aura/Equipment, not the host.
+    // Attached-subject forms scope `affected` to the enchanted/equipped host.
     if let Some(defs) = try_parse_dual_gated_cant_attack_and_cant_block(&tp, &stripped) {
         return defs;
     }
@@ -1965,20 +1964,24 @@ fn lower_subslice_to_original<'a>(tp: &'a TextPair<'a>, lower_sub: &str) -> Opti
     tp.original.get(start..start + lower_sub.len())
 }
 
+fn dual_gated_combat_affected(tp: &TextPair<'_>, subject_lower: &str) -> Option<TargetFilter> {
+    if let Some((filter, _)) = attached_subject_filter(tp) {
+        Some(filter)
+    } else if is_self_ref_combat_subject(subject_lower) {
+        Some(TargetFilter::SelfRef)
+    } else {
+        None
+    }
+}
+
 fn try_parse_dual_gated_cant_attack_and_cant_block(
     tp: &TextPair<'_>,
     text: &str,
 ) -> Option<Vec<StaticDefinition>> {
-    if attached_subject_filter(tp).is_some() {
-        return None;
-    }
     let (remainder, (subject_lower, attack_cond_lower, block_cond_lower)) =
         parse_dual_gated_cant_attack_block(tp.lower).ok()?;
-    if !is_self_ref_combat_subject(subject_lower)
-        || !remainder.trim().is_empty()
-        || attack_cond_lower.is_empty()
-        || block_cond_lower.is_empty()
-    {
+    let affected = dual_gated_combat_affected(tp, subject_lower)?;
+    if !remainder.trim().is_empty() || attack_cond_lower.is_empty() || block_cond_lower.is_empty() {
         return None;
     }
     let attack_cond = lower_subslice_to_original(tp, attack_cond_lower)?;
@@ -1993,11 +1996,11 @@ fn try_parse_dual_gated_cant_attack_and_cant_block(
     };
     Some(vec![
         StaticDefinition::new(StaticMode::CantAttack)
-            .affected(TargetFilter::SelfRef)
+            .affected(affected.clone())
             .condition(attack_condition)
             .description(text.to_string()),
         StaticDefinition::new(StaticMode::CantBlock)
-            .affected(TargetFilter::SelfRef)
+            .affected(affected)
             .condition(block_condition)
             .description(text.to_string()),
     ])

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1942,6 +1942,7 @@ fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
 /// CR 508.1c + CR 509.1b: Split a compound "~ can't attack if <A> and can't block
 /// if <B>" static into two gated restrictions (The Fallen Apart).
 fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &str)> {
+    let (input, _) = take_until("can't attack if ").parse(input)?;
     let (input, _) = tag("can't attack if ").parse(input)?;
     let (input, attack_cond) = take_until(" and can't block if ").parse(input)?;
     let (input, _) = tag(" and can't block if ").parse(input)?;

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1979,22 +1979,32 @@ fn lower_subslice_to_original<'a>(tp: &'a TextPair<'a>, lower_sub: &str) -> Opti
     tp.original.get(start..start + lower_sub.len())
 }
 
+fn parse_attached_combat_subject_nom(input: &str) -> OracleResult<'_, TargetFilter> {
+    all_consuming(alt((
+        value(
+            TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy])),
+            tag("enchanted permanent"),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EnchantedBy])),
+            tag("enchanted creature"),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::land().properties(vec![FilterProp::EnchantedBy])),
+            tag("enchanted land"),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EquippedBy])),
+            tag("equipped creature"),
+        ),
+    )))
+    .parse(input)
+}
+
 fn is_attached_combat_subject(subject: &str) -> Option<TargetFilter> {
-    match subject.trim() {
-        "enchanted creature" => Some(TargetFilter::Typed(
-            TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
-        )),
-        "enchanted permanent" => Some(TargetFilter::Typed(
-            TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy]),
-        )),
-        "enchanted land" => Some(TargetFilter::Typed(
-            TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
-        )),
-        "equipped creature" => Some(TargetFilter::Typed(
-            TypedFilter::creature().properties(vec![FilterProp::EquippedBy]),
-        )),
-        _ => None,
-    }
+    parse_attached_combat_subject_nom(subject.trim())
+        .ok()
+        .map(|(_, filter)| filter)
 }
 
 fn dual_gated_combat_affected(subject_lower: &str) -> Option<TargetFilter> {

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1103,6 +1103,13 @@ pub(crate) fn parse_static_line_multi_inner(text: &str) -> Vec<StaticDefinition>
         return defs;
     }
 
+    // CR 508.1c + CR 509.1b + CR 611.3a: "~ can't attack if <cond> and can't block
+    // if <cond>" (The Fallen Apart) — each restriction carries its own trailing
+    // gate; must split before the single-gate `can't block` dispatch arm.
+    if let Some(defs) = try_parse_dual_gated_cant_attack_and_cant_block(&tp, &stripped) {
+        return defs;
+    }
+
     // Check compound must-attack/block first — may return multiple.
     if let Some(defs) = try_parse_scoped_must_attack_block(&lower, &stripped) {
         return defs;
@@ -1922,6 +1929,60 @@ fn split_trailing_if_condition(lower: &str) -> Option<&str> {
     Some(tail.trim_start())
 }
 
+fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
+    let (_, _, tail_lower) = nom_primitives::scan_last_valid_at_word_boundaries_with_offset(
+        tp.lower,
+        |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+        |if_offset| !is_as_if_gate_marker(tp.lower, if_offset),
+    )?;
+    let start = tp.lower.len().checked_sub(tail_lower.len())?;
+    Some(tp.original.get(start..)?.trim_start())
+}
+
+/// CR 508.1c + CR 509.1b: Split a compound "~ can't attack if <A> and can't block
+/// if <B>" static into two gated restrictions (The Fallen Apart).
+fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &str)> {
+    let (input, _) = tag("can't attack if ").parse(input)?;
+    let (input, attack_cond) = take_until(" and can't block if ").parse(input)?;
+    let (input, _) = tag(" and can't block if ").parse(input)?;
+    let (input, block_cond) = rest.parse(input)?;
+    Ok((input, (attack_cond, block_cond)))
+}
+
+fn try_parse_dual_gated_cant_attack_and_cant_block(
+    tp: &TextPair<'_>,
+    text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    let (remainder, (attack_cond_lower, block_cond_lower)) =
+        parse_dual_gated_cant_attack_block(tp.lower).ok()?;
+    if !remainder.trim().trim_end_matches('.').is_empty()
+        || attack_cond_lower.is_empty()
+        || block_cond_lower.trim().is_empty()
+    {
+        return None;
+    }
+    let attack_cond = tp_slice_from_lower_substr(tp, attack_cond_lower)?;
+    let block_cond = tp_slice_from_lower_substr(tp, block_cond_lower.trim_end_matches('.'))?;
+    let mut attack = StaticDefinition::new(StaticMode::CantAttack)
+        .affected(TargetFilter::SelfRef)
+        .description(text.to_string());
+    if let Some(condition) = parse_static_condition(attack_cond.trim()) {
+        attack.condition = Some(condition);
+    }
+    let mut block = StaticDefinition::new(StaticMode::CantBlock)
+        .affected(TargetFilter::SelfRef)
+        .description(text.to_string());
+    if let Some(condition) = parse_static_condition(block_cond.trim()) {
+        block.condition = Some(condition);
+    }
+    Some(vec![attack, block])
+}
+
+fn tp_slice_from_lower_substr<'a>(tp: &'a TextPair<'a>, lower_substr: &str) -> Option<&'a str> {
+    let offset = tp.lower.find(lower_substr)?;
+    tp.original.get(offset..offset + lower_substr.len())
+}
+
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by
 /// either `" as long as <condition>"` (continuous) or `" if <condition>"` (state
 /// gate) — e.g. Rock Jockey: "You can't play lands if this creature was cast
@@ -1942,7 +2003,7 @@ pub(crate) fn split_trailing_gate_condition(lower: &str) -> Option<&str> {
 /// `parse_static_condition` → `parse_inner_condition` (the single authority
 /// for game-state conditions).
 pub(crate) fn parse_if_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
-    let condition_text = split_trailing_if_condition(tp.lower)?;
+    let condition_text = split_trailing_if_condition_tp(tp)?;
     parse_static_condition(condition_text.trim_end_matches('.'))
 }
 
@@ -2279,6 +2340,36 @@ fn exists_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondit
             },
             comparator: Comparator::GE,
             rhs: QuantityExpr::Fixed { value: 1 },
+        },
+    ))
+}
+
+/// CR 611.3a: "there's / there is another <type> on the battlefield" (Shauku).
+fn parse_another_on_battlefield_condition(lower: &str) -> Option<StaticCondition> {
+    another_on_battlefield_condition(lower)
+        .ok()
+        .and_then(|(rest, cond)| rest.trim().trim_end_matches('.').is_empty().then_some(cond))
+}
+
+fn another_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (input, _) = alt((tag("there's another "), tag("there is another "))).parse(input)?;
+    let (input, type_text) = take_until(" on the battlefield").parse(input)?;
+    let (input, _) = tag(" on the battlefield").parse(input)?;
+    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
+        return Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok((
+        input,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 2 },
         },
     ))
 }

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1964,14 +1964,27 @@ fn lower_subslice_to_original<'a>(tp: &'a TextPair<'a>, lower_sub: &str) -> Opti
     tp.original.get(start..start + lower_sub.len())
 }
 
-fn dual_gated_combat_affected(tp: &TextPair<'_>, subject_lower: &str) -> Option<TargetFilter> {
-    if let Some((filter, _)) = attached_subject_filter(tp) {
-        Some(filter)
-    } else if is_self_ref_combat_subject(subject_lower) {
-        Some(TargetFilter::SelfRef)
-    } else {
-        None
+fn is_attached_combat_subject(subject: &str) -> Option<TargetFilter> {
+    match subject.trim() {
+        "enchanted creature" => Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+        )),
+        "enchanted permanent" => Some(TargetFilter::Typed(
+            TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy]),
+        )),
+        "enchanted land" => Some(TargetFilter::Typed(
+            TypedFilter::land().properties(vec![FilterProp::EnchantedBy]),
+        )),
+        "equipped creature" => Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EquippedBy]),
+        )),
+        _ => None,
     }
+}
+
+fn dual_gated_combat_affected(subject_lower: &str) -> Option<TargetFilter> {
+    is_attached_combat_subject(subject_lower)
+        .or_else(|| is_self_ref_combat_subject(subject_lower).then_some(TargetFilter::SelfRef))
 }
 
 fn try_parse_dual_gated_cant_attack_and_cant_block(
@@ -1980,7 +1993,7 @@ fn try_parse_dual_gated_cant_attack_and_cant_block(
 ) -> Option<Vec<StaticDefinition>> {
     let (remainder, (subject_lower, attack_cond_lower, block_cond_lower)) =
         parse_dual_gated_cant_attack_block(tp.lower).ok()?;
-    let affected = dual_gated_combat_affected(tp, subject_lower)?;
+    let affected = dual_gated_combat_affected(subject_lower)?;
     if !remainder.trim().is_empty() || attack_cond_lower.is_empty() || block_cond_lower.is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1943,48 +1943,46 @@ fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
 
 /// CR 508.1c + CR 509.1b: Split a compound "~ can't attack if <A> and can't block
 /// if <B>" static into two gated restrictions (The Fallen Apart).
-fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &str)> {
-    let (input, _) = take_until("can't attack if ").parse(input)?;
+fn parse_dual_gated_cant_attack_block(input: &str) -> OracleResult<'_, (&str, &str, &str)> {
+    let (input, subject) = take_until("can't attack if ").parse(input)?;
     let (input, _) = tag("can't attack if ").parse(input)?;
     let (input, attack_cond) = take_until(" and can't block if ").parse(input)?;
     let (input, _) = tag(" and can't block if ").parse(input)?;
-    let (input, block_cond) = rest.parse(input)?;
-    Ok((input, (attack_cond, block_cond)))
+    let (input, block_cond) = terminated(rest, opt(tag("."))).parse(input)?;
+    Ok((input, (subject, attack_cond, block_cond)))
 }
 
-/// True when a dual-gated combat line's leading subject is the static source
-/// (~ / this creature / …), not an attached-subject or scoped form.
-fn dual_gated_combat_restriction_is_self_subject(tp: &TextPair<'_>) -> bool {
-    if attached_subject_filter(tp).is_some() {
-        return false;
-    }
-    let Some(subject_end) = tp.lower.find("can't attack if ") else {
-        return false;
-    };
-    let subject = tp.lower[..subject_end].trim();
+fn is_self_ref_combat_subject(subject: &str) -> bool {
+    let subject = subject.trim();
     subject == "~"
         || subject == "it"
         || SELF_REF_TYPE_PHRASES.contains(&subject)
         || SELF_REF_PARSE_ONLY_PHRASES.contains(&subject)
 }
 
+fn lower_subslice_to_original<'a>(tp: &'a TextPair<'a>, lower_sub: &str) -> Option<&'a str> {
+    let start = lower_sub.as_ptr() as usize - tp.lower.as_ptr() as usize;
+    tp.original.get(start..start + lower_sub.len())
+}
+
 fn try_parse_dual_gated_cant_attack_and_cant_block(
     tp: &TextPair<'_>,
     text: &str,
 ) -> Option<Vec<StaticDefinition>> {
-    if !dual_gated_combat_restriction_is_self_subject(tp) {
+    if attached_subject_filter(tp).is_some() {
         return None;
     }
-    let (remainder, (attack_cond_lower, block_cond_lower)) =
+    let (remainder, (subject_lower, attack_cond_lower, block_cond_lower)) =
         parse_dual_gated_cant_attack_block(tp.lower).ok()?;
-    if !remainder.trim().trim_end_matches('.').is_empty()
+    if !is_self_ref_combat_subject(subject_lower)
+        || !remainder.trim().is_empty()
         || attack_cond_lower.is_empty()
-        || block_cond_lower.trim().is_empty()
+        || block_cond_lower.is_empty()
     {
         return None;
     }
-    let attack_cond = tp_slice_from_lower_substr(tp, attack_cond_lower)?;
-    let block_cond = tp_slice_from_lower_substr(tp, block_cond_lower.trim_end_matches('.'))?;
+    let attack_cond = lower_subslice_to_original(tp, attack_cond_lower)?;
+    let block_cond = lower_subslice_to_original(tp, block_cond_lower)?;
     let (Some(attack_condition), Some(block_condition)) = (
         parse_static_condition(attack_cond.trim()),
         parse_static_condition(block_cond.trim()),
@@ -2003,11 +2001,6 @@ fn try_parse_dual_gated_cant_attack_and_cant_block(
             .condition(block_condition)
             .description(text.to_string()),
     ])
-}
-
-fn tp_slice_from_lower_substr<'a>(tp: &'a TextPair<'a>, lower_substr: &str) -> Option<&'a str> {
-    let offset = tp.lower.find(lower_substr)?;
-    tp.original.get(offset..offset + lower_substr.len())
 }
 
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2057,11 +2057,13 @@ fn try_split_grant_and_dual_gated_combat(
 ) -> Option<Vec<StaticDefinition>> {
     type VE<'a> = OracleError<'a>;
 
+    // `scan_preceded` resumes at word boundaries without the preceding space, so
+    // match `and can't attack if ` (not ` and …`) — same as `try_split_and_cant_attack`.
     let (grant_lower, _matched, gates_lower) =
         nom_primitives::scan_preceded(tp.lower, |i: &str| {
             let (i, _) = alt((
-                tag::<_, _, VE>(" and can't attack if "),
-                tag::<_, _, VE>(" and can\u{2019}t attack if "),
+                tag::<_, _, VE>("and can't attack if "),
+                tag::<_, _, VE>("and can\u{2019}t attack if "),
             ))
             .parse(i)?;
             Ok((i, ()))

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1891,10 +1891,15 @@ pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticC
 /// True when `if_offset` points at an `if …` gate immediately preceded by `as `
 /// (the `as if` phrase).
 fn is_as_if_gate_marker(input: &str, if_offset: usize) -> bool {
-    if_offset >= 3
-        && tag::<_, _, OracleError<'_>>("as ")
-            .parse(&input[if_offset - 3..if_offset])
-            .is_ok()
+    let Some(start) = if_offset.checked_sub(3) else {
+        return false;
+    };
+    if !input.is_char_boundary(start) {
+        return false;
+    }
+    tag::<_, _, OracleError<'_>>("as ")
+        .parse(&input[start..if_offset])
+        .is_ok()
 }
 
 /// Split a trailing `" as long as <condition>"` rider, anchored on the last

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1888,44 +1888,33 @@ pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticC
     })
 }
 
-/// True when `if_space_pos` is the space before "if" in an "as if" phrase.
-fn is_as_if_boundary(lower: &str, if_space_pos: usize) -> bool {
-    if_space_pos >= 2 && lower[..if_space_pos].ends_with("as")
+/// True when `if_offset` points at an `if …` gate immediately preceded by `as `
+/// (the `as if` phrase).
+fn is_as_if_gate_marker(input: &str, if_offset: usize) -> bool {
+    if_offset >= 3
+        && tag::<_, _, OracleError<'_>>("as ")
+            .parse(&input[if_offset - 3..if_offset])
+            .is_ok()
 }
 
 /// Split a trailing `" as long as <condition>"` rider, anchored on the last
 /// occurrence (restriction gates are terminal).
 fn split_trailing_as_long_as(lower: &str) -> Option<&str> {
-    const MARKER: &str = " as long as ";
-    let pos = lower.rfind(MARKER)?;
-    Some(lower[pos + MARKER.len()..].trim_start())
+    let (_, _, tail) = nom_primitives::scan_last_at_word_boundaries_with_offset(lower, |i| {
+        tag::<_, _, OracleError<'_>>("as long as ").parse(i)
+    })?;
+    Some(tail.trim_start())
 }
 
-/// Split a trailing `" if <condition>"` rider, skipping `as if` false positives.
+/// Split a trailing `" if <condition>"` rider, skipping `as if` false positives
+/// via word-boundary scanning with a nom `as ` prefix guard.
 fn split_trailing_if_condition(lower: &str) -> Option<&str> {
-    const MARKER: &str = " if ";
-    let mut end = lower.len();
-    while let Some(pos) = lower[..end].rfind(MARKER) {
-        if is_as_if_boundary(lower, pos) {
-            end = pos;
-            continue;
-        }
-        return Some(lower[pos + MARKER.len()..].trim_start());
-    }
-    None
-}
-
-fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
-    const MARKER: &str = " if ";
-    let mut end = tp.lower.len();
-    while let Some(pos) = tp.lower[..end].rfind(MARKER) {
-        if is_as_if_boundary(tp.lower, pos) {
-            end = pos;
-            continue;
-        }
-        return Some(&tp.original[pos + MARKER.len()..]);
-    }
-    None
+    let (_, _, tail) = nom_primitives::scan_last_valid_at_word_boundaries_with_offset(
+        lower,
+        |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+        |if_offset| !is_as_if_gate_marker(lower, if_offset),
+    )?;
+    Some(tail.trim_start())
 }
 
 /// CR 611.3a: A static restriction may carry a trailing gate introduced by
@@ -1935,20 +1924,21 @@ fn split_trailing_if_condition_tp<'a>(tp: &'a TextPair<'a>) -> Option<&'a str> {
 /// `as long as` form is tried first so a card carrying both keywords anchors on
 /// the continuous form; a bare `if` gate uses the last valid trailing "if"
 /// (not an "as if" substring). As with the `as long as` peel, an unrecognized
-/// leaves the line unsupported rather than enforcing the restriction
-/// unconditionally.
+/// condition downstream leaves the line unsupported rather than enforcing the
+/// restriction unconditionally.
 pub(crate) fn split_trailing_gate_condition(lower: &str) -> Option<&str> {
     split_trailing_as_long_as(lower).or_else(|| split_trailing_if_condition(lower))
 }
 
-/// CR 508.1 / CR 509.1c: Parse the trailing " if [condition]" clause of a
+/// CR 508.1c / CR 509.1b: Parse the trailing " if [condition]" clause of a
 /// combat-restriction static ("~ can't attack if defending player controls an
-/// untapped land"). Mirrors `parse_unless_static_condition`; delegates the
-/// condition body to `parse_static_condition` → `parse_inner_condition` (the
-/// single authority for game-state conditions).
+/// untapped land"; "~ can't block if you control an untapped land"). Mirrors
+/// `parse_unless_static_condition`; delegates the condition body to
+/// `parse_static_condition` → `parse_inner_condition` (the single authority
+/// for game-state conditions).
 pub(crate) fn parse_if_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
-    let condition_original = split_trailing_if_condition_tp(tp)?;
-    parse_static_condition(condition_original.trim_end_matches('.'))
+    let condition_text = split_trailing_if_condition(tp.lower)?;
+    parse_static_condition(condition_text.trim_end_matches('.'))
 }
 
 /// Result of the combat-tax nom parse.

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2385,14 +2385,31 @@ fn another_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondi
             nom::error::ErrorKind::Fail,
         )));
     }
+    let TargetFilter::Typed(mut tf) = filter else {
+        return Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    };
+    // CR 613.7: "another <type>" excludes the ability source — reuse
+    // FilterProp::Another rather than approximating with ObjectCount(type) >= 2.
+    if !tf
+        .properties
+        .iter()
+        .any(|p| matches!(p, FilterProp::Another))
+    {
+        tf.properties.push(FilterProp::Another);
+    }
     Ok((
         input,
         StaticCondition::QuantityComparison {
             lhs: QuantityExpr::Ref {
-                qty: QuantityRef::ObjectCount { filter },
+                qty: QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                },
             },
             comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: 2 },
+            rhs: QuantityExpr::Fixed { value: 1 },
         },
     ))
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -566,12 +566,29 @@ fn dual_gated_cant_attack_and_cant_block_requires_both_gates_parsed() {
         matches!(
             attack.condition,
             Some(StaticCondition::QuantityComparison {
-                rhs: QuantityExpr::Fixed { value: 2 },
+                rhs: QuantityExpr::Fixed { value: 1 },
                 ..
             })
         ),
-        "attack gate must be ObjectCount(creature) >= 2, got {:?}",
+        "attack gate must be ObjectCount(another creature) >= 1, got {:?}",
         attack.condition
+    );
+    let Some(StaticCondition::QuantityComparison {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        },
+        ..
+    }) = &attack.condition
+    else {
+        unreachable!()
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("expected Typed creature filter, got {filter:?}");
+    };
+    assert!(
+        tf.properties.contains(&FilterProp::Another),
+        "another creature gate must carry FilterProp::Another, got {:?}",
+        tf.properties
     );
     assert!(
         matches!(

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -648,16 +648,16 @@ fn dual_gated_attached_grant_plus_restrictions_not_preempted() {
         "Enchanted creature gets +2/+2 and can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
     );
     assert!(
-        defs.iter().any(|d| matches!(d.mode, StaticMode::Continuous)),
+        defs.iter()
+            .any(|d| matches!(d.mode, StaticMode::Continuous)),
         "pump grant must not be dropped by the dual-gate splitter, got {:?}",
         defs
     );
-    assert_ne!(
-        defs
-            .iter()
-            .filter(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))
-            .count(),
-        2,
+    assert!(
+        !(defs.len() == 2
+            && defs
+                .iter()
+                .all(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))),
         "grant+restriction line must not collapse to only dual-gated combat statics, got {:?}",
         defs
     );

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -639,6 +639,30 @@ fn dual_gated_attached_subject_defers_from_self_ref_splitter() {
     }
 }
 
+/// CR 508.1c + CR 509.1b: Grant + dual-gated restrictions must not be preempted
+/// by the dual-gate splitter — the leading pump/keyword grant defers to the
+/// established `and can't attack` / `and can't block` splitters.
+#[test]
+fn dual_gated_attached_grant_plus_restrictions_not_preempted() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature gets +2/+2 and can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
+    );
+    assert!(
+        defs.iter().any(|d| matches!(d.mode, StaticMode::Continuous)),
+        "pump grant must not be dropped by the dual-gate splitter, got {:?}",
+        defs
+    );
+    assert_ne!(
+        defs
+            .iter()
+            .filter(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))
+            .count(),
+        2,
+        "grant+restriction line must not collapse to only dual-gated combat statics, got {:?}",
+        defs
+    );
+}
+
 /// CR 509.1b: Kraken of the Straits — "Creatures with power less than the
 /// number of Islands you control can't block this creature." must lower to a
 /// `CantBeBlockedBy` restriction on the SOURCE whose blocker filter gates on a

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -315,6 +315,30 @@ fn rock_jockey_cant_play_land_gated_on_source_cast_this_turn() {
     );
 }
 
+/// CR 611.3a: `split_trailing_gate_condition` must anchor on the last valid
+/// trailing ` if `, not an `as if` substring earlier in the same restriction.
+#[test]
+fn trailing_if_gate_skips_as_if_false_positive_on_cant_play_lands() {
+    let defs = parse_static_line_multi(
+        "You can't play lands as if there were no restriction if ten or more lands are on the battlefield.",
+    );
+    let cant = defs
+        .iter()
+        .find(|d| matches!(&d.mode, StaticMode::Other(n) if n == "CantPlayLand"))
+        .expect("expected a CantPlayLand static gated by the battlefield-land count");
+    let Some(StaticCondition::QuantityComparison {
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 10 },
+        ..
+    }) = &cant.condition
+    else {
+        panic!(
+            "expected ObjectCount(land) >= 10 gate, got {:?}",
+            cant.condition
+        );
+    };
+}
+
 /// CR 508.1 + CR 611.3a: A trailing "if a[n] <type> is on the battlefield" gate
 /// on a "can't attack or block" static (Wirecat: "This creature can't attack or
 /// block if an enchantment is on the battlefield.") must attach as a condition,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -339,6 +339,40 @@ fn trailing_if_gate_skips_as_if_false_positive_on_cant_play_lands() {
     };
 }
 
+/// Regression: em-dash (U+2014) before a trailing `if` gate must not panic when
+/// checking the `as if` false-positive guard (byte slice at `if_offset - 3`).
+#[test]
+fn trailing_if_gate_does_not_panic_when_if_follows_em_dash() {
+    let defs = parse_static_line_multi(
+        "You can't play lands — if ten or more lands are on the battlefield.",
+    );
+    let cant = defs
+        .iter()
+        .find(|d| matches!(&d.mode, StaticMode::Other(n) if n == "CantPlayLand"))
+        .expect("expected a CantPlayLand static gated by the battlefield-land count");
+    let Some(StaticCondition::QuantityComparison {
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 10 },
+        ..
+    }) = &cant.condition
+    else {
+        panic!(
+            "expected ObjectCount(land) >= 10 gate, got {:?}",
+            cant.condition
+        );
+    };
+}
+
+/// Regression: `oracle_gen` must not panic when an em-dash immediately precedes
+/// `if` with no intervening space (gate may be unpeeled; crash is not acceptable).
+#[test]
+fn trailing_if_gate_no_panic_on_em_dash_glued_to_if() {
+    let result = std::panic::catch_unwind(|| {
+        parse_static_line_multi("You can't play lands—if ten or more lands are on the battlefield.")
+    });
+    assert!(result.is_ok(), "must not panic on em-dash glued to if");
+}
+
 /// CR 508.1 + CR 611.3a: A trailing "if a[n] <type> is on the battlefield" gate
 /// on a "can't attack or block" static (Wirecat: "This creature can't attack or
 /// block if an enchantment is on the battlefield.") must attach as a condition,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -502,6 +502,58 @@ fn shauku_cant_attack_gated_on_another_creature_exists() {
     );
 }
 
+/// CR 508.1c + CR 509.1b: The Fallen Apart — compound "~ can't attack if <A> and
+/// can't block if <B>" must split into separate gated CantAttack and CantBlock
+/// statics instead of mis-dispatching to a lone CantBlock.
+#[test]
+fn fallen_apart_dual_gated_cant_attack_and_cant_block_split() {
+    let defs = parse_static_line_multi(
+        "~ can't attack if it has no legs and can't block if it has no arms.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected CantAttack + CantBlock statics, got {:?}",
+        defs
+    );
+    let attack = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .expect("expected CantAttack static");
+    let block = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBlock)
+        .expect("expected CantBlock static");
+    assert!(
+        attack.condition.is_none(),
+        "leg gate not yet modeled; restriction must still split, got {:?}",
+        attack.condition
+    );
+    assert!(
+        block.condition.is_none(),
+        "arm gate not yet modeled; restriction must still split, got {:?}",
+        block.condition
+    );
+
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "~ can't attack if it has no legs and can't block if it has no arms.",
+        "The Fallen Apart",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert_eq!(
+        parsed
+            .statics
+            .iter()
+            .filter(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))
+            .count(),
+        2,
+        "full dispatch must split into CantAttack + CantBlock, got {:?}",
+        parsed.statics
+    );
+}
+
 /// CR 509.1b: Kraken of the Straits — "Creatures with power less than the
 /// number of Islands you control can't block this creature." must lower to a
 /// `CantBeBlockedBy` restriction on the SOURCE whose blocker filter gates on a

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -639,28 +639,52 @@ fn dual_gated_attached_subject_defers_from_self_ref_splitter() {
     }
 }
 
-/// CR 508.1c + CR 509.1b: Grant + dual-gated restrictions must not be preempted
-/// by the dual-gate splitter — the leading pump/keyword grant defers to the
-/// established `and can't attack` / `and can't block` splitters.
+/// CR 508.1c + CR 509.1b: Grant + dual-gated restrictions emit the pump grant
+/// plus both gated combat statics on the enchanted/equipped host.
 #[test]
 fn dual_gated_attached_grant_plus_restrictions_not_preempted() {
     let defs = parse_static_line_multi(
         "Enchanted creature gets +2/+2 and can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
     );
+    assert_eq!(
+        defs.len(),
+        3,
+        "expected Continuous grant + gated CantAttack + gated CantBlock, got {:?}",
+        defs
+    );
     assert!(
         defs.iter()
             .any(|d| matches!(d.mode, StaticMode::Continuous)),
-        "pump grant must not be dropped by the dual-gate splitter, got {:?}",
+        "pump grant must not be dropped, got {:?}",
         defs
     );
+    let attack = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantAttack)
+        .expect("expected gated CantAttack static");
+    let block = defs
+        .iter()
+        .find(|d| d.mode == StaticMode::CantBlock)
+        .expect("expected gated CantBlock static");
     assert!(
-        !(defs.len() == 2
-            && defs
-                .iter()
-                .all(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))),
-        "grant+restriction line must not collapse to only dual-gated combat statics, got {:?}",
-        defs
+        attack.condition.is_some() && block.condition.is_some(),
+        "both combat restrictions must carry parsed gates, got attack={:?} block={:?}",
+        attack.condition,
+        block.condition
     );
+    for def in [attack, block] {
+        let Some(TargetFilter::Typed(tf)) = &def.affected else {
+            panic!(
+                "expected Typed enchanted-creature filter, got {:?}",
+                def.affected
+            );
+        };
+        assert!(
+            tf.properties.contains(&FilterProp::EnchantedBy),
+            "combat restriction must affect the enchanted creature, got {:?}",
+            tf
+        );
+    }
 }
 
 /// CR 509.1b: Kraken of the Straits — "Creatures with power less than the

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -503,12 +503,50 @@ fn shauku_cant_attack_gated_on_another_creature_exists() {
 }
 
 /// CR 508.1c + CR 509.1b: The Fallen Apart — compound "~ can't attack if <A> and
-/// can't block if <B>" must split into separate gated CantAttack and CantBlock
-/// statics instead of mis-dispatching to a lone CantBlock.
+/// can't block if <B>" must not collapse to unconditional combat restrictions
+/// when either gate is unrecognized; the line stays unsupported (honest).
 #[test]
-fn fallen_apart_dual_gated_cant_attack_and_cant_block_split() {
+fn fallen_apart_dual_gated_unrecognized_gates_stay_unsupported() {
     let defs = parse_static_line_multi(
         "~ can't attack if it has no legs and can't block if it has no arms.",
+    );
+    assert!(
+        !defs.iter().any(|d| {
+            matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock)
+                && d.condition.is_none()
+        }),
+        "unrecognized dual gates must not emit unconditional CantAttack/CantBlock, got {:?}",
+        defs
+    );
+    assert!(
+        defs.is_empty(),
+        "unmodeled leg/arm gates must leave the line unsupported, got {:?}",
+        defs
+    );
+
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "~ can't attack if it has no legs and can't block if it has no arms.",
+        "The Fallen Apart",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert!(
+        !parsed
+            .statics
+            .iter()
+            .any(|d| { matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock) }),
+        "full dispatch must not emit combat restrictions without parsed gates, got {:?}",
+        parsed.statics
+    );
+}
+
+/// CR 508.1c + CR 509.1b: Dual-gated attack/block lines emit separate statics
+/// only when both trailing gates decompose.
+#[test]
+fn dual_gated_cant_attack_and_cant_block_requires_both_gates_parsed() {
+    let defs = parse_static_line_multi(
+        "~ can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
     );
     assert_eq!(
         defs.len(),
@@ -525,32 +563,26 @@ fn fallen_apart_dual_gated_cant_attack_and_cant_block_split() {
         .find(|d| d.mode == StaticMode::CantBlock)
         .expect("expected CantBlock static");
     assert!(
-        attack.condition.is_none(),
-        "leg gate not yet modeled; restriction must still split, got {:?}",
+        matches!(
+            attack.condition,
+            Some(StaticCondition::QuantityComparison {
+                rhs: QuantityExpr::Fixed { value: 2 },
+                ..
+            })
+        ),
+        "attack gate must be ObjectCount(creature) >= 2, got {:?}",
         attack.condition
     );
     assert!(
-        block.condition.is_none(),
-        "arm gate not yet modeled; restriction must still split, got {:?}",
+        matches!(
+            block.condition,
+            Some(StaticCondition::QuantityComparison {
+                rhs: QuantityExpr::Fixed { value: 1 },
+                ..
+            })
+        ),
+        "block gate must be ObjectCount(enchantment) >= 1, got {:?}",
         block.condition
-    );
-
-    let parsed = crate::parser::oracle::parse_oracle_text(
-        "~ can't attack if it has no legs and can't block if it has no arms.",
-        "The Fallen Apart",
-        &[],
-        &["Creature".to_string()],
-        &[],
-    );
-    assert_eq!(
-        parsed
-            .statics
-            .iter()
-            .filter(|d| matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock))
-            .count(),
-        2,
-        "full dispatch must split into CantAttack + CantBlock, got {:?}",
-        parsed.statics
     );
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -586,13 +586,18 @@ fn dual_gated_cant_attack_and_cant_block_requires_both_gates_parsed() {
     );
 }
 
-/// CR 508.1c + CR 509.1b: Attached-subject dual-gated combat lines must not be
-/// split by the self-ref dual-gate handler (SelfRef would scope the Aura, not
-/// the enchanted creature).
+/// CR 508.1c + CR 509.1b: Attached-subject dual-gated combat lines split with
+/// the enchanted/equipped host as `affected`, not SelfRef (the Aura source).
 #[test]
 fn dual_gated_attached_subject_defers_from_self_ref_splitter() {
     let defs = parse_static_line_multi(
         "Enchanted creature can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected CantAttack + CantBlock on the enchanted creature, got {:?}",
+        defs
     );
     assert!(
         !defs.iter().any(|d| {
@@ -602,6 +607,19 @@ fn dual_gated_attached_subject_defers_from_self_ref_splitter() {
         "attached-subject dual gate must not emit SelfRef combat statics, got {:?}",
         defs
     );
+    for def in &defs {
+        let Some(TargetFilter::Typed(tf)) = &def.affected else {
+            panic!(
+                "expected Typed enchanted-creature filter, got {:?}",
+                def.affected
+            );
+        };
+        assert!(
+            tf.properties.contains(&FilterProp::EnchantedBy),
+            "combat restriction must affect the enchanted creature, got {:?}",
+            tf
+        );
+    }
 }
 
 /// CR 509.1b: Kraken of the Straits — "Creatures with power less than the

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -586,6 +586,24 @@ fn dual_gated_cant_attack_and_cant_block_requires_both_gates_parsed() {
     );
 }
 
+/// CR 508.1c + CR 509.1b: Attached-subject dual-gated combat lines must not be
+/// split by the self-ref dual-gate handler (SelfRef would scope the Aura, not
+/// the enchanted creature).
+#[test]
+fn dual_gated_attached_subject_defers_from_self_ref_splitter() {
+    let defs = parse_static_line_multi(
+        "Enchanted creature can't attack if there's another creature on the battlefield and can't block if an enchantment is on the battlefield.",
+    );
+    assert!(
+        !defs.iter().any(|d| {
+            matches!(d.mode, StaticMode::CantAttack | StaticMode::CantBlock)
+                && d.affected == Some(TargetFilter::SelfRef)
+        }),
+        "attached-subject dual gate must not emit SelfRef combat statics, got {:?}",
+        defs
+    );
+}
+
 /// CR 509.1b: Kraken of the Straits — "Creatures with power less than the
 /// number of Islands you control can't block this creature." must lower to a
 /// `CantBeBlockedBy` restriction on the SOURCE whose blocker filter gates on a

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -13593,6 +13593,8 @@ fn spell_cost_reduction_for_creatures_that_attacked_preserves_damage_effect() {
 
 #[test]
 fn negative_self_casting_restriction_stays_metadata() {
+    use crate::types::statics::StaticMode;
+
     let r = parse(
             "You can't cast Rock Jockey if you've played a land this turn.\nYou can't play lands if Rock Jockey was cast this turn.",
             "Rock Jockey",
@@ -13608,6 +13610,19 @@ fn negative_self_casting_restriction_stays_metadata() {
                 condition: Box::new(ParsedCondition::YouPlayedLandThisTurn),
             }),
         }]
+    );
+    assert!(
+        r.statics.iter().any(|d| {
+            matches!(&d.mode, StaticMode::Other(n) if n == "CantPlayLand")
+                && matches!(
+                    d.condition,
+                    Some(StaticCondition::And { ref conditions })
+                        if conditions.contains(&StaticCondition::WasCast { zone: None })
+                            && conditions.contains(&StaticCondition::SourceEnteredThisTurn)
+                )
+        }),
+        "Rock Jockey's gated CantPlayLand static must survive full-card dispatch, got statics={:?}",
+        r.statics
     );
     assert!(
         r.abilities


### PR DESCRIPTION
## Summary

Re-scoped per maintainer feedback: trailing `if` / `as long as` gate peel hardening plus **concrete corpus static fixes** with honest fail-closed semantics.

### Infrastructure
- Promote `split_trailing_gate_condition` to `oracle_static/shared.rs` with nom word-boundary scan
- `as if` false-positive guard with UTF-8 char-boundary safety (em-dash panic fix)
- `parse_if_static_condition` routes through last-valid peel with original-case preservation

### Corpus unlocks
| Card / pattern | Fix | Behavior |
|----------------|-----|----------|
| **Shauku-style** | `there's another <type> on the battlefield` → `ObjectCount(type) >= 2` | Gated `CantAttack` gains `condition` |
| **Dual-gated attack/block** | Split `can't attack if <A> and can't block if <B>` before `can't block` dispatch | Emits `CantAttack` + `CantBlock` **only when both gates parse** |
| **The Fallen Apart** | Leg/arm gates not yet modeled | **Fail closed** — no unconditional combat statics (matches `can't play lands` unrecognized-gate policy) |

Rock Jockey / Wirecat / Limited Resources were already fixed on main (#4841 / #4844 / #4433).

Fixes #4876

## Test plan

- [x] `cargo check -p engine`, `cargo fmt --all`
- [x] Rock Jockey, `as if` fixture, em-dash peel, Shauku another-creature gate
- [x] Dual-gate happy path (both gates parse) + Fallen Apart fail-closed regression
- [ ] CI parse-diff / coverage
