### PR TITLE
fix(parser): gate keyword statics on graveyard-card presence, distribute "the same is true for" (Cairn Wanderer)

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -25,7 +25,7 @@ use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, BasicLandType,
     CastingPermission, ChosenSubtypeKind, CommanderOwnership, ContinuousModification,
     CopiableValues, Duration, Effect, FilterProp, ManaContribution, ManaProduction, PlayerScope,
-    QuantityExpr, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+    QuantityExpr, QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::attribution::EffectRef;
 use crate::types::card_type::{
@@ -1932,6 +1932,229 @@ pub fn evaluate_layers(state: &mut GameState) {
     // Step 5: Clear dirty flag. A full evaluation satisfies any pending request
     // (Clean / EnteredObjects / Full).
     state.layers_dirty = LayersDirty::Clean;
+}
+
+/// CR 404 + CR 611.3a: Does a `TargetFilter` test membership of a specific
+/// `zone` (a `FilterProp::InZone { zone }`)? Recurses `Or`/`And`/`Not` compounds.
+fn target_filter_reads_zone(filter: &TargetFilter, zone: Zone) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed
+            .properties
+            .iter()
+            .any(|prop| matches!(prop, FilterProp::InZone { zone: z } if *z == zone)),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(|f| target_filter_reads_zone(f, zone))
+        }
+        TargetFilter::Not { filter } => target_filter_reads_zone(filter, zone),
+        _ => false,
+    }
+}
+
+/// CR 404 + CR 611.3a: Does a static-ability enabling CONDITION depend on which
+/// objects occupy `zone` — an `IsPresent` (or a negated/compound thereof) whose
+/// filter tests `FilterProp::InZone { zone }`? Tarmogoyf / Cairn Wanderer ("as
+/// long as a creature card with <keyword> is in a graveyard, ~ has <keyword>")
+/// are the canonical cases. Such a gate can flip when `zone` membership changes,
+/// so a zone move into/out of `zone` must re-evaluate layers.
+fn static_condition_reads_zone_membership(condition: &StaticCondition, zone: Zone) -> bool {
+    match condition {
+        StaticCondition::IsPresent { filter: Some(f) } => target_filter_reads_zone(f, zone),
+        // CR 404 + CR 611.3a: a count/threshold gate whose either operand reads a
+        // zone's card count — Threshold ("fewer than eight cards in your
+        // graveyard"), `GraveyardSize`, `ZoneCardCount { Graveyard }`, or an
+        // `ObjectCount` over a graveyard-scoped filter — flips when that zone's
+        // membership crosses the threshold, so a move into/out of `zone` must
+        // re-evaluate it too. Distinct from the `IsPresent` presence gate above.
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            quantity_expr_reads_zone(lhs, zone) || quantity_expr_reads_zone(rhs, zone)
+        }
+        StaticCondition::Not { condition } => {
+            static_condition_reads_zone_membership(condition, zone)
+        }
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => conditions
+            .iter()
+            .any(|c| static_condition_reads_zone_membership(c, zone)),
+        _ => false,
+    }
+}
+
+/// CR 404: Does a `ZoneRef` denote the game `zone`?
+fn zone_ref_denotes_zone(zone_ref: &crate::types::ability::ZoneRef, zone: Zone) -> bool {
+    use crate::types::ability::ZoneRef;
+    matches!(
+        (zone_ref, zone),
+        (ZoneRef::Graveyard, Zone::Graveyard)
+            | (ZoneRef::Exile, Zone::Exile)
+            | (ZoneRef::Library, Zone::Library)
+            | (ZoneRef::Hand, Zone::Hand)
+    )
+}
+
+/// CR 404 + CR 611.3a: Does a `QuantityExpr` read the card count / object
+/// population of `zone`? Mirrors the structural recursion of
+/// `crate::game::quantity::quantity_expr_uses_object_count` so composite/nested
+/// aggregates are classified through the same expression tree.
+fn quantity_expr_reads_zone(expr: &QuantityExpr, zone: Zone) -> bool {
+    match expr {
+        QuantityExpr::Fixed { .. } => false,
+        QuantityExpr::Ref { qty } => quantity_ref_reads_zone(qty, zone),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_expr_reads_zone(inner, zone),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(|e| quantity_expr_reads_zone(e, zone))
+        }
+        QuantityExpr::UpTo { max } => quantity_expr_reads_zone(max, zone),
+        QuantityExpr::Power { exponent, .. } => quantity_expr_reads_zone(exponent, zone),
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_reads_zone(left, zone) || quantity_expr_reads_zone(right, zone)
+        }
+    }
+}
+
+/// CR 404 + CR 611.3a: Leaf classification for `quantity_expr_reads_zone` — does
+/// a `QuantityRef` read the card count / object population of `zone`? EXHAUSTIVE
+/// and wildcard-free (mirroring `quantity_ref_uses_object_count`) so any future
+/// quantity reference that reads a zone must be classified intentionally rather
+/// than silently under-escalating a zone-membership gate.
+fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
+    use crate::types::ability::CardTypeSetSource;
+    match qty {
+        // Direct graveyard card count (CR 404). `player` scope is irrelevant to
+        // the zone identity — any player's graveyard is still the graveyard.
+        QuantityRef::GraveyardSize { .. } => zone == Zone::Graveyard,
+        // Zone-parameterized card counts.
+        QuantityRef::ZoneCardCount {
+            zone: zone_ref,
+            filter,
+            ..
+        } => {
+            zone_ref_denotes_zone(zone_ref, zone)
+                || filter
+                    .as_ref()
+                    .is_some_and(|f| target_filter_reads_zone(f, zone))
+        }
+        QuantityRef::TargetZoneCardCount { zone: zone_ref } => {
+            zone_ref_denotes_zone(zone_ref, zone)
+        }
+        // Filter-based object counts read `zone` iff their filter is zone-scoped
+        // (an `ObjectCount` filter can carry `FilterProp::InZone { zone }`).
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
+        | QuantityRef::Aggregate { filter, .. } => target_filter_reads_zone(filter, zone),
+        // Distinct card types read `zone` only when sourced from that zone's cards
+        // (Tarmogoyf: card types among cards in all graveyards).
+        QuantityRef::DistinctCardTypes { source } => match source {
+            CardTypeSetSource::Zone { zone: zone_ref, .. } => zone_ref_denotes_zone(zone_ref, zone),
+            CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::Objects { .. }
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
+        // Everything else reads player-level state, single-object state, battle-
+        // field-only population, history records, choices, or tracked sets — none
+        // depend on `zone` membership. Enumerated explicitly (no wildcard) so a
+        // future zone-reading variant is forced through this classification.
+        QuantityRef::HandSize { .. }
+        | QuantityRef::LifeTotal { .. }
+        | QuantityRef::LifeAboveStarting
+        | QuantityRef::StartingLifeTotal
+        | QuantityRef::UnspentMana { .. }
+        | QuantityRef::CountersOnObjects { .. }
+        | QuantityRef::ControlledByEachPlayer { .. }
+        | QuantityRef::Devotion { .. }
+        | QuantityRef::BasicLandTypeCount { .. }
+        | QuantityRef::PartySize { .. }
+        | QuantityRef::DistinctColorsAmongPermanents { .. }
+        | QuantityRef::DistinctCounterKindsAmong { .. }
+        | QuantityRef::EnteredThisTurn { .. }
+        | QuantityRef::CommanderManaValue { .. }
+        | QuantityRef::PlayerCount { .. }
+        | QuantityRef::CountersOn { .. }
+        | QuantityRef::PlayerCounter { .. }
+        | QuantityRef::TargetControllerCounter { .. }
+        | QuantityRef::Variable { .. }
+        | QuantityRef::Power { .. }
+        | QuantityRef::Intensity { .. }
+        | QuantityRef::Toughness { .. }
+        | QuantityRef::ObjectManaValue { .. }
+        | QuantityRef::TargetObjectManaValue { .. }
+        | QuantityRef::ObjectColorCount { .. }
+        | QuantityRef::ObjectNameWordCount { .. }
+        | QuantityRef::ObjectTypelineComponentCount { .. }
+        | QuantityRef::ManaSymbolsInManaCost { .. }
+        | QuantityRef::SelfManaValue
+        | QuantityRef::CardsExiledBySource
+        | QuantityRef::ExiledCardPower { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::FilteredTrackedSetSize { .. }
+        | QuantityRef::TrackedSetAggregate { .. }
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount
+        | QuantityRef::LifeLostThisTurn { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::EventContextAmount
+        | QuantityRef::AttachmentsOnLeavingObject { .. }
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::SpellsCastThisTurn { .. }
+        | QuantityRef::SacrificedThisTurn { .. }
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::LifeGainedThisTurn { .. }
+        | QuantityRef::CardsDrawnThisTurn { .. }
+        | QuantityRef::CardsDiscardedThisTurn { .. }
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::AdditionalCostPaymentCountFor { .. }
+        | QuantityRef::AttackedThisTurn { .. }
+        | QuantityRef::BattlefieldEntriesThisTurn { .. }
+        | QuantityRef::ChosenNumber
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::CostXPaid
+        | QuantityRef::CounterAddedThisTurn { .. }
+        | QuantityRef::DamageDealtThisTurn { .. }
+        | QuantityRef::DescendedThisTurn
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::KickerCount
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::ManaSpentToCast { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::SpellsCastThisGame { .. }
+        | QuantityRef::TimesCostPaidThisResolution
+        | QuantityRef::TokensCreatedThisTurn { .. }
+        | QuantityRef::TurnsTaken
+        | QuantityRef::VoteCount { .. }
+        | QuantityRef::ZoneChangeAggregateThisTurn { .. }
+        | QuantityRef::ZoneChangeCountThisTurn { .. } => false,
+    }
+}
+
+/// CR 611.3a: Is any ACTIVE static-ability continuous effect gated on membership
+/// of `zone`? Consulted at the zone-change seam (`zones::move_to_zone`) so a card
+/// entering or leaving `zone` re-evaluates layers ONLY when a matching gate is
+/// live. This keeps routine off-battlefield churn (deaths, mill, discard) cheap
+/// in the common case where no `zone`-membership-gated static exists. Scans the
+/// static-effect-source index — O(generators), not O(zone).
+pub(crate) fn any_active_static_reads_zone_membership(state: &GameState, zone: Zone) -> bool {
+    let mut found = false;
+    for_each_static_effect_source(state, |_state, obj| {
+        if found {
+            return;
+        }
+        if obj.static_definitions.iter_all().any(|def| {
+            def.mode == StaticMode::Continuous
+                && def
+                    .condition
+                    .as_ref()
+                    .is_some_and(|c| static_condition_reads_zone_membership(c, zone))
+        }) {
+            found = true;
+        }
+    });
+    found
 }
 
 /// Mark the layer system as requiring a FULL battlefield re-evaluation. The
@@ -7376,6 +7599,96 @@ mod tests {
 
         state.objects.get_mut(&aura).unwrap().attached_to = Some(artifact.into());
         assert!(!evaluate_condition(&state, &condition, PlayerId(0), aura));
+    }
+
+    /// CR 611.3a + CR 702: End-to-end runtime proof for the Cairn Wanderer
+    /// graveyard-keyword static (issue #4774). Drives the real layer pipeline
+    /// (`evaluate_layers` + `has_keyword`), not just the parsed AST: the
+    /// conditional grant `~ has Flying as long as a creature card with Flying is in
+    /// a graveyard` must apply ONLY while such a card is present, and must
+    /// re-evaluate as the graveyard changes. This fails on revert of the
+    /// graveyard-presence gate — the pre-fix `Unrecognized`→always-true condition
+    /// would keep Flying even with an empty graveyard.
+    #[test]
+    fn cairn_graveyard_keyword_static_grants_flying_only_while_flyer_in_graveyard() {
+        let mut state = setup();
+
+        let cairn = make_creature(&mut state, "Cairn Wanderer", 4, 4, PlayerId(0));
+        let gate = StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(TypedFilter::creature().properties(
+                vec![
+                    FilterProp::WithKeyword {
+                        value: Keyword::Flying,
+                    },
+                    FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    },
+                ],
+            ))),
+        };
+        let cairn_static = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }])
+            .condition(gate);
+        state
+            .objects
+            .get_mut(&cairn)
+            .unwrap()
+            .static_definitions
+            .push(cairn_static);
+
+        // Empty graveyard → gate unsatisfied → Cairn must NOT have Flying.
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert!(
+            !state
+                .objects
+                .get(&cairn)
+                .unwrap()
+                .has_keyword(&Keyword::Flying),
+            "no flying creature card in a graveyard → conditional grant must not apply"
+        );
+
+        // A flying creature CARD in a graveyard → gate satisfied → Cairn gains Flying.
+        let gy_flyer = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Storm Crow".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&gy_flyer).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types = obj.card_types.clone();
+            obj.base_keywords.push(Keyword::Flying);
+            obj.keywords.push(Keyword::Flying);
+        }
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert!(
+            state
+                .objects
+                .get(&cairn)
+                .unwrap()
+                .has_keyword(&Keyword::Flying),
+            "a flying creature card in a graveyard → conditional grant must apply"
+        );
+
+        // Remove it → gate unsatisfied again → grant falls away (CR 611.3a re-eval).
+        state.objects.get_mut(&gy_flyer).unwrap().zone = Zone::Exile;
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+        assert!(
+            !state
+                .objects
+                .get(&cairn)
+                .unwrap()
+                .has_keyword(&Keyword::Flying),
+            "removing the flyer from the graveyard must drop the conditional Flying grant"
+        );
     }
 
     /// CR 107.4 + CR 202.1 + CR 613.4c: Light from Within-style statics count

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -713,6 +713,21 @@ pub fn move_to_zone(
         crate::game::layers::mark_layers_full(state);
     }
 
