### PR TITLE
Add Valakut Fireboar: switch its power and toughness (pronoun form)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4563,6 +4563,31 @@ pub(super) fn parse_utility_imperative_ast(
             return Some(UtilityImperativeAst::SwitchPT { target });
         }
     }
+    // CR 613.4d + CR 608.2c: pronoun form "switch its power and toughness" —
+    // "its" is the source or triggering creature (Valakut Fireboar: this
+    // creature on attack; Mangled Soulrager's granted boon: the entering
+    // creature), resolved via the shared it-pronoun anaphor. `parse_target`
+    // does not treat a bare "its" as a target, so the possessive and
+    // prepositional branches above miss it.
+    if let Some((_, rest)) = nom_on_lower(text, lower, |input| {
+        value((), tag("switch its power and toughness")).parse(input)
+    }) {
+        let rem_lower = rest.trim_start().to_ascii_lowercase();
+        let rem_after_duration = tag::<_, _, OracleError<'_>>("until end of turn")
+            .parse(rem_lower.as_str())
+            .map(|(rest, _)| rest)
+            .unwrap_or(rem_lower.as_str());
+        let mut terminal = alt((
+            value((), eof),
+            value((), all_consuming(tag::<_, _, OracleError<'_>>("."))),
+        ));
+        if terminal.parse(rem_after_duration).is_ok() {
+            return Some(UtilityImperativeAst::SwitchPT {
+                target: resolve_it_pronoun(ctx),
+            });
+        }
+    }
+
     // CR 613.4d: "switch [target]'s power and toughness"
     if let Some((_, rest)) =
         nom_on_lower(text, lower, |input| value((), tag("switch ")).parse(input))

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -26819,6 +26819,27 @@ fn effect_switch_pt_self() {
     );
 }
 
+/// CR 613.4d: pronoun surface form ("switch its power and toughness") —
+/// `parse_target` does not treat a bare "its" as a target, so this form is
+/// handled by a dedicated branch that resolves the "its" anaphor via
+/// `resolve_it_pronoun`. In a bare effect context (no trigger subject) that
+/// resolves to `SelfRef` (Valakut Fireboar's self-attack trigger); a typed
+/// trigger subject resolves it to `TriggeringSource` (Mangled Soulrager's
+/// granted boon).
+#[test]
+fn effect_switch_pt_pronoun_its() {
+    let e = parse_effect("switch its power and toughness until end of turn");
+    assert!(
+        matches!(
+            e,
+            Effect::SwitchPT {
+                target: TargetFilter::SelfRef
+            }
+        ),
+        "expected SwitchPT with SelfRef for the pronoun form, got: {e:?}"
+    );
+}
+
 /// CR 613.4d: prepositional surface form ("switch the power and toughness
 /// of target creature") — single-target sibling of the possessive form.
 #[test]

--- a/crates/engine/tests/valakut_fireboar_switch_pt_on_attack.rs
+++ b/crates/engine/tests/valakut_fireboar_switch_pt_on_attack.rs
@@ -1,0 +1,102 @@
+//! Valakut Fireboar (ZEN) — runtime proof that the self-attack trigger switches
+//! the creature's power and toughness via the "switch its power and toughness"
+//! pronoun surface form.
+//!
+//! Oracle: "Whenever this creature attacks, switch its power and toughness until
+//! end of turn."
+//!
+//! The effect parser recognized "switch the power and toughness of <target>" and
+//! "switch <target>'s power and toughness", but not the bare pronoun "switch its
+//! power and toughness": `parse_target` does not treat a bare "its" as a target,
+//! so both existing branches missed it and the trigger effect fell to
+//! `Effect::Unimplemented` — the swap never fired. The fix adds a pronoun branch
+//! that resolves "its" through the shared `resolve_it_pronoun` anaphor. Here the
+//! trigger subject is this creature, so "its" resolves to `SelfRef` and the
+//! source's own P/T is switched (CR 613.4d).
+//!
+//! Discriminating observable: Valakut Fireboar is printed 5/2. After it is
+//! declared as an attacker and the trigger resolves, its effective P/T must be
+//! 2/5. Reverting the parser branch drops the effect (no swap), so the P/T stays
+//! 5/2 and the final assertion flips to red.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const VALAKUT_FIREBOAR_ORACLE: &str =
+    "Whenever this creature attacks, switch its power and toughness until end of turn.";
+
+/// Effective (post-layer) power/toughness of an object.
+fn power_toughness(runner: &GameRunner, id: ObjectId) -> (i32, i32) {
+    let obj = runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("object still present");
+    (obj.power.unwrap_or(0), obj.toughness.unwrap_or(0))
+}
+
+#[test]
+fn valakut_fireboar_switches_power_and_toughness_when_it_attacks() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0 controls Valakut Fireboar, printed 5/2 (ZEN).
+    let boar = scenario
+        .add_creature_from_oracle(P0, "Valakut Fireboar", 5, 2, VALAKUT_FIREBOAR_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    // Sanity: printed 5/2 before combat.
+    assert_eq!(power_toughness(&runner, boar), (5, 2), "printed P/T");
+
+    // Advance to declare-attackers and swing at P1 — this fires the
+    // "Whenever this creature attacks" trigger (CR 508.2).
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(boar, AttackTarget::Player(P1))])
+        .expect("declare Valakut Fireboar as attacker");
+
+    // Drive the trigger through the real trigger -> stack -> resolution pipeline
+    // until the swap lands (or the loop exhausts).
+    for _ in 0..300 {
+        if power_toughness(&runner, boar) == (2, 5) {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .or_else(|_| runner.act(GameAction::OrderTriggers { order: vec![] }))
+                    .expect("order the single attack trigger");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("no blocks");
+            }
+            _ => break,
+        }
+    }
+
+    // CR 613.4d: the attack trigger switched power and toughness for the turn.
+    assert_eq!(
+        power_toughness(&runner, boar),
+        (2, 5),
+        "Valakut Fireboar's P/T must swap 5/2 -> 2/5 after it attacks"
+    );
+}


