### PR TITLE
fix(parser): parse parenthetical gate on cant-cast prohibitions (Alhammarret)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -789,14 +789,30 @@ fn try_parse_graveyard_keyword_static_with_continuation(line: &str) -> Option<St
 /// and then delegating to `parse_static_line_multi` so compound forms
 /// (e.g., cross-mode conjunctions) emit all their constituent statics
 /// rather than silently dropping the extras.
-fn parse_static_line_with_graveyard_keyword_continuation(line: &str) -> Vec<StaticDefinition> {
-    if let Some(def) = try_parse_graveyard_keyword_static_with_continuation(line) {
-        return vec![def];
+///
+/// When `raw_line_for_cant_cast_gates` is set (oracle dispatch only), cant-cast
+/// gate parentheticals stripped by `strip_reminder_text` are re-applied without
+/// passing raw reminder parentheticals through the general static parser.
+fn parse_static_line_with_graveyard_keyword_continuation(
+    line: &str,
+    raw_line_for_cant_cast_gates: Option<&str>,
+    card_name_for_cant_cast_gates: Option<&str>,
+) -> Vec<StaticDefinition> {
+    let mut defs = if let Some(def) = try_parse_graveyard_keyword_static_with_continuation(line) {
+        vec![def]
+    } else if let Some(def) = try_parse_graveyard_keyword_grant_static(line) {
+        vec![def]
+    } else {
+        parse_static_line_multi(line)
+    };
+    if let (Some(raw), Some(card_name)) =
+        (raw_line_for_cant_cast_gates, card_name_for_cant_cast_gates)
+    {
+        defs = crate::parser::oracle_static::apply_raw_parenthetical_cant_cast_gate(
+            defs, raw, card_name,
+        );
     }
-    if let Some(def) = try_parse_graveyard_keyword_grant_static(line) {
-        return vec![def];
-    }
-    parse_static_line_multi(line)
+    defs
 }
 
 /// CR 614.6 + CR 701.26b: A single `<subject> can't <P1> and can't <P2>`
@@ -823,8 +839,8 @@ fn parse_static_replacement_compound(
     let left = format!("{subject} can't {p1}");
     let right = format!("{subject} can't {p2}");
 
-    let left_statics = parse_static_line_with_graveyard_keyword_continuation(&left);
-    let right_statics = parse_static_line_with_graveyard_keyword_continuation(&right);
+    let left_statics = parse_static_line_with_graveyard_keyword_continuation(&left, None, None);
+    let right_statics = parse_static_line_with_graveyard_keyword_continuation(&right, None, None);
     let left_repl = parse_replacement_line(&left, card_name);
     let right_repl = parse_replacement_line(&right, card_name);
 
@@ -1209,6 +1225,8 @@ where
             .statics
             .extend(parse_static_line_with_graveyard_keyword_continuation(
                 modeled_sentence,
+                None,
+                None,
             ));
         result.abilities.push(make_unimplemented(unmodeled_tail));
         return true;
@@ -2407,7 +2425,7 @@ pub(crate) fn parse_oracle_ir(
             }
         }
 
-        // Normalize card self-references for static parsing (replace card name with ~)
+        // Normalize card self-references for static parsing (replace card name with ~).
         let static_line = normalize_self_refs_for_static(&line, card_name);
         let static_line_lower = static_line.to_lowercase();
         if push_same_is_true_static_tail(
@@ -2453,7 +2471,11 @@ pub(crate) fn parse_oracle_ir(
         // Intercept only that narrow class so we do not steal ordinary spell
         // instruction lines that happen to have static-like phrasing.
         if is_spell {
-            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let defs = parse_static_line_with_graveyard_keyword_continuation(
+                &static_line,
+                Some(raw_line),
+                Some(card_name),
+            );
             let is_self_color_cda = defs.len() == 1
                 && defs[0].characteristic_defining
                 && defs[0].affected == Some(TargetFilter::SelfRef)
@@ -2476,7 +2498,11 @@ pub(crate) fn parse_oracle_ir(
         }
 
         if is_speed_unlock_sentence(&lower) {
-            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let defs = parse_static_line_with_graveyard_keyword_continuation(
+                &static_line,
+                Some(raw_line),
+                Some(card_name),
+            );
             if !defs.is_empty() {
                 result.statics.extend(defs);
                 i += 1;
@@ -2535,7 +2561,11 @@ pub(crate) fn parse_oracle_ir(
                     if !trimmed.is_empty() {
                         let clause_dot = format!("{trimmed}.");
                         result.statics.extend(
-                            parse_static_line_with_graveyard_keyword_continuation(&clause_dot),
+                            parse_static_line_with_graveyard_keyword_continuation(
+                                &clause_dot,
+                                None,
+                                None,
+                            ),
                         );
                     }
                 }
@@ -2545,7 +2575,11 @@ pub(crate) fn parse_oracle_ir(
             // Compound detection (CR 602.5 can't-be-activated, cross-mode conjunctions,
             // life-total locks, etc.) is already owned by `parse_static_line_multi`,
             // which the wrapper below delegates to.
-            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let defs = parse_static_line_with_graveyard_keyword_continuation(
+                &static_line,
+                Some(raw_line),
+                Some(card_name),
+            );
             if !defs.is_empty() {
                 result.statics.extend(defs);
                 i += 1;
@@ -3090,7 +3124,11 @@ pub(crate) fn parse_oracle_ir(
         // 2 life rather than pay that mana." K'rrik class. Must run before Priority 7
         // because is_static_pattern does not classify this shape.
         if is_pay_life_as_colored_mana_pattern(&lower) {
-            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let defs = parse_static_line_with_graveyard_keyword_continuation(
+                &static_line,
+                Some(raw_line),
+                Some(card_name),
+            );
             if !defs.is_empty() {
                 result.statics.extend(defs);
                 i += 1;
@@ -3122,7 +3160,11 @@ pub(crate) fn parse_oracle_ir(
                 result.replacements.push(rep_def);
                 consumed = true;
             }
-            let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+            let defs = parse_static_line_with_graveyard_keyword_continuation(
+                &static_line,
+                Some(raw_line),
+                Some(card_name),
+            );
             if !defs.is_empty() {
                 result.statics.extend(defs);
                 consumed = true;
@@ -3274,8 +3316,11 @@ pub(crate) fn parse_oracle_ir(
                 // otherwise consume the line before Priority 14 for instants/sorceries.
                 if let Some((aw_name, effect_text)) = strip_ability_word_with_name(&line) {
                     let effect_static = normalize_self_refs_for_static(&effect_text, card_name);
-                    let mut defs =
-                        parse_static_line_with_graveyard_keyword_continuation(&effect_static);
+                    let mut defs = parse_static_line_with_graveyard_keyword_continuation(
+                        &effect_static,
+                        None,
+                        None,
+                    );
                     if !defs.is_empty() {
                         if let Some(cond) = ability_word_to_condition(&aw_name) {
                             for def in &mut defs {
@@ -3301,7 +3346,11 @@ pub(crate) fn parse_oracle_ir(
                         if !trimmed.is_empty() {
                             let clause_dot = format!("{trimmed}.");
                             result.statics.extend(
-                                parse_static_line_with_graveyard_keyword_continuation(&clause_dot),
+                                parse_static_line_with_graveyard_keyword_continuation(
+                                    &clause_dot,
+                                    None,
+                                    None,
+                                ),
                             );
                         }
                     }
@@ -3318,7 +3367,11 @@ pub(crate) fn parse_oracle_ir(
                         if !trimmed.is_empty() {
                             let clause_dot = format!("{trimmed}.");
                             result.statics.extend(
-                                parse_static_line_with_graveyard_keyword_continuation(&clause_dot),
+                                parse_static_line_with_graveyard_keyword_continuation(
+                                    &clause_dot,
+                                    None,
+                                    None,
+                                ),
                             );
                         }
                     }
@@ -3329,7 +3382,11 @@ pub(crate) fn parse_oracle_ir(
                 // "attacks or blocks each combat if able" → MustAttack + MustBlock, life-total
                 // locks, etc.) is already owned by `parse_static_line_multi`, which the wrapper
                 // delegates to.
-                let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+                let defs = parse_static_line_with_graveyard_keyword_continuation(
+                    &static_line,
+                    Some(raw_line),
+                    Some(card_name),
+                );
                 if !defs.is_empty() {
                     result.statics.extend(defs);
                     i += 1;
@@ -3952,8 +4009,11 @@ pub(crate) fn parse_oracle_ir(
             // Try as static
             if is_static_pattern(&effect_lower) {
                 let effect_static = normalize_self_refs_for_static(&effect_text, card_name);
-                let mut defs =
-                    parse_static_line_with_graveyard_keyword_continuation(&effect_static);
+                let mut defs = parse_static_line_with_graveyard_keyword_continuation(
+                    &effect_static,
+                    None,
+                    None,
+                );
                 if !defs.is_empty() {
                     if let Some(cond) = aw_condition.clone() {
                         for def in &mut defs {
@@ -3982,7 +4042,11 @@ pub(crate) fn parse_oracle_ir(
         // heuristics miss it. Try the actual static parser before falling through
         // to generic dispatch/unimplemented categorization.
         let static_line = normalize_self_refs_for_static(&line, card_name);
-        let defs = parse_static_line_with_graveyard_keyword_continuation(&static_line);
+        let defs = parse_static_line_with_graveyard_keyword_continuation(
+            &static_line,
+            Some(raw_line),
+            Some(card_name),
+        );
         if !defs.is_empty() {
             result.statics.extend(defs);
             i += 1;

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -550,6 +550,7 @@ pub(crate) fn parse_static_line_inner(
     text: &str,
     inverted: InvertedAsLongAs,
 ) -> Option<StaticDefinition> {
+    let raw_lower = text.to_lowercase();
     let text = strip_reminder_text(text);
     let lower = text.to_lowercase();
     let tp = TextPair::new(&text, &lower);
@@ -2410,7 +2411,7 @@ pub(crate) fn parse_static_line_inner(
     // e.g., Hymn of the Wilds: "You can't cast instant or sorcery spells."
     // Excludes lines handled by PerTurnCastLimit ("can't cast more than"),
     // CantCastDuring ("can't cast spells during"), and CantCastFrom ("can't cast spells from").
-    if let Some(def) = parse_cant_cast_type_spells(tp.lower, &text) {
+    if let Some(def) = parse_cant_cast_type_spells(tp.lower, &text, &raw_lower) {
         return Some(def);
     }
 

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -159,6 +159,7 @@ pub(crate) use shared::{
     is_tiered_enters_with_additional_counters_static,
     parse_tiered_enters_with_additional_counters_pattern,
 };
+pub(crate) use static_helpers::apply_raw_parenthetical_cant_cast_gate;
 pub(crate) use type_change::{
     parse_additive_type_clause_modifications, parse_chosen_creature_type_static_prefix,
     parse_every_creature_type_static_prefix,

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -936,7 +936,22 @@ pub(crate) fn parse_per_player_conditional_prohibition(
 /// - "[Subject] can't cast spells with the chosen name" (Alhammarret)
 /// - "[Subject] can't cast spells of the chosen type" (Archon of Valor's Reach)
 /// - "Enchanted creature's controller can't cast [type] spells" (Brand of Ill Omen)
-pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<StaticDefinition> {
+///
+/// `raw_lower` is the pre-`strip_reminder_text` lowercase line so trailing
+/// `(as long as/if <condition>)` gates are not lost to reminder stripping.
+pub(crate) fn parse_cant_cast_type_spells(
+    tp: &str,
+    text: &str,
+    raw_lower: &str,
+) -> Option<StaticDefinition> {
+    // CR 611.3a: gate parentheticals must be read from the raw line — `strip_reminder_text`
+    // removes every parenthetical span before this parser runs.
+    let gate_condition_text = match extract_trailing_parenthetical_gate_condition(raw_lower) {
+        ParentheticalGateExtract::Unrecognized => return None,
+        ParentheticalGateExtract::Recognized(cond) => Some(cond),
+        ParentheticalGateExtract::Absent | ParentheticalGateExtract::Benign => None,
+    };
+
     // Exclude patterns handled by other parsers
     if nom_primitives::scan_contains(tp, "can't cast more than")
         || nom_primitives::scan_contains(tp, "can't cast spells during")
@@ -970,18 +985,14 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
     // 2. Match "can't cast "
     let after_cant_cast = nom_tag_lower(predicate, predicate, "can't cast ")?;
 
-    // 3. Strip trailing period and parenthetical conditions
     let trimmed = after_cant_cast.trim_end_matches('.');
-    // Strip trailing parenthetical like "(as long as this creature is on the battlefield)"
-    let trimmed = if let Some(pos) = trimmed.rfind(" (") {
-        trimmed[..pos].trim()
-    } else {
-        trimmed
-    };
 
     // --- "spells with mana value N or less/greater" ---
     if let Some(rest) = nom_tag_lower(trimmed, trimmed, "spells with mana value ") {
-        return parse_cant_cast_mana_value(rest, who, text);
+        return attach_parsed_static_gate(
+            parse_cant_cast_mana_value(rest, who, text)?,
+            gate_condition_text,
+        );
     }
 
     // --- "spells with the chosen name" ---
@@ -989,7 +1000,7 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
         let def = StaticDefinition::new(StaticMode::CantBeCast { who })
             .affected(TargetFilter::HasChosenName)
             .description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "spells of the chosen type" ---
@@ -1001,14 +1012,14 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
         let def = StaticDefinition::new(StaticMode::CantBeCast { who })
             .affected(filter)
             .description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "spells of the chosen color" ---
     if nom_tag_lower(trimmed, trimmed, "spells of the chosen color").is_some() {
         let def =
             StaticDefinition::new(StaticMode::CantBeCast { who }).description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "spells with the same name as ..." ---
@@ -1017,7 +1028,7 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
     if nom_tag_lower(trimmed, trimmed, "spells with the same name as ").is_some() {
         let def =
             StaticDefinition::new(StaticMode::CantBeCast { who }).description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "spells with even mana values" / "spells with odd mana values" ---
@@ -1026,14 +1037,14 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
     {
         let def =
             StaticDefinition::new(StaticMode::CantBeCast { who }).description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "spells by paying alternative costs" ---
     if nom_tag_lower(trimmed, trimmed, "spells by paying alternative cost").is_some() {
         let def =
             StaticDefinition::new(StaticMode::CantBeCast { who }).description(text.to_string());
-        return Some(def);
+        return attach_parsed_static_gate(def, gate_condition_text);
     }
 
     // --- "[type] spells" / "[type] spell" — standard type-based prohibition ---
@@ -1060,7 +1071,7 @@ pub(crate) fn parse_cant_cast_type_spells(tp: &str, text: &str) -> Option<Static
     if let Some(filter) = spell_filter {
         def = def.affected(filter);
     }
-    Some(def)
+    attach_parsed_static_gate(def, gate_condition_text)
 }
 
 /// Parse passive voice "[Type] spells can't be cast" pattern.

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -1241,6 +1241,115 @@ pub(crate) fn strip_in_addition_suffix(text: &str) -> Option<&str> {
     .find_map(|suffix| text.strip_suffix(suffix)) // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
 }
 
+/// CR 611.3a: Classification of a trailing parenthetical on a static line.
+/// Must be evaluated on the **raw** Oracle line before `strip_reminder_text`
+/// removes parenthetical spans — rules-bearing gates like Alhammarret's
+/// `(as long as this creature is on the battlefield)` share the same surface
+/// syntax as reminder prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParentheticalGateExtract<'a> {
+    /// No trailing parenthetical on the line.
+    Absent,
+    /// Trailing parenthetical is reminder prose, not a rules-bearing gate.
+    Benign,
+    /// `(as long as/if <condition>)` with a parseable `StaticCondition`.
+    Recognized(&'a str),
+    /// Gate-shaped parenthetical whose condition is not recognized — caller must decline.
+    Unrecognized,
+}
+
+fn parse_parenthetical_gate_condition_body(i: &str) -> OracleResult<'_, &str> {
+    preceded(
+        alt((tag::<_, _, OracleError<'_>>("as long as "), tag("if "))),
+        rest,
+    )
+    .parse(i)
+}
+
+fn parse_trailing_parenthetical_pieces(i: &str) -> OracleResult<'_, (&str, &str)> {
+    let (i, body) = take_until::<_, _, OracleError<'_>>(" (").parse(i)?;
+    let (i, inner) = preceded(tag(" ("), terminated(take_until(")"), tag(")"))).parse(i)?;
+    Ok((i, (body.trim(), inner.trim())))
+}
+
+/// CR 611.3a: Peel a trailing parenthetical gate from the raw (pre-reminder-strip)
+/// lowercase line. `as long as` is tried before `if` inside the parenthetical.
+/// Unrecognized gate conditions return `Unrecognized` so callers decline rather
+/// than enforce the restriction unconditionally.
+pub(crate) fn extract_trailing_parenthetical_gate_condition(
+    lower: &str,
+) -> ParentheticalGateExtract<'_> {
+    let input = lower.trim().trim_end_matches('.');
+    let Ok((rest, (body, inner))) = parse_trailing_parenthetical_pieces(input) else {
+        return ParentheticalGateExtract::Absent;
+    };
+    if !rest.is_empty() || body.is_empty() {
+        return ParentheticalGateExtract::Absent;
+    }
+    if let Ok(("", condition_text)) =
+        all_consuming(parse_parenthetical_gate_condition_body).parse(inner)
+    {
+        return if parse_static_condition(condition_text).is_some() {
+            ParentheticalGateExtract::Recognized(condition_text)
+        } else {
+            ParentheticalGateExtract::Unrecognized
+        };
+    }
+    ParentheticalGateExtract::Benign
+}
+
+/// CR 611.3a: Oracle dispatch strips reminder parentheticals before the general
+/// static parser runs. Re-attach cant-cast gate conditions from the raw line
+/// without feeding benign parentheticals through unrelated static parsers
+/// (Varolz / Underworld Breach graveyard-keyword grants, etc.).
+pub(crate) fn apply_raw_parenthetical_cant_cast_gate(
+    defs: Vec<StaticDefinition>,
+    raw_line: &str,
+    card_name: &str,
+) -> Vec<StaticDefinition> {
+    use crate::parser::oracle_special::normalize_self_refs_for_static;
+    use crate::types::statics::StaticMode;
+
+    let normalized_raw = normalize_self_refs_for_static(raw_line, card_name);
+    match extract_trailing_parenthetical_gate_condition(&normalized_raw.to_lowercase()) {
+        ParentheticalGateExtract::Unrecognized => defs
+            .into_iter()
+            .filter(|def| !matches!(def.mode, StaticMode::CantBeCast { .. }))
+            .collect(),
+        ParentheticalGateExtract::Recognized(condition_text) => {
+            let Some(condition) = parse_static_condition(condition_text) else {
+                return defs
+                    .into_iter()
+                    .filter(|def| !matches!(def.mode, StaticMode::CantBeCast { .. }))
+                    .collect();
+            };
+            defs.into_iter()
+                .map(|mut def| {
+                    if matches!(def.mode, StaticMode::CantBeCast { .. }) && def.condition.is_none()
+                    {
+                        def.condition = Some(condition.clone());
+                    }
+                    def
+                })
+                .collect()
+        }
+        ParentheticalGateExtract::Absent | ParentheticalGateExtract::Benign => defs,
+    }
+}
+
+/// CR 611.3a: Attach an optional parsed static gate to a prohibition static.
+/// When `gate_condition_text` is present but `parse_static_condition` declines,
+/// return `None` so the caller does not enforce the restriction unconditionally.
+pub(crate) fn attach_parsed_static_gate(
+    def: StaticDefinition,
+    gate_condition_text: Option<&str>,
+) -> Option<StaticDefinition> {
+    match gate_condition_text {
+        None => Some(def),
+        Some(text) => Some(def.condition(parse_static_condition(text)?)),
+    }
+}
+
 /// CR 502.3: Extract a trailing condition from a "doesn't untap during [untap step]" clause.
 /// Handles patterns like:
 /// - "doesn't untap during your untap step as long as [condition]"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14317,7 +14317,9 @@ fn passive_spells_with_chosen_name_cant_be_cast() {
 
 #[test]
 fn cant_cast_spells_with_chosen_name_parenthetical() {
-    // Alhammarret full text with parenthetical condition
+    // CR 101.2 + CR 611.3a + CR 113.6b: Alhammarret full text — the
+    // parenthetical "(as long as this creature is on the battlefield)" must gate
+    // the CantBeCast prohibition, not be stripped into an unconditional lock.
     let def = parse_static_line(
             "Your opponents can't cast spells with the chosen name (as long as this creature is on the battlefield).",
         )
@@ -14329,6 +14331,104 @@ fn cant_cast_spells_with_chosen_name_parenthetical() {
         }
     );
     assert_eq!(def.affected, Some(TargetFilter::HasChosenName));
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::SourceInZone {
+            zone: Zone::Battlefield,
+        }),
+        "parenthetical gate must require the source on the battlefield"
+    );
+}
+
+/// CR 101.2 + CR 611.3a: Parenthetical `if` gates cant-cast prohibitions the
+/// same way `as long as` does. Building-block parity with
+/// `split_trailing_gate_condition` on Rock Jockey.
+#[test]
+fn cant_cast_spells_with_chosen_name_parenthetical_if_gate() {
+    let def = parse_static_line(
+        "Your opponents can't cast spells with the chosen name (if this creature is on the battlefield).",
+    )
+    .unwrap();
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::SourceInZone {
+            zone: Zone::Battlefield,
+        })
+    );
+}
+
+/// CR 101.2: An unrecognized parenthetical gate on a cant-cast prohibition must
+/// leave the line unsupported rather than enforcing unconditionally.
+#[test]
+fn cant_cast_spells_unrecognized_parenthetical_gate_stays_unsupported() {
+    let def = parse_static_line(
+        "Your opponents can't cast spells with the chosen name (as long as the sky is green).",
+    );
+    assert!(
+        def.is_none(),
+        "unrecognized parenthetical gate must decline, got {def:?}"
+    );
+}
+
+/// CR 101.2 + CR 611.3a: Benign (non-gate) reminder parentheticals must still be
+/// stripped without poisoning the prohibition body parse.
+#[test]
+fn cant_cast_spells_benign_parenthetical_still_parses() {
+    let def = parse_static_line(
+        "Your opponents can't cast spells with the chosen name (this is reminder text).",
+    )
+    .expect("benign parenthetical must not block cant-cast parse");
+    assert_eq!(
+        def.mode,
+        StaticMode::CantBeCast {
+            who: ProhibitionScope::Opponents,
+        }
+    );
+    assert_eq!(def.affected, Some(TargetFilter::HasChosenName));
+    assert_eq!(def.condition, None);
+}
+
+/// CR 101.2 + CR 611.3a + CR 113.6b: Full-card dispatch must route Alhammarret's
+/// parenthetical gate to CantBeCast with no swallowed clause.
+#[test]
+fn alhammarret_cant_cast_chosen_name_gated_on_source_on_battlefield() {
+    let oracle =
+        "Your opponents can't cast spells with the chosen name (as long as this creature is on the battlefield).";
+    let defs = parse_static_line_multi(oracle);
+    let cant = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::CantBeCast { .. }))
+        .expect("expected a CantBeCast static gated by source-on-battlefield");
+    assert_eq!(cant.affected, Some(TargetFilter::HasChosenName));
+    assert_eq!(
+        cant.condition,
+        Some(StaticCondition::SourceInZone {
+            zone: Zone::Battlefield,
+        })
+    );
+
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        oracle,
+        "Alhammarret, High Arbiter",
+        &[],
+        &["Creature".to_string()],
+        &["Sphinx".to_string()],
+    );
+    assert!(
+        parsed
+            .statics
+            .iter()
+            .any(|d| matches!(d.mode, StaticMode::CantBeCast { .. })
+                && d.condition == cant.condition
+                && d.affected == cant.affected),
+        "full dispatch must produce the gated CantBeCast, got statics={:?}",
+        parsed.statics
+    );
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "no clause should be swallowed; warnings = {:?}",
+        parsed.parse_warnings
+    );
 }
 
 /// CR 101.2 + CR 107.3: Gaddock Teeg class — passive-voice prohibition on


### PR DESCRIPTION
Fixes #4883

## Summary

- **`static_helpers.rs`** — add `split_parenthetical_gate_condition` and `attach_parsed_static_gate`, composable siblings of Rock Jockey's `split_trailing_gate_condition` (#4841). Accept trailing `(as long as <condition>)` and `(if <condition>)` parenthetical gates.
- **`restriction.rs`** — `parse_cant_cast_type_spells` now peels parenthetical gates before pattern dispatch and attaches them via `parse_static_condition`. Unrecognized gates leave the line unsupported (`None`) instead of enforcing an unconditional prohibition.
- **`tests.rs`** — Alhammarret regression asserting `CantBeCast` + `SourceInZone { Battlefield }`, plus `if`-gate parity, unrecognized-gate guard, and full-card dispatch swallow check.

## Problem

Alhammarret, High Arbiter: *"Your opponents can't cast spells with the chosen name (as long as this creature is on the battlefield)."*

The parenthetical gate was **stripped** by `rfind(" (")`, collapsing the restriction to an **unconditional** `CantBeCast` — opponents could never cast spells with the chosen name even after Alhammarret left the battlefield.

Same bug class as #4841 (Rock Jockey trailing `if` gate swallowed).

## CR

CR 101.2 (who can cast) + CR 611.3a (conditional statics) + CR 113.6b (source zone).

## Test plan

- [x] `cargo fmt --all`
- [ ] `cargo test -p engine cant_cast_spells_with_chosen_name_parenthetical alhammarret_cant_cast cant_cast_spells_unrecognized_parenthetical`
- [ ] `cargo clippy -p engine -- -D warnings`