+    // CR 404 + CR 611.3a: A card entering or leaving a graveyard changes
+    // graveyard population, which can flip a static condition gated on graveyard
+    // membership (Tarmogoyf, Cairn Wanderer: "as long as a creature card with
+    // <keyword> is in a graveyard, ~ has <keyword>"). The incremental layer path
+    // is battlefield-entry scoped and the hand/battlefield mark above does not
+    // cover graveyard moves (mill, discard, a death that lands in the graveyard),
+    // so re-evaluate layers on a graveyard membership change — but only when such
+    // a static is actually live, so routine graveyard churn stays cheap when no
+    // graveyard-gated static exists.
+    if (to == Zone::Graveyard || from == Zone::Graveyard)
+        && crate::game::layers::any_active_static_reads_zone_membership(state, Zone::Graveyard)
+    {
+        crate::game::layers::mark_layers_full(state);
+    }
+
     // CR 702.145c + CR 702.145f: Daybound/Nightbound permanents entering under
     // the opposite day/night designation transform immediately. Runs after
     // battlefield-entry bookkeeping but before the ZoneChanged event is emitted
@@ -1331,6 +1346,202 @@ mod tests {
         assert!(
             state.layers_dirty.is_dirty(),
             "hand-zone continuous effects must re-evaluate when a hand card departs"
+        );
+    }
+
+    /// CR 404 + CR 611.3a: PRODUCTION-PATH proof for the graveyard-gated static
+    /// invalidation seam (issue #4774). A flying creature card milled from the
+    /// library into a graveyard via the normal `move_to_zone` path — with NO
+    /// manual `mark_layers_full` — must dirty layers so Cairn Wanderer's "~ has
+    /// flying as long as a creature card with flying is in a graveyard"
+    /// re-evaluates and the grant applies. Library→Graveyard deliberately avoids
+    /// the pre-existing hand/battlefield invalidation, so this exercises the new
+    /// graveyard seam specifically; it fails on revert of that seam.
+    #[test]
+    fn graveyard_arrival_reevaluates_graveyard_gated_static_via_zone_move() {
+        let cairn_static = StaticDefinition::new(StaticMode::Continuous)
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }])
+            .condition(crate::types::ability::StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Creature).properties(vec![
+                        FilterProp::WithKeyword {
+                            value: Keyword::Flying,
+                        },
+                        FilterProp::InZone {
+                            zone: Zone::Graveyard,
+                        },
+                    ]),
+                )),
+            });
+
+        let mut state = setup();
+        let cairn = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cairn Wanderer".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&cairn).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+            o.static_definitions.push(cairn_static.clone());
+            o.base_static_definitions = Arc::new(vec![cairn_static]);
+        }
+
+        // A flying creature card in the library (to be milled into the graveyard).
+        let flyer = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Storm Crow".to_string(),
+            Zone::Library,
+        );
+        {
+            let o = state.objects.get_mut(&flyer).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+            o.base_keywords.push(Keyword::Flying);
+            o.keywords.push(Keyword::Flying);
+        }
+
+        // Baseline: empty graveyard → Cairn has no Flying; layers clean after eval.
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(!state.objects[&cairn].has_keyword(&Keyword::Flying));
+        assert!(!state.layers_dirty.is_dirty());
+
+        // PRODUCTION PATH: mill the flyer Library → Graveyard (no manual mark_full).
+        let mut events = Vec::new();
+        move_to_zone(&mut state, flyer, Zone::Graveyard, &mut events);
+
+        assert!(
+            state.layers_dirty.is_dirty(),
+            "a flying creature card entering a graveyard must dirty layers for Cairn's graveyard-gated static"
+        );
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            state.objects[&cairn].has_keyword(&Keyword::Flying),
+            "after the flyer reaches the graveyard via move_to_zone, Cairn gains Flying without a manual mark_full"
+        );
+    }
+
+    /// CR 404 + CR 611.3a: the graveyard invalidation is SCOPED — with no active
+    /// graveyard-membership-gated static, a card entering a graveyard must NOT
+    /// dirty layers, so routine graveyard churn (deaths, mill, discard) stays
+    /// cheap and this is not a blanket per-graveyard-move full re-eval.
+    #[test]
+    fn graveyard_arrival_does_not_dirty_layers_without_graveyard_gated_static() {
+        let mut state = setup();
+        let bear = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Grizzly Bears".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&bear).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+        }
+        let card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Storm Crow".to_string(),
+            Zone::Library,
+        );
+        {
+            let o = state.objects.get_mut(&card).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+        }
+
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(!state.layers_dirty.is_dirty());
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, card, Zone::Graveyard, &mut events);
+        assert!(
+            !state.layers_dirty.is_dirty(),
+            "graveyard arrival must NOT dirty layers when no graveyard-membership-gated static is active"
+        );
+    }
+
+    /// CR 404 + CR 611.3a: PRODUCTION-PATH proof that the graveyard invalidation
+    /// also covers COUNT/threshold gates, not just `IsPresent`. A static gated on
+    /// `QuantityComparison(GraveyardSize >= 1)` must re-evaluate when a card is
+    /// milled into the graveyard via the normal `move_to_zone` path (no manual
+    /// `mark_full`). Fails on revert of the `QuantityComparison`/`QuantityRef`
+    /// branch of the zone-read detector.
+    #[test]
+    fn graveyard_count_gated_static_reevaluates_via_zone_move() {
+        let count_static = StaticDefinition::new(StaticMode::Continuous)
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Trample,
+            }])
+            .condition(crate::types::ability::StaticCondition::QuantityComparison {
+                lhs: crate::types::ability::QuantityExpr::Ref {
+                    qty: crate::types::ability::QuantityRef::GraveyardSize {
+                        player: crate::types::ability::PlayerScope::Controller,
+                    },
+                },
+                comparator: crate::types::ability::Comparator::GE,
+                rhs: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+            });
+
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Graveyard-count source".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let o = state.objects.get_mut(&source).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+            o.static_definitions.push(count_static.clone());
+            o.base_static_definitions = Arc::new(vec![count_static]);
+        }
+        let card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Milled card".to_string(),
+            Zone::Library,
+        );
+        {
+            let o = state.objects.get_mut(&card).unwrap();
+            o.card_types.core_types.push(CoreType::Creature);
+            o.base_card_types = o.card_types.clone();
+        }
+
+        // Baseline: empty graveyard → count gate unsatisfied → no Trample.
+        crate::game::layers::mark_layers_full(&mut state);
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(!state.objects[&source].has_keyword(&Keyword::Trample));
+        assert!(!state.layers_dirty.is_dirty());
+
+        // Production path: mill a card Library → Graveyard (no manual mark_full).
+        let mut events = Vec::new();
+        move_to_zone(&mut state, card, Zone::Graveyard, &mut events);
+        assert!(
+            state.layers_dirty.is_dirty(),
+            "a card entering a graveyard must dirty layers for a GraveyardSize-count-gated static"
+        );
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            state.objects[&source].has_keyword(&Keyword::Trample),
+            "with one card in the graveyard the count gate is satisfied and the grant applies"
         );
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -27,7 +27,7 @@ use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
 use super::oracle_nom::bridge::{nom_on_lower, split_once_on_lower};
