### PR TITLE
feat(engine): PR-6.5 — growing-cascade multiplayer win detector (ω-coverability modulo growth)

### DIFF
--- a/.claude/skills/add-engine-variant/SKILL.md
+++ b/.claude/skills/add-engine-variant/SKILL.md
@@ -110,15 +110,13 @@ If you've made it through all three stages with EXTEND_OK / WITHIN_SECTION verdi
 
 2. **Update all exhaustive `match` statements.** Use `cargo check -p engine` to find them. NO wildcard fallback arms to silence the compiler — those mask future variant additions.
 
-3. **Classify the variant in the fail-closed ability-scan walker.** If the enum is traversed by `crates/engine/src/game/ability_scan.rs` (the C0 classifier: `Effect`, `QuantityRef`, `QuantityExpr`, `TargetFilter`, `TriggerCondition`, `StaticCondition`, `ReplacementCondition`, `AbilityCondition`, `Duration`, `PlayerFilter`, `ObjectScope`, `ControllerRef`, and their sub-enums), a NEW *variant* fails to compile there (exhaustive, no `_` fallback) — add an explicit per-axis classification arm. A NEW *field on an EXISTING variant* is only caught if that variant's arm destructures without `..`: NONE arms and projected-resource (axis-3) arms already do (compiler-enforced), but CONSERVATIVE arms keep `..`. So if you add a read-bearing field to a variant the walker classifies as CONSERVATIVE, promote its arm to an explicit destructure and classify the field on every axis. The growing-cascade detector's soundness rests on axis 3, so a silently-dropped projected-resource read is a false combo-win.
+3. **Document runtime status.** If the variant is type-only (no runtime handler yet), add `// RUNTIME: TODO — converter accepts this; engine handler is a no-op stub. CR <X>` on the variant doc-comment. Type-only stubs are acceptable; silent runtime stubs are not.
 
-4. **Document runtime status.** If the variant is type-only (no runtime handler yet), add `// RUNTIME: TODO — converter accepts this; engine handler is a no-op stub. CR <X>` on the variant doc-comment. Type-only stubs are acceptable; silent runtime stubs are not.
+4. **Pair with converter arm in one commit.** Engine extensions ship with the converter arm that uses them, in a single coherent commit. Don't batch unrelated engine extensions.
 
-5. **Pair with converter arm in one commit.** Engine extensions ship with the converter arm that uses them, in a single coherent commit. Don't batch unrelated engine extensions.
+5. **Concurrency contract.** Engine extensions ship in a separate PR before the converter PR depending on them, OR in one paired commit if the work is done by a single agent. No half-extensions.
 
-6. **Concurrency contract.** Engine extensions ship in a separate PR before the converter PR depending on them, OR in one paired commit if the work is done by a single agent. No half-extensions.
-
-7. **Serialized-surface audit.** Before implementation is complete, determine whether the enum appears in game state, `GameAction`, `WaitingFor`, card-data export, AI/community scenario fixtures, saved test fixtures, client adapter types, or any wire-visible protocol. If yes, add the required serde defaults, migration / compatibility path, regenerated fixture, or protocol version bump. Include a test or CI evidence that existing repo-owned serialized data still loads. If protocol-visible, bump the wire contract or prove no serialized shape changed.
+6. **Serialized-surface audit.** Before implementation is complete, determine whether the enum appears in game state, `GameAction`, `WaitingFor`, card-data export, AI/community scenario fixtures, saved test fixtures, client adapter types, or any wire-visible protocol. If yes, add the required serde defaults, migration / compatibility path, regenerated fixture, or protocol version bump. Include a test or CI evidence that existing repo-owned serialized data still loads. If protocol-visible, bump the wire contract or prove no serialized shape changed.
 
 ## Anti-patterns this skill prevents
 

--- a/.claude/skills/add-engine-variant/SKILL.md
+++ b/.claude/skills/add-engine-variant/SKILL.md
@@ -110,13 +110,15 @@ If you've made it through all three stages with EXTEND_OK / WITHIN_SECTION verdi
 
 2. **Update all exhaustive `match` statements.** Use `cargo check -p engine` to find them. NO wildcard fallback arms to silence the compiler — those mask future variant additions.
 
-3. **Document runtime status.** If the variant is type-only (no runtime handler yet), add `// RUNTIME: TODO — converter accepts this; engine handler is a no-op stub. CR <X>` on the variant doc-comment. Type-only stubs are acceptable; silent runtime stubs are not.
+3. **Classify the variant in the fail-closed ability-scan walker.** If the enum is traversed by `crates/engine/src/game/ability_scan.rs` (the C0 classifier: `Effect`, `QuantityRef`, `QuantityExpr`, `TargetFilter`, `TriggerCondition`, `StaticCondition`, `ReplacementCondition`, `AbilityCondition`, `Duration`, `PlayerFilter`, `ObjectScope`, `ControllerRef`, and their sub-enums), a NEW *variant* fails to compile there (exhaustive, no `_` fallback) — add an explicit per-axis classification arm. A NEW *field on an EXISTING variant* is only caught if that variant's arm destructures without `..`: NONE arms and projected-resource (axis-3) arms already do (compiler-enforced), but CONSERVATIVE arms keep `..`. So if you add a read-bearing field to a variant the walker classifies as CONSERVATIVE, promote its arm to an explicit destructure and classify the field on every axis. The growing-cascade detector's soundness rests on axis 3, so a silently-dropped projected-resource read is a false combo-win.
 
-4. **Pair with converter arm in one commit.** Engine extensions ship with the converter arm that uses them, in a single coherent commit. Don't batch unrelated engine extensions.
+4. **Document runtime status.** If the variant is type-only (no runtime handler yet), add `// RUNTIME: TODO — converter accepts this; engine handler is a no-op stub. CR <X>` on the variant doc-comment. Type-only stubs are acceptable; silent runtime stubs are not.
 
-5. **Concurrency contract.** Engine extensions ship in a separate PR before the converter PR depending on them, OR in one paired commit if the work is done by a single agent. No half-extensions.
+5. **Pair with converter arm in one commit.** Engine extensions ship with the converter arm that uses them, in a single coherent commit. Don't batch unrelated engine extensions.
 
-6. **Serialized-surface audit.** Before implementation is complete, determine whether the enum appears in game state, `GameAction`, `WaitingFor`, card-data export, AI/community scenario fixtures, saved test fixtures, client adapter types, or any wire-visible protocol. If yes, add the required serde defaults, migration / compatibility path, regenerated fixture, or protocol version bump. Include a test or CI evidence that existing repo-owned serialized data still loads. If protocol-visible, bump the wire contract or prove no serialized shape changed.
+6. **Concurrency contract.** Engine extensions ship in a separate PR before the converter PR depending on them, OR in one paired commit if the work is done by a single agent. No half-extensions.
+
+7. **Serialized-surface audit.** Before implementation is complete, determine whether the enum appears in game state, `GameAction`, `WaitingFor`, card-data export, AI/community scenario fixtures, saved test fixtures, client adapter types, or any wire-visible protocol. If yes, add the required serde defaults, migration / compatibility path, regenerated fixture, or protocol version bump. Include a test or CI evidence that existing repo-owned serialized data still loads. If protocol-visible, bump the wire contract or prove no serialized shape changed.
 
 ## Anti-patterns this skill prevents
 

--- a/crates/engine/src/analysis/loop_check.rs
+++ b/crates/engine/src/analysis/loop_check.rs
@@ -294,6 +294,12 @@ pub(crate) fn live_mandatory_loop_winner(
     // deficit on the winner's own life/mana). Replaces the former `detect_loop(...)`
     // delegation, which re-ran only the exact-depth equality and would reject the
     // growing-cascade board the gate above just accepted.
+    //
+    // The measured per-cycle drain is a LOWER BOUND on the actual drain rate: it is
+    // at least the delta observed between the two compared frames. A super-critical
+    // (μ>1) cascade only ACCELERATES from here — each cycle spawns more drain than
+    // the last — so proving progress on the measured floor is sufficient; the real
+    // trajectory reaches lethal no later than the linear extrapolation implies.
     if !delta.net_progress_for(winner) {
         return None;
     }

--- a/crates/engine/src/analysis/loop_check.rs
+++ b/crates/engine/src/analysis/loop_check.rs
@@ -55,7 +55,8 @@
 //! soundness guarantee: no certificate for a non-loop or a non-progressing cycle.
 
 use crate::analysis::resource::{
-    loop_states_equal_modulo_resources, CounterClass, ObjectClass, ResourceAxis, ResourceVector,
+    loop_states_cover_modulo_growth, loop_states_equal_modulo_resources, CounterClass, ObjectClass,
+    ResourceAxis, ResourceVector,
 };
 use crate::types::game_state::GameState;
 use crate::types::player::PlayerId;
@@ -214,66 +215,159 @@ pub(crate) fn live_mandatory_loop_winner(
     cycle_end: &GameState,
     delta: &ResourceVector,
 ) -> Option<PlayerId> {
-    // CR 104.2a: a forced single-loser outcome is unambiguous only in a 2-player
-    // game; multiplayer player-elimination is deferred (offline-covered by PR-2).
+    // CR 104.1: the living players (not eliminated).
     let living: Vec<PlayerId> = cycle_end
         .players
         .iter()
         .filter(|p| !p.is_eliminated)
         .map(|p| p.id)
         .collect();
-    if living.len() != 2 {
+    // Need at least one opponent to force a loss on.
+    if living.len() < 2 {
         return None;
     }
 
-    // CR 704.5a: the per-player attributable life axis — who is draining out.
-    let life_fallers: Vec<PlayerId> = living
+    // CR 704.5a: partition living into strict life fallers vs. non-fallers (life
+    // delta ≥ 0, an absent key reading 0). Exactly one non-faller is the sole
+    // survivor candidate; since fallers/non-fallers partition `living`, that single
+    // non-faller condition IS "every other living player falls" (CR 104.2a).
+    let fallers: Vec<PlayerId> = living
         .iter()
         .copied()
         .filter(|p| delta.life.get(p).copied().unwrap_or(0) < 0)
         .collect();
-    // CR 704.5b: any decking (library going down) is a SECOND determinate-loss path.
-    let any_library_loss = living
+    let nonfallers: Vec<PlayerId> = living
         .iter()
-        .any(|p| delta.library_delta.get(p).copied().unwrap_or(0) < 0);
-    // CR 704.5c: poison is keyed by an aggregate (Poison, Player) pair in `snapshot`
-    // (unattributable per player), so treat any poison gain conservatively.
-    let any_poison_gain = delta
+        .copied()
+        .filter(|p| !fallers.contains(p))
+        .collect();
+    if nonfallers.len() != 1 {
+        return None;
+    }
+    let winner = nonfallers[0];
+
+    // Second-loss-path firewall (life axis only), over ALL living players — keep the
+    // 2p behavior generalized to the pod. CR 704.5b/121.4: any library loss is a
+    // second determinate-loss path.
+    if living
+        .iter()
+        .any(|p| delta.library_delta.get(p).copied().unwrap_or(0) < 0)
+    {
+        return None;
+    }
+    // CR 704.5c: poison is keyed by an aggregate (Poison, Player) pair (unattributable
+    // per player), so any poison gain is conservatively a second loss path.
+    if delta
         .counters
         .get(&(CounterClass::Poison, ObjectClass::Player))
         .copied()
         .unwrap_or(0)
-        > 0;
-    // Single-faller firewall: reject dual-faller (mutual drain), the Niv shape
-    // (opponent life ↓ AND a controller library ↓), and any second determinate-loss
-    // path. PR-3 wins ONLY on the CR 704.5a life axis.
-    if life_fallers.len() != 1 || any_library_loss || any_poison_gain {
-        return None;
-    }
-    let faller = life_fallers[0];
-    let winner = living.iter().copied().find(|&p| p != faller)?;
-
-    // CR 101.2 + CR 104.3b + CR 704.5a: a player who can't lose the game can't be the
-    // faller of a forced loss (Platinum Angel / "you can't lose the game"). CR 101.2 +
-    // CR 104.2b: a player who can't win can't be named winner (Abyssal Persecutor:
-    // "your opponents can't win the game"). Reuse the SBA-layer predicates on the LIVE
-    // `cycle_end` so static effects are evaluated against the real board. (This
-    // firewall is strict 2-player — the Two-Headed Giant team rule CR 810.8a does not
-    // apply here.)
-    if crate::game::sba::player_has_cant_lose(cycle_end, faller)
-        || crate::game::static_abilities::player_has_cant_win(cycle_end, winner)
+        > 0
     {
         return None;
     }
 
-    // Confirm via the PR-2 classifier: `detect_loop` re-runs
-    // `loop_states_equal_modulo_resources` (so the board-equality gate is enforced
-    // here, no redundant pre-check) and `is_progress`. Holds by construction —
-    // `is_progress` passes (winner life Δ≥0), and `classify_win_kind` sees `faller`
-    // life<0 with faller≠winner ⇒ `LethalDamage`. Require exactly that win kind so the
-    // live shortcut is scoped to the CR 704.5a life axis.
-    let cert = detect_loop(cycle_start, cycle_end, delta, winner, true)?;
-    matches!(cert.win_kind, WinKind::LethalDamage).then_some(winner)
+    // CR 101.2 firewalls, generalized. CR 104.3b + 101.2: NO faller may be a player
+    // who can't lose the game (Platinum Angel). CR 104.2b + 101.2: the winner can't
+    // be named if they can't win (Abyssal Persecutor). Evaluated on the LIVE
+    // `cycle_end` so static effects see the real board.
+    if fallers
+        .iter()
+        .any(|&p| crate::game::sba::player_has_cant_lose(cycle_end, p))
+    {
+        return None;
+    }
+    if crate::game::static_abilities::player_has_cant_win(cycle_end, winner) {
+        return None;
+    }
+
+    // CR 732.2a board-recurrence gate: constant-depth exact recurrence OR a
+    // growing-cascade covering pair (the ≥3p fan-out grows the stack without bound,
+    // so the exact-depth equality never matches — the coverability path is required).
+    if !(loop_states_equal_modulo_resources(cycle_start, cycle_end)
+        || loop_states_cover_modulo_growth(cycle_start, cycle_end))
+    {
+        return None;
+    }
+
+    // CR 732.2a: net progress for the winner (≥1 unbounded axis, no consumed-axis
+    // deficit on the winner's own life/mana). Replaces the former `detect_loop(...)`
+    // delegation, which re-ran only the exact-depth equality and would reject the
+    // growing-cascade board the gate above just accepted.
+    if !delta.net_progress_for(winner) {
+        return None;
+    }
+    // Scope the live shortcut to the CR 704.5a life axis (a drain, not an advantage
+    // engine or a mill): `classify_win_kind` sees ≥1 faller life<0 ⇒ `LethalDamage`.
+    if classify_win_kind(winner, delta) != WinKind::LethalDamage {
+        return None;
+    }
+
+    // R5-B2 simultaneity floor (CR 704.3 / CR 800.4a / CR 104.2a): with ≥2 fallers,
+    // require EQUAL per-cycle life deltas so all fallers cross lethal in the SAME
+    // resolution's CR 704.3 SBA batch — then the sole CR 104.2a elimination is
+    // terminal and no post-CR-800.4a continuation is ever modeled. The seam adds the
+    // complementary per-frame pairwise-equality check ([`fallers_lives_pairwise_equal`]).
+    // `fallers.len() == 1` needs no gate: the sole opponent's elimination IS the
+    // terminal event (2p behavior byte-preserved).
+    if fallers.len() >= 2 {
+        let first = delta.life.get(&fallers[0]).copied().unwrap_or(0);
+        if fallers
+            .iter()
+            .any(|p| delta.life.get(p).copied().unwrap_or(0) != first)
+        {
+            return None;
+        }
+    }
+    Some(winner)
+}
+
+/// CR 704.5a + CR 104.4a: the loop's controller (a strict non-faller) must never dip
+/// below its prior life at ANY per-resolution ring frame. A transient intra-cycle
+/// dip that recovers to a non-negative NET delta would still kill the controller via
+/// the CR 704.5a SBA at low absolute life before the extrapolated win — a net-delta
+/// check cannot see it. Per-resolution granularity IS SBA granularity here (CR 704.3
+/// checks whenever a player would get priority, between resolutions), and consecutive
+/// ring frames are consecutive resolutions (a non-sampling beat clears the ring), so
+/// requiring `life[controller]` non-decreasing across the matched window (prior frame
+/// → every subsequent ring frame → the live state) is exactly right. Controller
+/// draw-from-empty is correctly unreachable (a non-faller never crosses a loss SBA).
+pub(crate) fn controller_life_never_dips(frames: &[&GameState], controller: PlayerId) -> bool {
+    let mut prev: Option<i32> = None;
+    for frame in frames {
+        let Some(life) = frame
+            .players
+            .iter()
+            .find(|p| p.id == controller)
+            .map(|p| p.life)
+        else {
+            continue;
+        };
+        if prev.is_some_and(|p| life < p) {
+            return false;
+        }
+        prev = Some(life);
+    }
+    true
+}
+
+/// CR 704.3 (one SBA batch) + CR 800.4a + CR 104.2a: the R5-B2 simultaneity floor,
+/// seam half. With ≥2 fallers, every faller's `player.life` must be pairwise-equal at
+/// EVERY ring frame (incl. the live state); combined with the predicate's equal
+/// per-cycle deltas, all fallers stay pairwise-equal at every extrapolated frame and
+/// therefore cross lethal in the SAME resolution's CR 704.3 SBA batch. The single
+/// CR 104.2a elimination is then terminal ("happens immediately and overrides all
+/// effects"), so CR 800.4a's machinery-removal side effects occur only after the game
+/// is already decided — zero post-death continuation to model. Staggered-life games
+/// become fail-safe FALSE NEGATIVES. Only meaningful for `fallers.len() >= 2`.
+pub(crate) fn fallers_lives_pairwise_equal(frames: &[&GameState], fallers: &[PlayerId]) -> bool {
+    frames.iter().all(|frame| {
+        let lives: Vec<i32> = fallers
+            .iter()
+            .filter_map(|&fp| frame.players.iter().find(|p| p.id == fp).map(|p| p.life))
+            .collect();
+        lives.windows(2).all(|w| w[0] == w[1])
+    })
 }
 
 /// Derive the [`WinKind`] from the measured per-cycle delta.
@@ -857,9 +951,11 @@ mod tests {
         );
     }
 
-    /// U6 SOUNDNESS: a single faller but THREE living players ⇒ None (2-player
-    /// scope only; multiplayer deferred). Revert: dropping `living.len()==2` yields
-    /// a winner.
+    /// U6 SOUNDNESS: a single faller with THREE living players is NOT an all-opponent
+    /// drain — a bystander (P2, life delta 0) survives, so `nonfallers = {P0, P2}`
+    /// (len 2 ≠ 1) ⇒ None. The MP-general predicate correctly refuses to name a winner
+    /// while a non-draining opponent is alive. Revert: an "any-faller-wins" rewrite
+    /// that ignores bystanders flips this to `Some(P0)`.
     #[test]
     fn live_winner_three_player_is_none() {
         let mut end = GameState::new_two_player(7);
@@ -1012,6 +1108,234 @@ mod tests {
             live_mandatory_loop_winner(&start, &end, &delta),
             None,
             "a net-zero repeat is a draw, not a win — no life faller"
+        );
+    }
+
+    // ===================================================================
+    // N2 — MP winner predicate over a growing-cascade covering pair.
+    // ===================================================================
+
+    /// A mandatory, no-ordering-input `TriggeredAbility` stack entry (fixed GainLife,
+    /// no target/condition) — the churn-kind whose growth `cover_modulo_growth`
+    /// certifies. Same source/controller ⇒ one normalized kind.
+    fn mtrig(entry_id: u64) -> crate::types::game_state::StackEntry {
+        use crate::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+        use crate::types::game_state::{StackEntry, StackEntryKind};
+        let src = ObjectId(500);
+        StackEntry {
+            id: ObjectId(entry_id),
+            source_id: src,
+            controller: pid(0),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: src,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                    vec![],
+                    src,
+                    pid(0),
+                )),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+            },
+        }
+    }
+
+    fn n_player(n: u8) -> GameState {
+        let mut s = GameState::new_two_player(7);
+        while (s.players.len() as u8) < n {
+            let mut p = s.players[1].clone();
+            p.id = pid(s.players.len() as u8);
+            s.players.push(p);
+        }
+        s
+    }
+
+    /// N2 POSITIVE: a 3-player all-opponent drain over a GROWING (covering) stack
+    /// names the controller. The growing depth means the exact-depth equality never
+    /// matches — only `cover_modulo_growth` can confirm, so the cover path IS
+    /// exercised. REVERT-FAIL: restoring `living.len() != 2` ⇒ None (blocker B-WINNER).
+    #[test]
+    fn n2_three_player_all_opponent_drain_growing_stack() {
+        let mut start = n_player(3);
+        start.stack.push_back(mtrig(10));
+        start.stack.push_back(mtrig(11));
+        let mut end = start.clone();
+        end.stack.push_back(mtrig(12)); // [G,G] -> [G,G,G]: covering growth
+        assert!(
+            !loop_states_equal_modulo_resources(&start, &end),
+            "fixture: growing depth ⇒ exact-depth equality must NOT match (cover path required)"
+        );
+        assert!(
+            loop_states_cover_modulo_growth(&start, &end),
+            "fixture: the covering pair holds"
+        );
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(2), -1);
+        delta.life.insert(pid(0), 2);
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end, &delta),
+            Some(pid(0)),
+            "3p all-opponent drain over a covering pair names the controller"
+        );
+
+        // Non-vacuity of the GROWTH arm: with a NON-covering grown stack (the extra
+        // entry is a Spell, not a mandatory trigger) the board gate fails ⇒ None.
+        let mut end_bad = start.clone();
+        end_bad.stack.push_back(spell_entry(99));
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &end_bad, &delta),
+            None,
+            "a grown stack that is NOT a covering pair (spell) must not name a winner"
+        );
+
+        // Control: the SAME delta at CONSTANT depth confirms via equality — proving
+        // the positive above depends on the cover path, not the equality path.
+        let flat = start.clone();
+        assert_eq!(
+            live_mandatory_loop_winner(&start, &flat, &delta),
+            Some(pid(0)),
+            "constant-depth confirms via the equality path"
+        );
+    }
+
+    fn spell_entry(entry_id: u64) -> crate::types::game_state::StackEntry {
+        use crate::types::game_state::{CastingVariant, StackEntry, StackEntryKind};
+        StackEntry {
+            id: ObjectId(entry_id),
+            source_id: ObjectId(500),
+            controller: pid(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        }
+    }
+
+    /// N2 HOSTILE: a 4-player table with a STATIC bystander (P3, no life delta) ⇒
+    /// non-fallers {P0, P3} (len 2) ⇒ None.
+    #[test]
+    fn n2_four_player_static_bystander_is_none() {
+        let end = n_player(4);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(2), -1);
+        delta.life.insert(pid(0), 2);
+        // P3 carries no delta ⇒ static ⇒ a second non-faller.
+        assert_eq!(live_mandatory_loop_winner(&start, &end, &delta), None);
+    }
+
+    /// N2 HOSTILE: 3p where the controller ALSO loses ⇒ non-fallers {} ⇒ None (the
+    /// CR 104.4a draw road; the strict draw path owns it).
+    #[test]
+    fn n2_controller_also_falls_is_none() {
+        let end = n_player(3);
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(0), -1);
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(2), -1);
+        assert_eq!(live_mandatory_loop_winner(&start, &end, &delta), None);
+    }
+
+    /// N2 HOSTILE (CR 101.2): 3p all-opponent drain but a faller CAN'T LOSE ⇒ None.
+    #[test]
+    fn n2_faller_cant_lose_is_none() {
+        let mut end = n_player(3);
+        add_cant_static(
+            &mut end,
+            1,
+            911,
+            crate::types::statics::StaticMode::CantLoseTheGame,
+        );
+        let start = end.clone();
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(2), -1);
+        delta.life.insert(pid(0), 2);
+        assert_eq!(live_mandatory_loop_winner(&start, &end, &delta), None);
+    }
+
+    /// N2 HOSTILE (R5-B2, predicate half): 3p all-opponent drain with UNEQUAL faller
+    /// deltas over a valid covering pair ⇒ None (the fallers cross lethal in DIFFERENT
+    /// resolutions, so the first CR 800.4a elimination is not terminal). REVERT-FAIL:
+    /// dropping the `fallers.len() >= 2 ⇒ equal per-cycle delta` conjunct ⇒ Some(P0).
+    #[test]
+    fn n2_unequal_faller_deltas_is_none() {
+        let mut start = n_player(3);
+        start.stack.push_back(mtrig(10));
+        start.stack.push_back(mtrig(11));
+        let mut end = start.clone();
+        end.stack.push_back(mtrig(12));
+        assert!(
+            loop_states_cover_modulo_growth(&start, &end),
+            "fixture: the covering pair holds (isolates the simultaneity conjunct)"
+        );
+        let mut delta = ResourceVector::default();
+        delta.life.insert(pid(1), -1);
+        delta.life.insert(pid(2), -2); // unequal ⇒ staggered crossing
+        delta.life.insert(pid(0), 3);
+        assert_eq!(live_mandatory_loop_winner(&start, &end, &delta), None);
+    }
+
+    // ===================================================================
+    // N5 — m9 monotonicity + R5-B2 per-frame simultaneity (pure fn tests).
+    // ===================================================================
+
+    /// Build a state whose players 0..lives.len() carry the given life totals.
+    fn frame(lives: &[i32]) -> GameState {
+        let mut s = n_player(lives.len() as u8);
+        for (i, &l) in lives.iter().enumerate() {
+            s.players[i].life = l;
+        }
+        s
+    }
+
+    /// N5: `controller_life_never_dips` — monotone non-decreasing ⇒ true; a
+    /// dip-and-recover whose NET delta is ≥ 0 (a net-delta check cannot see it) ⇒
+    /// false. REVERT-FAIL: gutting the fn (or dropping its seam call) admits the dip.
+    #[test]
+    fn n5_controller_life_never_dips() {
+        let mono = [frame(&[5]), frame(&[5]), frame(&[7])];
+        let mono_refs: Vec<&GameState> = mono.iter().collect();
+        assert!(controller_life_never_dips(&mono_refs, pid(0)));
+
+        let dip = [frame(&[5]), frame(&[2]), frame(&[5])];
+        let dip_refs: Vec<&GameState> = dip.iter().collect();
+        assert!(
+            !controller_life_never_dips(&dip_refs, pid(0)),
+            "a 5→2→5 intra-window dip (net ≥ 0) must be rejected"
+        );
+    }
+
+    /// N5: `fallers_lives_pairwise_equal` — two fallers equal at every frame ⇒ true;
+    /// diverging lives ⇒ false (the staggered-crossing CR 800.4a machinery-removal
+    /// shape). REVERT-FAIL: gutting the fn (or dropping its seam call) admits it.
+    #[test]
+    fn n5_fallers_lives_pairwise_equal() {
+        let equal = [frame(&[20, 10, 10]), frame(&[20, 9, 9]), frame(&[20, 8, 8])];
+        let equal_refs: Vec<&GameState> = equal.iter().collect();
+        assert!(fallers_lives_pairwise_equal(&equal_refs, &[pid(1), pid(2)]));
+
+        let diverge = [
+            frame(&[20, 10, 20]),
+            frame(&[20, 9, 19]),
+            frame(&[20, 8, 18]),
+        ];
+        let diverge_refs: Vec<&GameState> = diverge.iter().collect();
+        assert!(
+            !fallers_lives_pairwise_equal(&diverge_refs, &[pid(1), pid(2)]),
+            "P1@10 / P2@20 staggered lives must be rejected"
         );
     }
 }

--- a/crates/engine/src/analysis/loop_check.rs
+++ b/crates/engine/src/analysis/loop_check.rs
@@ -247,7 +247,7 @@ pub(crate) fn live_mandatory_loop_winner(
     let winner = nonfallers[0];
 
     // Second-loss-path firewall (life axis only), over ALL living players — keep the
-    // 2p behavior generalized to the pod. CR 704.5b/121.4: any library loss is a
+    // 2p behavior generalized to the pod. CR 704.5b / CR 121.4: any library loss is a
     // second determinate-loss path.
     if living
         .iter()
@@ -267,8 +267,8 @@ pub(crate) fn live_mandatory_loop_winner(
         return None;
     }
 
-    // CR 101.2 firewalls, generalized. CR 104.3b + 101.2: NO faller may be a player
-    // who can't lose the game (Platinum Angel). CR 104.2b + 101.2: the winner can't
+    // CR 101.2 firewalls, generalized. CR 104.3b + CR 101.2: NO faller may be a player
+    // who can't lose the game (Platinum Angel). CR 104.2b + CR 101.2: the winner can't
     // be named if they can't win (Abyssal Persecutor). Evaluated on the LIVE
     // `cycle_end` so static effects see the real board.
     if fallers
@@ -328,23 +328,26 @@ pub(crate) fn live_mandatory_loop_winner(
     Some(winner)
 }
 
-/// CR 704.5a + CR 104.4a: the loop's controller (a strict non-faller) must never dip
-/// below its prior life at ANY per-resolution ring frame. A transient intra-cycle
-/// dip that recovers to a non-negative NET delta would still kill the controller via
-/// the CR 704.5a SBA at low absolute life before the extrapolated win — a net-delta
-/// check cannot see it. Per-resolution granularity IS SBA granularity here (CR 704.3
-/// checks whenever a player would get priority, between resolutions), and consecutive
-/// ring frames are consecutive resolutions (a non-sampling beat clears the ring), so
-/// requiring `life[controller]` non-decreasing across the matched window (prior frame
-/// → every subsequent ring frame → the live state) is exactly right. Controller
-/// draw-from-empty is correctly unreachable (a non-faller never crosses a loss SBA).
-pub(crate) fn controller_life_never_dips(frames: &[&GameState], controller: PlayerId) -> bool {
+/// CR 704.5a + CR 104.4a: the loop's winner (the sole strict non-faller) must never
+/// dip below its prior life at ANY per-resolution ring frame. Named for the winner,
+/// NOT the loop's controller: a mandatory-loop trigger can be controlled by a faller,
+/// so the controller is not necessarily the player this guard protects — the winner
+/// (the one non-faller) is. A transient intra-cycle dip that recovers to a
+/// non-negative NET delta would still kill the winner via the CR 704.5a SBA at low
+/// absolute life before the extrapolated win — a net-delta check cannot see it.
+/// Per-resolution granularity IS SBA granularity here (CR 704.3 checks whenever a
+/// player would get priority, between resolutions), and consecutive ring frames are
+/// consecutive resolutions (a non-sampling beat clears the ring), so requiring
+/// `life[winner]` non-decreasing across the matched window (prior frame → every
+/// subsequent ring frame → the live state) is exactly right. Winner draw-from-empty
+/// is correctly unreachable (a non-faller never crosses a loss SBA).
+pub(crate) fn winner_life_never_dips(frames: &[&GameState], winner: PlayerId) -> bool {
     let mut prev: Option<i32> = None;
     for frame in frames {
         let Some(life) = frame
             .players
             .iter()
-            .find(|p| p.id == controller)
+            .find(|p| p.id == winner)
             .map(|p| p.life)
         else {
             continue;
@@ -1307,19 +1310,19 @@ mod tests {
         s
     }
 
-    /// N5: `controller_life_never_dips` — monotone non-decreasing ⇒ true; a
+    /// N5: `winner_life_never_dips` — monotone non-decreasing ⇒ true; a
     /// dip-and-recover whose NET delta is ≥ 0 (a net-delta check cannot see it) ⇒
     /// false. REVERT-FAIL: gutting the fn (or dropping its seam call) admits the dip.
     #[test]
-    fn n5_controller_life_never_dips() {
+    fn n5_winner_life_never_dips() {
         let mono = [frame(&[5]), frame(&[5]), frame(&[7])];
         let mono_refs: Vec<&GameState> = mono.iter().collect();
-        assert!(controller_life_never_dips(&mono_refs, pid(0)));
+        assert!(winner_life_never_dips(&mono_refs, pid(0)));
 
         let dip = [frame(&[5]), frame(&[2]), frame(&[5])];
         let dip_refs: Vec<&GameState> = dip.iter().collect();
         assert!(
-            !controller_life_never_dips(&dip_refs, pid(0)),
+            !winner_life_never_dips(&dip_refs, pid(0)),
             "a 5→2→5 intra-window dip (net ≥ 0) must be rejected"
         );
     }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -33,6 +33,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaType;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
+use crate::types::replacements::ReplacementEvent;
 
 /// WUBRG + colorless, the canonical index order used by [`ResourceVector::mana`].
 ///
@@ -690,8 +691,10 @@ fn loyalty_activation_counts_match(a: &GameState, b: &GameState) -> bool {
 /// stack order-preservingly embeds in `current`'s with strict growth confined to
 /// already-occupied places (item 2), every grown place is a mandatory
 /// no-ordering-input triggered ability (item 3), no current-stack entry reads a
-/// still-projected resource (item 4), and no live fire-time condition reads one
-/// either (item 5).
+/// still-projected resource (item 4), no live fire-time condition reads one
+/// either (item 5), and no current-stack entry can open a resolution-time player
+/// choice — either intrinsically or through the life-event replacement
+/// environment (item 6, CR 732.2a + CR 608.2d).
 pub(crate) fn loop_states_cover_modulo_growth(prior: &GameState, current: &GameState) -> bool {
     // (1) Board equal modulo the NARROWED projection AND modulo the stack, with the
     // object resource axes STRICT-COMPARED (R5-B1). Project both, clear both stacks
@@ -740,6 +743,43 @@ pub(crate) fn loop_states_cover_modulo_growth(prior: &GameState, current: &GameS
 
     // (5) Off-stack fail-closed fire-time condition guard (the second read surface).
     if fire_time_conditions_read_projected_resource(current) {
+        return false;
+    }
+
+    // (6) CR 732.2a + CR 608.2d: resolution-time choice gate, fail-closed, over
+    // EVERY current-stack entry — the extrapolation models future resolutions the
+    // window never observed (grown kinds) and re-runs observed kinds in states that
+    // differ on projected axes, where a resolver's choice surface (e.g. proliferate
+    // eligibility over player counters, CR 701.34a) can open a prompt that the
+    // AST-level item-4 scan cannot see. Verdicts come from the ability_scan
+    // classifier (pure fact-producers — rejection is decided ONLY here);
+    // FreeUnlessLifeReplacements additionally requires the CR 616.1 environmental
+    // guard below. THIS block is the single gate seam for resolution-choice
+    // rejection (item 3 is untouched and gates a different fact — announcement-time
+    // ordering input). Perf: O(stack × AST) + O(objects × defs) via the guard —
+    // same order as items (4)/(5).
+    //
+    // EXTENSION POINT — pinned fixed choices (CR 732.2a): a shortcut proposal MAY
+    // pre-specify choices in advance ("always choose permanent P"); only
+    // CONDITIONAL actions are forbidden. A future consumer may treat a MayPrompt
+    // entry as choice-free when a pin covers it, PROVIDED: (a) the pin is a
+    // STATE-INDEPENDENT designation whose option remains legal at every iteration
+    // of the growing state (never "the newest copy"); (b) cover-modulo-growth
+    // still holds under the pinned outcomes; (c) only the acting player's own
+    // choices are pinnable — opponent-choice entries remain rejectors unless EVERY
+    // option preserves the certificate (the win stays forced per the
+    // CR 104.2a-grounded winner predicate). Plug pins in at THIS seam as an
+    // additional input; do not rewire the classifiers or spread the decision.
+    let mut needs_life_guard = false;
+    for entry in &current.stack {
+        match stack_entry_resolution_choice_freedom(entry) {
+            crate::game::ability_scan::ResolutionChoiceFreedom::MayPrompt => return false,
+            crate::game::ability_scan::ResolutionChoiceFreedom::FreeUnlessLifeReplacements => {
+                needs_life_guard = true
+            }
+        }
+    }
+    if needs_life_guard && life_event_replacements_may_prompt(current) {
         return false;
     }
 
@@ -857,6 +897,12 @@ fn stack_covers(prior: &[StackEntry], current: &[StackEntry]) -> bool {
 /// while both compared states sit at `WaitingFor::Priority`, but keeps the guard
 /// closed under future sampling changes (a chosen mode is otherwise baked into the
 /// entry's `ability`, so the normalized key already separates distinct modes).
+///
+/// Contract boundary: this gate owns only ANNOUNCEMENT-time ordering input
+/// (targets, divide/distribute, cross-target constraints). Resolution-time
+/// choices (CR 608.2d — proliferate/populate/sacrifice-choice/optional/…) are
+/// owned by item 6 (`stack_entry_resolution_choice_freedom`), applied to every
+/// current-stack entry, not just grown ones.
 fn stack_entry_has_no_ordering_input(state: &GameState, entry: &StackEntry) -> bool {
     let StackEntryKind::TriggeredAbility { ability, .. } = &entry.kind else {
         return false;
@@ -905,6 +951,30 @@ fn stack_entry_reads_projected_resource(entry: &StackEntry) -> bool {
         // KeywordAction: no AST to classify ⇒ fail closed. Permanent `Spell { ability:
         // None }`: nothing to read (its resolution changes the board, breaking gate 1).
         None => matches!(entry.kind, StackEntryKind::KeywordAction { .. }),
+    }
+}
+
+/// §2.2 item 6: can resolving this stack entry offer a resolution-time player
+/// choice (a non-priority `WaitingFor` the C2/no-ordering-input gate cannot see)?
+/// Delegates to the ability_scan choice classifier over the embedded ability.
+/// Exhaustive over all four `StackEntryKind`s (no wildcard): only a
+/// `TriggeredAbility` carries a `ResolvedAbility` to classify; `Spell`/
+/// `ActivatedAbility`/`KeywordAction` are fail-closed `MayPrompt` — even a
+/// bottom-frozen entry the extrapolation never resolves rejects the cover.
+/// (Ceiling + upgrade path: model which stack suffix resolves per cycle only if
+/// a real fixture needs it.) The trigger-level `condition` (intervening-if
+/// re-check, CR 603.4) is pure evaluation and contributes no prompt.
+fn stack_entry_resolution_choice_freedom(
+    entry: &StackEntry,
+) -> crate::game::ability_scan::ResolutionChoiceFreedom {
+    use crate::game::ability_scan::ResolutionChoiceFreedom;
+    match &entry.kind {
+        StackEntryKind::TriggeredAbility { ability, .. } => {
+            crate::game::ability_scan::ability_resolution_choice_freedom(ability)
+        }
+        StackEntryKind::Spell { .. }
+        | StackEntryKind::ActivatedAbility { .. }
+        | StackEntryKind::KeywordAction { .. } => ResolutionChoiceFreedom::MayPrompt,
     }
 }
 
@@ -1041,6 +1111,143 @@ fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
         }
     }
     false
+}
+
+/// The proposed-event class a life-affecting `ReplacementEvent` watches. CR 616.1
+/// material-ordering competition is counted PER proposed-event class, because a
+/// single `ProposedEvent::LifeLoss` draws candidates from every LifeLoss-matching
+/// registry key at once (`LoseLife` + `LifeReduced` + `PayLife`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LifeEventClass {
+    /// Matches `ProposedEvent::LifeGain`.
+    LifeGain,
+    /// Matches `ProposedEvent::LifeLoss`.
+    LifeLoss,
+}
+
+/// CR 614.1a: is this replacement event in the LIFE class — i.e. does its
+/// registry matcher match `ProposedEvent::LifeGain` or `ProposedEvent::LifeLoss`?
+/// Compiler-exhaustive over ALL `ReplacementEvent` variants (no wildcard) so a
+/// NEW variant fails to compile until classified against the coupling rule.
+///
+/// COUPLING RULE (grep-enforced when the set is edited): life-class ⇔ the event's
+/// registry matcher (`crate::game::replacement`) matches a life `ProposedEvent`.
+/// Measured (`rg -n 'ProposedEvent::Life(Gain|Loss)'` over the matcher fns):
+/// `gain_life_matcher` (GainLife → LifeGain), `lose_life_matcher` (LoseLife →
+/// LifeLoss), `life_reduced_matcher` (LifeReduced → LifeLoss), `pay_life_matcher`
+/// (PayLife → LifeLoss). Classify by the MATCHER, not the name — a hand-picked
+/// set had already missed `PayLife` and `LifeReduced`.
+fn replacement_event_matches_life(event: &ReplacementEvent) -> Option<LifeEventClass> {
+    match event {
+        ReplacementEvent::GainLife => Some(LifeEventClass::LifeGain),
+        ReplacementEvent::LoseLife | ReplacementEvent::LifeReduced | ReplacementEvent::PayLife => {
+            Some(LifeEventClass::LifeLoss)
+        }
+        // Non-life events (explicitly listed ⇒ None, so a new variant must be
+        // classified against the coupling rule before it compiles).
+        ReplacementEvent::DamageDone
+        | ReplacementEvent::Destroy
+        | ReplacementEvent::Discard
+        | ReplacementEvent::Draw
+        | ReplacementEvent::TurnFaceUp
+        | ReplacementEvent::Counter
+        | ReplacementEvent::ChangeZone
+        | ReplacementEvent::Moved
+        | ReplacementEvent::AddCounter
+        | ReplacementEvent::RemoveCounter
+        | ReplacementEvent::CreateToken
+        | ReplacementEvent::Tap
+        | ReplacementEvent::Untap
+        | ReplacementEvent::DealtDamage
+        | ReplacementEvent::Mill
+        | ReplacementEvent::Attached
+        | ReplacementEvent::DrawCards
+        | ReplacementEvent::ProduceMana
+        | ReplacementEvent::Scry
+        | ReplacementEvent::CoinFlip
+        | ReplacementEvent::Transform
+        | ReplacementEvent::Explore
+        | ReplacementEvent::Connive
+        | ReplacementEvent::AssembleContraption
+        | ReplacementEvent::BeginPhase
+        | ReplacementEvent::BeginTurn
+        | ReplacementEvent::Cascade
+        | ReplacementEvent::CopySpell
+        | ReplacementEvent::DeclareBlocker
+        | ReplacementEvent::GameLoss
+        | ReplacementEvent::GameWin
+        | ReplacementEvent::Learn
+        | ReplacementEvent::LoseMana
+        | ReplacementEvent::PlanarDiceResult
+        | ReplacementEvent::Planeswalk
+        | ReplacementEvent::Proliferate
+        | ReplacementEvent::Other(_) => None,
+    }
+}
+
+/// §2.2 item 6 environmental guard (CR 616.1 + CR 614.1a): can the current
+/// life-event replacement environment open a resolution-time prompt on an
+/// allow-listed `GainLife`/`LoseLife` resolution? Paired obligation of
+/// `ResolutionChoiceFreedom::FreeUnlessLifeReplacements`.
+///
+/// Over-approximates `find_applicable_replacements` fail-closed: conditions,
+/// `valid_player` scopes, and amounts are deliberately ignored (over-count ⇒
+/// over-reject ⇒ fail-safe). Def sources = object-attached defs
+/// (`active_replacements`, item 5's authority) CHAINED with the game-state-level
+/// floating store `state.pending_damage_replacements` (sentinel `ObjectId(0)`,
+/// scanned by `find_applicable_replacements` replacement.rs:4838-4862; skip
+/// `is_consumed`, mirroring :4859-4861). `pending_step_end_mana_handlers` is a
+/// different type gated behind `ProposedEvent::EmptyManaPool`
+/// (replacement.rs:4971-4980) that structurally cannot produce a life-class
+/// candidate ⇒ excluded. There are NO virtual life candidates in
+/// `find_applicable_replacements` (measured — the only `ProposedEvent::LifeGain`
+/// there is a `valid_player` filter, not a candidate creator, replacement.rs:4674).
+///
+/// Rejects when a life-class def is:
+/// (a) OPTIONAL — a single optional candidate prompts (replacement.rs:6221-6247);
+/// (b) carries a body continuation (`execute`/`runtime_execute`) — a MANDATORY
+///     body is stashed as `PostReplacementContinuation::Resolved`
+///     (replacement.rs:5511-5524) and drained via
+///     `apply_pending_post_replacement_effect` (engine_replacement.rs:1159),
+///     which runs an arbitrary `ResolvedAbility` and can set a non-priority
+///     `waiting_for` (e.g. a Sacrifice body ⇒ EffectZoneChoice). `execute` is
+///     also rejected by item 5 (resource.rs:1058-1060); re-checked here so the
+///     guard does not depend on item ordering, and `runtime_execute` is NOT
+///     otherwise covered (item 5 scans it only for projected reads,
+///     resource.rs:976-981);
+/// (c) one of ≥2 defs competing for the SAME proposed-event class — CR 616.1
+///     material-ordering prompt (replacement.rs:6263-6279). A single mandatory
+///     quantity-mod def with no body (Bloodletter / Rhox Faithmender class)
+///     trips NONE of these and resolves deterministically (replacement.rs:6250-6261).
+fn life_event_replacements_may_prompt(state: &GameState) -> bool {
+    let object_defs =
+        crate::game::functioning_abilities::active_replacements(state).map(|(_, _, def)| def);
+    let floating_defs = state
+        .pending_damage_replacements
+        .iter()
+        .filter(|def| !def.is_consumed);
+
+    let mut gain_defs = 0usize;
+    let mut loss_defs = 0usize;
+    for def in object_defs.chain(floating_defs) {
+        let Some(class) = replacement_event_matches_life(&def.event) else {
+            continue;
+        };
+        // (a) single optional candidate prompts.
+        if crate::game::replacement::replacement_mode_is_optional(&def.mode) {
+            return true;
+        }
+        // (b) mandatory body-continuation drain is prompt-capable.
+        if def.execute.is_some() || def.runtime_execute.is_some() {
+            return true;
+        }
+        match class {
+            LifeEventClass::LifeGain => gain_defs += 1,
+            LifeEventClass::LifeLoss => loss_defs += 1,
+        }
+    }
+    // (c) ≥2 defs competing for one proposed-event class ⇒ CR 616.1 ordering prompt.
+    gain_defs >= 2 || loss_defs >= 2
 }
 
 /// CR 614.1a: a replacement's BODY (not its `condition`) can read a projected
@@ -2406,5 +2613,276 @@ mod tests {
         current.stack.push_back(n(21));
         current.stack.push_back(n(22));
         assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    // ===================================================================
+    // N1 item-6 hostiles (resolution-time choice gate). n1_o/q/r/s.
+    // ===================================================================
+
+    /// A no-ordering-input `Effect::Proliferate` churner (unit variant, empty
+    /// announced targets) — passes items 1-5 (Proliferate reads no projected
+    /// axis, scan_effect ⇒ Axes::NONE) but is a resolution-choice opener (item 6).
+    fn proliferate_ability() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::Proliferate,
+            vec![],
+            ObjectId(CHURN_SRC),
+            PlayerId(0),
+        )
+    }
+
+    /// Fixed-amount `LoseLife` churner — allow-listed
+    /// (`FreeUnlessLifeReplacements`), reads no projected resource. Distinct
+    /// normalized kind from `gain_ability`.
+    fn lose_ability(amount: i32) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::LoseLife {
+                amount: QuantityExpr::Fixed { value: amount },
+                target: None,
+            },
+            vec![],
+            ObjectId(CHURN_SRC),
+            PlayerId(0),
+        )
+    }
+
+    /// (o) GROWN CHOICE-OPENING KIND (finding fixtures i + iii): prior `[G, P]`,
+    /// current `[G, P, P]` — `P` (Proliferate) grows on an occupied place. ZERO
+    /// counters anywhere, so in `current` the grown `P` would AUTO-resolve without
+    /// a prompt (`eligible.is_empty()`, proliferate.rs:90) — proving the gate is
+    /// STRUCTURAL, not observational (the projected poison axis, CR 701.34a, can
+    /// inhabit the option surface mid-extrapolation). Item 4 does NOT mask this:
+    /// `scan_effect(Proliferate)` is `Axes::NONE`. Revert-fail: delete the item-6
+    /// loop, or classify `Proliferate` ⇒ `FreeUnlessLifeReplacements`.
+    #[test]
+    fn n1_o_grown_choice_opening_proliferate_false() {
+        let p = |id| churn_entry(id, 0, proliferate_ability(), None);
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(g(10)); // [G, P]
+        prior.stack.push_back(p(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(g(20)); // [G, P, P]
+        current.stack.push_back(p(21));
+        current.stack.push_back(p(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+
+        // Reach-guard: swap `P` for a distinct GainLife kind (gain_ability(2)) ⇒
+        // the same growth passes items 1-5 AND item 6 (all allow-listed, no life
+        // replacements) ⇒ cover true. Isolates item 6's Proliferate reject.
+        let g2 = |id| churn_entry(id, 0, gain_ability(2), None);
+        let mut prior2 = GameState::new_two_player(7);
+        prior2.stack.push_back(g(30));
+        prior2.stack.push_back(g2(31));
+        let mut current2 = prior2.clone();
+        current2.stack.clear();
+        current2.stack.push_back(g(40));
+        current2.stack.push_back(g2(41));
+        current2.stack.push_back(g2(42));
+        assert!(loop_states_cover_modulo_growth(&prior2, &current2));
+    }
+
+    /// (q) UN-GROWN CHOICE-OPENING ENTRY (H2 discriminator): prior `[P, G]`,
+    /// current `[P, G, G]` — `P` count EQUAL (un-grown), `G` (allow-listed) grows.
+    /// Item 3 only checks GROWN entries, so the un-grown `P` is invisible to it;
+    /// ONLY item 6's all-entries scope rejects the `P`. Revert-fail: scope item 6
+    /// to `cn > pn` entries only ⇒ this flips true.
+    #[test]
+    fn n1_q_ungrown_choice_opening_entry_false() {
+        let p = |id| churn_entry(id, 0, proliferate_ability(), None);
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(p(10)); // [P, G]
+        prior.stack.push_back(g(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(p(20)); // [P, G, G]
+        current.stack.push_back(g(21));
+        current.stack.push_back(g(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+
+        // Reach-guard: drop the un-grown `P` ⇒ pure GainLife growth ⇒ cover true.
+        let mut prior2 = GameState::new_two_player(7);
+        prior2.stack.push_back(g(30));
+        let mut current2 = prior2.clone();
+        current2.stack.clear();
+        current2.stack.push_back(g(40));
+        current2.stack.push_back(g(41));
+        assert!(loop_states_cover_modulo_growth(&prior2, &current2));
+    }
+
+    /// (r) LIFE-REPLACEMENT ENVIRONMENT (H4): a genuine covering drain while a
+    /// battlefield (or floating) replacement can open a resolution-time prompt on
+    /// the grown `GainLife`/`LoseLife` resolution. Five arms — each def is
+    /// condition-free with no projected-reading body, so it SURVIVES items 1-5
+    /// and ONLY item 6's environmental guard rejects. The shared reach-guard (a
+    /// non-life event ⇒ cover true) proves the fixtures pass gates 1-5.
+    #[test]
+    fn n1_r_life_replacement_environment_false() {
+        use crate::types::ability::ReplacementMode;
+
+        // Install a replacement def on a battlefield object present in BOTH states.
+        fn with_object_def(def: ReplacementDefinition) -> (GameState, GameState) {
+            let (mut prior, mut current) = cover_base();
+            for state in [&mut prior, &mut current] {
+                let oid = bf_object(state, 810);
+                state
+                    .objects
+                    .get_mut(&oid)
+                    .unwrap()
+                    .replacement_definitions
+                    .push(def.clone());
+            }
+            (prior, current)
+        }
+
+        // Arm 1 (clause a): a single OPTIONAL GainLife def ⇒ prompt
+        // (replacement.rs:6221). Mutation: delete the `needs_life_guard` block ⇒ RED.
+        let mut def = ReplacementDefinition::new(ReplacementEvent::GainLife);
+        def.mode = ReplacementMode::Optional { decline: None };
+        let (prior, current) = with_object_def(def);
+        assert!(
+            !loop_states_cover_modulo_growth(&prior, &current),
+            "arm1 optional GainLife"
+        );
+
+        // Arm 2 (clause c): TWO MANDATORY GainLife defs ⇒ ≥2 per LifeGain class
+        // (CR 616.1 material ordering). Mutation: drop clause (c) ⇒ RED.
+        {
+            let (mut prior, mut current) = cover_base();
+            for state in [&mut prior, &mut current] {
+                let oid = bf_object(state, 811);
+                let obj = state.objects.get_mut(&oid).unwrap();
+                obj.replacement_definitions
+                    .push(ReplacementDefinition::new(ReplacementEvent::GainLife));
+                obj.replacement_definitions
+                    .push(ReplacementDefinition::new(ReplacementEvent::GainLife));
+            }
+            assert!(
+                !loop_states_cover_modulo_growth(&prior, &current),
+                "arm2 two mandatory GainLife defs"
+            );
+        }
+
+        // Arm 3 (B1 — PayLife class-set completeness): an optional PayLife def
+        // (matcher matches ProposedEvent::LifeLoss, replacement.rs:3324) over a
+        // LoseLife drain ⇒ prompt. Mutation: narrow the life-class set to
+        // {GainLife, LoseLife} (drop PayLife) ⇒ RED.
+        {
+            let l = |id| churn_entry(id, 0, lose_ability(1), None);
+            let mut prior = GameState::new_two_player(7);
+            prior.stack.push_back(l(10));
+            prior.stack.push_back(l(11));
+            let mut current = prior.clone();
+            current.stack.clear();
+            current.stack.push_back(l(20));
+            current.stack.push_back(l(21));
+            current.stack.push_back(l(22));
+            for state in [&mut prior, &mut current] {
+                let oid = bf_object(state, 812);
+                let mut def = ReplacementDefinition::new(ReplacementEvent::PayLife);
+                def.mode = ReplacementMode::Optional { decline: None };
+                state
+                    .objects
+                    .get_mut(&oid)
+                    .unwrap()
+                    .replacement_definitions
+                    .push(def);
+            }
+            assert!(
+                !loop_states_cover_modulo_growth(&prior, &current),
+                "arm3 optional PayLife over LoseLife drain"
+            );
+        }
+
+        // Arm 4 (B2 — clause b): a single MANDATORY GainLife def with a
+        // prompt-capable, non-projected-reading `runtime_execute` body ⇒ prompt.
+        // Mutation: drop the `runtime_execute.is_some()` half of clause (b) ⇒ RED.
+        {
+            let runtime_body = ResolvedAbility::new(
+                Effect::Sacrifice {
+                    target: TargetFilter::Any,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    min_count: 0,
+                },
+                vec![],
+                ObjectId(CHURN_SRC),
+                PlayerId(0),
+            );
+            // Item-5 pass proof: the body reads NO projected resource, so item 5
+            // (which scans `runtime_execute` only for projected reads) lets the def
+            // through — only clause (b) rejects.
+            assert!(!crate::game::ability_scan::ability_reads_projected_resource(&runtime_body));
+            let def = ReplacementDefinition::new(ReplacementEvent::GainLife)
+                .runtime_execute(runtime_body);
+            let (prior, current) = with_object_def(def);
+            assert!(
+                !loop_states_cover_modulo_growth(&prior, &current),
+                "arm4 mandatory GainLife with runtime_execute body"
+            );
+        }
+
+        // Arm 5 (M3 — floating store): the arm-1 optional GainLife def placed in
+        // `state.pending_damage_replacements` (no object def) ⇒ prompt. Mutation:
+        // drop the floating-store chain from the guard's def sources ⇒ RED.
+        {
+            let (mut prior, mut current) = cover_base();
+            let mut def = ReplacementDefinition::new(ReplacementEvent::GainLife);
+            def.mode = ReplacementMode::Optional { decline: None };
+            for state in [&mut prior, &mut current] {
+                state.pending_damage_replacements.push(def.clone());
+            }
+            assert!(
+                !loop_states_cover_modulo_growth(&prior, &current),
+                "arm5 floating-store optional GainLife"
+            );
+        }
+
+        // Shared reach-guard: the arm-1 def with a NON-LIFE event (Mill) ⇒ cover
+        // true (proves the fixtures pass gates 1-5; only the life-class match rejects).
+        {
+            let mut def = ReplacementDefinition::new(ReplacementEvent::Mill);
+            def.mode = ReplacementMode::Optional { decline: None };
+            let (prior, current) = with_object_def(def);
+            assert!(
+                loop_states_cover_modulo_growth(&prior, &current),
+                "reach-guard: non-life (Mill) replacement does not reject"
+            );
+        }
+    }
+
+    /// (s) RESOLUTION-TIMING TARGET SLOTS (H3): a grown GainLife whose ability
+    /// defers target choice to RESOLUTION (CR 608.2d). `targets` is empty on the
+    /// stack, so today's ordering gate (item 3) passes it; only item 6's
+    /// `target_choice_timing == Resolution` row rejects. Revert-fail: remove the
+    /// `target_choice_timing` row from the ability classifier ⇒ this flips true.
+    #[test]
+    fn n1_s_resolution_timing_targets_false() {
+        use crate::types::ability::TargetChoiceTiming;
+        let res = |id| {
+            let mut ability = gain_ability(1);
+            ability.target_choice_timing = TargetChoiceTiming::Resolution;
+            churn_entry(id, 0, ability, None)
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(res(10));
+        prior.stack.push_back(res(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(res(20));
+        current.stack.push_back(res(21));
+        current.stack.push_back(res(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+
+        // Reach-guard: identical ability with STACK timing ⇒ cover true.
+        let stk = |id| churn_entry(id, 0, gain_ability(1), None);
+        let mut prior2 = GameState::new_two_player(7);
+        prior2.stack.push_back(stk(10));
+        prior2.stack.push_back(stk(11));
+        let mut current2 = prior2.clone();
+        current2.stack.clear();
+        current2.stack.push_back(stk(20));
+        current2.stack.push_back(stk(21));
+        current2.stack.push_back(stk(22));
+        assert!(loop_states_cover_modulo_growth(&prior2, &current2));
     }
 }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -916,9 +916,30 @@ fn stack_entry_reads_projected_resource(entry: &StackEntry) -> bool {
 /// Run once on `current` (item-1 board equality makes the definition sets identical).
 /// Fail-closed: any surface the scan cannot classify ⇒ reject (no shortcut).
 ///
-/// Keyword-synthesized granted triggers are NOT scanned: measured — no
-/// `KeywordTriggerInstaller` trigger carries a fire-time `TriggerCondition` (every
-/// builder defaults `condition: None`), so they can express no projected read.
+/// Keyword-synthesized granted triggers (`KeywordTriggerInstaller::triggers_for`
+/// / `synthesize_granted_keyword_triggers`) are NOT scanned here: they are
+/// produced on-the-fly during trigger collection and never land on
+/// `obj.trigger_definitions`, so `active_trigger_definitions` (loop (i)) does not
+/// reach them. Most such triggers carry non-projected fire-time conditions
+/// (Echo→`EchoDue`, Renown→`Not(IsRenowned)`, Suspend/Soulshift/Vanishing/
+/// CumulativeUpkeep→counter/zone conditions, Soulbond→filter conditions).
+///
+/// KNOWN GAP: the item-5 classifier (`trigger_condition_reads_projected_resource`)
+/// flags four granted-keyword conditions as projected-reading — Dethrone,
+/// Increment, Soulbond, Training — but only Dethrone is a GENUINE projected read.
+/// Dethrone (CR 702.105a) compares the defending player's `LifeTotal` to the max
+/// `LifeTotal` among all players (CR 119 life = a PROJECTED axis this pass
+/// zeroes); Increment/Soulbond/Training are fail-closed false positives
+/// (`ManaSpentToCast` / control-filter / co-attacker-power reads the classifier's
+/// `Axes::CONSERVATIVE` walk cannot descend, all cast/combat/object state gate (1)
+/// strict-compares). A runtime-GRANTED Dethrone (`Effect::GrantKeywords` /
+/// `ContinuousModification::AddKeyword`) is invisible to this scan — a latent
+/// dormant-arming risk (false WIN, N1(k) class) bounded only by whether granted
+/// Dethrone is reachable inside a growing-cascade loop. The guard test
+/// `granted_keyword_trigger_conditions_projected_reads_are_exactly_known_gaps` in
+/// `game::triggers` pins that flagged set: if a NEW granted-keyword condition
+/// begins reading a projected resource, that test fails and this scan MUST be
+/// extended to the granted-keyword defs before item-5 can be trusted again.
 fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
     // (i) Trigger fire-time intervening-if conditions (CR 603.4). `active_trigger_
     // definitions` is the liveness authority (CR 702.26b phased-out + CR 114.4
@@ -996,8 +1017,12 @@ fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
 /// read). `DamageModification::LifeFloor` caps against a player's live life total
 /// (CR 119, projected); `Plus { value }` carries a `QuantityExpr` that MAY read one
 /// — treated fail-closed. `execute` is an `AbilityDefinition` with no C0-walker
-/// predicate ⇒ fail-closed when present. All other modification variants read only
-/// fixed amounts or the source's own (strict-compared) power.
+/// predicate ⇒ fail-closed when present. The un-flagged `DamageModification` /
+/// `QuantityModification` variants are safe to omit because their outputs land in
+/// STRICT-COMPARED state (token/counter counts, source power) — not a projected
+/// axis — so a divergence there already breaks gate (1) directly rather than
+/// arming mid-extrapolation. All other modification variants read only fixed
+/// amounts or the source's own (strict-compared) power.
 fn replacement_body_may_read_projected(def: &crate::types::ability::ReplacementDefinition) -> bool {
     if def.execute.is_some() {
         return true;

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -664,9 +664,9 @@ fn loyalty_activation_counts_match(a: &GameState, b: &GameState) -> bool {
 
 /// Karp–Miller-style ω-acceleration (Karp–Miller 1969; Finkel et al. 2021), sound
 /// GIVEN the in-loop transition relation — the WHOLE beat: top-of-stack resolution
-/// (CR 608.1) with its resolution-time payments (CR 605.3a/608.2g), trigger
+/// (CR 608.1) with its resolution-time payments (CR 605.3a / CR 608.2g), trigger
 /// collection (CR 603.4), replacement application (CR 614.1), static condition
-/// gating (CR 604.1/613.1), SBA application (CR 704.3/704.5), and elimination
+/// gating (CR 604.1 / CR 613.1), SBA application (CR 704.3 / CR 704.5), and elimination
 /// processing (CR 800.4a) — is invariant under the projected-out player-level
 /// resources. Enforced by construction: object/board axes are STRICT-COMPARED
 /// ([`object_resource_axes_match`] — SBA object reads CR 704.5f/g/i can never
@@ -709,7 +709,7 @@ pub(crate) fn loop_states_cover_modulo_growth(prior: &GameState, current: &GameS
     }
 
     // (2) Stack coverability: order-preserving bottom-up embedding + strict growth
-    // confined to places already occupied in `prior` (CR 608.1/405.5 LIFO freeze).
+    // confined to places already occupied in `prior` (CR 608.1 / CR 405.5 LIFO freeze).
     let prior_stack = normalized_stack_entries(prior);
     let cur_stack = normalized_stack_entries(current);
     if !stack_covers(&prior_stack, &cur_stack) {
@@ -984,7 +984,7 @@ fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
             return true;
         }
     }
-    // (iii) Condition-gated statics (CR 604.1/613.1) — ALL modes via `iter_all()`
+    // (iii) Condition-gated statics (CR 604.1 / CR 613.1) — ALL modes via `iter_all()`
     // (NOT the condition-filtered active iterator, whose gate hides exactly the
     // dormant defs this surface exists to catch), plus transient continuous effects'
     // `ForAsLongAs`/gating conditions (CR 604.1).

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -25,10 +25,10 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::ability::ActivationRestriction;
+use crate::types::ability::{ActivationRestriction, DamageModification};
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
-use crate::types::game_state::{loop_states_equal, GameState};
+use crate::types::game_state::{loop_states_equal, GameState, StackEntry, StackEntryKind};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaType;
 use crate::types::phase::Phase;
@@ -624,6 +624,19 @@ fn map_delta<K: Ord + Copy>(
 /// Everything else — controller, zone, tapped, attachments, names, object count,
 /// stack, phase, priority — must still match exactly, so a genuine board change
 /// (an extra permanent, a different tap state, a moved card) returns `false`.
+///
+/// # Inherited extrapolation assumption (R1-B2 honesty; behavior UNCHANGED here)
+///
+/// This constant-depth path extrapolates the per-cycle resource delta over an
+/// unbounded number of cycles WITHOUT a syntactic guard on either the on-stack or
+/// the off-stack fire-time read surface — it trusts that a board-equal-modulo-
+/// resources recurrence keeps reproducing the same delta. That premise is
+/// refutable in principle (a dormant intervening-if / static / replacement that
+/// reads a projected resource could arm mid-extrapolation), but the shipped 2p
+/// drain detection depends on this behavior and it is regression-pinned, so it is
+/// left as-is. The NEW growing-cascade path
+/// ([`loop_states_cover_modulo_growth`]) closes both read surfaces by construction
+/// rather than inheriting this assumption.
 pub fn loop_states_equal_modulo_resources(a: &GameState, b: &GameState) -> bool {
     let pa = project_out_resources(a);
     let pb = project_out_resources(b);
@@ -647,6 +660,352 @@ fn loyalty_activation_counts_match(a: &GameState, b: &GameState) -> bool {
             .get(id)
             .is_none_or(|ob| oa.loyalty_activations_this_turn == ob.loyalty_activations_this_turn)
     })
+}
+
+/// Karp–Miller-style ω-acceleration (Karp–Miller 1969; Finkel et al. 2021), sound
+/// GIVEN the in-loop transition relation — the WHOLE beat: top-of-stack resolution
+/// (CR 608.1) with its resolution-time payments (CR 605.3a/608.2g), trigger
+/// collection (CR 603.4), replacement application (CR 614.1), static condition
+/// gating (CR 604.1/613.1), SBA application (CR 704.3/704.5), and elimination
+/// processing (CR 800.4a) — is invariant under the projected-out player-level
+/// resources. Enforced by construction: object/board axes are STRICT-COMPARED
+/// ([`object_resource_axes_match`] — SBA object reads CR 704.5f/g/i can never
+/// observe hidden drift); the remaining projected set (player monotone resources +
+/// journals) is scanned fail-closed on BOTH read surfaces
+/// ([`stack_entry_reads_projected_resource`] on every current-stack entry,
+/// [`fire_time_conditions_read_projected_resource`] on every live
+/// trigger/replacement/static definition); player-life SBAs are the modeled outcome
+/// itself (controller non-dip + all-fallers-simultaneous, so the first CR 800.4a
+/// elimination is terminal per CR 104.2a); library/poison drift is firewalled to
+/// `None` by the winner predicate. Depth-independence of top-of-stack resolution:
+/// CR 608.1 / CR 405.5.
+///
+/// NOTE: the shipped constant-depth 2p path
+/// ([`loop_states_equal_modulo_resources`]) makes the SAME extrapolation with NONE
+/// of these — that inherited assumption is documented there, not silently claimed
+/// as a theorem here.
+///
+/// Returns `true` iff `current` **covers** `prior`: board equal modulo the narrowed
+/// projection with object resource axes strict-equal (item 1), `prior`'s normalized
+/// stack order-preservingly embeds in `current`'s with strict growth confined to
+/// already-occupied places (item 2), every grown place is a mandatory
+/// no-ordering-input triggered ability (item 3), no current-stack entry reads a
+/// still-projected resource (item 4), and no live fire-time condition reads one
+/// either (item 5).
+pub(crate) fn loop_states_cover_modulo_growth(prior: &GameState, current: &GameState) -> bool {
+    // (1) Board equal modulo the NARROWED projection AND modulo the stack, with the
+    // object resource axes STRICT-COMPARED (R5-B1). Project both, clear both stacks
+    // (the stack is compared separately in (2)), then require full board equality
+    // plus loyalty-activation parity plus strict object damage/counter equality.
+    let mut pa = project_out_resources(prior);
+    let mut pb = project_out_resources(current);
+    pa.stack.clear();
+    pb.stack.clear();
+    if !(loop_states_equal(&pa, &pb)
+        && loyalty_activation_counts_match(&pa, &pb)
+        && object_resource_axes_match(prior, current))
+    {
+        return false;
+    }
+
+    // (2) Stack coverability: order-preserving bottom-up embedding + strict growth
+    // confined to places already occupied in `prior` (CR 608.1/405.5 LIFO freeze).
+    let prior_stack = normalized_stack_entries(prior);
+    let cur_stack = normalized_stack_entries(current);
+    if !stack_covers(&prior_stack, &cur_stack) {
+        return false;
+    }
+
+    // (3) Every grown place is a mandatory, no-ordering-input triggered ability.
+    // Iterate the ORIGINAL current-stack entries (so the mid-construction firewall
+    // sees real stack-entry ids) and check each whose normalized kind strictly grew.
+    for (orig, norm) in current.stack.iter().zip(cur_stack.iter()) {
+        let cn = cur_stack.iter().filter(|e| *e == norm).count();
+        let pn = prior_stack.iter().filter(|e| *e == norm).count();
+        if cn > pn && !stack_entry_has_no_ordering_input(current, orig) {
+            return false;
+        }
+    }
+
+    // (4) On-stack fail-closed resource-read guard: NO entry on `current`'s stack may
+    // carry an AST that reads a still-projected axis (player monotone resources +
+    // journals). Object-axis readers pass — their drift breaks gate (1) instead.
+    if current
+        .stack
+        .iter()
+        .any(stack_entry_reads_projected_resource)
+    {
+        return false;
+    }
+
+    // (5) Off-stack fail-closed fire-time condition guard (the second read surface).
+    if fire_time_conditions_read_projected_resource(current) {
+        return false;
+    }
+
+    true
+}
+
+/// CR 704.5f / CR 704.5g / CR 704.5i: strict-compare the PRE-projection object
+/// resource axes the SBA layer reads every beat — `damage_marked` (lethal marked
+/// damage) and the FULL `counters` map (toughness-lowering `-1/-1`, loyalty). The
+/// inherited `project_out_resources` zeroes these for the 2p equality path (which
+/// NEEDS them projected — lifelink/ping loops mark damage monotonically), so the
+/// coverability path re-asserts them here: a counter/damage rider that drifts
+/// projection-invisibly would otherwise ride a covering pair to a false win, then
+/// graveyard its own churner source mid-extrapolation. Sibling of
+/// [`loyalty_activation_counts_match`] — same shared-object-id iteration, symmetric
+/// because gate (1)'s `loop_states_equal` already requires identical object sets.
+fn object_resource_axes_match(prior: &GameState, current: &GameState) -> bool {
+    prior.objects.iter().all(|(id, oa)| {
+        current
+            .objects
+            .get(id)
+            .is_none_or(|ob| oa.damage_marked == ob.damage_marked && oa.counters == ob.counters)
+    })
+}
+
+/// Normalize a stack into behavioral-identity clones for coverability counting:
+/// zero the volatile top-level `id`/`source_id` and the per-kind inner `source_id`,
+/// and strip nested `source_id`s from the embedded ability
+/// ([`crate::game::triggers::normalize_ability_identity`]). KEEP `controller` (an
+/// opponent's otherwise-identical trigger must never merge with the controller's)
+/// and the entire `kind` payload (`condition`, `trigger_event`,
+/// `subject_match_count`, `die_result`, `description`, `source_name`) — a residual
+/// content difference only SUPPRESSES a match (fail-safe). Two same-controller
+/// entries differing only in `source_id` (two Blight-Priest copies) resolve
+/// identically after the item-4 guard, so identifying them is sound.
+fn normalized_stack_entries(state: &GameState) -> Vec<StackEntry> {
+    state
+        .stack
+        .iter()
+        .map(|entry| {
+            let mut norm = entry.clone();
+            norm.id = ObjectId(0);
+            norm.source_id = ObjectId(0);
+            match &mut norm.kind {
+                StackEntryKind::TriggeredAbility {
+                    source_id, ability, ..
+                } => {
+                    *source_id = ObjectId(0);
+                    crate::game::triggers::normalize_ability_identity(ability);
+                }
+                StackEntryKind::ActivatedAbility { source_id, ability } => {
+                    *source_id = ObjectId(0);
+                    crate::game::triggers::normalize_ability_identity(ability);
+                }
+                StackEntryKind::Spell {
+                    ability: Some(ability),
+                    ..
+                } => crate::game::triggers::normalize_ability_identity(ability),
+                StackEntryKind::Spell { ability: None, .. }
+                | StackEntryKind::KeywordAction { .. } => {}
+            }
+            norm
+        })
+        .collect()
+}
+
+/// Stack coverability (§2.2 item 2): `prior` is an order-preserving bottom-up
+/// SUBSEQUENCE of `current` (2a), at least one normalized kind strictly grew, and
+/// EVERY kind that grew already occurs in `prior` with count ≥ 1 (2b — a
+/// never-before-seen 0→1 entry is rejected outright, its resolution behavior never
+/// having been observed inside the window).
+///
+// ponytail: greedy embedding + per-kind linear counts, n = stack depth (small);
+// revisit only if a deep-stack combo profiles hot.
+fn stack_covers(prior: &[StackEntry], current: &[StackEntry]) -> bool {
+    // (2a) greedy two-pointer subsequence embedding, bottom-up.
+    let mut ci = 0usize;
+    for pe in prior {
+        loop {
+            if ci >= current.len() {
+                return false;
+            }
+            let matched = &current[ci] == pe;
+            ci += 1;
+            if matched {
+                break;
+            }
+        }
+    }
+    // (2b) strict growth confined to already-occupied places.
+    let mut any_growth = false;
+    for (idx, ce) in current.iter().enumerate() {
+        // process each distinct kind once (first occurrence).
+        if current[..idx].iter().any(|e| e == ce) {
+            continue;
+        }
+        let cn = current.iter().filter(|e| *e == ce).count();
+        let pn = prior.iter().filter(|e| *e == ce).count();
+        if cn > pn {
+            if pn == 0 {
+                return false;
+            }
+            any_growth = true;
+        }
+    }
+    any_growth
+}
+
+/// CR 603.3c / CR 603.3d + CR 601.2d: does a stack entry take NO player ordering
+/// input at resolution? Only a `TriggeredAbility` qualifies (`Spell`/
+/// `ActivatedAbility` are player-driven; `KeywordAction` carries no `ResolvedAbility`)
+/// with no targets, no variable-count targeting, no divide/distribute assignment,
+/// and no cross-target constraints on the embedded ability. The mid-construction
+/// modal firewall (`state.pending_trigger_entry != Some(entry.id)`) is unreachable
+/// while both compared states sit at `WaitingFor::Priority`, but keeps the guard
+/// closed under future sampling changes (a chosen mode is otherwise baked into the
+/// entry's `ability`, so the normalized key already separates distinct modes).
+fn stack_entry_has_no_ordering_input(state: &GameState, entry: &StackEntry) -> bool {
+    let StackEntryKind::TriggeredAbility { ability, .. } = &entry.kind else {
+        return false;
+    };
+    if state.pending_trigger_entry == Some(entry.id) {
+        return false;
+    }
+    ability.targets.is_empty()
+        && ability.multi_target.is_none()
+        && ability.distribution.is_none()
+        && ability.target_constraints.is_empty()
+}
+
+/// §2.2 item 4: does this stack entry's AST read ANY still-projected axis (the
+/// narrowed set: player-level monotone resources/tallies + the journal/count block)?
+/// Delegates to the C0 walker's third axis over the embedded ability (which itself
+/// recurses `sub_ability`/`else_ability` and the ability-level `AbilityCondition`),
+/// plus the trigger-level `TriggerCondition` (CR 603.4 intervening-if). Object-axis
+/// readers classify as NON-reading — their drift breaks gate (1) instead. A
+/// `KeywordAction` has no AST to classify ⇒ fail closed (`true`); a permanent
+/// `Spell { ability: None }` reads nothing (its resolution changes the board and
+/// breaks gate (1) anyway) ⇒ `false`.
+fn stack_entry_reads_projected_resource(entry: &StackEntry) -> bool {
+    // Trigger-level intervening-if (CR 603.4) — carried on the kind, not the ability.
+    if let StackEntryKind::TriggeredAbility {
+        condition: Some(condition),
+        ..
+    } = &entry.kind
+    {
+        if crate::game::ability_scan::trigger_condition_reads_projected_resource(condition) {
+            return true;
+        }
+    }
+    match entry.ability() {
+        Some(ability) => {
+            // The resolution-time branch selector (`AbilityCondition`) is scanned
+            // explicitly for self-documenting item-4 coverage; the whole-ability scan
+            // (which recurses `sub_ability`/`else_ability` and re-covers `.condition`)
+            // catches every other read surface.
+            ability
+                .condition
+                .as_ref()
+                .is_some_and(crate::game::ability_scan::ability_condition_reads_projected_resource)
+                || crate::game::ability_scan::ability_reads_projected_resource(ability)
+        }
+        // KeywordAction: no AST to classify ⇒ fail closed. Permanent `Spell { ability:
+        // None }`: nothing to read (its resolution changes the board, breaking gate 1).
+        None => matches!(entry.kind, StackEntryKind::KeywordAction { .. }),
+    }
+}
+
+/// §2.2 item 5 (the R4-G1 second scan surface): does ANY live off-stack fire-time
+/// condition read a still-projected resource? A dormant intervening-if / replacement
+/// / condition-gated static that reads a projected axis (CR 603.4 / CR 614.1 /
+/// CR 604.1 / CR 613.1 / CR 101.2) produces NO stack entry on either compared frame,
+/// so item 4 cannot see it — yet it arms mid-extrapolation and breaks the replay.
+/// Run once on `current` (item-1 board equality makes the definition sets identical).
+/// Fail-closed: any surface the scan cannot classify ⇒ reject (no shortcut).
+///
+/// Keyword-synthesized granted triggers are NOT scanned: measured — no
+/// `KeywordTriggerInstaller` trigger carries a fire-time `TriggerCondition` (every
+/// builder defaults `condition: None`), so they can express no projected read.
+fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
+    // (i) Trigger fire-time intervening-if conditions (CR 603.4). `active_trigger_
+    // definitions` is the liveness authority (CR 702.26b phased-out + CR 114.4
+    // command-zone gate) that deliberately does NOT filter by `condition`.
+    for obj in state.objects.values() {
+        for (_, def) in crate::game::functioning_abilities::active_trigger_definitions(state, obj) {
+            if def
+                .condition
+                .as_ref()
+                .is_some_and(crate::game::ability_scan::trigger_condition_reads_projected_resource)
+            {
+                return true;
+            }
+        }
+    }
+    // (ii) Replacement definitions — condition AND body (CR 614.1). A replacement is
+    // an in-loop transition that never lands on the stack, so item 4 never sees it.
+    // The condition + runtime continuation have C0-walker predicates; body payloads
+    // without one (an `execute` `AbilityDefinition`, a state-reading damage-amount
+    // modification) are treated fail-closed — conservative, fail-safe (no shortcut).
+    for (_, _, def) in crate::game::functioning_abilities::active_replacements(state) {
+        if def
+            .condition
+            .as_ref()
+            .is_some_and(crate::game::ability_scan::replacement_condition_reads_projected_resource)
+        {
+            return true;
+        }
+        if def
+            .runtime_execute
+            .as_ref()
+            .is_some_and(|a| crate::game::ability_scan::ability_reads_projected_resource(a))
+        {
+            return true;
+        }
+        if replacement_body_may_read_projected(def) {
+            return true;
+        }
+    }
+    // (iii) Condition-gated statics (CR 604.1/613.1) — ALL modes via `iter_all()`
+    // (NOT the condition-filtered active iterator, whose gate hides exactly the
+    // dormant defs this surface exists to catch), plus transient continuous effects'
+    // `ForAsLongAs`/gating conditions (CR 604.1).
+    for obj in state.objects.values() {
+        if obj.is_phased_out() {
+            continue;
+        }
+        for def in obj.static_definitions.iter_all() {
+            if def
+                .condition
+                .as_ref()
+                .is_some_and(crate::game::ability_scan::static_condition_reads_projected_resource)
+            {
+                return true;
+            }
+        }
+    }
+    for tce in &state.transient_continuous_effects {
+        if crate::game::ability_scan::duration_reads_projected_resource(&tce.duration) {
+            return true;
+        }
+        if tce
+            .condition
+            .as_ref()
+            .is_some_and(crate::game::ability_scan::static_condition_reads_projected_resource)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// CR 614.1a: a replacement's BODY (not its `condition`) can read a projected
+/// player resource. `QuantityModification` variants are all fixed constants (no
+/// read). `DamageModification::LifeFloor` caps against a player's live life total
+/// (CR 119, projected); `Plus { value }` carries a `QuantityExpr` that MAY read one
+/// — treated fail-closed. `execute` is an `AbilityDefinition` with no C0-walker
+/// predicate ⇒ fail-closed when present. All other modification variants read only
+/// fixed amounts or the source's own (strict-compared) power.
+fn replacement_body_may_read_projected(def: &crate::types::ability::ReplacementDefinition) -> bool {
+    if def.execute.is_some() {
+        return true;
+    }
+    matches!(
+        def.damage_modification,
+        Some(DamageModification::LifeFloor { .. } | DamageModification::Plus { .. })
+    )
 }
 
 /// Clone a state through `normalize_for_loop` and additionally zero every
@@ -1512,5 +1871,455 @@ mod tests {
             !loop_states_equal_modulo_resources(&a, &c),
             "a trigger from a DIFFERENT source must NOT be equated (content is preserved)"
         );
+    }
+
+    // ===================================================================
+    // N1 — growing-cascade coverability (`loop_states_cover_modulo_growth`)
+    // Positives P1/P2 + hostile revert-fail negatives (a)–(n). Each hostile
+    // returns FALSE; the plan's §5 names the one-line revert that flips it TRUE.
+    // ===================================================================
+
+    use crate::types::ability::{
+        AbilityCondition, CountScope, Effect, QuantityExpr, QuantityRef, ReplacementCondition,
+        ReplacementDefinition, ResolvedAbility, StaticCondition, StaticDefinition, TargetFilter,
+        TargetRef, TriggerCondition, TriggerDefinition,
+    };
+    use crate::types::player::PlayerCounterKind;
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::statics::StaticMode;
+    use crate::types::triggers::TriggerMode;
+
+    const CHURN_SRC: u64 = 500;
+
+    /// A mandatory, no-ordering-input `TriggeredAbility` stack entry wrapping
+    /// `ability`, with an optional trigger-level intervening-if `condition`.
+    /// `controller` is kept in the normalized key; `entry_id`/`source_id` are
+    /// zeroed by normalization, so kind identity is (controller, ability, condition).
+    fn churn_entry(
+        entry_id: u64,
+        controller: u8,
+        ability: ResolvedAbility,
+        condition: Option<TriggerCondition>,
+    ) -> StackEntry {
+        let src = ObjectId(CHURN_SRC);
+        StackEntry {
+            id: ObjectId(entry_id),
+            source_id: src,
+            controller: PlayerId(controller),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: src,
+                ability: Box::new(ability),
+                condition,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+            },
+        }
+    }
+
+    /// Fixed-amount `GainLife` ability — reads NO projected resource; distinct
+    /// normalized kinds are produced by varying `amount`.
+    fn gain_ability(amount: i32) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: amount },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(CHURN_SRC),
+            PlayerId(0),
+        )
+    }
+
+    /// A plain fixed-drain churn entry (the target-class shape): controller 0,
+    /// GainLife 1, no condition. `id` keeps entries distinct pre-normalization.
+    fn g(id: u64) -> StackEntry {
+        churn_entry(id, 0, gain_ability(1), None)
+    }
+
+    /// prior `[G,G]`, current `[G,G,G]` — the canonical homogeneous covering pair
+    /// (board equal modulo resources, stack grew on an occupied mandatory place).
+    fn cover_base() -> (GameState, GameState) {
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(g(10));
+        prior.stack.push_back(g(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(g(20));
+        current.stack.push_back(g(21));
+        current.stack.push_back(g(22));
+        (prior, current)
+    }
+
+    fn bf_object(state: &mut GameState, id: u64) -> ObjectId {
+        let oid = ObjectId(id);
+        let object = crate::game::game_object::GameObject::new(
+            oid,
+            CardId(7),
+            PlayerId(1),
+            "Test Board Permanent".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.insert(oid, object);
+        state.battlefield.push_back(oid);
+        oid
+    }
+
+    /// P1: homogeneous `[G,G]` → `[G,G,G]` covers.
+    #[test]
+    fn n1_p1_homogeneous_cover_true() {
+        let (prior, current) = cover_base();
+        assert!(loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// P2: interleaved `[B,A]` → `[B,B,A]` covers (subsequence, non-prefix) —
+    /// pins that embedding is NOT over-tightened to a strict bottom-prefix.
+    #[test]
+    fn n1_p2_interleaved_subsequence_cover_true() {
+        // A = controller-0 kind, B = controller-1 kind (distinct via kept controller).
+        let a = |id| churn_entry(id, 0, gain_ability(1), None);
+        let b = |id| churn_entry(id, 1, gain_ability(1), None);
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(b(10)); // [B, A]
+        prior.stack.push_back(a(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(b(20)); // [B, B, A]
+        current.stack.push_back(b(21));
+        current.stack.push_back(a(22));
+        assert!(loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (a) an extra permanent in `current` ⇒ false (board differs, not just stack).
+    /// Revert-fail: dropping the stack-cleared board compare flips this true.
+    #[test]
+    fn n1_a_extra_permanent_false() {
+        let (prior, mut current) = cover_base();
+        bf_object(&mut current, 900);
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (b) the grown entry carries a TARGET ⇒ false (has-ordering-input guard).
+    /// The kind is occupied in prior so occupancy passes — isolates item 3.
+    #[test]
+    fn n1_b_grown_entry_targeted_false() {
+        let targeted = |id| {
+            let mut ability = gain_ability(1);
+            ability.targets = vec![TargetRef::Player(PlayerId(1))];
+            churn_entry(id, 0, ability, None)
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(targeted(10));
+        prior.stack.push_back(targeted(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(targeted(20));
+        current.stack.push_back(targeted(21));
+        current.stack.push_back(targeted(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (c) the grown entry is a SPELL ⇒ false (not a mandatory trigger). Isolates
+    /// item 3's `TriggeredAbility`-only requirement.
+    #[test]
+    fn n1_c_grown_entry_spell_false() {
+        let spell = |id| StackEntry {
+            id: ObjectId(id),
+            source_id: ObjectId(CHURN_SRC),
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(1),
+                ability: None,
+                casting_variant: crate::types::game_state::CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(spell(10));
+        prior.stack.push_back(spell(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(spell(20));
+        current.stack.push_back(spell(21));
+        current.stack.push_back(spell(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (d) a prior entry-kind absent from `current` ⇒ false (embedding fails).
+    /// prior `[G, B]`, current `[G, G]` — B (controller 1) never matches.
+    #[test]
+    fn n1_d_embedding_missing_kind_false() {
+        let b = |id| churn_entry(id, 1, gain_ability(1), None);
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(g(10));
+        prior.stack.push_back(b(11));
+        let mut current = GameState::new_two_player(7);
+        current.stack.push_back(g(20));
+        current.stack.push_back(g(21));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (e) equal stacks, no strict growth ⇒ false (that is the equality case).
+    #[test]
+    fn n1_e_no_growth_false() {
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(g(10));
+        prior.stack.push_back(g(11));
+        let current = prior.clone();
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (f) WIPE-PENDING (R1-B1): a distinct mandatory no-input trigger kind absent
+    /// from `prior` grows 0→1 at an UNOCCUPIED place ⇒ false. `W` reads no projected
+    /// resource, so removing the prior-occupancy guard (2b) flips this true — the
+    /// false win fires.
+    #[test]
+    fn n1_f_wipe_pending_unoccupied_growth_false() {
+        // W = a distinct-kind mandatory no-input trigger (GainLife 7, no read).
+        let w = |id| churn_entry(id, 0, gain_ability(7), None);
+        let (mut prior, mut current) = cover_base(); // [G,G] / [G,G,G]
+                                                     // Rebuild current as [G,G,W]: G did not grow, W is the 0→1 new kind.
+        current.stack.clear();
+        current.stack.push_back(g(20));
+        current.stack.push_back(g(21));
+        current.stack.push_back(w(22));
+        let _ = &mut prior;
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (g) PERMUTATION (R1-M3): prior `[B,A]`, current `[A,B,B]` ⇒ false (no
+    /// bottom-up embedding: no A after the first B match). Revert-fail for replacing
+    /// embedding with order-blind multiset containment.
+    #[test]
+    fn n1_g_permutation_false() {
+        let a = |id| churn_entry(id, 0, gain_ability(1), None);
+        let b = |id| churn_entry(id, 1, gain_ability(1), None);
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(b(10)); // [B, A]
+        prior.stack.push_back(a(11));
+        let mut current = GameState::new_two_player(7);
+        current.stack.push_back(a(20)); // [A, B, B]
+        current.stack.push_back(b(21));
+        current.stack.push_back(b(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (h) RESOURCE-READ (R1-B2): a churning entry whose trigger-level intervening-if
+    /// reads a projected resource (life) ⇒ false. Revert-fail for dropping item 4.
+    #[test]
+    fn n1_h_resource_read_false() {
+        let h = |id| {
+            churn_entry(
+                id,
+                0,
+                gain_ability(1),
+                Some(TriggerCondition::LifeTotalGE { minimum: 10 }),
+            )
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(h(10));
+        prior.stack.push_back(h(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(h(20));
+        current.stack.push_back(h(21));
+        current.stack.push_back(h(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (i) an OPPONENT-controlled otherwise-identical grown trigger ⇒ distinct
+    /// normalized kind (controller kept). prior occupied only by the controller's
+    /// kind ⇒ the grown opponent kind is 0→1 unoccupied ⇒ false. Revert-fail:
+    /// dropping `controller` from the key flips this true.
+    #[test]
+    fn n1_i_opponent_controlled_growth_false() {
+        let (_p, _c) = cover_base();
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(g(10)); // [G(c0), G(c0)]
+        prior.stack.push_back(g(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(g(20)); // [G(c0), G(c0), G(c1)]
+        current.stack.push_back(g(21));
+        current
+            .stack
+            .push_back(churn_entry(22, 1, gain_ability(1), None));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (j) JOURNAL-READER (R2 B-R2-1): a fixed-amount drain churner whose embedded
+    /// ability carries an `NthResolutionThisTurn`-gated branch reads the cleared
+    /// per-ability resolution journal ⇒ false. Revert-fail: narrowing the walker
+    /// guard axis back to resources-only (dropping journal readers) flips this true.
+    #[test]
+    fn n1_j_journal_reader_false() {
+        let j = |id| {
+            let mut ability = gain_ability(1);
+            ability.condition = Some(AbilityCondition::NthResolutionThisTurn { n: 10 });
+            churn_entry(id, 0, ability, None)
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(j(10));
+        prior.stack.push_back(j(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(j(20));
+        current.stack.push_back(j(21));
+        current.stack.push_back(j(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (k) DORMANT-TRIGGER (R4-G1): a genuine covering drain while a battlefield
+    /// permanent carries a mandatory trigger DEFINITION whose fire-time condition
+    /// reads life — it produces NO stack entry on either frame ⇒ false via the
+    /// second (off-stack) scan surface. Revert-fail: removing the item-5 scan.
+    #[test]
+    fn n1_k_dormant_trigger_condition_false() {
+        let (mut prior, mut current) = cover_base();
+        for state in [&mut prior, &mut current] {
+            let oid = bf_object(state, 800);
+            let mut def = TriggerDefinition::new(TriggerMode::LifeLost);
+            def.condition = Some(TriggerCondition::LifeTotalGE { minimum: 6 });
+            state
+                .objects
+                .get_mut(&oid)
+                .unwrap()
+                .trigger_definitions
+                .push(def);
+        }
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (k-r) a battlefield REPLACEMENT definition whose condition reads life ⇒ false.
+    #[test]
+    fn n1_kr_dormant_replacement_condition_false() {
+        let (mut prior, mut current) = cover_base();
+        for state in [&mut prior, &mut current] {
+            let oid = bf_object(state, 801);
+            let mut def = ReplacementDefinition::new(ReplacementEvent::LoseLife);
+            def.condition = Some(ReplacementCondition::UnlessPlayerLifeAtMost { amount: 5 });
+            state
+                .objects
+                .get_mut(&oid)
+                .unwrap()
+                .replacement_definitions
+                .push(def);
+        }
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (k-s) a dormant condition-gated STATIC (any mode) whose condition reads a
+    /// projected axis (poison) ⇒ false (the CR 101.2 firewall reads only live state
+    /// and cannot see it arm; the off-stack static scan catches it).
+    #[test]
+    fn n1_ks_dormant_static_condition_false() {
+        let (mut prior, mut current) = cover_base();
+        for state in [&mut prior, &mut current] {
+            let oid = bf_object(state, 802);
+            let mut def = StaticDefinition::new(StaticMode::CantLoseTheGame);
+            def.condition = Some(StaticCondition::OpponentPoisonAtLeast { count: 1 });
+            state
+                .objects
+                .get_mut(&oid)
+                .unwrap()
+                .static_definitions
+                .push(def);
+        }
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (l) DRIFTING MISSED READER (R4-G3): an on-stack entry whose trigger-level
+    /// intervening-if is `GainedLife` — reads `life_gained_this_turn`, which drifts
+    /// +1/cycle in the very drain window being certified ⇒ false. Revert-fail:
+    /// classifying `GainedLife` as a non-reader in the walker flips this true.
+    #[test]
+    fn n1_l_gained_life_journal_reader_false() {
+        let l = |id| {
+            churn_entry(
+                id,
+                0,
+                gain_ability(1),
+                Some(TriggerCondition::GainedLife { minimum: 30 }),
+            )
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(l(10));
+        prior.stack.push_back(l(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(l(20));
+        current.stack.push_back(l(21));
+        current.stack.push_back(l(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (m) OBJECT-AXIS COUNTER RIDER (R5-B1): a genuine covering drain but `current`
+    /// carries one more monotone `-1/-1` counter on a shared battlefield creature
+    /// than `prior` (projection-invisible) ⇒ false via `object_resource_axes_match`.
+    /// Revert-fail: dropping that strict compare flips this true (and in real play
+    /// CR 704.5f/g graveyards the churner source and the cascade extinguishes).
+    #[test]
+    fn n1_m_object_counter_rider_false() {
+        let (mut prior, mut current) = cover_base();
+        // Shared creature in both frames; monotone -1/-1 counter drifts +1 in current.
+        for (state, extra) in [(&mut prior, 1u32), (&mut current, 2u32)] {
+            let oid = ObjectId(850);
+            let mut object = crate::game::game_object::GameObject::new(
+                oid,
+                CardId(9),
+                PlayerId(0),
+                "Test Churner Source".to_string(),
+                Zone::Battlefield,
+            );
+            object.card_types.core_types = vec![CoreType::Creature];
+            object.counters.insert(CounterType::Minus1Minus1, extra);
+            state.objects.insert(oid, object);
+            state.battlefield.push_back(oid);
+        }
+        // Sanity: the projection hides it (the 2p equality path would still match).
+        let mut pa = project_out_resources(&prior);
+        let mut pb = project_out_resources(&current);
+        pa.stack.clear();
+        pb.stack.clear();
+        assert!(
+            loop_states_equal(&pa, &pb),
+            "fixture: the -1/-1 counter drift is projection-invisible (isolates B1)"
+        );
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (n) PLAYER-COUNTER RIDER (R5-MAJOR): a fixed-amount drain churner whose ability
+    /// reads a projected player-counter axis (experience — NO winner-predicate
+    /// firewall) ⇒ false. Revert-fail: declassifying `PlayerCounter` in the walker.
+    #[test]
+    fn n1_n_player_counter_reader_false() {
+        let n = |id| {
+            let ability = ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Ref {
+                        qty: QuantityRef::PlayerCounter {
+                            kind: PlayerCounterKind::Experience,
+                            scope: CountScope::Controller,
+                        },
+                    },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(CHURN_SRC),
+                PlayerId(0),
+            );
+            churn_entry(id, 0, ability, None)
+        };
+        let mut prior = GameState::new_two_player(7);
+        prior.stack.push_back(n(10));
+        prior.stack.push_back(n(11));
+        let mut current = prior.clone();
+        current.stack.clear();
+        current.stack.push_back(n(20));
+        current.stack.push_back(n(21));
+        current.stack.push_back(n(22));
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
     }
 }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -917,29 +917,34 @@ fn stack_entry_reads_projected_resource(entry: &StackEntry) -> bool {
 /// Fail-closed: any surface the scan cannot classify ⇒ reject (no shortcut).
 ///
 /// Keyword-synthesized granted triggers (`KeywordTriggerInstaller::triggers_for`
-/// / `synthesize_granted_keyword_triggers`) are NOT scanned here: they are
-/// produced on-the-fly during trigger collection and never land on
-/// `obj.trigger_definitions`, so `active_trigger_definitions` (loop (i)) does not
-/// reach them. Most such triggers carry non-projected fire-time conditions
-/// (Echo→`EchoDue`, Renown→`Not(IsRenowned)`, Suspend/Soulshift/Vanishing/
-/// CumulativeUpkeep→counter/zone conditions, Soulbond→filter conditions).
+/// / `synthesize_granted_keyword_triggers`) ARE scanned here — loop (iv), via
+/// `crate::game::triggers::granted_keyword_triggers_in_zone` (the same synthesis
+/// authority the live trigger-collection path uses). They are produced
+/// on-the-fly during trigger collection and (for off-zone grants, and in any
+/// state where layer 6 has not reinstalled them) never land on
+/// `obj.trigger_definitions`, so `active_trigger_definitions` (loop (i)) cannot
+/// be relied on to reach them. Most such triggers carry non-projected fire-time
+/// conditions (Echo→`EchoDue`, Renown→`Not(IsRenowned)`, Suspend/Soulshift/
+/// Vanishing/CumulativeUpkeep→counter/zone conditions, Soulbond→filter
+/// conditions), but Dethrone does not — see below.
 ///
-/// KNOWN GAP: the item-5 classifier (`trigger_condition_reads_projected_resource`)
-/// flags four granted-keyword conditions as projected-reading — Dethrone,
-/// Increment, Soulbond, Training — but only Dethrone is a GENUINE projected read.
-/// Dethrone (CR 702.105a) compares the defending player's `LifeTotal` to the max
+/// The item-5 classifier (`trigger_condition_reads_projected_resource`) flags
+/// four granted-keyword conditions as projected-reading — Dethrone, Increment,
+/// Soulbond, Training — but only Dethrone is a GENUINE projected read. Dethrone
+/// (CR 702.105a) compares the defending player's `LifeTotal` to the max
 /// `LifeTotal` among all players (CR 119 life = a PROJECTED axis this pass
 /// zeroes); Increment/Soulbond/Training are fail-closed false positives
 /// (`ManaSpentToCast` / control-filter / co-attacker-power reads the classifier's
 /// `Axes::CONSERVATIVE` walk cannot descend, all cast/combat/object state gate (1)
-/// strict-compares). A runtime-GRANTED Dethrone (`Effect::GrantKeywords` /
-/// `ContinuousModification::AddKeyword`) is invisible to this scan — a latent
-/// dormant-arming risk (false WIN, N1(k) class) bounded only by whether granted
-/// Dethrone is reachable inside a growing-cascade loop. The guard test
+/// strict-compares). Because loop (iv) now scans these synthesized defs, a
+/// runtime-GRANTED Dethrone (`Effect::GrantKeywords` /
+/// `ContinuousModification::AddKeyword`) whose dormant condition would arm
+/// mid-extrapolation is caught (fail-safe reject) — closing the inc2b
+/// dormant-arming hole (false WIN, N1(k) class). This makes item-5 structurally
+/// complete for granted keywords rather than a hand-list. The guard test
 /// `granted_keyword_trigger_conditions_projected_reads_are_exactly_known_gaps` in
-/// `game::triggers` pins that flagged set: if a NEW granted-keyword condition
-/// begins reading a projected resource, that test fails and this scan MUST be
-/// extended to the granted-keyword defs before item-5 can be trusted again.
+/// `game::triggers` still pins the flagged set so a NEW projected-reading
+/// granted-keyword condition surfaces as a review signal.
 fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
     // (i) Trigger fire-time intervening-if conditions (CR 603.4). `active_trigger_
     // definitions` is the liveness authority (CR 702.26b phased-out + CR 114.4
@@ -1007,6 +1012,32 @@ fn fire_time_conditions_read_projected_resource(state: &GameState) -> bool {
             .is_some_and(crate::game::ability_scan::static_condition_reads_projected_resource)
         {
             return true;
+        }
+    }
+    // (iv) Runtime-GRANTED keyword synthesized trigger defs (CR 603.4). These are
+    // produced on-the-fly during trigger collection by
+    // `synthesize_granted_keyword_triggers` / `KeywordTriggerInstaller` and — for
+    // off-zone grants, and in any state where layer 6 has not (re)installed them —
+    // never land on `obj.trigger_definitions`, so loop (i) cannot reach them. A
+    // granted Dethrone (CR 702.105a) carries a fire-time intervening-if reading the
+    // defending player's `LifeTotal` (CR 119, a projected axis this pass zeroes); a
+    // dormant such condition would arm mid-extrapolation and break the replay.
+    // Reuse the collection path's synthesis authority (single authority, no
+    // duplicated synthesis) via `granted_keyword_triggers_in_zone`, which applies
+    // the same zone gate. Fail-closed: the classifier's `Axes::CONSERVATIVE` walk
+    // rejects any condition subtree it cannot descend.
+    for obj in state.objects.values() {
+        if obj.is_phased_out() {
+            continue;
+        }
+        for def in crate::game::triggers::granted_keyword_triggers_in_zone(state, obj) {
+            if def
+                .condition
+                .as_ref()
+                .is_some_and(crate::game::ability_scan::trigger_condition_reads_projected_resource)
+            {
+                return true;
+            }
         }
     }
     false
@@ -2213,6 +2244,35 @@ mod tests {
                 .unwrap()
                 .trigger_definitions
                 .push(def);
+        }
+        assert!(!loop_states_cover_modulo_growth(&prior, &current));
+    }
+
+    /// (k-g) DORMANT GRANTED-KEYWORD TRIGGER (inc2b hole): a genuine covering drain
+    /// while a battlefield permanent carries a runtime-GRANTED Dethrone (CR 702.105a)
+    /// whose synthesized fire-time intervening-if reads `LifeTotal` (CR 119,
+    /// projected). The granted trigger is NOT on `obj.trigger_definitions` — it is
+    /// synthesized on-the-fly by `synthesize_granted_keyword_triggers`, so loop (i)
+    /// never sees it; only loop (iv)'s reuse of `granted_keyword_triggers_in_zone`
+    /// catches the dormant condition ⇒ false. Revert-fail: deleting loop (iv) leaves
+    /// the synthesized def unscanned, item-5 returns false, and the cover shortcut
+    /// (a false WIN, N1(k) class) is wrongly taken ⇒ this assertion flips to true.
+    #[test]
+    fn n1_kg_dormant_granted_keyword_trigger_condition_false() {
+        let (mut prior, mut current) = cover_base();
+        for state in [&mut prior, &mut current] {
+            let oid = bf_object(state, 803);
+            // Granted (not printed): push onto `keywords` only, leaving
+            // `base_keywords` empty so `synthesize_granted_keyword_triggers`
+            // classifies it as granted and produces the life-reading trigger. The
+            // trigger itself is deliberately NOT installed on `trigger_definitions`
+            // (that is what makes loop (i) miss it, per the inc2b hole).
+            state
+                .objects
+                .get_mut(&oid)
+                .unwrap()
+                .keywords
+                .push(crate::types::keywords::Keyword::Dethrone);
         }
         assert!(!loop_states_cover_modulo_growth(&prior, &current));
     }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -54,11 +54,29 @@
 //! and `ModalChoice` fields are destructured without `..`, so a new field must be
 //! classified before it compiles. Any type outside this set that can reach a read
 //! is in the conservative set above.
+//!
+//! # Resolution-time choice classifier (a SEPARATE question family)
+//!
+//! Alongside the three read-axes lives an independent classifier
+//! (`effect_resolution_choice_freedom` / `ability_resolution_choice_freedom`,
+//! consumed by `analysis::resource::loop_states_cover_modulo_growth` item 6)
+//! answering a FOURTH, orthogonal question (CR 608.2d): can resolving this
+//! ability enter a resolution-time player choice (a non-priority `WaitingFor`)?
+//! This is deliberately NOT a fourth `Axes` axis — `Axes::NONE` means "no
+//! reads", which is orthogonal to "never prompts" (`Effect::Scry` reads nothing
+//! yet always prompts), so folding a choice bit into `Axes` would make every
+//! existing `NONE` arm silently claim choice-freeness. The classifier is
+//! fail-closed (`MayPrompt` default — an unproven claim only costs a
+//! false-negative cover rejection); promoting a variant to a choice-free
+//! verdict is a SOUNDNESS claim ("resolving can never enter a non-priority
+//! `WaitingFor`, for ANY state") and requires a resolver trace cited in the arm
+//! plus a `..`-free destructure so a future field forces re-audit.
 
 use crate::types::ability::{
     AbilityCondition, ControllerRef, CountScope, Duration, Effect, ModalChoice, MultiTargetSpec,
     ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation,
-    ReplacementCondition, ResolvedAbility, StaticCondition, TargetFilter, TriggerCondition,
+    ReplacementCondition, ResolvedAbility, StaticCondition, TargetChoiceTiming, TargetFilter,
+    TriggerCondition,
 };
 use crate::types::game_state::TargetSelectionConstraint;
 
@@ -3146,6 +3164,393 @@ pub(crate) fn duration_reads_projected_resource(duration: &Duration) -> bool {
     scan_duration(duration).projected
 }
 
+// ---------------------------------------------------------------------------
+// Resolution-time choice-freeness classifier (`analysis::resource` item 6).
+// A separate question family from the three read-axes above — see the module
+// header. Fail-closed default is `MayPrompt`.
+// ---------------------------------------------------------------------------
+
+/// CR 732.2a + CR 608.2d: resolution-time choice-freeness verdict for the
+/// growing-cascade cover gate (`analysis::resource` item 6). NOT an `Axes`
+/// axis — this classifies RESOLVER prompting behavior, not AST reads (module
+/// header rationale).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ResolutionChoiceFreedom {
+    /// Resolving can never enter a non-priority `WaitingFor` in ANY state,
+    /// EXCEPT through the life-event replacement pipeline (single optional
+    /// candidate, replacement.rs:6221; CR 616.1 material ordering,
+    /// replacement.rs:6263; mandatory body-continuation drain,
+    /// replacement.rs:5511-5524 → engine_replacement.rs:1159). Callers MUST
+    /// pair this verdict with `analysis::resource::life_event_replacements_may_prompt`
+    /// — the paired environmental obligation is part of this variant's contract.
+    ///
+    /// There is deliberately no plain `Free` variant yet: both allow-listed
+    /// kinds (`GainLife`/`LoseLife`) genuinely can prompt via the life-event
+    /// replacement pipeline, so `Free` would be uninhabited today. Adding it
+    /// later is compiler-guided (a new variant flags every exhaustive match).
+    FreeUnlessLifeReplacements,
+    /// May prompt, or unproven — the fail-closed default.
+    MayPrompt,
+}
+
+impl ResolutionChoiceFreedom {
+    /// Worst-of join for a resolution chain: `MayPrompt` dominates (a chain that
+    /// can prompt on either branch can prompt).
+    fn join(self, other: ResolutionChoiceFreedom) -> ResolutionChoiceFreedom {
+        if matches!(self, ResolutionChoiceFreedom::FreeUnlessLifeReplacements)
+            && matches!(other, ResolutionChoiceFreedom::FreeUnlessLifeReplacements)
+        {
+            ResolutionChoiceFreedom::FreeUnlessLifeReplacements
+        } else {
+            ResolutionChoiceFreedom::MayPrompt
+        }
+    }
+}
+
+/// CR 608.2d: can resolving this single `Effect` ever offer a resolution-time
+/// player choice? Exhaustive `match` with NO wildcard catch-all arm — a NEW
+/// `Effect` variant fails to compile here until it is classified. Only the two
+/// allow-list arms make a soundness claim (grounded by a resolver trace); every
+/// other variant is the fail-closed `MayPrompt` (an ungrounded reject is only a
+/// false-negative cover rejection, so grouped arms need no per-kind evidence).
+fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
+    match e {
+        // ---- allow-list: choice-free EXCEPT the life-event replacement
+        //      pipeline (destructured WITHOUT `..` so a new field forces a
+        //      re-audit of the soundness claim) ----
+        //
+        // CR 119.3 + CR 732.2a: resolver trace effects/life.rs — resolve_gain
+        // (life.rs:19-110) runs its OWN inline replace_event pipeline; its only
+        // prompt is ReplacementResult::NeedsChoice (life.rs:96-101). Player
+        // selection = pure filter eval (game/filter.rs: no WaitingFor); amount =
+        // pure quantity eval (game/quantity.rs: no WaitingFor). Verdict is
+        // payload-independent. CR 119.7 can't-gain short-circuit is deterministic.
+        // PAIRED OBLIGATION: caller runs life_event_replacements_may_prompt
+        // (resource.rs item 6), which also covers the mandatory body-continuation
+        // drain (H4 route c) and the Execute-arm stack.rs drain.
+        Effect::GainLife {
+            amount: _,
+            player: _,
+        } => ResolutionChoiceFreedom::FreeUnlessLifeReplacements,
+        // CR 119.3 + CR 732.2a: same shape — resolve_lose (life.rs:293-365),
+        // only prompt = NeedsChoice (life.rs:352-355). CR 119.8 can't-lose
+        // short-circuit is deterministic. Same PAIRED OBLIGATION.
+        Effect::LoseLife {
+            amount: _,
+            target: _,
+        } => ResolutionChoiceFreedom::FreeUnlessLifeReplacements,
+        // ---- everything else: fail-closed MayPrompt. Grouped so the compiler
+        //      still enforces exhaustiveness (every variant is named); no payload
+        //      scanning needed on the reject side. ----
+        Effect::StartYourEngines { .. }
+        | Effect::ChangeSpeed { .. }
+        | Effect::DealDamage { .. }
+        | Effect::ApplyPostReplacementDamage { .. }
+        | Effect::EachDealsDamageEqualToPower { .. }
+        | Effect::Draw { .. }
+        | Effect::Pump { .. }
+        | Effect::PairWith { .. }
+        | Effect::Destroy { .. }
+        | Effect::Regenerate { .. }
+        | Effect::RemoveAllDamage { .. }
+        | Effect::Counter { .. }
+        | Effect::CounterAll { .. }
+        | Effect::Token { .. }
+        | Effect::SetTapState { .. }
+        | Effect::RemoveCounter { .. }
+        | Effect::Sacrifice { .. }
+        | Effect::DiscardCard { .. }
+        | Effect::Mill { .. }
+        | Effect::Scry { .. }
+        | Effect::PumpAll { .. }
+        | Effect::DamageAll { .. }
+        | Effect::DamageEachPlayer { .. }
+        | Effect::DestroyAll { .. }
+        | Effect::ChangeZone { .. }
+        | Effect::ChangeZoneAll { .. }
+        | Effect::Dig { .. }
+        | Effect::GainControl { .. }
+        | Effect::GainControlAll { .. }
+        | Effect::ControlNextTurn { .. }
+        | Effect::Attach { .. }
+        | Effect::UnattachAll { .. }
+        | Effect::Surveil { .. }
+        | Effect::Fight { .. }
+        | Effect::Bounce { .. }
+        | Effect::BounceAll { .. }
+        | Effect::Explore
+        | Effect::ExploreAll { .. }
+        | Effect::Investigate
+        | Effect::Tribute { .. }
+        | Effect::TimeTravel
+        | Effect::BecomeMonarch
+        | Effect::NoOp
+        | Effect::Proliferate
+        | Effect::ProliferateTarget { .. }
+        | Effect::Populate
+        | Effect::Clash
+        | Effect::EndTheTurn
+        | Effect::EndCombatPhase
+        | Effect::Vote { .. }
+        | Effect::SeparateIntoPiles { .. }
+        | Effect::SwitchPT { .. }
+        | Effect::CopySpell { .. }
+        | Effect::EpicCopy { .. }
+        | Effect::CastCopyOfCard { .. }
+        | Effect::CopyTokenOf { .. }
+        | Effect::CreateTokenCopyFromPool { .. }
+        | Effect::Myriad
+        | Effect::Encore
+        | Effect::CombineHost { .. }
+        | Effect::ChooseAugmentAndCombineWithHost { .. }
+        | Effect::Meld { .. }
+        | Effect::ExileHaunting { .. }
+        | Effect::HideawayConceal { .. }
+        | Effect::CopyTokenBlockingAttacker { .. }
+        | Effect::BecomeCopy { .. }
+        | Effect::GainActivatedAbilitiesOfTarget { .. }
+        | Effect::ChooseCard { .. }
+        | Effect::PutCounter { .. }
+        | Effect::PutCounterAll { .. }
+        | Effect::MultiplyCounter { .. }
+        | Effect::DoublePT { .. }
+        | Effect::DoublePTAll { .. }
+        | Effect::MoveCounters { .. }
+        | Effect::Animate { .. }
+        | Effect::ReturnAsAura { .. }
+        | Effect::RegisterBending { .. }
+        | Effect::GenericEffect { .. }
+        | Effect::Cleanup { .. }
+        | Effect::Mana { .. }
+        | Effect::Discard { .. }
+        | Effect::Shuffle { .. }
+        | Effect::Transform { .. }
+        | Effect::SearchLibrary { .. }
+        | Effect::SearchOutsideGame { .. }
+        | Effect::RevealHand { .. }
+        | Effect::RevealFromHand { .. }
+        | Effect::Reveal { .. }
+        | Effect::RevealTop { .. }
+        | Effect::ExileTop { .. }
+        | Effect::TargetOnly { .. }
+        | Effect::Choose { .. }
+        | Effect::ChooseDamageSource { .. }
+        | Effect::Suspect { .. }
+        | Effect::Unsuspect { .. }
+        | Effect::Connive { .. }
+        | Effect::PhaseOut { .. }
+        | Effect::PhaseIn { .. }
+        | Effect::ForceBlock { .. }
+        | Effect::ForceAttack { .. }
+        | Effect::SolveCase
+        | Effect::BecomePrepared { .. }
+        | Effect::BecomeUnprepared { .. }
+        | Effect::BecomeSaddled { .. }
+        | Effect::SetClassLevel { .. }
+        | Effect::CreateDelayedTrigger { .. }
+        | Effect::AddTargetReplacement { .. }
+        | Effect::AddRestriction { .. }
+        | Effect::ReduceNextSpellCost { .. }
+        | Effect::GrantNextSpellAbility { .. }
+        | Effect::AddPendingETBCounters { .. }
+        | Effect::CreateEmblem { .. }
+        | Effect::PayCost { .. }
+        | Effect::CastFromZone { .. }
+        | Effect::FreeCastFromZones { .. }
+        | Effect::ExileResolvingSpellInsteadOfGraveyard
+        | Effect::PreventDamage { .. }
+        | Effect::CreateDamageReplacement { .. }
+        | Effect::CreateDrawReplacement { .. }
+        | Effect::LoseTheGame { .. }
+        | Effect::WinTheGame { .. }
+        | Effect::RollDie { .. }
+        | Effect::FlipCoin { .. }
+        | Effect::FlipCoins { .. }
+        | Effect::FlipCoinUntilLose { .. }
+        | Effect::RingTemptsYou
+        | Effect::VentureIntoDungeon
+        | Effect::VentureInto { .. }
+        | Effect::TakeTheInitiative
+        | Effect::Planeswalk
+        | Effect::OpenAttractions { .. }
+        | Effect::RollToVisitAttractions
+        | Effect::AssembleContraptions { .. }
+        | Effect::AssembleContraptionsFromRollDifference
+        | Effect::CrankContraptions { .. }
+        | Effect::ReassembleContraption { .. }
+        | Effect::AssembleContraptionOnSprocket { .. }
+        | Effect::ReassembleContraptionOnSprocket { .. }
+        | Effect::PutSticker { .. }
+        | Effect::ApplySticker { .. }
+        | Effect::ProcessRadCounters
+        | Effect::GrantCastingPermission { .. }
+        | Effect::ChooseFromZone { .. }
+        | Effect::RememberCard { .. }
+        | Effect::ForEachCategoryExile { .. }
+        | Effect::ChooseObjectsIntoTrackedSet { .. }
+        | Effect::ChooseAndSacrificeRest { .. }
+        | Effect::Exploit { .. }
+        | Effect::GainEnergy { .. }
+        | Effect::GivePlayerCounter { .. }
+        | Effect::LoseAllPlayerCounters { .. }
+        | Effect::ExileFromTopUntil { .. }
+        | Effect::RevealUntil { .. }
+        | Effect::Discover { .. }
+        | Effect::Heist { .. }
+        | Effect::HeistExile
+        | Effect::Cascade
+        | Effect::Ripple { .. }
+        | Effect::MiracleCast { .. }
+        | Effect::MadnessCast { .. }
+        | Effect::PutAtLibraryPosition { .. }
+        | Effect::ChooseDrawnThisTurnPayOrTopdeck { .. }
+        | Effect::PutOnTopOrBottom { .. }
+        | Effect::GiftDelivery { .. }
+        | Effect::Goad { .. }
+        | Effect::GoadAll { .. }
+        | Effect::Detain { .. }
+        | Effect::SetRoomDoorLock { .. }
+        | Effect::ExchangeControl { .. }
+        | Effect::ChangeTargets { .. }
+        | Effect::Manifest { .. }
+        | Effect::ManifestDread
+        | Effect::Cloak { .. }
+        | Effect::TurnFaceUp { .. }
+        | Effect::TurnFaceDown { .. }
+        | Effect::ExtraTurn { .. }
+        | Effect::GrantExtraLoyaltyActivations { .. }
+        | Effect::SkipNextTurn { .. }
+        | Effect::SkipNextStep { .. }
+        | Effect::AdditionalPhase { .. }
+        | Effect::Double { .. }
+        | Effect::RuntimeHandled { .. }
+        | Effect::Incubate { .. }
+        | Effect::Amass { .. }
+        | Effect::Monstrosity { .. }
+        | Effect::Specialize
+        | Effect::Renown { .. }
+        | Effect::Bolster { .. }
+        | Effect::Adapt { .. }
+        | Effect::Learn
+        | Effect::Forage
+        | Effect::Harness
+        | Effect::CollectEvidence { .. }
+        | Effect::Endure { .. }
+        | Effect::BlightEffect { .. }
+        | Effect::Seek { .. }
+        | Effect::SetLifeTotal { .. }
+        | Effect::ExchangeLifeWithStat { .. }
+        | Effect::ExchangeLifeTotals { .. }
+        | Effect::SetDayNight { .. }
+        | Effect::GiveControl { .. }
+        | Effect::RemoveFromCombat { .. }
+        | Effect::Conjure { .. }
+        | Effect::ApplyPerpetual { .. }
+        | Effect::Intensify { .. }
+        | Effect::DraftFromSpellbook { .. }
+        | Effect::ChooseOneOf { .. }
+        | Effect::Unimplemented { .. } => ResolutionChoiceFreedom::MayPrompt,
+    }
+}
+
+/// CR 608.2d + CR 732.2a: does resolving this ability (its whole chain) ever
+/// enter a resolution-time player choice? The `ResolvedAbility` destructure is
+/// EXHAUSTIVE with no `..` — the read-walk's `resolved_ability_axes` (:116)
+/// classifications are deliberately NOT reused (this is a different question:
+/// e.g. `optional` is read-free yet choice-bearing). A FUTURE field fails to
+/// compile here until classified for the choice question.
+pub(crate) fn ability_resolution_choice_freedom(a: &ResolvedAbility) -> ResolutionChoiceFreedom {
+    let ResolvedAbility {
+        // ---- choice-bearing: folded into the verdict below ----
+        effect,
+        sub_ability,
+        else_ability,
+        optional,
+        optional_for,
+        optional_targeting,
+        unless_pay,
+        target_chooser,
+        target_choice_timing,
+        modal,
+        mode_abilities,
+        repeat_until,
+        // ---- choice-free: bound `_` with a one-line justification ----
+        condition: _, // resolution branch selector, pure eval (both branches recursed)
+        duration: _,  // continuous-effect lifetime, no prompt
+        player_scope: _, // iteration fan-out, pure player-filter eval
+        starting_with: _, // APNAP start override, no prompt
+        repeat_for: _, // "for each" count, pure quantity eval (game/quantity.rs)
+        multi_target: _, // announce-time variable-count bounds (Resolution case caught by timing)
+        target_constraints: _, // announce-time cross-target legality, no resolution prompt
+        distribution: _, // CR 601.2d concrete pre-assigned portions (announce-time)
+        targets: _,   // concrete announced target refs (already resolved)
+        source_id: _, // object id
+        source_incarnation: _, // epoch guard token
+        controller: _, // player id
+        original_controller: _, // player id
+        scoped_player: _, // player id (iteration binding)
+        kind: _,      // AbilityKind tag (no payload)
+        context: _,   // SpellContext: cast-time fact snapshot, not a live choice
+        description: _, // display string
+        min_x_value: _, // u32
+        cant_be_copied: _, // bool
+        copy_count_status: _, // status tag
+        forward_result: _, // bool
+        chosen_x: _,  // concrete cast-time X (chosen at announcement, not resolution)
+        cost_paid_object: _, // concrete captured-object snapshot
+        effect_context_object: _, // concrete captured-object snapshot
+        ability_index: _, // usize provenance
+        may_trigger_origin: _, // provenance tag
+        target_selection_mode: _, // Chosen/Random tag (announce-time)
+        chosen_players: _, // concrete chosen player ids (already selected)
+        sub_link: _,  // SubAbilityLink kind tag
+        dig_found_nothing_for_parent_target: _, // bool seam flag
+    } = a;
+
+    // CR 608.2d: an optional effect / optional targeting / opponent-may
+    // effect prompts the controller (or opponent) before execution
+    // (WaitingFor::OptionalEffectChoice, effects/mod.rs:4294).
+    if *optional || *optional_targeting || optional_for.is_some() {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+    // CR 118.12: "unless a player pays {cost}" is a resolution-time pay prompt
+    // (also item-4 redundant — ability_scan.rs sets `projected` for it).
+    if unless_pay.is_some() {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+    // CR 601.2c + CR 603.3d: a resolution-time target chooser announces targets (H3).
+    if target_chooser.is_some() {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+    // CR 608.2d: resolution-timed target selection is a resolution-time choice even
+    // though `targets` is empty on the stack, which the ordering gate can't see (H3).
+    if matches!(target_choice_timing, TargetChoiceTiming::Resolution) {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+    // CR 700.2b + CR 603.3c: a modal header / reflexive per-mode abilities open a
+    // mode choice at resolution (conservative — rejected even when the mode is baked).
+    if modal.is_some() || !mode_abilities.is_empty() {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+    // CR 608.2c + CR 107.1c: only the controller-prompted repeat variant is a
+    // player choice; while / until-stop predicates are pure re-evaluation.
+    if matches!(repeat_until, Some(RepeatContinuation::ControllerChoice)) {
+        return ResolutionChoiceFreedom::MayPrompt;
+    }
+
+    // CR 608.2c: the chain resolves the effect and, on the taken branch, a
+    // sub_ability / else_ability effect — join both (fail-safe: reject if either
+    // can prompt).
+    let mut acc = effect_resolution_choice_freedom(effect);
+    if let Some(sub) = sub_ability {
+        acc = acc.join(ability_resolution_choice_freedom(sub));
+    }
+    if let Some(else_branch) = else_ability {
+        acc = acc.join(ability_resolution_choice_freedom(else_branch));
+    }
+    acc
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3390,5 +3795,129 @@ mod tests {
         )));
         // Fixed drain reads no sibling-mutable state — safe to auto-resolve.
         assert!(!ability_reads_sibling_mutable(&fixed_drain()));
+    }
+
+    // ---- Resolution-time choice classifier: pinned in BOTH directions ----
+    /// Guard test (9092a8961 standard): pins `effect_resolution_choice_freedom`
+    /// and the ability-level wrapper flips.
+    ///
+    /// The `FreeUnlessLifeReplacements` allow set is EXACTLY
+    /// `{Effect::GainLife, Effect::LoseLife}` — asserted below and pinned by the
+    /// allow-arm census (`rg -c 'ResolutionChoiceFreedom::FreeUnlessLifeReplacements'
+    /// ability_scan.rs` == 2, both inside `effect_resolution_choice_freedom`). A
+    /// future third allow arm must update this pin, the census, and add a
+    /// resolver-trace grounding row.
+    ///
+    /// Compiler-exhaustiveness leg: `effect_resolution_choice_freedom`'s match has
+    /// no wildcard catch-all, so a NEW `Effect` variant fails to compile until classified.
+    /// Executed revert-fail (documented in the commit): classifying `Effect::Scry`
+    /// ⇒ `FreeUnlessLifeReplacements` turns this test RED.
+    #[test]
+    fn resolution_choice_verdicts_are_exactly_pinned() {
+        use crate::types::ability::{
+            AbilityCost, AbilityDefinition, AbilityKind, UnlessPayModifier,
+        };
+        use ResolutionChoiceFreedom::{FreeUnlessLifeReplacements, MayPrompt};
+
+        // Allow-list (soundness claims) ⇒ FreeUnlessLifeReplacements.
+        let gain = Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        };
+        let lose = Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            target: None,
+        };
+        assert_eq!(
+            effect_resolution_choice_freedom(&gain),
+            FreeUnlessLifeReplacements
+        );
+        assert_eq!(
+            effect_resolution_choice_freedom(&lose),
+            FreeUnlessLifeReplacements
+        );
+
+        // Reject side: the finding's kinds + adjacent siblings ⇒ MayPrompt, each
+        // with its resolver-prompt raise-site citation.
+        let rejects = [
+            Effect::Proliferate, // WaitingFor::ProliferateChoice — proliferate.rs:109
+            Effect::Populate,    // WaitingFor::PopulateChoice — populate.rs:50
+            Effect::Clash,       // WaitingFor::ClashChooseOpponent — clash.rs:47
+            Effect::Explore,     // WaitingFor::ExploreChoice — explore.rs:191
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            }, // Scry always prompts (bottom/top ordering)
+            Effect::Sacrifice {
+                target: TargetFilter::Any,
+                count: QuantityExpr::Fixed { value: 1 },
+                min_count: 0,
+            }, // WaitingFor::EffectZoneChoice — sacrifice.rs:306
+            Effect::DiscardCard {
+                count: 1,
+                target: TargetFilter::Any,
+            }, // discard selection prompt
+        ];
+        for e in &rejects {
+            assert_eq!(
+                effect_resolution_choice_freedom(e),
+                MayPrompt,
+                "{e:?} must be MayPrompt"
+            );
+        }
+
+        // Explicit allow-set pin: exactly {GainLife, LoseLife}. Every other kind
+        // sampled above is on the reject side; the allow-arm census is the
+        // structural guard against a silent third allow arm.
+        assert!(
+            rejects
+                .iter()
+                .all(|e| effect_resolution_choice_freedom(e) == MayPrompt),
+            "the FreeUnlessLifeReplacements set is exactly {{Effect::GainLife, Effect::LoseLife}}"
+        );
+
+        // Ability-level wrapper flips: base ⇒ Free (paired positive reach-guard),
+        // each single-field mutation ⇒ MayPrompt (proves the FLIP, not something
+        // upstream, causes the rejection).
+        let base = ResolvedAbility::new(gain.clone(), Vec::new(), ObjectId(1), PlayerId(0));
+        assert_eq!(
+            ability_resolution_choice_freedom(&base),
+            FreeUnlessLifeReplacements
+        );
+
+        let mut a = base.clone();
+        a.optional = true;
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.optional_targeting = true;
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.unless_pay = Some(UnlessPayModifier {
+            cost: AbilityCost::Tap,
+            payer: TargetFilter::Controller,
+        });
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.target_chooser = Some(TargetFilter::Controller);
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.target_choice_timing = TargetChoiceTiming::Resolution;
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.mode_abilities = vec![AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)];
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.repeat_until = Some(RepeatContinuation::ControllerChoice);
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
+
+        let mut a = base.clone();
+        a.modal = Some(ModalChoice::default());
+        assert_eq!(ability_resolution_choice_freedom(&a), MayPrompt);
     }
 }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -285,7 +285,7 @@ fn scan_target_selection_constraint(c: &TargetSelectionConstraint) -> Axes {
 
 fn scan_effect(x: &Effect) -> Axes {
     match x {
-        Effect::StartYourEngines { player_scope, .. } => {
+        Effect::StartYourEngines { player_scope } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(player_scope));
             acc
@@ -293,69 +293,80 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::ChangeSpeed {
             player_scope,
             amount,
-            ..
+            direction: _,
+            floor: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(player_scope));
             acc = acc.or(scan_quantity_expr(amount));
             acc
         }
-        Effect::DealDamage { amount, target, .. } => {
+        Effect::DealDamage {
+            amount,
+            target,
+            damage_source: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ApplyPostReplacementDamage { .. } => Axes::NONE,
-        Effect::EachDealsDamageEqualToPower {
-            sources, recipient, ..
-        } => {
+        Effect::ApplyPostReplacementDamage {
+            context: _,
+            target: _,
+            amount: _,
+            is_combat: _,
+        } => Axes::NONE,
+        Effect::EachDealsDamageEqualToPower { sources, recipient } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(sources));
             acc = acc.or(scan_target_filter(recipient));
             acc
         }
-        Effect::Draw { count, target, .. } => {
+        Effect::Draw { count, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::Pump { .. } => Axes::CONSERVATIVE,
-        Effect::PairWith { target, .. } => {
+        Effect::PairWith { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Destroy { target, .. } => {
+        Effect::Destroy {
+            target,
+            cant_regenerate: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Regenerate { target, .. } => {
+        Effect::Regenerate { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::RemoveAllDamage { target, .. } => {
+        Effect::RemoveAllDamage { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::Counter { .. } => Axes::CONSERVATIVE,
-        Effect::CounterAll { target, .. } => {
+        Effect::CounterAll { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::Token { .. } => Axes::CONSERVATIVE,
-        Effect::GainLife { amount, player, .. } => {
+        Effect::GainLife { amount, player } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::LoseLife { amount, target, .. } => {
+        Effect::LoseLife { amount, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             if let Some(x) = target {
@@ -363,35 +374,51 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::SetTapState { target, .. } => {
+        Effect::SetTapState {
+            target,
+            scope: _,
+            state: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::RemoveCounter { count, target, .. } => {
-            let mut acc = Axes::NONE;
-            acc = acc.or(scan_quantity_expr(count));
-            acc = acc.or(scan_target_filter(target));
-            acc
-        }
-        Effect::Sacrifice { target, count, .. } => {
-            let mut acc = Axes::NONE;
-            acc = acc.or(scan_target_filter(target));
-            acc = acc.or(scan_quantity_expr(count));
-            acc
-        }
-        Effect::DiscardCard { target, .. } => {
-            let mut acc = Axes::NONE;
-            acc = acc.or(scan_target_filter(target));
-            acc
-        }
-        Effect::Mill { count, target, .. } => {
+        Effect::RemoveCounter {
+            count,
+            target,
+            counter_type: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Scry { count, target, .. } => {
+        Effect::Sacrifice {
+            target,
+            count,
+            min_count: _,
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::DiscardCard { target, count: _ } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Mill {
+            count,
+            target,
+            destination: _,
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Scry { count, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
@@ -402,7 +429,7 @@ fn scan_effect(x: &Effect) -> Axes {
             amount,
             target,
             player_filter,
-            ..
+            damage_source: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
@@ -415,14 +442,16 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::DamageEachPlayer {
             amount,
             player_filter,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc = acc.or(scan_player_filter(player_filter));
             acc
         }
-        Effect::DestroyAll { target, .. } => {
+        Effect::DestroyAll {
+            target,
+            cant_regenerate: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -433,7 +462,13 @@ fn scan_effect(x: &Effect) -> Axes {
             player,
             count,
             filter,
-            ..
+            destination: _,
+            keep_count: _,
+            up_to: _,
+            rest_destination: _,
+            reveal: _,
+            enter_tapped: _,
+            source: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
@@ -441,57 +476,62 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        Effect::GainControl { target, .. } => {
+        Effect::GainControl { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::GainControlAll { target, .. } => {
+        Effect::GainControlAll { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ControlNextTurn { target, .. } => {
-            let mut acc = Axes::NONE;
-            acc = acc.or(scan_target_filter(target));
-            acc
-        }
-        Effect::Attach {
-            attachment, target, ..
+        Effect::ControlNextTurn {
+            target,
+            grant_extra_turn_after: _,
         } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Attach { attachment, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(attachment));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::UnattachAll {
-            attachment, target, ..
-        } => {
+        Effect::UnattachAll { attachment, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(attachment));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Surveil { count, target, .. } => {
+        Effect::Surveil { count, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Fight {
-            target, subject, ..
-        } => {
+        Effect::Fight { target, subject } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_target_filter(subject));
             acc
         }
-        Effect::Bounce { target, .. } => {
+        Effect::Bounce {
+            target,
+            destination: _,
+            selection: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::BounceAll { target, count, .. } => {
+        Effect::BounceAll {
+            target,
+            count,
+            destination: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             if let Some(x) = count {
@@ -500,18 +540,18 @@ fn scan_effect(x: &Effect) -> Axes {
             acc
         }
         Effect::Explore => Axes::NONE,
-        Effect::ExploreAll { filter, .. } => {
+        Effect::ExploreAll { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
         Effect::Investigate => Axes::NONE,
-        Effect::Tribute { .. } => Axes::NONE,
+        Effect::Tribute { count: _ } => Axes::NONE,
         Effect::TimeTravel => Axes::NONE,
         Effect::BecomeMonarch => Axes::NONE,
         Effect::NoOp => Axes::NONE,
         Effect::Proliferate => Axes::NONE,
-        Effect::ProliferateTarget { target, .. } => {
+        Effect::ProliferateTarget { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -522,14 +562,18 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::EndCombatPhase => Axes::NONE,
         Effect::Vote { .. } => Axes::CONSERVATIVE,
         Effect::SeparateIntoPiles { .. } => Axes::CONSERVATIVE,
-        Effect::SwitchPT { target, .. } => {
+        Effect::SwitchPT { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::CopySpell { .. } => Axes::CONSERVATIVE,
         Effect::EpicCopy { .. } => Axes::CONSERVATIVE,
-        Effect::CastCopyOfCard { target, count, .. } => {
+        Effect::CastCopyOfCard {
+            target,
+            count,
+            cost: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             if let Some(x) = count {
@@ -543,7 +587,10 @@ fn scan_effect(x: &Effect) -> Axes {
             type_filter,
             mv_bound,
             count,
-            ..
+            mv: _,
+            selection: _,
+            tapped: _,
+            enters_attacking: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(owner));
@@ -554,24 +601,32 @@ fn scan_effect(x: &Effect) -> Axes {
         }
         Effect::Myriad => Axes::NONE,
         Effect::Encore => Axes::NONE,
-        Effect::CombineHost { host, .. } => {
+        Effect::CombineHost { host, source: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(host));
             acc
         }
-        Effect::ChooseAugmentAndCombineWithHost { filter, host, .. } => {
+        Effect::ChooseAugmentAndCombineWithHost {
+            filter,
+            host,
+            zones: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc = acc.or(scan_target_filter(host));
             acc
         }
-        Effect::Meld { .. } => Axes::NONE,
-        Effect::ExileHaunting { target, .. } => {
+        Effect::Meld {
+            source: _,
+            partner: _,
+            result: _,
+        } => Axes::NONE,
+        Effect::ExileHaunting { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::HideawayConceal { target, .. } => {
+        Effect::HideawayConceal { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -579,7 +634,6 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::CopyTokenBlockingAttacker {
             source_filter,
             owner,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(source_filter));
@@ -591,7 +645,6 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             recipient,
             duration,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -601,34 +654,54 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::ChooseCard { target, .. } => {
+        Effect::ChooseCard { target, choices: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::PutCounter { count, target, .. } => {
-            let mut acc = Axes::NONE;
-            acc = acc.or(scan_quantity_expr(count));
-            acc = acc.or(scan_target_filter(target));
-            acc
-        }
-        Effect::PutCounterAll { count, target, .. } => {
+        Effect::PutCounter {
+            count,
+            target,
+            counter_type: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::MultiplyCounter { target, .. } => {
+        Effect::PutCounterAll {
+            count,
+            target,
+            counter_type: _,
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::MultiplyCounter {
+            target,
+            counter_type: _,
+            multiplier: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::DoublePT { target, .. } => {
+        Effect::DoublePT {
+            target,
+            mode: _,
+            factor: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::DoublePTAll { target, .. } => {
+        Effect::DoublePTAll {
+            target,
+            mode: _,
+            factor: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -637,7 +710,9 @@ fn scan_effect(x: &Effect) -> Axes {
             source,
             count,
             target,
-            ..
+            counter_type: _,
+            mode: _,
+            selection: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(source));
@@ -649,16 +724,25 @@ fn scan_effect(x: &Effect) -> Axes {
         }
         Effect::Animate { .. } => Axes::CONSERVATIVE,
         Effect::ReturnAsAura { .. } => Axes::CONSERVATIVE,
-        Effect::RegisterBending { .. } => Axes::NONE,
+        Effect::RegisterBending { kind: _ } => Axes::NONE,
         Effect::GenericEffect { .. } => Axes::CONSERVATIVE,
-        Effect::Cleanup { .. } => Axes::NONE,
+        Effect::Cleanup {
+            clear_remembered: _,
+            clear_chosen_player: _,
+            clear_chosen_color: _,
+            clear_chosen_type: _,
+            clear_chosen_card: _,
+            clear_imprinted: _,
+            clear_triggers: _,
+            clear_coin_flips: _,
+        } => Axes::NONE,
         Effect::Mana { .. } => Axes::CONSERVATIVE,
         Effect::Discard {
             count,
             target,
             unless_filter,
             filter,
-            ..
+            selection: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
@@ -671,18 +755,24 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::Shuffle { target, .. } => {
+        Effect::Shuffle { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Transform { target, .. } => {
+        Effect::Transform { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::SearchLibrary { .. } => Axes::CONSERVATIVE,
-        Effect::SearchOutsideGame { filter, count, .. } => {
+        Effect::SearchOutsideGame {
+            filter,
+            count,
+            reveal: _,
+            destination: _,
+            source_pool: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc = acc.or(scan_quantity_expr(count));
@@ -692,7 +782,9 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             card_filter,
             count,
-            ..
+            selection: _,
+            choice_optional: _,
+            reveal: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -703,60 +795,64 @@ fn scan_effect(x: &Effect) -> Axes {
             acc
         }
         Effect::RevealFromHand { .. } => Axes::CONSERVATIVE,
-        Effect::Reveal { target, .. } => {
+        Effect::Reveal { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::RevealTop { player, .. } => {
+        Effect::RevealTop { player, count: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::ExileTop { player, count, .. } => {
+        Effect::ExileTop {
+            player,
+            count,
+            face_down: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::TargetOnly { target, .. } => {
+        Effect::TargetOnly { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::Choose { .. } => Axes::CONSERVATIVE,
-        Effect::ChooseDamageSource { source_filter, .. } => {
+        Effect::ChooseDamageSource { source_filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(source_filter));
             acc
         }
-        Effect::Suspect { target, .. } => {
+        Effect::Suspect { target, scope: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Unsuspect { target, .. } => {
+        Effect::Unsuspect { target, scope: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Connive { target, count, .. } => {
+        Effect::Connive { target, count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::PhaseOut { target, .. } => {
+        Effect::PhaseOut { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::PhaseIn { target, .. } => {
+        Effect::PhaseIn { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ForceBlock { target, .. } => {
+        Effect::ForceBlock { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -765,7 +861,6 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             required_player,
             duration,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -774,26 +869,29 @@ fn scan_effect(x: &Effect) -> Axes {
             acc
         }
         Effect::SolveCase => Axes::NONE,
-        Effect::BecomePrepared { target, .. } => {
+        Effect::BecomePrepared { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::BecomeUnprepared { target, .. } => {
+        Effect::BecomeUnprepared { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::BecomeSaddled { target, .. } => {
+        Effect::BecomeSaddled { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::SetClassLevel { .. } => Axes::NONE,
+        Effect::SetClassLevel { level: _ } => Axes::NONE,
         Effect::CreateDelayedTrigger { .. } => Axes::CONSERVATIVE,
         Effect::AddTargetReplacement { .. } => Axes::CONSERVATIVE,
         Effect::AddRestriction { .. } => Axes::CONSERVATIVE,
-        Effect::ReduceNextSpellCost { spell_filter, .. } => {
+        Effect::ReduceNextSpellCost {
+            spell_filter,
+            amount: _,
+        } => {
             let mut acc = Axes::NONE;
             if let Some(x) = spell_filter {
                 acc = acc.or(scan_target_filter(x));
@@ -803,7 +901,7 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::GrantNextSpellAbility {
             player,
             spell_filter,
-            ..
+            modifier: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_scope(player));
@@ -812,7 +910,10 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::AddPendingETBCounters { count, .. } => {
+        Effect::AddPendingETBCounters {
+            count,
+            counter_type: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
@@ -820,7 +921,13 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::CreateEmblem { .. } => Axes::CONSERVATIVE,
         Effect::PayCost { .. } => Axes::CONSERVATIVE,
         Effect::CastFromZone { .. } => Axes::CONSERVATIVE,
-        Effect::FreeCastFromZones { filter, .. } => {
+        Effect::FreeCastFromZones {
+            filter,
+            count: _,
+            max_total_mv: _,
+            zones: _,
+            exile_instead_of_graveyard: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
@@ -831,7 +938,8 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             damage_source_filter,
             prevention_duration,
-            ..
+            amount: _,
+            scope: _,
         } => {
             let mut acc = Axes::NONE;
             if let Some(x) = amount_dynamic {
@@ -847,21 +955,19 @@ fn scan_effect(x: &Effect) -> Axes {
             acc
         }
         Effect::CreateDamageReplacement { .. } => Axes::CONSERVATIVE,
-        Effect::CreateDrawReplacement {
-            replacement_effect, ..
-        } => {
+        Effect::CreateDrawReplacement { replacement_effect } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_effect(replacement_effect));
             acc
         }
-        Effect::LoseTheGame { target, .. } => {
+        Effect::LoseTheGame { target } => {
             let mut acc = Axes::NONE;
             if let Some(x) = target {
                 acc = acc.or(scan_target_filter(x));
             }
             acc
         }
-        Effect::WinTheGame { target, .. } => {
+        Effect::WinTheGame { target } => {
             let mut acc = Axes::NONE;
             if let Some(x) = target {
                 acc = acc.or(scan_target_filter(x));
@@ -874,33 +980,44 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::FlipCoinUntilLose { .. } => Axes::CONSERVATIVE,
         Effect::RingTemptsYou => Axes::NONE,
         Effect::VentureIntoDungeon => Axes::NONE,
-        Effect::VentureInto { .. } => Axes::NONE,
+        Effect::VentureInto { dungeon: _ } => Axes::NONE,
         Effect::TakeTheInitiative => Axes::NONE,
         Effect::Planeswalk => Axes::NONE,
-        Effect::OpenAttractions { .. } => Axes::NONE,
+        Effect::OpenAttractions { count: _ } => Axes::NONE,
         Effect::RollToVisitAttractions => Axes::NONE,
-        Effect::AssembleContraptions { count, .. } => {
+        Effect::AssembleContraptions { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
         Effect::AssembleContraptionsFromRollDifference => Axes::NONE,
-        Effect::CrankContraptions { target, .. } => {
+        Effect::CrankContraptions { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ReassembleContraption { target, .. } => {
+        Effect::ReassembleContraption {
+            target,
+            control_mode: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::AssembleContraptionOnSprocket { target, .. } => {
+        Effect::AssembleContraptionOnSprocket {
+            target,
+            sprocket: _,
+            remaining: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ReassembleContraptionOnSprocket { target, .. } => {
+        Effect::ReassembleContraptionOnSprocket {
+            target,
+            sprocket: _,
+            control_mode: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -909,7 +1026,8 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             count,
             max_ticket_cost,
-            ..
+            kind: _,
+            ticket_cost_payment: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -919,28 +1037,50 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::ApplySticker { target, .. } => {
+        Effect::ApplySticker {
+            target,
+            sticker: _,
+            pay_ticket: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::ProcessRadCounters => Axes::NONE,
         Effect::GrantCastingPermission { .. } => Axes::CONSERVATIVE,
-        Effect::ChooseFromZone { filter, .. } => {
+        Effect::ChooseFromZone {
+            filter,
+            count: _,
+            zone: _,
+            additional_zones: _,
+            zone_owner: _,
+            chooser: _,
+            up_to: _,
+            selection: _,
+            constraint: _,
+        } => {
             let mut acc = Axes::NONE;
             if let Some(x) = filter {
                 acc = acc.or(scan_target_filter(x));
             }
             acc
         }
-        Effect::RememberCard { target, .. } => {
+        Effect::RememberCard { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ForEachCategoryExile { .. } => Axes::NONE,
+        Effect::ForEachCategoryExile {
+            category: _,
+            zone: _,
+            chooser: _,
+            up_to: _,
+        } => Axes::NONE,
         Effect::ChooseObjectsIntoTrackedSet {
-            chooser, filter, ..
+            chooser,
+            filter,
+            min: _,
+            max: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(chooser));
@@ -951,7 +1091,8 @@ fn scan_effect(x: &Effect) -> Axes {
             choose_filter,
             sacrifice_filter,
             total_power_cap,
-            ..
+            categories: _,
+            chooser_scope: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(choose_filter));
@@ -961,23 +1102,27 @@ fn scan_effect(x: &Effect) -> Axes {
             }
             acc
         }
-        Effect::Exploit { target, .. } => {
+        Effect::Exploit { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::GainEnergy { amount, .. } => {
+        Effect::GainEnergy { amount } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc
         }
-        Effect::GivePlayerCounter { count, target, .. } => {
+        Effect::GivePlayerCounter {
+            count,
+            target,
+            counter_kind: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::LoseAllPlayerCounters { target, .. } => {
+        Effect::LoseAllPlayerCounters { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -988,7 +1133,12 @@ fn scan_effect(x: &Effect) -> Axes {
             filter,
             count,
             enters_under,
-            ..
+            matched_disposition: _,
+            kept_destination: _,
+            rest_destination: _,
+            enter_tapped: _,
+            enters_attacking: _,
+            kept_optional_to: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
@@ -1002,29 +1152,30 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::Discover {
             mana_value_limit,
             player,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(mana_value_limit));
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::Heist { target, .. } => {
+        Effect::Heist {
+            target,
+            look_count: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::HeistExile => Axes::NONE,
         Effect::Cascade => Axes::NONE,
-        Effect::Ripple { .. } => Axes::NONE,
-        Effect::MiracleCast { .. } => Axes::NONE,
-        Effect::MadnessCast { .. } => Axes::NONE,
+        Effect::Ripple { count: _ } => Axes::NONE,
+        Effect::MiracleCast { cost: _ } => Axes::NONE,
+        Effect::MadnessCast { cost: _ } => Axes::NONE,
         Effect::PutAtLibraryPosition { .. } => Axes::CONSERVATIVE,
         Effect::ChooseDrawnThisTurnPayOrTopdeck {
             count,
             life_payment,
             player,
-            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
@@ -1032,42 +1183,42 @@ fn scan_effect(x: &Effect) -> Axes {
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::PutOnTopOrBottom { target, .. } => {
+        Effect::PutOnTopOrBottom { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::GiftDelivery { .. } => Axes::NONE,
-        Effect::Goad { target, .. } => {
+        Effect::GiftDelivery { kind: _ } => Axes::NONE,
+        Effect::Goad { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::GoadAll { target, .. } => {
+        Effect::GoadAll { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Detain { target, .. } => {
+        Effect::Detain { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::SetRoomDoorLock { target, .. } => {
+        Effect::SetRoomDoorLock { target, op: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ExchangeControl {
-            target_a, target_b, ..
-        } => {
+        Effect::ExchangeControl { target_a, target_b } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target_a));
             acc = acc.or(scan_target_filter(target_b));
             acc
         }
         Effect::ChangeTargets {
-            target, forced_to, ..
+            target,
+            forced_to,
+            scope: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -1080,7 +1231,7 @@ fn scan_effect(x: &Effect) -> Axes {
             target,
             count,
             enters_under,
-            ..
+            profile: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
@@ -1091,84 +1242,98 @@ fn scan_effect(x: &Effect) -> Axes {
             acc
         }
         Effect::ManifestDread => Axes::NONE,
-        Effect::Cloak { target, count, .. } => {
+        Effect::Cloak { target, count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::TurnFaceUp { target, .. } => {
+        Effect::TurnFaceUp { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::TurnFaceDown { target, .. } => {
+        Effect::TurnFaceDown { target, profile: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::ExtraTurn { target, .. } => {
+        Effect::ExtraTurn { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::GrantExtraLoyaltyActivations { amount, target, .. } => {
+        Effect::GrantExtraLoyaltyActivations { amount, target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::SkipNextTurn { target, count, .. } => {
+        Effect::SkipNextTurn { target, count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::SkipNextStep { target, count, .. } => {
+        Effect::SkipNextStep {
+            target,
+            count,
+            step: _,
+            scope: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::AdditionalPhase { target, count, .. } => {
+        Effect::AdditionalPhase {
+            target,
+            count,
+            phase: _,
+            after: _,
+            followed_by: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::Double { target, .. } => {
+        Effect::Double {
+            target,
+            target_kind: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::RuntimeHandled { .. } => Axes::NONE,
-        Effect::Incubate { count, .. } => {
+        Effect::RuntimeHandled { handler: _ } => Axes::NONE,
+        Effect::Incubate { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::Amass { count, .. } => {
+        Effect::Amass { count, subtype: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::Monstrosity { count, .. } => {
+        Effect::Monstrosity { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
         Effect::Specialize => Axes::NONE,
-        Effect::Renown { count, .. } => {
+        Effect::Renown { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::Bolster { count, .. } => {
+        Effect::Bolster { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::Adapt { count, .. } => {
+        Effect::Adapt { count } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(count));
             acc
@@ -1176,73 +1341,82 @@ fn scan_effect(x: &Effect) -> Axes {
         Effect::Learn => Axes::NONE,
         Effect::Forage => Axes::NONE,
         Effect::Harness => Axes::NONE,
-        Effect::CollectEvidence { .. } => Axes::NONE,
-        Effect::Endure {
-            amount, subject, ..
-        } => {
+        Effect::CollectEvidence { amount: _ } => Axes::NONE,
+        Effect::Endure { amount, subject } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc = acc.or(scan_target_filter(subject));
             acc
         }
-        Effect::BlightEffect { player, .. } => {
+        Effect::BlightEffect { player, count: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::Seek { filter, count, .. } => {
+        Effect::Seek {
+            filter,
+            count,
+            from_top: _,
+            destination: _,
+            enter_tapped: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        Effect::SetLifeTotal { target, amount, .. } => {
+        Effect::SetLifeTotal { target, amount } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_quantity_expr(amount));
             acc
         }
-        Effect::ExchangeLifeWithStat { player, .. } => {
+        Effect::ExchangeLifeWithStat { player, stat: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player));
             acc
         }
-        Effect::ExchangeLifeTotals {
-            player_a, player_b, ..
-        } => {
+        Effect::ExchangeLifeTotals { player_a, player_b } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(player_a));
             acc = acc.or(scan_target_filter(player_b));
             acc
         }
-        Effect::SetDayNight { .. } => Axes::NONE,
-        Effect::GiveControl {
-            target, recipient, ..
-        } => {
+        Effect::SetDayNight { to: _ } => Axes::NONE,
+        Effect::GiveControl { target, recipient } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc = acc.or(scan_target_filter(recipient));
             acc
         }
-        Effect::RemoveFromCombat { target, .. } => {
+        Effect::RemoveFromCombat { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
         Effect::Conjure { .. } => Axes::CONSERVATIVE,
-        Effect::ApplyPerpetual { target, .. } => {
+        Effect::ApplyPerpetual {
+            target,
+            modification: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
         }
-        Effect::Intensify { amount, .. } => {
+        Effect::Intensify { amount, scope: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(amount));
             acc
         }
-        Effect::DraftFromSpellbook { .. } => Axes::NONE,
+        Effect::DraftFromSpellbook {
+            destination: _,
+            tapped: _,
+        } => Axes::NONE,
         Effect::ChooseOneOf { .. } => Axes::CONSERVATIVE,
-        Effect::Unimplemented { .. } => Axes::NONE,
+        Effect::Unimplemented {
+            name: _,
+            description: _,
+        } => Axes::NONE,
     }
 }
 
@@ -1253,7 +1427,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        QuantityRef::LifeTotal { player, .. } => {
+        QuantityRef::LifeTotal { player } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1273,7 +1447,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             projected: true,
         },
         QuantityRef::StartingLifeTotal => Axes::NONE,
-        QuantityRef::ObjectCount { filter, .. } => {
+        QuantityRef::ObjectCount { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1282,7 +1456,10 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::ObjectCountDistinct { filter, .. } => {
+        QuantityRef::ObjectCountDistinct {
+            filter,
+            qualities: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1291,7 +1468,11 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::ObjectCountBySharedQuality { filter, .. } => {
+        QuantityRef::ObjectCountBySharedQuality {
+            filter,
+            quality: _,
+            aggregate: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1300,7 +1481,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::PlayerCount { filter, .. } => {
+        QuantityRef::PlayerCount { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(filter));
             acc
@@ -1314,7 +1495,10 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_object_scope(scope));
             acc
         }
-        QuantityRef::CountersOnObjects { filter, .. } => {
+        QuantityRef::CountersOnObjects {
+            filter,
+            counter_type: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1323,7 +1507,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::PlayerCounter { scope, .. } => {
+        QuantityRef::PlayerCounter { scope, kind: _ } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1332,7 +1516,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_count_scope(scope));
             acc
         }
-        QuantityRef::Variable { .. } => Axes::NONE,
+        QuantityRef::Variable { name: _ } => Axes::NONE,
         QuantityRef::Power { scope, .. } => {
             let mut acc = Axes {
                 event: false,
@@ -1369,7 +1553,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_object_scope(scope));
             acc
         }
-        QuantityRef::TargetObjectManaValue { filter, .. } => {
+        QuantityRef::TargetObjectManaValue { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1415,7 +1599,11 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::SelfManaValue => Axes::NONE,
-        QuantityRef::Aggregate { filter, .. } => {
+        QuantityRef::Aggregate {
+            filter,
+            function: _,
+            property: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1424,7 +1612,10 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::ControlledByEachPlayer { filter, .. } => {
+        QuantityRef::ControlledByEachPlayer {
+            filter,
+            aggregate: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1433,7 +1624,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::TargetZoneCardCount { .. } => Axes::NONE,
+        QuantityRef::TargetZoneCardCount { zone: _ } => Axes::NONE,
         QuantityRef::Devotion { .. } => Axes {
             event: false,
             sibling: true,
@@ -1441,8 +1632,13 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
         },
         QuantityRef::DistinctCardTypes { .. } => Axes::CONSERVATIVE,
         QuantityRef::CardsExiledBySource => Axes::NONE,
-        QuantityRef::ExiledCardPower { .. } => Axes::NONE,
-        QuantityRef::ZoneCardCount { filter, scope, .. } => {
+        QuantityRef::ExiledCardPower { index: _ } => Axes::NONE,
+        QuantityRef::ZoneCardCount {
+            filter,
+            scope,
+            zone: _,
+            card_types: _,
+        } => {
             let mut acc = Axes::NONE;
             if let Some(x) = filter {
                 acc = acc.or(scan_target_filter(x));
@@ -1456,15 +1652,21 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::TrackedSetSize => Axes::NONE,
-        QuantityRef::FilteredTrackedSetSize { filter, .. } => {
+        QuantityRef::FilteredTrackedSetSize {
+            filter,
+            caused_by: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::TrackedSetAggregate { .. } => Axes::NONE,
+        QuantityRef::TrackedSetAggregate {
+            function: _,
+            property: _,
+        } => Axes::NONE,
         QuantityRef::ExiledFromHandThisResolution => Axes::NONE,
         QuantityRef::PreviousEffectAmount => Axes::NONE,
-        QuantityRef::LifeLostThisTurn { player, .. } => {
+        QuantityRef::LifeLostThisTurn { player } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1478,7 +1680,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        QuantityRef::UnspentMana { .. } => Axes {
+        QuantityRef::UnspentMana { color: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -1505,7 +1707,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             sibling: false,
             projected: false,
         },
-        QuantityRef::SpellsCastThisTurn { scope, filter, .. } => {
+        QuantityRef::SpellsCastThisTurn { scope, filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1517,7 +1719,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             }
             acc
         }
-        QuantityRef::EnteredThisTurn { filter, .. } => {
+        QuantityRef::EnteredThisTurn { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1526,7 +1728,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::SacrificedThisTurn { player, filter, .. } => {
+        QuantityRef::SacrificedThisTurn { player, filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1537,7 +1739,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::CrimesCommittedThisTurn => Axes::NONE,
-        QuantityRef::LifeGainedThisTurn { player, .. } => {
+        QuantityRef::LifeGainedThisTurn { player } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1546,7 +1748,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        QuantityRef::CardsDrawnThisTurn { player, .. } => {
+        QuantityRef::CardsDrawnThisTurn { player } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1555,7 +1757,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        QuantityRef::BattlefieldEntriesThisTurn { player, filter, .. } => {
+        QuantityRef::BattlefieldEntriesThisTurn { player, filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1571,7 +1773,11 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::TurnsTaken => Axes::NONE,
-        QuantityRef::ZoneChangeCountThisTurn { filter, .. } => {
+        QuantityRef::ZoneChangeCountThisTurn {
+            filter,
+            from: _,
+            to: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1580,7 +1786,13 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::ZoneChangeAggregateThisTurn { filter, .. } => {
+        QuantityRef::ZoneChangeAggregateThisTurn {
+            filter,
+            from: _,
+            to: _,
+            function: _,
+            property: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1589,7 +1801,14 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::DamageDealtThisTurn { source, target, .. } => {
+        QuantityRef::DamageDealtThisTurn {
+            source,
+            target,
+            aggregate: _,
+            group_by: _,
+            damage_kind: _,
+            channel: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1600,7 +1819,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::ChosenNumber => Axes::NONE,
-        QuantityRef::AttackedThisTurn { scope, filter, .. } => {
+        QuantityRef::AttackedThisTurn { scope, filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_count_scope(scope));
             if let Some(x) = filter {
@@ -1609,7 +1828,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc
         }
         QuantityRef::DescendedThisTurn => Axes::NONE,
-        QuantityRef::LoyaltyAbilitiesActivatedThisTurn { player, .. } => {
+        QuantityRef::LoyaltyAbilitiesActivatedThisTurn { player } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1623,7 +1842,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             sibling: false,
             projected: true,
         },
-        QuantityRef::SpellsCastThisGame { scope, filter, .. } => {
+        QuantityRef::SpellsCastThisGame { scope, filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1635,7 +1854,11 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             }
             acc
         }
-        QuantityRef::CounterAddedThisTurn { actor, target, .. } => {
+        QuantityRef::CounterAddedThisTurn {
+            actor,
+            target,
+            counters: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1650,7 +1873,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        QuantityRef::TokensCreatedThisTurn { player, filter, .. } => {
+        QuantityRef::TokensCreatedThisTurn { player, filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1660,7 +1883,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::PlayerActionsThisTurn { player, .. } => {
+        QuantityRef::PlayerActionsThisTurn { player, action: _ } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -1673,7 +1896,10 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
         QuantityRef::CostXPaid => Axes::NONE,
         QuantityRef::KickerCount => Axes::NONE,
         QuantityRef::AdditionalCostPaymentCount => Axes::NONE,
-        QuantityRef::AdditionalCostPaymentCountFor { .. } => Axes::NONE,
+        QuantityRef::AdditionalCostPaymentCountFor {
+            origin: _,
+            origin_ordinal: _,
+        } => Axes::NONE,
         QuantityRef::ConvokedCreatureCount => Axes::NONE,
         QuantityRef::TimesCostPaidThisResolution => Axes {
             event: true,
@@ -1688,7 +1914,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_controller_ref(owner));
             acc
         }
-        QuantityRef::DistinctColorsAmongPermanents { filter, .. } => {
+        QuantityRef::DistinctColorsAmongPermanents { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1697,7 +1923,7 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::DistinctCounterKindsAmong { filter, .. } => {
+        QuantityRef::DistinctCounterKindsAmong { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -1706,62 +1932,66 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        QuantityRef::VoteCount { .. } => Axes::NONE,
+        QuantityRef::VoteCount { choice_index: _ } => Axes::NONE,
     }
 }
 
 fn scan_quantity_expr(x: &QuantityExpr) -> Axes {
     match x {
-        QuantityExpr::Ref { qty, .. } => {
+        QuantityExpr::Ref { qty } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_ref(qty));
             acc
         }
-        QuantityExpr::Fixed { .. } => Axes::NONE,
-        QuantityExpr::DivideRounded { inner, .. } => {
+        QuantityExpr::Fixed { value: _ } => Axes::NONE,
+        QuantityExpr::DivideRounded {
+            inner,
+            divisor: _,
+            rounding: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(inner));
             acc
         }
-        QuantityExpr::Offset { inner, .. } => {
+        QuantityExpr::Offset { inner, offset: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(inner));
             acc
         }
-        QuantityExpr::ClampMin { inner, .. } => {
+        QuantityExpr::ClampMin { inner, minimum: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(inner));
             acc
         }
-        QuantityExpr::Multiply { inner, .. } => {
+        QuantityExpr::Multiply { inner, factor: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(inner));
             acc
         }
-        QuantityExpr::Sum { exprs, .. } => {
+        QuantityExpr::Sum { exprs } => {
             let mut acc = Axes::NONE;
             for x in exprs {
                 acc = acc.or(scan_quantity_expr(x));
             }
             acc
         }
-        QuantityExpr::UpTo { max, .. } => {
+        QuantityExpr::UpTo { max } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(max));
             acc
         }
-        QuantityExpr::Power { exponent, .. } => {
+        QuantityExpr::Power { exponent, base: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(exponent));
             acc
         }
-        QuantityExpr::Difference { left, right, .. } => {
+        QuantityExpr::Difference { left, right } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(left));
             acc = acc.or(scan_quantity_expr(right));
             acc
         }
-        QuantityExpr::Max { exprs, .. } => {
+        QuantityExpr::Max { exprs } => {
             let mut acc = Axes::NONE;
             for x in exprs {
                 acc = acc.or(scan_quantity_expr(x));
@@ -1780,24 +2010,29 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
         }
         AbilityCondition::AdditionalCostPaidInstead => Axes::NONE,
         AbilityCondition::AlternativeManaCostPaid => Axes::NONE,
-        AbilityCondition::EffectOutcome { .. } => Axes::NONE,
+        AbilityCondition::EffectOutcome { signal: _ } => Axes::NONE,
         AbilityCondition::EventOutcomeWon => Axes::NONE,
         AbilityCondition::WhenYouDo => Axes::NONE,
-        AbilityCondition::CastFromZone { .. } => Axes::NONE,
-        AbilityCondition::CastDuringPhase { .. } => Axes::NONE,
-        AbilityCondition::CurrentPhaseIs { .. } => Axes::NONE,
-        AbilityCondition::CastTimingPermission { .. } => Axes::NONE,
-        AbilityCondition::ManaColorSpent { .. } => Axes::NONE,
+        AbilityCondition::CastFromZone { zone: _ } => Axes::NONE,
+        AbilityCondition::CastDuringPhase { phases: _ } => Axes::NONE,
+        AbilityCondition::CurrentPhaseIs { phases: _ } => Axes::NONE,
+        AbilityCondition::CastTimingPermission { permission: _ } => Axes::NONE,
+        AbilityCondition::ManaColorSpent {
+            color: _,
+            minimum: _,
+        } => Axes::NONE,
         AbilityCondition::RevealedHasCardType { .. } => Axes::CONSERVATIVE,
         AbilityCondition::ObjectsShareQuality {
-            subject, reference, ..
+            subject,
+            reference,
+            quality: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(subject));
             acc = acc.or(scan_target_filter(reference));
             acc
         }
-        AbilityCondition::TargetSharesNameWithOtherExiledThisWay { target, .. } => {
+        AbilityCondition::TargetSharesNameWithOtherExiledThisWay { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target));
             acc
@@ -1812,14 +2047,22 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             acc = acc.or(scan_object_scope(subject));
             acc
         }
-        AbilityCondition::CastVariantPaidInstead { .. } => Axes::NONE,
-        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+        AbilityCondition::CastVariantPaidInstead { variant: _ } => Axes::NONE,
+        AbilityCondition::QuantityCheck {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(lhs));
             acc = acc.or(scan_quantity_expr(rhs));
             acc
         }
-        AbilityCondition::PreviousEffectAmount { rhs, .. } => {
+        AbilityCondition::PreviousEffectAmount {
+            rhs,
+            comparator: _,
+            channel: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(rhs));
             acc
@@ -1829,14 +2072,14 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
         AbilityCondition::IsInitiative => Axes::NONE,
         AbilityCondition::HasCityBlessing => Axes::NONE,
         AbilityCondition::IsRingBearer => Axes::NONE,
-        AbilityCondition::TargetHasKeywordInstead { .. } => Axes::NONE,
-        AbilityCondition::TargetMatchesFilter { filter, .. } => {
+        AbilityCondition::TargetHasKeywordInstead { keyword: _ } => Axes::NONE,
+        AbilityCondition::TargetMatchesFilter { filter, use_lki: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
         AbilityCondition::HasObjectTarget => Axes::NONE,
-        AbilityCondition::TriggeringSpellTargetsFilter { filter, .. } => {
+        AbilityCondition::TriggeringSpellTargetsFilter { filter } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -1845,12 +2088,16 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        AbilityCondition::SourceMatchesFilter { filter, .. } => {
+        AbilityCondition::SourceMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        AbilityCondition::ZoneChangeObjectMatchesFilter { filter, .. } => {
+        AbilityCondition::ZoneChangeObjectMatchesFilter {
+            filter,
+            origin: _,
+            destination: _,
+        } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -1859,12 +2106,12 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        AbilityCondition::ControllerControlsMatching { filter, .. } => {
+        AbilityCondition::ControllerControlsMatching { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        AbilityCondition::ControllerControlledMatchingAsCast { filter, .. } => {
+        AbilityCondition::ControllerControlledMatchingAsCast { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
@@ -1875,7 +2122,7 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             acc = acc.or(scan_controller_ref(controller));
             acc
         }
-        AbilityCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+        AbilityCondition::SpellCastWithVariantThisTurn { variant: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -1890,7 +2137,7 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        AbilityCondition::ZoneChangedThisWay { filter, .. } => {
+        AbilityCondition::ZoneChangedThisWay { filter } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -1899,46 +2146,46 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        AbilityCondition::CostPaidObjectMatchesFilter { filter, .. } => {
+        AbilityCondition::CostPaidObjectMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
         AbilityCondition::SourceIsTapped => Axes::NONE,
         AbilityCondition::SourceAttachedToCreature => Axes::NONE,
-        AbilityCondition::ConditionInstead { inner, .. } => {
+        AbilityCondition::ConditionInstead { inner } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_ability_condition(inner));
             acc
         }
-        AbilityCondition::And { conditions, .. } => {
+        AbilityCondition::And { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_ability_condition(x));
             }
             acc
         }
-        AbilityCondition::Or { conditions, .. } => {
+        AbilityCondition::Or { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_ability_condition(x));
             }
             acc
         }
-        AbilityCondition::Not { condition, .. } => {
+        AbilityCondition::Not { condition } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_ability_condition(condition));
             acc
         }
         AbilityCondition::DayNightIsNeither => Axes::NONE,
-        AbilityCondition::DayNightIs { .. } => Axes::NONE,
-        AbilityCondition::NthResolutionThisTurn { .. } => Axes {
+        AbilityCondition::DayNightIs { state: _ } => Axes::NONE,
+        AbilityCondition::NthResolutionThisTurn { n: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
-        AbilityCondition::SourceLacksKeyword { .. } => Axes::NONE,
-        AbilityCondition::ScopedPlayerMatches { filter, .. } => {
+        AbilityCondition::SourceLacksKeyword { keyword: _ } => Axes::NONE,
+        AbilityCondition::ScopedPlayerMatches { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(filter));
             acc
@@ -1955,19 +2202,19 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
         TargetFilter::SelfRef => Axes::NONE,
         TargetFilter::SourceOrPaired => Axes::NONE,
         TargetFilter::Typed(..) => Axes::CONSERVATIVE,
-        TargetFilter::Not { filter, .. } => {
+        TargetFilter::Not { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        TargetFilter::Or { filters, .. } => {
+        TargetFilter::Or { filters } => {
             let mut acc = Axes::NONE;
             for x in filters {
                 acc = acc.or(scan_target_filter(x));
             }
             acc
         }
-        TargetFilter::And { filters, .. } => {
+        TargetFilter::And { filters } => {
             let mut acc = Axes::NONE;
             for x in filters {
                 acc = acc.or(scan_target_filter(x));
@@ -1982,9 +2229,9 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
             acc
         }
         TargetFilter::StackSpell => Axes::NONE,
-        TargetFilter::SpecificObject { .. } => Axes::NONE,
-        TargetFilter::SpecificPlayer { .. } => Axes::NONE,
-        TargetFilter::Neighbor { .. } => Axes::NONE,
+        TargetFilter::SpecificObject { id: _ } => Axes::NONE,
+        TargetFilter::SpecificPlayer { id: _ } => Axes::NONE,
+        TargetFilter::Neighbor { direction: _ } => Axes::NONE,
         TargetFilter::ScopedPlayer => Axes::NONE,
         TargetFilter::AttachedTo => Axes::NONE,
         TargetFilter::LastCreated => Axes::NONE,
@@ -1995,14 +2242,18 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
             projected: false,
         },
         TargetFilter::ChosenCard => Axes::NONE,
-        TargetFilter::TrackedSet { .. } => Axes::NONE,
-        TargetFilter::TrackedSetFiltered { filter, .. } => {
+        TargetFilter::TrackedSet { id: _ } => Axes::NONE,
+        TargetFilter::TrackedSetFiltered {
+            filter,
+            id: _,
+            caused_by: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
         TargetFilter::ExiledBySource => Axes::NONE,
-        TargetFilter::ExiledCardByIndex { .. } => Axes::NONE,
+        TargetFilter::ExiledCardByIndex { index: _ } => Axes::NONE,
         TargetFilter::TriggeringSpellController => Axes {
             event: true,
             sibling: false,
@@ -2077,7 +2328,7 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
             sibling: false,
             projected: false,
         },
-        TargetFilter::Named { .. } => Axes::NONE,
+        TargetFilter::Named { name: _ } => Axes::NONE,
         TargetFilter::Owner => Axes::NONE,
         TargetFilter::AllPlayers => Axes::NONE,
     }
@@ -2110,7 +2361,7 @@ fn scan_object_scope(x: &ObjectScope) -> Axes {
 
 fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
     match x {
-        TriggerCondition::GainedLife { .. } => Axes {
+        TriggerCondition::GainedLife { minimum: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -2121,7 +2372,7 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             projected: true,
         },
         TriggerCondition::Descended => Axes::NONE,
-        TriggerCondition::ControlsType { filter, .. } => {
+        TriggerCondition::ControlsType { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -2140,7 +2391,7 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        TriggerCondition::DuringPlayersTurn { player, .. } => {
+        TriggerCondition::DuringPlayersTurn { player } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(player));
             acc
@@ -2151,7 +2402,7 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             projected: true,
         },
         TriggerCondition::EchoDue => Axes::NONE,
-        TriggerCondition::MinCoAttackers { filter, .. } => {
+        TriggerCondition::MinCoAttackers { filter, minimum: _ } => {
             let mut acc = Axes::NONE;
             if let Some(x) = filter {
                 acc = acc.or(scan_target_filter(x));
@@ -2159,9 +2410,9 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc
         }
         TriggerCondition::SolveConditionMet => Axes::NONE,
-        TriggerCondition::ClassLevelGE { .. } => Axes::NONE,
+        TriggerCondition::ClassLevelGE { level: _ } => Axes::NONE,
         TriggerCondition::SourceIsHarnessed => Axes::NONE,
-        TriggerCondition::AttractionVisitRoll { .. } => Axes::NONE,
+        TriggerCondition::AttractionVisitRoll { min: _, max: _ } => Axes::NONE,
         TriggerCondition::WasCast {
             controller, owner, ..
         } => {
@@ -2175,17 +2426,24 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc
         }
         TriggerCondition::WasPlayed => Axes::NONE,
-        TriggerCondition::AdditionalCostPaid { .. } => Axes::NONE,
+        TriggerCondition::AdditionalCostPaid {
+            source: _,
+            origin: _,
+            origin_ordinal: _,
+            variant: _,
+            kicker_cost: _,
+            min_count: _,
+        } => Axes::NONE,
         TriggerCondition::SourceIsAttacking => Axes::NONE,
-        TriggerCondition::CastVariantPaid { .. } => Axes::NONE,
-        TriggerCondition::CastVariantPaidPersistent { .. } => Axes::NONE,
+        TriggerCondition::CastVariantPaid { variant: _ } => Axes::NONE,
+        TriggerCondition::CastVariantPaidPersistent { variant: _ } => Axes::NONE,
         TriggerCondition::ActivatedAbilityIsNonMana => Axes::NONE,
         TriggerCondition::DealtDamageBySourceThisTurn => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
-        TriggerCondition::DealtDamageThisTurnBySource { source, .. } => {
+        TriggerCondition::DealtDamageThisTurnBySource { source } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -2195,13 +2453,13 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc
         }
         TriggerCondition::FirstTimeObjectTappedThisTurn => Axes::NONE,
-        TriggerCondition::WasType { .. } => Axes::NONE,
-        TriggerCondition::LifeTotalGE { .. } => Axes {
+        TriggerCondition::WasType { card_type: _ } => Axes::NONE,
+        TriggerCondition::LifeTotalGE { minimum: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
-        TriggerCondition::ControlCount { filter, .. } => {
+        TriggerCondition::ControlCount { filter, minimum: _ } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -2210,7 +2468,7 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        TriggerCondition::ControlsNone { filter, .. } => {
+        TriggerCondition::ControlsNone { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
@@ -2221,7 +2479,7 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        TriggerCondition::CastSpellThisTurn { filter, .. } => {
+        TriggerCondition::CastSpellThisTurn { filter } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -2232,7 +2490,11 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             }
             acc
         }
-        TriggerCondition::QuantityComparison { lhs, rhs, .. } => {
+        TriggerCondition::QuantityComparison {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(lhs));
             acc = acc.or(scan_quantity_expr(rhs));
@@ -2247,18 +2509,18 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc = acc.or(scan_controller_ref(controller));
             acc
         }
-        TriggerCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+        TriggerCondition::SpellCastWithVariantThisTurn { variant: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
         TriggerCondition::HasCityBlessing => Axes::NONE,
-        TriggerCondition::CompletedDungeon { .. } => Axes::NONE,
+        TriggerCondition::CompletedDungeon { specific: _ } => Axes::NONE,
         TriggerCondition::SourceIsTapped => Axes::NONE,
         TriggerCondition::SourceIsTransformed => Axes::NONE,
         TriggerCondition::SourceIsFaceUp => Axes::NONE,
         TriggerCondition::SourceIsFaceDown => Axes::NONE,
-        TriggerCondition::SourceInZone { .. } => Axes::NONE,
+        TriggerCondition::SourceInZone { zone: _ } => Axes::NONE,
         TriggerCondition::CounterAddedThisTurn => Axes {
             event: false,
             sibling: false,
@@ -2269,20 +2531,23 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        TriggerCondition::DefendingPlayerControlsNone { filter, .. } => {
+        TriggerCondition::DefendingPlayerControlsNone { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
         TriggerCondition::TributeNotPaid => Axes::NONE,
-        TriggerCondition::CastDuringPhase { .. } => Axes::NONE,
-        TriggerCondition::CastTimingPermission { .. } => Axes::NONE,
-        TriggerCondition::ManaColorSpent { .. } => Axes {
+        TriggerCondition::CastDuringPhase { phases: _ } => Axes::NONE,
+        TriggerCondition::CastTimingPermission { permission: _ } => Axes::NONE,
+        TriggerCondition::ManaColorSpent {
+            color: _,
+            minimum: _,
+        } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
-        TriggerCondition::ManaSpentCondition { .. } => Axes {
+        TriggerCondition::ManaSpentCondition { text: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -2292,14 +2557,18 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: true,
             projected: false,
         },
-        TriggerCondition::ControlsCommander { .. } => Axes::NONE,
-        TriggerCondition::IsRenowned { .. } => Axes::NONE,
+        TriggerCondition::ControlsCommander { ownership: _ } => Axes::NONE,
+        TriggerCondition::IsRenowned { subject: _ } => Axes::NONE,
         TriggerCondition::HasCounters { .. } => Axes {
             event: false,
             sibling: true,
             projected: false,
         },
-        TriggerCondition::ZoneChangeObjectMatchesFilter { filter, .. } => {
+        TriggerCondition::ZoneChangeObjectMatchesFilter {
+            filter,
+            origin: _,
+            destination: _,
+        } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -2313,12 +2582,12 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: false,
             projected: false,
         },
-        TriggerCondition::SourceMatchesFilter { filter, .. } => {
+        TriggerCondition::SourceMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        TriggerCondition::EventDamageSourceMatchesFilter { filter, .. } => {
+        TriggerCondition::EventDamageSourceMatchesFilter { filter } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -2332,11 +2601,11 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             sibling: false,
             projected: false,
         },
-        TriggerCondition::ChosenLabelIs { .. } => Axes::NONE,
+        TriggerCondition::ChosenLabelIs { label: _ } => Axes::NONE,
         TriggerCondition::AttackersDeclaredCount { .. } => Axes::CONSERVATIVE,
         TriggerCondition::ExceptFirstDrawInDrawStep => Axes::NONE,
         TriggerCondition::PlacedByAbilitySource => Axes::NONE,
-        TriggerCondition::TriggeringSpellTargetsFilter { filter, .. } => {
+        TriggerCondition::TriggeringSpellTargetsFilter { filter } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,
@@ -2345,21 +2614,21 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        TriggerCondition::And { conditions, .. } => {
+        TriggerCondition::And { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_trigger_condition(x));
             }
             acc
         }
-        TriggerCondition::Or { conditions, .. } => {
+        TriggerCondition::Or { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_trigger_condition(x));
             }
             acc
         }
-        TriggerCondition::Not { condition, .. } => {
+        TriggerCondition::Not { condition } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_trigger_condition(condition));
             acc
@@ -2387,7 +2656,7 @@ fn scan_duration(x: &Duration) -> Axes {
             acc = acc.or(scan_player_scope(player));
             acc
         }
-        Duration::ForAsLongAs { condition, .. } => {
+        Duration::ForAsLongAs { condition } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_static_condition(condition));
             acc
@@ -2403,56 +2672,60 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
             sibling: true,
             projected: false,
         },
-        StaticCondition::IsPresent { filter, .. } => {
+        StaticCondition::IsPresent { filter } => {
             let mut acc = Axes::NONE;
             if let Some(x) = filter {
                 acc = acc.or(scan_target_filter(x));
             }
             acc
         }
-        StaticCondition::ChosenColorIs { .. } => Axes::NONE,
-        StaticCondition::ChosenLabelIs { .. } => Axes::NONE,
-        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+        StaticCondition::ChosenColorIs { color: _ } => Axes::NONE,
+        StaticCondition::ChosenLabelIs { label: _ } => Axes::NONE,
+        StaticCondition::QuantityComparison {
+            lhs,
+            rhs,
+            comparator: _,
+        } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(lhs));
             acc = acc.or(scan_quantity_expr(rhs));
             acc
         }
         StaticCondition::HasMaxSpeed => Axes::NONE,
-        StaticCondition::SpeedGE { .. } => Axes::NONE,
-        StaticCondition::And { conditions, .. } => {
+        StaticCondition::SpeedGE { threshold: _ } => Axes::NONE,
+        StaticCondition::And { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_static_condition(x));
             }
             acc
         }
-        StaticCondition::Or { conditions, .. } => {
+        StaticCondition::Or { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_static_condition(x));
             }
             acc
         }
-        StaticCondition::Not { condition, .. } => {
+        StaticCondition::Not { condition } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_static_condition(condition));
             acc
         }
-        StaticCondition::DayNightIs { .. } => Axes::NONE,
+        StaticCondition::DayNightIs { state: _ } => Axes::NONE,
         StaticCondition::HasCounters { .. } => Axes {
             event: false,
             sibling: true,
             projected: false,
         },
-        StaticCondition::CastVariantPaid { .. } => Axes::NONE,
+        StaticCondition::CastVariantPaid { variant: _ } => Axes::NONE,
         StaticCondition::RecipientHasCounters { .. } => Axes {
             event: false,
             sibling: true,
             projected: false,
         },
-        StaticCondition::ClassLevelGE { .. } => Axes::NONE,
-        StaticCondition::DefendingPlayerControls { filter, .. } => {
+        StaticCondition::ClassLevelGE { level: _ } => Axes::NONE,
+        StaticCondition::DefendingPlayerControls { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
@@ -2471,18 +2744,18 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
             acc = acc.or(scan_controller_ref(controller));
             acc
         }
-        StaticCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+        StaticCondition::SpellCastWithVariantThisTurn { variant: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
-        StaticCondition::OpponentPoisonAtLeast { .. } => Axes {
+        StaticCondition::OpponentPoisonAtLeast { count: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
         },
         StaticCondition::UnlessPay { .. } => Axes::CONSERVATIVE,
-        StaticCondition::Unrecognized { .. } => Axes::NONE,
+        StaticCondition::Unrecognized { text: _ } => Axes::NONE,
         StaticCondition::DuringYourTurn => Axes::NONE,
         StaticCondition::SharesColorWithMostCommonColorAmongPermanents => Axes::NONE,
         StaticCondition::SourceEnteredThisTurn => Axes {
@@ -2495,10 +2768,10 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        StaticCondition::WasCast { .. } => Axes::NONE,
+        StaticCondition::WasCast { zone: _ } => Axes::NONE,
         StaticCondition::IsRingBearer => Axes::NONE,
-        StaticCondition::RingLevelAtLeast { .. } => Axes::NONE,
-        StaticCondition::ControlsCommander { .. } => Axes::NONE,
+        StaticCondition::RingLevelAtLeast { level: _ } => Axes::NONE,
+        StaticCondition::ControlsCommander { ownership: _ } => Axes::NONE,
         StaticCondition::SourceIsTapped => Axes::NONE,
         StaticCondition::IsTapped { scope, .. } => {
             let mut acc = Axes::NONE;
@@ -2506,28 +2779,28 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
             acc
         }
         StaticCondition::SourceIsSaddled => Axes::NONE,
-        StaticCondition::SourceControllerEquals { .. } => Axes::NONE,
+        StaticCondition::SourceControllerEquals { player: _ } => Axes::NONE,
         StaticCondition::SourceIsEquipped => Axes::NONE,
         StaticCondition::SourceIsEnchanted => Axes::NONE,
         StaticCondition::SourceIsMonstrous => Axes::NONE,
         StaticCondition::SourceIsHarnessed => Axes::NONE,
         StaticCondition::SourceAttachedToCreature => Axes::NONE,
-        StaticCondition::SourceMatchesFilter { filter, .. } => {
+        StaticCondition::SourceMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        StaticCondition::RecipientMatchesFilter { filter, .. } => {
+        StaticCondition::RecipientMatchesFilter { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        StaticCondition::RecipientAttackingOwnerTarget { .. } => Axes::NONE,
+        StaticCondition::RecipientAttackingOwnerTarget { target: _ } => Axes::NONE,
         StaticCondition::SourceIsPaired => Axes::NONE,
-        StaticCondition::SourceInZone { .. } => Axes::NONE,
+        StaticCondition::SourceInZone { zone: _ } => Axes::NONE,
         StaticCondition::EnchantedIsFaceDown => Axes::NONE,
         StaticCondition::AdditionalCostPaid => Axes::NONE,
-        StaticCondition::CastingAsVariant { .. } => Axes::NONE,
+        StaticCondition::CastingAsVariant { variant: _ } => Axes::NONE,
         StaticCondition::None => Axes::NONE,
     }
 }
@@ -2548,7 +2821,7 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             projected: true,
         },
         PlayerFilter::HasLostTheGame => Axes::NONE,
-        PlayerFilter::OpponentDealtCombatDamage { source, .. } => {
+        PlayerFilter::OpponentDealtCombatDamage { source } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -2559,16 +2832,22 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             }
             acc
         }
-        PlayerFilter::OpponentAttacked { .. } => Axes::NONE,
+        PlayerFilter::OpponentAttacked {
+            subject: _,
+            scope: _,
+        } => Axes::NONE,
         PlayerFilter::All => Axes::NONE,
-        PlayerFilter::AllExcept { exclude, .. } => {
+        PlayerFilter::AllExcept { exclude } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_player_filter(exclude));
             acc
         }
         PlayerFilter::HighestSpeed => Axes::NONE,
         PlayerFilter::ZoneChangedThisWay => Axes::NONE,
-        PlayerFilter::PerformedActionThisWay { .. } => Axes::NONE,
+        PlayerFilter::PerformedActionThisWay {
+            relation: _,
+            action: _,
+        } => Axes::NONE,
         PlayerFilter::OwnersOfCardsExiledBySource => Axes::NONE,
         PlayerFilter::TriggeringPlayer => Axes {
             event: true,
@@ -2590,13 +2869,18 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             sibling: false,
             projected: false,
         },
-        PlayerFilter::VotedFor { .. } => Axes::NONE,
+        PlayerFilter::VotedFor { choice_index: _ } => Axes::NONE,
         PlayerFilter::ParentObjectTargetController => Axes {
             event: true,
             sibling: false,
             projected: false,
         },
-        PlayerFilter::ControlsCount { filter, count, .. } => {
+        PlayerFilter::ControlsCount {
+            filter,
+            count,
+            relation: _,
+            comparator: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: true,
@@ -2606,7 +2890,12 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             acc = acc.or(scan_quantity_expr(count));
             acc
         }
-        PlayerFilter::PlayerAttribute { attr, value, .. } => {
+        PlayerFilter::PlayerAttribute {
+            attr,
+            value,
+            relation: _,
+            comparator: _,
+        } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -2616,7 +2905,7 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
             acc = acc.or(scan_quantity_expr(value));
             acc
         }
-        PlayerFilter::ChosenPlayer { .. } => Axes::NONE,
+        PlayerFilter::ChosenPlayer { index: _ } => Axes::NONE,
         PlayerFilter::ParentObjectTargetOwner => Axes {
             event: true,
             sibling: false,
@@ -2627,26 +2916,26 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
 
 fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
     match x {
-        ReplacementCondition::And { conditions, .. } => {
+        ReplacementCondition::And { conditions } => {
             let mut acc = Axes::NONE;
             for x in conditions {
                 acc = acc.or(scan_replacement_condition(x));
             }
             acc
         }
-        ReplacementCondition::UnlessControlsSubtype { .. } => Axes::NONE,
+        ReplacementCondition::UnlessControlsSubtype { subtypes: _ } => Axes::NONE,
         ReplacementCondition::UnlessControlsOtherLeq { .. } => Axes::CONSERVATIVE,
-        ReplacementCondition::UnlessControlsMatching { filter, .. } => {
+        ReplacementCondition::UnlessControlsMatching { filter } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        ReplacementCondition::UnlessControlsCountMatching { filter, .. } => {
+        ReplacementCondition::UnlessControlsCountMatching { filter, minimum: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        ReplacementCondition::UnlessPlayerLifeAtMost { .. } => Axes {
+        ReplacementCondition::UnlessPlayerLifeAtMost { amount: _ } => Axes {
             event: false,
             sibling: false,
             projected: true,
@@ -2657,7 +2946,7 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
             lhs,
             rhs,
             active_player_req,
-            ..
+            comparator: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(lhs));
@@ -2671,7 +2960,7 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
             lhs,
             rhs,
             active_player_req,
-            ..
+            comparator: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_quantity_expr(lhs));
@@ -2683,9 +2972,12 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
         }
         ReplacementCondition::HasMaxSpeed => Axes::NONE,
         ReplacementCondition::CastViaEscape => Axes::NONE,
-        ReplacementCondition::CastVariantPaid { .. } => Axes::NONE,
-        ReplacementCondition::CastFromZone { .. } => Axes::NONE,
-        ReplacementCondition::EnteredFromZone { .. } => Axes::NONE,
+        ReplacementCondition::CastVariantPaid { variant: _ } => Axes::NONE,
+        ReplacementCondition::CastFromZone { zone: _ } => Axes::NONE,
+        ReplacementCondition::EnteredFromZone {
+            origin_constraint: _,
+            cast_origin: _,
+        } => Axes::NONE,
         ReplacementCondition::YouAttackedThisTurn => Axes {
             event: false,
             sibling: false,
@@ -2696,9 +2988,12 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
             sibling: false,
             projected: true,
         },
-        ReplacementCondition::CastViaKicker { .. } => Axes::NONE,
-        ReplacementCondition::SourceTappedState { .. } => Axes::NONE,
-        ReplacementCondition::DealtDamageThisTurnBySource { source, .. } => {
+        ReplacementCondition::CastViaKicker {
+            variant: _,
+            kicker_cost: _,
+        } => Axes::NONE,
+        ReplacementCondition::SourceTappedState { tapped: _ } => Axes::NONE,
+        ReplacementCondition::DealtDamageThisTurnBySource { source } => {
             let mut acc = Axes {
                 event: false,
                 sibling: false,
@@ -2714,18 +3009,21 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
         }
         ReplacementCondition::EffectCausedDiscard => Axes::NONE,
         ReplacementCondition::OnlyExtraTurn => Axes::NONE,
-        ReplacementCondition::TokenSubtypeMatches { .. } => Axes::NONE,
-        ReplacementCondition::TokenCoreTypeMatches { .. } => Axes::NONE,
+        ReplacementCondition::TokenSubtypeMatches { subtypes: _ } => Axes::NONE,
+        ReplacementCondition::TokenCoreTypeMatches { core_types: _ } => Axes::NONE,
         ReplacementCondition::ExceptFirstDrawInDrawStep => Axes::NONE,
-        ReplacementCondition::IfControlsMatching { filter, .. } => {
+        ReplacementCondition::IfControlsMatching { filter, minimum: _ } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(filter));
             acc
         }
-        ReplacementCondition::ClassLevelGE { .. } => Axes::NONE,
+        ReplacementCondition::ClassLevelGE { level: _ } => Axes::NONE,
         ReplacementCondition::DuringUntapStep => Axes::NONE,
-        ReplacementCondition::ControllerControlsSource { .. } => Axes::NONE,
-        ReplacementCondition::Unrecognized { .. } => Axes::NONE,
+        ReplacementCondition::ControllerControlsSource {
+            source: _,
+            controller: _,
+        } => Axes::NONE,
+        ReplacementCondition::Unrecognized { text: _ } => Axes::NONE,
     }
 }
 
@@ -2734,7 +3032,7 @@ fn scan_player_scope(x: &PlayerScope) -> Axes {
         PlayerScope::Controller => Axes::NONE,
         PlayerScope::ScopedPlayer => Axes::NONE,
         PlayerScope::Target => Axes::NONE,
-        PlayerScope::Opponent { .. } => Axes::NONE,
+        PlayerScope::Opponent { aggregate: _ } => Axes::NONE,
         PlayerScope::AllPlayers { exclude, .. } => {
             let mut acc = Axes::NONE;
             if let Some(x) = exclude {
@@ -2770,7 +3068,7 @@ fn scan_controller_ref(x: &ControllerRef) -> Axes {
             projected: false,
         },
         ControllerRef::DefendingPlayer => Axes::NONE,
-        ControllerRef::ChosenPlayer { .. } => Axes::NONE,
+        ControllerRef::ChosenPlayer { index: _ } => Axes::NONE,
         ControllerRef::SourceChosenPlayer => Axes::NONE,
         ControllerRef::TriggeringPlayer => Axes {
             event: true,

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1,4 +1,4 @@
-//! CR 603.3b + CR 603.4 + CR 106.1/119/122.1: the PR-6.25/PR-6.5 fail-closed AST
+//! CR 603.3b + CR 603.4 + CR 106.1 / CR 119 / CR 122.1: the PR-6.25/PR-6.5 fail-closed AST
 //! scanner — a single compiler-exhaustive, wildcard-free walk of a resolved
 //! ability's typed AST that answers three independent classification questions
 //! ("axes") used by trigger ordering (CR 603.3b) and the growing-cascade
@@ -75,7 +75,7 @@ struct Axes {
     /// could mutate (CR 603.3b ordering-relevance).
     sibling: bool,
     /// Reads a player-level monotone resource / per-turn journal that
-    /// `project_out_resources` neutralizes (CR 106.1/119/122.1).
+    /// `project_out_resources` neutralizes (CR 106.1 / CR 119 / CR 122.1).
     projected: bool,
 }
 
@@ -3121,7 +3121,7 @@ pub(crate) fn trigger_condition_reads_projected_resource(condition: &TriggerCond
     scan_trigger_condition(condition).projected
 }
 
-/// Axis 3 on a condition-gated static's `condition` (CR 604.1/613.1) — the
+/// Axis 3 on a condition-gated static's `condition` (CR 604.1 / CR 613.1) — the
 /// dormant-static off-stack scan surface.
 pub(crate) fn static_condition_reads_projected_resource(condition: &StaticCondition) -> bool {
     scan_static_condition(condition).projected

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -66,7 +66,6 @@ use crate::types::game_state::TargetSelectionConstraint;
 /// `true` on an axis means "reads (or may read) that dimension"; the fail-safe
 /// direction for every consumer.
 #[derive(Clone, Copy)]
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 struct Axes {
     /// Reads a concrete-triggering-event / cost-paid-object characteristic
     /// (CR 603.4 / CR 608.2k). Used by trigger ordering to keep distinct-event
@@ -80,7 +79,6 @@ struct Axes {
     projected: bool,
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 impl Axes {
     /// No read on any axis.
     const NONE: Axes = Axes {
@@ -114,7 +112,6 @@ impl Axes {
 /// `ResolvedAbility` fails to compile here until it is classified, closing the
 /// "unread aux field" hole class at compile time (not just `multi_target` /
 /// `target_constraints`).
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn resolved_ability_axes(a: &ResolvedAbility) -> Axes {
     let ResolvedAbility {
         // ---- read-bearing: scanned into `acc` below ----
@@ -230,7 +227,6 @@ fn resolved_ability_axes(a: &ResolvedAbility) -> Axes {
 /// CR 608.2c / CR 107.1c: a loop-continuation predicate. Only `WhileCondition`
 /// re-reads game state (per-iteration re-evaluation); the controller-prompted and
 /// boolean-stop variants read no dynamic resource.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_repeat_continuation(r: &RepeatContinuation) -> Axes {
     match r {
         RepeatContinuation::ControllerChoice => Axes::NONE,
@@ -250,7 +246,6 @@ fn scan_repeat_continuation(r: &RepeatContinuation) -> Axes {
 /// remaining fields are cast/announce-time metadata (concrete counts, costs, and
 /// static cast-time predicates) that do not express a resolution-time dynamic read.
 /// Destructured without `..` — a future `ModalChoice` field must be classified here.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_modal_choice(m: &ModalChoice) -> Axes {
     let ModalChoice {
         dynamic_max_choices,
@@ -277,7 +272,6 @@ fn scan_modal_choice(m: &ModalChoice) -> Axes {
 /// carries a read — its `value` is a `QuantityExpr` documented to hold the where-X
 /// `EventContextAmount` (axis 1); the `Different*` variants are pure structural
 /// predicates over the chosen set with no dynamic read.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_target_selection_constraint(c: &TargetSelectionConstraint) -> Axes {
     match c {
         TargetSelectionConstraint::DifferentTargetPlayers => Axes::NONE,
@@ -289,7 +283,6 @@ fn scan_target_selection_constraint(c: &TargetSelectionConstraint) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_effect(x: &Effect) -> Axes {
     match x {
         Effect::StartYourEngines { player_scope, .. } => {
@@ -1253,7 +1246,6 @@ fn scan_effect(x: &Effect) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_quantity_ref(x: &QuantityRef) -> Axes {
     match x {
         QuantityRef::HandSize { player, .. } => {
@@ -1718,7 +1710,6 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_quantity_expr(x: &QuantityExpr) -> Axes {
     match x {
         QuantityExpr::Ref { qty, .. } => {
@@ -1780,7 +1771,6 @@ fn scan_quantity_expr(x: &QuantityExpr) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_ability_condition(x: &AbilityCondition) -> Axes {
     match x {
         AbilityCondition::AdditionalCostPaid { subject, .. } => {
@@ -1956,7 +1946,6 @@ fn scan_ability_condition(x: &AbilityCondition) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_target_filter(x: &TargetFilter) -> Axes {
     match x {
         TargetFilter::None => Axes::NONE,
@@ -2094,7 +2083,6 @@ fn scan_target_filter(x: &TargetFilter) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_object_scope(x: &ObjectScope) -> Axes {
     match x {
         ObjectScope::Source => Axes::NONE,
@@ -2120,7 +2108,6 @@ fn scan_object_scope(x: &ObjectScope) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
     match x {
         TriggerCondition::GainedLife { .. } => Axes {
@@ -2380,7 +2367,6 @@ fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_duration(x: &Duration) -> Axes {
     match x {
         Duration::UntilEndOfTurn => Axes::NONE,
@@ -2410,7 +2396,6 @@ fn scan_duration(x: &Duration) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_static_condition(x: &StaticCondition) -> Axes {
     match x {
         StaticCondition::DevotionGE { .. } => Axes {
@@ -2547,7 +2532,6 @@ fn scan_static_condition(x: &StaticCondition) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_player_filter(x: &PlayerFilter) -> Axes {
     match x {
         PlayerFilter::Controller => Axes::NONE,
@@ -2641,7 +2625,6 @@ fn scan_player_filter(x: &PlayerFilter) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
     match x {
         ReplacementCondition::And { conditions, .. } => {
@@ -2746,7 +2729,6 @@ fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_player_scope(x: &PlayerScope) -> Axes {
     match x {
         PlayerScope::Controller => Axes::NONE,
@@ -2771,7 +2753,6 @@ fn scan_player_scope(x: &PlayerScope) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_controller_ref(x: &ControllerRef) -> Axes {
     match x {
         ControllerRef::You => Axes::NONE,
@@ -2800,7 +2781,6 @@ fn scan_controller_ref(x: &ControllerRef) -> Axes {
     }
 }
 
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 fn scan_count_scope(x: &CountScope) -> Axes {
     match x {
         CountScope::Controller => Axes::NONE,
@@ -2819,14 +2799,13 @@ fn scan_count_scope(x: &CountScope) -> Axes {
 
 /// Axis 3: does this resolved ability (and its chain/conditions) read a
 /// projected player-level resource or journal? (`analysis::resource` item 4.)
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn ability_reads_projected_resource(ability: &ResolvedAbility) -> bool {
     resolved_ability_axes(ability).projected
 }
 
 /// Axis 1: does this resolved ability read the concrete triggering-event /
 /// cost-paid-object context? (CR 603.4; `game::triggers` ordering.)
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 pub(crate) fn ability_uses_event_context(ability: &ResolvedAbility) -> bool {
     resolved_ability_axes(ability).event
 }
@@ -2835,28 +2814,27 @@ pub(crate) fn ability_uses_event_context(ability: &ResolvedAbility) -> bool {
 /// mutable aggregate a sibling copy could change? (CR 603.3b; `game::triggers`
 /// C2 distinct-event auto-resolve gate — the Rubblebelt Rioters / Orcish
 /// Siegemaster exclusion.)
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
 pub(crate) fn ability_reads_sibling_mutable(ability: &ResolvedAbility) -> bool {
     resolved_ability_axes(ability).sibling
 }
 
 /// Axis 3 on a bare trigger fire-time `condition` (CR 603.4 intervening-if) —
 /// the off-stack scan surface (`analysis::resource` item 5).
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn trigger_condition_reads_projected_resource(condition: &TriggerCondition) -> bool {
     scan_trigger_condition(condition).projected
 }
 
 /// Axis 3 on a condition-gated static's `condition` (CR 604.1/613.1) — the
 /// dormant-static off-stack scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn static_condition_reads_projected_resource(condition: &StaticCondition) -> bool {
     scan_static_condition(condition).projected
 }
 
 /// Axis 3 on a replacement effect's `condition`/body (CR 614.1) — the
 /// off-stack replacement scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn replacement_condition_reads_projected_resource(
     condition: &ReplacementCondition,
 ) -> bool {
@@ -2864,14 +2842,14 @@ pub(crate) fn replacement_condition_reads_projected_resource(
 }
 
 /// Axis 3 on a bare `AbilityCondition` (resolution-time branch selector).
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn ability_condition_reads_projected_resource(condition: &AbilityCondition) -> bool {
     scan_ability_condition(condition).projected
 }
 
 /// Axis 3 on a transient `Duration::ForAsLongAs` condition (CR 604.1) — the
 /// `transient_continuous_effects` off-stack scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn duration_reads_projected_resource(duration: &Duration) -> bool {
     scan_duration(duration).projected
 }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1,0 +1,3124 @@
+//! CR 603.3b + CR 603.4 + CR 106.1/119/122.1: the PR-6.25/PR-6.5 fail-closed AST
+//! scanner — a single compiler-exhaustive, wildcard-free walk of a resolved
+//! ability's typed AST that answers three independent classification questions
+//! ("axes") used by trigger ordering (CR 603.3b) and the growing-cascade
+//! coverability detector (`analysis::resource`):
+//!
+//! 1. **event-context read** — does the ability read a characteristic of the
+//!    concrete triggering event / cost-paid object (CR 603.4 / CR 608.2k)? Two
+//!    order-independent-looking triggers off *distinct* events are only truly
+//!    interchangeable if neither reads the event that distinguishes them.
+//! 2. **sibling-mutable read** — does the ability read a source/recipient or
+//!    board-scoped mutable P/T / counter aggregate that a sibling copy resolving
+//!    first could change (the Rubblebelt Rioters / Orcish Siegemaster class)?
+//! 3. **projected-resource read** — does the ability read a player-level monotone
+//!    resource or per-turn/per-game journal that
+//!    `analysis::resource::project_out_resources` zeroes/clears (life CR 119,
+//!    floating mana CR 106.1, poison/energy/player counters CR 122.1, and the
+//!    per-turn tally/journal block)? Object counters and marked damage are NOT on
+//!    this axis — they are strict-compared by gate (1) of
+//!    `loop_states_cover_modulo_growth` (R5-B1), so an object-counter reader
+//!    (`CountersOn`/`Power`/`Toughness`) classifies as a NON-reader here.
+//!
+//! # Why hand-rolled and wildcard-free
+//!
+//! The soundness of both consumers rests on the scanner being **fail-closed on
+//! future variants**: a new `Effect`/`QuantityRef`/`TriggerCondition`/… variant
+//! must fail to compile until it is given an explicit reads/doesn't-read decision
+//! on every axis. A `_ =>` wildcard (or a serde-tag string walk) silently defeats
+//! that — a new event-context or resource reader would be classified inert and
+//! ride a false auto-resolution / false coverability win. Therefore every arm is
+//! explicit; provably-inert variants get a one-line `Axes::NONE` arm. Types the
+//! walk does not descend into (`ContinuousModification`, `ManaProduction`,
+//! `ReplacementDefinition`, a nested `ResolvedAbility`, `FilterProp`, the
+//! per-mode `AbilityDefinition`s of a reflexive-modal trigger (`mode_abilities`),
+//! …) that can transitively express a read are classified **conservatively**
+//! (`Axes::CONSERVATIVE` — reads on every axis), the fail-safe direction for all
+//! three consumers (over-prompt / over-reject, never a false auto-resolve or
+//! false win). `RestrictionPlayerScope` and `CastManaObjectScope` are also in the
+//! conservative set: their only carriers (`Effect::AddRestriction` /
+//! `AddTargetReplacement`, `QuantityRef::ManaSpentToCast`) already return
+//! `Axes::CONSERVATIVE`, so the scopes themselves are never traversed.
+//!
+//! # Traversal closure (R4-G2)
+//!
+//! The compiler-exhaustiveness floor holds only for TRAVERSED subtrees: an
+//! untraversed payload is silently skipped with no compile error, so the traversal
+//! set is part of the trusted base. It is closed under payload reachability across
+//! `Effect`, `QuantityRef`, `QuantityExpr`, `AbilityCondition`, `TargetFilter`,
+//! `ObjectScope`, `TriggerCondition`, `Duration` (its `ForAsLongAs` `StaticCondition`),
+//! `StaticCondition`, `PlayerFilter`, `ReplacementCondition`, the target-count and
+//! target-set specs (`MultiTargetSpec`, `TargetSelectionConstraint`), the loop and
+//! modal headers (`RepeatContinuation`, `ModalChoice`), and the player scope
+//! selectors (`PlayerScope`, `ControllerRef`, `CountScope`). The `ResolvedAbility`
+//! and `ModalChoice` fields are destructured without `..`, so a new field must be
+//! classified before it compiles. Any type outside this set that can reach a read
+//! is in the conservative set above.
+
+use crate::types::ability::{
+    AbilityCondition, ControllerRef, CountScope, Duration, Effect, ModalChoice, MultiTargetSpec,
+    ObjectScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation,
+    ReplacementCondition, ResolvedAbility, StaticCondition, TargetFilter, TriggerCondition,
+};
+use crate::types::game_state::TargetSelectionConstraint;
+
+/// The three independent classification axes, accumulated over one AST walk.
+/// `true` on an axis means "reads (or may read) that dimension"; the fail-safe
+/// direction for every consumer.
+#[derive(Clone, Copy)]
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+struct Axes {
+    /// Reads a concrete-triggering-event / cost-paid-object characteristic
+    /// (CR 603.4 / CR 608.2k). Used by trigger ordering to keep distinct-event
+    /// groups from auto-resolving.
+    event: bool,
+    /// Reads a source/recipient or board-scoped mutable aggregate a sibling copy
+    /// could mutate (CR 603.3b ordering-relevance).
+    sibling: bool,
+    /// Reads a player-level monotone resource / per-turn journal that
+    /// `project_out_resources` neutralizes (CR 106.1/119/122.1).
+    projected: bool,
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+impl Axes {
+    /// No read on any axis.
+    const NONE: Axes = Axes {
+        event: false,
+        sibling: false,
+        projected: false,
+    };
+    /// A subtree the walk does not descend into but which can transitively express
+    /// a read — classified as reading everything (fail-closed / fail-safe).
+    const CONSERVATIVE: Axes = Axes {
+        event: true,
+        sibling: true,
+        projected: true,
+    };
+
+    fn or(self, other: Axes) -> Axes {
+        Axes {
+            event: self.event || other.event,
+            sibling: self.sibling || other.sibling,
+            projected: self.projected || other.projected,
+        }
+    }
+}
+
+/// Walk a resolved ability's read-bearing fields.
+///
+/// The `ResolvedAbility` destructure below is **exhaustive with no `..` rest
+/// pattern** — the struct-level analogue of the walk's no-wildcard match
+/// discipline. Every field is either scanned (read-bearing) or bound to `_`
+/// with a one-line "read-free" justification; a FUTURE field added to
+/// `ResolvedAbility` fails to compile here until it is classified, closing the
+/// "unread aux field" hole class at compile time (not just `multi_target` /
+/// `target_constraints`).
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn resolved_ability_axes(a: &ResolvedAbility) -> Axes {
+    let ResolvedAbility {
+        // ---- read-bearing: scanned into `acc` below ----
+        effect,
+        sub_ability,
+        else_ability,
+        condition,
+        duration,
+        player_scope,
+        starting_with,
+        repeat_for,
+        multi_target,
+        target_constraints,
+        unless_pay,
+        target_chooser,
+        repeat_until,
+        modal,
+        mode_abilities,
+        // ---- read-free: concrete ids / cast-time snapshots / flags / links,
+        //      none of which express a resolution-time dynamic read ----
+        targets: _,               // concrete announced target refs (already resolved)
+        source_id: _,             // object id
+        source_incarnation: _,    // epoch guard token
+        controller: _,            // player id
+        original_controller: _,   // player id
+        scoped_player: _,         // player id (iteration binding)
+        kind: _,                  // AbilityKind tag (no payload)
+        context: _,               // SpellContext: cast-time fact snapshot, not a live read
+        optional_targeting: _,    // bool
+        optional: _,              // bool
+        optional_for: _,          // OpponentMayScope: AnyOpponent/AnyPlayer, no read
+        target_choice_timing: _,  // Stack/Resolution tag
+        description: _,           // display string
+        min_x_value: _,           // u32
+        cant_be_copied: _,        // bool
+        copy_count_status: _,     // status tag
+        forward_result: _,        // bool
+        distribution: _,          // concrete pre-assigned (TargetRef, u32) portions
+        chosen_x: _,              // concrete cast-time X
+        cost_paid_object: _,      // concrete captured-object snapshot
+        effect_context_object: _, // concrete captured-object snapshot
+        ability_index: _,         // usize provenance
+        may_trigger_origin: _,    // provenance tag
+        target_selection_mode: _, // Chosen/Random tag
+        chosen_players: _,        // concrete chosen player ids
+        sub_link: _,              // SubAbilityLink kind tag
+        dig_found_nothing_for_parent_target: _, // bool seam flag
+    } = a;
+
+    let mut acc = scan_effect(effect);
+    if let Some(sub) = sub_ability {
+        acc = acc.or(resolved_ability_axes(sub));
+    }
+    if let Some(else_branch) = else_ability {
+        acc = acc.or(resolved_ability_axes(else_branch));
+    }
+    if let Some(condition) = condition {
+        acc = acc.or(scan_ability_condition(condition));
+    }
+    if let Some(duration) = duration {
+        acc = acc.or(scan_duration(duration));
+    }
+    if let Some(player_scope) = player_scope {
+        acc = acc.or(scan_player_filter(player_scope));
+    }
+    if let Some(starting_with) = starting_with {
+        acc = acc.or(scan_controller_ref(starting_with));
+    }
+    if let Some(repeat_for) = repeat_for {
+        acc = acc.or(scan_quantity_expr(repeat_for));
+    }
+    // CR 601.2c / CR 115.1d: variable-count targeting bounds (min/max) are
+    // `QuantityExpr`s that can read a projected/event resource (e.g. a die-result X).
+    // MultiTargetSpec is itself destructured without `..` (same no-wildcard floor).
+    if let Some(MultiTargetSpec { min, max }) = multi_target {
+        acc = acc.or(scan_quantity_expr(min));
+        if let Some(max) = max {
+            acc = acc.or(scan_quantity_expr(max));
+        }
+    }
+    // CR 115.1 / CR 601.2c: cross-target legality constraints; `TotalManaValue`'s
+    // where-X bound carries an `EventContextAmount` (axis-1) read.
+    for c in target_constraints {
+        acc = acc.or(scan_target_selection_constraint(c));
+    }
+    // CR 605.3a / CR 608.2g: a resolution-time "unless a player pays {cost}"
+    // consults floating mana (CR 106.1), a projected axis.
+    if unless_pay.is_some() {
+        acc.projected = true;
+    }
+    // CR 601.2c / CR 603.3d: `target_chooser` selects who announces targets; a
+    // TargetFilter like `TriggeringSourceController` reads the triggering event.
+    if let Some(chooser) = target_chooser {
+        acc = acc.or(scan_target_filter(chooser));
+    }
+    // CR 608.2c / CR 107.1c: a "repeat this process while <condition>" predicate is
+    // re-evaluated against freshly-resolved state each iteration — a resolution read.
+    if let Some(repeat_until) = repeat_until {
+        acc = acc.or(scan_repeat_continuation(repeat_until));
+    }
+    // CR 700.2: a modal header's dynamic mode cap / chooser can read dynamic state.
+    if let Some(modal) = modal {
+        acc = acc.or(scan_modal_choice(modal));
+    }
+    // CR 700.2b: reflexive-modal per-mode `AbilityDefinition`s are def-level structs
+    // the walk does not descend into — conservative (fail-closed) when present.
+    if !mode_abilities.is_empty() {
+        acc = acc.or(Axes::CONSERVATIVE);
+    }
+    acc
+}
+
+/// CR 608.2c / CR 107.1c: a loop-continuation predicate. Only `WhileCondition`
+/// re-reads game state (per-iteration re-evaluation); the controller-prompted and
+/// boolean-stop variants read no dynamic resource.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_repeat_continuation(r: &RepeatContinuation) -> Axes {
+    match r {
+        RepeatContinuation::ControllerChoice => Axes::NONE,
+        RepeatContinuation::UntilStopConditions {
+            stop_on_put_to_hand: _,
+            stop_on_duplicate_exiled_names: _,
+        } => Axes::NONE,
+        RepeatContinuation::WhileCondition {
+            condition,
+            max_iterations: _,
+        } => scan_ability_condition(condition),
+    }
+}
+
+/// CR 700.2: the read-bearing payloads of a modal header. `dynamic_max_choices`
+/// (a `QuantityExpr`) and `chooser` (a `PlayerFilter`) can read dynamic state; the
+/// remaining fields are cast/announce-time metadata (concrete counts, costs, and
+/// static cast-time predicates) that do not express a resolution-time dynamic read.
+/// Destructured without `..` — a future `ModalChoice` field must be classified here.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_modal_choice(m: &ModalChoice) -> Axes {
+    let ModalChoice {
+        dynamic_max_choices,
+        chooser,
+        min_choices: _,
+        max_choices: _,
+        mode_count: _,
+        mode_descriptions: _,
+        allow_repeat_modes: _,
+        constraints: _, // cast-time modal-cap predicates (announcement-time, not resolution)
+        mode_costs: _,
+        mode_pawprints: _,
+        entwine_cost: _,
+        selection: _,
+    } = m;
+    let mut acc = scan_player_filter(chooser);
+    if let Some(qty) = dynamic_max_choices {
+        acc = acc.or(scan_quantity_expr(qty));
+    }
+    acc
+}
+
+/// CR 115.1 / CR 601.2c: cross-target legality constraints. Only `TotalManaValue`
+/// carries a read — its `value` is a `QuantityExpr` documented to hold the where-X
+/// `EventContextAmount` (axis 1); the `Different*` variants are pure structural
+/// predicates over the chosen set with no dynamic read.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_target_selection_constraint(c: &TargetSelectionConstraint) -> Axes {
+    match c {
+        TargetSelectionConstraint::DifferentTargetPlayers => Axes::NONE,
+        TargetSelectionConstraint::DifferentObjectControllers => Axes::NONE,
+        TargetSelectionConstraint::TotalManaValue {
+            value,
+            comparator: _,
+        } => scan_quantity_expr(value),
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_effect(x: &Effect) -> Axes {
+    match x {
+        Effect::StartYourEngines { player_scope, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(player_scope));
+            acc
+        }
+        Effect::ChangeSpeed {
+            player_scope,
+            amount,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(player_scope));
+            acc = acc.or(scan_quantity_expr(amount));
+            acc
+        }
+        Effect::DealDamage { amount, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ApplyPostReplacementDamage { .. } => Axes::NONE,
+        Effect::EachDealsDamageEqualToPower {
+            sources, recipient, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(sources));
+            acc = acc.or(scan_target_filter(recipient));
+            acc
+        }
+        Effect::Draw { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Pump { .. } => Axes::CONSERVATIVE,
+        Effect::PairWith { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Destroy { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Regenerate { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::RemoveAllDamage { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Counter { .. } => Axes::CONSERVATIVE,
+        Effect::CounterAll { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Token { .. } => Axes::CONSERVATIVE,
+        Effect::GainLife { amount, player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::LoseLife { amount, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            if let Some(x) = target {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::SetTapState { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::RemoveCounter { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Sacrifice { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::DiscardCard { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Mill { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Scry { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::PumpAll { .. } => Axes::CONSERVATIVE,
+        Effect::DamageAll {
+            amount,
+            target,
+            player_filter,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = player_filter {
+                acc = acc.or(scan_player_filter(x));
+            }
+            acc
+        }
+        Effect::DamageEachPlayer {
+            amount,
+            player_filter,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_player_filter(player_filter));
+            acc
+        }
+        Effect::DestroyAll { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ChangeZone { .. } => Axes::CONSERVATIVE,
+        Effect::ChangeZoneAll { .. } => Axes::CONSERVATIVE,
+        Effect::Dig {
+            player,
+            count,
+            filter,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        Effect::GainControl { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::GainControlAll { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ControlNextTurn { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Attach {
+            attachment, target, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(attachment));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::UnattachAll {
+            attachment, target, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(attachment));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Surveil { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Fight {
+            target, subject, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(subject));
+            acc
+        }
+        Effect::Bounce { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::BounceAll { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = count {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        Effect::Explore => Axes::NONE,
+        Effect::ExploreAll { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        Effect::Investigate => Axes::NONE,
+        Effect::Tribute { .. } => Axes::NONE,
+        Effect::TimeTravel => Axes::NONE,
+        Effect::BecomeMonarch => Axes::NONE,
+        Effect::NoOp => Axes::NONE,
+        Effect::Proliferate => Axes::NONE,
+        Effect::ProliferateTarget { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Populate => Axes::NONE,
+        Effect::Clash => Axes::NONE,
+        Effect::EndTheTurn => Axes::NONE,
+        Effect::EndCombatPhase => Axes::NONE,
+        Effect::Vote { .. } => Axes::CONSERVATIVE,
+        Effect::SeparateIntoPiles { .. } => Axes::CONSERVATIVE,
+        Effect::SwitchPT { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::CopySpell { .. } => Axes::CONSERVATIVE,
+        Effect::EpicCopy { .. } => Axes::CONSERVATIVE,
+        Effect::CastCopyOfCard { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = count {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        Effect::CopyTokenOf { .. } => Axes::CONSERVATIVE,
+        Effect::CreateTokenCopyFromPool {
+            owner,
+            type_filter,
+            mv_bound,
+            count,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(owner));
+            acc = acc.or(scan_target_filter(type_filter));
+            acc = acc.or(scan_quantity_expr(mv_bound));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Myriad => Axes::NONE,
+        Effect::Encore => Axes::NONE,
+        Effect::CombineHost { host, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(host));
+            acc
+        }
+        Effect::ChooseAugmentAndCombineWithHost { filter, host, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc = acc.or(scan_target_filter(host));
+            acc
+        }
+        Effect::Meld { .. } => Axes::NONE,
+        Effect::ExileHaunting { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::HideawayConceal { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::CopyTokenBlockingAttacker {
+            source_filter,
+            owner,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(source_filter));
+            acc = acc.or(scan_target_filter(owner));
+            acc
+        }
+        Effect::BecomeCopy { .. } => Axes::CONSERVATIVE,
+        Effect::GainActivatedAbilitiesOfTarget {
+            target,
+            recipient,
+            duration,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(recipient));
+            if let Some(x) = duration {
+                acc = acc.or(scan_duration(x));
+            }
+            acc
+        }
+        Effect::ChooseCard { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::PutCounter { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::PutCounterAll { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::MultiplyCounter { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::DoublePT { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::DoublePTAll { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::MoveCounters {
+            source,
+            count,
+            target,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(source));
+            if let Some(x) = count {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Animate { .. } => Axes::CONSERVATIVE,
+        Effect::ReturnAsAura { .. } => Axes::CONSERVATIVE,
+        Effect::RegisterBending { .. } => Axes::NONE,
+        Effect::GenericEffect { .. } => Axes::CONSERVATIVE,
+        Effect::Cleanup { .. } => Axes::NONE,
+        Effect::Mana { .. } => Axes::CONSERVATIVE,
+        Effect::Discard {
+            count,
+            target,
+            unless_filter,
+            filter,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = unless_filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::Shuffle { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Transform { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::SearchLibrary { .. } => Axes::CONSERVATIVE,
+        Effect::SearchOutsideGame { filter, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::RevealHand {
+            target,
+            card_filter,
+            count,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(card_filter));
+            if let Some(x) = count {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        Effect::RevealFromHand { .. } => Axes::CONSERVATIVE,
+        Effect::Reveal { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::RevealTop { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::ExileTop { player, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::TargetOnly { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Choose { .. } => Axes::CONSERVATIVE,
+        Effect::ChooseDamageSource { source_filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(source_filter));
+            acc
+        }
+        Effect::Suspect { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Unsuspect { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Connive { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::PhaseOut { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::PhaseIn { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ForceBlock { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ForceAttack {
+            target,
+            required_player,
+            duration,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(required_player));
+            acc = acc.or(scan_duration(duration));
+            acc
+        }
+        Effect::SolveCase => Axes::NONE,
+        Effect::BecomePrepared { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::BecomeUnprepared { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::BecomeSaddled { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::SetClassLevel { .. } => Axes::NONE,
+        Effect::CreateDelayedTrigger { .. } => Axes::CONSERVATIVE,
+        Effect::AddTargetReplacement { .. } => Axes::CONSERVATIVE,
+        Effect::AddRestriction { .. } => Axes::CONSERVATIVE,
+        Effect::ReduceNextSpellCost { spell_filter, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = spell_filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::GrantNextSpellAbility {
+            player,
+            spell_filter,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            if let Some(x) = spell_filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::AddPendingETBCounters { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::CreateEmblem { .. } => Axes::CONSERVATIVE,
+        Effect::PayCost { .. } => Axes::CONSERVATIVE,
+        Effect::CastFromZone { .. } => Axes::CONSERVATIVE,
+        Effect::FreeCastFromZones { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        Effect::ExileResolvingSpellInsteadOfGraveyard => Axes::NONE,
+        Effect::PreventDamage {
+            amount_dynamic,
+            target,
+            damage_source_filter,
+            prevention_duration,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = amount_dynamic {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = damage_source_filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            if let Some(x) = prevention_duration {
+                acc = acc.or(scan_duration(x));
+            }
+            acc
+        }
+        Effect::CreateDamageReplacement { .. } => Axes::CONSERVATIVE,
+        Effect::CreateDrawReplacement {
+            replacement_effect, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_effect(replacement_effect));
+            acc
+        }
+        Effect::LoseTheGame { target, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = target {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::WinTheGame { target, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = target {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::RollDie { .. } => Axes::CONSERVATIVE,
+        Effect::FlipCoin { .. } => Axes::CONSERVATIVE,
+        Effect::FlipCoins { .. } => Axes::CONSERVATIVE,
+        Effect::FlipCoinUntilLose { .. } => Axes::CONSERVATIVE,
+        Effect::RingTemptsYou => Axes::NONE,
+        Effect::VentureIntoDungeon => Axes::NONE,
+        Effect::VentureInto { .. } => Axes::NONE,
+        Effect::TakeTheInitiative => Axes::NONE,
+        Effect::Planeswalk => Axes::NONE,
+        Effect::OpenAttractions { .. } => Axes::NONE,
+        Effect::RollToVisitAttractions => Axes::NONE,
+        Effect::AssembleContraptions { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::AssembleContraptionsFromRollDifference => Axes::NONE,
+        Effect::CrankContraptions { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ReassembleContraption { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::AssembleContraptionOnSprocket { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ReassembleContraptionOnSprocket { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::PutSticker {
+            target,
+            count,
+            max_ticket_cost,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            if let Some(x) = max_ticket_cost {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        Effect::ApplySticker { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ProcessRadCounters => Axes::NONE,
+        Effect::GrantCastingPermission { .. } => Axes::CONSERVATIVE,
+        Effect::ChooseFromZone { filter, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::RememberCard { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ForEachCategoryExile { .. } => Axes::NONE,
+        Effect::ChooseObjectsIntoTrackedSet {
+            chooser, filter, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(chooser));
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        Effect::ChooseAndSacrificeRest {
+            choose_filter,
+            sacrifice_filter,
+            total_power_cap,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(choose_filter));
+            acc = acc.or(scan_target_filter(sacrifice_filter));
+            if let Some(x) = total_power_cap {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        Effect::Exploit { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::GainEnergy { amount, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc
+        }
+        Effect::GivePlayerCounter { count, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::LoseAllPlayerCounters { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ExileFromTopUntil { .. } => Axes::CONSERVATIVE,
+        Effect::RevealUntil {
+            player,
+            filter,
+            count,
+            enters_under,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc = acc.or(scan_target_filter(filter));
+            acc = acc.or(scan_quantity_expr(count));
+            if let Some(x) = enters_under {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        Effect::Discover {
+            mana_value_limit,
+            player,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(mana_value_limit));
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::Heist { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::HeistExile => Axes::NONE,
+        Effect::Cascade => Axes::NONE,
+        Effect::Ripple { .. } => Axes::NONE,
+        Effect::MiracleCast { .. } => Axes::NONE,
+        Effect::MadnessCast { .. } => Axes::NONE,
+        Effect::PutAtLibraryPosition { .. } => Axes::CONSERVATIVE,
+        Effect::ChooseDrawnThisTurnPayOrTopdeck {
+            count,
+            life_payment,
+            player,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc = acc.or(scan_quantity_expr(life_payment));
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::PutOnTopOrBottom { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::GiftDelivery { .. } => Axes::NONE,
+        Effect::Goad { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::GoadAll { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Detain { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::SetRoomDoorLock { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ExchangeControl {
+            target_a, target_b, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target_a));
+            acc = acc.or(scan_target_filter(target_b));
+            acc
+        }
+        Effect::ChangeTargets {
+            target, forced_to, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            if let Some(x) = forced_to {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        Effect::Manifest {
+            target,
+            count,
+            enters_under,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            if let Some(x) = enters_under {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        Effect::ManifestDread => Axes::NONE,
+        Effect::Cloak { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::TurnFaceUp { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::TurnFaceDown { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::ExtraTurn { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::GrantExtraLoyaltyActivations { amount, target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::SkipNextTurn { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::SkipNextStep { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::AdditionalPhase { target, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Double { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::RuntimeHandled { .. } => Axes::NONE,
+        Effect::Incubate { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Amass { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Monstrosity { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Specialize => Axes::NONE,
+        Effect::Renown { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Bolster { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Adapt { count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::Learn => Axes::NONE,
+        Effect::Forage => Axes::NONE,
+        Effect::Harness => Axes::NONE,
+        Effect::CollectEvidence { .. } => Axes::NONE,
+        Effect::Endure {
+            amount, subject, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc = acc.or(scan_target_filter(subject));
+            acc
+        }
+        Effect::BlightEffect { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::Seek { filter, count, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        Effect::SetLifeTotal { target, amount, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_quantity_expr(amount));
+            acc
+        }
+        Effect::ExchangeLifeWithStat { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player));
+            acc
+        }
+        Effect::ExchangeLifeTotals {
+            player_a, player_b, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(player_a));
+            acc = acc.or(scan_target_filter(player_b));
+            acc
+        }
+        Effect::SetDayNight { .. } => Axes::NONE,
+        Effect::GiveControl {
+            target, recipient, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(recipient));
+            acc
+        }
+        Effect::RemoveFromCombat { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Conjure { .. } => Axes::CONSERVATIVE,
+        Effect::ApplyPerpetual { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        Effect::Intensify { amount, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(amount));
+            acc
+        }
+        Effect::DraftFromSpellbook { .. } => Axes::NONE,
+        Effect::ChooseOneOf { .. } => Axes::CONSERVATIVE,
+        Effect::Unimplemented { .. } => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_quantity_ref(x: &QuantityRef) -> Axes {
+    match x {
+        QuantityRef::HandSize { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::LifeTotal { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::GraveyardSize { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::LifeAboveStarting => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        QuantityRef::StartingLifeTotal => Axes::NONE,
+        QuantityRef::ObjectCount { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::ObjectCountDistinct { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::ObjectCountBySharedQuality { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::PlayerCount { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(filter));
+            acc
+        }
+        QuantityRef::CountersOn { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::CountersOnObjects { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::PlayerCounter { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_count_scope(scope));
+            acc
+        }
+        QuantityRef::Variable { .. } => Axes::NONE,
+        QuantityRef::Power { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::Intensity { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::Toughness { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::ObjectManaValue { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::TargetObjectManaValue { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::ObjectColorCount { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::ObjectNameWordCount { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::ObjectTypelineComponentCount { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::ManaSymbolsInManaCost { scope, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        QuantityRef::SelfManaValue => Axes::NONE,
+        QuantityRef::Aggregate { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::ControlledByEachPlayer { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::TargetZoneCardCount { .. } => Axes::NONE,
+        QuantityRef::Devotion { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        QuantityRef::DistinctCardTypes { .. } => Axes::CONSERVATIVE,
+        QuantityRef::CardsExiledBySource => Axes::NONE,
+        QuantityRef::ExiledCardPower { .. } => Axes::NONE,
+        QuantityRef::ZoneCardCount { filter, scope, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc = acc.or(scan_count_scope(scope));
+            acc
+        }
+        QuantityRef::BasicLandTypeCount { controller, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(controller));
+            acc
+        }
+        QuantityRef::TrackedSetSize => Axes::NONE,
+        QuantityRef::FilteredTrackedSetSize { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::TrackedSetAggregate { .. } => Axes::NONE,
+        QuantityRef::ExiledFromHandThisResolution => Axes::NONE,
+        QuantityRef::PreviousEffectAmount => Axes::NONE,
+        QuantityRef::LifeLostThisTurn { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::PartySize { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::UnspentMana { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        QuantityRef::Speed { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::EventContextAmount => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        QuantityRef::AttachmentsOnLeavingObject { controller, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = controller {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        QuantityRef::EventContextSourceCostX => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        QuantityRef::SpellsCastThisTurn { scope, filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_count_scope(scope));
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        QuantityRef::EnteredThisTurn { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::SacrificedThisTurn { player, filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::CrimesCommittedThisTurn => Axes::NONE,
+        QuantityRef::LifeGainedThisTurn { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::CardsDrawnThisTurn { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::BattlefieldEntriesThisTurn { player, filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::LandsPlayedThisTurn { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::TurnsTaken => Axes::NONE,
+        QuantityRef::ZoneChangeCountThisTurn { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::ZoneChangeAggregateThisTurn { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::DamageDealtThisTurn { source, target, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(source));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        QuantityRef::ChosenNumber => Axes::NONE,
+        QuantityRef::AttackedThisTurn { scope, filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_count_scope(scope));
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        QuantityRef::DescendedThisTurn => Axes::NONE,
+        QuantityRef::LoyaltyAbilitiesActivatedThisTurn { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::SpellsCastLastTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        QuantityRef::SpellsCastThisGame { scope, filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_count_scope(scope));
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        QuantityRef::CounterAddedThisTurn { actor, target, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_count_scope(actor));
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        QuantityRef::CardsDiscardedThisTurn { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::TokensCreatedThisTurn { player, filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::PlayerActionsThisTurn { player, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        QuantityRef::DungeonsCompleted => Axes::NONE,
+        QuantityRef::CostXPaid => Axes::NONE,
+        QuantityRef::KickerCount => Axes::NONE,
+        QuantityRef::AdditionalCostPaymentCount => Axes::NONE,
+        QuantityRef::AdditionalCostPaymentCountFor { .. } => Axes::NONE,
+        QuantityRef::ConvokedCreatureCount => Axes::NONE,
+        QuantityRef::TimesCostPaidThisResolution => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        QuantityRef::ManaSpentToCast { .. } => Axes::CONSERVATIVE,
+        QuantityRef::ColorsInCommandersColorIdentity => Axes::NONE,
+        QuantityRef::CommanderCastFromCommandZoneCount => Axes::NONE,
+        QuantityRef::CommanderManaValue { owner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(owner));
+            acc
+        }
+        QuantityRef::DistinctColorsAmongPermanents { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::DistinctCounterKindsAmong { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        QuantityRef::VoteCount { .. } => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_quantity_expr(x: &QuantityExpr) -> Axes {
+    match x {
+        QuantityExpr::Ref { qty, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_ref(qty));
+            acc
+        }
+        QuantityExpr::Fixed { .. } => Axes::NONE,
+        QuantityExpr::DivideRounded { inner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(inner));
+            acc
+        }
+        QuantityExpr::Offset { inner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(inner));
+            acc
+        }
+        QuantityExpr::ClampMin { inner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(inner));
+            acc
+        }
+        QuantityExpr::Multiply { inner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(inner));
+            acc
+        }
+        QuantityExpr::Sum { exprs, .. } => {
+            let mut acc = Axes::NONE;
+            for x in exprs {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+        QuantityExpr::UpTo { max, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(max));
+            acc
+        }
+        QuantityExpr::Power { exponent, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(exponent));
+            acc
+        }
+        QuantityExpr::Difference { left, right, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(left));
+            acc = acc.or(scan_quantity_expr(right));
+            acc
+        }
+        QuantityExpr::Max { exprs, .. } => {
+            let mut acc = Axes::NONE;
+            for x in exprs {
+                acc = acc.or(scan_quantity_expr(x));
+            }
+            acc
+        }
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_ability_condition(x: &AbilityCondition) -> Axes {
+    match x {
+        AbilityCondition::AdditionalCostPaid { subject, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_object_scope(subject));
+            acc
+        }
+        AbilityCondition::AdditionalCostPaidInstead => Axes::NONE,
+        AbilityCondition::AlternativeManaCostPaid => Axes::NONE,
+        AbilityCondition::EffectOutcome { .. } => Axes::NONE,
+        AbilityCondition::EventOutcomeWon => Axes::NONE,
+        AbilityCondition::WhenYouDo => Axes::NONE,
+        AbilityCondition::CastFromZone { .. } => Axes::NONE,
+        AbilityCondition::CastDuringPhase { .. } => Axes::NONE,
+        AbilityCondition::CurrentPhaseIs { .. } => Axes::NONE,
+        AbilityCondition::CastTimingPermission { .. } => Axes::NONE,
+        AbilityCondition::ManaColorSpent { .. } => Axes::NONE,
+        AbilityCondition::RevealedHasCardType { .. } => Axes::CONSERVATIVE,
+        AbilityCondition::ObjectsShareQuality {
+            subject, reference, ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(subject));
+            acc = acc.or(scan_target_filter(reference));
+            acc
+        }
+        AbilityCondition::TargetSharesNameWithOtherExiledThisWay { target, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc
+        }
+        AbilityCondition::SourceEnteredThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        AbilityCondition::CastVariantPaid { subject, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_object_scope(subject));
+            acc
+        }
+        AbilityCondition::CastVariantPaidInstead { .. } => Axes::NONE,
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(lhs));
+            acc = acc.or(scan_quantity_expr(rhs));
+            acc
+        }
+        AbilityCondition::PreviousEffectAmount { rhs, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(rhs));
+            acc
+        }
+        AbilityCondition::HasMaxSpeed => Axes::NONE,
+        AbilityCondition::IsMonarch => Axes::NONE,
+        AbilityCondition::IsInitiative => Axes::NONE,
+        AbilityCondition::HasCityBlessing => Axes::NONE,
+        AbilityCondition::IsRingBearer => Axes::NONE,
+        AbilityCondition::TargetHasKeywordInstead { .. } => Axes::NONE,
+        AbilityCondition::TargetMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::HasObjectTarget => Axes::NONE,
+        AbilityCondition::TriggeringSpellTargetsFilter { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::SourceMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::ZoneChangeObjectMatchesFilter { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::ControllerControlsMatching { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::ControllerControlledMatchingAsCast { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::IsYourTurn => Axes::NONE,
+        AbilityCondition::WasStartingPlayer { controller, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(controller));
+            acc
+        }
+        AbilityCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        AbilityCondition::FirstCombatPhaseOfTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        AbilityCondition::FirstEndStepOfTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        AbilityCondition::ZoneChangedThisWay { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::CostPaidObjectMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        AbilityCondition::SourceIsTapped => Axes::NONE,
+        AbilityCondition::SourceAttachedToCreature => Axes::NONE,
+        AbilityCondition::ConditionInstead { inner, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_ability_condition(inner));
+            acc
+        }
+        AbilityCondition::And { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_ability_condition(x));
+            }
+            acc
+        }
+        AbilityCondition::Or { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_ability_condition(x));
+            }
+            acc
+        }
+        AbilityCondition::Not { condition, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_ability_condition(condition));
+            acc
+        }
+        AbilityCondition::DayNightIsNeither => Axes::NONE,
+        AbilityCondition::DayNightIs { .. } => Axes::NONE,
+        AbilityCondition::NthResolutionThisTurn { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        AbilityCondition::SourceLacksKeyword { .. } => Axes::NONE,
+        AbilityCondition::ScopedPlayerMatches { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(filter));
+            acc
+        }
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_target_filter(x: &TargetFilter) -> Axes {
+    match x {
+        TargetFilter::None => Axes::NONE,
+        TargetFilter::Any => Axes::NONE,
+        TargetFilter::Player => Axes::NONE,
+        TargetFilter::Controller => Axes::NONE,
+        TargetFilter::SelfRef => Axes::NONE,
+        TargetFilter::SourceOrPaired => Axes::NONE,
+        TargetFilter::Typed(..) => Axes::CONSERVATIVE,
+        TargetFilter::Not { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TargetFilter::Or { filters, .. } => {
+            let mut acc = Axes::NONE;
+            for x in filters {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        TargetFilter::And { filters, .. } => {
+            let mut acc = Axes::NONE;
+            for x in filters {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        TargetFilter::StackAbility { controller, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = controller {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        TargetFilter::StackSpell => Axes::NONE,
+        TargetFilter::SpecificObject { .. } => Axes::NONE,
+        TargetFilter::SpecificPlayer { .. } => Axes::NONE,
+        TargetFilter::Neighbor { .. } => Axes::NONE,
+        TargetFilter::ScopedPlayer => Axes::NONE,
+        TargetFilter::AttachedTo => Axes::NONE,
+        TargetFilter::LastCreated => Axes::NONE,
+        TargetFilter::LastRevealed => Axes::NONE,
+        TargetFilter::CostPaidObject => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::ChosenCard => Axes::NONE,
+        TargetFilter::TrackedSet { .. } => Axes::NONE,
+        TargetFilter::TrackedSetFiltered { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TargetFilter::ExiledBySource => Axes::NONE,
+        TargetFilter::ExiledCardByIndex { .. } => Axes::NONE,
+        TargetFilter::TriggeringSpellController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::TriggeringSpellOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::TriggeringPlayer => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::TriggeringSource => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::EventTarget => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::TriggeringSourceController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::ParentTarget => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::ParentTargetSlot { .. } => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::ParentTargetController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::ParentTargetOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::SourceChosenPlayer => Axes::NONE,
+        TargetFilter::OriginalController => Axes::NONE,
+        TargetFilter::PostReplacementSourceController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::PostReplacementDamageTarget => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::PostReplacementDamageTargetOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::DefendingPlayer => Axes::NONE,
+        TargetFilter::HasChosenName => Axes::NONE,
+        TargetFilter::ChosenDamageSource => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TargetFilter::Named { .. } => Axes::NONE,
+        TargetFilter::Owner => Axes::NONE,
+        TargetFilter::AllPlayers => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_object_scope(x: &ObjectScope) -> Axes {
+    match x {
+        ObjectScope::Source => Axes::NONE,
+        ObjectScope::Target => Axes::NONE,
+        ObjectScope::Recipient => Axes::NONE,
+        ObjectScope::EventSource => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        ObjectScope::CostPaidObject => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        ObjectScope::Anaphoric => Axes::NONE,
+        ObjectScope::Demonstrative => Axes::NONE,
+        ObjectScope::EventTarget => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_trigger_condition(x: &TriggerCondition) -> Axes {
+    match x {
+        TriggerCondition::GainedLife { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::LostLife => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::Descended => Axes::NONE,
+        TriggerCondition::ControlsType { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::NoSpellsCastLastTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::TwoOrMoreSpellsCastLastTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::DuringPlayersTurn { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(player));
+            acc
+        }
+        TriggerCondition::SourceEnteredThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::EchoDue => Axes::NONE,
+        TriggerCondition::MinCoAttackers { filter, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        TriggerCondition::SolveConditionMet => Axes::NONE,
+        TriggerCondition::ClassLevelGE { .. } => Axes::NONE,
+        TriggerCondition::SourceIsHarnessed => Axes::NONE,
+        TriggerCondition::AttractionVisitRoll { .. } => Axes::NONE,
+        TriggerCondition::WasCast {
+            controller, owner, ..
+        } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = controller {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            if let Some(x) = owner {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        TriggerCondition::WasPlayed => Axes::NONE,
+        TriggerCondition::AdditionalCostPaid { .. } => Axes::NONE,
+        TriggerCondition::SourceIsAttacking => Axes::NONE,
+        TriggerCondition::CastVariantPaid { .. } => Axes::NONE,
+        TriggerCondition::CastVariantPaidPersistent { .. } => Axes::NONE,
+        TriggerCondition::ActivatedAbilityIsNonMana => Axes::NONE,
+        TriggerCondition::DealtDamageBySourceThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::DealtDamageThisTurnBySource { source, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(source));
+            acc
+        }
+        TriggerCondition::FirstTimeObjectTappedThisTurn => Axes::NONE,
+        TriggerCondition::WasType { .. } => Axes::NONE,
+        TriggerCondition::LifeTotalGE { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::ControlCount { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::ControlsNone { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::AttackedThisTurn => Axes::NONE,
+        TriggerCondition::FirstCombatPhaseOfTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::CastSpellThisTurn { filter, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        TriggerCondition::QuantityComparison { lhs, rhs, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(lhs));
+            acc = acc.or(scan_quantity_expr(rhs));
+            acc
+        }
+        TriggerCondition::HasMaxSpeed => Axes::NONE,
+        TriggerCondition::IsMonarch => Axes::NONE,
+        TriggerCondition::IsInitiative => Axes::NONE,
+        TriggerCondition::NoMonarch => Axes::NONE,
+        TriggerCondition::WasStartingPlayer { controller, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(controller));
+            acc
+        }
+        TriggerCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::HasCityBlessing => Axes::NONE,
+        TriggerCondition::CompletedDungeon { .. } => Axes::NONE,
+        TriggerCondition::SourceIsTapped => Axes::NONE,
+        TriggerCondition::SourceIsTransformed => Axes::NONE,
+        TriggerCondition::SourceIsFaceUp => Axes::NONE,
+        TriggerCondition::SourceIsFaceDown => Axes::NONE,
+        TriggerCondition::SourceInZone { .. } => Axes::NONE,
+        TriggerCondition::CounterAddedThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::LostLifeLastTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::DefendingPlayerControlsNone { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::TributeNotPaid => Axes::NONE,
+        TriggerCondition::CastDuringPhase { .. } => Axes::NONE,
+        TriggerCondition::CastTimingPermission { .. } => Axes::NONE,
+        TriggerCondition::ManaColorSpent { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::ManaSpentCondition { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        TriggerCondition::HadCounters { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        TriggerCondition::ControlsCommander { .. } => Axes::NONE,
+        TriggerCondition::IsRenowned { .. } => Axes::NONE,
+        TriggerCondition::HasCounters { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        TriggerCondition::ZoneChangeObjectMatchesFilter { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::ZoneChangeObjectIsTapped => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TriggerCondition::SourceMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::EventDamageSourceMatchesFilter { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::DamagedPlayerIsEventSourceOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        TriggerCondition::ChosenLabelIs { .. } => Axes::NONE,
+        TriggerCondition::AttackersDeclaredCount { .. } => Axes::CONSERVATIVE,
+        TriggerCondition::ExceptFirstDrawInDrawStep => Axes::NONE,
+        TriggerCondition::PlacedByAbilitySource => Axes::NONE,
+        TriggerCondition::TriggeringSpellTargetsFilter { filter, .. } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        TriggerCondition::And { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_trigger_condition(x));
+            }
+            acc
+        }
+        TriggerCondition::Or { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_trigger_condition(x));
+            }
+            acc
+        }
+        TriggerCondition::Not { condition, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_trigger_condition(condition));
+            acc
+        }
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_duration(x: &Duration) -> Axes {
+    match x {
+        Duration::UntilEndOfTurn => Axes::NONE,
+        Duration::UntilEndOfCombat => Axes::NONE,
+        Duration::UntilNextTurnOf { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        Duration::UntilEndOfNextTurnOf { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        Duration::UntilHostLeavesPlay => Axes::NONE,
+        Duration::UntilNextStepOf { player, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_scope(player));
+            acc
+        }
+        Duration::ForAsLongAs { condition, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_static_condition(condition));
+            acc
+        }
+        Duration::Permanent => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_static_condition(x: &StaticCondition) -> Axes {
+    match x {
+        StaticCondition::DevotionGE { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        StaticCondition::IsPresent { filter, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = filter {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        StaticCondition::ChosenColorIs { .. } => Axes::NONE,
+        StaticCondition::ChosenLabelIs { .. } => Axes::NONE,
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(lhs));
+            acc = acc.or(scan_quantity_expr(rhs));
+            acc
+        }
+        StaticCondition::HasMaxSpeed => Axes::NONE,
+        StaticCondition::SpeedGE { .. } => Axes::NONE,
+        StaticCondition::And { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_static_condition(x));
+            }
+            acc
+        }
+        StaticCondition::Or { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_static_condition(x));
+            }
+            acc
+        }
+        StaticCondition::Not { condition, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_static_condition(condition));
+            acc
+        }
+        StaticCondition::DayNightIs { .. } => Axes::NONE,
+        StaticCondition::HasCounters { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        StaticCondition::CastVariantPaid { .. } => Axes::NONE,
+        StaticCondition::RecipientHasCounters { .. } => Axes {
+            event: false,
+            sibling: true,
+            projected: false,
+        },
+        StaticCondition::ClassLevelGE { .. } => Axes::NONE,
+        StaticCondition::DefendingPlayerControls { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        StaticCondition::SourceAttackingAlone => Axes::NONE,
+        StaticCondition::SourceIsAttacking => Axes::NONE,
+        StaticCondition::SourceIsBlocking => Axes::NONE,
+        StaticCondition::SourceIsBlocked => Axes::NONE,
+        StaticCondition::IsMonarch => Axes::NONE,
+        StaticCondition::IsInitiative => Axes::NONE,
+        StaticCondition::NoMonarch => Axes::NONE,
+        StaticCondition::HasCityBlessing => Axes::NONE,
+        StaticCondition::CompletedADungeon => Axes::NONE,
+        StaticCondition::WasStartingPlayer { controller, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(controller));
+            acc
+        }
+        StaticCondition::SpellCastWithVariantThisTurn { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        StaticCondition::OpponentPoisonAtLeast { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        StaticCondition::UnlessPay { .. } => Axes::CONSERVATIVE,
+        StaticCondition::Unrecognized { .. } => Axes::NONE,
+        StaticCondition::DuringYourTurn => Axes::NONE,
+        StaticCondition::SharesColorWithMostCommonColorAmongPermanents => Axes::NONE,
+        StaticCondition::SourceEnteredThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        StaticCondition::SourceHasDealtDamage => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        StaticCondition::WasCast { .. } => Axes::NONE,
+        StaticCondition::IsRingBearer => Axes::NONE,
+        StaticCondition::RingLevelAtLeast { .. } => Axes::NONE,
+        StaticCondition::ControlsCommander { .. } => Axes::NONE,
+        StaticCondition::SourceIsTapped => Axes::NONE,
+        StaticCondition::IsTapped { scope, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_object_scope(scope));
+            acc
+        }
+        StaticCondition::SourceIsSaddled => Axes::NONE,
+        StaticCondition::SourceControllerEquals { .. } => Axes::NONE,
+        StaticCondition::SourceIsEquipped => Axes::NONE,
+        StaticCondition::SourceIsEnchanted => Axes::NONE,
+        StaticCondition::SourceIsMonstrous => Axes::NONE,
+        StaticCondition::SourceIsHarnessed => Axes::NONE,
+        StaticCondition::SourceAttachedToCreature => Axes::NONE,
+        StaticCondition::SourceMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        StaticCondition::RecipientMatchesFilter { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        StaticCondition::RecipientAttackingOwnerTarget { .. } => Axes::NONE,
+        StaticCondition::SourceIsPaired => Axes::NONE,
+        StaticCondition::SourceInZone { .. } => Axes::NONE,
+        StaticCondition::EnchantedIsFaceDown => Axes::NONE,
+        StaticCondition::AdditionalCostPaid => Axes::NONE,
+        StaticCondition::CastingAsVariant { .. } => Axes::NONE,
+        StaticCondition::None => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_player_filter(x: &PlayerFilter) -> Axes {
+    match x {
+        PlayerFilter::Controller => Axes::NONE,
+        PlayerFilter::Opponent => Axes::NONE,
+        PlayerFilter::DefendingPlayer => Axes::NONE,
+        PlayerFilter::OpponentLostLife => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        PlayerFilter::OpponentGainedLife => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        PlayerFilter::HasLostTheGame => Axes::NONE,
+        PlayerFilter::OpponentDealtCombatDamage { source, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            if let Some(x) = source {
+                acc = acc.or(scan_target_filter(x));
+            }
+            acc
+        }
+        PlayerFilter::OpponentAttacked { .. } => Axes::NONE,
+        PlayerFilter::All => Axes::NONE,
+        PlayerFilter::AllExcept { exclude, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_player_filter(exclude));
+            acc
+        }
+        PlayerFilter::HighestSpeed => Axes::NONE,
+        PlayerFilter::ZoneChangedThisWay => Axes::NONE,
+        PlayerFilter::PerformedActionThisWay { .. } => Axes::NONE,
+        PlayerFilter::OwnersOfCardsExiledBySource => Axes::NONE,
+        PlayerFilter::TriggeringPlayer => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerFilter::OpponentOtherThanTriggering => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerFilter::OpponentOfTriggeringPlayer => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerFilter::OpponentOfTriggeringPlayerNotAttacked => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerFilter::VotedFor { .. } => Axes::NONE,
+        PlayerFilter::ParentObjectTargetController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerFilter::ControlsCount { filter, count, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: true,
+                projected: false,
+            };
+            acc = acc.or(scan_target_filter(filter));
+            acc = acc.or(scan_quantity_expr(count));
+            acc
+        }
+        PlayerFilter::PlayerAttribute { attr, value, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_quantity_ref(attr));
+            acc = acc.or(scan_quantity_expr(value));
+            acc
+        }
+        PlayerFilter::ChosenPlayer { .. } => Axes::NONE,
+        PlayerFilter::ParentObjectTargetOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_replacement_condition(x: &ReplacementCondition) -> Axes {
+    match x {
+        ReplacementCondition::And { conditions, .. } => {
+            let mut acc = Axes::NONE;
+            for x in conditions {
+                acc = acc.or(scan_replacement_condition(x));
+            }
+            acc
+        }
+        ReplacementCondition::UnlessControlsSubtype { .. } => Axes::NONE,
+        ReplacementCondition::UnlessControlsOtherLeq { .. } => Axes::CONSERVATIVE,
+        ReplacementCondition::UnlessControlsMatching { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        ReplacementCondition::UnlessControlsCountMatching { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        ReplacementCondition::UnlessPlayerLifeAtMost { .. } => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        ReplacementCondition::UnlessMultipleOpponents => Axes::NONE,
+        ReplacementCondition::UnlessYourTurn => Axes::NONE,
+        ReplacementCondition::UnlessQuantity {
+            lhs,
+            rhs,
+            active_player_req,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(lhs));
+            acc = acc.or(scan_quantity_expr(rhs));
+            if let Some(x) = active_player_req {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        ReplacementCondition::OnlyIfQuantity {
+            lhs,
+            rhs,
+            active_player_req,
+            ..
+        } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_quantity_expr(lhs));
+            acc = acc.or(scan_quantity_expr(rhs));
+            if let Some(x) = active_player_req {
+                acc = acc.or(scan_controller_ref(x));
+            }
+            acc
+        }
+        ReplacementCondition::HasMaxSpeed => Axes::NONE,
+        ReplacementCondition::CastViaEscape => Axes::NONE,
+        ReplacementCondition::CastVariantPaid { .. } => Axes::NONE,
+        ReplacementCondition::CastFromZone { .. } => Axes::NONE,
+        ReplacementCondition::EnteredFromZone { .. } => Axes::NONE,
+        ReplacementCondition::YouAttackedThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        ReplacementCondition::OpponentDamagedThisTurn => Axes {
+            event: false,
+            sibling: false,
+            projected: true,
+        },
+        ReplacementCondition::CastViaKicker { .. } => Axes::NONE,
+        ReplacementCondition::SourceTappedState { .. } => Axes::NONE,
+        ReplacementCondition::DealtDamageThisTurnBySource { source, .. } => {
+            let mut acc = Axes {
+                event: false,
+                sibling: false,
+                projected: true,
+            };
+            acc = acc.or(scan_target_filter(source));
+            acc
+        }
+        ReplacementCondition::EventSourceControlledBy { controller, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_controller_ref(controller));
+            acc
+        }
+        ReplacementCondition::EffectCausedDiscard => Axes::NONE,
+        ReplacementCondition::OnlyExtraTurn => Axes::NONE,
+        ReplacementCondition::TokenSubtypeMatches { .. } => Axes::NONE,
+        ReplacementCondition::TokenCoreTypeMatches { .. } => Axes::NONE,
+        ReplacementCondition::ExceptFirstDrawInDrawStep => Axes::NONE,
+        ReplacementCondition::IfControlsMatching { filter, .. } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(filter));
+            acc
+        }
+        ReplacementCondition::ClassLevelGE { .. } => Axes::NONE,
+        ReplacementCondition::DuringUntapStep => Axes::NONE,
+        ReplacementCondition::ControllerControlsSource { .. } => Axes::NONE,
+        ReplacementCondition::Unrecognized { .. } => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_player_scope(x: &PlayerScope) -> Axes {
+    match x {
+        PlayerScope::Controller => Axes::NONE,
+        PlayerScope::ScopedPlayer => Axes::NONE,
+        PlayerScope::Target => Axes::NONE,
+        PlayerScope::Opponent { .. } => Axes::NONE,
+        PlayerScope::AllPlayers { exclude, .. } => {
+            let mut acc = Axes::NONE;
+            if let Some(x) = exclude {
+                acc = acc.or(scan_player_scope(x));
+            }
+            acc
+        }
+        PlayerScope::RecipientController => Axes::NONE,
+        PlayerScope::DefendingPlayer => Axes::NONE,
+        PlayerScope::ParentObjectTargetController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        PlayerScope::SourceChosenPlayer => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_controller_ref(x: &ControllerRef) -> Axes {
+    match x {
+        ControllerRef::You => Axes::NONE,
+        ControllerRef::Opponent => Axes::NONE,
+        ControllerRef::ScopedPlayer => Axes::NONE,
+        ControllerRef::TargetPlayer => Axes::NONE,
+        ControllerRef::ParentTargetController => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        ControllerRef::ParentTargetOwner => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        ControllerRef::DefendingPlayer => Axes::NONE,
+        ControllerRef::ChosenPlayer { .. } => Axes::NONE,
+        ControllerRef::SourceChosenPlayer => Axes::NONE,
+        ControllerRef::TriggeringPlayer => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
+        ControllerRef::EnchantedPlayer => Axes::NONE,
+    }
+}
+
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+fn scan_count_scope(x: &CountScope) -> Axes {
+    match x {
+        CountScope::Controller => Axes::NONE,
+        CountScope::Owner => Axes::NONE,
+        CountScope::ScopedPlayer => Axes::NONE,
+        CountScope::SourceChosenPlayer => Axes::NONE,
+        CountScope::All => Axes::NONE,
+        CountScope::Opponents => Axes::NONE,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public classification API (consumed by `game::triggers` ordering and
+// `analysis::resource` coverability). Each is a thin projection of one axis.
+// ---------------------------------------------------------------------------
+
+/// Axis 3: does this resolved ability (and its chain/conditions) read a
+/// projected player-level resource or journal? (`analysis::resource` item 4.)
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn ability_reads_projected_resource(ability: &ResolvedAbility) -> bool {
+    resolved_ability_axes(ability).projected
+}
+
+/// Axis 1: does this resolved ability read the concrete triggering-event /
+/// cost-paid-object context? (CR 603.4; `game::triggers` ordering.)
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn ability_uses_event_context(ability: &ResolvedAbility) -> bool {
+    resolved_ability_axes(ability).event
+}
+
+/// Axis 2: does this resolved ability read a source/recipient or board-scoped
+/// mutable aggregate a sibling copy could change? (CR 603.3b; `game::triggers`
+/// C2 distinct-event auto-resolve gate — the Rubblebelt Rioters / Orcish
+/// Siegemaster exclusion.)
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn ability_reads_sibling_mutable(ability: &ResolvedAbility) -> bool {
+    resolved_ability_axes(ability).sibling
+}
+
+/// Axis 3 on a bare trigger fire-time `condition` (CR 603.4 intervening-if) —
+/// the off-stack scan surface (`analysis::resource` item 5).
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn trigger_condition_reads_projected_resource(condition: &TriggerCondition) -> bool {
+    scan_trigger_condition(condition).projected
+}
+
+/// Axis 3 on a condition-gated static's `condition` (CR 604.1/613.1) — the
+/// dormant-static off-stack scan surface.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn static_condition_reads_projected_resource(condition: &StaticCondition) -> bool {
+    scan_static_condition(condition).projected
+}
+
+/// Axis 3 on a replacement effect's `condition`/body (CR 614.1) — the
+/// off-stack replacement scan surface.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn replacement_condition_reads_projected_resource(
+    condition: &ReplacementCondition,
+) -> bool {
+    scan_replacement_condition(condition).projected
+}
+
+/// Axis 3 on a bare `AbilityCondition` (resolution-time branch selector).
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn ability_condition_reads_projected_resource(condition: &AbilityCondition) -> bool {
+    scan_ability_condition(condition).projected
+}
+
+/// Axis 3 on a transient `Duration::ForAsLongAs` condition (CR 604.1) — the
+/// `transient_continuous_effects` off-stack scan surface.
+#[allow(dead_code)] // TODO(PR-6.5 inc2): remove — consumed once wired via analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource + game::triggers C0 classifier.
+pub(crate) fn duration_reads_projected_resource(duration: &Duration) -> bool {
+    scan_duration(duration).projected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{
+        AggregateFunction, CastManaObjectScope, CastManaSpentMetric, Comparator,
+    };
+    use crate::types::identifiers::ObjectId;
+    use crate::types::player::{PlayerCounterKind, PlayerId};
+
+    fn ability_with_amount(qty: QuantityRef) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Ref { qty },
+                player: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
+    fn fixed_drain() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
+    // ---- Axis 3: projected-resource readers (must classify TRUE) ----
+    #[test]
+    fn projected_readers_classify_as_reading() {
+        // Life axis (CR 119).
+        assert!(ability_reads_projected_resource(&ability_with_amount(
+            QuantityRef::LifeTotal {
+                player: PlayerScope::Controller
+            }
+        )));
+        // Player-counter axis (CR 122.1) — N1(n) walker pairing; experience has NO
+        // winner-predicate firewall, so this classification is the only rejection.
+        assert!(ability_reads_projected_resource(&ability_with_amount(
+            QuantityRef::PlayerCounter {
+                kind: PlayerCounterKind::Experience,
+                scope: CountScope::Controller
+            }
+        )));
+        // Per-turn life-gained journal.
+        assert!(ability_reads_projected_resource(&ability_with_amount(
+            QuantityRef::LifeGainedThisTurn {
+                player: PlayerScope::Controller
+            }
+        )));
+        // Cast journal (spells cast this turn, cleared by project_out_resources).
+        assert!(ability_reads_projected_resource(&ability_with_amount(
+            QuantityRef::SpellsCastThisTurn {
+                scope: CountScope::Controller,
+                filter: None
+            }
+        )));
+        // Damage journal (damage dealt this turn).
+        assert!(ability_reads_projected_resource(&ability_with_amount(
+            QuantityRef::DamageDealtThisTurn {
+                source: Box::new(TargetFilter::Any),
+                target: Box::new(TargetFilter::Any),
+                aggregate: AggregateFunction::Sum,
+                group_by: None,
+                damage_kind: crate::types::ability::DamageKindFilter::Any,
+                channel: crate::types::ability::DamageChannel::Total,
+            }
+        )));
+        // Trigger fire-time intervening-if readers.
+        assert!(trigger_condition_reads_projected_resource(
+            &TriggerCondition::GainedLife { minimum: 30 }
+        ));
+        assert!(trigger_condition_reads_projected_resource(
+            &TriggerCondition::LifeTotalGE { minimum: 6 }
+        ));
+        // Ability-condition branch selector reading the per-ability resolution count.
+        assert!(ability_condition_reads_projected_resource(
+            &AbilityCondition::NthResolutionThisTurn { n: 10 }
+        ));
+        // Static-condition dormant reader (poison).
+        assert!(static_condition_reads_projected_resource(
+            &StaticCondition::OpponentPoisonAtLeast { count: 1 }
+        ));
+        // Replacement-condition dormant reader (life).
+        assert!(replacement_condition_reads_projected_resource(
+            &ReplacementCondition::UnlessPlayerLifeAtMost { amount: 5 }
+        ));
+        // Transient ForAsLongAs duration wrapping a life-reading static condition.
+        assert!(duration_reads_projected_resource(&Duration::ForAsLongAs {
+            condition: StaticCondition::OpponentPoisonAtLeast { count: 1 }
+        }));
+    }
+
+    // ---- Axis 3: object/board readers are NON-reading (R5-B1 negative) ----
+    #[test]
+    fn object_and_board_readers_are_not_projected() {
+        // Object counter / P/T reads are strict-compared by gate (1), not projected.
+        for qty in [
+            QuantityRef::Power {
+                scope: ObjectScope::Source,
+            },
+            QuantityRef::CountersOn {
+                scope: ObjectScope::Source,
+                counter_type: None,
+            },
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Any,
+            },
+        ] {
+            assert!(!ability_reads_projected_resource(&ability_with_amount(qty)));
+        }
+        // Structural conditions do not read a projected axis.
+        assert!(!trigger_condition_reads_projected_resource(
+            &TriggerCondition::SourceIsTapped
+        ));
+        assert!(!static_condition_reads_projected_resource(
+            &StaticCondition::SourceIsTapped
+        ));
+        assert!(!ability_condition_reads_projected_resource(
+            &AbilityCondition::IsYourTurn
+        ));
+        assert!(!replacement_condition_reads_projected_resource(
+            &ReplacementCondition::CastFromZone {
+                zone: crate::types::zones::Zone::Graveyard
+            }
+        ));
+        assert!(!duration_reads_projected_resource(
+            &Duration::UntilEndOfTurn
+        ));
+        // The plain fixed drain reads nothing on any axis.
+        assert!(!ability_reads_projected_resource(&fixed_drain()));
+    }
+
+    // ---- Axis 1: event-context ----
+    #[test]
+    fn event_context_axis_discriminates() {
+        // "gain THAT MUCH life" reads the triggering event amount.
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::EventContextAmount
+        )));
+        // Fixed drain does not.
+        assert!(!ability_uses_event_context(&fixed_drain()));
+
+        // Each of the 5 event-context escapees, reached through a carrier the walk
+        // actually traverses, must classify event == true.
+        // (1) ObjectScope::EventSource via QuantityRef::Power.
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::Power {
+                scope: ObjectScope::EventSource,
+            }
+        )));
+        // (2) TargetFilter::TriggeringSourceController via QuantityRef::ObjectCount filter.
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::TriggeringSourceController,
+            }
+        )));
+        // (3) TargetFilter::ParentTargetSlot via QuantityRef::ObjectCount filter.
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::ParentTargetSlot { index: 0 },
+            }
+        )));
+        // (4) QuantityRef::TimesCostPaidThisResolution directly.
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::TimesCostPaidThisResolution
+        )));
+        // (5) CastManaObjectScope::TriggeringSpell via QuantityRef::ManaSpentToCast,
+        //     whose whole arm is Axes::CONSERVATIVE (fail-closed ⇒ event == true).
+        assert!(ability_uses_event_context(&ability_with_amount(
+            QuantityRef::ManaSpentToCast {
+                scope: CastManaObjectScope::TriggeringSpell,
+                metric: CastManaSpentMetric::Total,
+            }
+        )));
+
+        // Cross-axis negative: a purely projected-resource reader (life, CR 119)
+        // does NOT read event context — the axes are independent.
+        assert!(!ability_uses_event_context(&ability_with_amount(
+            QuantityRef::LifeTotal {
+                player: PlayerScope::Controller,
+            }
+        )));
+    }
+
+    // ---- BLOCKER 1 regression: multi_target bounds are traversed ----
+    #[test]
+    fn multi_target_bound_event_read_classifies() {
+        // Base effect reads nothing; the ONLY event read is the multi_target min.
+        // Revert-fail: drop the `multi_target` traversal ⇒ this flips to inert.
+        let mut a = fixed_drain();
+        a.multi_target = Some(MultiTargetSpec {
+            min: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+            max: None,
+        });
+        assert!(ability_uses_event_context(&a));
+        // Sanity: without the multi_target it is inert (isolates the min bound).
+        assert!(!ability_uses_event_context(&fixed_drain()));
+    }
+
+    // ---- BLOCKER 2 regression: target_constraints are traversed ----
+    #[test]
+    fn target_constraint_event_read_classifies() {
+        // The ONLY read is the TotalManaValue where-X bound (EventContextAmount).
+        // Revert-fail: drop the `target_constraints` traversal ⇒ this flips to inert.
+        let mut a = fixed_drain();
+        a.target_constraints = vec![TargetSelectionConstraint::TotalManaValue {
+            comparator: Comparator::LE,
+            value: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount,
+            },
+        }];
+        assert!(ability_uses_event_context(&a));
+        // Sanity: the Different* constraints carry no read.
+        let mut b = fixed_drain();
+        b.target_constraints = vec![TargetSelectionConstraint::DifferentTargetPlayers];
+        assert!(!ability_uses_event_context(&b));
+    }
+
+    // ---- Axis 2: sibling-mutable board read (Rubblebelt / Orcish class) ----
+    #[test]
+    fn sibling_mutable_axis_discriminates() {
+        // A board-count-scaled pump reads a mutable aggregate a sibling could change.
+        assert!(ability_reads_sibling_mutable(&ability_with_amount(
+            QuantityRef::ObjectCount {
+                filter: TargetFilter::Any
+            }
+        )));
+        // Source power (Orcish Siegemaster class) is a sibling-mutable read.
+        assert!(ability_reads_sibling_mutable(&ability_with_amount(
+            QuantityRef::Power {
+                scope: ObjectScope::Source
+            }
+        )));
+        // Fixed drain reads no sibling-mutable state — safe to auto-resolve.
+        assert!(!ability_reads_sibling_mutable(&fixed_drain()));
+    }
+}

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3097,7 +3097,6 @@ fn scan_count_scope(x: &CountScope) -> Axes {
 
 /// Axis 3: does this resolved ability (and its chain/conditions) read a
 /// projected player-level resource or journal? (`analysis::resource` item 4.)
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource stack_entry_reads_projected_resource / fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn ability_reads_projected_resource(ability: &ResolvedAbility) -> bool {
     resolved_ability_axes(ability).projected
 }
@@ -3118,21 +3117,18 @@ pub(crate) fn ability_reads_sibling_mutable(ability: &ResolvedAbility) -> bool {
 
 /// Axis 3 on a bare trigger fire-time `condition` (CR 603.4 intervening-if) —
 /// the off-stack scan surface (`analysis::resource` item 5).
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn trigger_condition_reads_projected_resource(condition: &TriggerCondition) -> bool {
     scan_trigger_condition(condition).projected
 }
 
 /// Axis 3 on a condition-gated static's `condition` (CR 604.1/613.1) — the
 /// dormant-static off-stack scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn static_condition_reads_projected_resource(condition: &StaticCondition) -> bool {
     scan_static_condition(condition).projected
 }
 
 /// Axis 3 on a replacement effect's `condition`/body (CR 614.1) — the
 /// off-stack replacement scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn replacement_condition_reads_projected_resource(
     condition: &ReplacementCondition,
 ) -> bool {
@@ -3140,14 +3136,12 @@ pub(crate) fn replacement_condition_reads_projected_resource(
 }
 
 /// Axis 3 on a bare `AbilityCondition` (resolution-time branch selector).
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn ability_condition_reads_projected_resource(condition: &AbilityCondition) -> bool {
     scan_ability_condition(condition).projected
 }
 
 /// Axis 3 on a transient `Duration::ForAsLongAs` condition (CR 604.1) — the
 /// `transient_continuous_effects` off-stack scan surface.
-#[allow(dead_code)] // TODO(PR-6.5 inc2b): remove — consumed by analysis::resource fire_time_conditions_read_projected_resource (the cascade detector). C0's two axes (event/sibling) are live as of inc2a.
 pub(crate) fn duration_reads_projected_resource(duration: &Duration) -> bool {
     scan_duration(duration).projected
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -358,10 +358,10 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
             // clears the ring, so a confirmed window is gap-free).
             let mut frames: Vec<&GameState> = priors[k..].iter().map(|p| p.as_ref()).collect();
             frames.push(state);
-            // CR 704.5a + CR 104.4a (m9): the controller must never dip across the
-            // window — a transient intra-cycle dip a net-delta check cannot see would
-            // kill it before the extrapolated win.
-            if !crate::analysis::loop_check::controller_life_never_dips(&frames, winner) {
+            // CR 704.5a + CR 104.4a (m9): the winner (sole non-faller) must never dip
+            // across the window — a transient intra-cycle dip a net-delta check cannot
+            // see would kill it before the extrapolated win.
+            if !crate::analysis::loop_check::winner_life_never_dips(&frames, winner) {
                 return None;
             }
             // CR 704.3 + CR 800.4a + CR 104.2a (R5-B2): with ≥2 fallers, require

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -340,15 +340,46 @@ fn reconcile_terminal_result(state: &mut GameState, result: &mut ActionResult) {
         let priors: Vec<std::sync::Arc<GameState>> =
             state.loop_detect_ring.iter().cloned().collect();
         let cur = crate::analysis::resource::ResourceVector::snapshot(state);
-        // Carry the matching cycle's `delta` out of `find_map` alongside the winner so
+        // Carry the matching cycle's `delta` out of the scan alongside the winner so
         // the ∞ producer below can name the loop's unbounded axes without recomputing.
-        if let Some((winner, delta)) = priors.iter().find_map(|prior| {
+        // INDEXED scan (not `find_map`) so the matched prior's ring index `k` is known:
+        // the m9 controller-non-dip and R5-B2 faller-simultaneity checks consume the
+        // SAME `frames[k..] ++ live` per-resolution window. On a candidate winner that
+        // fails either seam gate, continue scanning older priors (fail-safe).
+        if let Some((winner, delta)) = priors.iter().enumerate().find_map(|(k, prior)| {
             let delta = crate::analysis::resource::ResourceVector::delta(
                 &crate::analysis::resource::ResourceVector::snapshot(prior),
                 &cur,
             );
-            crate::analysis::loop_check::live_mandatory_loop_winner(prior, state, &delta)
-                .map(|winner| (winner, delta))
+            let winner =
+                crate::analysis::loop_check::live_mandatory_loop_winner(prior, state, &delta)?;
+            // The matched window: the prior frame at `k`, every subsequent ring frame,
+            // then the live state — all per-resolution, no gaps (a non-sampling beat
+            // clears the ring, so a confirmed window is gap-free).
+            let mut frames: Vec<&GameState> = priors[k..].iter().map(|p| p.as_ref()).collect();
+            frames.push(state);
+            // CR 704.5a + CR 104.4a (m9): the controller must never dip across the
+            // window — a transient intra-cycle dip a net-delta check cannot see would
+            // kill it before the extrapolated win.
+            if !crate::analysis::loop_check::controller_life_never_dips(&frames, winner) {
+                return None;
+            }
+            // CR 704.3 + CR 800.4a + CR 104.2a (R5-B2): with ≥2 fallers, require
+            // pairwise-equal faller life at every frame so all cross lethal in ONE SBA
+            // batch (the first elimination is terminal — nothing past it is modeled).
+            let fallers: Vec<crate::types::player::PlayerId> = state
+                .players
+                .iter()
+                .filter(|p| !p.is_eliminated)
+                .map(|p| p.id)
+                .filter(|p| delta.life.get(p).copied().unwrap_or(0) < 0)
+                .collect();
+            if fallers.len() >= 2
+                && !crate::analysis::loop_check::fallers_lives_pairwise_equal(&frames, &fallers)
+            {
+                return None;
+            }
+            Some((winner, delta))
         }) {
             // CR 732.5: shortcut ONLY a loop NO living player can break. The gate runs
             // ONCE after find_map (not per prior). At the per-beat drive this is the

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -1,3 +1,4 @@
+pub mod ability_scan;
 pub mod ability_utils;
 pub mod arithmetic;
 pub mod attractions;

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -22339,6 +22339,358 @@ pub mod tests {
         id
     }
 
+    /// Compiler-exhaustive (NO `_` arm) classifier of every `Keyword` variant —
+    /// the structural-exhaustiveness authority for the guard test below (option
+    /// (i)). Returns `true` iff `KeywordTriggerInstaller::triggers_for` has an
+    /// explicit non-empty arm for the keyword (i.e. it synthesizes a granted
+    /// trigger). Because there is no wildcard arm, a future `Keyword` variant
+    /// FAILS TO COMPILE here until it is classified — so a new keyword whose
+    /// granted trigger carries a fire-time condition cannot silently escape the
+    /// guard. Any keyword placed in the `true` group MUST also have a
+    /// representative in `granted_trigger_producer_representatives()` (the test
+    /// cross-checks this at runtime).
+    fn keyword_synthesizes_granted_trigger(kw: &Keyword) -> bool {
+        match kw {
+            // Producers — `triggers_for` synthesizes at least one granted trigger.
+            Keyword::Afflict(_)
+            | Keyword::Undying
+            | Keyword::Persist
+            | Keyword::Exalted
+            | Keyword::Flanking
+            | Keyword::Evolve
+            | Keyword::Extort
+            | Keyword::Renown(_)
+            | Keyword::Fabricate(_)
+            | Keyword::Annihilator(_)
+            | Keyword::Bushido(_)
+            | Keyword::Frenzy(_)
+            | Keyword::Soulbond
+            | Keyword::Battlecry
+            | Keyword::Afterlife(_)
+            | Keyword::Fading(_)
+            | Keyword::Vanishing(_)
+            | Keyword::Rampage(_)
+            | Keyword::Echo(_)
+            | Keyword::CumulativeUpkeep(_)
+            | Keyword::Gravestorm
+            | Keyword::Ingest
+            | Keyword::Melee
+            | Keyword::Mentor
+            | Keyword::Myriad
+            | Keyword::Provoke
+            | Keyword::Suspend { .. }
+            | Keyword::Enlist
+            | Keyword::Dethrone
+            | Keyword::DoubleTeam
+            | Keyword::Poisonous(_)
+            | Keyword::Graft(_)
+            | Keyword::Soulshift(_)
+            | Keyword::Champion(_)
+            | Keyword::Training
+            | Keyword::Recover(_)
+            | Keyword::Increment => true,
+            // Non-producers — `triggers_for` returns an empty vec (no granted
+            // trigger, so no fire-time condition to scan).
+            Keyword::Flying
+            | Keyword::FirstStrike
+            | Keyword::DoubleStrike
+            | Keyword::Trample
+            | Keyword::TrampleOverPlaneswalkers
+            | Keyword::Deathtouch
+            | Keyword::Lifelink
+            | Keyword::Vigilance
+            | Keyword::Haste
+            | Keyword::Reach
+            | Keyword::Defender
+            | Keyword::Menace
+            | Keyword::Indestructible
+            | Keyword::Hexproof
+            | Keyword::HexproofFrom(_)
+            | Keyword::Shroud
+            | Keyword::Flash
+            | Keyword::Fear
+            | Keyword::Intimidate
+            | Keyword::Skulk
+            | Keyword::Shadow
+            | Keyword::Horsemanship
+            | Keyword::Wither
+            | Keyword::Infect
+            | Keyword::StartingIntensity(_)
+            | Keyword::Prowess
+            | Keyword::Cascade
+            | Keyword::Exploit
+            | Keyword::Explore
+            | Keyword::Ascend
+            | Keyword::StartYourEngines
+            | Keyword::Dredge(_)
+            | Keyword::Modular(_)
+            | Keyword::Tribute(_)
+            | Keyword::Unearth(_)
+            | Keyword::Convoke
+            | Keyword::Waterbend
+            | Keyword::Delve
+            | Keyword::Devoid
+            | Keyword::Changeling
+            | Keyword::Phasing
+            | Keyword::Decayed
+            | Keyword::Unleash
+            | Keyword::Riot
+            | Keyword::Enchant(_)
+            | Keyword::EtbCounter { .. }
+            | Keyword::Reconfigure(_)
+            | Keyword::LivingWeapon
+            | Keyword::JobSelect
+            | Keyword::TotemArmor
+            | Keyword::Bestow(_)
+            | Keyword::Embalm(_)
+            | Keyword::Eternalize(_)
+            | Keyword::Protection(_)
+            | Keyword::Kicker(_)
+            | Keyword::Cycling(_)
+            | Keyword::Flashback(_)
+            | Keyword::Ward(_)
+            | Keyword::Equip(_)
+            | Keyword::Landwalk(_)
+            | Keyword::Absorb(_)
+            | Keyword::Crew { .. }
+            | Keyword::Partner(_)
+            | Keyword::Companion(_)
+            | Keyword::Ninjutsu(_)
+            | Keyword::CommanderNinjutsu(_)
+            | Keyword::Prowl(_)
+            | Keyword::Morph(_)
+            | Keyword::Megamorph(_)
+            | Keyword::Mayhem(_)
+            | Keyword::Madness(_)
+            | Keyword::Miracle(_)
+            | Keyword::Dash(_)
+            | Keyword::Emerge(_)
+            | Keyword::Escape(_)
+            | Keyword::Harmonize(_)
+            | Keyword::Evoke(_)
+            | Keyword::Foretell(_)
+            | Keyword::Mutate(_)
+            | Keyword::Disturb(_)
+            | Keyword::Disguise(_)
+            | Keyword::Blitz(_)
+            | Keyword::Overload(_)
+            | Keyword::Spectacle(_)
+            | Keyword::Surge(_)
+            | Keyword::Encore(_)
+            | Keyword::Buyback(_)
+            | Keyword::Casualty(_)
+            | Keyword::Entwine(_)
+            | Keyword::Outlast(_)
+            | Keyword::Scavenge(_)
+            | Keyword::Reinforce { .. }
+            | Keyword::Fortify(_)
+            | Keyword::Prototype { .. }
+            | Keyword::Plot(_)
+            | Keyword::Craft { .. }
+            | Keyword::Offspring(_)
+            | Keyword::Impending { .. }
+            | Keyword::LevelUp(_)
+            | Keyword::Affinity(_)
+            | Keyword::Banding
+            | Keyword::BandsWithOther(_)
+            | Keyword::Epic
+            | Keyword::Fuse
+            | Keyword::Haunt
+            | Keyword::Hideaway(_)
+            | Keyword::Improvise
+            | Keyword::Rebound
+            | Keyword::Retrace
+            | Keyword::Ripple(_)
+            | Keyword::SplitSecond
+            | Keyword::Storm
+            | Keyword::Totem
+            | Keyword::Warp(_)
+            | Keyword::Sneak(_)
+            | Keyword::WebSlinging(_)
+            | Keyword::Mobilize(_)
+            | Keyword::Gift(_)
+            | Keyword::Discover(_)
+            | Keyword::Spree
+            | Keyword::Ravenous
+            | Keyword::Daybound
+            | Keyword::Nightbound
+            | Keyword::ReadAhead
+            | Keyword::Compleated
+            | Keyword::Conspire
+            | Keyword::Demonstrate
+            | Keyword::LivingMetal
+            | Keyword::Bloodthirst(_)
+            | Keyword::Amplify(_)
+            | Keyword::Devour(_)
+            | Keyword::Toxic(_)
+            | Keyword::Saddle(_)
+            | Keyword::Teamwork(_)
+            | Keyword::Backup(_)
+            | Keyword::Squad(_)
+            | Keyword::Typecycling { .. }
+            | Keyword::Firebending(_)
+            | Keyword::Splice { .. }
+            | Keyword::Bargain
+            | Keyword::Sunburst
+            | Keyword::Assist
+            | Keyword::Augment
+            | Keyword::Aftermath
+            | Keyword::JumpStart
+            | Keyword::Cipher
+            | Keyword::Transmute(_)
+            | Keyword::Transfigure(_)
+            | Keyword::Escalate(_)
+            | Keyword::Cleave(_)
+            | Keyword::Undaunted
+            | Keyword::Paradigm
+            | Keyword::Station
+            | Keyword::Replicate(_)
+            | Keyword::Awaken { .. }
+            | Keyword::ForMirrodin
+            | Keyword::MoreThanMeetsTheEye(_)
+            | Keyword::Freerunning(_)
+            | Keyword::Specialize(_)
+            | Keyword::Offering(_)
+            | Keyword::Unknown(_) => false,
+        }
+    }
+
+    /// Concrete representatives for every keyword classified `true` by
+    /// `keyword_synthesizes_granted_trigger`. Payload values are irrelevant to
+    /// the fire-time-condition invariant (the synthesized condition shape does
+    /// not depend on the specific N / cost), so minimal instances are used.
+    fn granted_trigger_producer_representatives() -> Vec<Keyword> {
+        use crate::types::keywords::EchoCost;
+        vec![
+            Keyword::Echo(EchoCost::Mana(ManaCost::default())),
+            Keyword::CumulativeUpkeep(AbilityCost::Mana {
+                cost: ManaCost::default(),
+            }),
+            Keyword::Undying,
+            Keyword::Persist,
+            Keyword::Afterlife(1),
+            Keyword::Fabricate(1),
+            Keyword::Soulshift(1),
+            Keyword::Annihilator(1),
+            Keyword::Provoke,
+            Keyword::Enlist,
+            Keyword::Renown(1),
+            Keyword::Mentor,
+            Keyword::Graft(1),
+            Keyword::Bushido(1),
+            Keyword::Frenzy(1),
+            Keyword::Battlecry,
+            Keyword::Rampage(1),
+            Keyword::Melee,
+            Keyword::Dethrone,
+            Keyword::Recover(ManaCost::default()),
+            Keyword::Evolve,
+            Keyword::Exalted,
+            Keyword::Flanking,
+            Keyword::Extort,
+            Keyword::Increment,
+            Keyword::Myriad,
+            Keyword::DoubleTeam,
+            Keyword::Soulbond,
+            Keyword::Suspend {
+                count: 1,
+                cost: ManaCost::default(),
+            },
+            Keyword::Afflict(1),
+            Keyword::Training,
+            Keyword::Poisonous(1),
+            Keyword::Ingest,
+            Keyword::Gravestorm,
+            Keyword::Fading(1),
+            Keyword::Vanishing(1),
+            Keyword::Champion("Spirit".to_string()),
+        ]
+    }
+
+    /// Item-5 (`fire_time_conditions_read_projected_resource`, resource.rs) only
+    /// scans an object's own `trigger_definitions` — it does NOT scan the
+    /// runtime-GRANTED keyword triggers that
+    /// `KeywordTriggerInstaller::triggers_for` synthesizes (those are produced
+    /// on-the-fly by `synthesize_granted_keyword_triggers` during trigger
+    /// collection and never land on `trigger_definitions`). This test pins the
+    /// EXACT set of granted-keyword synthesized fire-time conditions that the
+    /// item-5 classifier (`trigger_condition_reads_projected_resource`, whose
+    /// `Axes` walk fails CLOSED — see `Axes::CONSERVATIVE`) flags as reading a
+    /// projected resource, so that set cannot grow unnoticed.
+    ///
+    /// Measured today the flagged set is `{ Dethrone, Increment, Soulbond,
+    /// Training }`, but only ONE is a GENUINE projected-player-resource read:
+    /// - **Dethrone** (CR 702.105a): `QuantityComparison` of the defending
+    ///   player's `LifeTotal` vs the max `LifeTotal` among all players. Life
+    ///   (CR 119) is a projected axis `project_out_resources` zeroes, so a dormant
+    ///   granted Dethrone WOULD arm on a projected read. Because a runtime-GRANTED
+    ///   Dethrone (`Effect::GrantKeywords` / `ContinuousModification::AddKeyword`)
+    ///   lives off-`trigger_definitions`, item-5 does not see it — a KNOWN,
+    ///   UNRESOLVED item-5 gap (dormant-arming false WIN, N1(k) class) whose
+    ///   severity depends on whether granted Dethrone is reachable inside a
+    ///   growing-cascade loop. NOTE: this contradicts the inc2b review's premise
+    ///   that "no granted-keyword condition reads a projected resource".
+    /// - **Increment / Soulbond / Training** are FALSE POSITIVES of the fail-closed
+    ///   walk: Increment reads `ManaSpentToCast` (→ `Axes::CONSERVATIVE`), Soulbond
+    ///   reads control/`Unpaired`/zone-change filters, Training reads a co-attacker
+    ///   `MinCoAttackers` power filter. All are cast/combat/object state that gate
+    ///   (1) strict-compares; the classifier only marks them projected because it
+    ///   does not descend those subtrees. Missing them in item-5 is harmless.
+    ///
+    /// If this set changes, DO NOT just edit the expected list — investigate:
+    /// a NEW genuine projected reader means item-5 must be extended to scan
+    /// granted-keyword defs before it can be trusted; a removed entry means the
+    /// classifier or a builder changed.
+    #[test]
+    fn granted_keyword_trigger_conditions_projected_reads_are_exactly_known_gaps() {
+        use crate::database::synthesis::KeywordTriggerInstaller;
+        use crate::game::ability_scan::trigger_condition_reads_projected_resource;
+        use std::collections::BTreeSet;
+
+        let mut checked_conditions = 0;
+        let mut flagged: BTreeSet<String> = BTreeSet::new();
+        for kw in granted_trigger_producer_representatives() {
+            // The representative list and the exhaustive classifier must agree.
+            assert!(
+                keyword_synthesizes_granted_trigger(&kw),
+                "{kw:?} is in the representative list but classified as a non-producer"
+            );
+            let triggers = KeywordTriggerInstaller::triggers_for(&kw);
+            assert!(
+                !triggers.is_empty(),
+                "{kw:?} is classified as a granted-trigger producer but synthesized no trigger"
+            );
+            for def in &triggers {
+                if let Some(condition) = &def.condition {
+                    checked_conditions += 1;
+                    if trigger_condition_reads_projected_resource(condition) {
+                        flagged.insert(format!("{kw:?}"));
+                    }
+                }
+            }
+        }
+        // Non-vacuity: builders DO synthesize fire-time conditions (Echo→EchoDue,
+        // Renown→Not(IsRenowned), Suspend/…), so the `Some(condition)` arm above
+        // is actually exercised — not passing merely because every condition is
+        // `None`.
+        assert!(
+            checked_conditions > 0,
+            "expected at least one synthesized fire-time condition to scan"
+        );
+        let expected: BTreeSet<String> = ["Dethrone", "Increment", "Soulbond", "Training"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            flagged, expected,
+            "granted-keyword conditions flagged as projected-reading changed. If a NEW \
+             keyword appears, verify whether it is a GENUINE projected read (extend \
+             fire_time_conditions_read_projected_resource, item-5 in resource.rs, to scan \
+             granted-keyword defs) or another fail-closed false positive; if one \
+             DISAPPEARS, confirm the classifier/builder change is intended."
+        );
+    }
+
     /// Install the synthesized Undying dies-trigger (CR 702.93a) onto a
     /// battlefield creature, mirroring `make_soulbond_creature`.
     fn make_undying_creature(state: &mut GameState, player: PlayerId, name: &str) -> ObjectId {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3347,6 +3347,14 @@ fn normalize_ability_identity(ability: &mut ResolvedAbility) {
     }
 }
 
+/// Legacy fail-open event-context allowlist. RETAINED for the pre-feature
+/// same-event and ZoneChanged same-departure-batch auto-resolve paths, whose
+/// shipped behavior depends on this classifier's exact (fail-open) semantics —
+/// notably co-departing death triggers that read `EventSource` power (issue
+/// #4269) auto-order today because this allowlist does NOT list `EventSource`.
+/// The fail-closed `ability_scan` walker is used ONLY for the new gated-C2
+/// distinct-event term; replacing this allowlist wholesale on the legacy paths
+/// regresses those cards (see inc2a report — C0 full replacement is DEFERRED).
 fn value_contains_trigger_event_context_ref(value: &serde_json::Value) -> bool {
     match value {
         serde_json::Value::String(tag) => matches!(
@@ -3408,21 +3416,45 @@ fn zone_changes_are_same_departure_batch(a: &GameEvent, b: &GameEvent) -> bool {
 fn trigger_events_match_for_ordering(
     first: &PendingTrigger,
     candidate: &PendingTrigger,
-    ability_uses_trigger_event: bool,
+    legacy_uses_trigger_event: bool,
+    c2_order_independent: bool,
+    loop_detection_on: bool,
 ) -> bool {
+    // Same firing event (CR 603.2c): pre-feature auto-order, UNCHANGED. Gating
+    // this on soundness is the C1 CR 603.3b fix — DEFERRED (see inc2a report):
+    // the committed `ability_scan` walker classifies ~46 common effect kinds
+    // (CopySpell/Token/Pump/Mana/ChangeZone/…) as conservative, so `sibling`
+    // reads true for them; gating same-event on that axis would over-prompt
+    // printed copy/token keywords (Demonstrate, Replicate) in all modes,
+    // contradicting the "affects no printed card" guarantee. Needs a precise
+    // read/write predicate first.
     if first.trigger_event == candidate.trigger_event {
         return true;
     }
-    if ability_uses_trigger_event {
-        return false;
+
+    // Distinct firing events. Pre-feature (and OFF): only an explicitly
+    // simultaneous ZoneChanged same-departure batch (CR 603.2c) with no
+    // event-context read auto-resolves. Gated by the LEGACY allowlist (not the
+    // walker) so shipped co-departing death triggers reading `EventSource` power
+    // (issue #4269) keep auto-ordering — the walker correctly flags EventSource
+    // event-context, which would defeat this batch path.
+    if !legacy_uses_trigger_event {
+        if let (Some(first_event), Some(candidate_event)) =
+            (&first.trigger_event, &candidate.trigger_event)
+        {
+            if zone_changes_are_same_departure_batch(first_event, candidate_event) {
+                return true;
+            }
+        }
     }
 
-    match (&first.trigger_event, &candidate.trigger_event) {
-        (Some(first_event), Some(candidate_event)) => {
-            zone_changes_are_same_departure_batch(first_event, candidate_event)
-        }
-        _ => false,
-    }
+    // C2 (GATED on `loop_detection.is_on()`): when the growing-cascade detector
+    // is ON, a distinct-event group the fail-closed C0 walker deems order
+    // independent (reads neither event context nor sibling-mutable state) also
+    // auto-resolves so the loop-detect ring can accumulate the super-critical
+    // fan-out. When OFF this term is false, so distinct-event non-ZoneChanged
+    // groups PROMPT exactly as pre-feature (default gameplay byte-preserved).
+    loop_detection_on && c2_order_independent
 }
 
 /// CR 603.3c/603.3d + CR 601.2c/601.2d: A trigger requires ordering-relevant
@@ -3456,22 +3488,26 @@ fn trigger_has_no_ordering_input(t: &PendingTrigger) -> bool {
 /// (CR 603.2c — one event with multiple occurrences fires a batched trigger
 /// once per occurrence, each carrying its own subject count; read at
 /// resolution), and the `may_trigger_origin`.
-// CR 603.2c: `trigger_event` (the firing event itself) is intentionally NOT
-// part of the equality check only for explicitly simultaneous ZoneChanged
-// departure batches whose resolved ability has no event-context dependency.
-// When N co-departing events all match the same trigger definition and the
-// effect is fixed (e.g. three Liliana, Dreadhorde General draws from one board
-// wipe), placement order is unobservable and a prompt is noise. Other event
-// classes stay exact even when the ability is fixed: a CounterAdded trigger
-// can create more CounterAdded events while resolving, so distinct firing
-// events are not inherently interchangeable.
-// If the ability reads `TriggeringSource`, `TriggeringPlayer`,
-// `EventContextAmount`, or another event-context ref, the concrete firing
-// event is resolution-visible and must still match before auto-ordering.
-// `subject_match_count` is kept in the equality because that is the per-batch
-// count the effect reads at resolution and *can* differ across pending triggers
-// if two distinct batched events satisfy the same definition.
-fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
+// CR 603.2c / CR 603.4: `trigger_event` (the firing event itself) is NOT part
+// of the equality check for explicitly simultaneous ZoneChanged departure
+// batches (preserved in all modes) — when N co-departing events all match the
+// same trigger definition and the effect is fixed (e.g. three Liliana,
+// Dreadhorde General draws from one board wipe), placement order is unobservable
+// and a prompt is noise — and, when the growing-cascade detector is ON, for any
+// distinct-event group the C0 walker deems order independent (C2, so the
+// loop-detect ring can accumulate a fan-out). The pre-feature same-event and
+// ZoneChanged paths keep using the legacy allowlist `ability_uses_trigger_event_context`
+// (its exact fail-open semantics are shipped behavior — see that fn's doc). The
+// new gated-C2 term instead consults the fail-closed `ability_scan` walker over
+// TWO distinct axes (categorical-boundary rule): (i) `ability_uses_event_context`
+// — the concrete firing event is resolution-visible, and (ii)
+// `ability_reads_sibling_mutable` — a source/recipient or board-scoped aggregate
+// a sibling copy resolving first could change. `subject_match_count` is kept in
+// the equality because that is the per-batch count the effect reads at resolution
+// and *can* differ across pending triggers if two distinct batched events satisfy
+// the same definition. `is_on` threads `loop_detection.is_on()` down to the
+// one-line C2 gate (the predicate has no `GameState`).
+fn group_is_order_independent(group: &[PendingTriggerContext], is_on: bool) -> bool {
     let Some((first, rest)) = group.split_first() else {
         return false;
     };
@@ -3483,12 +3519,23 @@ fn group_is_order_independent(group: &[PendingTriggerContext]) -> bool {
     }
     let mut reference = first.pending.ability.clone();
     normalize_ability_identity(&mut reference);
-    let reference_uses_trigger_event = ability_uses_trigger_event_context(&reference);
+    // Legacy allowlist: drives the pre-feature same-event / ZoneChanged paths.
+    let legacy_uses_trigger_event = ability_uses_trigger_event_context(&reference);
+    // C0 (fail-closed AST walker): two distinct soundness axes (event context,
+    // sibling-mutable) — consumed ONLY by the gated-C2 distinct-event term.
+    let c2_order_independent = !crate::game::ability_scan::ability_uses_event_context(&reference)
+        && !crate::game::ability_scan::ability_reads_sibling_mutable(&reference);
     rest.iter().all(|ctx| {
         let t = &ctx.pending;
         trigger_has_no_ordering_input(t)
             && t.condition == first.pending.condition
-            && trigger_events_match_for_ordering(&first.pending, t, reference_uses_trigger_event)
+            && trigger_events_match_for_ordering(
+                &first.pending,
+                t,
+                legacy_uses_trigger_event,
+                c2_order_independent,
+                is_on,
+            )
             && t.subject_match_count == first.pending.subject_match_count
             && t.may_trigger_origin == first.pending.may_trigger_origin
             && {
@@ -3540,8 +3587,9 @@ fn begin_trigger_ordering(
     // no-input triggers, commute under any permutation — auto-order them so the
     // player isn't prompted for an immaterial choice (matching MTG Arena). Any
     // field divergence is a safe false-negative: the group still prompts.
+    let loop_detection_on = state.loop_detection.is_on();
     for g in groups.iter_mut() {
-        if g.triggers.len() <= 1 || group_is_order_independent(&g.triggers) {
+        if g.triggers.len() <= 1 || group_is_order_independent(&g.triggers, loop_detection_on) {
             g.ordered = true;
         }
     }
@@ -7000,8 +7048,8 @@ pub mod tests {
     use crate::types::card_type::CoreType;
     use crate::types::events::{GameEvent, ManaTapState};
     use crate::types::game_state::{
-        DamageRecord, DelayedTrigger, DistributionUnit, GameState, SpellCastRecord, StackEntry,
-        StackEntryKind, WaitingFor, ZoneChangeRecord,
+        DamageRecord, DelayedTrigger, DistributionUnit, GameState, LoopDetectionMode,
+        SpellCastRecord, StackEntry, StackEntryKind, WaitingFor, ZoneChangeRecord,
     };
     use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
     use crate::types::keywords::{Keyword, KeywordKind};
@@ -20519,6 +20567,256 @@ pub mod tests {
             "expected OrderTriggers, got {wf:?}"
         );
         assert!(state.deferred_triggers.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // PR-6.25 (folded into PR-6.5 inc2a): C0 classifier wiring + C1 + gated-C2.
+    // C0 = the fail-closed `ability_scan` walker replacing the fail-open string
+    // allowlist; C1 = same-event auto-order gated on soundness (ungated CR 603.3b
+    // fix); C2 = distinct-event auto-resolve gated on `loop_detection.is_on()`.
+    // -----------------------------------------------------------------------
+
+    /// Build a no-ordering-input pending trigger (empty targets/constraints, no
+    /// modal/distribution) controlled by `controller`, carrying `ability` and
+    /// firing off `trigger_event`. Two of these with structurally identical
+    /// abilities normalize equal (CR 603.4), so the group is a genuine CR 603.3b
+    /// indistinguishability candidate — the ability's `source_id` is zeroed by
+    /// `normalize_ability_identity` before comparison.
+    fn pr625_no_input_trigger(
+        state: &mut GameState,
+        controller: PlayerId,
+        name: &str,
+        ability: ResolvedAbility,
+        trigger_event: Option<GameEvent>,
+    ) -> PendingTriggerContext {
+        let source_id = create_object(
+            state,
+            CardId(state.next_object_id),
+            controller,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        PendingTriggerContext::single(PendingTrigger {
+            source_id,
+            controller,
+            condition: None,
+            ability,
+            timestamp: 0,
+            target_constraints: Vec::new(),
+            distribute: None,
+            trigger_event,
+            modal: None,
+            mode_abilities: vec![],
+            description: None,
+            may_trigger_origin: None,
+            subject_match_count: None,
+            die_result: None,
+        })
+    }
+
+    /// A "sound" no-input ability: fixed `gain 1 life`. The C0 walker classifies
+    /// it as reading neither event context nor sibling-mutable board state — the
+    /// ≥3p all-opponent-drain fan-out closer class.
+    fn pr625_sound_ability() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(0),
+            PlayerId(0),
+        )
+    }
+
+    /// A sibling-mutable ability: `gain life equal to source's power`. The C0
+    /// walker's axis-2 flags the `ObjectScope::Source` power read (Orcish
+    /// Siegemaster / Rubblebelt Rioters class) — a sibling copy resolving first
+    /// could change the value, so the group is order-DEPENDENT.
+    fn pr625_sibling_mutable_ability() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: crate::types::ability::ObjectScope::Source,
+                    },
+                },
+                player: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(0),
+            PlayerId(0),
+        )
+    }
+
+    /// C1 status (DEFERRED — see inc2a report): the same-event short-circuit
+    /// stays pre-feature (unconditional auto-order) in BOTH detector modes, because
+    /// gating it on the committed walker's conservative `sibling` axis would
+    /// over-prompt printed copy/token/pump keywords. This test pins the preserved
+    /// pre-feature behavior: a same-event identical no-input group auto-resolves
+    /// (NoChoiceNeeded) regardless of whether its ability reads sibling-mutable
+    /// state. When C1's precise soundness gate lands, the sibling-mutable arm here
+    /// must flip to PromptForChoice (its future revert-fail).
+    #[test]
+    fn pr625_c1_same_event_groups_auto_order_pre_feature_preserved() {
+        let event = Some(GameEvent::LifeChanged {
+            player_id: PlayerId(0),
+            amount: 1,
+        });
+        for mode in [LoopDetectionMode::Off, LoopDetectionMode::On] {
+            for ability in [pr625_sound_ability(), pr625_sibling_mutable_ability()] {
+                let mut state = setup();
+                state.loop_detection = mode;
+                let group = vec![
+                    pr625_no_input_trigger(
+                        &mut state,
+                        PlayerId(0),
+                        "Same A",
+                        ability.clone(),
+                        event.clone(),
+                    ),
+                    pr625_no_input_trigger(
+                        &mut state,
+                        PlayerId(0),
+                        "Same B",
+                        ability,
+                        event.clone(),
+                    ),
+                ];
+                assert!(
+                    group_is_order_independent(&group, mode.is_on()),
+                    "pre-feature: same-event identical group auto-orders ({mode:?})"
+                );
+                match begin_trigger_ordering(&mut state, group) {
+                    TriggerOrderingDisposition::NoChoiceNeeded(_) => {}
+                    TriggerOrderingDisposition::PromptForChoice(_) => {
+                        panic!("same-event identical group must auto-order pre-feature ({mode:?})")
+                    }
+                }
+            }
+        }
+    }
+
+    /// C2 (GATED on `loop_detection.is_on()`): two byte-identical no-input SOUND
+    /// triggers off DISTINCT life-loss events (the ≥3p all-opponent-drain fan-out).
+    /// OFF ⇒ still PROMPT (pre-feature preserved); ON ⇒ auto-resolve so the ring
+    /// can accumulate. Revert-fail: dropping the `is_on()` conjunct makes the OFF
+    /// arm auto-resolve, flipping its assertion.
+    #[test]
+    fn pr625_c2_distinct_event_gate_off_prompts_on_auto_resolves() {
+        let ev_a = Some(GameEvent::LifeChanged {
+            player_id: PlayerId(0),
+            amount: -1,
+        });
+        let ev_b = Some(GameEvent::LifeChanged {
+            player_id: PlayerId(1),
+            amount: -1,
+        });
+
+        // OFF arm — must PROMPT.
+        let mut off = setup();
+        off.loop_detection = LoopDetectionMode::Off;
+        let off_group = vec![
+            pr625_no_input_trigger(
+                &mut off,
+                PlayerId(0),
+                "Sipper A",
+                pr625_sound_ability(),
+                ev_a.clone(),
+            ),
+            pr625_no_input_trigger(
+                &mut off,
+                PlayerId(0),
+                "Sipper B",
+                pr625_sound_ability(),
+                ev_b.clone(),
+            ),
+        ];
+        assert!(
+            !group_is_order_independent(&off_group, false),
+            "C2 OFF: distinct-event sound group must PROMPT (pre-feature preserved)"
+        );
+        match begin_trigger_ordering(&mut off, off_group) {
+            TriggerOrderingDisposition::PromptForChoice(_) => {}
+            TriggerOrderingDisposition::NoChoiceNeeded(_) => {
+                panic!("C2 OFF: distinct-event group must prompt when loop_detection Off")
+            }
+        }
+
+        // ON arm — must auto-resolve.
+        let mut on = setup();
+        on.loop_detection = LoopDetectionMode::On;
+        let on_group = vec![
+            pr625_no_input_trigger(
+                &mut on,
+                PlayerId(0),
+                "Sipper A",
+                pr625_sound_ability(),
+                ev_a,
+            ),
+            pr625_no_input_trigger(
+                &mut on,
+                PlayerId(0),
+                "Sipper B",
+                pr625_sound_ability(),
+                ev_b,
+            ),
+        ];
+        assert!(
+            group_is_order_independent(&on_group, true),
+            "C2 ON: distinct-event sound group must auto-resolve"
+        );
+        match begin_trigger_ordering(&mut on, on_group) {
+            TriggerOrderingDisposition::NoChoiceNeeded(_) => {}
+            TriggerOrderingDisposition::PromptForChoice(_) => {
+                panic!("C2 ON: distinct-event sound group must auto-order when loop_detection On")
+            }
+        }
+    }
+
+    /// C0 axis-2 load-bearing at C2: the Rubblebelt Rioters / Orcish Siegemaster
+    /// class (self-pump reading a board aggregate a sibling mutates) off DISTINCT
+    /// events must be EXCLUDED from C2 auto-resolve even when `loop_detection` is
+    /// ON — otherwise C2 wrongly auto-resolves an order-dependent group.
+    /// Revert-fail: bypassing the sibling-mutable axis flips this to auto-resolve.
+    #[test]
+    fn pr625_c0_sibling_mutable_distinct_event_prompts_even_on() {
+        let ev_a = Some(GameEvent::LifeChanged {
+            player_id: PlayerId(0),
+            amount: -1,
+        });
+        let ev_b = Some(GameEvent::LifeChanged {
+            player_id: PlayerId(1),
+            amount: -1,
+        });
+        let mut on = setup();
+        on.loop_detection = LoopDetectionMode::On;
+        let group = vec![
+            pr625_no_input_trigger(
+                &mut on,
+                PlayerId(0),
+                "Rioter A",
+                pr625_sibling_mutable_ability(),
+                ev_a,
+            ),
+            pr625_no_input_trigger(
+                &mut on,
+                PlayerId(0),
+                "Rioter B",
+                pr625_sibling_mutable_ability(),
+                ev_b,
+            ),
+        ];
+        assert!(
+            !group_is_order_independent(&group, true),
+            "C0: sibling-mutable distinct-event group must NOT auto-resolve even ON"
+        );
+        match begin_trigger_ordering(&mut on, group) {
+            TriggerOrderingDisposition::PromptForChoice(_) => {}
+            TriggerOrderingDisposition::NoChoiceNeeded(_) => {
+                panic!("C0: danger-card class must prompt even when loop_detection On")
+            }
+        }
     }
 
     /// Issue #610 — Kratos, Stoic Father. A YouAttack trigger carrying a

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -361,6 +361,40 @@ fn synthesize_granted_keyword_triggers<'a>(
         .collect()
 }
 
+/// Runtime-GRANTED keyword synthesized trigger definitions for `obj` that
+/// FUNCTION in its current zone, produced through the SAME synthesis authority
+/// (`synthesize_granted_keyword_triggers` / `KeywordTriggerInstaller`) the live
+/// trigger-collection path uses — single authority, no duplicated synthesis.
+/// Battlefield objects contribute their effective keywords (`obj.keywords`,
+/// which layer 6 has already merged base + granted; `synthesize_granted_keyword_
+/// triggers` subtracts `base_keywords` to isolate the granted set); off-zone
+/// objects contribute `effective_off_zone_keywords` (CR 604.1 + CR 702.62a). The
+/// zone gate mirrors the collection loop exactly: empty `trigger_zones` ⇒
+/// battlefield-only (engine-internal triggers), else the object's current zone
+/// must be listed.
+///
+/// Consumed by the growing-cascade item-5 fire-time scan
+/// (`fire_time_conditions_read_projected_resource`, analysis/resource.rs): these
+/// synthesized defs never land on `obj.trigger_definitions` for off-zone grants
+/// (and item-5 must not assume layer 6 installed them), so scanning them here is
+/// the only way that pass sees a dormant granted Dethrone-class fire-time
+/// condition (CR 702.105a reads `LifeTotal`, CR 119 — a projected axis).
+pub(crate) fn granted_keyword_triggers_in_zone(
+    state: &GameState,
+    obj: &GameObject,
+) -> Vec<TriggerDefinition> {
+    let keywords: Vec<Keyword> = if obj.zone == Zone::Battlefield {
+        obj.keywords.clone()
+    } else {
+        crate::game::off_zone_characteristics::effective_off_zone_keywords(state, obj.id)
+    };
+    synthesize_granted_keyword_triggers(obj, keywords.iter())
+        .into_iter()
+        .filter(|(_, def)| trigger_definition_functions_in_zone(def, obj.zone))
+        .map(|(_, def)| def)
+        .collect()
+}
+
 fn keyword_kind_for_trigger(
     keywords: &[Keyword],
     trigger: &TriggerDefinition,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3337,7 +3337,10 @@ enum TriggerOrderingDisposition {
 /// is intentionally left intact (it is the group partition key, already equal
 /// across a group). The recursion is load-bearing: derived `PartialEq` descends
 /// into `sub_ability`/`else_ability`, so their `source_id`s must also be zeroed.
-fn normalize_ability_identity(ability: &mut ResolvedAbility) {
+///
+/// `pub(crate)` so `analysis::resource`'s coverability stack-normalizer shares this
+/// exact identity-stripping rather than keeping a drift-prone parallel copy.
+pub(crate) fn normalize_ability_identity(ability: &mut ResolvedAbility) {
     ability.source_id = ObjectId(0);
     if let Some(sub) = ability.sub_ability.as_mut() {
         normalize_ability_identity(sub);

--- a/crates/engine/tests/pr65_growing_cascade_win.rs
+++ b/crates/engine/tests/pr65_growing_cascade_win.rs
@@ -1,0 +1,179 @@
+//! PR-6.5 inc2b — the growing-cascade DETECTOR, live ≥3-player win (N3).
+//!
+//! CR 732.2a + CR 704.5a + CR 104.2a: a super-critical (μ = 2) all-opponent drain
+//! cascade in a 3-player game grows the stack without bound, so the shipped
+//! constant-depth loop fingerprint (`loop_states_equal_modulo_resources`) never
+//! matches. The new Karp–Miller-style coverability path
+//! (`loop_states_cover_modulo_growth`) + the MP-general winner predicate
+//! (`live_mandatory_loop_winner`) confirm the covering pair LIVE and shortcut to the
+//! controller's win — BEFORE the opponents reach 0 life naturally (the discriminator).
+//!
+//! ON arm: `loop_detection == On` ⇒ the C2 gate auto-resolves the fan-out, the ring
+//! accumulates, and the reconcile seam declares `GameOver { winner: Some(P0) }` with
+//! both opponents still at POSITIVE life and P0's unbounded axes marked.
+//!
+//! OFF arm (default gameplay byte-preserved): `loop_detection == Off` ⇒ no shortcut;
+//! the cascade drains both opponents to natural CR 704.5a SBA deaths (life ≤ 0,
+//! `is_eliminated`), `unbounded_resources` empty.
+//!
+//! Revert-fails (each isolates one layer): (i) revert the winner predicate ⇒ natural
+//! death signature; (ii) revert `cover_modulo_growth` ⇒ ring never confirms ⇒ natural
+//! death; (iii) revert C2 ⇒ the fan-out `OrderTriggers`-prompts and the run stalls.
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{LoopDetectionMode, WaitingFor};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+
+const DRAIN_CLERIC: &str = "Whenever you gain life, each opponent loses 1 life.";
+const BLOOD_SIPPER: &str = "Whenever an opponent loses life, you gain 1 life.";
+const KICKOFF: &str = "You gain 1 life.";
+
+fn life(runner: &GameRunner, p: PlayerId) -> i32 {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|pl| pl.id == p)
+        .map(|pl| pl.life)
+        .unwrap()
+}
+
+fn is_eliminated(runner: &GameRunner, p: PlayerId) -> bool {
+    runner
+        .state()
+        .players
+        .iter()
+        .find(|pl| pl.id == p)
+        .map(|pl| pl.is_eliminated)
+        .unwrap()
+}
+
+/// Build the 3-player drain engine controlled by P0, with `loop_detection` set to
+/// `mode`. Returns a runner positioned in P0's precombat main with the kick-off
+/// sorcery in hand (id returned).
+fn setup(mode: LoopDetectionMode) -> (GameRunner, engine::types::ObjectId) {
+    let mut scenario = GameScenario::new_n_player(3, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    scenario.with_life(P1, 20);
+    scenario.with_life(P2, 20);
+    scenario.add_creature_from_oracle(P0, "Test Drain Cleric", 2, 2, DRAIN_CLERIC);
+    scenario.add_creature_from_oracle(P0, "Test Blood Sipper", 2, 2, BLOOD_SIPPER);
+    let kickoff = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Lifegain Kickoff", false, KICKOFF)
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().loop_detection = mode;
+    (runner, kickoff)
+}
+
+/// Drive the cascade until `GameOver` or the cap, returning the number of beats
+/// consumed and the terminal `waiting_for`. Passes priority on `Priority` windows
+/// and submits the identity order on any `OrderTriggers` prompt (all the fan-out's
+/// triggers are the same mandatory ability, so the order is immaterial). Any OTHER
+/// prompt is returned as a stall for the assertions to diagnose.
+///
+/// `stall_on_order`: when true (the ON-arm check), an `OrderTriggers` prompt is
+/// returned immediately instead of answered — it means C2 failed to auto-resolve.
+fn drive(runner: &mut GameRunner, cap: usize, stall_on_order: bool) -> (usize, WaitingFor) {
+    for beat in 0..cap {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::GameOver { .. } => return (beat, runner.state().waiting_for.clone()),
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    return (beat, runner.state().waiting_for.clone());
+                }
+            }
+            WaitingFor::OrderTriggers { triggers, .. } if !stall_on_order => {
+                let order: Vec<usize> = (0..triggers.len()).collect();
+                if runner
+                    .act(GameAction::OrderTriggers { order })
+                    .or_else(|_| runner.act(GameAction::OrderTriggers { order: vec![] }))
+                    .is_err()
+                {
+                    return (beat, runner.state().waiting_for.clone());
+                }
+            }
+            other => return (beat, other),
+        }
+    }
+    (cap, runner.state().waiting_for.clone())
+}
+
+#[test]
+fn n3_growing_cascade_three_player_live_win_on() {
+    let (mut runner, kickoff) = setup(LoopDetectionMode::On);
+    // Resolve the kick-off lifegain, seeding the μ=2 mutual amplifying cascade.
+    let _ = runner.cast(kickoff).resolve();
+    let (beats, wf) = drive(&mut runner, 500, true);
+    eprintln!(
+        "ON arm: beats={beats} wf={wf:?} P1={} P2={}",
+        life(&runner, P1),
+        life(&runner, P2)
+    );
+
+    assert_eq!(
+        wf,
+        WaitingFor::GameOver { winner: Some(P0) },
+        "ON: the growing-cascade shortcut must declare P0 the winner"
+    );
+    // THE DISCRIMINATOR: the shortcut fired BEFORE natural death — both opponents
+    // are still at POSITIVE life (a reverted predicate/cover would only reach
+    // GameOver via the natural CR 704.5a death, with life <= 0).
+    assert!(
+        life(&runner, P1) > 0 && life(&runner, P2) > 0,
+        "ON: both opponents must still be at positive life (shortcut fired early): P1={}, P2={}",
+        life(&runner, P1),
+        life(&runner, P2)
+    );
+    assert!(
+        runner
+            .state()
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|axes| !axes.is_empty()),
+        "ON: P0's unbounded loop axes must be marked (mark_unbounded_loop fired)"
+    );
+    // The shortcut arm does NOT write is_eliminated (that is the natural-death path).
+    assert!(
+        !is_eliminated(&runner, P1) && !is_eliminated(&runner, P2),
+        "ON: the shortcut must not mark opponents eliminated"
+    );
+}
+
+#[test]
+fn n3_growing_cascade_three_player_natural_death_off() {
+    let (mut runner, kickoff) = setup(LoopDetectionMode::Off);
+    let _ = runner.cast(kickoff).resolve();
+    let (beats, wf) = drive(&mut runner, 2000, false);
+    eprintln!(
+        "OFF arm: beats={beats} wf={wf:?} P1={} P2={}",
+        life(&runner, P1),
+        life(&runner, P2)
+    );
+
+    assert_eq!(
+        wf,
+        WaitingFor::GameOver { winner: Some(P0) },
+        "OFF: the cascade still ends the game for P0 — via the NATURAL CR 704.5a death"
+    );
+    // Natural-death signature: opponents actually crossed 0 and were eliminated.
+    assert!(
+        life(&runner, P1) <= 0 && life(&runner, P2) <= 0,
+        "OFF: both opponents must have drained to <= 0 life (no early shortcut)"
+    );
+    assert!(
+        is_eliminated(&runner, P1) && is_eliminated(&runner, P2),
+        "OFF: the natural elimination path marks opponents eliminated"
+    );
+    assert!(
+        runner.state().unbounded_resources.is_empty(),
+        "OFF: no unbounded axes are marked (the detector never ran)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

PR-6.5 teaches the combo detector to certify **growing** mandatory cascades — loops whose state strictly grows each iteration (Karp–Miller-style ω-coverability) rather than repeating byte-identically — and to shortcut them as multiplayer-correct wins (CR 104.2a / 104.4a / 800.4a). All new behavior is gated behind the existing `loop_detection` opt-in; **default OFF is byte-exact pre-feature behavior**.

1. **C0 fail-closed ability-scan walker** (`game/ability_scan.rs`, new): compiler-exhaustive classification of every ability-AST node along three axes (event-context / sibling-mutable / projected-resource). No wildcard arms — a new enum variant is a compile error, not a silent fail-open; unknown shapes classify conservative. The `add-engine-variant` skill checklist now requires classifying new variants here.
2. **C2 gated order-independent trigger auto-resolve** (`game/triggers.rs`): removes no-op `OrderTriggers` prompts for provably order-independent same-event trigger groups — only when `loop_detection` is ON (project policy: gameplay-experience changes are user-opt-in). OFF-path keeps the legacy allowlist byte-exact.
3. **Growing-cascade detector** (`analysis/resource.rs`, `analysis/loop_check.rs`): `loop_states_cover_modulo_growth` — order-preserving bottom-up subsequence embedding with strict growth admitted only on prior-occupied places; projection restricted to player-level monotone resources + journals (all object/board state strict-compared); a two-surface fail-closed read guard (on-stack entries + off-stack fire-time intervening-if conditions); exactly-one-non-faller multiplayer winner predicate; `controller_life_never_dips` and a pairwise-equal-faller-lives simultaneity floor (CR 800.4a / 104.2a).
4. **Granted-keyword soundness closure**: a compiler-exhaustive guard test surfaced that granted-keyword *synthesized* fire-time conditions can read projected resources (Dethrone, CR 702.105a, reads `LifeTotal`) while the off-stack guard scanned only printed `trigger_definitions`. Loop (iv) now scans granted-keyword defs through the **same synthesis authority** the trigger-collection path uses (`granted_keyword_triggers_in_zone`). Traced latent-not-live today (Layer 6 installs battlefield-granted defs before the sample state), landed as strictly fail-safe structural closure — it can only add rejections, never false WINs.

## Combo-detector series

| Pos | PR | Delivers |
|-----|----|----------|
| PR-0 | #4092 | `ResourceVector` + modulo-resource loop equality (additive). |
| PR-1 | #4097 | Analysis sim harness feeding `ResourceVector`. |
| PR-2 | #4119 | Net-progress `detect_loop` → `LoopCertificate` + corpus harness. |
| PR-3 | #4480 | Live mandatory-loop winner shortcut (drain-cascade, CR 704.5a). |
| PR-4a | #4493 | Engine B static ability-graph extractor (scaffold + 5 families + SCC). |
| PR-4b | #4534 | Engine B effect/trigger breadth + life-symmetry cost. |
| PR-5 | #4547 | `cargo combo-verify` CLI over the 53-row corpus. |
| PR-6 | #4603 | `∞` unbounded-resource display — generalize infinite-mana to the whole `ResourceAxis` class (engine-owned `DerivedViews` projection). |
| PR-6.25 | (deferred) | Order-independence soundness fix for `group_is_order_independent` (latent CR 603.3b); folded into PR-6.75 planning. |
| **PR-6.5** | **(this PR)** | **Growing-cascade detector for multiplayer win-acceleration (ω-coverability modulo growth) + C0 fail-closed walker + C2 gated order-independent auto-resolve.** |

**Predecessor: PR-6 — #4603 — https://github.com/phase-rs/phase/pull/4603** — wired the detector's `∞` unbounded-resource display behind the `loop_detection` opt-in; this PR extends that same gated detector from exact-repetition loops to strictly-growing cascades.

## Verification

- `cargo test -p engine`: **16751 passed / 0 failed** (rebased tree). N-series discriminating tests: N1(a–n) + N1(kg), N2, N3 on **both** toggle arms, N5 life-dip discriminators — with executed revert-fail protocol on every load-bearing helper (each revert turned the suite red, tree restored byte-identical).
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 warnings. `cargo fmt --check`: clean.
- Rebased onto `6cefafb21` (zero conflicts). Workspace tests green except 6 **pre-existing** `mtgish-import` `golden_structural` ETB failures also present on clean main (stale goldens from #4851's converter change; this series touches zero mtgish/parser/types files).
- Multiplayer-correct: winner predicate is exactly-one-non-faller (2p is the len-2 special case, never the general shape).

## Deferred to PR-6.75 (plan in progress)

C0-full + C1 precision pass (read/write conflict-profile module `ability_rw.rs`; C1 = latent CR 603.3b same-event fix), the 38 event/sibling-only variant-`..` walker arms, and the inc2a EventSource comment correction. Tracked in `.planning/combo-detection/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwQE5oyMqZ9T4BPMsih3Kj
