### PR TITLE
Support "Skip the [step] step of that turn" (Savor the Moment)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7736,6 +7736,33 @@ fn try_parse_skip_next_step(tp: TextPair, ctx: &ParseContext) -> Option<ParsedEf
         }
     }
 
+    // CR 614.10 + CR 614.10a + CR 502.3: "Skip the [step] step of that turn" —
+    // the current-turn-anaphor sibling of the "skip your next [step] step" form
+    // above. Printed on extra-turn spells that take an extra turn, then skip a
+    // step of it (Savor the Moment, Time Bends to My Will: "Take an extra turn
+    // after this one. Skip the untap step of that turn."). "That turn" is the
+    // extra turn just created, which is the controller's next turn, so its
+    // untap step is exactly the next occurrence of that step for the controller
+    // (CR 614.10a: a skip waits for the first occurrence that isn't skipped).
+    // The subject is elided to the resolving controller. Lowers to the same
+    // `SkipNextStep { NextOccurrence }` the "skip your next [step] step" sibling
+    // produces — no new effect or scope is required.
+    if let Some((step, rest)) = nom_on_lower(tp.original, tp.lower, |input| {
+        let (input, _) = tag::<_, _, OracleError<'_>>("skip the ").parse(input)?;
+        let (input, step) = parse_skip_step_name(input)?;
+        let (input, _) = tag(" of that turn").parse(input)?;
+        Ok((input, step))
+    }) {
+        if rest.trim().trim_end_matches('.').is_empty() {
+            return Some(parsed_clause(Effect::SkipNextStep {
+                target: TargetFilter::Controller,
+                step,
+                count: QuantityExpr::Fixed { value: 1 },
+                scope: SkipScope::NextOccurrence,
+            }));
+        }
+    }
+
     if let Some((target, after_verb_orig)) = nom_on_lower(tp.original, tp.lower, |input| {
         alt((
             value(

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -30514,6 +30514,90 @@ fn skip_next_untap_step_parses_as_step_skip() {
     );
 }
 
+/// CR 614.10 + CR 614.10a + CR 502.3: "Skip the untap step of that turn" (the
+/// second sentence of Savor the Moment / Time Bends to My Will, following an
+/// extra-turn effect) is the current-turn-anaphor sibling of "skip your next
+/// untap step". "That turn" is the extra turn just created — the controller's
+/// next turn — so the clause lowers to the same `SkipNextStep` with
+/// `NextOccurrence` scope, `Controller` target, and a `Untap` step. Fail-before:
+/// without the recognizer this clause falls through to `Effect::Unimplemented`.
+#[test]
+fn skip_the_untap_step_of_that_turn_parses_as_step_skip() {
+    let def = parse_effect_chain("Skip the untap step of that turn.", AbilityKind::Spell);
+    let Effect::SkipNextStep {
+        target,
+        step,
+        count,
+        scope,
+    } = &*def.effect
+    else {
+        panic!("expected SkipNextStep, got {:?}", def.effect);
+    };
+    assert_eq!(scope, &SkipScope::NextOccurrence);
+    assert_eq!(target, &TargetFilter::Controller);
+    assert_eq!(step, &StepSkipTarget::Step(Phase::Untap));
+    assert_eq!(
+        count,
+        &crate::types::ability::QuantityExpr::Fixed { value: 1 }
+    );
+}
+
+/// CR 614.10a: Full-card regression for Savor the Moment. The extra-turn spell
+/// must parse to an `ExtraTurn` primary effect with a chained `SkipNextStep`
+/// sub-ability for "Skip the untap step of that turn." — and NO `Unimplemented`
+/// clause anywhere in the chain. Fail-before: the skip clause is `Unimplemented`
+/// and the card is unsupported in coverage.
+#[test]
+fn savor_the_moment_full_card_has_no_unimplemented() {
+    let parsed = parse_oracle_text(
+        "Take an extra turn after this one. Skip the untap step of that turn.",
+        "Savor the Moment",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    fn walk<'a>(ad: &'a AbilityDefinition, out: &mut Vec<&'a Effect>) {
+        out.push(&ad.effect);
+        if let Some(sub) = ad.sub_ability.as_deref() {
+            walk(sub, out);
+        }
+        if let Some(alt) = ad.else_ability.as_deref() {
+            walk(alt, out);
+        }
+    }
+
+    let mut effects = Vec::new();
+    for a in &parsed.abilities {
+        walk(a, &mut effects);
+    }
+
+    assert!(
+        !effects
+            .iter()
+            .any(|e| matches!(e, Effect::Unimplemented { .. })),
+        "Savor the Moment must have no Unimplemented clause; effects = {effects:?}"
+    );
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::ExtraTurn { .. })),
+        "expected an ExtraTurn effect; effects = {effects:?}"
+    );
+    assert!(
+        effects.iter().any(|e| matches!(
+            e,
+            Effect::SkipNextStep {
+                target: TargetFilter::Controller,
+                step: StepSkipTarget::Step(Phase::Untap),
+                scope: SkipScope::NextOccurrence,
+                ..
+            }
+        )),
+        "expected a controller untap-step SkipNextStep; effects = {effects:?}"
+    );
+}
+
 #[test]
 fn target_player_skips_next_draw_step_parses_as_step_skip() {
     let def = parse_effect_chain(


### PR DESCRIPTION
## Summary

Two extra-turn cards fell through to `Effect::Unimplemented` on their **second** sentence:

- **Savor the Moment** (SHM) — *"Take an extra turn after this one. Skip the untap step of that turn."*
- **Time Bends to My Will** (scheme) — *"When you set this scheme in motion, take an extra turn after this one. Skip the untap step of that turn."*

The extra-turn clause already parsed; only *"Skip the untap step of that turn."* was unimplemented. This unlocks both cards fully.

## Change

Add a `"skip the <step> of that turn"` arm to `try_parse_skip_next_step` (`crates/engine/src/parser/oracle_effect/mod.rs`), the current-turn-anaphor sibling of the existing `"skip your next <step> step"` arm. It reuses the shared `parse_skip_step_name` vocabulary and lowers to the existing `Effect::SkipNextStep { target: Controller, step, count: 1, scope: NextOccurrence }` — no new effect, scope, or resolver.

Per CR 614.10a, a "next"/first-unskipped-occurrence skip is exactly right here: "that turn" is the extra turn just created, which is the controller's next turn, so its untap step is the next occurrence of that step for the controller. The arm is whole-clause anchored (the remainder after "of that turn" must be empty modulo a trailing period), so compound clauses fall through to their own recognizers. Corpus grep confirms *"skip the untap step of that turn"* is the only occurrence of this shape.

## Tests

- `skip_the_untap_step_of_that_turn_parses_as_step_skip` — the isolated clause lowers to `SkipNextStep`.
- `savor_the_moment_full_card_has_no_unimplemented` — full-card reach guard: the extra-turn effect parses, the skip chains, and there is zero `Unimplemented`.

Fails-before (clause → `Unimplemented`) / passes-after confirmed. Green: rustfmt, parser-combinator (Rule Zero) gate, `clippy -D warnings`, full engine suite (14518 passed / 0 failed).