-use super::oracle_nom::condition::parse_inner_condition;
+use super::oracle_nom::condition::{parse_graveyard_keyword_grant_sentence, parse_inner_condition};
 use super::oracle_nom::primitives::parse_number as nom_parse_number;
 use super::oracle_nom::primitives::scan_contains;
 
@@ -51,9 +51,10 @@ use super::oracle_classifier::{
 use super::oracle_condition::parse_restriction_condition;
 use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_reduction};
 use super::oracle_dispatch::dispatch_line_nom;
+use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
     lower_effect_chain_ir, parse_effect_chain, parse_effect_chain_with_context,
-    try_parse_temporal_delayed_trigger_ability,
+    rewrite_condition_keyword, try_parse_temporal_delayed_trigger_ability,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
@@ -1233,6 +1234,91 @@ where
     }
 
     false
+}
+
+/// CR 611.3a + CR 702: Distribute a "The same is true for <keyword list>"
+/// continuation across a graveyard-keyword-gated static grant (Cairn Wanderer).
+///
+/// The modeled sentence "As long as a creature card with <kw> is in a graveyard,
+/// this creature has <kw>" parses to ONE gated `StaticDefinition` (grant
+/// `AddKeyword { kw }` gated on `IsPresent(<kw>-card in a graveyard)`). Each
+/// keyword in the trailing list clones that template, swapping BOTH the granted
+/// keyword and the gate condition's `WithKeyword`, so each keyword is granted
+/// independently — only while a creature card WITH that keyword is in a graveyard
+/// (CR 611.3a per-keyword conditional continuous static). This is the plain-
+/// `StaticDefinition` analogue of `attach_same_is_true_keywords` (which operates
+/// on the trigger path's `GenericEffect`), reusing the same keyword-list parser
+/// (`try_parse_same_is_true_continuation`) and keyword-rewrite building block
+/// (`rewrite_condition_keyword`) so it covers the whole class, not one card.
+///
+/// Returns `false` (leaving the line for the generic dispatch) when the modeled
+/// sentence, the keyword list, or the gated template cannot be recovered. Any
+/// continuation keyword that resolves to `Keyword::Unknown` (unqualified
+/// `protection` / `landwalk`) is emitted as an explicit `Unimplemented` residual
+/// rather than an inert `AddKeyword(Unknown)` static, so it stays a loud
+/// unsupported gap in coverage instead of silently reading as supported.
+fn push_graveyard_keyword_same_is_true_tail(
+    result: &mut ParsedAbilities,
+    line: &str,
+    lower: &str,
+) -> bool {
+    let Some((modeled_sentence, tail)) =
+        split_same_is_true_static_tail(line, lower, parse_graveyard_keyword_grant_sentence)
+    else {
+        return false;
+    };
+    // No cant-cast gate applies to a graveyard-keyword grant, so the raw-line /
+    // card-name gate params are None (matching the other non-cant-cast callers).
+    let mut statics =
+        parse_static_line_with_graveyard_keyword_continuation(modeled_sentence, None, None);
+    // The modeled sentence must yield exactly the gated keyword grant to clone.
+    let Some(template) = statics.first().cloned() else {
+        return false;
+    };
+    // CR 611.3a: only distribute a genuinely gated grant. If the modeled sentence
+    // ever parsed without its graveyard-presence condition, fall through to the
+    // generic path rather than cloning an UNGATED grant per keyword — that would
+    // reintroduce the unconditional over-grant this distribution exists to remove.
+    if template.condition.is_none() {
+        return false;
+    }
+    let Some(keywords) = try_parse_same_is_true_continuation(tail) else {
+        return false;
+    };
+    // CR 611.3a coverage-honesty: a continuation keyword that resolves to
+    // `Keyword::Unknown` (an unqualified `protection` / `landwalk` — those keyword
+    // abilities require a quality/subtype that a bare continuation clause does not
+    // supply) is NOT semantically modeled. Cloning it into an
+    // `AddKeyword(Keyword::Unknown(_))` static would still read as Continuous-mode
+    // "supported" in `game/coverage.rs` (which checks static mode + child
+    // grant-abilities/triggers, not the granted keyword's identity), letting the
+    // card become coverage-supported while that clause does nothing. Keep those as
+    // an explicit `Unimplemented` residual so they remain a loud unsupported gap.
+    let mut unqualified: Vec<String> = Vec::new();
+    for keyword in &keywords {
+        if let Keyword::Unknown(name) = keyword {
+            unqualified.push(name.clone());
+            continue;
+        }
+        let mut new_def = template.clone();
+        for modification in &mut new_def.modifications {
+            if let ContinuousModification::AddKeyword { keyword: kw } = modification {
+                *kw = keyword.clone();
+            }
+        }
+        if let Some(condition) = &mut new_def.condition {
+            rewrite_condition_keyword(condition, keyword);
+        }
+        statics.push(new_def);
+    }
+    result.statics.extend(statics);
+    if !unqualified.is_empty() {
+        result.abilities.push(make_unimplemented(&format!(
+            "the same is true for {}",
+            unqualified.join(", ")
+        )));
+    }
+    true
 }
 
 use crate::parser::oracle_ir::ast::ActivatedConstraintAst;
