### PR TITLE
feat(scripts): gittensor contributor impact analysis

### DIFF
--- a/scripts/gittensor/contrib_infographic.py
+++ b/scripts/gittensor/contrib_infographic.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Render the gittensor contributor-impact infographic from contrib-stats.json.
+
+Emits a self-contained dark-mode SVG (stdlib only, mirroring
+plot-coverage-history.py) and rasterizes it to PNG with the first available of
+rsvg-convert / magick / inkscape. Designed as a weekly/monthly share to the
+gittensor subnet owners.
+
+Layout follows the repo's dataviz method:
+  * headline metrics are STAT TILES (each metric normalized to its own gittensor-
+    vs-non-gittensor share bar) — never one axis across different-scale measures;
+  * the area distribution is the one true bar chart (all values in code-lines),
+    drawn as 100%-stacked share bars so "where does each cohort work" reads
+    directly.
+Two CVD-validated categorical hues carry identity (blue = gittensor, aqua =
+non-gittensor); every mark is direct-labeled since a static image has no hover.
+
+Usage:
+    python3 scripts/gittensor/contrib_infographic.py [contrib-stats.json] [out.png]
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# ── Palette (dark; validated: worst adjacent CVD ΔE 15.7, both ≥3:1 on surface) ─
+SURFACE = "#1a1a19"
+PLANE = "#0d0d0d"
+INK = "#ffffff"
+INK2 = "#c3c2b7"
+MUTED = "#898781"
+GRID = "#2c2c2a"
+BORDER = "rgba(255,255,255,0.10)"
+GITTENSOR = "#3987e5"   # categorical slot 1 (blue)
+NONGT = "#199e70"       # categorical slot 2 (aqua)
+FONT = "system-ui, -apple-system, &quot;Segoe UI&quot;, sans-serif"
+
+W = 1200
+MARGIN = 60
+
+
+def esc(s: str) -> str:
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def commas(n: int) -> str:
+    return f"{n:,}"
+
+
+def compact(n: int) -> str:
+    """Abbreviated form (1.7M, 30.3k) so large LOC values fit a stat tile."""
+    a = abs(n)
+    if a < 1000:
+        return str(n)
+    if a < 1_000_000:
+        return f"{n / 1e3:.1f}k"
+    return f"{n / 1e6:.1f}M"
+
+
+class Svg:
+    def __init__(self) -> None:
+        self.parts: list[str] = []
+
+    def rect(self, x, y, w, h, fill, rx=0, stroke=None, sw=1):
+        s = f' stroke="{stroke}" stroke-width="{sw}"' if stroke else ""
+        self.parts.append(
+            f'<rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{h:.1f}" '
+            f'rx="{rx}" fill="{fill}"{s}/>')
+
+    def text(self, x, y, s, size, fill=INK, weight=400, anchor="start",
+             tabular=False):
+        tn = ' font-variant-numeric="tabular-nums"' if tabular else ""
+        self.parts.append(
+            f'<text x="{x:.1f}" y="{y:.1f}" font-family="{FONT}" '
+            f'font-size="{size}" font-weight="{weight}" fill="{fill}" '
+            f'text-anchor="{anchor}"{tn}>{esc(s)}</text>')
+
+    def svg(self, h: int) -> str:
+        body = "\n".join(self.parts)
+        return (f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" '
+                f'height="{h}" viewBox="0 0 {W} {h}">\n'
+                f'<rect width="{W}" height="{h}" fill="{PLANE}"/>\n{body}\n</svg>\n')
+
+
+def share_bar(svg: Svg, x, y, w, h, g_val, n_val):
+    """A single 100%-stacked bar: gittensor (blue) | 2px gap | non-gittensor (aqua)."""
+    total = g_val + n_val
+    if total <= 0:
+        svg.rect(x, y, w, h, GRID, rx=h / 2)
+        return 0.0
+    frac = g_val / total
+    gap = 2
+    gw = max(0.0, (w - gap) * frac)
+    nw = max(0.0, (w - gap) * (1 - frac))
+    svg.rect(x, y, w, h, GRID, rx=h / 2)                       # track
+    if gw > 0:
+        svg.rect(x, y, gw, h, GITTENSOR, rx=h / 2)
+    if nw > 0:
+        svg.rect(x + gw + gap, y, nw, h, NONGT, rx=h / 2)
+    return frac
+
+
+def stat_tile(svg: Svg, x, y, w, h, label, g_val, n_val, fmt=commas):
+    svg.rect(x, y, w, h, SURFACE, rx=10, stroke=BORDER)
+    pad = 18
+    svg.text(x + pad, y + 26, label.upper(), 12, MUTED, weight=600)
+    svg.text(x + pad, y + 62, fmt(g_val), 30, GITTENSOR, weight=700, tabular=True)
+    svg.text(x + pad, y + 86, "gittensor", 12, INK2)
+    svg.text(x + w - pad, y + 62, fmt(n_val), 30, NONGT, weight=700,
+             anchor="end", tabular=True)
+    svg.text(x + w - pad, y + 86, "non-gittensor", 12, INK2, anchor="end")
+    frac = share_bar(svg, x + pad, y + h - 34, w - 2 * pad, 10, g_val, n_val)
+    svg.text(x + pad, y + h - 12, f"{frac * 100:.0f}% gittensor", 11, MUTED)
+
+
+def render(d: dict) -> str:
+    g = d["groups"]["gittensor"]
+    n = d["groups"]["nongittensor"]
+    svg = Svg()
+
+    # Header
+    svg.text(MARGIN, 58, "Gittensor Contributor Impact", 34, INK, weight=700)
+    win = d.get("window", {})
+    span = win.get("since") or (win.get("first_commit") or "")[:10] or "all-time"
+    until = win.get("until") or "now"
+    sub = (f'{d.get("repo", "")}  ·  {span} → {until}  ·  '
+           f'{commas(d.get("total_commits", 0))} commits  ·  '
+           f'generated {d.get("generated_at", "")[:10]}')
+    svg.text(MARGIN, 86, sub, 14, MUTED)
+
+    # Legend
+    lx = W - MARGIN - 320
+    svg.rect(lx, 44, 12, 12, GITTENSOR, rx=3)
+    svg.text(lx + 20, 55, "gittensor", 13, INK2)
+    svg.rect(lx + 120, 44, 12, 12, NONGT, rx=3)
+    svg.text(lx + 140, 55, "non-gittensor", 13, INK2)
+
+    # Stat tiles
+    tiles = [
+        ("Contributors", g["contributors"], n["contributors"], commas),
+        ("Merged PRs", g["prs"], n["prs"], commas),
+        ("Code churn", g["code_churn"], n["code_churn"], compact),
+        ("Code net LOC", g["code_additions"] - g["code_deletions"],
+         n["code_additions"] - n["code_deletions"], compact),
+    ]
+    ty = 112
+    th = 150
+    gap = 24
+    tw = (W - 2 * MARGIN - gap * (len(tiles) - 1)) / len(tiles)
+    for i, (label, gv, nv, fmt) in enumerate(tiles):
+        stat_tile(svg, MARGIN + i * (tw + gap), ty, tw, th, label, gv, nv, fmt)
+
+    # Area distribution — 100%-stacked share bars, sorted by gittensor share
+    ay = ty + th + 48
+    svg.text(MARGIN, ay, "Where each cohort works", 20, INK, weight=700)
+    svg.text(MARGIN, ay + 22, "Share of code-only lines changed per repo area "
+             "(excludes generated & card data)", 13, MUTED)
+    areas = sorted(set(g["areas"]) | set(n["areas"]),
+                   key=lambda a: -(g["areas"].get(a, 0) + n["areas"].get(a, 0)))
+    label_col = 130
+    pct_col = 128
+    bar_x = MARGIN + label_col
+    bar_w = W - MARGIN - bar_x - pct_col
+    row_h = 30
+    by = ay + 48
+    for a in areas[:9]:
+        gv, nv = g["areas"].get(a, 0), n["areas"].get(a, 0)
+        cy = by + row_h / 2
+        svg.text(bar_x - 14, cy + 4, a, 13, INK2, anchor="end")
+        frac = share_bar(svg, bar_x, by + 5, bar_w, row_h - 12, gv, nv)
+        svg.text(W - MARGIN, cy + 4, f"{frac * 100:.0f}%  ·  {commas(gv + nv)} ln",
+                 12, MUTED, anchor="end", tabular=True)
+        by += row_h
+
+    # Footer
+    fy = by + 34
+    svg.rect(MARGIN, fy - 20, W - 2 * MARGIN, 1, GRID)
+    ref = f'{d.get("ref", "")} @ {d.get("ref_sha", "")[:10]}'
+    note = "" if not d.get("pr_limit_hit") else "  ·  ⚠ PR limit hit"
+    svg.text(MARGIN, fy, f"ref {ref}{note}", 12, MUTED)
+    unclassified = len(d.get("unclassified", []))
+    if unclassified:
+        svg.text(W - MARGIN, fy, f"{unclassified} unclassified contributor(s) — "
+                 f"run contrib_stats.py --triage", 12, MUTED, anchor="end")
+    return svg.svg(int(fy + 30))
+
+
+def rasterize(svg_path: Path, out: Path) -> bool:
+    if rc := shutil.which("rsvg-convert"):
+        subprocess.run([rc, "-o", str(out), str(svg_path)], check=True)
+    elif mg := shutil.which("magick"):
+        subprocess.run([mg, str(svg_path), str(out)], check=True)
+    elif ik := shutil.which("inkscape"):
+        subprocess.run([ik, str(svg_path), "--export-filename", str(out)], check=True)
+    else:
+        return False
+    return True
+
+
+def main() -> None:
+    src = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("contrib-stats.json")
+    out = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("contrib-infographic.png")
+    data = json.loads(src.read_text())
+    svg = render(data)
+
+    svg_path = out.with_suffix(".svg")
+    svg_path.write_text(svg)
+    if out.suffix.lower() == ".svg":
+        print(f"Wrote {svg_path}")
+        return
+    if rasterize(svg_path, out):
+        print(f"Wrote {out} (and {svg_path})")
+    else:
+        print(f"Wrote {svg_path} (no rasterizer found for {out.suffix})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gittensor/contrib_stats.py
+++ b/scripts/gittensor/contrib_stats.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Gittensor contributor impact analysis for phase.rs.
+
+Splits the repository's contributions into two cohorts — gittensor miners vs.
+everyone else (core team + outside collaborators) — and computes comparative
+statistics for a recurring update to the gittensor subnet owners.
+
+Attribution model (why this is trustworthy)
+--------------------------------------------
+This is *adversarial* attribution: the cohort being measured is paid, and git
+author name/email are attacker-controlled (a miner can commit as
+`matt.evans.dev@gmail.com` and it survives squash-merge). So identity is derived
+from an unspoofable source wherever possible:
+
+  * The repo squash-merges through a merge queue, so every commit on the measured
+    ref carries `(#N)` in its subject. We join `N -> gh pr list -> author.login`,
+    a GitHub-authenticated identity that cannot be forged in a commit.
+  * Only for rare direct pushes (no `(#N)`) do we fall back to email-based
+    coalescing via the whitelist. Display-name matching is intentionally NOT a
+    resolution path — it is the easiest field to spoof.
+
+The whitelist (scripts/contributors.toml) then maps each login to a group.
+
+Data sources
+------------
+* `git log --numstat` on the measured ref -> commits, code LOC, area mix, churn.
+* `gh pr list` -> the N->login map (complete via the API, independent of the
+  local clone's depth).
+
+LOC is reported twice: gross (everything) and code-only (excluding generated &
+data files: data/, lockfiles, *.d.ts, fixtures/*.json, node_modules) so a cohort
+touching the 93 MB card database can't dwarf one writing hand-authored code.
+
+Requires FULL history: a shallow clone's graft-boundary commit dumps the entire
+tree as one author's additions, so the tool refuses to run on one.
+
+Usage
+-----
+    python3 scripts/gittensor/contrib_stats.py                       # origin/main, all-time
+    python3 scripts/gittensor/contrib_stats.py --since 2026-06-01    # windowed
+    python3 scripts/gittensor/contrib_stats.py --ref v1.2.3 --triage # list unclassified
+    python3 scripts/gittensor/contrib_stats.py --repo-dir ~/phase-analysis   # full clone
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+VALID_GROUPS = {"gittensor", "nongittensor", "bot"}
+
+# ── Repo-area bucketing (first matching prefix wins) ─────────────────────────
+# Only applied to non-generated paths, so data/ never reaches here.
+AREA_RULES: list[tuple[str, str]] = [
+    ("crates/engine/src/parser", "Parser"),
+    ("crates/engine", "Engine"),
+    ("crates/phase-ai", "AI"),
+    ("crates/phase-server", "Server"),
+    ("crates/server-core", "Server"),
+    ("crates/lobby-broker", "Server"),
+    ("crates/seat-reducer", "Server"),
+    ("crates/engine-wasm", "WASM"),
+    ("crates/draft-wasm", "WASM"),
+    ("crates/", "Other crates"),
+    ("client/src-tauri", "Desktop"),
+    ("client/", "Frontend"),
+    ("mtgish/", "mtgish"),
+    ("scripts/", "Tooling"),
+    ("docs/", "Docs"),
+    (".claude/", "Agent tooling"),
+    (".agents/", "Agent tooling"),
+    ("deploy/", "Infra"),
+    ("docker/", "Infra"),
+    ("supabase/", "Infra"),
+    ("lobby-worker/", "Infra"),
+]
+
+
+def area_of(path: str) -> str:
+    for prefix, area in AREA_RULES:
+        if path.startswith(prefix):
+            return area
+    return "Other"
+
+
+# ── Generated / non-code files (excluded from the code-only metric) ──────────
+_GEN_SUFFIXES = (".lock", ".d.ts", ".min.js", ".min.css", ".wasm", ".map", ".snap")
+_GEN_NAMES = {
+    "card-data.json", "card-data.json.new", "coverage-data.json",
+    "coverage-history.json", "coverage-summary.json", "pnpm-lock.yaml",
+    "package-lock.json", "yarn.lock",
+}
+
+
+def is_generated(path: str) -> bool:
+    p = path.lower()
+    if p.startswith("data/") or "node_modules/" in p:
+        return True
+    if p.endswith(_GEN_SUFFIXES):
+        return True
+    if p.rsplit("/", 1)[-1] in _GEN_NAMES:
+        return True
+    if "fixtures/" in p and p.endswith(".json"):
+        return True
+    return False
+
+
+# ── Whitelist / identity resolution ──────────────────────────────────────────
+# GitHub noreply email -> login. Logins are [A-Za-z0-9-]; `[^@+]+` keeps a
+# spreadsheet-mangled numeric id (e.g. "6.60056e+06+Whovencroft@...") from being
+# swallowed as the login by the plain form.
+_NOREPLY_ID = re.compile(r"^\d+\+([A-Za-z0-9-]+)@users\.noreply\.github\.com$")
+_NOREPLY_PLAIN = re.compile(r"^([^@+]+)@users\.noreply\.github\.com$")
+_PR_NUM = re.compile(r"\(#(\d+)\)")
+
+
+class Whitelist:
+    """Maps a GitHub login (primary) or a git email (fallback) to a group."""
+
+    def __init__(self, path: Path):
+        data = tomllib.loads(path.read_text())
+        self.group_of: dict[str, str] = {}        # canonical login -> group
+        self.email_to_login: dict[str, str] = {}  # alias email     -> canonical login
+        self.login_alias: dict[str, str] = {}     # any login       -> canonical login
+        seen_emails: dict[str, str] = {}
+        for entry in data.get("contributor", []):
+            login = entry["login"].lower()
+            group = entry["group"]
+            if group not in VALID_GROUPS:
+                raise SystemExit(
+                    f"{path}: contributor '{login}' has invalid group '{group}' "
+                    f"(must be one of {sorted(VALID_GROUPS)})")
+            self.group_of[login] = group
+            self.login_alias[login] = login
+            for alias in entry.get("aliases", []):
+                a = alias.lower()
+                if "@" in a:
+                    if a in seen_emails and seen_emails[a] != login:
+                        raise SystemExit(
+                            f"{path}: email alias '{a}' is claimed by both "
+                            f"'{seen_emails[a]}' and '{login}' — a shared email "
+                            f"must belong to exactly one contributor.")
+                    seen_emails[a] = login
+                    self.email_to_login[a] = login
+                else:
+                    self.login_alias[a] = login
+
+    def by_login(self, login: str) -> tuple[str, str]:
+        """Primary path: resolve a GitHub PR-author login to (canon, group)."""
+        canon = self.login_alias.get(login.lower(), login.lower())
+        return canon, self.group_of.get(canon, "unclassified")
+
+    def by_commit(self, name: str, email: str) -> tuple[str, str]:
+        """Fallback path (direct pushes only): resolve git (name, email).
+
+        Name is deliberately not consulted — it is the easiest field to spoof.
+        """
+        email_l = email.lower()
+        if email_l in self.email_to_login:
+            return self.by_login(self.email_to_login[email_l])
+        for rx in (_NOREPLY_ID, _NOREPLY_PLAIN):
+            m = rx.match(email_l)
+            if m:
+                return self.by_login(m.group(1))
+        return email_l or name.lower(), "unclassified"  # key by email for triage
+
+
+# ── git / gh helpers ─────────────────────────────────────────────────────────
+def run(cmd: list[str]) -> str:
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        sys.stderr.write(f"command failed: {' '.join(cmd)}\n{res.stderr}\n")
+        sys.exit(1)
+    return res.stdout
+
+
+def git(repo: Path, *args: str) -> str:
+    return run(["git", "-C", str(repo), *args])
+
+
+def pr_login_map(repo_slug: str, limit: int) -> tuple[dict[int, dict], bool]:
+    """N -> {login, is_bot} for merged PRs, straight from the GitHub API."""
+    out = run(["gh", "pr", "list", "--repo", repo_slug, "--state", "merged",
+               "--limit", str(limit), "--json", "number,author"])
+    prs = json.loads(out)
+    m: dict[int, dict] = {}
+    for pr in prs:
+        author = pr.get("author") or {}
+        m[pr["number"]] = {"login": author.get("login", ""),
+                           "is_bot": author.get("is_bot", False)}
+    return m, len(prs) >= limit
+
+
+# ── commit walk (unified attribution) ────────────────────────────────────────
+REC, US = "\x00", "\x1f"                       # emitted by git's %x00 / %x1f
+FMT = "%x00%H%x1f%an%x1f%ae%x1f%at%x1f%s"       # sha, name, email, unixtime, subject
+
+
+def walk(repo: Path, ref: str, since: str | None, until: str | None,
+         prmap: dict[int, dict], wl: Whitelist):
+    cmd = ["log", ref, "--no-merges", "--no-renames", "--numstat", f"--format={FMT}"]
+    if since:
+        cmd.append(f"--since={since}")
+    if until:
+        cmd.append(f"--until={until}")
+
+    def blank():
+        return {"group": "unclassified", "name": "", "login": "", "commits": 0,
+                "code_commits": 0, "prs": 0, "additions": 0, "deletions": 0,
+                "code_additions": 0, "code_deletions": 0, "files": 0,
+                "areas": defaultdict(int)}
+
+    stats: dict[str, dict] = defaultdict(blank)
+    first = last = None
+    cur = None
+    cur_has_code = False
+
+    for line in git(repo, *cmd).splitlines():
+        if line.startswith(REC):
+            if cur is not None and cur_has_code:
+                cur["code_commits"] += 1
+            _sha, name, email, ts, subject = line[1:].split(US, 4)
+            nums = _PR_NUM.findall(subject)
+            pr = prmap.get(int(nums[-1])) if nums else None
+            if pr:
+                login = wl.login_alias.get(pr["login"].lower(), pr["login"].lower())
+                group = "bot" if pr["is_bot"] else wl.group_of.get(login, "unclassified")
+            else:
+                login, group = wl.by_commit(name, email)
+            s = stats[login]
+            s["group"] = group
+            s["login"] = login
+            if not s["name"]:
+                s["name"] = name
+            s["commits"] += 1
+            if pr:
+                s["prs"] += 1
+            cur, cur_has_code = s, False
+            t = int(ts)
+            first = t if first is None else min(first, t)
+            last = t if last is None else max(last, t)
+        elif line.strip() and cur is not None:
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            adds, dels, path = parts
+            a = 0 if adds == "-" else int(adds)
+            d = 0 if dels == "-" else int(dels)
+            cur["additions"] += a
+            cur["deletions"] += d
+            cur["files"] += 1
+            if not is_generated(path):
+                cur["code_additions"] += a
+                cur["code_deletions"] += d
+                cur["areas"][area_of(path)] += a + d
+                cur_has_code = True
+    if cur is not None and cur_has_code:
+        cur["code_commits"] += 1
+    return stats, first, last
+
+
+# ── aggregation & output ─────────────────────────────────────────────────────
+def blank_group() -> dict:
+    return {"contributors": 0, "logins": [], "commits": 0, "code_commits": 0,
+            "prs": 0, "additions": 0, "deletions": 0, "code_additions": 0,
+            "code_deletions": 0, "code_churn": 0, "files_touched": 0,
+            "areas": defaultdict(int)}
+
+
+def iso(ts: int | None) -> str | None:
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat() if ts else None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ref", default="origin/main", help="git ref to measure")
+    ap.add_argument("--repo-dir", type=Path, help="full clone to analyze "
+                    "(default: this repo; must not be shallow)")
+    ap.add_argument("--repo", help="owner/name for gh (default: auto-detect)")
+    ap.add_argument("--since", help="git date, e.g. 2026-06-01 or '30 days ago'")
+    ap.add_argument("--until", help="git date")
+    ap.add_argument("--whitelist", type=Path,
+                    default=Path(__file__).with_name("contributors.toml"))
+    ap.add_argument("-o", "--out", default="contrib-stats.json", type=Path)
+    ap.add_argument("--pr-limit", type=int, default=6000)
+    ap.add_argument("--allow-shallow", action="store_true",
+                    help="bypass the shallow-clone guard (numbers will be wrong)")
+    ap.add_argument("--triage", action="store_true",
+                    help="print unclassified contributors and exit")
+    args = ap.parse_args()
+
+    repo = args.repo_dir or Path(git(Path.cwd(), "rev-parse", "--show-toplevel").strip())
+    if not args.allow_shallow and \
+            git(repo, "rev-parse", "--is-shallow-repository").strip() == "true":
+        sys.exit(
+            f"ERROR: {repo} is a SHALLOW clone — a graft-boundary commit would\n"
+            f"attribute the entire tree to one author. Get full history first:\n"
+            f"  git -C {repo} fetch --unshallow\n"
+            f"or point --repo-dir at a full clone. (--allow-shallow to override.)")
+    sha = git(repo, "rev-parse", args.ref).strip()
+    slug = args.repo or run(["gh", "repo", "view", "--json", "nameWithOwner",
+                             "-q", ".nameWithOwner"]).strip()
+
+    wl = Whitelist(args.whitelist)
+    prmap, capped = pr_login_map(slug, args.pr_limit)
+    stats, first, last = walk(repo, args.ref, args.since, args.until, prmap, wl)
+
+    if args.triage:
+        rows = sorted(((k, v) for k, v in stats.items() if v["group"] == "unclassified"),
+                      key=lambda kv: -kv[1]["commits"])
+        if not rows:
+            print("No unclassified contributors for this ref/window.")
+            return
+        print(f"{'commits':>8} {'prs':>4}  {'name':<26}  triage-key")
+        print("-" * 72)
+        for key, v in rows:
+            print(f"{v['commits']:>8} {v['prs']:>4}  {v['name'][:26]:<26}  {key}")
+        print(f"\n{len(rows)} unclassified. Add to {args.whitelist} and re-run.")
+        return
+
+    groups = {"gittensor": blank_group(), "nongittensor": blank_group()}
+    bots = {"commits": 0, "prs": 0}
+    unclassified: list[dict] = []
+    per_contributor: dict[str, dict] = {}
+
+    for login, s in stats.items():
+        g = s["group"]
+        per_contributor[login] = {
+            "group": g, "name": s["name"], "commits": s["commits"],
+            "code_commits": s["code_commits"], "prs": s["prs"],
+            "code_net": s["code_additions"] - s["code_deletions"],
+            "code_churn": s["code_additions"] + s["code_deletions"]}
+        if g == "bot":
+            bots["commits"] += s["commits"]
+            bots["prs"] += s["prs"]
+            continue
+        if g == "unclassified":
+            unclassified.append({"key": login, "name": s["name"],
+                                 "commits": s["commits"], "prs": s["prs"]})
+            continue
+        gr = groups[g]
+        gr["contributors"] += 1
+        gr["logins"].append(login)
+        for k in ("commits", "code_commits", "prs", "additions", "deletions",
+                  "code_additions", "code_deletions"):
+            gr[k] += s[k]
+        gr["files_touched"] += s["files"]
+        for area, n in s["areas"].items():
+            gr["areas"][area] += n
+
+    for gr in groups.values():
+        gr["code_churn"] = gr["code_additions"] + gr["code_deletions"]
+        gr["logins"].sort()
+        gr["areas"] = dict(sorted(gr["areas"].items(), key=lambda kv: -kv[1]))
+    unclassified.sort(key=lambda r: -r["commits"])
+
+    result = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "repo": slug,
+        "ref": args.ref,
+        "ref_sha": sha,
+        "window": {"since": args.since, "until": args.until,
+                   "first_commit": iso(first), "last_commit": iso(last)},
+        "total_commits": sum(s["commits"] for s in stats.values()),
+        "pr_limit_hit": capped,
+        "groups": groups,
+        "bots": bots,
+        "unclassified": unclassified,
+        "per_contributor": per_contributor,
+    }
+    args.out.write_text(json.dumps(result, indent=2))
+
+    g, n = groups["gittensor"], groups["nongittensor"]
+    def row(label, key):
+        return f"{label:>16}{g[key]:>14}{n[key]:>16}\n"
+    sys.stderr.write(
+        f"\n{slug} @ {args.ref} ({sha[:10]})  "
+        f"window: {args.since or 'all'} .. {args.until or 'now'}\n"
+        f"{'':>16}{'gittensor':>14}{'non-gittensor':>16}\n"
+        + row("contributors", "contributors") + row("commits", "commits")
+        + row("code commits", "code_commits") + row("merged PRs", "prs")
+        + row("code churn", "code_churn")
+        + f"{'code net LOC':>16}{g['code_additions'] - g['code_deletions']:>14}"
+        f"{n['code_additions'] - n['code_deletions']:>16}\n"
+        f"{'unclassified':>16}{len(unclassified):>14} (run --triage)\n\n"
+        f"Wrote {args.out}\n")
+    if capped:
+        sys.stderr.write(f"WARNING: hit --pr-limit={args.pr_limit}; raise it.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gittensor/contributors.toml
+++ b/scripts/gittensor/contributors.toml
@@ -1,0 +1,386 @@
+# Contributor classification whitelist for gittensor impact analysis.
+# =====================================================================
+# Consumed by scripts/contrib_stats.py to split the repo's contributions
+# into two cohorts and compare them:
+#
+#   group = "gittensor"     external gittensor miners
+#   group = "nongittensor"  core team + outside/institutional collaborators
+#   group = "bot"           automation (excluded from the comparison entirely)
+#
+# HOW COALESCING WORKS
+# --------------------
+# The canonical identity is the GitHub `login`. A single person appears under
+# many git author lines (renamed accounts, multiple emails, sock puppets), so:
+#
+#   * GitHub noreply emails of the form  <id>+<login>@users.noreply.github.com
+#     auto-resolve to their `login` with NO manual alias needed. A display-name
+#     change on the same account (e.g. "kpdev" -> "kiannidev") coalesces for free.
+#
+#   * Any OTHER git email (a vanity gmail/outlook/proton address, or a mangled
+#     noreply) must be listed in `aliases` so it folds into the right login.
+#
+#   * `aliases` may also list a *different* login to fold sock-puppet accounts
+#     that share a person into one canonical entry.
+#
+# Matching is case-insensitive. Order of resolution: alias-email -> noreply
+# login -> alias-login. Anything unmatched is reported as "unclassified" by
+# `contrib_stats.py --triage` so you can add it here before the next run.
+#
+# TO RECLASSIFY: move an entry between groups, or add a new [[contributor]]
+# block. This file is the single source of truth — re-run the tool afterward.
+
+# ── Non-gittensor: core team & outside/institutional collaborators ───────────
+
+[[contributor]]
+login = "matthewevans"          # project owner
+group = "nongittensor"
+aliases = ["matt.evans.dev@gmail.com"]
+
+[[contributor]]
+login = "lgray"                 # Lindsey Gray (fnal.gov)
+group = "nongittensor"
+aliases = ["lindsey.gray@gmail.com", "lagray@fnal.gov"]
+
+[[contributor]]
+login = "ntindle"               # Nicholas Tindle (agpt.co)
+group = "nongittensor"
+aliases = ["nicholas.tindle@agpt.co", "nicktindle@outlook.com"]
+
+[[contributor]]
+login = "bruno-branco-brito"    # Accenture
+group = "nongittensor"
+aliases = ["bruno.b.brito@accenture.com", "bbbrito@stuff.com"]
+
+[[contributor]]
+login = "bartlomiejszczotka"    # Bartłomiej Szczotka (Accenture / Sainsbury's)
+group = "nongittensor"
+aliases = ["bartlomiej.szczotka@accenture.com", "szczotka.bartlomiej@gmail.com", "bartlomiej.szczotka@sainsburys.co.uk"]
+
+[[contributor]]
+login = "sdig-ondrej-hadamek"   # klobass-skoda, skodagroup.com
+group = "nongittensor"
+aliases = ["ondrej.hadamek@skodagroup.com"]
+
+[[contributor]]
+login = "AgilErck"
+group = "nongittensor"
+aliases = ["Erickd1190@gmail.com"]
+
+[[contributor]]
+login = "mike-theDude"          # shares mbriningstool@gmail.com with "Michael Briningstool"
+group = "nongittensor"
+aliases = ["mbriningstool@gmail.com", "mike@pop-os.cable.tks-net.com"]
+
+[[contributor]]
+login = "Whovencroft"           # noreply id was spreadsheet-mangled to float form
+group = "nongittensor"
+aliases = ["whovencroft@gmail.com", "erik@whovencroft.com", "6.60056e+06+Whovencroft@users.noreply.github.com"]
+
+[[contributor]]
+login = "wlaursen"              # Wes Laursen
+group = "nongittensor"
+aliases = ["wlaursen@mac.com", "wlaursen@gmail.com"]
+
+# ── Gittensor miners ─────────────────────────────────────────────────────────
+
+[[contributor]]
+login = "kiannidev"
+group = "gittensor"
+aliases = ["kiannidev@gmail.com"]
+
+[[contributor]]
+login = "dripsmvcp"
+group = "gittensor"
+aliases = ["duykhanh9242@gmail.com"]
+
+[[contributor]]
+login = "jony376"
+group = "gittensor"
+aliases = ["phoenix.dev734@outlook.com", "contact@duerrimports.com"]
+
+[[contributor]]
+login = "techforgeworks"
+group = "gittensor"
+aliases = ["techforgeworks@outlook.com"]
+
+[[contributor]]
+login = "philluiz2323"
+group = "gittensor"
+aliases = ["philluiz2323@gmail.com"]
+
+[[contributor]]
+login = "jsdevninja"
+group = "gittensor"
+aliases = ["topit89807@gmail.com"]
+
+[[contributor]]
+login = "galuis116"
+group = "gittensor"
+aliases = ["galuis116@gmail.com"]
+
+[[contributor]]
+login = "kelvinchen03"
+group = "gittensor"
+aliases = ["kelvinchen03@outlook.com"]
+
+[[contributor]]
+login = "andriypolanski"
+group = "gittensor"
+aliases = ["andriy.polanski@outlook.com", "axisflow.dev@outlook.com"]
+
+[[contributor]]
+login = "carlos4s"
+group = "gittensor"
+aliases = ["carloscosimano1005@gmail.com"]
+
+[[contributor]]
+login = "minion1227"
+group = "gittensor"
+aliases = ["romantymkiv1999@gmail.com"]
+
+[[contributor]]
+login = "jaso0n0818"
+group = "gittensor"
+aliases = ["hirakawatsuneteru@gmail.com"]
+
+[[contributor]]
+login = "jpette1783"            # display name "web-dev0521"
+group = "gittensor"
+aliases = ["jasonpette1783@proton.me"]
+
+[[contributor]]
+login = "dale053"
+group = "gittensor"
+aliases = ["star05223@outlook.com"]
+
+[[contributor]]
+login = "claytonlin1110"        # display name "Clayton"
+group = "gittensor"
+aliases = ["claytonlin1110@gmail.com"]
+
+[[contributor]]
+login = "glorysr1209-png"       # shares glorysr1209@gmail.com with "Hernandez Avelino"
+group = "gittensor"
+aliases = ["glorysr1209@gmail.com"]
+
+[[contributor]]
+login = "nickmopen"             # display names "Nick M" / "Nickmopen"
+group = "gittensor"
+aliases = ["nickmelnikov82@proton.me", "barco01014@gmail.com"]
+
+[[contributor]]
+login = "acocalypso"
+group = "gittensor"
+aliases = ["st.luzifer6663@hotmail.com"]
+
+[[contributor]]
+login = "bohdansolovie"
+group = "gittensor"
+aliases = ["bohdansolovie@gmail.com"]
+
+[[contributor]]
+login = "glorydavid03023"
+group = "gittensor"
+aliases = ["glorydavid03023@gmail.com"]
+
+[[contributor]]
+login = "danielbrock58"         # display names "Danie" / "Dedatox"
+group = "gittensor"
+aliases = ["danielbrock58@gmail.com"]
+
+[[contributor]]
+login = "milosde111"
+group = "gittensor"
+aliases = ["milosdelic.tech@gmail.com"]
+
+[[contributor]]
+login = "jonathanchang31"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "monsterdavidliu-ux"    # display name "monsterDavid"
+group = "gittensor"
+aliases = ["monsterdavidliu@gmail.com"]
+
+[[contributor]]
+login = "carlh7777"             # display name "Carl Harris"
+group = "gittensor"
+aliases = ["carlh171112@gmail.com"]
+
+[[contributor]]
+login = "GildardoDev"           # display name "Gildardo Guerra"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "tmimmanuel"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "dearsishs"             # display name "DearsisHS"
+group = "gittensor"
+aliases = ["dearsishs@outlook.com", "MCarter112116@outlook.com"]
+
+[[contributor]]
+login = "real-venus"            # display name "venus"
+group = "gittensor"
+aliases = ["haruharuno120@gmail.com"]
+
+[[contributor]]
+login = "e11734937-beep"
+group = "gittensor"
+aliases = ["e11734937@gmail.com", "joeoutlier804@gmail.com"]
+
+[[contributor]]
+login = "RenzoMXD"              # display name "Renzo"
+group = "gittensor"
+aliases = []
+
+# ── Bots / automation (excluded from the comparison) ─────────────────────────
+
+[[contributor]]
+login = "phase-rs-release-bot"
+group = "bot"
+aliases = ["phase-rs-release-bot@users.noreply.github.com", "bot@local"]
+
+[[contributor]]
+login = "claude-bot"
+group = "bot"
+aliases = ["noreply@anthropic.com"]
+
+[[contributor]]
+login = "codex-bot"
+group = "bot"
+aliases = ["codex@openai.com"]
+
+[[contributor]]
+login = "github-actions[bot]"
+group = "bot"
+aliases = ["41898282+github-actions[bot]@users.noreply.github.com"]
+
+[[contributor]]
+login = "dependabot[bot]"
+group = "bot"
+aliases = []
+
+[[contributor]]
+login = "phase-ai-contributor"
+group = "bot"
+aliases = ["ai-contrib@phase.rs", "ai-contributor@phase-rs.dev"]
+
+[[contributor]]
+login = "manus-agent"
+group = "bot"
+aliases = ["manus@manus.im", "erik@manus.app"]
+
+# ── Triaged additions (2026-07 full-history pass) ────────────────────────────
+# Real logins recovered via the (#N)->PR-author join. Ambiguous real-name gmail
+# accounts default to gittensor (base rate on a gittensor-incentivized repo) and
+# are marked `# ambiguous` for review.
+
+[[contributor]]
+login = "reckless5040"
+group = "gittensor"
+aliases = ["reckless50407@gmail.com", "platypusofaction5040@proton.me"]
+
+[[contributor]]
+login = "seekmistar01"
+group = "gittensor"
+aliases = ["seekmistar@proton.me"]
+
+[[contributor]]
+login = "yb0y"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "hazard975"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "derrickspartan1"
+group = "gittensor"
+aliases = ["derrickspartan1@gmail.com"]
+
+[[contributor]]
+login = "batou1"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "ascaletty"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "expki"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "plind-junior"
+group = "gittensor"
+aliases = []
+
+[[contributor]]
+login = "khaostica"
+group = "gittensor"
+aliases = ["markbaillie2007@gmail.com"]
+
+[[contributor]]
+login = "dean-alley"
+group = "gittensor"
+aliases = ["dizzean@gmail.com"]
+
+[[contributor]]
+login = "michaelmillsofficial"   # real individual dev (non-gittensor, confirmed)
+group = "nongittensor"
+aliases = ["michaelmills@michaels-macbook-air.local", "tubas.unite@gmail.com"]
+
+[[contributor]]
+login = "alexd-richardson"       # real individual dev (non-gittensor, confirmed)
+group = "nongittensor"
+aliases = ["richardson.d.alex@gmail.com"]
+
+[[contributor]]
+login = "colin-riddell"          # real individual dev (non-gittensor, confirmed)
+group = "nongittensor"
+aliases = ["colinjohnriddell@gmail.com"]
+
+[[contributor]]
+login = "arieliny"               # real individual dev (non-gittensor, confirmed)
+group = "nongittensor"
+aliases = []
+
+[[contributor]]
+login = "scherven"               # Simon Chervenak — real individual dev (non-gittensor)
+group = "nongittensor"
+aliases = ["sarras305@gmail.com"]
+
+[[contributor]]
+login = "benecollyridam"         # Alexander M. Scheurer-Volkmann — real dev (non-gittensor)
+group = "nongittensor"
+aliases = ["alexandermscheurer@gmail.com"]
+
+[[contributor]]
+login = "mpbunce"                # Matthew Bunce — real individual dev (non-gittensor)
+group = "nongittensor"
+aliases = ["matthew-bunce@outlook.com"]
+
+[[contributor]]
+login = "jeremytboyer"           # Jeremy Boyer — real individual dev (non-gittensor)
+group = "nongittensor"
+aliases = ["jeremytboyer@gmail.com"]
+
+[[contributor]]
+login = "luizservando"           # ambiguous — 1 direct-push commit
+group = "gittensor"
+aliases = ["luizservando.junior@gmail.com"]
+
+[[contributor]]
+login = "nathanchase"            # ambiguous — owns nathanchase.com (leaning real dev)
+group = "nongittensor"
+aliases = ["nathan@nathanchase.com"]

--- a/scripts/gittensor/report.sh
+++ b/scripts/gittensor/report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Gittensor contributor impact report — one command, no flags to remember.
+#
+#   scripts/gittensor/report.sh                 # monthly (last 30 days)
+#   scripts/gittensor/report.sh weekly          # last 7 days
+#   scripts/gittensor/report.sh monthly         # last 30 days
+#   scripts/gittensor/report.sh all             # all-time
+#   scripts/gittensor/report.sh 2026-06-01      # since a specific date
+#
+# It maintains a full (non-shallow) analysis clone, refreshes it, runs the
+# stats + infographic, writes dated + "latest" artifacts, and opens the PNG.
+#
+# Overridable via env: GITTENSOR_REPO, ANALYSIS_DIR, REPORT_DIR.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_SLUG="${GITTENSOR_REPO:-phase-rs/phase}"
+ANALYSIS_DIR="${ANALYSIS_DIR:-$HOME/phase-analysis}"
+REPORT_DIR="${REPORT_DIR:-$ANALYSIS_DIR/gittensor-report}"
+
+# ── window ───────────────────────────────────────────────────────────────────
+case "${1:-monthly}" in
+  -h|--help) sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^#//;s/^ //'; exit 0 ;;
+  weekly)    SINCE=(--since "7 days ago");  LABEL="weekly" ;;
+  monthly)   SINCE=(--since "30 days ago"); LABEL="monthly" ;;
+  all)       SINCE=();                      LABEL="all-time" ;;
+  *)         SINCE=(--since "$1");          LABEL="since-${1// /_}" ;;
+esac
+
+# ── analysis clone: create on first run, otherwise refresh ───────────────────
+if [[ ! -d "$ANALYSIS_DIR/.git" ]]; then
+  echo "→ First run: cloning full history of $REPO_SLUG into $ANALYSIS_DIR ..."
+  if command -v gh >/dev/null 2>&1; then
+    gh repo clone "$REPO_SLUG" "$ANALYSIS_DIR"
+  else
+    git clone "https://github.com/$REPO_SLUG" "$ANALYSIS_DIR"
+  fi
+else
+  echo "→ Refreshing $ANALYSIS_DIR ..."
+  git -C "$ANALYSIS_DIR" fetch --quiet origin
+fi
+
+# ── render ───────────────────────────────────────────────────────────────────
+mkdir -p "$REPORT_DIR"
+STAMP="$(date +%Y-%m-%d)"
+STATS="$REPORT_DIR/gittensor-stats-$LABEL-$STAMP.json"
+IMG="$REPORT_DIR/gittensor-impact-$LABEL-$STAMP.png"
+
+python3 "$SCRIPT_DIR/contrib_stats.py" --repo-dir "$ANALYSIS_DIR" "${SINCE[@]}" -o "$STATS"
+python3 "$SCRIPT_DIR/contrib_infographic.py" "$STATS" "$IMG"
+
+# Stable "latest" copies for quick access / sharing.
+cp "$STATS" "$REPORT_DIR/gittensor-stats-latest.json"
+cp "$IMG" "$REPORT_DIR/gittensor-impact-latest.png"
+
+echo "→ Report ($LABEL): $IMG"
+[[ "$(uname)" == "Darwin" ]] && command -v open >/dev/null 2>&1 && open "$IMG" || true


### PR DESCRIPTION
Re-runnable tool comparing gittensor-miner vs non-gittensor contributions.

- contributors.toml: hand-maintained whitelist (login->group) with alias
  coalescing; identity keyed on the unspoofable (#N)->PR-author-login join.
- contrib_stats.py: git-log + gh-PR analysis -> JSON. Code-only LOC (excludes
  data/generated), area mix, churn, code_commits. Refuses to run on a shallow
  clone (graft-boundary attributes the whole tree to one author).
- contrib_infographic.py: JSON -> dark-mode SVG/PNG (stdlib only, dataviz-
  validated palette), mirroring plot-coverage-history.py.
- report.sh: one-command wrapper (weekly/monthly/all) that maintains a full
  analysis clone, refreshes it, and renders dated + latest artifacts.
