### PR TITLE
feat(scripts): pr-review deferral labels + author-followup holds; gittensor report wrapper

### DIFF
--- a/.agents/pr-review-policy.toml
+++ b/.agents/pr-review-policy.toml
@@ -7,6 +7,9 @@ tier = "T2"
 [domain]
 rules_domain = "mtg-cr"
 
+[labels]
+frontend_deferred = "defer-fe"
+
 [hard_stops]
 patterns = [
   ".agents/skills/**",

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -54,7 +54,7 @@ python3 scripts/pr_review.py compact
    - `hard_stop` / `request_changes` — surface the precise blocker; do not enqueue.
    - `skip` — disambiguate by `reason`: `closed` / `self_authored` need no action; `contributor_standing_skip` is an explicit maintainer standing override — record the skip and move on without reviewing. A skip-listed contributor touching hard-stop paths still surfaces as `request_changes` (safety outranks the skip).
    - `blocked` — current head already has blocking maintainer feedback; wait for a new head or author follow-up.
-   - `defer` — record the deferral event; do not approve, label, enqueue, or merge.
+   - `defer` — record the deferral event; do not approve, enqueue, or merge. If the recommendation carries `label_to_apply`, add that label to the PR for maintainer filtering before moving on. Label names must come from repo policy, not from this skill.
    - `hold_ci` — record a non-terminal hold only when the packet is incomplete or an external condition prevents review. CI being pending, unknown, or red is not itself a review/enqueue blocker; merge-when-ready will wait for required checks.
    - `dequeue_stale_for_handler` / `update_branch_for_handler` / `approve_ready_for_handler` — advisory only; delegate execution to `pr-contribution-handler` in authorized mode.
    - `review` — fetch an `inspect --mode full` packet, then run `review-impl` against the current head and GitHub API/local diff evidence. For engine/parser-surface PRs, the parse-diff sticky comment (`<!-- coverage-parse-diff -->`) is REQUIRED review evidence: fetch its full body and confront the card-level diff against the PR's claimed scope. The packet's `parse_diff` field carries presence/state/`updated_at`. If state is `baseline_pending` on a stale branch (the `review_parse_baseline_pending` reason), route to update-branch first — that is the one staleness case where updating is the remedy, since the CI diff is merge-base-pinned and immune to branch staleness (see `ci.yml` "Parse-detail diff vs base baseline" step). If the comment is absent but engine source changed, treat it as missing evidence: check whether CI ran for the current head before reviewing.
@@ -92,7 +92,7 @@ The CLI may recommend that a PR is ready for handler execution only when its str
 
 When the user explicitly authorizes maintainer actions, the loop may pass clean PRs to `pr-contribution-handler`. That skill owns assignee locks, checkout/worktree handling, fixups, formal approval, labels, update-branch, enqueue, dequeue, and live GraphQL verification.
 
-Do not perform GitHub mutations from this skill except ordinary review/comment actions explicitly required by the current sweep.
+Do not perform GitHub mutations from this skill except ordinary review/comment actions explicitly required by the current sweep and policy-configured deferral labels. Approval, queue, update-branch, dequeue, and merge execution still belongs to `pr-contribution-handler`.
 
 ## Drift Rule
 

--- a/scripts/gittensor/report.sh
+++ b/scripts/gittensor/report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Gittensor contributor impact report — one command, no flags to remember.
+#
+#   scripts/gittensor/report.sh                 # monthly (last 30 days)
+#   scripts/gittensor/report.sh weekly          # last 7 days
+#   scripts/gittensor/report.sh monthly         # last 30 days
+#   scripts/gittensor/report.sh all             # all-time
+#   scripts/gittensor/report.sh 2026-06-01      # since a specific date
+#
+# It maintains a full (non-shallow) analysis clone, refreshes it, runs the
+# stats + infographic, writes dated + "latest" artifacts, and opens the PNG.
+#
+# Overridable via env: GITTENSOR_REPO, ANALYSIS_DIR, REPORT_DIR.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_SLUG="${GITTENSOR_REPO:-phase-rs/phase}"
+ANALYSIS_DIR="${ANALYSIS_DIR:-$HOME/phase-analysis}"
+REPORT_DIR="${REPORT_DIR:-$ANALYSIS_DIR/gittensor-report}"
+
+# ── window ───────────────────────────────────────────────────────────────────
+case "${1:-monthly}" in
+  -h|--help) sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^#//;s/^ //'; exit 0 ;;
+  weekly)    SINCE=(--since "7 days ago");  LABEL="weekly" ;;
+  monthly)   SINCE=(--since "30 days ago"); LABEL="monthly" ;;
+  all)       SINCE=();                      LABEL="all-time" ;;
+  *)         SINCE=(--since "$1");          LABEL="since-${1// /_}" ;;
+esac
+
+# ── analysis clone: create on first run, otherwise refresh ───────────────────
+if [[ ! -d "$ANALYSIS_DIR/.git" ]]; then
+  echo "→ First run: cloning full history of $REPO_SLUG into $ANALYSIS_DIR ..."
+  if command -v gh >/dev/null 2>&1; then
+    gh repo clone "$REPO_SLUG" "$ANALYSIS_DIR"
+  else
+    git clone "https://github.com/$REPO_SLUG" "$ANALYSIS_DIR"
+  fi
+else
+  echo "→ Refreshing $ANALYSIS_DIR ..."
+  git -C "$ANALYSIS_DIR" fetch --quiet origin
+fi
+
+# ── render ───────────────────────────────────────────────────────────────────
+mkdir -p "$REPORT_DIR"
+STAMP="$(date +%Y-%m-%d)"
+STATS="$REPORT_DIR/gittensor-stats-$LABEL-$STAMP.json"
+IMG="$REPORT_DIR/gittensor-impact-$LABEL-$STAMP.png"
+
+python3 "$SCRIPT_DIR/contrib_stats.py" --repo-dir "$ANALYSIS_DIR" "${SINCE[@]}" -o "$STATS"
+python3 "$SCRIPT_DIR/contrib_infographic.py" "$STATS" "$IMG"
+
+# Stable "latest" copies for quick access / sharing.
+cp "$STATS" "$REPORT_DIR/gittensor-stats-latest.json"
+cp "$IMG" "$REPORT_DIR/gittensor-impact-latest.png"
+
+echo "→ Report ($LABEL): $IMG"
+[[ "$(uname)" == "Darwin" ]] && command -v open >/dev/null 2>&1 && open "$IMG" || true

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -489,6 +489,12 @@ def parse_event_datetime(value: str | None) -> datetime | None:
     return parsed
 
 
