### PR TITLE
fix(parser): parse Eidolon's distributive dual-subject dynamic pump

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -580,6 +580,16 @@ pub(crate) fn contextual_continuous_subject_filter(
     subject_original: &str,
     condition: Option<&StaticCondition>,
 ) -> Option<TargetFilter> {
+    // CR 613.1: a distributive "each" trailing a multi-subject list ("this
+    // creature and enchanted creature each get +1/+1 …", Eidolon of Countless
+    // Battles) shares one predicate across every named subject. Strip the marker
+    // from both views so the compound subject parses; the `Or` union below
+    // already applies the predicate to each branch. Stripping each view with the
+    // same combinator keeps them aligned without slicing one by the other's byte
+    // length (safe when case-folding changes width).
+    let subject_lower = strip_trailing_distributive_each(subject_lower);
+    let subject_original = strip_trailing_distributive_each(subject_original);
+
     if subject_lower == "that creature" {
         return condition
             .and_then(exactly_one_creature_you_control_filter)
@@ -777,6 +787,19 @@ pub(crate) fn parse_continuous_gets_has(
         }
     }
 
+    // CR 613.4c: Handle repeated dynamic pump terms — "gets +N/+M for each X and
+    // +P/+Q for each Y" (Eidolon of Countless Battles) — where each term scales
+    // by its own count. Try this before the single-"for each" path so the second
+    // term isn't silently dropped and the pump collapsed to a fixed value.
+    if let Some(modifications) = parse_repeated_for_each_pt_modifications(text) {
+        return Some(
+            StaticDefinition::continuous()
+                .affected(affected)
+                .modifications(modifications)
+                .description(description.to_string()),
+        );
+    }
+
     // CR 613.4c: Handle "gets +N/+M for each [clause]" — dynamic P/T via ObjectCount.
     if let Some((before_for_each, after_for_each)) = tp.split_around("for each ") {
         let pt_text = before_for_each.original.trim();
@@ -871,6 +894,96 @@ pub(crate) fn parse_dynamic_for_each_pt_modifications(
     let mut modifications = Vec::new();
     push_dynamic_pt_modifications(&mut modifications, power, toughness, quantity);
     (!modifications.is_empty()).then_some(modifications)
+}
+
+/// CR 613.4c: A compound of repeated dynamic pump terms — "gets +N/+M for each X
+/// and +P/+Q for each Y" (Eidolon of Countless Battles) — where each term scales
+/// by its own count. Splits on the " and " that introduces another "+n/+m for
+/// each" pump term (so a single term's embedded "for each A and B" count-list
+/// stays with the single-term path) and accumulates every term's dynamic
+/// modifications. Returns `None` unless at least two whole pump terms parse, so
+/// the single-term path keeps ownership of every non-repeated case.
+fn parse_repeated_for_each_pt_modifications(text: &str) -> Option<Vec<ContinuousModification>> {
+    let lower = text.to_lowercase();
+    let mut terms: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for (index, segment) in split_on_and(&lower).into_iter().enumerate() {
+        if index > 0 && segment_starts_pump_term(segment) {
+            terms.push(std::mem::take(&mut current));
+            current.push_str(segment);
+        } else {
+            if !current.is_empty() {
+                current.push_str(" and ");
+            }
+            current.push_str(segment);
+        }
+    }
+    if !current.is_empty() {
+        terms.push(current);
+    }
+    if terms.len() < 2 {
+        return None;
+    }
+
+    let mut modifications = Vec::new();
+    for term in &terms {
+        // `parse_dynamic_for_each_pt_modifications` expects the "gets"/"get" verb;
+        // only the first term carries it once the predicate is split.
+        let owned;
+        let term = if segment_has_gets_verb(term) {
+            term.as_str()
+        } else {
+            owned = format!("gets {term}");
+            owned.as_str()
+        };
+        modifications.extend(parse_dynamic_for_each_pt_modifications(term)?);
+    }
+    (!modifications.is_empty()).then_some(modifications)
+}
+
+/// Split `s` into its " and "-delimited segments via a forward `take_until`
+/// scan (the combinator form of `str::split(" and ")`).
+fn split_on_and(s: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut remaining = s;
+    while let Ok((rest, before)) =
+        terminated(take_until::<_, _, OracleError<'_>>(" and "), tag(" and ")).parse(remaining)
+    {
+        segments.push(before);
+        remaining = rest;
+    }
+    segments.push(remaining);
+    segments
+}
+
+/// True iff `segment` (already lowercased) opens with a "gets"/"get" verb.
+fn segment_has_gets_verb(segment: &str) -> bool {
+    alt((tag::<_, _, OracleError<'_>>("gets "), tag("get ")))
+        .parse(segment)
+        .is_ok()
+}
+
+/// True iff `segment` (already lowercased) begins a "+N/+M for each …" pump term:
+/// an optional "gets"/"get" verb, a P/T modifier, then " for each ". Used to tell
+/// a repeated-pump term boundary apart from an " and " inside a count clause.
+fn segment_starts_pump_term(segment: &str) -> bool {
+    preceded(
+        opt(alt((tag::<_, _, OracleError<'_>>("gets "), tag("get ")))),
+        preceded(nom_primitives::parse_pt_modifier, tag(" for each ")),
+    )
+    .parse(segment.trim_start())
+    .is_ok()
+}
+
+/// Strip a trailing distributive " each" ("this creature and enchanted creature
+/// each") so a multi-subject list parses. Only strips when " each" is the final
+/// token, and returns `s` unchanged otherwise, so applying it to both the lower
+/// and original views of a subject keeps them aligned without length slicing.
+fn strip_trailing_distributive_each(s: &str) -> &str {
+    match terminated(take_until::<_, _, OracleError<'_>>(" each"), tag(" each")).parse(s) {
+        Ok(("", before)) => before,
+        _ => s,
+    }
 }
 
 pub(crate) fn parse_dynamic_pt_in_text(

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22243,3 +22243,81 @@ fn granted_ability_inner_unless_stays_inside_quoted_ability() {
         "the granted ability's inner `unless` must NOT become a static-grant condition"
     );
 }
+
+/// CR 613.1 + CR 613.4c: Eidolon of Countless Battles (#4777). The Bestow aura
+/// buffs both itself and its enchanted host ("this creature and enchanted
+/// creature each get ..."), and each buff scales by two independent counts
+/// ("+1/+1 for each creature you control and +1/+1 for each Aura you control").
+/// A raw parse dropped the distributive-"each" subject and collapsed the dynamic
+/// pump to a fixed +1/+1; all three pieces must now survive.
+#[test]
+fn static_self_and_enchanted_each_repeated_dynamic_pump() {
+    let def = parse_static_line(
+        "This creature and enchanted creature each get +1/+1 for each creature you control and +1/+1 for each Aura you control.",
+    )
+    .unwrap();
+
+    // Both the source and its enchanted host receive the buff.
+    match def.affected {
+        Some(TargetFilter::Or { ref filters }) => {
+            assert!(filters.iter().any(|f| f == &TargetFilter::SelfRef));
+            assert!(filters.iter().any(|f| matches!(
+                f,
+                TargetFilter::Typed(tf) if tf.properties.contains(&FilterProp::EnchantedBy)
+            )));
+        }
+        other => panic!("expected an Or subject (source + enchanted host), got {other:?}"),
+    }
+
+    // Both dynamic terms survive as dynamic P/T — not collapsed to a fixed +1/+1.
+    let object_count = |value: &QuantityExpr| match value {
+        QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount { filter },
+        } => Some(filter.clone()),
+        _ => None,
+    };
+    let power_counts: Vec<TargetFilter> = def
+        .modifications
+        .iter()
+        .filter_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => object_count(value),
+            _ => None,
+        })
+        .collect();
+    let toughness_count = def
+        .modifications
+        .iter()
+        .filter(|m| matches!(m, ContinuousModification::AddDynamicToughness { .. }))
+        .count();
+    assert_eq!(
+        power_counts.len(),
+        2,
+        "both pump terms must scale power dynamically"
+    );
+    assert_eq!(
+        toughness_count, 2,
+        "both pump terms must scale toughness dynamically"
+    );
+
+    let counts_creatures = power_counts.iter().any(|f| {
+        matches!(
+            f,
+            TargetFilter::Typed(tf)
+                if tf.type_filters == vec![TypeFilter::Creature]
+                    && tf.controller == Some(ControllerRef::You)
+        )
+    });
+    let counts_auras = power_counts.iter().any(|f| {
+        matches!(
+            f,
+            TargetFilter::Typed(tf)
+                if tf.type_filters == vec![TypeFilter::Subtype("Aura".to_string())]
+                    && tf.controller == Some(ControllerRef::You)
+        )
+    });
+    assert!(
+        counts_creatures,
+        "one term must count creatures you control"
+    );
+    assert!(counts_auras, "the other term must count Auras you control");
+}


### PR DESCRIPTION
## Problem (#4777)

Eidolon of Countless Battles' static —

> This creature and enchanted creature each get +1/+1 for each creature you control and +1/+1 for each Aura you control.

— was mis-parsed as a **fixed `+1/+1` `Pump`** ability. Two independent gaps combined:

1. The distributive **"each"** after the multi-subject list (`this creature and enchanted creature each get …`) broke `contextual_continuous_subject_filter`, so the whole static failed and fell back to the imperative pump path.
2. Even with the subject fixed, the **repeated** `+N/+M for each X and +N/+M for each Y` pump collapsed to a fixed value — `parse_continuous_gets_has` splits on the first `for each` only, and the second term was silently dropped (the `DynamicQty` swallow the parser flagged).

## Fix (both in the clean `oracle_static/anthem.rs`)

- Strip the distributive `" each"` marker in `contextual_continuous_subject_filter` so the compound subject unions into `Or { SelfRef, <enchanted host> }`. No single subject legitimately ends in `" each"`, so it only fires on the distributive form.
- Add `parse_repeated_for_each_pt_modifications`, which splits on the `" and "` that introduces another `+n/+m for each` pump term (leaving a single term's embedded `for each A and B` count-list to the existing single-term path) and accumulates each term's dynamic modifications via the existing `parse_dynamic_for_each_pt_modifications`. Returns `None` unless ≥2 whole pump terms parse, so every non-repeated case is untouched.

## Result

Eidolon now parses to one continuous static on `{source, enchanted host}` with dynamic `+1/+1` per creature you control **and** `+1/+1` per Aura you control. The spurious `Pump` ability and the `DynamicQty` swallow warning are both gone.

## Testing

- New regression test `static_self_and_enchanted_each_repeated_dynamic_pump`.
- Full engine lib suite green: `cargo test -p engine --lib` → **14,551 passed, 0 failed**.
- `cargo fmt -p engine --check` clean.

Closes #4777