### PR DESCRIPTION
## Summary
Adds engine support for **Valakut Fireboar** (ZEN) — "Whenever this creature attacks, switch its power and toughness until end of turn." — by teaching the effect parser the pronoun surface form **"switch its power and toughness"**.

`Effect::SwitchPT` and its layer-7d runtime already exist (Invert, Inversion Behemoth are the supported siblings). The parser recognized two surface forms — prepositional "switch the power and toughness of `<target>`" and possessive "switch `<target>`'s power and toughness" — but not the bare pronoun "switch **its** power and toughness". `parse_target` does not treat a bare "its" as a target, so both branches missed it and the trigger effect fell to `Effect::Unimplemented`; the P/T swap never fired.

The fix adds a third branch that matches "switch its power and toughness" and resolves the "its" anaphor through the shared `resolve_it_pronoun(ctx)` helper — the same anaphor resolution already used by the sacrifice/counter clauses. For Valakut Fireboar the trigger subject is this creature, so "its" resolves to `SelfRef` (the source switches its own P/T). The change is generic: any effect written as "switch its power and toughness" now lowers to `Effect::SwitchPT`.

## Files changed
- `crates/engine/src/parser/oracle_effect/imperative.rs` — pronoun branch in the SwitchPT parser
- `crates/engine/src/parser/oracle_effect/tests.rs` — parser unit test `effect_switch_pt_pronoun_its`
- `crates/engine/tests/valakut_fireboar_switch_pt_on_attack.rs` — integration test

## Anchored on
- `crates/engine/src/parser/oracle_effect/imperative.rs` (~4516) — the existing prepositional and possessive SwitchPT branches; this adds the pronoun sibling immediately before the possessive one.
- `crates/engine/src/parser/oracle_effect/mod.rs:172` — `resolve_it_pronoun` already maps "it/its" to `SelfRef` or `TriggeringSource` from `ctx.subject`; reused verbatim.
- `crates/engine/src/game/effects/switch_pt.rs` — `Effect::SwitchPT` runtime (layer-7d `SwitchPowerToughness`); unchanged. Invert and Inversion Behemoth exercise this handler today.

## CR references
- `CR 613.4d` — switching a creature's power and toughness is a single continuous effect applied in layer 7d.
- `CR 608.2c` — the triggered ability's instruction resolves as written; "its" refers to the object established by the trigger (here, the attacking creature).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy-strict` — clean (0 warnings)
- `./scripts/check-parser-combinators.sh` — clean
- `cargo test -p engine` — full engine suite green, 0 failed across all binaries (adds `effect_switch_pt_pronoun_its` + `valakut_fireboar_switches_power_and_toughness_when_it_attacks`)
- `./scripts/gen-card-data.sh` — Valakut Fireboar: 0 Unimplemented entries
- Coverage regression (clean main baseline vs this change, `scripts/coverage-regression-check.sh --fail-on-engine`): supported **31223 → 31224 (net +1)**. GAINED: Valakut Fireboar. REGRESSED (engine): 0. REGRESSED (coverage honesty): 0. ORACLE CHANGED: 0. (Invert / Inversion Behemoth unchanged.)
- `cargo semantic-audit` — Valakut Fireboar: 0 findings.

The integration test drives the real declare-attackers → trigger → stack → resolution pipeline: Valakut Fireboar (printed 5/2) is declared as an attacker; after the trigger resolves, its effective power/toughness must be 2/5. It flips if the parser branch is reverted — the trigger effect becomes `Unimplemented` and the P/T stays 5/2.

## Scope Expansion
None. (Mangled Soulrager's granted "twelve-time boon" also uses this phrasing, and its "switch its" orphan is now closed; but that card's boon-granting mechanic is a separate unsupported infra gap, so it stays `gap_count 1` and is out of scope here.)

## Validation Failures
None.

## CI Failures
None.
