### PR TITLE
Trigger on your own countered spell (Multani's Presence)

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -4678,6 +4678,73 @@ mod tests {
     }
 
     #[test]
+    fn countered_trigger_valid_card_gates_own_spell() {
+        // CR 701.6a + CR 108.4: Multani's Presence -- "Whenever a spell you've
+        // cast is countered". The trigger gates the COUNTERED spell via
+        // `valid_card = Controller(You)`, so it fires only when the countered
+        // spell's controller matches the trigger source's controller. Prove
+        // the chosen `You` filter is honored: an own countered spell fires,
+        // an opponent's countered spell does not.
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Multani's Presence".to_string(),
+            Zone::Battlefield,
+        );
+        // A spell you control (owner/controller P0 == source controller).
+        let own_spell = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Your Countered Spell".to_string(),
+            Zone::Stack,
+        );
+        // A spell an opponent controls (controller P1 != source controller).
+        let opponent_spell = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opponent's Countered Spell".to_string(),
+            Zone::Stack,
+        );
+        let countering_source = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Some Counterspell".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Countered);
+        trigger.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You),
+        ));
+
+        // Your spell is countered -> trigger fires (regardless of who countered it).
+        let own_event = GameEvent::SpellCountered {
+            object_id: own_spell,
+            countered_by: countering_source,
+            countered_by_controller: PlayerId(1),
+        };
+        assert!(
+            match_countered(&own_event, &trigger, source, &state),
+            "your own countered spell must satisfy the trigger"
+        );
+
+        // An opponent's spell is countered -> trigger does NOT fire.
+        let opponent_event = GameEvent::SpellCountered {
+            object_id: opponent_spell,
+            countered_by: countering_source,
+            countered_by_controller: PlayerId(0),
+        };
+        assert!(
+            !match_countered(&opponent_event, &trigger, source, &state),
+            "an opponent's countered spell must not satisfy the trigger"
+        );
+    }
+
+    #[test]
     fn discarded_valid_target_controller_rejects_opponent_discard() {
         let mut state = setup();
         let source = create_object(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11709,6 +11709,42 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         }
     }
 
+    // CR 701.6a + CR 603.2 + CR 108.4: "Whenever a spell you've cast is
+    // countered" is the *passive* dual of the countering-side arm above -- it
+    // fires when a spell whose controller is you leaves the stack via a
+    // counter. `TriggerMode::Countered` matches on `SpellCountered` events;
+    // `valid_card` gates the *countered* spell (the event's `object_id`), so a
+    // `You` controller filter restricts the trigger to your own countered
+    // spells, exactly as `valid_card_matches` evaluates it inside
+    // `match_countered`. This differs from the arm above, which gates the
+    // *countering* source via `valid_source`. A spell's controller is
+    // "you've cast"/"you control" both (CR 108.4), so both possessive forms
+    // route to the single `ControllerRef::You` filter.
+    fn parse_own_spell_countered_line(i: &str) -> OracleResult<'_, ()> {
+        value(
+            (),
+            all_consuming(preceded(
+                alt((tag("whenever "), tag("when "))),
+                preceded(
+                    tag("a spell "),
+                    terminated(
+                        alt((tag("you've cast"), tag("you control"))),
+                        tag(" is countered"),
+                    ),
+                ),
+            )),
+        )
+        .parse(i)
+    }
+    if parse_own_spell_countered_line(lower).is_ok() {
+        let mut def = make_base();
+        def.mode = TriggerMode::Countered;
+        def.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You),
+        ));
+        return Some((TriggerMode::Countered, def));
+    }
+
     // CR 601.2: "Whenever you cast a/an [type] spell [post-spell modifier]" — extract
     // the spell filter. Handles pre-spell type qualifier, post-spell modifier
     // (e.g. "with {X} in its mana cost", CR 107.3 + CR 202.1), or both.

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -8203,6 +8203,47 @@ fn trigger_spell_or_ability_opponent_controls_counters_a_spell() {
 }
 
 #[test]
+fn trigger_a_spell_youve_cast_is_countered() {
+    // CR 701.6a + CR 108.4: Multani's Presence -- the passive dual of the
+    // countering-side arm. The trigger fires when a spell YOU control leaves
+    // the stack via a counter, so it gates the *countered* spell through
+    // `valid_card` (the `SpellCountered` event's `object_id`), not the
+    // countering source through `valid_source`.
+    let def = parse_trigger_line(
+        "Whenever a spell you've cast is countered, draw a card.",
+        "Multani's Presence",
+    );
+    assert_eq!(def.mode, TriggerMode::Countered);
+    assert_eq!(
+        def.valid_card,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        ))
+    );
+    // The passive form must NOT populate `valid_source` (that gates the
+    // countering source, the active-side semantics).
+    assert_eq!(def.valid_source, None);
+}
+
+#[test]
+fn trigger_a_spell_you_control_is_countered() {
+    // CR 108.4: the plain "you control" possessive is synonymous with
+    // "you've cast" for a spell (a spell's controller is its caster), so it
+    // routes to the same `ControllerRef::You` `valid_card` filter.
+    let def = parse_trigger_line(
+        "Whenever a spell you control is countered, draw a card.",
+        "Hypothetical Own-Spell Countered Watcher",
+    );
+    assert_eq!(def.mode, TriggerMode::Countered);
+    assert_eq!(
+        def.valid_card,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        ))
+    );
+}
+
+#[test]
 fn trigger_you_sacrifice_a_creature() {
     let def = parse_trigger_line(
         "Whenever you sacrifice a creature, draw a card.",


### PR DESCRIPTION
## Summary

**Multani's Presence** — *"Whenever a spell you've cast is countered, draw a card."* — parsed its trigger to `Unknown("Whenever a spell you've cast is countered")` and silently dropped it. The engine already models this via `TriggerMode::Countered`, but only the *active* side ("a spell or ability you control counters a spell") had a recognizer.

## Change

Add `parse_own_spell_countered_line` to `try_parse_player_trigger` (`crates/engine/src/parser/oracle_trigger.rs`) — the *passive* dual of the existing countering-side arm. It recognizes `"whenever|when a spell you've cast|you control is countered"` (whole-clause `all_consuming`, nom combinators only) and emits `TriggerMode::Countered` with `valid_card = Typed(controller = You)`.

At runtime, `match_countered` (`game/trigger_matchers.rs`) evaluates `valid_card` against the `SpellCountered` event's `object_id` (the countered spell), so the `You` controller filter restricts the trigger to *your own* countered spell — the passive dual of the active arm, which gates the countering source via `valid_source`. The `Draw` child was already supported.

**Semantics:** a spell's controller is its caster (CR 108.4), so "you've cast" ≡ "you control" for a spell; both route to `ControllerRef::You`. The trigger fires only for your own countered spell, never an opponent's.

CR annotations grep-verified: CR 701.6a (countering), CR 603.2 (trigger conditions), CR 108.4 (a spell's controller).

## Tests

- `trigger_a_spell_youve_cast_is_countered` / `trigger_a_spell_you_control_is_countered` — both forms parse to `Countered` with `valid_card = Controller(You)`, `valid_source = None`.
- `countered_trigger_valid_card_gates_own_spell` — **runtime**: your countered spell fires the trigger; an opponent's countered spell does NOT.

Fails-before (trigger → `Unknown`) / passes-after confirmed. Green: rustfmt, parser-combinator (Rule Zero) gate, `clippy -D warnings`, full engine suite (14546 passed / 0 failed), `cargo coverage` clean. The new arm is a whole-clause `all_consuming` match on a clause that previously parsed to `Unknown`, so no other card's parse is affected.