+def timestamp_after(candidate: str | None, baseline: str | None) -> bool:
+    candidate_dt = parse_event_datetime(candidate)
+    baseline_dt = parse_event_datetime(baseline)
+    return candidate_dt is not None and baseline_dt is not None and candidate_dt > baseline_dt
+
+
 def filtered_events_by_days(events: list[dict[str, Any]], days: int | None) -> list[dict[str, Any]]:
     if days is None:
         return events
@@ -1513,6 +1519,13 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     local_event = packet.get("local_current_event") or {}
     local_event_type = local_event.get("event_type")
     local_outcome = local_event.get("outcome")
+    local_event_timestamp = local_event.get("timestamp")
+    author_login = pr.get("author_login")
+    author_followup_after_local_event = any(
+        comment.get("author") == author_login
+        and timestamp_after(comment.get("createdAt"), local_event_timestamp)
+        for comment in pr.get("comments", [])
+    )
     author_policy = packet.get("author_policy", {})
     local_block_event = local_outcome != "ci_failed" and local_event_type in {
         "review_blocked",
@@ -1551,6 +1564,12 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif (local_outcome or "").lower() == "defer-fe":
         action = "defer"
         reason = "local_defer_fe_current_head"
+    elif (local_event_type == "held" or local_outcome in HOLD_STATES) and author_followup_after_local_event:
+        action = "review"
+        reason = "author_followup_after_local_hold"
+    elif local_event_type == "held" or local_outcome in HOLD_STATES:
+        action = "hold_ci"
+        reason = "local_hold_current_head"
     elif local_block_event or local_block_outcome:
         action = "blocked"
         reason = "local_block_current_head"
@@ -1619,7 +1638,9 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     return recommendation
 
 
-def parse_diff_comment_state(comments: list[dict[str, Any]]) -> dict[str, Any]:
+def parse_diff_comment_state(
+    comments: list[dict[str, Any]], trusted_authors: set[str]
+) -> dict[str, Any]:
     """Classify the parse-diff sticky comment from FULL comment bodies.
 
     Must run on raw (un-excerpted) comments — compact_pr_view truncates bodies to
@@ -1628,7 +1649,7 @@ def parse_diff_comment_state(comments: list[dict[str, Any]]) -> dict[str, Any]:
     """
     for comment in comments:
         author_login = (comment.get("author") or {}).get("login")
-        if author_login != "github-actions":
+        if author_login not in trusted_authors:
             continue
         body = comment.get("body") or ""
         if not body.lstrip().startswith(PARSE_DIFF_MARKER):
@@ -1664,7 +1685,9 @@ def make_packet(
     checks = status_summary(pr.get("statusCheckRollup", []))
     # Classify the parse-diff sticky comment from raw bodies, before compact_pr_view
     # excerpts them to 300 chars and would drop the marker substrings.
-    parse_diff = parse_diff_comment_state(pr.get("comments", []))
+    parse_diff = parse_diff_comment_state(
+        pr.get("comments", []), {"github-actions", acting_login}
+    )
     compact_pr = compact_pr_view(pr, acting_login)
     author_policy = {
         "frontend_review_allowed": frontend_review_allowed(


### PR DESCRIPTION
pr-review:
- Add a [labels] policy section (frontend_deferred = "defer-fe") so deferral
  label names come from repo policy, not the skill.
- pr_review.py: re-review a locally-held PR when the author posts a follow-up
  after the hold event (timestamp_after helper + author_followup_after_local_hold
  reason); otherwise emit a non-terminal local_hold_current_head.
- Trust the acting login (not just github-actions) as a parse-diff sticky-comment
  author in parse_diff_comment_state.
- pr-review-loop SKILL: allow applying a policy-configured deferral label on defer;
  keep approve/queue/update-branch/dequeue/merge with pr-contribution-handler.

gittensor:
- Add report.sh: one-command contributor impact report (weekly/monthly/all/since),
  maintains a full analysis clone, writes dated + latest artifacts, opens the PNG.
