### PR TITLE
fix(ai): dedup hidden-pool accounting overlap; discard rungs whose final candidate outlived the deadline

### DIFF
--- a/crates/phase-ai/src/deck_knowledge.rs
+++ b/crates/phase-ai/src/deck_knowledge.rs
@@ -172,12 +172,18 @@ pub fn unknown_hidden_pool(
     }
 
     // Decrement one per public-zone object and per pinned-known hidden object.
-    // `decrement` guards owner/token, so `known_ids` from any zone/player is
-    // safe to pass wholesale — only this player's non-token cards subtract.
+    // The owner/token guards below make `known_ids` from any zone/player safe
+    // to pass wholesale, and `seen` dedups the overlap: a one-shot-revealed
+    // card (`public_revealed_cards` never clears) that later reaches a public
+    // zone appears in BOTH iterators but must subtract only once.
+    let mut seen: HashSet<ObjectId> = HashSet::new();
     for object_id in public_account_object_ids(state, player)
         .into_iter()
         .chain(known_ids.iter().copied())
     {
+        if !seen.insert(object_id) {
+            continue;
+        }
         let Some(object) = state.objects.get(&object_id) else {
             continue;
         };
@@ -358,5 +364,35 @@ mod tests {
 
         let counts = known_remaining_deck_counts(&state, PlayerId(0));
         assert!(!counts.contains_key(&DeckCardKey::FaceName("Alpha".to_string())));
+    }
+
+    #[test]
+    fn pool_decrements_once_for_public_object_also_in_known_ids() {
+        let mut state = GameState::new_two_player(42);
+        state.deck_pools.push(PlayerDeckPool {
+            player: PlayerId(0),
+            current_main: std::sync::Arc::new(vec![deck_entry("Alpha", 2, None)]),
+            ..Default::default()
+        });
+
+        // A card revealed while hidden (one-shot reveals never clear) that has
+        // since moved to the public graveyard: present in BOTH the public
+        // account and `known_ids`. It must subtract exactly once, leaving one
+        // Alpha in the unknown pool.
+        let alpha = create_object(
+            &mut state,
+            CardId(40),
+            PlayerId(0),
+            "Alpha".to_string(),
+            Zone::Graveyard,
+        );
+        let known: HashSet<ObjectId> = [alpha].into_iter().collect();
+
+        let pool = unknown_hidden_pool(&state, PlayerId(0), &known);
+        assert_eq!(
+            pool.iter().filter(|face| face.name == "Alpha").count(),
+            1,
+            "overlapping public + known object must decrement the pool once, not twice"
+        );
     }
 }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1859,8 +1859,15 @@ fn score_candidates_core(
                 rung_scored.push((r.candidate.action.clone(), score));
             }
 
-            if completed {
-                best_scored = rung_scored; // deepest completed rung so far
+            // "Fully completed" also requires the deadline to be live after the
+            // LAST candidate: expiry mid-final-evaluation is invisible to the
+            // per-candidate entry check and would accept a rung whose tail score
+            // was truncated. Rung 0 stays exempt (atomic once entered — it is the
+            // no-regression floor, == origin/main's deadline collapse). Node-budget
+            // exhaustion deliberately does NOT discard: the deepest rung consuming
+            // its full `max_nodes` reproduces origin/main's single fixed-depth pass.
+            if completed && (iter_depth == 0 || !services.deadline.expired()) {
+                best_scored = rung_scored; // deepest fully-completed rung so far
             } else {
                 break;
             }


### PR DESCRIPTION
Review fixes from Gemini's pass on #4911 (the branch was already locked in the merge queue, so they ship here):

- **unknown_hidden_pool double-decrement**: an object present in both the public account and `known_ids` (`public_revealed_cards` never clears) subtracted its card face twice, violating card conservation in determinized sampling. Fixed with an in-loop `seen` dedup preserving deterministic iteration order; regression test `pool_decrements_once_for_public_object_also_in_known_ids`.
- **Iterative deepening rung acceptance**: deadline expiry during the LAST candidate of a rung was invisible to the per-candidate entry check, accepting a rung with a truncated tail score. Rung acceptance now requires a live deadline (rung 0 exempt — atomic no-regression floor). Node-budget exhaustion intentionally still accepts (origin/main single-pass parity); measurement mode uses `Deadline::none()`, so ai-gate baselines are unaffected.