### PR TITLE
Fix Riku, Of Many Paths triggering on every spell instead of only modal spells

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -612,6 +612,9 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::HasManaAbility
         | FilterProp::HasNoAbilities
         | FilterProp::Named { .. }
+        // CR 700.2: modality reads `obj.modal`, an apply()-constant printed-card
+        // field on the candidate — safe to memoize.
+        | FilterProp::Modal
         | FilterProp::IsCommander => true,
 
         // SAFE only when the embedded `QuantityExpr` is memo-safe.

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -873,6 +873,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
                 ));
             }
             FilterProp::HasSingleTarget => parts.push("single target".into()),
+            FilterProp::Modal => parts.push("modal spell".into()),
             FilterProp::FaceDown => parts.push("face-down".into()),
             FilterProp::TargetsOnly { filter } => {
                 parts.push(format!("targets only {}", fmt_target(filter)));

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -192,6 +192,9 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::IsChosenCardType
         | FilterProp::IsChosenLandOrNonlandKind
         | FilterProp::HasSingleTarget
+        // CR 700.2: modality reads the object's own printed characteristic, not
+        // the board population.
+        | FilterProp::Modal
         | FilterProp::NotColor { .. }
         | FilterProp::NotSupertype { .. }
         | FilterProp::Suspected
@@ -406,6 +409,9 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::IsChosenCardType
         | FilterProp::IsChosenLandOrNonlandKind
         | FilterProp::HasSingleTarget
+        // CR 700.2: modality is candidate-local (the object's own printed
+        // characteristic), so a board entry cannot perturb it.
+        | FilterProp::Modal
         | FilterProp::NotColor { .. }
         | FilterProp::NotSupertype { .. }
         | FilterProp::Suspected
@@ -2890,6 +2896,9 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // Approach of the Second Sun's "you've cast another spell named
         // {LITERAL} this game" relies on this against the game-scope history.
         FilterProp::Named { name } => record.name.eq_ignore_ascii_case(name),
+        // SpellCastRecord carries no modal field — conservative gap (CR 700.2
+        // evaluated on the live stack object, not the snapshot).
+        FilterProp::Modal => false,
         // All remaining props require on-battlefield or stack state unavailable from a snapshot.
         FilterProp::Attacking { .. }
         | FilterProp::Blocking
@@ -3888,6 +3897,10 @@ fn matches_filter_prop(
         // CR 115.7: Stack entry has exactly one target — permissive at filter level,
         // validated by retarget effects at resolution time.
         FilterProp::HasSingleTarget => true,
+        // CR 700.2: The object is modal iff its printed modality is present. Read
+        // from the static printed characteristic populated at object creation,
+        // available at SpellCast-trigger match time (Riku, of Many Paths).
+        FilterProp::Modal => obj.modal.is_some(),
         // CR 115.9c: Stack entry's targets all match the inner filter — permissive at
         // per-object level, validated by trigger matchers and retarget effects against the
         // stack entry's actual targets.
@@ -4323,6 +4336,9 @@ fn zone_change_record_matches_property(
         | FilterProp::IsChosenCardType
         | FilterProp::IsChosenLandOrNonlandKind
         | FilterProp::HasSingleTarget
+        // ZoneChangeRecord carries no modal field — conservative gap (CR 700.2
+        // evaluated on the live stack object, not the snapshot).
+        | FilterProp::Modal
         | FilterProp::Suspected
         | FilterProp::Renowned
         // CR 700.9: Modified is a live-battlefield predicate (counters +

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7062,6 +7062,39 @@ fn add_another_prop(filter: TargetFilter) -> TargetFilter {
     }
 }
 
+/// CR 700.2: Attach `FilterProp::Modal` to a spell filter parsed from a "modal
+/// [type] spell" qualifier, mirroring `add_another_prop`. Distributes into
+/// `Or`/`And` branches; wraps a non-`Typed` filter in an `And` so the modality
+/// constraint is preserved.
+fn add_modal_prop(filter: TargetFilter) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(TypedFilter {
+            type_filters,
+            controller,
+            mut properties,
+        }) => {
+            properties.push(FilterProp::Modal);
+            TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller,
+                properties,
+            })
+        }
+        TargetFilter::Or { filters } => TargetFilter::Or {
+            filters: filters.into_iter().map(add_modal_prop).collect(),
+        },
+        TargetFilter::And { filters } => TargetFilter::And {
+            filters: filters.into_iter().map(add_modal_prop).collect(),
+        },
+        other => TargetFilter::And {
+            filters: vec![
+                other,
+                TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Modal])),
+            ],
+        },
+    }
+}
+
 fn add_controller(filter: TargetFilter, controller: ControllerRef) -> TargetFilter {
     match filter {
         TargetFilter::Typed(TypedFilter {
@@ -11732,11 +11765,34 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         };
         def.spell_cast_origin = cast_origin;
 
+        // CR 700.2: Peel an optional leading "modal " qualifier off the payload
+        // BEFORE the type-phrase / spell-qualifier parsers run. "modal" is not a
+        // card type, so `parse_type_phrase("modal spell")` yields an empty filter
+        // and `parse_spell_qualifier_payload` treats "modal" as an unknown pre-
+        // spell word — either way the modality is silently dropped and
+        // `valid_card` is left `None`, over-triggering on every spell (issue
+        // #750, Riku, of Many Paths). Peeling here reduces the payload to the
+        // bare type phrase (e.g. "modal spell" → "spell", "modal instant spell"
+        // → "instant spell"); the modality is re-attached as `FilterProp::Modal`
+        // after the filter is built. Scoped to the type-phrase / spell-qualifier
+        // paths below — the color-disjunction `parse_spell_that_clause_filter`
+        // branch above (Questing Druid: "a spell that's white…") returns before
+        // reaching here and is not exercised by any "modal <color>" card.
+        let (payload, is_modal) = opt(value((), tag::<_, _, OracleError<'_>>("modal ")))
+            .parse(payload)
+            .map(|(rest, matched)| (rest, matched.is_some()))
+            .unwrap_or((payload, false));
+
         // First, try the post-spell-modifier-aware decomposition for shapes
         // that include "with {X} in its mana cost" etc.
         if let Some(filter) = parse_spell_qualifier_payload(payload) {
             let filter = if is_another {
                 add_another_prop(filter)
+            } else {
+                filter
+            };
+            let filter = if is_modal {
+                add_modal_prop(filter)
             } else {
                 filter
             };
@@ -11753,6 +11809,11 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
         let (filter, _rest) = parse_type_phrase(payload);
         let filter = if is_another {
             add_another_prop(filter)
+        } else {
+            filter
+        };
+        let filter = if is_modal {
+            add_modal_prop(filter)
         } else {
             filter
         };
@@ -14418,3 +14479,105 @@ mod controlled_chosen_type_enters_tests;
 #[cfg(test)]
 #[path = "oracle_trigger_enchanted_player_controls_tests.rs"]
 mod enchanted_player_controls_tests;
+
+/// Issue #750: "Whenever you cast a modal spell" (Riku, of Many Paths) must
+/// parse a `valid_card` carrying `FilterProp::Modal` (CR 700.2), not `None`.
+/// A `None` `valid_card` over-triggers on every spell the controller casts.
+#[cfg(test)]
+mod modal_spell_cast_trigger_tests {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::{FilterProp, TargetFilter, TypeFilter};
+    use crate::types::TriggerMode;
+
+    /// Collect the top-level `FilterProp`s of a `Typed` `valid_card`, or an empty
+    /// vec for any other shape (so assertions read `contains`).
+    fn valid_card_props(vc: Option<&TargetFilter>) -> Vec<FilterProp> {
+        match vc {
+            Some(TargetFilter::Typed(tf)) => tf.properties.clone(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// PARSER (revert-failing): Riku's SpellCast trigger's `valid_card` must be
+    /// `Some(Typed{ properties contains FilterProp::Modal })`. Reverting the
+    /// peel/attach leaves `valid_card == None` (the over-trigger bug).
+    #[test]
+    fn riku_modal_spell_cast_trigger_attaches_modal_prop() {
+        let parsed = parse_oracle_text(
+            "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell —\n\u{2022} Exile the top card of your library. Until the end of your next turn, you may play it.\n\u{2022} Put a +1/+1 counter on Riku. It gains trample until end of turn.\n\u{2022} Create a 1/1 blue Bird creature token with flying.",
+            "Riku, of Many Paths",
+            &[],
+            &["Legendary".into(), "Creature".into()],
+            &["Human".into(), "Wizard".into()],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::SpellCast))
+            .expect("Riku must parse a SpellCast trigger");
+        // CR 700.2: the "modal" qualifier must survive as FilterProp::Modal.
+        assert!(
+            trigger.valid_card.is_some(),
+            "valid_card must NOT be None — a None filter over-triggers on every spell"
+        );
+        assert!(
+            valid_card_props(trigger.valid_card.as_ref()).contains(&FilterProp::Modal),
+            "valid_card must carry FilterProp::Modal, got {:?}",
+            trigger.valid_card
+        );
+    }
+
+    /// Class generality: "modal instant spell" keeps BOTH the Modal prop and the
+    /// Instant type constraint (the peel only removes the "modal " qualifier).
+    #[test]
+    fn modal_instant_spell_keeps_type_and_modal() {
+        let parsed = parse_oracle_text(
+            "Whenever you cast a modal instant spell, draw a card.",
+            "Test Modal Instant Watcher",
+            &[],
+            &["Creature".into()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::SpellCast))
+            .expect("must parse a SpellCast trigger");
+        let props = valid_card_props(trigger.valid_card.as_ref());
+        assert!(
+            props.contains(&FilterProp::Modal),
+            "must carry FilterProp::Modal, got {props:?}"
+        );
+        // The Instant type constraint must remain on the type_filters.
+        match trigger.valid_card.as_ref() {
+            Some(TargetFilter::Typed(tf)) => assert!(
+                tf.type_filters.contains(&TypeFilter::Instant),
+                "modal instant must keep the Instant type filter, got {:?}",
+                tf.type_filters
+            ),
+            other => panic!("expected Typed valid_card, got {other:?}"),
+        }
+    }
+
+    /// Negative (no over-attach): a plain "you cast a spell" trigger must NOT
+    /// gain a Modal prop — the optional peel matches nothing.
+    #[test]
+    fn plain_spell_cast_trigger_has_no_modal_prop() {
+        let parsed = parse_oracle_text(
+            "Whenever you cast a spell, draw a card.",
+            "Test Plain Spell Watcher",
+            &[],
+            &["Creature".into()],
+            &[],
+        );
+        let trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| matches!(t.mode, TriggerMode::SpellCast))
+            .expect("must parse a SpellCast trigger");
+        assert!(
+            !valid_card_props(trigger.valid_card.as_ref()).contains(&FilterProp::Modal),
+            "a plain 'you cast a spell' trigger must not gain FilterProp::Modal"
+        );
+    }
+}

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3145,6 +3145,11 @@ pub enum FilterProp {
     /// CR 115.7: Matches stack entries that have exactly one target.
     /// Used for "with a single target" qualifiers on retarget effects.
     HasSingleTarget,
+    /// CR 700.2: Matches a spell/ability on the stack that is modal (its printed
+    /// text offers two or more options in a bulleted list). Evaluated against the
+    /// stack object's static printed modality (`obj.modal.is_some()`), a printed
+    /// characteristic present from object creation.
+    Modal,
     /// CR 205.4b: Matches objects that do NOT have a specific color.
     /// Parallel to `HasColor` — used for "nonblack", "nonwhite" in negation stacks.
     NotColor {

--- a/crates/engine/tests/riku_modal_spell_trigger.rs
+++ b/crates/engine/tests/riku_modal_spell_trigger.rs
@@ -1,0 +1,177 @@
+//! Issue #750 — Riku, of Many Paths: "Whenever you cast a MODAL spell, choose
+//! up to X …" must fire ONLY on modal spells, not on every spell its controller
+//! casts.
+//!
+//! ROOT CAUSE: the parser dropped the "modal" qualifier because `FilterProp`
+//! could not express modality, leaving the SpellCast trigger's `valid_card` as
+//! `None` — which matches every spell (over-trigger). The fix adds
+//! `FilterProp::Modal` (CR 700.2) and evaluates it against the stack object's
+//! static printed modality (`obj.modal.is_some()`), a printed characteristic
+//! populated at object creation and available at SpellCast-trigger match time.
+//!
+//! These are full cast-pipeline tests: Riku sits on P0's battlefield, P0 casts a
+//! spell through `GameRunner::cast(..).commit()`, and we assert whether Riku's
+//! SpellCast trigger landed on the stack as a `TriggeredAbility` (CR 603.3 —
+//! triggers go on the stack the next time a player would receive priority, which
+//! is the post-cast Priority window `commit()` halts at).
+//!
+//! CARD TEXT is this engine's authoritative Oracle text for each card:
+//!   * Abrade — "Choose one —\n• Abrade deals 3 damage to target creature.\n•
+//!     Destroy target artifact." — a real MODAL instant (`obj.modal.is_some()`).
+//!   * Shock — "Shock deals 2 damage to any target." — a plain NON-MODAL instant.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{StackEntryKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const RIKU_ORACLE: &str = "Whenever you cast a modal spell, choose up to X, where X is the number of times you chose a mode for that spell —\n\u{2022} Exile the top card of your library. Until the end of your next turn, you may play it.\n\u{2022} Put a +1/+1 counter on Riku. It gains trample until end of turn.\n\u{2022} Create a 1/1 blue Bird creature token with flying.";
+
+const ABRADE_ORACLE: &str =
+    "Choose one \u{2014}\n\u{2022} Abrade deals 3 damage to target creature.\n\u{2022} Destroy target artifact.";
+const SHOCK_ORACLE: &str = "Shock deals 2 damage to any target.";
+
+/// Add `count` red mana to P0's pool so the auto-pay path funds the cast
+/// (mirrors the Chord/Green Sun's Zenith harness — deterministic payment
+/// without modelling lands).
+fn add_red_mana(runner: &mut engine::game::scenario::GameRunner, count: usize) {
+    for _ in 0..count {
+        let unit = ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]);
+        runner.state_mut().players[0].mana_pool.add(unit);
+    }
+}
+
+/// Count Riku's SpellCast trigger instances currently on the stack (matched by
+/// the trigger's source object id).
+fn riku_triggers_on_stack(state: &engine::types::game_state::GameState, riku: ObjectId) -> usize {
+    state
+        .stack
+        .iter()
+        .filter(|entry| {
+            entry.source_id == riku && matches!(entry.kind, StackEntryKind::TriggeredAbility { .. })
+        })
+        .count()
+}
+
+/// Cast `spell` (announcing `modes`/`targets` for the spell's own choices) and
+/// drive the pipeline only until the spell has committed to the stack and the
+/// post-cast trigger-placement window is reached (CR 603.3): either the
+/// `Priority` window, or — when the fired trigger is itself modal — Riku's own
+/// `AbilityModeChoice`. At either boundary the trigger, if it fired, is already
+/// on the stack. Returns the number of Riku triggers observed on the stack.
+///
+/// This is a purpose-built driver (not `SpellCast::commit`) because Riku's
+/// modal trigger surfaces `AbilityModeChoice` before the `Priority` window,
+/// which the general commit driver intentionally rejects.
+fn cast_and_count_riku_triggers(
+    runner: &mut GameRunner,
+    spell: ObjectId,
+    riku: ObjectId,
+    modes: &[usize],
+    targets: &[ObjectId],
+) -> usize {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+        })
+        .expect("CastSpell must be accepted");
+
+    let mut remaining_targets = targets.to_vec();
+    for _ in 0..64 {
+        match &runner.state().waiting_for {
+            // Spell's own modal choice (Abrade "Choose one").
+            WaitingFor::ModeChoice { .. } => {
+                runner
+                    .act(GameAction::SelectModes {
+                        indices: modes.to_vec(),
+                    })
+                    .expect("SelectModes must be accepted");
+            }
+            // Spell's own target slot(s).
+            WaitingFor::TargetSelection { .. } => {
+                let target = remaining_targets.remove(0);
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(engine::types::ability::TargetRef::Object(target)),
+                    })
+                    .expect("ChooseTarget must be accepted");
+            }
+            // Trigger-placement boundary: the spell is on the stack and any
+            // SpellCast trigger has been placed above it. Riku's modal trigger
+            // surfaces its own AbilityModeChoice here; a non-firing cast reaches
+            // Priority. Either way, inspect the stack now.
+            WaitingFor::Priority { .. } | WaitingFor::AbilityModeChoice { .. } => {
+                return riku_triggers_on_stack(runner.state(), riku);
+            }
+            other => panic!(
+                "unexpected WaitingFor while driving the cast: {}",
+                other.variant_name()
+            ),
+        }
+    }
+    panic!("cast pipeline did not reach a trigger-placement boundary within the step budget");
+}
+
+/// RUNTIME POSITIVE: casting a MODAL spell (Abrade) fires Riku's trigger.
+#[test]
+fn riku_fires_on_modal_spell() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Riku on P0's battlefield watching for modal casts.
+    let riku = scenario
+        .add_creature_from_oracle(P0, "Riku, of Many Paths", 2, 4, RIKU_ORACLE)
+        .id();
+    // A target creature for Abrade's "3 damage to target creature" mode.
+    let dummy = scenario.add_creature(P1, "Target Dummy", 3, 3).id();
+    let abrade = scenario
+        .add_spell_to_hand_from_oracle(P0, "Abrade", true, ABRADE_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    add_red_mana(&mut runner, 2);
+
+    assert!(
+        runner.state().objects[&abrade].modal.is_some(),
+        "Abrade must be modal (obj.modal.is_some()) — the runtime predicate this test rests on"
+    );
+    let fired = cast_and_count_riku_triggers(&mut runner, abrade, riku, &[0], &[dummy]);
+    assert_eq!(
+        fired, 1,
+        "Riku's SpellCast trigger MUST fire when a modal spell is cast (CR 700.2)"
+    );
+}
+
+/// RUNTIME NEGATIVE (load-bearing): casting a PLAIN NON-MODAL spell (Shock) does
+/// NOT fire Riku's trigger. Reverting the fix leaves `valid_card == None`, and
+/// Shock wrongly fires (the #750 over-trigger).
+#[test]
+fn riku_does_not_fire_on_non_modal_spell() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let riku = scenario
+        .add_creature_from_oracle(P0, "Riku, of Many Paths", 2, 4, RIKU_ORACLE)
+        .id();
+    // A creature so Shock's "any target" has a legal referent.
+    let dummy = scenario.add_creature(P1, "Target Dummy", 3, 3).id();
+    let shock = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, SHOCK_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    add_red_mana(&mut runner, 1);
+
+    assert!(
+        runner.state().objects[&shock].modal.is_none(),
+        "Shock must be non-modal (obj.modal.is_none())"
+    );
+    // Shock is non-modal and has a single "any target" slot.
+    let fired = cast_and_count_riku_triggers(&mut runner, shock, riku, &[], &[dummy]);
+    assert_eq!(
+        fired, 0,
+        "Riku's trigger MUST NOT fire on a non-modal spell — reverting the fix over-triggers here (#750)"
+    );
+}


### PR DESCRIPTION
**Anchored on:** #750

**Problem:** Riku, Of Many Paths — "Whenever you cast a modal spell, choose up to X…" — triggered on *every* spell its controller cast, not just modal spells.

**Root cause:** The cast-trigger parser could not express "modal spell" as a filter. In the "you cast a …" branch, the "modal" qualifier ran through `parse_type_phrase`, which doesn't recognize "modal" as a type, producing an empty filter; `has_meaningful_type_constraint()` was then false, so `valid_card` was left `None` and the qualifier was silently dropped. With no spell filter, the `SpellCast` trigger matched every cast.

**Fix:** Add `FilterProp::Modal` (CR 700.2) — an arity-0 intrinsic spell predicate alongside `HasSingleTarget`/`Foretold`. The parser now peels an optional leading "modal " qualifier (nom `opt(tag)`) before the type-phrase parse and attaches `FilterProp::Modal` to the filter's properties, so `valid_card` is assigned. At runtime it evaluates against the stack object's static printed modality (`obj.modal.is_some()`), which is present from object creation. The predicate is wired at every exhaustive `FilterProp` match site: the live evaluation, the two population classifiers and coverage render, conservative `false` at the two record-snapshot matchers (which carry no modal field), and the safe (apply-constant) group of the AI memoization classifier — with no new wildcard added. It is class-general (Riku plus Your Wish Is My Command, and any future "modal spell" reference), not a Riku special-case.

**Tests:** Three parser tests (Riku's trigger `valid_card` gains `FilterProp::Modal`; "modal instant spell" keeps the type *and* Modal; a plain "cast a spell" trigger gets no Modal) and two full-cast-pipeline runtime tests — Riku fires when a modal spell (Abrade) is cast and does **not** fire on a plain non-modal spell (Shock). Reverting the parser attach restores `valid_card == None` and makes Shock wrongly fire, so both directions are load-bearing.

**Verification:** cargo fmt, cargo check -p engine, cargo clippy -p engine --lib -D warnings, and ./scripts/check-parser-combinators.sh all clean. Regression green: filter, spell_cast, filterprop, trigger, and coverage suites. The new variant is additive on the serialized surface (`{"type":"Modal"}`), so existing card data loads unchanged.

Closes #750.

Model: claude-opus-4-8
Tier: Frontier
