### PR TITLE
fix(parser): source-scoped "if ~ attacked or blocked this turn" intervening-if

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3883,6 +3883,25 @@ fn extract_if_condition(text: &str) -> (String, Option<TriggerCondition>) {
                     ),
                 },
             ),
+            // CR 508.1 + CR 509.1 + CR 603.4: source-scoped "if ~ attacked or
+            // blocked this turn" — the sibling of the attacked-only arm above,
+            // gating on the source creature having attacked OR blocked this turn
+            // (Inferno Hellion). Reuses the existing, already-evaluated
+            // `FilterProp::AttackedOrBlockedThisTurn` (checked against
+            // `state.creatures_attacked_this_turn` / `creatures_blocked_this_turn`)
+            // via `SourceMatchesFilter`, so no new `TriggerCondition` variant is
+            // needed. The turn-scoped "this turn" form only; the "this combat"
+            // form (Clockwork cycle, Kjeldoran Home Guard) needs combat-scoped
+            // tracking the engine does not yet keep and is intentionally excluded.
+            (
+                "if ~ attacked or blocked this turn",
+                TriggerCondition::SourceMatchesFilter {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::creature()
+                            .properties(vec![FilterProp::AttackedOrBlockedThisTurn]),
+                    ),
+                },
+            ),
             // CR 603.4: past-turn life loss.
             (
                 "if an opponent lost life during their last turn",

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -416,6 +416,32 @@ fn intervening_if_source_attacked_this_turn_populates_condition() {
 }
 
 #[test]
+fn intervening_if_source_attacked_or_blocked_this_turn_populates_condition() {
+    // CR 508.1 + CR 509.1 + CR 603.4: the "attacked or blocked" sibling of the
+    // attacked-only intervening-if. Gates on the source creature having attacked
+    // OR blocked this turn, composed from the existing, already-evaluated
+    // `FilterProp::AttackedOrBlockedThisTurn` via `SourceMatchesFilter` — no new
+    // `TriggerCondition` variant.
+    let expected = Some(TriggerCondition::SourceMatchesFilter {
+        filter: TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::AttackedOrBlockedThisTurn]),
+        ),
+    });
+
+    // Inferno Hellion — without the gate it would shuffle itself into its
+    // owner's library every end step, even on a turn it neither attacked nor
+    // blocked.
+    let hellion = parse_trigger_line(
+        "At the beginning of each end step, if Inferno Hellion attacked or blocked this turn, \
+         its owner shuffles it into their library.",
+        "Inferno Hellion",
+    );
+    assert_eq!(hellion.condition, expected);
+    // The intervening-if clause is stripped, so the effect still parses.
+    assert!(hellion.execute.is_some());
+}
+
+#[test]
 fn trigger_etb_self() {
     let def = parse_trigger_line(
         "When this creature enters, it deals 1 damage to each opponent.",


### PR DESCRIPTION
## Summary

The intervening-if *"…, if ~ attacked or blocked this turn, …"* (CR 603.4) was silently dropped on triggered abilities — the trigger's `condition` was left `None`, so the ability resolved **unconditionally**. **Inferno Hellion** shuffled itself into its owner's library at *every* end step, even on a turn it neither attacked nor blocked.

## Root cause

The `try_extract_simple_condition` dispatch table in `oracle_trigger.rs` handles the attacked-only sibling (`"if ~ attacked this turn"`, added in #4863) but had **no arm for the attacked-**or**-blocked form**.

## Fix

Add one dispatch arm mapping `"if ~ attacked or blocked this turn"` to:

```rust
TriggerCondition::SourceMatchesFilter {
    filter: TargetFilter::Typed(
        TypedFilter::creature().properties(vec![FilterProp::AttackedOrBlockedThisTurn]),
    ),
}
```

Reuses the existing, already-evaluated `FilterProp::AttackedOrBlockedThisTurn` (checked against `state.creatures_attacked_this_turn` / `creatures_blocked_this_turn` in `game/filter.rs`). **No new `TriggerCondition` variant, no engine/resolver changes** — the direct sibling of #4863.

**Scope:** turn-scoped (`"this turn"`) only. The `"this combat"` form (Clockwork cycle, Kjeldoran Home Guard) needs combat-scoped tracking the engine doesn't keep; mapping it to the turn set would be CR-incorrect on multi-combat turns, so it's intentionally excluded.

## Testing

`intervening_if_source_attacked_or_blocked_this_turn_populates_condition` asserts Inferno Hellion gets the gated condition and the effect still parses. Passes:

```
test parser::oracle_trigger::tests::intervening_if_source_attacked_or_blocked_this_turn_populates_condition ... ok
```

CR 508.1 + CR 509.1 + CR 603.4.
