### PR TITLE
fix(pwa): remove scryfall-images SW cache route that broke mana pips + card backs

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -256,31 +256,19 @@ export default defineConfig(({ mode }) => ({
               expiration: { maxEntries: 16 },
             },
           },
-          {
-            // Card imagery from Scryfall's CDNs. Image URLs are content-stable
-            // (upstream serves `max-age=31556952`), so CacheFirst is correct.
-            // `<img>` elements issue no-cors requests whose opaque responses
-            // Chrome pads to ~7MB each against origin quota; `fetchOptions`
-            // upgrades the SW-side fetch to CORS (Scryfall sends
-            // `access-control-allow-origin: *`), so cached entries count at
-            // true size. `credentials: "omit"` is required: crossorigin-less
-            // <img> requests carry `credentials: "include"`, which fetchOptions
-            // would otherwise inherit, and the CORS check hard-fails wildcard
-            // ACAO for credentialed requests — every Scryfall fetch would
-            // reject. This cache is also the offline card-image store that an
-            // explicit "download deck for offline" prefetch warms.
-            urlPattern: /^https:\/\/(cards|backs|svgs)\.scryfall\.io\//,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "scryfall-images",
-              fetchOptions: { mode: "cors", credentials: "omit" },
-              expiration: {
-                maxEntries: 4000,
-                maxAgeSeconds: 31536000,
-                purgeOnQuotaError: true,
-              },
-            },
-          },
+          // NOTE: Scryfall card imagery (cards/backs/svgs.scryfall.io) is
+          // intentionally NOT runtime-cached here. A CacheFirst rule forces the
+          // SW to re-fetch <img> requests in CORS mode (needed to avoid opaque-
+          // response quota padding), and that broke every mana pip and card
+          // back in production: edge-cached Scryfall variants (svgs/backs are
+          // served from the Cloudflare edge with `vary: Origin`) get handed to
+          // the SW's cors fetch without an `access-control-allow-origin` header,
+          // failing the CORS check. Plain no-cors <img> loading (opaque, no CORS
+          // check) is the long-standing, working behavior. Re-introducing an
+          // offline image cache requires first giving EVERY Scryfall <img> a
+          // consistent crossOrigin="anonymous" so page and SW never create
+          // colliding cache variants. See the #4822 (introduced) / #4855
+          // (credentials patch) incident before re-adding.
           {
             // Same-origin static imagery from public/ (battlefield art, nav
             // icons, logos). Not in the precache manifest — the default glob


### PR DESCRIPTION
The scryfall-images CacheFirst runtime route (added #4822) makes the service
worker re-fetch cards/backs/svgs.scryfall.io <img> requests in CORS mode.
svgs/backs are served from the Cloudflare edge (cf-cache-status: HIT, vary:
Origin); a no-cors <img> (no Origin header) can populate an edge variant lacking
access-control-allow-origin, which CF then hands to the SW's cors fetch — the
CORS check fails and every mana pip and card back fails to load in production.
The #4855 credentials: "omit" patch was necessary but insufficient (it only
covers wildcard-ACAO-with-credentials, not the ACAO-less edge variant).

Remove the route entirely, restoring pre-#4822 behavior where the SW never
intercepts Scryfall imagery: plain no-cors <img> loads (opaque, no CORS check),
as the app worked for its entire history. Offline card-image caching is dropped;
re-introducing it requires a consistent crossOrigin="anonymous" on every
Scryfall <img> so page and SW never create colliding cache variants.
