### PR TITLE
fix(parser): attach board-state count gate to self-spell cost reduction (Hour of Revelation)

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1548,6 +1548,14 @@ pub(crate) fn parse_static_condition(text: &str) -> Option<StaticCondition> {
         return Some(condition);
     }
 
+    // "there are [N] or more [type] on the battlefield" (Hour of Revelation:
+    // "... if there are ten or more nonland permanents on the battlefield") —
+    // the existential-phrasing counterpart of the "[N] or more [type] are on the
+    // battlefield" count form. Same ObjectCount(type) >= N shape.
+    if let Some(condition) = parse_there_are_count_on_battlefield_condition(tp.lower) {
+        return Some(condition);
+    }
+
     // "it shares a color with the most common color among all permanents
     // [or a color tied for most common]" (Heroic Defiance)
     if let Some(condition) = parse_shares_most_common_color_condition(tp.lower) {
@@ -1996,6 +2004,46 @@ pub(crate) fn parse_count_on_battlefield_condition(lower: &str) -> Option<Static
     count_on_battlefield_condition(lower)
         .ok()
         .and_then(|(rest, cond)| rest.trim().is_empty().then_some(cond))
+}
+
+/// CR 611.3a: "there are [N] or more [type] on the battlefield" → the same count
+/// gate as `count_on_battlefield_condition` (`ObjectCount(type) >= N`) but in the
+/// existential "there are …" phrasing (Hour of Revelation: "This spell costs {3}
+/// less to cast if there are ten or more nonland permanents on the
+/// battlefield."). The count form anchors "are on the battlefield" after the
+/// type; this form fronts the "there are" existential and closes with a bare
+/// "on the battlefield".
+pub(crate) fn parse_there_are_count_on_battlefield_condition(
+    lower: &str,
+) -> Option<StaticCondition> {
+    there_are_count_on_battlefield_condition(lower)
+        .ok()
+        .and_then(|(rest, cond)| rest.trim().is_empty().then_some(cond))
+}
+
+fn there_are_count_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (input, _) = tag("there are ").parse(input)?;
+    let (input, n) = nom_primitives::parse_number(input)?;
+    let (input, _) = tag(" or more ").parse(input)?;
+    let (input, type_text) = take_until(" on the battlefield").parse(input)?;
+    let (input, _) = tag(" on the battlefield").parse(input)?;
+    let (filter, remainder) = parse_type_phrase(type_text.trim());
+    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
+        return Err(nom::Err::Error(OracleError::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok((
+        input,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectCount { filter },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: n as i32 },
+        },
+    ))
 }
 
 fn count_on_battlefield_condition(input: &str) -> OracleResult<'_, StaticCondition> {

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -702,7 +702,13 @@ pub(crate) fn try_parse_cost_modification(
             let cond_text = lower[cond_pos + marker.len()..]
                 .trim()
                 .trim_end_matches('.');
-            if let Some(sc) = parse_cost_modifier_condition(cond_text) {
+            // CR 601.2f + CR 611.3a: try the cost-specific predicates first, then
+            // fall back to the shared static-condition grammar so board-state
+            // gates ("if there are ten or more nonland permanents on the
+            // battlefield", Hour of Revelation) attach instead of being swallowed.
+            if let Some(sc) = parse_cost_modifier_condition(cond_text)
+                .or_else(|| parse_static_condition(cond_text))
+            {
                 definition.condition = Some(sc);
             } else if let Ok((rest, sc)) = nom_condition::parse_inner_condition(cond_text) {
                 if rest.trim().is_empty() || rest.trim() == "." {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -442,6 +442,51 @@ fn kraken_of_the_straits_dynamic_power_cant_be_blocked_by() {
     );
 }
 
+/// CR 601.2f + CR 611.3a: A self-spell cost reduction gated on a board-state
+/// count — Hour of Revelation: "This spell costs {3} less to cast if there are
+/// ten or more nonland permanents on the battlefield." — must attach the count
+/// condition, not swallow it (an unconditional reduction is wrong). Exercises the
+/// existential "there are [N] or more [type] on the battlefield" phrasing routed
+/// into the cost-modifier condition extraction.
+#[test]
+fn hour_of_revelation_cost_reduction_gated_on_battlefield_count() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "This spell costs {3} less to cast if there are ten or more nonland permanents on the battlefield.",
+        "Hour of Revelation",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let def = parsed
+        .statics
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::ModifyCost { .. }))
+        .expect("expected a ModifyCost self-spell reduction");
+    let Some(StaticCondition::QuantityComparison {
+        lhs: QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 10 },
+    }) = &def.condition
+    else {
+        panic!(
+            "cost reduction must be gated on ObjectCount(nonland permanents) >= 10, got {:?}",
+            def.condition
+        );
+    };
+    let dbg = format!("{filter:?}");
+    assert!(
+        dbg.contains("Permanent") && dbg.to_lowercase().contains("non"),
+        "gate filter must be nonland permanents, got {dbg}"
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "the board-state gate must attach, not be swallowed; warnings = {:?}",
+        parsed.parse_warnings
+    );
+}
+
 /// CR 509.1b: Brave the Sands — "Creatures you control have vigilance and can
 /// block an additional creature each combat." must decompose into BOTH the
 /// vigilance grant AND an `ExtraBlockers` grant affecting creatures you control.


### PR DESCRIPTION
Fixes a parser correctness bug on **Hour of Revelation** — *"This spell costs {3} less to cast if there are ten or more nonland permanents on the battlefield."*

## Problem
The trailing `if [board-state]` gate was **swallowed**, so the cost reduction applied **unconditionally** (Hour of Revelation would always cost {3} less, regardless of the board). The self-spell cost-mod condition extractor tried `parse_cost_modifier_condition` and `parse_inner_condition`, but neither recognized the **existential** phrasing `"there are [N] or more [type] on the battlefield"` (the existing count helper anchors on `"[N] or more [type] are on the battlefield"`).

## Fix (both edits in test-free files)
- **`oracle_static/shared.rs`** — add `parse_there_are_count_on_battlefield_condition`, the existential counterpart of `count_on_battlefield_condition`, with the same `ObjectCount(type) >= N` shape. Wired into `parse_static_condition` alongside the count/existence helpers.
- **`oracle_static/static_helpers.rs`** — fall back to `parse_static_condition` in the self-spell cost-mod trailing-condition extraction, so board-state gates attach.

Composed from existing `ObjectCount` / `QuantityComparison` primitives — **no new variant**. General across the *"costs {N} less if there are [N] or more [type] on the battlefield"* class.

## CR
CR 601.2f (cost modification) + CR 611.3a (conditional statics).

## Verification
- Full `parser::oracle_static` suite green — **930 passed, 0 failed**.
- New regression `hour_of_revelation_cost_reduction_gated_on_battlefield_count` asserts the `ModifyCost` static gains an `ObjectCount(nonland permanents) >= 10` gate with zero swallowed clauses.
- `cargo fmt` + `cargo clippy -p engine -- -D warnings` clean.
- Regression-checked: the existing `"[N] or more [type] are on the battlefield"` count form and other cost-mod conditions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)