@@ -2428,6 +2514,15 @@ pub(crate) fn parse_oracle_ir(
         // Normalize card self-references for static parsing (replace card name with ~).
         let static_line = normalize_self_refs_for_static(&line, card_name);
         let static_line_lower = static_line.to_lowercase();
+        // CR 611.3a + CR 702: "As long as a creature card with <kw> is in a
+        // graveyard, this creature has <kw>. The same is true for <keyword list>."
+        // (Cairn Wanderer) — distribute the gated grant per keyword before the
+        // chosen/every-type same-is-true arms (which gap the tail) or the generic
+        // static path (which mis-tokenizes the keyword list) can claim the line.
+        if push_graveyard_keyword_same_is_true_tail(&mut result, &static_line, &static_line_lower) {
+            i += 1;
+            continue;
+        }
         if push_same_is_true_static_tail(
             &mut result,
             &static_line,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -17358,7 +17358,7 @@ fn rewrite_filter_keyword(filter: &mut TargetFilter, new_keyword: &Keyword) {
 }
 
 /// Swap the granted keyword inside a `StaticCondition` to `new_keyword`.
-fn rewrite_condition_keyword(condition: &mut StaticCondition, new_keyword: &Keyword) {
+pub(crate) fn rewrite_condition_keyword(condition: &mut StaticCondition, new_keyword: &Keyword) {
     match condition {
         StaticCondition::IsPresent {
             filter: Some(filter),

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -6345,7 +6345,7 @@ pub(super) fn parse_keyword_grant_list(input: &str) -> Option<(Vec<Keyword>, &st
 /// `GenericEffect` clause and clones its grant template once per keyword.
 /// Generalized over the whole evergreen-keyword vocabulary — covers every card
 /// of this "the same is true for …" class, not Odric alone.
-pub(super) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyword>> {
+pub(crate) fn try_parse_same_is_true_continuation(text: &str) -> Option<Vec<Keyword>> {
     let lower = text.to_lowercase();
     let (keywords, rest) = nom_on_lower(text, &lower, |i| {
         let (i, _) = tag("the same is true for ").parse(i)?;

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -135,6 +135,11 @@ fn parse_remaining_state_presence_conditions(input: &str) -> OracleResult<'_, St
         parse_there_exists_compound_zone_condition,
         parse_there_exists_condition,
         parse_subject_first_zone_count,
+        // CR 611.3a + CR 702: "a <type> card [with <keyword>] is in a graveyard"
+        // — graveyard-presence gate for conditional continuous statics
+        // (Tarmogoyf, Cairn Wanderer). Guarded by the "is in a graveyard"
+        // suffix, so it never mis-claims the other presence phrases above.
+        parse_card_in_graveyard,
     ))
     .parse(input)
 }
@@ -3158,6 +3163,89 @@ fn parse_creature_has_keyword(input: &str) -> OracleResult<'_, StaticCondition> 
             filter: Some(filter),
         },
     ))
+}
+
+/// CR 611.3a + CR 702: Parse "[a/an] <type-phrase> [with <keyword>] is in a
+/// graveyard" → `IsPresent` whose filter carries `FilterProp::InZone { zone:
+/// Graveyard }` (plus any `FilterProp::WithKeyword` the type phrase's "with
+/// <keyword>" clause supplies).
+///
+/// Graveyard-presence sibling of `parse_creature_has_keyword`: instead of a "has
+/// <keyword>" battlefield predicate, the subject's presence is checked in a
+/// graveyard. This is the gate half of a conditional continuous static (CR
+/// 611.3a) whose grant is a keyword ability (CR 702). Generalized over every
+/// type phrase `parse_type_phrase` recognizes and every keyword its "with
+/// <keyword>" suffix folds in, so it covers the whole class, not one card:
+///   - Tarmogoyf: "a land card is in a graveyard" (bare card-type gate)
+///   - Cairn Wanderer: "a creature card with flying is in a graveyard"
+///     (card-type + `WithKeyword { Flying }` gate)
+///
+/// In a graveyard every object is a card, so "creature card" / "land card" is the
+/// card-type filter — `parse_type_phrase` folds the informational " card" suffix
+/// and the "with <keyword>" suffix, so no bespoke keyword parsing is needed here.
+/// "in a graveyard" is controller-agnostic (any graveyard); no controller is
+/// injected. The `is in a graveyard` suffix is required, so this never mis-claims
+/// a bare "a creature card ..." presence phrase handled elsewhere.
+pub(crate) fn parse_card_in_graveyard(input: &str) -> OracleResult<'_, StaticCondition> {
+    // Optional leading article — `parse_type_phrase` also strips it, but guard it
+    // explicitly first to mirror `parse_creature_has_keyword`.
+    let (rest, _) = opt(parse_article).parse(input)?;
+    // `parse_type_phrase` consumes the type word, the informational " card"
+    // suffix, and any "with <keyword>" clause (folded into the filter as
+    // `FilterProp::WithKeyword`). The remainder begins at the presence predicate.
+    let (filter, remainder) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let (after, _) = (
+        opt(tag(" ")),
+        opt(alt((tag("is "), tag("are ")))),
+        tag("in "),
+        // CR 404: "a graveyard" (any player's graveyard) or "any graveyard" —
+        // require the article so an ungrammatical bare "in graveyard" or a
+        // dangling "graveyards" is not loosely claimed.
+        alt((tag("a graveyard"), tag("any graveyard"))),
+    )
+        .parse(remainder)?;
+    let filter = add_filter_property(
+        filter,
+        FilterProp::InZone {
+            zone: Zone::Graveyard,
+        },
+    );
+    Ok((
+        after,
+        StaticCondition::IsPresent {
+            filter: Some(filter),
+        },
+    ))
+}
+
+/// CR 611.3a + CR 702: Consume a full modeled graveyard-keyword grant sentence —
+/// "as long as <type> card [with <keyword>] is in a graveyard, this creature has
+/// <keyword>" — returning `()` on success. This is the sentence-boundary
+/// recognizer for a following "The same is true for <keyword list>" continuation
+/// (Cairn Wanderer). It reuses `parse_card_in_graveyard` for the gate half so it
+/// stays in lockstep with the condition grammar; the grant keyword itself is not
+/// captured here (the static distributor re-parses it from the resulting
+/// `StaticDefinition`), only the sentence extent matters. `input` is lowercased
+/// by the caller (`split_same_is_true_static_tail`).
+pub(crate) fn parse_graveyard_keyword_grant_sentence(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = tag("as long as ").parse(input)?;
+    let (input, _condition) = parse_card_in_graveyard(input)?;
+    let (input, _) = tag(", ").parse(input)?;
+    let (input, _) = alt((
+        tag("this creature has "),
+        tag("this permanent has "),
+        tag("~ has "),
+    ))
+    .parse(input)?;
+    let (input, _keyword) = parse_keyword_name(input)?;
+    let (input, _) = opt(tag(".")).parse(input)?;
+    Ok((input, ()))
 }
 
 fn add_filter_property(filter: TargetFilter, prop: FilterProp) -> TargetFilter {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5019,6 +5019,9 @@ fn static_enchanted_or_equipped_stays_unrecognized() {
 
 #[test]
 fn static_has_keyword_as_long_as() {
+    // CR 611.3a: "as long as a land card is in a graveyard" is a graveyard-presence
+    // gate — it must type to IsPresent(land card in a graveyard), never the
+    // always-true Unrecognized fallback (which would grant trample unconditionally).
     let def = parse_static_line("Tarmogoyf has trample as long as a land card is in a graveyard.")
         .unwrap();
     assert_eq!(def.mode, StaticMode::Continuous);
@@ -5027,10 +5030,71 @@ fn static_has_keyword_as_long_as() {
         .contains(&ContinuousModification::AddKeyword {
             keyword: Keyword::Trample,
         }));
-    assert!(matches!(
-        def.condition,
-        Some(StaticCondition::Unrecognized { .. })
-    ));
+    let filter = match &def.condition {
+        Some(StaticCondition::IsPresent {
+            filter: Some(filter),
+        }) => filter,
+        other => panic!("expected typed IsPresent graveyard gate, got {other:?}"),
+    };
+    match filter {
+        TargetFilter::Typed(typed) => {
+            assert!(
+                typed
+                    .type_filters
+                    .iter()
+                    .any(|type_filter| type_filter == &TypeFilter::Land),
+                "gate must carry the Land card-type filter, got {typed:?}"
+            );
+            assert!(
+                typed.properties.contains(&FilterProp::InZone {
+                    zone: Zone::Graveyard
+                }),
+                "gate must carry InZone(Graveyard), got {typed:?}"
+            );
+        }
+        other => panic!("expected a typed filter, got {other:?}"),
+    }
+}
+
+#[test]
+fn condition_card_with_keyword_in_graveyard_types_to_is_present() {
+    // CR 611.3a + CR 702: the graveyard-presence gate combinator — a per-keyword
+    // conditional-continuous gate (Cairn Wanderer's "a creature card with flying
+    // is in a graveyard"). Must carry BOTH the Creature card-type filter and the
+    // WithKeyword(Flying) predicate plus InZone(Graveyard), so the static grants
+    // its keyword ONLY while a matching card is in a graveyard.
+    let condition = parse_static_condition("a creature card with flying is in a graveyard")
+        .expect("graveyard-presence gate should parse");
+    let filter = match &condition {
+        StaticCondition::IsPresent {
+            filter: Some(filter),
+        } => filter,
+        other => panic!("expected typed IsPresent graveyard gate, got {other:?}"),
+    };
+    match filter {
+        TargetFilter::Typed(typed) => {
+            assert!(
+                typed
+                    .type_filters
+                    .iter()
+                    .any(|type_filter| type_filter == &TypeFilter::Creature),
+                "gate must carry the Creature card-type filter, got {typed:?}"
+            );
+            assert!(
+                typed.properties.contains(&FilterProp::WithKeyword {
+                    value: Keyword::Flying
+                }),
+                "gate must carry WithKeyword(Flying), got {typed:?}"
+            );
+            assert!(
+                typed.properties.contains(&FilterProp::InZone {
+                    zone: Zone::Graveyard
+                }),
+                "gate must carry InZone(Graveyard), got {typed:?}"
+            );
+        }
+        other => panic!("expected a typed filter, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -7941,6 +7941,132 @@ fn conditional_modal_max_reuses_static_condition_parser() {
 }
 
 #[test]
+fn cairn_wanderer_distributes_graveyard_keyword_gate_per_keyword() {
+    use crate::types::ability::{
+        ContinuousModification, Effect, FilterProp, StaticCondition, StaticDefinition,
+        TargetFilter, TypeFilter,
+    };
+    use crate::types::keywords::Keyword;
+    use crate::types::zones::Zone;
+
+    // CR 611.3a + CR 702: Cairn Wanderer grants each listed keyword ONLY while a
+    // creature card WITH that keyword is in a graveyard — an independent per-keyword
+    // conditional continuous static. The "The same is true for <list>" tail must
+    // distribute the modeled flying grant across every listed keyword, each with its
+    // OWN keyword swapped into both the grant and the graveyard-presence gate.
+    let r = parse(
+        "Changeling (This card is every creature type.)\nAs long as a creature card with flying is in a graveyard, this creature has flying. The same is true for fear, first strike, double strike, deathtouch, haste, landwalk, lifelink, protection, reach, trample, shroud, and vigilance.",
+        "Cairn Wanderer",
+        &[Keyword::Changeling],
+        &["Creature"],
+        &["Shapeshifter"],
+    );
+
+    // 11 gated grants: the modeled "flying" plus the 10 continuation keywords that
+    // resolve to a real Keyword. The unqualified `landwalk` / `protection` entries
+    // resolve to Keyword::Unknown (no quality/subtype to type) and are NOT cloned into
+    // inert statics — they surface as an explicit Unimplemented residual instead
+    // (coverage-honesty; asserted below), so the card is not falsely marked supported.
+    assert_eq!(
+        r.statics.len(),
+        11,
+        "expected one gated static per parameter-free keyword, got {:#?}",
+        r.statics
+    );
+
+    let grant_keyword = |def: &StaticDefinition| -> Option<Keyword> {
+        def.modifications.iter().find_map(|m| match m {
+            ContinuousModification::AddKeyword { keyword } => Some(keyword.clone()),
+            _ => None,
+        })
+    };
+    let gate_keyword = |def: &StaticDefinition| -> Option<Keyword> {
+        match def.condition.as_ref()? {
+            StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(typed)),
+            } => typed.properties.iter().find_map(|p| match p {
+                FilterProp::WithKeyword { value } => Some(value.clone()),
+                _ => None,
+            }),
+            _ => None,
+        }
+    };
+
+    // Spot-check the two the spec calls out: flying gates on flying, trample on
+    // trample — proving the gate keyword is swapped PER static, not left on flying.
+    for kw in [Keyword::Flying, Keyword::Trample] {
+        let def = r
+            .statics
+            .iter()
+            .find(|d| grant_keyword(d) == Some(kw.clone()))
+            .unwrap_or_else(|| panic!("no static granting {kw:?}"));
+        let StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(typed)),
+        } = def.condition.as_ref().expect("gated")
+        else {
+            panic!(
+                "expected typed IsPresent gate for {kw:?}, got {:?}",
+                def.condition
+            );
+        };
+        assert!(
+            typed
+                .type_filters
+                .iter()
+                .any(|t| t == &TypeFilter::Creature),
+            "{kw:?} gate must carry the Creature card-type filter"
+        );
+        assert!(
+            typed.properties.contains(&FilterProp::InZone {
+                zone: Zone::Graveyard
+            }),
+            "{kw:?} gate must carry InZone(Graveyard)"
+        );
+        assert_eq!(
+            gate_keyword(def),
+            Some(kw.clone()),
+            "{kw:?} grant must gate on a graveyard card with {kw:?} (per-keyword gate)"
+        );
+    }
+
+    // Every gated static grants exactly the keyword it gates on.
+    for def in &r.statics {
+        assert_eq!(
+            grant_keyword(def),
+            gate_keyword(def),
+            "each static's granted keyword must equal its gate keyword: {def:#?}"
+        );
+    }
+
+    // Coverage-honesty: NO static may grant Keyword::Unknown — an inert
+    // AddKeyword(Unknown) would still read as Continuous-mode "supported" in
+    // game/coverage.rs, letting the card be marked supported while a clause does
+    // nothing. The unqualified `landwalk` / `protection` continuation clauses must
+    // instead surface as an explicit Unimplemented residual (a loud unsupported gap).
+    for def in &r.statics {
+        assert!(
+            !matches!(grant_keyword(def), Some(Keyword::Unknown(_))),
+            "no gated static may grant Keyword::Unknown, got {def:#?}"
+        );
+    }
+    let residual = r
+        .abilities
+        .iter()
+        .find_map(|a| match &*a.effect {
+            Effect::Unimplemented {
+                description: Some(d),
+                ..
+            } => Some(d.to_lowercase()),
+            _ => None,
+        })
+        .expect("unqualified landwalk/protection must surface as an Unimplemented residual");
+    assert!(
+        residual.contains("landwalk") && residual.contains("protection"),
+        "the Unimplemented residual must name the unqualified keywords, got {residual:?}"
+    );
+}
+
+#[test]
 fn conditional_modal_max_supports_compound_presence_conditions() {
     let r = parse(
             "Choose one. If you control an artifact and an enchantment as you cast this spell, you may choose both instead.\n• Exile target creature or planeswalker.\n• Return target creature or planeswalker card from your graveyard to your hand.",


### PR DESCRIPTION
## Problem

Cairn Wanderer gains **every** listed keyword unconditionally, even with no matching creature card in any graveyard. Two compounding parser defects on the graveyard-keyword static:

1. **Gate-swallow.** "As long as a creature card with `<kw>` is in a graveyard, this creature has `<kw>`" had no combinator for the `<card> is in a graveyard` gate, so it fell to `StaticCondition::Unrecognized`, which evaluates as **always true** at runtime — the same gate-swallow class fixed for trailing "if" gates in #4841. The same bug made **Tarmogoyf** grant trample with no land card in any graveyard.
2. **Distributive-tail mis-tokenization.** The "The same is true for `<keyword list>`" continuation was not distributed per keyword.

## Fix (parser-only)

- **`parse_card_in_graveyard`** (`oracle_nom/condition.rs`): nom combinator, sibling of `parse_creature_has_keyword`, parsing "[a/an] `<type-phrase>` [with `<keyword>`] is in a graveyard" → `IsPresent(Typed + InZone{Graveyard} [+ WithKeyword])`. Covers the whole class — Tarmogoyf's bare card-type gate and Cairn's card-type + keyword gate.
- **`push_graveyard_keyword_same_is_true_tail`** (`oracle.rs`): distributes the "same is true for" list, cloning the gated static per keyword and swapping **both** the granted keyword and the gate's `WithKeyword`, so each keyword is granted only while a card with **that** keyword is in a graveyard (CR 611.3a per-keyword conditional continuous static). Plain-`StaticDefinition` analogue of the trigger path's `attach_same_is_true_keywords`, reusing `try_parse_same_is_true_continuation` and `rewrite_condition_keyword`.

- **Graveyard layer invalidation** (`game/zones.rs` + `game/layers.rs`): the zone-change seam only re-armed layers for battlefield/hand moves, so a graveyard membership change never re-evaluated a graveyard-gated static in production. Added a graveyard entry/exit invalidation gated on `any_active_static_reads_zone_membership(Graveyard)` (scans the static-effect-source index — O(generators)). The detector covers both `IsPresent(InZone{Graveyard})` presence gates **and** `QuantityComparison` count gates via an exhaustive, wildcard-free `QuantityExpr`/`QuantityRef` walk (`GraveyardSize`, `ZoneCardCount{Graveyard}`, graveyard-scoped `ObjectCount`/`Aggregate`, `DistinctCardTypes` from graveyard). Mill/deaths/discard stay cheap when no such static is live; layers re-evaluate only when a graveyard move can flip a live gate.

The one runtime addition is that graveyard invalidation; `IsPresent` + `FilterProp::InZone`/`WithKeyword` already evaluate the gate itself, and a card's printed keywords are visible in the graveyard.

## Anchored on
- `crates/engine/src/parser/oracle_nom/condition.rs:3116` — `parse_creature_has_keyword`: the sibling `OracleResult<StaticCondition>` combinator that runs `parse_type_phrase` then `add_filter_property(FilterProp::WithKeyword)` into an `IsPresent` gate. `parse_card_in_graveyard` mirrors it exactly, substituting the `is in a graveyard` predicate and `FilterProp::InZone{Graveyard}`, and is registered in the same condition `alt()` dispatcher (`parse_remaining_state_presence_conditions`), just as `parse_creature_has_keyword` is registered in `parse_control_conditions` (condition.rs:2779).
- `crates/engine/src/parser/oracle_effect/mod.rs:17379` — `attach_same_is_true_keywords`: the "same is true for" distributor that clones a template per keyword and swaps both the `AddKeyword` modification and the gate keyword via `rewrite_condition_keyword`. `push_graveyard_keyword_same_is_true_tail` is the plain-`StaticDefinition` analogue of this exact pattern and reuses the same `rewrite_condition_keyword` / `try_parse_same_is_true_continuation` building blocks.

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(no output; exit 0 — no combinator-purity violations)
```

## Tests

- `condition_card_with_keyword_in_graveyard_types_to_is_present` — the new gate types to `IsPresent(Creature + WithKeyword{Flying} + InZone{Graveyard})`.
- `static_has_keyword_as_long_as` — **tightened** from `Unrecognized` to the typed gate (Tarmogoyf no longer grants trample unconditionally).
- `cairn_wanderer_distributes_graveyard_keyword_gate_per_keyword` — full-dispatch: **11** gated statics (10 continuation + the modeled flying), each granting exactly the keyword it gates on (flying-gates-on-flying, trample-gates-on-trample); asserts **no** static grants `Keyword::Unknown` and that the unqualified `protection`/`landwalk` clauses surface as an `Effect::Unimplemented` residual.
- `cairn_graveyard_keyword_static_grants_flying_only_while_flyer_in_graveyard` (**runtime**, `game/layers.rs`) — drives `evaluate_layers` + `has_keyword`: empty graveyard → no Flying; a flying creature card in a graveyard → Cairn gains Flying; remove it → grant falls away. Fails on revert of the gate.
- `graveyard_arrival_reevaluates_graveyard_gated_static_via_zone_move` (**production path**, `game/zones.rs`) — mills a flying creature card Library→Graveyard via `move_to_zone` **with no manual `mark_full`**, then asserts layers are dirty and `evaluate_layers` grants Cairn Flying. Fails on revert of the zone-seam invalidation.
- `graveyard_arrival_does_not_dirty_layers_without_graveyard_gated_static` — proves the invalidation is scoped: no graveyard-gated static → milling a card does **not** dirty layers (no per-graveyard-move perf regression).
- `graveyard_count_gated_static_reevaluates_via_zone_move` (**production path**) — a `QuantityComparison(GraveyardSize >= 1)`-gated static grants its keyword after a card is milled into the graveyard via `move_to_zone`; fails on revert of the count-gate detector branch.

See **## Verification** below.

## Notes

Unqualified `protection` / `landwalk` in the list resolve to `Keyword::Unknown` via the shared `Keyword::from_str` (no quality/subtype to type). Rather than clone them into inert `AddKeyword(Unknown)` statics — which `game/coverage.rs` would read as Continuous-mode *supported*, falsely marking the card covered — they are emitted as an explicit `Effect::Unimplemented` residual (via the existing `make_unimplemented` helper, the same mechanism the chosen/every-type `same is true for` path uses), so they stay a loud unsupported gap. Typing generic `protection`/`landwalk` is a separate keyword-vocabulary change, left as a follow-up.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -p engine` — clean (`-D warnings`). Full-workspace `cargo clippy-strict` is not runnable in my sandbox (a non-engine binary target needs OpenSSL/`pkg-config`, unavailable, no sudo); CI **Rust lint (fmt, clippy, parser gate)** runs it green.
- `./scripts/check-parser-combinators.sh` — clean (exit 0, no violations) — see **## Gate A**
- `cargo test -p engine --lib -- parser:: game::layers:: game::zones::` — **7435 passed / 0 failed** (includes the Cairn runtime + graveyard presence/count invalidation production-path tests). The full sharded `cargo test -p engine` runs green in CI (**Rust tests 1/2 + 2/2**).
- Card-data / coverage / semantic-audit — the local pipeline needs an MTGJSON `AtomicCards.json` download unavailable in my sandbox; CI **Card data (generate, validate, coverage)** runs `gen-card-data` + `coverage` + the parser-honesty regression check green on this head. Honesty note: unqualified `protection` / `landwalk` are emitted as an explicit `Effect::Unimplemented` residual (see **## Notes**) so `coverage` marks them unsupported rather than the card reading as fully covered; the 11 parameter-typed keywords are gated and supported.

## CR

CR 611.3a (conditional continuous static, re-evaluated each moment) + CR 702 (keyword abilities) + CR 404 (graveyard zone). Verified against `docs/MagicCompRules.txt`.

Closes #4774

Tier: Frontier
Model: claude-opus-4-8
Thinking: high




