### PR TITLE
feat(pr-review): contributor intelligence + transient-failure hardening for pr_review.py

### DIFF
--- a/.claude/skills/pr-contribution-handler/SKILL.md
+++ b/.claude/skills/pr-contribution-handler/SKILL.md
@@ -18,6 +18,7 @@ This skill lands contributor work, but **only after it meets the maintainer's ba
 2. **CI/Tilt green is necessary, NOT sufficient.** Green CI proves it compiles and existing tests pass. It does **not** prove correctness, no-regression, or performance. Never present "CI green" as evidence a PR is ready. For every PR you must additionally:
    - **Trace the changed logic by hand**, end to end, for the target case AND 2–3 sibling cases in the class AND the obvious edge cases (multiplayer, zero/empty, interaction with existing effects). Confirm it actually produces the rules-correct result — not merely that it "conforms to CLAUDE.md."
    - **Verify the tests DISCRIMINATE.** For every assertion, ask: *would this fail if the fix were reverted?* An assertion that passes both before and after the fix is coverage theater. A bug-fix PR must have at least one runtime test that drives the engine through the real pipeline (`apply()` / scenario runner) and would fail without the change. Name any behavior with no discriminating test as a gap, and add the missing test before enqueue.
+   - **Read the parse-diff sticky comment (engine/parser-surface PRs).** CI posts a sticky comment (marker `<!-- coverage-parse-diff -->`) with the card-level parse changes this PR introduces — it exists *for the reviewing LLM* and is required evidence, not optional context. Fetch its full body and confront the card diff against the PR's claimed scope: unexplained gained/lost/changed cards are findings (scope contamination or unintended parser blast radius). The `pr_review.py` packet's `parse_diff` field carries presence/state/`updated_at`; compare `updated_at` against the head's push time to confirm the diff reflects the current head. If the comment is absent but engine source changed, treat it as missing evidence and check whether CI ran for the current head before reviewing.
 
 3. **Regressions, performance, and clean architecture are first-class enqueue gates.** Before enqueue, answer each with evidence:
    - *Regression:* which existing cards/paths could this break? Anything touching a shared resolver, the casting/priority path, the protection/targeting gate, the layer system, or combat — i.e. code with many callers — gets a hand-traced blast-radius review and, where coverage is thin, a new regression test.
@@ -230,6 +231,15 @@ The judgement is yours (the maintainer or the agent executing the skill) — kee
 
 If `## Anchored on` is absent, do not penalize — the policy is new and most existing PRs will lack it. Just apply normal Architecture Review.
 
+### Contributor standing gauge (informs scrutiny level)
+
+`python3 scripts/pr_review.py recommend <N>` returns an advisory `contributor` block — `standing`, `scrutiny`, `scrutiny_reasons`, `recurrence`, `first_contribution` — derived from local review history plus `contributor_standing` in the review host's gitignored `private-overrides.json` (other hosts see only derived standing). Use it alongside the Tier line:
+
+- A self-declared `Tier: Frontier` PR whose author sits at `elevated` or `maintainer_attention` scrutiny gets Standard-tier scrutiny regardless of the declared tier — declared tier never outranks observed track record.
+- When `recurrence` lists the same signal class you just found in review, say so in the review comment ("Nth PR with `<signal>` in the last 60 days") — repeat-after-feedback is the primary pattern the maintainer wants surfaced.
+- `first_contribution` → apply the full evidence bar and point the author at the `docs/AI-CONTRIBUTOR.md` gates in the first review comment.
+- When your review finds a quality-signal defect, attach `signals` (closed vocabulary) to the recorded outcome event — this review's defects only, never re-recorded history — so recurrence stays derivable.
+
 ## Checkout
 
 Prefer a worktree for contributor PRs. If using the main workspace, first verify the current changes are intentional and do not overwrite or stash them.
@@ -274,6 +284,8 @@ Resolve conflicts in the same architectural style as the surrounding code. Do no
 **The `main.rs` mod-line tax (recurring, deterministic).** `crates/engine/tests/integration/main.rs` is rustfmt-sorted (`reorder_modules`), and every test-carrying PR appends a `mod issue_XXXX;` line. Two test PRs near each other in the queue therefore conflict **deterministically** on that file, and GitHub's auto-rebase bails (leaving the PR `DIRTY`). The resolution is always the same: keep **both** mod lines, in sorted order. This is a merge-queue serialization artifact, not a contributor defect — resolve it mechanically and move on. (Inline `#[cfg(test)]` tests avoid it entirely.)
 
 If `origin/main` is already an ancestor and there are no conflicts, skip the merge — repeatedly bringing-current adds noise to the PR history without changing mergeability under the queue.
+
+**One targeted exception — `baseline_pending` parse-diff.** The parse-diff CI step is merge-base-pinned and immune to branch staleness (see `ci.yml` "Parse-detail diff vs base baseline"), so staleness alone is never a reason to bring-current-and-push. But when the sticky parse-diff comment shows *Baseline pending* (packet reason `review_parse_baseline_pending`), the merge-base's R2 baseline has likely aged out of retention and will **never** populate — bringing the branch current with `origin/main` and pushing is the remedy, because a fresh merge-base has a live baseline and the re-triggered CI regenerates the diff. Do this *before* the review so the card diff is available as evidence (and remember a push to an enqueued PR cancels auto-merge — re-run `gh pr merge --auto` after).
 
 ## Review Comment Resolution
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -14,10 +14,12 @@ This skill is intentionally small. Mutable policy and contributor-specific state
 - **GitHub is authoritative** for PR head, author, reviews, comments, labels, CI, and merge-queue state.
 - **Repo policy** lives in `.agents/pr-review-policy.toml` and must contain only repo-level, non-personal rules: path classifiers, domain capabilities, labels, hard-stop path patterns, generated-file patterns, and default gates.
 - **Local review memory** lives outside the repo by default under `~/.local/state/pr-review/<owner>__<repo>/` unless `PR_REVIEW_STATE_DIR` or `--state-dir` is set. This directory contains:
-  - `review-events.jsonl` — canonical append-only local event log.
-  - `review-state.sqlite` — derived query index/cache.
-  - `review-summary.json` — generated token-minimal summary.
+  - `review-events.jsonl` — the sole canonical store: an append-only local event log with locked, deduplicated, `fsync`'d appends.
+  - `review-summary.json` — generated token-minimal summary derived from the log.
+  - A stray `review-state.sqlite` from an older build is an orphaned leftover; it is no longer read or written, and is safe to ignore or delete manually.
+- **Never Read `review-events.jsonl` directly.** It is unbounded and not token-shaped; all queries must go through the `pr_review.py` CLI (`scan`/`inspect`/`recommend`/`analytics`/`compact`). `review-summary.json` is the only state file intended for direct reading.
 - **No hardcoded names.** Contributor standings, frontend exceptions, reviewer identities, private overrides, and one-off maintainer policy belong in local/private state, never in this skill.
+- **Contributor standing lives in `private-overrides.json`** under `contributor_standing` (`skip`/`probation`/`watch`/`trusted`, lowercase-matched logins). It sits in the gitignored state dir on the review host; other hosts see only derived standing. The narrative quality log is a historical appendix — the event log, via recorded `signals`, is the data authority for per-contributor patterns.
 
 ## Commands
 
@@ -27,9 +29,12 @@ Use the CLI from the repo root:
 python3 scripts/pr_review.py scan --repo phase-rs/phase --config .agents/pr-review-policy.toml
 python3 scripts/pr_review.py inspect <PR> --repo phase-rs/phase --mode full
 python3 scripts/pr_review.py recommend <PR> --repo phase-rs/phase
+python3 scripts/pr_review.py recommend <PR> --repo phase-rs/phase --emit-event
 python3 scripts/pr_review.py record --event-json -
 python3 scripts/pr_review.py compact
 ```
+
+`record` validates each event's `event_type` and (when present) `outcome` against a closed vocabulary and lowercases the outcome on write; an out-of-vocabulary event is rejected with exit 1 and the allowed values, and `--force` bypasses validation (flagging the event `"forced": true`). The preferred recording path is to add `--emit-event` to `inspect`/`recommend`, fill the returned `event_skeleton` (its prefilled timestamp gives idempotent retries), and pipe it back to `record --event-json -`.
 
 Import legacy state once:
 
@@ -44,14 +49,16 @@ python3 scripts/pr_review.py compact
 
 1. Resolve the acting identity from GitHub. Do not review PRs authored by the acting login.
 2. Run `scan`. Use `action_counts` / `candidates_by_action` for routing; do not infer legacy bucket names. Treat its result as a triage packet, not a final approval gate.
-3. For each candidate:
+3. Every packet (and `recommend` output) carries an advisory `contributor` block — standing, scrutiny, `scrutiny_reasons`, `recurrence`, `first_contribution` — derived from the local event log plus `contributor_standing` overrides; it is `null` only when the PR has no author login. Scale review depth by it: `first_contribution` → full evidence bar, and point the author at the `docs/AI-CONTRIBUTOR.md` gates in the first review comment; `elevated` → dig specifically into the recurring signals named in `scrutiny_reasons`; `maintainer_attention` → include the contributor in the sweep report for the maintainer. `light_touch_eligible` permits a lighter pass only while scrutiny is `normal`.
+4. For each candidate:
    - `hard_stop` / `request_changes` — surface the precise blocker; do not enqueue.
+   - `skip` — disambiguate by `reason`: `closed` / `self_authored` need no action; `contributor_standing_skip` is an explicit maintainer standing override — record the skip and move on without reviewing. A skip-listed contributor touching hard-stop paths still surfaces as `request_changes` (safety outranks the skip).
    - `blocked` — current head already has blocking maintainer feedback; wait for a new head or author follow-up.
    - `defer` — record the deferral event; do not approve, label, enqueue, or merge.
    - `hold_ci` — record a non-terminal hold only when the packet is incomplete or an external condition prevents review. CI being pending, unknown, or red is not itself a review/enqueue blocker; merge-when-ready will wait for required checks.
    - `dequeue_stale_for_handler` / `update_branch_for_handler` / `approve_ready_for_handler` — advisory only; delegate execution to `pr-contribution-handler` in authorized mode.
-   - `review` — fetch an `inspect --mode full` packet, then run `review-impl` against the current head and GitHub API/local diff evidence.
-4. Record every material outcome with `record`; regenerate summaries with `compact` when useful.
+   - `review` — fetch an `inspect --mode full` packet, then run `review-impl` against the current head and GitHub API/local diff evidence. For engine/parser-surface PRs, the parse-diff sticky comment (`<!-- coverage-parse-diff -->`) is REQUIRED review evidence: fetch its full body and confront the card-level diff against the PR's claimed scope. The packet's `parse_diff` field carries presence/state/`updated_at`. If state is `baseline_pending` on a stale branch (the `review_parse_baseline_pending` reason), route to update-branch first — that is the one staleness case where updating is the remedy, since the CI diff is merge-base-pinned and immune to branch staleness (see `ci.yml` "Parse-detail diff vs base baseline" step). If the comment is absent but engine source changed, treat it as missing evidence: check whether CI ran for the current head before reviewing.
+5. Record every material outcome with `record`. When the review found a quality-signal defect, attach `signals` (closed vocabulary, validated at record time) to the outcome event — for defects found in THIS review only, never re-recorded history — so per-contributor recurrence stays derivable data. Regenerate summaries with `compact` when useful.
 
 ## Review Freshness
 

--- a/.claude/skills/review-impl/SKILL.md
+++ b/.claude/skills/review-impl/SKILL.md
@@ -13,7 +13,8 @@ Review for gaps: things that are missing or wrong. Do not spend findings on styl
 2. Classify the surface area: engine logic, parser, frontend/UI, multiplayer/transport, AI heuristics, deck/format/feeds, build/CI/release, or docs.
 3. Apply only the relevant lenses below.
 4. If the scope is a PR, fetch existing bot/human review comments (Gemini, CodeRabbit, reviewers) and confirm-or-refute each against the current head with code evidence. Fold confirmed findings into your own. Never review in a vacuum — silently omitting a finding another reviewer already raised, or returning a verdict less severe than an open, unrefuted finding from another reviewer, is itself a defect.
-5. Report findings only. Silence means LGTM.
+5. If the scope is a PR touching engine/parser source, the parse-diff sticky comment (marker `<!-- coverage-parse-diff -->`) is required evidence: fetch its full body and confront the card-level diff against the PR's claimed scope. Unexplained gained/lost/changed cards are findings (unintended parser blast radius). A *Baseline pending* body means the diff is unavailable — flag it so the handler brings the branch current to regenerate it; an absent comment despite changed engine source means CI evidence is missing for the current head.
+6. Report findings only. Silence means LGTM.
 
 Skip checks CI already enforces:
 

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -5,6 +5,31 @@ This tool keeps durable review memory as an append-only JSONL event log
 (`review-events.jsonl`), the sole canonical store; `review-summary.json` is a
 derived artifact. It is advisory: GitHub mutations stay in the maintainer
 handling skills.
+
+Architecture (one-way data flow, top to bottom):
+
+    GitHub GraphQL (read-only, via `gh`)      Event log (JSONL, append-only)
+        fetch_open_prs / gh_pr_view               all_events -> normalize_event
+        normalize_graphql_pr                      |         |
+              |                                   |    build_analytics_model
+              |                                   |    collect_signal_occurrences
+              |                              latest_events_by_pr_head
+              v                                   v
+        make_packet  <---  ReviewContext (policy + overrides + local history)
+              |             build_contributor_summary (standing/scrutiny)
+              v
+        recommend_from_packet (ordered advisory-action ladder)
+
+Commands: `scan` (triage every open PR), `inspect`/`recommend` (one PR),
+`record` (validated event append), `import` (legacy TSV/markdown), `compact`
+(summary artifact), `analytics` (contributor tables), `check-skill-sync`.
+
+Invariants:
+- All GitHub access is read-only and goes through run_json (retried).
+- The event log is the only mutable store; append_event is its only writer.
+- Every tunable threshold lives in the constants block below, not inline.
+- Recommendations are advisory; precedence is the elif ladder in
+  recommend_from_packet, ordered so safety (hard_stop) always wins.
 """
 from __future__ import annotations
 
@@ -114,6 +139,43 @@ ANALYTICS_DEFAULT_MIN_PRS = 3
 # "skip" changes the advisory action; watch/probation force elevated scrutiny;
 # trusted marks light-touch eligibility. Anything else in the file is ignored.
 ALLOWED_STANDINGS = {"skip", "probation", "watch", "trusted"}
+# Score bands. SCORE_WATCH_FLOOR is shared by the score_label display bands and
+# the scrutiny ladder (score below it at medium/high confidence elevates).
+SCORE_EXCELLENT = 90
+SCORE_STRONG = 75
+SCORE_WATCH_FLOOR = 55
+# Derived-trusted gate: enough terminal history, high success, and a clean
+# recurrence window (see build_contributor_summary).
+TRUSTED_MIN_TERMINAL_PRS = 5
+TRUSTED_MIN_SUCCESS_RATE = 0.85
+# Same signal on this many distinct PRs inside RECURRENCE_WINDOW_DAYS.
+RECURRENCE_ELEVATED_PRS = 2
+RECURRENCE_ATTENTION_PRS = 3
+# Non-terminal states that still advance a head's "latest known posture".
+PROGRESS_STATES = {"held", "held_ci", "deferred", "review", "pending"}
+# GitHub read retry policy (see run_json).
+RUN_JSON_ATTEMPTS = 3
+RUN_JSON_BACKOFF_SECONDS = (2, 5)
+# Sticky-comment marker posted by .github/workflows/coverage-parse-diff-comment.yml
+# as the first (HTML-comment) line of the parse-detail diff body.
+PARSE_DIFF_MARKER = "<!-- coverage-parse-diff -->"
+# Sweep-priority order for scan output buckets (lower sorts first).
+CANDIDATE_ACTION_ORDER = {
+    "dequeue_stale_for_handler": 0,
+    "update_branch_for_handler": 1,
+    "approve_ready_for_handler": 2,
+    "review": 3,
+    "hold_ci": 4,
+    "request_changes": 5,
+    "blocked": 6,
+    "defer": 7,
+    "queued": 8,
+    "merged_prune": 9,
+    "skip": 10,
+}
+
+
+# ─── Config, overrides, and small helpers ────────────────────────────────────
 
 
 @dataclass(frozen=True)
@@ -236,36 +298,7 @@ def event_id(event: dict[str, Any]) -> str:
     return hashlib.sha256(json_dumps(clean).encode("utf-8")).hexdigest()
 
 
-def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
-    normalized = dict(event)
-    if normalized.get("head_sha") is None and normalized.get("head") is not None:
-        normalized["head_sha"] = normalized["head"]
-    action = normalized.get("action")
-    if normalized.get("event_type") is None and action is not None:
-        normalized["event_type"] = action
-    summary = str(normalized.get("summary") or normalized.get("note") or "")
-    if normalized.get("event_type") in {None, "observation"} and (
-        summary.startswith("CHANGES_REQUESTED:")
-        or summary.startswith("Requested changes:")
-    ):
-        normalized["event_type"] = "changes_requested"
-    if normalized.get("outcome") is None and action in {
-        "changes_requested",
-        "blocked",
-        "approved_enqueued",
-        "deferred",
-        "held",
-    }:
-        normalized["outcome"] = action
-    normalized.setdefault("timestamp", now_iso())
-    normalized.setdefault("event_type", "observation")
-    normalized.setdefault("schema_version", 1)
-    normalized["event_id"] = normalized.get("event_id") or event_id(normalized)
-    return normalized
-
-
-RUN_JSON_ATTEMPTS = 3
-RUN_JSON_BACKOFF_SECONDS = (2, 5)
+# ─── GitHub subprocess helpers (read-only) ───────────────────────────────────
 
 
 def run_json(command: list[str]) -> Any:
@@ -306,20 +339,39 @@ def run_json(command: list[str]) -> Any:
     raise last_error
 
 
-def run_text(command: list[str]) -> str:
-    result = subprocess.run(
-        command,
-        cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    return result.stdout
-
-
 def gh_user() -> str:
     return str(run_json(["gh", "api", "user"])["login"])
+
+
+# ─── Event log (the sole mutable store) ──────────────────────────────────────
+
+
+def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(event)
+    if normalized.get("head_sha") is None and normalized.get("head") is not None:
+        normalized["head_sha"] = normalized["head"]
+    action = normalized.get("action")
+    if normalized.get("event_type") is None and action is not None:
+        normalized["event_type"] = action
+    summary = str(normalized.get("summary") or normalized.get("note") or "")
+    if normalized.get("event_type") in {None, "observation"} and (
+        summary.startswith("CHANGES_REQUESTED:")
+        or summary.startswith("Requested changes:")
+    ):
+        normalized["event_type"] = "changes_requested"
+    if normalized.get("outcome") is None and action in {
+        "changes_requested",
+        "blocked",
+        "approved_enqueued",
+        "deferred",
+        "held",
+    }:
+        normalized["outcome"] = action
+    normalized.setdefault("timestamp", now_iso())
+    normalized.setdefault("event_type", "observation")
+    normalized.setdefault("schema_version", 1)
+    normalized["event_id"] = normalized.get("event_id") or event_id(normalized)
+    return normalized
 
 
 def append_event(state_dir: Path, event: dict[str, Any]) -> bool:
@@ -352,10 +404,16 @@ def all_events(state_dir: Path) -> list[dict[str, Any]]:
         return []
     events = []
     with log_path.open("r", encoding="utf-8") as file:
-        for line in file:
-            if not line.strip():
-                continue
-            events.append(normalize_event(json.loads(line)))
+        # Shared lock pairs with append_event's exclusive lock: a reader can't
+        # observe a partially flushed line from a concurrent agent's append.
+        fcntl.flock(file, fcntl.LOCK_SH)
+        try:
+            for line in file:
+                if not line.strip():
+                    continue
+                events.append(normalize_event(json.loads(line)))
+        finally:
+            fcntl.flock(file, fcntl.LOCK_UN)
     # Preserve the previous SELECT ... ORDER BY timestamp, event_id semantics that
     # downstream aggregation relies on.
     return sorted(events, key=event_sort_key)
@@ -398,6 +456,9 @@ def filtered_events_by_days(events: list[dict[str, Any]], days: int | None) -> l
         if timestamp is not None and timestamp.timestamp() >= cutoff:
             filtered.append(event)
     return filtered
+
+
+# ─── Canonical outcome mapping (read-side, legacy-tolerant) ──────────────────
 
 
 def canonical_from_text(value: str | None) -> tuple[str, str] | None:
@@ -521,6 +582,9 @@ def unknown_event_values(events: list[dict[str, Any]]) -> dict[str, dict[str, in
     return {name: values for name, values in unknowns.items() if values}
 
 
+# ─── Analytics aggregation (events → PR rows → contributor rows) ─────────────
+
+
 def head_analytics(pr: int, head_sha: str, events: list[dict[str, Any]]) -> dict[str, Any]:
     sorted_events = sorted(events, key=event_sort_key)
     ever_states: dict[str, int] = {}
@@ -530,13 +594,7 @@ def head_analytics(pr: int, head_sha: str, events: list[dict[str, Any]]) -> dict
         ever_states[outcome.state] = ever_states.get(outcome.state, 0) + 1
         if outcome.state in TERMINAL_STATES:
             terminal = outcome
-        elif terminal.state not in TERMINAL_STATES and outcome.state in {
-            "held",
-            "held_ci",
-            "deferred",
-            "review",
-            "pending",
-        }:
+        elif terminal.state not in TERMINAL_STATES and outcome.state in PROGRESS_STATES:
             terminal = outcome
     return {
         "pr": pr,
@@ -621,11 +679,11 @@ def confidence_for(total_prs: int, terminal_prs: int, unclassified_ratio: float,
 def score_label(score: int, confidence: str) -> str:
     if confidence == "low":
         return "Insufficient Data"
-    if score >= 90:
+    if score >= SCORE_EXCELLENT:
         return "Excellent Signal"
-    if score >= 75:
+    if score >= SCORE_STRONG:
         return "Strong Signal"
-    if score >= 55:
+    if score >= SCORE_WATCH_FLOOR:
         return "Watch"
     return "Elevated Scrutiny"
 
@@ -747,7 +805,7 @@ def contributor_rows_from_prs(
             )
         )
     for login, signals in contributor_quality.items():
-        if author and login.lower() != author.lower():
+        if author and fold_login(login) != fold_login(author):
             continue
         if login not in contributor_prs:
             contributors.append(
@@ -803,7 +861,7 @@ def build_analytics_model(
             if login:
                 folded = fold_login(str(login))
                 display_names.setdefault(folded, str(login))
-                signals = event.get("quality", {}).get("signals", [])
+                signals = (event.get("quality") or {}).get("signals") or []
                 quality = contributor_quality.setdefault(folded, {})
                 for signal in signals:
                     add_counter(quality, str(signal))
@@ -887,6 +945,9 @@ def finalize_contributor_model(
         row["login"] = display_names.get(row["login"], row["login"])
 
 
+# ─── Contributor intelligence (recurrence, standing, scrutiny) ───────────────
+
+
 def collect_signal_occurrences(
     events: list[dict[str, Any]],
 ) -> dict[str, list[dict[str, Any]]]:
@@ -963,8 +1024,8 @@ def build_contributor_summary(
     override = contributor_standing_override(author_login, private_overrides)
     derived_trusted = bool(
         row
-        and row["terminal_prs"] >= 5
-        and (row["observed_success_rate"] or 0) >= 0.85
+        and row["terminal_prs"] >= TRUSTED_MIN_TERMINAL_PRS
+        and (row["observed_success_rate"] or 0) >= TRUSTED_MIN_SUCCESS_RATE
         and not recurrence
     )
     if override:
@@ -976,16 +1037,16 @@ def build_contributor_summary(
     score = row["local_signal_score"] if row else None
     confidence = row["confidence"] if row else None
     scrutiny_reasons = []
-    if score is not None and score < 55 and confidence in {"medium", "high"}:
+    if score is not None and score < SCORE_WATCH_FLOOR and confidence in {"medium", "high"}:
         scrutiny_reasons.append(f"low_score_{score}_{confidence}_confidence")
     for entry in recurrence:
-        if entry["distinct_prs_window"] >= 2:
+        if entry["distinct_prs_window"] >= RECURRENCE_ELEVATED_PRS:
             scrutiny_reasons.append(
                 f"recurrence_{entry['signal']}_{entry['distinct_prs_window']}_prs_in_window"
             )
     if standing in {"watch", "probation"}:
         scrutiny_reasons.append(f"standing_{standing}")
-    if any(entry["distinct_prs_window"] >= 3 for entry in recurrence):
+    if any(entry["distinct_prs_window"] >= RECURRENCE_ATTENTION_PRS for entry in recurrence):
         scrutiny = "maintainer_attention"
     elif scrutiny_reasons:
         scrutiny = "elevated"
@@ -1010,6 +1071,9 @@ def build_contributor_summary(
     }
 
 
+# ─── ASCII rendering for analytics ───────────────────────────────────────────
+
+
 def score_bar(score: int, width: int = 12) -> str:
     filled = round((score / 100) * width)
     return "#" * filled + "." * (width - filled)
@@ -1023,27 +1087,19 @@ def sorted_contributors(
     def confidence_rank(item: dict[str, Any]) -> int:
         return {"high": 0, "medium": 1, "low": 2}.get(item["confidence"], 3)
 
-    if sort_key == "activity":
-        key = lambda item: (confidence_rank(item), -item["prs"], item["login"].lower())
-    elif sort_key == "acceptance":
-        key = lambda item: (
-            confidence_rank(item),
-            -(item["observed_success_rate"] or 0),
-            item["login"].lower(),
-        )
-    elif sort_key == "observed-heads":
-        key = lambda item: (
-            confidence_rank(item),
-            -item["observed_heads_avg"],
-            item["login"].lower(),
-        )
-    else:
-        key = lambda item: (
-            confidence_rank(item),
-            -item["local_signal_score"],
-            item["login"].lower(),
-        )
-    rows = sorted(contributors, key=key)
+    # Sort metric per --sort choice; every ordering tiebreaks on confidence first
+    # and folded login last so rows are stable across runs.
+    metrics = {
+        "activity": lambda item: -item["prs"],
+        "acceptance": lambda item: -(item["observed_success_rate"] or 0),
+        "observed-heads": lambda item: -item["observed_heads_avg"],
+        "score": lambda item: -item["local_signal_score"],
+    }
+    metric = metrics.get(sort_key, metrics["score"])
+    rows = sorted(
+        contributors,
+        key=lambda item: (confidence_rank(item), metric(item), fold_login(item["login"])),
+    )
     return rows[:limit] if limit is not None else rows
 
 
@@ -1095,7 +1151,7 @@ def render_count_bar(label: str, value: int, max_value: int) -> str:
 def render_contributor_detail(model: dict[str, Any], login: str) -> str:
     matches = [
         contributor for contributor in model["contributors"]
-        if contributor["login"].lower() == login.lower()
+        if fold_login(contributor["login"]) == fold_login(login)
     ]
     if not matches:
         return f"No analytics found for {login}."
@@ -1149,6 +1205,9 @@ def render_analytics_ascii(model: dict[str, Any], args: argparse.Namespace) -> s
     return render_analytics_table(model, sort_key=args.sort, limit=args.limit)
 
 
+# ─── GitHub live refresh (analytics --refresh-github) ────────────────────────
+
+
 def gh_pr_refresh_chunk(repo: str, numbers: list[int]) -> dict[str, dict[str, Any] | None]:
     """Fetch live terminal state for up to 50 PRs in one aliased GraphQL query.
 
@@ -1165,7 +1224,9 @@ def gh_pr_refresh_chunk(repo: str, numbers: list[int]) -> dict[str, dict[str, An
     result = run_json(
         ["gh", "api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}", "-f", f"query={query}"]
     )
-    repository = result.get("data", {}).get("repository", {}) or {}
+    # GraphQL can answer HTTP 200 with `"data": null` plus an errors array, so
+    # every level of the response is guarded with `or {}`, not a .get default.
+    repository = (result.get("data") or {}).get("repository") or {}
     return {str(number): repository.get(f"q{index}") for index, number in enumerate(numbers)}
 
 
@@ -1210,6 +1271,9 @@ def apply_github_refresh(model: dict[str, Any], repo: str) -> None:
     model["mode"] = "github_refreshed"
     model["title"] = "GitHub Refreshed Review Analytics"
     model["github_refreshed_prs"] = refreshed
+
+
+# ─── Path classification, CI summary, and packet assembly ────────────────────
 
 
 def matches_any(path: str, patterns: list[str]) -> bool:
@@ -1337,6 +1401,9 @@ def compact_pr_view(pr: dict[str, Any], acting_login: str) -> dict[str, Any]:
     }
 
 
+# ─── Advisory recommendation (ordered precedence ladder) ─────────────────────
+
+
 def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     pr = packet["pr"]
     head = pr.get("headRefOid")
@@ -1450,11 +1517,6 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-# Sticky-comment marker posted by .github/workflows/coverage-parse-diff-comment.yml
-# as the first (HTML-comment) line of the parse-detail diff body.
-PARSE_DIFF_MARKER = "<!-- coverage-parse-diff -->"
-
-
 def parse_diff_comment_state(comments: list[dict[str, Any]]) -> dict[str, Any]:
     """Classify the parse-diff sticky comment from FULL comment bodies.
 
@@ -1543,6 +1605,9 @@ def policy_trace(classification: dict[str, Any], standing: str | None = None) ->
     if classification.get("surface") == "mixed":
         trace.append("matched:mixed")
     return trace
+
+
+# ─── GraphQL queries and PR-node normalization ───────────────────────────────
 
 
 def pr_node_fields(*, comments_last: int, include_full_reviews: bool) -> str:
@@ -1699,7 +1764,7 @@ def fetch_open_prs(repo: str, limit: int) -> list[dict[str, Any]]:
         if cursor:
             variables += ["-f", f"after={cursor}"]
         result = run_json(["gh", "api", "graphql", "-f", f"query={SCAN_PR_QUERY}", *variables])
-        connection = result.get("data", {}).get("repository", {}).get("pullRequests", {})
+        connection = ((result.get("data") or {}).get("repository") or {}).get("pullRequests") or {}
         nodes.extend(graphql_nodes(connection))
         page_info = connection.get("pageInfo", {})
         if not page_info.get("hasNextPage"):
@@ -1725,23 +1790,68 @@ def gh_pr_view(repo: str, pr_number: int) -> dict[str, Any]:
             f"query={SINGLE_PR_QUERY}",
         ]
     )
-    node = result.get("data", {}).get("repository", {}).get("pullRequest")
+    node = ((result.get("data") or {}).get("repository") or {}).get("pullRequest")
     return normalize_graphql_pr(node or {})
 
 
-CANDIDATE_ACTION_ORDER = {
-    "dequeue_stale_for_handler": 0,
-    "update_branch_for_handler": 1,
-    "approve_ready_for_handler": 2,
-    "review": 3,
-    "hold_ci": 4,
-    "request_changes": 5,
-    "blocked": 6,
-    "defer": 7,
-    "queued": 8,
-    "merged_prune": 9,
-    "skip": 10,
-}
+# ─── Commands ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    """Everything a packet needs besides the PR node itself, loaded once per command.
+
+    One event-log read feeds the head-freshness index, contributor analytics, and
+    signal recurrence for every packet a command builds — scan amortizes it across
+    the whole sweep; inspect/recommend build it for their single PR.
+    """
+
+    policy: Policy
+    private_overrides: dict[str, Any]
+    acting_login: str
+    local_events: dict[tuple[int, str], dict[str, Any]]
+    analytics_model: dict[str, Any]
+    signal_occurrences: dict[str, list[dict[str, Any]]]
+
+
+def load_review_context(args: argparse.Namespace) -> ReviewContext:
+    events = all_events(args.state_dir)
+    return ReviewContext(
+        policy=load_policy(args.config),
+        private_overrides=load_private_overrides(args.state_dir),
+        acting_login=args.acting_login or gh_user(),
+        local_events=latest_events_by_pr_head(events),
+        analytics_model=build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=ANALYTICS_DEFAULT_MIN_PRS,
+            include_open=True,
+        ),
+        signal_occurrences=collect_signal_occurrences(events),
+    )
+
+
+def packet_for_pr(context: ReviewContext, pr: dict[str, Any], mode: str) -> dict[str, Any]:
+    """Assemble the full packet for one normalized PR view."""
+    pr_number = int(pr.get("number") or 0)
+    local_event = context.local_events.get((pr_number, pr.get("headRefOid") or ""))
+    contributor_summary = build_contributor_summary(
+        (pr.get("author") or {}).get("login"),
+        pr_number,
+        context.analytics_model,
+        context.signal_occurrences,
+        context.private_overrides,
+    )
+    return make_packet(
+        pr,
+        context.policy,
+        context.acting_login,
+        mode,
+        context.private_overrides,
+        local_event,
+        contributor_summary,
+    )
 
 
 def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
@@ -1757,18 +1867,37 @@ def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
     return (order, pr_number)
 
 
+def scan_candidate(pr: dict[str, Any], packet: dict[str, Any]) -> dict[str, Any]:
+    """Project a full packet down to the token-minimal triage row scan prints."""
+    contributor = packet.get("contributor") or {}
+    return {
+        "pr": pr.get("number"),
+        "title": pr.get("title"),
+        "created_at": pr.get("createdAt"),
+        "updated_at": pr.get("updatedAt"),
+        "head_sha": pr.get("headRefOid"),
+        "author_login": packet["pr"].get("author_login"),
+        "self_authored": packet["pr"].get("self_authored"),
+        "surface": packet["classification"]["surface"],
+        "gate": packet["classification"]["gate"],
+        "hard_stop_paths": packet["classification"]["hard_stop_paths"],
+        "ci": packet["ci"]["state"],
+        "parse_diff": packet["parse_diff"],
+        "review_decision": pr.get("reviewDecision"),
+        "is_in_merge_queue": packet["pr"].get("isInMergeQueue"),
+        "merge_queue_entry": packet["pr"].get("mergeQueueEntry"),
+        "auto_merge_request": packet["pr"].get("autoMergeRequest"),
+        "advisory_action": packet["recommendation"]["advisory_action"],
+        "reason": packet["recommendation"]["reason"],
+        "policy_trace": packet["policy_trace"],
+        "standing": contributor.get("standing"),
+        "scrutiny": contributor.get("scrutiny"),
+        "first_contribution": contributor.get("first_contribution"),
+    }
+
+
 def command_scan(args: argparse.Namespace) -> int:
-    policy = load_policy(args.config)
-    private_overrides = load_private_overrides(args.state_dir)
-    acting_login = args.acting_login or gh_user()
-    # One event-log read feeds head-freshness lookup, contributor analytics, and
-    # signal recurrence for every packet in the sweep.
-    events = all_events(args.state_dir)
-    local_events = latest_events_by_pr_head(events)
-    analytics_model = build_analytics_model(
-        events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
-    )
-    signal_occurrences = collect_signal_occurrences(events)
+    context = load_review_context(args)
     # One paginated GraphQL query returns every field a full packet needs (files,
     # comments, reviews, queue state, CI), so there is no light/full escalation:
     # each packet is built once, mode "full".
@@ -1776,46 +1905,8 @@ def command_scan(args: argparse.Namespace) -> int:
     candidates = []
     for node in nodes:
         pr = normalize_graphql_pr(node)
-        pr_number = int(pr["number"])
-        local_event = local_events.get((pr_number, pr.get("headRefOid") or ""))
-        contributor_summary = build_contributor_summary(
-            pr.get("author", {}).get("login"),
-            pr_number,
-            analytics_model,
-            signal_occurrences,
-            private_overrides,
-        )
-        packet = make_packet(
-            pr, policy, acting_login, "full", private_overrides, local_event, contributor_summary
-        )
-        candidates.append(
-            {
-                "pr": pr.get("number"),
-                "title": pr.get("title"),
-                "created_at": pr.get("createdAt"),
-                "updated_at": pr.get("updatedAt"),
-                "head_sha": pr.get("headRefOid"),
-                "author_login": packet["pr"].get("author_login"),
-                "self_authored": packet["pr"].get("self_authored"),
-                "surface": packet["classification"]["surface"],
-                "gate": packet["classification"]["gate"],
-                "hard_stop_paths": packet["classification"]["hard_stop_paths"],
-                "ci": packet["ci"]["state"],
-                "parse_diff": packet["parse_diff"],
-                "review_decision": pr.get("reviewDecision"),
-                "is_in_merge_queue": packet["pr"].get("isInMergeQueue"),
-                "merge_queue_entry": packet["pr"].get("mergeQueueEntry"),
-                "auto_merge_request": packet["pr"].get("autoMergeRequest"),
-                "advisory_action": packet["recommendation"]["advisory_action"],
-                "reason": packet["recommendation"]["reason"],
-                "policy_trace": packet["policy_trace"],
-                "standing": (packet.get("contributor") or {}).get("standing"),
-                "scrutiny": (packet.get("contributor") or {}).get("scrutiny"),
-                "first_contribution": (packet.get("contributor") or {}).get(
-                    "first_contribution"
-                ),
-            }
-        )
+        packet = packet_for_pr(context, pr, "full")
+        candidates.append(scan_candidate(pr, packet))
 
     candidates.sort(key=candidate_sort_key)
     candidates_by_action: dict[str, list[dict[str, Any]]] = {}
@@ -1823,7 +1914,7 @@ def command_scan(args: argparse.Namespace) -> int:
         candidates_by_action.setdefault(candidate["advisory_action"], []).append(candidate)
     action_counts = {action: len(items) for action, items in candidates_by_action.items()}
     output = {
-        "acting_login": acting_login,
+        "acting_login": context.acting_login,
         "completeness": "triage",
         "action_counts": action_counts,
         "candidates_by_action": candidates_by_action,
@@ -1852,26 +1943,9 @@ def event_skeleton(pr_number: int, compact_pr: dict[str, Any]) -> dict[str, Any]
 
 
 def command_inspect(args: argparse.Namespace) -> int:
-    policy = load_policy(args.config)
-    private_overrides = load_private_overrides(args.state_dir)
-    acting_login = args.acting_login or gh_user()
+    context = load_review_context(args)
     pr = gh_pr_view(args.repo, args.pr)
-    events = all_events(args.state_dir)
-    local_event = latest_events_by_pr_head(events).get(
-        (args.pr, pr.get("headRefOid") or "")
-    )
-    contributor_summary = build_contributor_summary(
-        pr.get("author", {}).get("login"),
-        args.pr,
-        build_analytics_model(
-            events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
-        ),
-        collect_signal_occurrences(events),
-        private_overrides,
-    )
-    packet = make_packet(
-        pr, policy, acting_login, args.mode, private_overrides, local_event, contributor_summary
-    )
+    packet = packet_for_pr(context, pr, args.mode)
     if args.emit_event:
         packet["event_skeleton"] = event_skeleton(args.pr, packet["pr"])
     print(json_dumps(packet))
@@ -1879,26 +1953,9 @@ def command_inspect(args: argparse.Namespace) -> int:
 
 
 def command_recommend(args: argparse.Namespace) -> int:
-    policy = load_policy(args.config)
-    private_overrides = load_private_overrides(args.state_dir)
-    acting_login = args.acting_login or gh_user()
+    context = load_review_context(args)
     pr = gh_pr_view(args.repo, args.pr)
-    events = all_events(args.state_dir)
-    local_event = latest_events_by_pr_head(events).get(
-        (args.pr, pr.get("headRefOid") or "")
-    )
-    contributor_summary = build_contributor_summary(
-        pr.get("author", {}).get("login"),
-        args.pr,
-        build_analytics_model(
-            events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
-        ),
-        collect_signal_occurrences(events),
-        private_overrides,
-    )
-    packet = make_packet(
-        pr, policy, acting_login, "full", private_overrides, local_event, contributor_summary
-    )
+    packet = packet_for_pr(context, pr, "full")
     recommendation = packet["recommendation"]
     if packet["completeness"] != "complete" and recommendation["advisory_action"].endswith("_for_handler"):
         recommendation = {
@@ -2090,7 +2147,7 @@ def command_compact(args: argparse.Namespace) -> int:
             )
             entry["events"] += 1
             entry["latest_timestamp"] = event.get("timestamp")
-            for signal in list(event.get("quality", {}).get("signals", [])) + list(
+            for signal in list((event.get("quality") or {}).get("signals") or []) + list(
                 event.get("signals") or []
             ):
                 entry["signals"][signal] = entry["signals"].get(signal, 0) + 1
@@ -2128,6 +2185,9 @@ def command_analytics(args: argparse.Namespace) -> int:
     else:
         print(render_analytics_ascii(model, args))
     return 0
+
+
+# ─── CLI wiring ──────────────────────────────────────────────────────────────
 
 
 def existing_path(value: str) -> Path:

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python3
 """Portable PR review intelligence helper.
 
-This tool keeps durable review memory as an append-only JSONL event log and
-maintains a derived SQLite index for cheap queries. It is advisory: GitHub
-mutations stay in the maintainer handling skills.
+This tool keeps durable review memory as an append-only JSONL event log
+(`review-events.jsonl`), the sole canonical store; `review-summary.json` is a
+derived artifact. It is advisory: GitHub mutations stay in the maintainer
+handling skills.
 """
 from __future__ import annotations
 
 import argparse
 import csv
+import fcntl
 import fnmatch
 import hashlib
 import json
 import os
-import sqlite3
 import subprocess
 import sys
+import time
 import tomllib
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from statistics import median
 from typing import Any
@@ -58,6 +60,33 @@ PR_ATTRIBUTED_EVENTS = {
     "tracker_row",
     "update_branch",
 }
+# Closed vocabulary enforced at record time (see command_record). New events must
+# use one of these event types; legacy events already in the log are read via
+# canonical_from_text without validation.
+ALLOWED_EVENT_TYPES = PR_ATTRIBUTED_EVENTS | {"observation", "quality_entry", "tracker_row"}
+# Closed vocabulary for the optional `outcome` field, derived from the high-confidence
+# states canonical_from_text recognizes. Enforced (lowercased) at record time.
+ALLOWED_OUTCOMES = {
+    "changes_requested",
+    "blocked",
+    "hard_stop",
+    "merged",
+    "closed",
+    "deferred",
+    "defer-fe",
+    "ci_failed",
+    "hold_ci",
+    "held",
+    "held_ci",
+    "approved",
+    "approved_enqueued",
+    "enqueued",
+    "review",
+    "pending",
+    "accepted",
+    "queued",
+    "pruned",
+}
 QUALITY_SIGNAL_WEIGHTS = {
     "wrong-seam": 14,
     "false-green": 12,
@@ -65,13 +94,26 @@ QUALITY_SIGNAL_WEIGHTS = {
     "scope-contamination": 10,
     "rebase-not-fix": 8,
     "build-for-card": 8,
+    "inert-fix": 8,
     "fmt/clippy-slip": 5,
     "stale-approval": 4,
     "low-effort-risk": 8,
     "author-created-issue-high-bar": 6,
+    "no-repro": 6,
     "value-bar": 6,
     "careful-watch": 4,
 }
+# Recurrence ("same defect, multiple PRs after feedback") and the derived-trusted
+# gate both read signal occurrences within this window, so an improving contributor
+# ages out of elevation instead of carrying lifetime signals forever.
+RECURRENCE_WINDOW_DAYS = 60
+# Shared by the analytics CLI default and the packet-path contributor summary so a
+# contributor's score/confidence (and thus scrutiny) never diverges between the two.
+ANALYTICS_DEFAULT_MIN_PRS = 3
+# Closed vocabulary for private-overrides.json contributor_standing entries. Only
+# "skip" changes the advisory action; watch/probation force elevated scrutiny;
+# trusted marks light-touch eligibility. Anything else in the file is ignored.
+ALLOWED_STANDINGS = {"skip", "probation", "watch", "trusted"}
 
 
 @dataclass(frozen=True)
@@ -88,7 +130,6 @@ class PrAccumulator:
     contributor_login: str
     events: list[dict[str, Any]]
     head_events: dict[str, list[dict[str, Any]]]
-    quality_signals: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -146,12 +187,29 @@ def load_private_overrides(state_dir: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def fold_login(login: str) -> str:
+    """Case-fold a GitHub login for grouping/lookup; GitHub logins are case-insensitive."""
+    return login.lower()
+
+
 def frontend_review_allowed(author_login: str | None, overrides: dict[str, Any]) -> bool:
     if not author_login:
         return False
     authors = overrides.get("frontend_review_authors", [])
-    normalized = {str(author).lower() for author in authors}
-    return author_login.lower() in normalized
+    normalized = {fold_login(str(author)) for author in authors}
+    return fold_login(author_login) in normalized
+
+
+def contributor_standing_override(
+    author_login: str, overrides: dict[str, Any]
+) -> dict[str, Any] | None:
+    standings = overrides.get("contributor_standing") or {}
+    folded = fold_login(author_login)
+    for login, entry in standings.items():
+        if fold_login(str(login)) == folded and isinstance(entry, dict):
+            if entry.get("standing") in ALLOWED_STANDINGS:
+                return entry
+    return None
 
 
 def json_dumps(value: Any) -> str:
@@ -206,16 +264,46 @@ def normalize_event(event: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+RUN_JSON_ATTEMPTS = 3
+RUN_JSON_BACKOFF_SECONDS = (2, 5)
+
+
 def run_json(command: list[str]) -> Any:
-    result = subprocess.run(
-        command,
-        cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    return json.loads(result.stdout or "null")
+    """Run a read-only gh query, retrying transient failures with backoff.
+
+    Every caller is a GitHub read (scan pagination, PR view, refresh chunk,
+    identity), so retries are idempotent. The expensive scan GraphQL query
+    (100 comments/reviews/files per PR node) intermittently times out
+    server-side ("Something went wrong" / HTTP 5xx), which `gh` reports as a
+    non-zero exit — one such blip must not kill a whole sweep.
+    """
+    last_error: subprocess.CalledProcessError | None = None
+    for attempt in range(RUN_JSON_ATTEMPTS):
+        try:
+            result = subprocess.run(
+                command,
+                cwd=REPO_ROOT,
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            return json.loads(result.stdout or "null")
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+            if attempt < RUN_JSON_ATTEMPTS - 1:
+                delay = RUN_JSON_BACKOFF_SECONDS[min(attempt, len(RUN_JSON_BACKOFF_SECONDS) - 1)]
+                print(
+                    f"gh query failed (attempt {attempt + 1}/{RUN_JSON_ATTEMPTS}), "
+                    f"retrying in {delay}s: {(exc.stderr or '').strip()[:300]}",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+    # Surface gh's captured stderr before re-raising — CalledProcessError's own
+    # message shows only the command and exit code, which is undiagnosable.
+    assert last_error is not None
+    print((last_error.stderr or "").strip(), file=sys.stderr)
+    raise last_error
 
 
 def run_text(command: list[str]) -> str:
@@ -234,107 +322,48 @@ def gh_user() -> str:
     return str(run_json(["gh", "api", "user"])["login"])
 
 
-def ensure_state(state_dir: Path) -> sqlite3.Connection:
-    state_dir.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(state_dir / "review-state.sqlite")
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS events (
-            event_id TEXT PRIMARY KEY,
-            event_type TEXT NOT NULL,
-            pr INTEGER,
-            head_sha TEXT,
-            author TEXT,
-            timestamp TEXT NOT NULL,
-            payload_json TEXT NOT NULL
-        )
-        """
-    )
-    conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS leases (
-            pr INTEGER NOT NULL,
-            head_sha TEXT NOT NULL,
-            acting_login TEXT NOT NULL,
-            run_id TEXT NOT NULL,
-            acquired_at TEXT NOT NULL,
-            PRIMARY KEY (pr, head_sha, acting_login)
-        )
-        """
-    )
-    return conn
-
-
 def append_event(state_dir: Path, event: dict[str, Any]) -> bool:
     normalized = normalize_event(event)
-    conn = ensure_state(state_dir)
-    inserted = False
-    with conn:
-        cursor = conn.execute(
-            """
-            INSERT OR IGNORE INTO events
-              (event_id, event_type, pr, head_sha, author, timestamp, payload_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                normalized["event_id"],
-                normalized["event_type"],
-                normalized.get("pr"),
-                normalized.get("head_sha"),
-                normalized.get("author"),
-                normalized["timestamp"],
-                json_dumps(normalized),
-            ),
-        )
-        inserted = cursor.rowcount == 1
-    if inserted:
-        with (state_dir / "review-events.jsonl").open("a", encoding="utf-8") as file:
-            file.write(json_dumps(normalized) + "\n")
-    conn.close()
-    return inserted
-
-
-def rebuild_index(state_dir: Path) -> None:
-    conn = ensure_state(state_dir)
-    with conn:
-        conn.execute("DELETE FROM events")
-        event_log = state_dir / "review-events.jsonl"
-        if event_log.exists():
-            for line in event_log.read_text(encoding="utf-8").splitlines():
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log_path = state_dir / "review-events.jsonl"
+    # An exclusive flock makes the read-existing-ids-then-append sequence atomic
+    # across concurrent agent processes, so simultaneous records can't both write
+    # the same event or interleave a partial line into the canonical log.
+    with log_path.open("a+", encoding="utf-8") as file:
+        fcntl.flock(file, fcntl.LOCK_EX)
+        try:
+            file.seek(0)
+            for line in file:
                 if not line.strip():
                     continue
-                event = normalize_event(json.loads(line))
-                conn.execute(
-                    """
-                    INSERT OR IGNORE INTO events
-                      (event_id, event_type, pr, head_sha, author, timestamp, payload_json)
-                    VALUES (?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        event["event_id"],
-                        event["event_type"],
-                        event.get("pr"),
-                        event.get("head_sha"),
-                        event.get("author"),
-                        event["timestamp"],
-                        json_dumps(event),
-                    ),
-                )
-    conn.close()
+                if json.loads(line).get("event_id") == normalized["event_id"]:
+                    return False
+            file.write(json_dumps(normalized) + "\n")
+            file.flush()
+            os.fsync(file.fileno())
+            return True
+        finally:
+            fcntl.flock(file, fcntl.LOCK_UN)
 
 
 def all_events(state_dir: Path) -> list[dict[str, Any]]:
-    conn = ensure_state(state_dir)
-    rows = conn.execute(
-        "SELECT payload_json FROM events ORDER BY timestamp, event_id"
-    ).fetchall()
-    conn.close()
-    return [json.loads(row[0]) for row in rows]
+    log_path = state_dir / "review-events.jsonl"
+    if not log_path.exists():
+        return []
+    events = []
+    with log_path.open("r", encoding="utf-8") as file:
+        for line in file:
+            if not line.strip():
+                continue
+            events.append(normalize_event(json.loads(line)))
+    # Preserve the previous SELECT ... ORDER BY timestamp, event_id semantics that
+    # downstream aggregation relies on.
+    return sorted(events, key=event_sort_key)
 
 
-def latest_events_by_pr_head(state_dir: Path) -> dict[tuple[int, str], dict[str, Any]]:
+def latest_events_by_pr_head(events: list[dict[str, Any]]) -> dict[tuple[int, str], dict[str, Any]]:
     latest: dict[tuple[int, str], dict[str, Any]] = {}
-    for event in all_events(state_dir):
+    for event in events:
         pr = event.get("pr")
         head_sha = event.get("head_sha")
         if pr is None or not head_sha:
@@ -372,6 +401,10 @@ def filtered_events_by_days(events: list[dict[str, Any]], days: int | None) -> l
 
 
 def canonical_from_text(value: str | None) -> tuple[str, str] | None:
+    # Read-side legacy mapper: collapses the free-form strings already present in
+    # historical events (and in the `import` path) into canonical states. New
+    # events are validated against ALLOWED_EVENT_TYPES/ALLOWED_OUTCOMES at write
+    # time (see command_record), so this is not a write-side authority.
     if not value:
         return None
     text = value.lower().replace("_", "-")
@@ -519,10 +552,6 @@ def head_analytics(pr: int, head_sha: str, events: list[dict[str, Any]]) -> dict
     }
 
 
-def no_head_analytics(pr: int, events: list[dict[str, Any]]) -> dict[str, Any]:
-    return head_analytics(pr, "", events)
-
-
 def pr_analytics(accumulator: PrAccumulator) -> dict[str, Any]:
     head_rows = [
         head_analytics(accumulator.pr, head_sha, events)
@@ -530,7 +559,7 @@ def pr_analytics(accumulator: PrAccumulator) -> dict[str, Any]:
     ]
     no_head_events = [event for event in accumulator.events if not event.get("head_sha")]
     if not head_rows and no_head_events:
-        head_rows.append(no_head_analytics(accumulator.pr, no_head_events))
+        head_rows.append(head_analytics(accumulator.pr, "", no_head_events))
     head_rows.sort(key=lambda item: (item.get("last_seen") or "", item.get("head_sha") or ""))
     latest = head_rows[-1] if head_rows else {
         "terminal_state": "unknown",
@@ -554,7 +583,6 @@ def pr_analytics(accumulator: PrAccumulator) -> dict[str, Any]:
         "terminal_state_source": latest["terminal_state_source"],
         "terminal_state_reason": latest["terminal_state_reason"],
         "ever_states": ever_states,
-        "quality_signals": accumulator.quality_signals,
         "first_seen": all_events_for_pr[0].get("timestamp") if all_events_for_pr else None,
         "last_seen": all_events_for_pr[-1].get("timestamp") if all_events_for_pr else None,
         "is_open_or_pending": latest["terminal_state"] not in TERMINAL_STATES,
@@ -568,7 +596,7 @@ def rate(numerator: int, denominator: int) -> float | None:
     return numerator / denominator
 
 
-def percentile(value: float | None) -> str:
+def format_percent(value: float | None) -> str:
     if value is None:
         return "-"
     return f"{round(value * 100):d}%"
@@ -765,13 +793,18 @@ def build_analytics_model(
     filtered_events = filtered_events_by_days(all_sorted_events, days)
     pr_accumulators: dict[int, PrAccumulator] = {}
     contributor_quality: dict[str, dict[str, int]] = {}
+    # GitHub logins are case-insensitive, so all grouping keys are folded; the
+    # first-seen original casing is kept for display and restored on the final rows.
+    display_names: dict[str, str] = {}
     for event in filtered_events:
         event_type = event.get("event_type")
         login = contributor_login_for_event(event)
         if event_type == "quality_entry":
             if login:
+                folded = fold_login(str(login))
+                display_names.setdefault(folded, str(login))
                 signals = event.get("quality", {}).get("signals", [])
-                quality = contributor_quality.setdefault(str(login), {})
+                quality = contributor_quality.setdefault(folded, {})
                 for signal in signals:
                     add_counter(quality, str(signal))
             continue
@@ -779,40 +812,34 @@ def build_analytics_model(
         if pr is None:
             continue
         pr_number = int(pr)
-        contributor = login or pr_contributors.get(pr_number)
-        if contributor is None:
+        raw_contributor = login or pr_contributors.get(pr_number)
+        if raw_contributor is None:
             continue
-        if author and contributor.lower() != author.lower():
+        contributor = fold_login(str(raw_contributor))
+        display_names.setdefault(contributor, str(raw_contributor))
+        if author and contributor != fold_login(author):
             continue
+        # Signals recorded on PR-attributed outcome events join the same lifetime
+        # aggregate the legacy quality_entry import feeds (per-occurrence recurrence
+        # is collected separately by collect_signal_occurrences).
+        for signal in event.get("signals") or []:
+            add_counter(contributor_quality.setdefault(contributor, {}), str(signal))
         accumulator = pr_accumulators.setdefault(
             pr_number,
-            PrAccumulator(pr_number, contributor, [], {}, {}),
+            PrAccumulator(pr_number, contributor, [], {}),
         )
         accumulator.events.append(event)
         head_sha = event.get("head_sha")
         if head_sha:
             accumulator.head_events.setdefault(str(head_sha), []).append(event)
-    for pr_number, accumulator in pr_accumulators.items():
-        quality = contributor_quality.get(accumulator.contributor_login, {})
-        accumulator.quality_signals.update(quality)
     prs = [pr_analytics(accumulator) for accumulator in pr_accumulators.values()]
     if not include_open:
         prs = [pr for pr in prs if not pr["is_open_or_pending"]]
-    observed_head_values = [pr["observed_heads"] for pr in prs if pr["observed_heads"] > 0]
-    repo_median_heads = median(observed_head_values) if observed_head_values else 0
     contributor_signals = {
         login: dict(signals) for login, signals in contributor_quality.items()
-        if author is None or login.lower() == author.lower()
+        if author is None or login == fold_login(author)
     }
-    contributors = contributor_rows_from_prs(
-        prs,
-        contributor_signals,
-        repo_median_heads,
-        refreshed,
-        min_prs,
-        author,
-    )
-    return {
+    model = {
         "generated_at": now_iso(),
         "mode": "github_refreshed" if refreshed else "local_observed",
         "title": "Local Observed Review Analytics",
@@ -822,13 +849,164 @@ def build_analytics_model(
             "min_prs": min_prs,
             "include_open": include_open,
         },
-        "repo_medians": {"observed_heads": repo_median_heads},
-        "contributors": contributors,
+        "repo_medians": {"observed_heads": 0},
+        "contributors": [],
+        "display_names": display_names,
         "prs": prs,
         "quality_by_contributor": contributor_signals,
         "unclassified_counts": unknown_event_values(filtered_events),
         "audit_counts": audit_event_values(filtered_events),
         "warnings": [],
+    }
+    finalize_contributor_model(model, min_prs=min_prs, author=author, refreshed=refreshed)
+    return model
+
+
+def finalize_contributor_model(
+    model: dict[str, Any], *, min_prs: int, author: str | None, refreshed: bool
+) -> None:
+    """Recompute repo medians and contributor rows from the current PR rows.
+
+    Called once after all PR-row mutations (github refresh, open-PR filter) so the
+    expensive contributor aggregation happens a single time rather than per stage.
+    """
+    observed_head_values = [pr["observed_heads"] for pr in model["prs"] if pr["observed_heads"] > 0]
+    repo_median_heads = median(observed_head_values) if observed_head_values else 0
+    model["repo_medians"]["observed_heads"] = repo_median_heads
+    model["contributors"] = contributor_rows_from_prs(
+        model["prs"],
+        model.get("quality_by_contributor", {}),
+        float(repo_median_heads),
+        refreshed,
+        min_prs,
+        author,
+    )
+    # Rows are grouped by folded login; restore first-seen casing for display.
+    display_names = model.get("display_names", {})
+    for row in model["contributors"]:
+        row["login"] = display_names.get(row["login"], row["login"])
+
+
+def collect_signal_occurrences(
+    events: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Collect dated, PR-attributed quality-signal occurrences per folded login.
+
+    Only top-level `signals` on PR-attributed events qualify: legacy quality_entry
+    imports carry neither a PR nor a real observation date (their timestamp is the
+    import time), so they can never feed windowed recurrence.
+    """
+    occurrences: dict[str, list[dict[str, Any]]] = {}
+    for event in events:
+        if event.get("event_type") not in PR_ATTRIBUTED_EVENTS:
+            continue
+        signals = event.get("signals") or []
+        pr = event.get("pr")
+        login = contributor_login_for_event(event)
+        if not signals or pr is None or not login:
+            continue
+        entries = occurrences.setdefault(fold_login(str(login)), [])
+        for signal in signals:
+            entries.append(
+                {"signal": str(signal), "pr": int(pr), "timestamp": event.get("timestamp")}
+            )
+    return occurrences
+
+
+def windowed_recurrence(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Reduce signal occurrences to per-signal distinct-PR counts within the window."""
+    cutoff = datetime.now(UTC) - timedelta(days=RECURRENCE_WINDOW_DAYS)
+    per_signal: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        timestamp = parse_event_datetime(entry.get("timestamp"))
+        if timestamp is None or timestamp < cutoff:
+            continue
+        info = per_signal.setdefault(entry["signal"], {"prs": set(), "last_seen": ""})
+        info["prs"].add(entry["pr"])
+        info["last_seen"] = max(info["last_seen"], str(entry.get("timestamp") or ""))
+    return [
+        {
+            "signal": signal,
+            "distinct_prs_window": len(info["prs"]),
+            "last_seen": info["last_seen"] or None,
+        }
+        for signal, info in sorted(per_signal.items())
+    ]
+
+
+def build_contributor_summary(
+    author_login: str | None,
+    current_pr: int | None,
+    model: dict[str, Any],
+    occurrences: dict[str, list[dict[str, Any]]],
+    private_overrides: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build the packet's advisory `contributor` block from local observed history.
+
+    Single authority for standing/scrutiny: make_packet and recommend_from_packet
+    both read this block rather than re-deriving from overrides. Only an override
+    standing of "skip" ever changes the advisory action; everything else informs
+    review posture (scrutiny wins over light-touch when they disagree).
+    """
+    if not author_login:
+        return None
+    folded = fold_login(author_login)
+    row = next(
+        (r for r in model["contributors"] if fold_login(r["login"]) == folded), None
+    )
+    prior_prs = {
+        pr["pr"]
+        for pr in model["prs"]
+        if pr["contributor_login"] == folded and pr["pr"] != current_pr
+    }
+    recurrence = windowed_recurrence(occurrences.get(folded, []))
+    override = contributor_standing_override(author_login, private_overrides)
+    derived_trusted = bool(
+        row
+        and row["terminal_prs"] >= 5
+        and (row["observed_success_rate"] or 0) >= 0.85
+        and not recurrence
+    )
+    if override:
+        standing, standing_source = str(override["standing"]), "override"
+    elif derived_trusted:
+        standing, standing_source = "trusted", "derived"
+    else:
+        standing, standing_source = "unknown", "derived"
+    score = row["local_signal_score"] if row else None
+    confidence = row["confidence"] if row else None
+    scrutiny_reasons = []
+    if score is not None and score < 55 and confidence in {"medium", "high"}:
+        scrutiny_reasons.append(f"low_score_{score}_{confidence}_confidence")
+    for entry in recurrence:
+        if entry["distinct_prs_window"] >= 2:
+            scrutiny_reasons.append(
+                f"recurrence_{entry['signal']}_{entry['distinct_prs_window']}_prs_in_window"
+            )
+    if standing in {"watch", "probation"}:
+        scrutiny_reasons.append(f"standing_{standing}")
+    if any(entry["distinct_prs_window"] >= 3 for entry in recurrence):
+        scrutiny = "maintainer_attention"
+    elif scrutiny_reasons:
+        scrutiny = "elevated"
+    else:
+        scrutiny = "normal"
+    return {
+        "login": author_login,
+        "first_contribution": not prior_prs,
+        "prior_prs": len(prior_prs),
+        "score": score,
+        "confidence": confidence,
+        "top_signals": row["top_signals"] if row else [],
+        "recurrence": recurrence,
+        "standing": standing,
+        "standing_source": standing_source,
+        "standing_note": override.get("note") if override else None,
+        "scrutiny": scrutiny,
+        "scrutiny_reasons": scrutiny_reasons,
+        # Scrutiny wins: trusted standing never grants light touch while any
+        # elevation reason is live.
+        "light_touch_eligible": standing == "trusted" and scrutiny == "normal",
     }
 
 
@@ -894,7 +1072,7 @@ def render_analytics_table(model: dict[str, Any], *, sort_key: str, limit: int |
             f"{row['login'][:20]:20} "
             f"{row['prs']:4d} "
             f"{row['terminal_prs']:4d} "
-            f"{percentile(row['observed_success_rate']):>5} "
+            f"{format_percent(row['observed_success_rate']):>5} "
             f"{row['observed_heads_avg']:5.1f} "
             f"{row['blocks']:6d} "
             f"{row['holds']:5d} "
@@ -929,7 +1107,7 @@ def render_contributor_detail(model: dict[str, Any], login: str) -> str:
         "Note: local observed data; use --refresh-github for authoritative merge/close state.",
         "",
         f"Local Signal Score: {row['local_signal_score']} / 100 ({row['score_label']}, confidence: {row['confidence']})",
-        f"PRs: {row['prs']}  Terminal: {row['terminal_prs']}  Observed success: {percentile(row['observed_success_rate'])}",
+        f"PRs: {row['prs']}  Terminal: {row['terminal_prs']}  Observed success: {format_percent(row['observed_success_rate'])}",
         f"Observed heads avg: {row['observed_heads_avg']}  median: {row['observed_heads_median']}",
         "",
         "Score Components",
@@ -971,68 +1149,67 @@ def render_analytics_ascii(model: dict[str, Any], args: argparse.Namespace) -> s
     return render_analytics_table(model, sort_key=args.sort, limit=args.limit)
 
 
-def gh_pr_analytics_state(repo: str, pr_number: int) -> dict[str, Any]:
-    fields = "number,state,author,headRefOid,reviewDecision,mergedAt,closedAt"
-    return run_json(["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", fields])
+def gh_pr_refresh_chunk(repo: str, numbers: list[int]) -> dict[str, dict[str, Any] | None]:
+    """Fetch live terminal state for up to 50 PRs in one aliased GraphQL query.
+
+    Alias names (q0, q1, ...) are generated and the PR numbers are cast with int()
+    before formatting, so they cannot carry injection; owner/name stay as variables.
+    """
+    owner, name = repo.split("/", 1)
+    aliases = " ".join(
+        f"q{index}: pullRequest(number: {int(number)}){{"
+        "number state author{login} headRefOid reviewDecision mergedAt closedAt}"
+        for index, number in enumerate(numbers)
+    )
+    query = f"query($owner:String!,$name:String!){{repository(owner:$owner,name:$name){{{aliases}}}}}"
+    result = run_json(
+        ["gh", "api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}", "-f", f"query={query}"]
+    )
+    repository = result.get("data", {}).get("repository", {}) or {}
+    return {str(number): repository.get(f"q{index}") for index, number in enumerate(numbers)}
 
 
-def apply_github_refresh(model: dict[str, Any], repo: str, min_prs: int, author: str | None) -> None:
+def apply_github_refresh(model: dict[str, Any], repo: str) -> None:
     warnings = model.setdefault("warnings", [])
     refreshed = 0
-    for pr in model["prs"]:
+    prs_by_number = {str(pr["pr"]): pr for pr in model["prs"]}
+    numbers = [int(pr["pr"]) for pr in model["prs"]]
+    for start in range(0, len(numbers), 50):
+        chunk = numbers[start : start + 50]
         try:
-            live = gh_pr_analytics_state(repo, int(pr["pr"]))
+            live_by_number = gh_pr_refresh_chunk(repo, chunk)
         except subprocess.CalledProcessError as exc:
-            warnings.append(f"failed to refresh PR {pr['pr']}: {exc}")
+            warnings.append(f"failed to refresh PRs {chunk[0]}-{chunk[-1]}: {exc}")
             continue
-        if not isinstance(live, dict):
-            warnings.append(f"failed to refresh PR {pr['pr']}: empty or invalid response")
-            continue
-        refreshed += 1
-        state = str(live.get("state") or "").upper()
-        pr["github"] = {
-            "state": state,
-            "author_login": (live.get("author") or {}).get("login"),
-            "headRefOid": live.get("headRefOid"),
-            "reviewDecision": live.get("reviewDecision"),
-            "mergedAt": live.get("mergedAt"),
-            "closedAt": live.get("closedAt"),
-        }
-        if state == "MERGED":
-            pr["terminal_state"] = "merged"
-            pr["terminal_state_source"] = "github.state"
-            pr["terminal_state_reason"] = "merged"
-            pr["is_open_or_pending"] = False
-        elif state == "CLOSED":
-            pr["terminal_state"] = "closed"
-            pr["terminal_state_source"] = "github.state"
-            pr["terminal_state_reason"] = "closed"
-            pr["is_open_or_pending"] = False
+        for number in chunk:
+            pr = prs_by_number[str(number)]
+            live = live_by_number.get(str(number))
+            if not isinstance(live, dict):
+                warnings.append(f"failed to refresh PR {number}: empty or invalid response")
+                continue
+            refreshed += 1
+            state = str(live.get("state") or "").upper()
+            pr["github"] = {
+                "state": state,
+                "author_login": (live.get("author") or {}).get("login"),
+                "headRefOid": live.get("headRefOid"),
+                "reviewDecision": live.get("reviewDecision"),
+                "mergedAt": live.get("mergedAt"),
+                "closedAt": live.get("closedAt"),
+            }
+            if state == "MERGED":
+                pr["terminal_state"] = "merged"
+                pr["terminal_state_source"] = "github.state"
+                pr["terminal_state_reason"] = "merged"
+                pr["is_open_or_pending"] = False
+            elif state == "CLOSED":
+                pr["terminal_state"] = "closed"
+                pr["terminal_state_source"] = "github.state"
+                pr["terminal_state_reason"] = "closed"
+                pr["is_open_or_pending"] = False
     model["mode"] = "github_refreshed"
     model["title"] = "GitHub Refreshed Review Analytics"
     model["github_refreshed_prs"] = refreshed
-    model["contributors"] = contributor_rows_from_prs(
-        model["prs"],
-        model.get("quality_by_contributor", {}),
-        float(model["repo_medians"]["observed_heads"]),
-        True,
-        min_prs,
-        author,
-    )
-
-
-def filter_open_prs(model: dict[str, Any], min_prs: int, author: str | None, refreshed: bool) -> None:
-    model["prs"] = [pr for pr in model["prs"] if not pr["is_open_or_pending"]]
-    observed_head_values = [pr["observed_heads"] for pr in model["prs"] if pr["observed_heads"] > 0]
-    model["repo_medians"]["observed_heads"] = median(observed_head_values) if observed_head_values else 0
-    model["contributors"] = contributor_rows_from_prs(
-        model["prs"],
-        model.get("quality_by_contributor", {}),
-        float(model["repo_medians"]["observed_heads"]),
-        refreshed,
-        min_prs,
-        author,
-    )
 
 
 def matches_any(path: str, patterns: list[str]) -> bool:
@@ -1196,7 +1373,18 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif classification.get("hard_stop_paths"):
         action = "request_changes"
         reason = "hard_stop"
-    elif local_outcome == "DEFER-FE":
+    elif (packet.get("contributor") or {}).get("standing") == "skip":
+        # Explicit maintainer standing override (private-overrides.json). Ordered
+        # after hard_stop deliberately: a skip-listed contributor touching guarded
+        # paths still surfaces as request_changes — safety wins over the skip.
+        action = "skip"
+        reason = "contributor_standing_skip"
+    elif classification.get("files_truncated"):
+        # A truncated file list may hide a hard-stop path, so it must never silently
+        # defer or pass to a handler — force a manual review before any softer branch.
+        action = "review"
+        reason = "files_truncated_needs_manual_classification"
+    elif (local_outcome or "").lower() == "defer-fe":
         action = "defer"
         reason = "local_defer_fe_current_head"
     elif local_block_event or local_block_outcome:
@@ -1236,6 +1424,19 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
         action = "review"
         reason = "needs_review"
 
+    # Advisory-only parse-diff hint (the comment job is continue-on-error/non-blocking):
+    # a stale merge-base whose R2 baseline aged out shows "Baseline pending" forever, so
+    # flag engine-surface review candidates to consider update-branch first. The
+    # files_truncated safety reason from make_packet is preserved — it must not be masked.
+    parse_diff = packet.get("parse_diff") or {}
+    if (
+        action == "review"
+        and reason != "files_truncated_needs_manual_classification"
+        and "engine" in (classification.get("path_classes") or {})
+        and parse_diff.get("state") == "baseline_pending"
+    ):
+        reason = "review_parse_baseline_pending"
+
     return {
         "pr": pr.get("number"),
         "head_sha": head,
@@ -1243,7 +1444,39 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
         "reason": reason,
         "requires_live_verification": action.endswith("_for_handler"),
         "policy_trace": packet.get("policy_trace", []),
+        # The `recommend` command prints only this dict, so the advisory contributor
+        # block (standing/scrutiny/recurrence) must ride along for skill consumers.
+        "contributor": packet.get("contributor"),
     }
+
+
+# Sticky-comment marker posted by .github/workflows/coverage-parse-diff-comment.yml
+# as the first (HTML-comment) line of the parse-detail diff body.
+PARSE_DIFF_MARKER = "<!-- coverage-parse-diff -->"
+
+
+def parse_diff_comment_state(comments: list[dict[str, Any]]) -> dict[str, Any]:
+    """Classify the parse-diff sticky comment from FULL comment bodies.
+
+    Must run on raw (un-excerpted) comments — compact_pr_view truncates bodies to
+    300 chars, which can drop the "signature(s)"/"Baseline pending" markers. The
+    comment is edited in place on re-push, so updatedAt (not createdAt) is freshness.
+    """
+    for comment in comments:
+        author_login = (comment.get("author") or {}).get("login")
+        if author_login != "github-actions":
+            continue
+        body = comment.get("body") or ""
+        if not body.lstrip().startswith(PARSE_DIFF_MARKER):
+            continue
+        if "Baseline pending" in body:
+            state = "baseline_pending"
+        elif "signature(s)" in body:
+            state = "real_changes"
+        else:
+            state = "no_changes"
+        return {"present": True, "state": state, "updated_at": comment.get("updatedAt")}
+    return {"present": False, "state": "absent", "updated_at": None}
 
 
 def make_packet(
@@ -1252,10 +1485,22 @@ def make_packet(
     acting_login: str,
     mode: str,
     private_overrides: dict[str, Any],
+    local_event: dict[str, Any] | None = None,
+    contributor_summary: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     files = pr_files_from_view(pr)
     classification = classify_files(files, policy)
+    changed_files = pr.get("changedFiles")
+    if isinstance(changed_files, int) and changed_files > len(files):
+        # GitHub truncated the file list (files(first:100) caps at 100), so the
+        # classification is untrusted — a hard-stop path may be hidden past the cap.
+        classification["surface"] = "files_truncated"
+        classification["gate"] = "review"
+        classification["files_truncated"] = True
     checks = status_summary(pr.get("statusCheckRollup", []))
+    # Classify the parse-diff sticky comment from raw bodies, before compact_pr_view
+    # excerpts them to 300 chars and would drop the marker substrings.
+    parse_diff = parse_diff_comment_state(pr.get("comments", []))
     compact_pr = compact_pr_view(pr, acting_login)
     author_policy = {
         "frontend_review_allowed": frontend_review_allowed(
@@ -1270,19 +1515,29 @@ def make_packet(
         "files": files,
         "classification": classification,
         "ci": checks,
+        "parse_diff": parse_diff,
         "latest_maintainer_review_commit": latest_review_commit(pr, acting_login),
         "domain": {"rules_domain": policy.rules_domain},
         "author_policy": author_policy,
-        "policy_trace": policy_trace(classification),
+        "contributor": contributor_summary,
+        "policy_trace": policy_trace(
+            classification, (contributor_summary or {}).get("standing")
+        ),
+        "local_current_event": local_event,
     }
     packet["recommendation"] = recommend_from_packet(packet)
     return packet
 
 
-def policy_trace(classification: dict[str, Any]) -> list[str]:
+def policy_trace(classification: dict[str, Any], standing: str | None = None) -> list[str]:
+    # Trace records MATCHED patterns, not fired actions: a merged PR with hard-stop
+    # paths still traces matched:hard_stop, and a skip-standing contributor traces
+    # matched:standing_skip even when hard_stop wins the action ladder.
     trace = ["hard_stop", "safety_queue_freshness", "private_override", "standing", "path_policy", "default"]
     if classification.get("hard_stop_paths"):
         trace.append("matched:hard_stop")
+    if standing == "skip":
+        trace.append("matched:standing_skip")
     if classification.get("surface") == "frontend":
         trace.append("matched:frontend")
     if classification.get("surface") == "mixed":
@@ -1290,92 +1545,249 @@ def policy_trace(classification: dict[str, Any]) -> list[str]:
     return trace
 
 
-def gh_pr_view(repo: str, pr_number: int) -> dict[str, Any]:
-    fields = (
-        "number,title,body,state,isDraft,url,author,createdAt,updatedAt,headRefName,headRefOid,"
-        "baseRefName,mergeStateStatus,reviewDecision,labels,assignees,"
-        "statusCheckRollup,latestReviews,reviews,comments,files"
+def pr_node_fields(*, comments_last: int, include_full_reviews: bool) -> str:
+    """GraphQL selection set for a PR node, shared by the scan and single-PR queries.
+
+    Only static field names are interpolated (comment count, whether to fetch the
+    full review history) — never user input, which travels as GraphQL variables.
+    """
+    full_reviews = (
+        "reviews(first:50){nodes{author{login} state submittedAt commit{oid} body}} "
+        if include_full_reviews
+        else ""
     )
-    pr = run_json(["gh", "pr", "view", str(pr_number), "--repo", repo, "--json", fields])
-    pr.update(gh_queue_state(repo, pr_number))
-    return pr
+    return (
+        "number title body state isDraft url createdAt updatedAt headRefName headRefOid "
+        "baseRefName mergeStateStatus reviewDecision changedFiles "
+        "author{login} "
+        "labels(first:20){nodes{name}} "
+        "assignees(first:10){nodes{login}} "
+        "isInMergeQueue mergeQueueEntry{position state} autoMergeRequest{enabledAt} "
+        "files(first:100){nodes{path}} "
+        "latestReviews(first:20){nodes{author{login} state submittedAt commit{oid} body}} "
+        f"{full_reviews}"
+        f"comments(last:{comments_last}){{nodes{{author{{login}} createdAt updatedAt body}}}} "
+        "commits(last:1){nodes{commit{statusCheckRollup{contexts(first:80){nodes{__typename "
+        "... on CheckRun{name status conclusion} "
+        "... on StatusContext{context state}}}}}}}"
+    )
 
 
-def gh_queue_state(repo: str, pr_number: int) -> dict[str, Any]:
-    owner, name = repo.split("/", 1)
-    query = (
-        "query($owner:String!,$repo:String!,$number:Int!){"
-        "repository(owner:$owner,name:$repo){"
-        "pullRequest(number:$number){"
-        "isInMergeQueue mergeQueueEntry{position state} autoMergeRequest{enabledAt}"
-        "}}}"
-    )
-    try:
-        result = run_json(
-            [
-                "gh",
-                "api",
-                "graphql",
-                "-f",
-                f"owner={owner}",
-                "-f",
-                f"repo={name}",
-                "-F",
-                f"number={pr_number}",
-                "-f",
-                f"query={query}",
-            ]
-        )
-    except subprocess.CalledProcessError:
-        return {"isInMergeQueue": None, "mergeQueueEntry": None, "autoMergeRequest": None}
-    pull = result.get("data", {}).get("repository", {}).get("pullRequest", {})
+SCAN_PR_QUERY = (
+    "query($owner:String!,$name:String!,$first:Int!,$after:String){"
+    "repository(owner:$owner,name:$name){"
+    "pullRequests(states:[OPEN], first:$first, after:$after,"
+    " orderBy:{field:CREATED_AT, direction:DESC}){"
+    "pageInfo{hasNextPage endCursor}"
+    f"nodes{{{pr_node_fields(comments_last=15, include_full_reviews=False)}}}"
+    "}}}"
+)
+
+SINGLE_PR_QUERY = (
+    "query($owner:String!,$name:String!,$number:Int!){"
+    "repository(owner:$owner,name:$name){"
+    f"pullRequest(number:$number){{{pr_node_fields(comments_last=30, include_full_reviews=True)}}}"
+    "}}"
+)
+
+
+def graphql_nodes(container: Any) -> list[dict[str, Any]]:
+    if not isinstance(container, dict):
+        return []
+    return [node for node in container.get("nodes", []) if isinstance(node, dict)]
+
+
+def graphql_rollup_contexts(node: dict[str, Any]) -> list[dict[str, Any]]:
+    commits = graphql_nodes(node.get("commits"))
+    if not commits:
+        return []
+    rollup = (commits[0].get("commit") or {}).get("statusCheckRollup")
+    if not isinstance(rollup, dict):
+        return []
+    checks = []
+    for ctx in graphql_nodes(rollup.get("contexts")):
+        if ctx.get("__typename") == "StatusContext":
+            # Map legacy commit statuses onto the CheckRun shape status_summary expects:
+            # a terminal state becomes COMPLETED with its state as the conclusion.
+            state = ctx.get("state")
+            checks.append(
+                {
+                    "name": ctx.get("context"),
+                    "status": "COMPLETED" if state in {"SUCCESS", "ERROR", "FAILURE"} else "IN_PROGRESS",
+                    "conclusion": state,
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": ctx.get("name"),
+                    "status": ctx.get("status"),
+                    "conclusion": ctx.get("conclusion"),
+                }
+            )
+    return checks
+
+
+def graphql_reviews(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "author": {"login": (review.get("author") or {}).get("login")},
+            "state": review.get("state"),
+            "submittedAt": review.get("submittedAt"),
+            "commit": review.get("commit"),
+            "body": review.get("body"),
+        }
+        for review in nodes
+    ]
+
+
+def normalize_graphql_pr(node: dict[str, Any]) -> dict[str, Any]:
+    """Adapt a GraphQL PR node into the gh `--json`-style shape downstream code reads."""
+    latest_reviews = graphql_reviews(graphql_nodes(node.get("latestReviews")))
+    full_reviews = graphql_nodes(node.get("reviews"))
     return {
-        "isInMergeQueue": pull.get("isInMergeQueue"),
-        "mergeQueueEntry": pull.get("mergeQueueEntry"),
-        "autoMergeRequest": pull.get("autoMergeRequest"),
+        "number": node.get("number"),
+        "title": node.get("title"),
+        "body": node.get("body"),
+        "state": node.get("state"),
+        "isDraft": node.get("isDraft"),
+        "url": node.get("url"),
+        "createdAt": node.get("createdAt"),
+        "updatedAt": node.get("updatedAt"),
+        "headRefName": node.get("headRefName"),
+        "headRefOid": node.get("headRefOid"),
+        "baseRefName": node.get("baseRefName"),
+        "mergeStateStatus": node.get("mergeStateStatus"),
+        "reviewDecision": node.get("reviewDecision"),
+        "changedFiles": node.get("changedFiles"),
+        "author": {"login": (node.get("author") or {}).get("login")},
+        "labels": [{"name": label.get("name")} for label in graphql_nodes(node.get("labels"))],
+        "assignees": [{"login": a.get("login")} for a in graphql_nodes(node.get("assignees"))],
+        "isInMergeQueue": node.get("isInMergeQueue"),
+        "mergeQueueEntry": node.get("mergeQueueEntry"),
+        "autoMergeRequest": node.get("autoMergeRequest"),
+        "files": [{"path": f.get("path")} for f in graphql_nodes(node.get("files"))],
+        "comments": [
+            {
+                "author": {"login": (c.get("author") or {}).get("login")},
+                "createdAt": c.get("createdAt"),
+                "updatedAt": c.get("updatedAt"),
+                "body": c.get("body"),
+            }
+            for c in graphql_nodes(node.get("comments"))
+        ],
+        "latestReviews": latest_reviews,
+        "reviews": graphql_reviews(full_reviews) if full_reviews else latest_reviews,
+        "statusCheckRollup": graphql_rollup_contexts(node),
     }
+
+
+def fetch_open_prs(repo: str, limit: int) -> list[dict[str, Any]]:
+    owner, name = repo.split("/", 1)
+    nodes: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while len(nodes) < limit:
+        page_size = min(limit - len(nodes), 100)
+        variables = [
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"first={page_size}",
+        ]
+        if cursor:
+            variables += ["-f", f"after={cursor}"]
+        result = run_json(["gh", "api", "graphql", "-f", f"query={SCAN_PR_QUERY}", *variables])
+        connection = result.get("data", {}).get("repository", {}).get("pullRequests", {})
+        nodes.extend(graphql_nodes(connection))
+        page_info = connection.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+    return nodes[:limit]
+
+
+def gh_pr_view(repo: str, pr_number: int) -> dict[str, Any]:
+    owner, name = repo.split("/", 1)
+    result = run_json(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={int(pr_number)}",
+            "-f",
+            f"query={SINGLE_PR_QUERY}",
+        ]
+    )
+    node = result.get("data", {}).get("repository", {}).get("pullRequest")
+    return normalize_graphql_pr(node or {})
+
+
+CANDIDATE_ACTION_ORDER = {
+    "dequeue_stale_for_handler": 0,
+    "update_branch_for_handler": 1,
+    "approve_ready_for_handler": 2,
+    "review": 3,
+    "hold_ci": 4,
+    "request_changes": 5,
+    "blocked": 6,
+    "defer": 7,
+    "queued": 8,
+    "merged_prune": 9,
+    "skip": 10,
+}
+
+
+def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
+    action = candidate.get("advisory_action") or ""
+    created = candidate.get("created_at") or ""
+    updated = candidate.get("updated_at") or ""
+    pr_number = candidate.get("pr") or 0
+    order = CANDIDATE_ACTION_ORDER.get(action, 99)
+    if action == "review":
+        return (order, created, pr_number)
+    if action in {"dequeue_stale_for_handler", "update_branch_for_handler", "approve_ready_for_handler"}:
+        return (order, updated, created, pr_number)
+    return (order, pr_number)
 
 
 def command_scan(args: argparse.Namespace) -> int:
     policy = load_policy(args.config)
     private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
-    local_events = latest_events_by_pr_head(args.state_dir)
-    prs = run_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--repo",
-            args.repo,
-            "--state",
-            "open",
-            "--limit",
-            str(args.limit),
-            "--json",
-            "number,title,author,createdAt,updatedAt,headRefOid,isDraft,mergeStateStatus,reviewDecision,latestReviews,labels,statusCheckRollup,files",
-        ]
+    # One event-log read feeds head-freshness lookup, contributor analytics, and
+    # signal recurrence for every packet in the sweep.
+    events = all_events(args.state_dir)
+    local_events = latest_events_by_pr_head(events)
+    analytics_model = build_analytics_model(
+        events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
     )
+    signal_occurrences = collect_signal_occurrences(events)
+    # One paginated GraphQL query returns every field a full packet needs (files,
+    # comments, reviews, queue state, CI), so there is no light/full escalation:
+    # each packet is built once, mode "full".
+    nodes = fetch_open_prs(args.repo, args.limit)
     candidates = []
-    for pr in prs:
+    for node in nodes:
+        pr = normalize_graphql_pr(node)
         pr_number = int(pr["number"])
-        packet = make_packet(pr, policy, acting_login, "light", private_overrides)
-        packet["local_current_event"] = local_events.get((pr_number, pr.get("headRefOid") or ""))
-        packet["recommendation"] = recommend_from_packet(packet)
-        if packet["recommendation"]["reason"] in {
-            "stale_changes_requested",
-            "stale_approval",
-        } or packet["recommendation"]["advisory_action"] in {
-            "approve_ready_for_handler",
-            "update_branch_for_handler",
-            "dequeue_stale_for_handler",
-        }:
-            pr = gh_pr_view(args.repo, pr_number)
-            packet = make_packet(pr, policy, acting_login, "full", private_overrides)
-            packet["local_current_event"] = local_events.get(
-                (pr_number, pr.get("headRefOid") or "")
-            )
-            packet["recommendation"] = recommend_from_packet(packet)
+        local_event = local_events.get((pr_number, pr.get("headRefOid") or ""))
+        contributor_summary = build_contributor_summary(
+            pr.get("author", {}).get("login"),
+            pr_number,
+            analytics_model,
+            signal_occurrences,
+            private_overrides,
+        )
+        packet = make_packet(
+            pr, policy, acting_login, "full", private_overrides, local_event, contributor_summary
+        )
         candidates.append(
             {
                 "pr": pr.get("number"),
@@ -1389,6 +1801,7 @@ def command_scan(args: argparse.Namespace) -> int:
                 "gate": packet["classification"]["gate"],
                 "hard_stop_paths": packet["classification"]["hard_stop_paths"],
                 "ci": packet["ci"]["state"],
+                "parse_diff": packet["parse_diff"],
                 "review_decision": pr.get("reviewDecision"),
                 "is_in_merge_queue": packet["pr"].get("isInMergeQueue"),
                 "merge_queue_entry": packet["pr"].get("mergeQueueEntry"),
@@ -1396,51 +1809,46 @@ def command_scan(args: argparse.Namespace) -> int:
                 "advisory_action": packet["recommendation"]["advisory_action"],
                 "reason": packet["recommendation"]["reason"],
                 "policy_trace": packet["policy_trace"],
+                "standing": (packet.get("contributor") or {}).get("standing"),
+                "scrutiny": (packet.get("contributor") or {}).get("scrutiny"),
+                "first_contribution": (packet.get("contributor") or {}).get(
+                    "first_contribution"
+                ),
             }
         )
-
-    action_order = {
-        "dequeue_stale_for_handler": 0,
-        "update_branch_for_handler": 1,
-        "approve_ready_for_handler": 2,
-        "review": 3,
-        "hold_ci": 4,
-        "request_changes": 5,
-        "blocked": 6,
-        "defer": 7,
-        "queued": 8,
-        "merged_prune": 9,
-        "skip": 10,
-    }
-
-    def candidate_sort_key(candidate: dict[str, Any]) -> tuple[Any, ...]:
-        action = candidate.get("advisory_action") or ""
-        created = candidate.get("created_at") or ""
-        updated = candidate.get("updated_at") or ""
-        pr_number = candidate.get("pr") or 0
-        if action == "review":
-            return (action_order.get(action, 99), created, pr_number)
-        if action in {"dequeue_stale_for_handler", "update_branch_for_handler", "approve_ready_for_handler"}:
-            return (action_order.get(action, 99), updated, created, pr_number)
-        return (action_order.get(action, 99), pr_number)
 
     candidates.sort(key=candidate_sort_key)
     candidates_by_action: dict[str, list[dict[str, Any]]] = {}
     for candidate in candidates:
         candidates_by_action.setdefault(candidate["advisory_action"], []).append(candidate)
     action_counts = {action: len(items) for action, items in candidates_by_action.items()}
-    print(
-        json_dumps(
-            {
-                "acting_login": acting_login,
-                "completeness": "triage",
-                "action_counts": action_counts,
-                "candidates_by_action": candidates_by_action,
-                "candidates": candidates,
-            }
-        )
-    )
+    output = {
+        "acting_login": acting_login,
+        "completeness": "triage",
+        "action_counts": action_counts,
+        "candidates_by_action": candidates_by_action,
+    }
+    if len(candidates) == args.limit:
+        output["warnings"] = [
+            f"open PR count reached --limit {args.limit}; increase --limit"
+        ]
+    print(json_dumps(output))
     return 0
+
+
+def event_skeleton(pr_number: int, compact_pr: dict[str, Any]) -> dict[str, Any]:
+    # Timestamp is prefilled because event_id hashes it: an agent that fills the
+    # skeleton and pipes it to `record --event-json -` gets idempotent retries.
+    return {
+        "event_type": "<FILL: review|changes_requested|blocked|approved_enqueued|deferred|held>",
+        "pr": pr_number,
+        "head_sha": compact_pr.get("headRefOid"),
+        "author": compact_pr.get("author_login"),
+        "timestamp": now_iso(),
+        "outcome": "<FILL or omit>",
+        "summary": "<FILL>",
+        "signals": f"<FILL or omit: [] or subset of {sorted(QUALITY_SIGNAL_WEIGHTS)}>",
+    }
 
 
 def command_inspect(args: argparse.Namespace) -> int:
@@ -1448,11 +1856,24 @@ def command_inspect(args: argparse.Namespace) -> int:
     private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
     pr = gh_pr_view(args.repo, args.pr)
-    packet = make_packet(pr, policy, acting_login, args.mode, private_overrides)
-    packet["local_current_event"] = latest_events_by_pr_head(args.state_dir).get(
+    events = all_events(args.state_dir)
+    local_event = latest_events_by_pr_head(events).get(
         (args.pr, pr.get("headRefOid") or "")
     )
-    packet["recommendation"] = recommend_from_packet(packet)
+    contributor_summary = build_contributor_summary(
+        pr.get("author", {}).get("login"),
+        args.pr,
+        build_analytics_model(
+            events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
+        ),
+        collect_signal_occurrences(events),
+        private_overrides,
+    )
+    packet = make_packet(
+        pr, policy, acting_login, args.mode, private_overrides, local_event, contributor_summary
+    )
+    if args.emit_event:
+        packet["event_skeleton"] = event_skeleton(args.pr, packet["pr"])
     print(json_dumps(packet))
     return 0
 
@@ -1462,11 +1883,22 @@ def command_recommend(args: argparse.Namespace) -> int:
     private_overrides = load_private_overrides(args.state_dir)
     acting_login = args.acting_login or gh_user()
     pr = gh_pr_view(args.repo, args.pr)
-    packet = make_packet(pr, policy, acting_login, "full", private_overrides)
-    packet["local_current_event"] = latest_events_by_pr_head(args.state_dir).get(
+    events = all_events(args.state_dir)
+    local_event = latest_events_by_pr_head(events).get(
         (args.pr, pr.get("headRefOid") or "")
     )
-    packet["recommendation"] = recommend_from_packet(packet)
+    contributor_summary = build_contributor_summary(
+        pr.get("author", {}).get("login"),
+        args.pr,
+        build_analytics_model(
+            events, days=None, author=None, min_prs=ANALYTICS_DEFAULT_MIN_PRS, include_open=True
+        ),
+        collect_signal_occurrences(events),
+        private_overrides,
+    )
+    packet = make_packet(
+        pr, policy, acting_login, "full", private_overrides, local_event, contributor_summary
+    )
     recommendation = packet["recommendation"]
     if packet["completeness"] != "complete" and recommendation["advisory_action"].endswith("_for_handler"):
         recommendation = {
@@ -1476,7 +1908,11 @@ def command_recommend(args: argparse.Namespace) -> int:
             "reason": "insufficient_data",
             "requires_live_verification": False,
             "policy_trace": packet.get("policy_trace", []),
+            "contributor": packet.get("contributor"),
         }
+    if args.emit_event:
+        recommendation = dict(recommendation)
+        recommendation["event_skeleton"] = event_skeleton(args.pr, packet["pr"])
     print(json_dumps(recommendation))
     return 0
 
@@ -1487,11 +1923,53 @@ def read_event_arg(value: str) -> dict[str, Any]:
     return json.loads(Path(value).read_text(encoding="utf-8"))
 
 
+def event_validation_error(event: dict[str, Any]) -> str | None:
+    event_type = event.get("event_type")
+    if event_type not in ALLOWED_EVENT_TYPES:
+        return f"event_type {event_type!r} is not in the allowed vocabulary"
+    outcome = event.get("outcome")
+    if outcome is not None and outcome not in ALLOWED_OUTCOMES:
+        return f"outcome {outcome!r} is not in the allowed vocabulary"
+    if event_type != "quality_entry" and not isinstance(event.get("pr"), int):
+        return "pr (int) is required for non-quality_entry events"
+    signals = event.get("signals")
+    if signals is not None:
+        if not isinstance(signals, list) or not all(
+            isinstance(signal, str) for signal in signals
+        ):
+            return "signals must be a list of strings"
+        unknown = sorted(set(signals) - set(QUALITY_SIGNAL_WEIGHTS))
+        if unknown:
+            return f"signals {unknown} are not in the allowed vocabulary"
+    return None
+
+
 def command_record(args: argparse.Namespace) -> int:
     event = read_event_arg(args.event_json)
-    state_dir = args.state_dir
-    inserted = append_event(state_dir, event)
-    print(json_dumps({"inserted": inserted, "event_id": normalize_event(event)["event_id"]}))
+    # Lower-case the outcome before normalization so the write-time value (and the
+    # event_id that hashes it) is the canonical lowercase form.
+    if isinstance(event.get("outcome"), str):
+        event["outcome"] = event["outcome"].lower()
+    normalized = normalize_event(event)
+    error = event_validation_error(normalized)
+    if error is not None and not args.force:
+        print(
+            json_dumps(
+                {
+                    "inserted": False,
+                    "error": error,
+                    "allowed_event_types": sorted(ALLOWED_EVENT_TYPES),
+                    "allowed_outcomes": sorted(ALLOWED_OUTCOMES),
+                    "allowed_signals": sorted(QUALITY_SIGNAL_WEIGHTS),
+                }
+            )
+        )
+        return 1
+    inserted = append_event(args.state_dir, normalized)
+    result = {"inserted": inserted, "event_id": normalized["event_id"]}
+    if error is not None:
+        result["forced"] = True
+    print(json_dumps(result))
     return 0
 
 
@@ -1540,19 +2018,9 @@ def quality_import_events(path: Path) -> list[dict[str, Any]]:
 
 def quality_entry(path: Path, line_number: int, login: str, lines: list[str]) -> dict[str, Any]:
     body = "\n".join(lines).strip()
-    signals = []
-    for token in [
-        "runtime-test-gap",
-        "false-green",
-        "fmt/clippy-slip",
-        "wrong-seam",
-        "rebase-not-fix",
-        "scope-contamination",
-        "build-for-card",
-        "stale-approval",
-    ]:
-        if token in body:
-            signals.append(token)
+    # The recognized tokens are the signal vocabulary itself — one authority with
+    # record-time validation and the event_skeleton hint.
+    signals = [token for token in sorted(QUALITY_SIGNAL_WEIGHTS) if token in body]
     return {
         "event_type": "quality_entry",
         "timestamp": now_iso(),
@@ -1579,25 +2047,28 @@ def command_import(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_rebuild_index(args: argparse.Namespace) -> int:
-    rebuild_index(args.state_dir)
-    print(json_dumps({"rebuilt": True, "state_dir": str(args.state_dir)}))
-    return 0
-
-
 def command_check_skill_sync(args: argparse.Namespace) -> int:
-    canonical = args.canonical
-    mirror = args.mirror
-    canonical_bytes = canonical.read_bytes()
-    mirror_bytes = mirror.read_bytes()
-    synced = canonical_bytes == mirror_bytes
-    print(json_dumps({"synced": synced, "canonical": str(canonical), "mirror": str(mirror)}))
+    # `.agents/skills` is a symlink to `.claude/skills`, so a byte-compare is
+    # vacuous. Verify the symlink still points at the canonical directory instead.
+    link = REPO_ROOT / ".agents/skills"
+    expected = (REPO_ROOT / ".claude/skills").resolve()
+    is_symlink = link.is_symlink()
+    resolved_target = link.resolve() if is_symlink else None
+    synced = is_symlink and resolved_target == expected
+    print(
+        json_dumps(
+            {
+                "synced": synced,
+                "is_symlink": is_symlink,
+                "target": str(resolved_target) if resolved_target is not None else None,
+            }
+        )
+    )
     return 0 if synced else 1
 
 
 def command_compact(args: argparse.Namespace) -> int:
-    rebuild_index(args.state_dir)
-    events = all_events(args.state_dir)
+    events = filtered_events_by_days(all_events(args.state_dir), args.days)
     prs: dict[str, dict[str, Any]] = {}
     contributors: dict[str, dict[str, Any]] = {}
     for event in events:
@@ -1614,12 +2085,14 @@ def command_compact(args: argparse.Namespace) -> int:
             }
         if author:
             entry = contributors.setdefault(
-                author,
+                fold_login(str(author)),
                 {"login": author, "events": 0, "signals": {}, "latest_timestamp": None},
             )
             entry["events"] += 1
             entry["latest_timestamp"] = event.get("timestamp")
-            for signal in event.get("quality", {}).get("signals", []):
+            for signal in list(event.get("quality", {}).get("signals", [])) + list(
+                event.get("signals") or []
+            ):
                 entry["signals"][signal] = entry["signals"].get(signal, 0) + 1
     summary = {
         "generated_at": now_iso(),
@@ -1633,7 +2106,6 @@ def command_compact(args: argparse.Namespace) -> int:
 
 
 def command_analytics(args: argparse.Namespace) -> int:
-    rebuild_index(args.state_dir)
     events = all_events(args.state_dir)
     model = build_analytics_model(
         events,
@@ -1643,10 +2115,13 @@ def command_analytics(args: argparse.Namespace) -> int:
         include_open=args.include_open or args.refresh_github,
     )
     if args.refresh_github:
-        apply_github_refresh(model, args.repo, args.min_prs, args.author)
+        # Refresh and open-PR filtering only mutate the PR rows; contributor
+        # aggregation + repo medians are recomputed exactly once afterward.
+        apply_github_refresh(model, args.repo)
         if not args.include_open:
-            filter_open_prs(model, args.min_prs, args.author, True)
+            model["prs"] = [pr for pr in model["prs"] if not pr["is_open_or_pending"]]
         model["filters"]["include_open"] = args.include_open
+        finalize_contributor_model(model, min_prs=args.min_prs, author=args.author, refreshed=True)
     model["contributors"] = sorted_contributors(model["contributors"], args.sort, args.limit)
     if args.format == "json":
         print(json.dumps(model, indent=2, sort_keys=True))
@@ -1693,16 +2168,19 @@ def build_parser() -> argparse.ArgumentParser:
     add_common(inspect)
     inspect.add_argument("pr", type=int)
     inspect.add_argument("--mode", choices=["light", "full"], default="light")
+    inspect.add_argument("--emit-event", action="store_true")
     inspect.set_defaults(func=command_inspect)
 
     recommend = sub.add_parser("recommend")
     add_common(recommend)
     recommend.add_argument("pr", type=int)
+    recommend.add_argument("--emit-event", action="store_true")
     recommend.set_defaults(func=command_recommend)
 
     record = sub.add_parser("record")
     add_state(record)
     record.add_argument("--event-json", required=True)
+    record.add_argument("--force", action="store_true")
     record.set_defaults(func=command_record)
 
     import_cmd = sub.add_parser("import")
@@ -1713,13 +2191,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     compact = sub.add_parser("compact")
     add_state(compact)
+    compact.add_argument("--days", type=int, default=None)
     compact.set_defaults(func=command_compact)
 
     analytics = sub.add_parser("analytics")
     add_state(analytics)
     analytics.add_argument("--author")
     analytics.add_argument("--days", type=int, default=None)
-    analytics.add_argument("--min-prs", type=int, default=3)
+    analytics.add_argument("--min-prs", type=int, default=ANALYTICS_DEFAULT_MIN_PRS)
     analytics.add_argument("--format", choices=["ascii", "json"], default="ascii")
     analytics.add_argument(
         "--sort",
@@ -1731,21 +2210,7 @@ def build_parser() -> argparse.ArgumentParser:
     analytics.add_argument("--refresh-github", action="store_true")
     analytics.set_defaults(func=command_analytics)
 
-    rebuild = sub.add_parser("rebuild-index")
-    add_state(rebuild)
-    rebuild.set_defaults(func=command_rebuild_index)
-
     skill_sync = sub.add_parser("check-skill-sync")
-    skill_sync.add_argument(
-        "--canonical",
-        type=Path,
-        default=REPO_ROOT / ".agents/skills/pr-review-loop/SKILL.md",
-    )
-    skill_sync.add_argument(
-        "--mirror",
-        type=Path,
-        default=REPO_ROOT / ".claude/skills/pr-review-loop/SKILL.md",
-    )
     skill_sync.set_defaults(func=command_check_skill_sync)
     return parser
 

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -6,7 +6,7 @@ import io
 import json
 import tempfile
 import unittest
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pr_review
@@ -28,7 +28,7 @@ class PrReviewTests(unittest.TestCase):
             self.assertTrue(pr_review.append_event(state_dir, event))
             self.assertFalse(pr_review.append_event(state_dir, event))
 
-            args = type("Args", (), {"state_dir": state_dir})()
+            args = type("Args", (), {"state_dir": state_dir, "days": None})()
             pr_review.command_compact(args)
 
             summary = json.loads((state_dir / "review-summary.json").read_text())
@@ -312,7 +312,7 @@ class PrReviewTests(unittest.TestCase):
         self.assertIn("Local Observed Review Analytics", rendered)
         self.assertIn("contributor", rendered)
 
-    def test_filter_open_prs_recomputes_contributors_after_refresh(self) -> None:
+    def test_finalize_recomputes_contributors_after_open_filter(self) -> None:
         events = [
             {
                 "event_type": "hold_ci",
@@ -332,8 +332,9 @@ class PrReviewTests(unittest.TestCase):
         )
         model["prs"][0]["terminal_state"] = "merged"
         model["prs"][0]["is_open_or_pending"] = False
+        model["prs"] = [pr for pr in model["prs"] if not pr["is_open_or_pending"]]
 
-        pr_review.filter_open_prs(model, min_prs=1, author=None, refreshed=True)
+        pr_review.finalize_contributor_model(model, min_prs=1, author=None, refreshed=True)
 
         self.assertEqual(model["contributors"][0]["terminal_prs"], 1)
         self.assertEqual(model["contributors"][0]["accepted_or_enqueued"], 1)
@@ -356,12 +357,12 @@ class PrReviewTests(unittest.TestCase):
             min_prs=1,
             include_open=True,
         )
-        original = pr_review.gh_pr_analytics_state
-        pr_review.gh_pr_analytics_state = lambda _repo, _pr_number: None
+        original = pr_review.gh_pr_refresh_chunk
+        pr_review.gh_pr_refresh_chunk = lambda _repo, _numbers: {"1": None}
         try:
-            pr_review.apply_github_refresh(model, "phase-rs/phase", min_prs=1, author=None)
+            pr_review.apply_github_refresh(model, "phase-rs/phase")
         finally:
-            pr_review.gh_pr_analytics_state = original
+            pr_review.gh_pr_refresh_chunk = original
 
         self.assertEqual(
             model["warnings"],
@@ -418,11 +419,544 @@ class PrReviewTests(unittest.TestCase):
             ["high-score", "low-score"],
         )
 
+    def test_canonical_from_text_covers_every_mapping_branch(self) -> None:
+        cases = [
+            ("changes-requested", ("changes_requested", "negative_review")),
+            ("request-changes", ("changes_requested", "negative_review")),
+            ("reviewed-request-changes", ("changes_requested", "negative_review")),
+            ("still-blocked", ("blocked", "blocked")),
+            ("blocked", ("blocked", "blocked")),
+            ("blocked-on-author", ("blocked", "blocked")),
+            ("hard-stop", ("blocked", "hard_stop")),
+            ("merged", ("merged", "merged")),
+            ("pruned-as-merged", ("merged", "merged")),
+            ("pruned-merged", ("merged", "merged")),
+            ("defer-fe", ("deferred", "deferred")),
+            ("defer", ("deferred", "deferred")),
+            ("deferred", ("deferred", "deferred")),
+            ("ci-failed", ("changes_requested", "ci_failed")),
+            ("pending-ci", ("held_ci", "ci_pending")),
+            ("hold-ci", ("held_ci", "ci_pending")),
+            ("hold", ("held", "held")),
+            ("held", ("held", "held")),
+            ("held-for-author", ("held", "held")),
+            ("approved-enqueued", ("accepted", "approved_enqueued")),
+            ("approved-labeled-enqueued", ("accepted", "approved_enqueued")),
+            ("enqueued", ("accepted", "enqueued")),
+            ("handler-enqueue", ("accepted", "enqueued")),
+            ("approved", ("accepted", "approved")),
+            ("approve", ("accepted", "approved")),
+            ("approve-pending", ("held_ci", "approval_pending_ci")),
+            ("content-clean-pending", ("held_ci", "approval_pending_ci")),
+            ("review", ("review", "review")),
+            ("review-needed", ("review", "review")),
+            ("pending", ("pending", "pending")),
+            ("pending-author", ("pending", "pending")),
+            ("closed", ("closed", "closed")),
+            ("superseded", ("closed", "closed")),
+            ("queued", ("accepted", "queued")),
+            ("pruned", ("accepted", "pruned")),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(pr_review.canonical_from_text(value), expected)
+        self.assertIsNone(pr_review.canonical_from_text("totally-unknown-value"))
+        self.assertIsNone(pr_review.canonical_from_text(""))
+        self.assertIsNone(pr_review.canonical_from_text(None))
+
+    def _record_args(self, state_dir: Path, event_path: Path, force: bool = False):
+        return type(
+            "Args",
+            (),
+            {"state_dir": state_dir, "event_json": str(event_path), "force": force},
+        )()
+
+    def test_record_validates_vocabulary_and_lowercases_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            state_dir = Path(temp)
+            valid_path = state_dir / "valid.json"
+            valid_path.write_text(
+                json.dumps(
+                    {"event_type": "approved_enqueued", "pr": 5, "head_sha": "h", "outcome": "APPROVED"}
+                ),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = pr_review.command_record(self._record_args(state_dir, valid_path))
+            result = json.loads(output.getvalue())
+            self.assertEqual(code, 0)
+            self.assertTrue(result["inserted"])
+            events = pr_review.all_events(state_dir)
+            self.assertEqual(events[0]["outcome"], "approved")
+
+            bad_path = state_dir / "bad.json"
+            bad_path.write_text(
+                json.dumps({"event_type": "not_a_real_type", "pr": 6}), encoding="utf-8"
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = pr_review.command_record(self._record_args(state_dir, bad_path))
+            rejected = json.loads(output.getvalue())
+            self.assertEqual(code, 1)
+            self.assertFalse(rejected["inserted"])
+            self.assertIn("not_a_real_type", rejected["error"])
+            self.assertIn("observation", rejected["allowed_event_types"])
+            self.assertIn("approved", rejected["allowed_outcomes"])
+
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = pr_review.command_record(self._record_args(state_dir, bad_path, force=True))
+            forced = json.loads(output.getvalue())
+            self.assertEqual(code, 0)
+            self.assertTrue(forced["inserted"])
+            self.assertTrue(forced["forced"])
+
+    def test_append_event_is_idempotent_under_flock(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            state_dir = Path(temp)
+            event = {
+                "event_type": "review",
+                "timestamp": "2026-06-28T00:00:00Z",
+                "pr": 42,
+                "author": "contributor",
+                "head_sha": "abc",
+            }
+            self.assertTrue(pr_review.append_event(state_dir, event))
+            self.assertFalse(pr_review.append_event(state_dir, dict(event)))
+            lines = (state_dir / "review-events.jsonl").read_text().strip().splitlines()
+            self.assertEqual(len(lines), 1)
+
+    def test_candidate_sort_orders_by_action_priority(self) -> None:
+        candidates = [
+            {"advisory_action": "skip", "pr": 10},
+            {"advisory_action": "review", "created_at": "2026-06-02T00:00:00Z", "pr": 3},
+            {"advisory_action": "dequeue_stale_for_handler", "updated_at": "2026-06-01T00:00:00Z", "pr": 8},
+            {"advisory_action": "review", "created_at": "2026-06-01T00:00:00Z", "pr": 4},
+        ]
+        ordered = [c["advisory_action"] for c in sorted(candidates, key=pr_review.candidate_sort_key)]
+        self.assertEqual(
+            ordered,
+            ["dequeue_stale_for_handler", "review", "review", "skip"],
+        )
+        # review is ordered by created-date: the 06-01 review precedes the 06-02 review.
+        review_prs = [
+            c["pr"]
+            for c in sorted(candidates, key=pr_review.candidate_sort_key)
+            if c["advisory_action"] == "review"
+        ]
+        self.assertEqual(review_prs, [4, 3])
+
+    def test_files_truncated_forces_manual_review(self) -> None:
+        policy = pr_review.Policy(
+            {"path_classes": {"frontend": {"patterns": ["client/**"]}}}
+        )
+        pr = {
+            "number": 4600,
+            "state": "OPEN",
+            "headRefOid": "head",
+            "changedFiles": 150,
+            "files": [{"path": f"client/src/f{i}.tsx"} for i in range(3)],
+        }
+        packet = pr_review.make_packet(pr, policy, "maintainer", "full", {})
+
+        self.assertTrue(packet["classification"]["files_truncated"])
+        self.assertEqual(packet["classification"]["surface"], "files_truncated")
+        self.assertEqual(packet["recommendation"]["advisory_action"], "review")
+        self.assertEqual(
+            packet["recommendation"]["reason"], "files_truncated_needs_manual_classification"
+        )
+
+    def test_normalize_graphql_pr_maps_status_contexts(self) -> None:
+        node = {
+            "number": 1,
+            "author": {"login": "contributor"},
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {
+                                "contexts": {
+                                    "nodes": [
+                                        {
+                                            "__typename": "CheckRun",
+                                            "name": "clippy",
+                                            "status": "COMPLETED",
+                                            "conclusion": "SUCCESS",
+                                        },
+                                        {
+                                            "__typename": "StatusContext",
+                                            "context": "legacy-ci",
+                                            "state": "FAILURE",
+                                        },
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+        normalized = pr_review.normalize_graphql_pr(node)
+        summary = pr_review.status_summary(normalized["statusCheckRollup"])
+
+        self.assertEqual(summary["state"], "failed")
+        self.assertIn("legacy-ci", summary["failures"])
+        self.assertIn("clippy", summary["successes"])
+
+    def test_recommend_defer_fe_is_case_insensitive(self) -> None:
+        for outcome in ("DEFER-FE", "defer-fe"):
+            packet = {
+                "pr": {
+                    "number": 4700,
+                    "state": "OPEN",
+                    "headRefOid": "head",
+                    "reviewDecision": "",
+                    "isInMergeQueue": False,
+                },
+                "ci": {"state": "green"},
+                "classification": {"hard_stop_paths": [], "surface": "backend"},
+                "latest_maintainer_review_commit": None,
+                "local_current_event": {"event_type": "deferred", "outcome": outcome},
+                "policy_trace": [],
+            }
+            recommendation = pr_review.recommend_from_packet(packet)
+            self.assertEqual(recommendation["advisory_action"], "defer")
+            self.assertEqual(recommendation["reason"], "local_defer_fe_current_head")
+
+    def test_parse_diff_comment_state_classifies_all_states(self) -> None:
+        marker = pr_review.PARSE_DIFF_MARKER
+        bot = {"login": "github-actions"}
+
+        absent = pr_review.parse_diff_comment_state(
+            [{"author": bot, "body": "just a normal comment", "updatedAt": "2026-06-30T00:00:00Z"}]
+        )
+        self.assertEqual(absent, {"present": False, "state": "absent", "updated_at": None})
+
+        # A marker-shaped body from a non-bot author is a spoof and must not classify.
+        spoofed = pr_review.parse_diff_comment_state(
+            [
+                {
+                    "author": {"login": "contrib"},
+                    "body": f"{marker}\n2 signature(s) changed",
+                    "updatedAt": "2026-06-30T00:30:00Z",
+                }
+            ]
+        )
+        self.assertEqual(spoofed["state"], "absent")
+
+        real = pr_review.parse_diff_comment_state(
+            [{"author": bot, "body": f"{marker}\n2 signature(s) changed", "updatedAt": "2026-06-30T01:00:00Z"}]
+        )
+        self.assertEqual(real["state"], "real_changes")
+        self.assertTrue(real["present"])
+        self.assertEqual(real["updated_at"], "2026-06-30T01:00:00Z")
+
+        pending = pr_review.parse_diff_comment_state(
+            [
+                {
+                    "author": bot,
+                    "body": f"{marker}\nBaseline pending (R2 baseline not found)",
+                    "updatedAt": "2026-06-30T02:00:00Z",
+                }
+            ]
+        )
+        self.assertEqual(pending["state"], "baseline_pending")
+        self.assertEqual(pending["updated_at"], "2026-06-30T02:00:00Z")
+
+        no_changes = pr_review.parse_diff_comment_state(
+            [
+                {
+                    "author": bot,
+                    "body": f"{marker}\nNo parse-detail changes in this diff.",
+                    "updatedAt": "2026-06-30T03:00:00Z",
+                }
+            ]
+        )
+        self.assertEqual(no_changes["state"], "no_changes")
+        self.assertTrue(no_changes["present"])
+
+    def test_recommend_flags_engine_baseline_pending(self) -> None:
+        base_packet = {
+            "pr": {
+                "number": 4900,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "reviewDecision": "",
+                "isInMergeQueue": False,
+            },
+            "ci": {"state": "green"},
+            "classification": {
+                "hard_stop_paths": [],
+                "surface": "backend",
+                "path_classes": {"engine": ["crates/engine/src/x.rs"]},
+            },
+            "latest_maintainer_review_commit": None,
+            "policy_trace": [],
+            "parse_diff": {"present": True, "state": "baseline_pending", "updated_at": "t"},
+        }
+
+        recommendation = pr_review.recommend_from_packet(base_packet)
+        self.assertEqual(recommendation["advisory_action"], "review")
+        self.assertEqual(recommendation["reason"], "review_parse_baseline_pending")
+
+        # Frontend-only surface (no engine path class) keeps the generic review reason.
+        frontend_packet = dict(base_packet)
+        frontend_packet["classification"] = {
+            "hard_stop_paths": [],
+            "surface": "backend",
+            "path_classes": {"skill": ["docs/x.md"]},
+        }
+        frontend = pr_review.recommend_from_packet(frontend_packet)
+        self.assertEqual(frontend["reason"], "needs_review")
+
     def test_wrapper_script_exists_and_is_executable(self) -> None:
         wrapper = Path(__file__).resolve().parent / "pr-analytics"
 
         self.assertTrue(wrapper.exists())
         self.assertTrue(wrapper.stat().st_mode & 0o111)
+
+    @staticmethod
+    def _days_ago(days: int) -> str:
+        stamp = datetime.now(UTC).replace(microsecond=0) - timedelta(days=days)
+        return stamp.isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _signal_event(pr: int, author: str, signals: list[str], days_ago: int) -> dict:
+        return {
+            "event_type": "review",
+            "timestamp": PrReviewTests._days_ago(days_ago),
+            "event_id": f"sig-{pr}-{author}-{days_ago}",
+            "pr": pr,
+            "author": author,
+            "head_sha": f"head-{pr}",
+            "signals": signals,
+        }
+
+    def _summary_for(
+        self,
+        events: list[dict],
+        author: str,
+        current_pr: int | None,
+        overrides: dict | None = None,
+    ) -> dict:
+        model = pr_review.build_analytics_model(
+            events,
+            days=None,
+            author=None,
+            min_prs=pr_review.ANALYTICS_DEFAULT_MIN_PRS,
+            include_open=True,
+        )
+        return pr_review.build_contributor_summary(
+            author,
+            current_pr,
+            model,
+            pr_review.collect_signal_occurrences(events),
+            overrides or {},
+        )
+
+    def test_first_contribution_excludes_current_pr(self) -> None:
+        events = [
+            {
+                "event_type": "review",
+                "timestamp": self._days_ago(1),
+                "event_id": "a",
+                "pr": 10,
+                "author": "newbie",
+                "head_sha": "h1",
+            }
+        ]
+
+        same_pr = self._summary_for(events, "newbie", current_pr=10)
+        self.assertTrue(same_pr["first_contribution"])
+        self.assertEqual(same_pr["prior_prs"], 0)
+
+        other_pr = self._summary_for(events, "newbie", current_pr=11)
+        self.assertFalse(other_pr["first_contribution"])
+        self.assertEqual(other_pr["prior_prs"], 1)
+
+        unseen = self._summary_for(events, "brand-new", current_pr=1)
+        self.assertTrue(unseen["first_contribution"])
+        self.assertIsNone(unseen["score"])
+
+    def test_recurrence_window_counts_distinct_prs(self) -> None:
+        events = [
+            self._signal_event(1, "repeat", ["false-green"], days_ago=5),
+            self._signal_event(2, "repeat", ["false-green"], days_ago=10),
+            # Outside RECURRENCE_WINDOW_DAYS: must not count toward the window.
+            self._signal_event(3, "repeat", ["false-green"], days_ago=200),
+        ]
+
+        summary = self._summary_for(events, "repeat", current_pr=99)
+        entry = next(r for r in summary["recurrence"] if r["signal"] == "false-green")
+        self.assertEqual(entry["distinct_prs_window"], 2)
+        self.assertEqual(summary["scrutiny"], "elevated")
+        self.assertTrue(
+            any(reason.startswith("recurrence_false-green") for reason in summary["scrutiny_reasons"])
+        )
+        self.assertFalse(summary["light_touch_eligible"])
+
+        events.append(self._signal_event(4, "repeat", ["false-green"], days_ago=2))
+        attention = self._summary_for(events, "repeat", current_pr=99)
+        self.assertEqual(attention["scrutiny"], "maintainer_attention")
+
+    def test_legacy_quality_entry_excluded_from_recurrence(self) -> None:
+        events = [
+            {
+                "event_type": "quality_entry",
+                "timestamp": self._days_ago(1),
+                "event_id": "q",
+                "author": "legacy",
+                "quality": {"login": "legacy", "signals": ["wrong-seam"]},
+            }
+        ]
+
+        summary = self._summary_for(events, "legacy", current_pr=1)
+        self.assertEqual(summary["recurrence"], [])
+        self.assertEqual(summary["scrutiny"], "normal")
+        # Lifetime aggregation still sees the legacy signal.
+        self.assertEqual(summary["top_signals"], [{"signal": "wrong-seam", "count": 1}])
+
+    def test_standing_override_skip_recommends_skip_and_traces(self) -> None:
+        overrides = {"contributor_standing": {"Dale053": {"standing": "skip", "note": "probation"}}}
+        summary = self._summary_for([], "dale053", current_pr=1, overrides=overrides)
+        self.assertEqual(summary["standing"], "skip")
+        self.assertEqual(summary["standing_source"], "override")
+
+        policy = pr_review.Policy({"hard_stops": {"patterns": [".claude/skills/**"]}})
+        pr = {
+            "number": 1,
+            "state": "OPEN",
+            "author": {"login": "dale053"},
+            "files": [{"path": "crates/engine/src/lib.rs"}],
+            "changedFiles": 1,
+        }
+        packet = pr_review.make_packet(pr, policy, "maintainer", "full", overrides, None, summary)
+        self.assertEqual(packet["recommendation"]["advisory_action"], "skip")
+        self.assertEqual(packet["recommendation"]["reason"], "contributor_standing_skip")
+        self.assertIn("matched:standing_skip", packet["policy_trace"])
+        self.assertEqual(packet["recommendation"]["contributor"]["standing"], "skip")
+
+        # Safety ordering: a guarded path still wins over the skip standing, but the
+        # matched standing pattern stays visible in the trace.
+        hard_stop_pr = dict(pr)
+        hard_stop_pr["files"] = [{"path": ".claude/skills/pr-review-loop/SKILL.md"}]
+        hard_stop_packet = pr_review.make_packet(
+            hard_stop_pr, policy, "maintainer", "full", overrides, None, summary
+        )
+        self.assertEqual(hard_stop_packet["recommendation"]["advisory_action"], "request_changes")
+        self.assertEqual(hard_stop_packet["recommendation"]["reason"], "hard_stop")
+        self.assertIn("matched:standing_skip", hard_stop_packet["policy_trace"])
+
+    def test_standing_watch_forces_elevated_scrutiny(self) -> None:
+        overrides = {"contributor_standing": {"jaso0n0818": {"standing": "watch"}}}
+        summary = self._summary_for([], "jaso0n0818", current_pr=1, overrides=overrides)
+        self.assertEqual(summary["standing"], "watch")
+        self.assertEqual(summary["scrutiny"], "elevated")
+        self.assertIn("standing_watch", summary["scrutiny_reasons"])
+        self.assertFalse(summary["light_touch_eligible"])
+
+        unknown_standing = {"contributor_standing": {"jaso0n0818": {"standing": "banished"}}}
+        ignored = self._summary_for([], "jaso0n0818", current_pr=1, overrides=unknown_standing)
+        self.assertEqual(ignored["standing"], "unknown")
+
+    def test_derived_trusted_requires_clean_window(self) -> None:
+        events = [
+            {
+                "event_type": "approved_enqueued",
+                "timestamp": self._days_ago(30 + pr),
+                "event_id": f"ok-{pr}",
+                "pr": pr,
+                "author": "solid",
+                "head_sha": f"h{pr}",
+            }
+            for pr in range(1, 6)
+        ]
+
+        summary = self._summary_for(events, "solid", current_pr=99)
+        self.assertEqual(summary["standing"], "trusted")
+        self.assertEqual(summary["standing_source"], "derived")
+        self.assertEqual(summary["scrutiny"], "normal")
+        self.assertTrue(summary["light_touch_eligible"])
+
+        # One windowed signal occurrence breaks the clean-window requirement.
+        events.append(self._signal_event(6, "solid", ["fmt/clippy-slip"], days_ago=3))
+        dirty = self._summary_for(events, "solid", current_pr=99)
+        self.assertEqual(dirty["standing"], "unknown")
+        self.assertFalse(dirty["light_touch_eligible"])
+
+    def test_record_validates_signals_vocabulary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            state_dir = Path(temp)
+            bad_path = state_dir / "bad.json"
+            bad_path.write_text(
+                json.dumps(
+                    {"event_type": "review", "pr": 7, "head_sha": "h", "signals": ["bogus-signal"]}
+                ),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = pr_review.command_record(self._record_args(state_dir, bad_path))
+            rejected = json.loads(output.getvalue())
+            self.assertEqual(code, 1)
+            self.assertIn("bogus-signal", rejected["error"])
+            self.assertIn("wrong-seam", rejected["allowed_signals"])
+
+            good_path = state_dir / "good.json"
+            good_path.write_text(
+                json.dumps(
+                    {"event_type": "review", "pr": 7, "head_sha": "h", "signals": ["wrong-seam"]}
+                ),
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                code = pr_review.command_record(self._record_args(state_dir, good_path))
+            self.assertEqual(code, 0)
+            self.assertTrue(json.loads(output.getvalue())["inserted"])
+
+    def test_analytics_groups_logins_case_insensitively(self) -> None:
+        events = [
+            {
+                "event_type": "review",
+                "timestamp": self._days_ago(2),
+                "event_id": "a",
+                "pr": 1,
+                "author": "Contrib",
+                "head_sha": "h1",
+            },
+            {
+                "event_type": "review",
+                "timestamp": self._days_ago(1),
+                "event_id": "b",
+                "pr": 2,
+                "author": "contrib",
+                "head_sha": "h2",
+            },
+        ]
+
+        model = pr_review.build_analytics_model(
+            events, days=None, author=None, min_prs=1, include_open=True
+        )
+        self.assertEqual(len(model["contributors"]), 1)
+        row = model["contributors"][0]
+        self.assertEqual(row["login"], "Contrib")
+        self.assertEqual(row["prs"], 2)
+
+    def test_make_packet_without_summary_has_null_contributor(self) -> None:
+        policy = pr_review.Policy({})
+        pr = {
+            "number": 1,
+            "state": "OPEN",
+            "author": {"login": "someone"},
+            "files": [{"path": "crates/engine/src/lib.rs"}],
+            "changedFiles": 1,
+        }
+        packet = pr_review.make_packet(pr, policy, "maintainer", "full", {})
+        self.assertIsNone(packet["contributor"])
+        self.assertNotIn("matched:standing_skip", packet["policy_trace"])
+        self.assertNotEqual(packet["recommendation"]["reason"], "contributor_standing_skip")
 
 
 if __name__ == "__main__":

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -944,6 +944,33 @@ class PrReviewTests(unittest.TestCase):
         self.assertEqual(row["login"], "Contrib")
         self.assertEqual(row["prs"], 2)
 
+    def test_analytics_tolerates_explicit_null_quality(self) -> None:
+        # A logged event can carry "quality": null (JSON round-trip or --force
+        # record); signal aggregation must treat it like an absent block.
+        events = [
+            {
+                "event_type": "quality_entry",
+                "timestamp": self._days_ago(2),
+                "event_id": "q1",
+                "author": "contrib",
+                "quality": None,
+            },
+            {
+                "event_type": "review",
+                "timestamp": self._days_ago(1),
+                "event_id": "r1",
+                "pr": 1,
+                "author": "contrib",
+                "head_sha": "h1",
+                "quality": None,
+            },
+        ]
+        model = pr_review.build_analytics_model(
+            events, days=None, author=None, min_prs=1, include_open=True
+        )
+        self.assertEqual(len(model["contributors"]), 1)
+        self.assertEqual(model["contributors"][0]["quality_signals"], {})
+
     def test_make_packet_without_summary_has_null_contributor(self) -> None:
         policy = pr_review.Policy({})
         pr = {


### PR DESCRIPTION
Rework scripts/pr_review.py around the JSONL event log as sole canonical
store and add an advisory contributor block to every packet and recommend
output: standing (private-overrides.json contributor_standing or derived
trusted), scrutiny (normal|elevated|maintainer_attention) with reasons,
windowed signal recurrence (60d, PR-attributed signals only), and
first-contribution detection. Only a standing override of 'skip' changes
advisory_action, ordered after hard_stop so safety wins.

record validates optional per-review 'signals' against
QUALITY_SIGNAL_WEIGHTS (single authority); all login grouping is
case-folded via fold_login across analytics, packets, and compact.
parse_diff sticky-comment classification requires the github-actions
author and rides on packets for engine-surface review evidence.

run_json now retries transient gh/GraphQL failures (3 attempts, backoff)
and surfaces gh's captured stderr on final failure — the expensive scan
query intermittently times out server-side and a single blip was killing
whole review sweeps.

Skills updated to consume the contributor block (pr-review-loop sweep
protocol, pr-contribution-handler standing gauge, review-impl parse-diff
evidence gate). 36/36 tests.
