### PR TITLE
Parse exile target of "exile N cards from your graveyard" for N>6 (Ultimecia, Emeritus of Ideation)

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -479,6 +479,29 @@ pub fn parse_target_with_syntax<'a>(
         return parse_target_with_syntax(original_rest, ctx);
     }
 
+    // CR 107.1 + CR 400.7: A fixed spelled-out count before the generic
+    // "card"/"cards" noun (Ultimecia, Time Sorceress and Emeritus of Ideation:
+    // "exile eight cards from your graveyard"). The `QUANTIFIED_PREFIXES` list
+    // below only enumerates bare counts through "six", and it is deliberately NOT
+    // extended for higher counts: a bare "seven "/"ten " prefix would also strip
+    // the leading word of a number-named card used as a copy/target source ("a
+    // copy of Seven Dwarves" -> the Dwarf subtype, "Ten Wizards Mountain"), a
+    // silent mis-parse. Anchoring the strip to the generic card noun keeps the
+    // count discard scoped to genuine "N cards" quantities: the count is dropped
+    // here (callers that need it read it separately) and the recursion parses the
+    // "card[s] from <zone>" remainder as the underlying zone filter, matching the
+    // already-supported five-card siblings (Kroxa and Kunoros, Young Necromancer).
+    if let Ok((rest, _)) = (
+        nom_primitives::parse_number,
+        space1,
+        peek(alt((tag::<_, _, OracleError<'_>>("cards"), tag("card")))),
+    )
+        .parse(lower.as_str())
+    {
+        let original_rest = &text[lower.len() - rest.len()..];
+        return parse_target_with_syntax(original_rest, ctx);
+    }
+
     // Quantified target phrases routed here from callers that only need the filter,
     // not the target-count metadata.
     static QUANTIFIED_PREFIXES: &[&str] = &[
@@ -7470,6 +7493,46 @@ mod tests {
             )
         );
         assert_eq!(rest, "");
+    }
+
+    /// CR 107.1 + CR 400.7: A spelled-out count before the generic "card"/"cards"
+    /// noun is stripped so the underlying zone filter parses; the count itself is
+    /// discarded here (callers that need it read it separately). The bare-number
+    /// `QUANTIFIED_PREFIXES` list stops at "six", so before the anchored
+    /// number+card recognizer a fixed count of seven or more fell through to
+    /// `TargetFilter::Any` with the phrase left unconsumed — Emeritus of Ideation
+    /// and Ultimecia, Time Sorceress both "exile eight cards from your graveyard"
+    /// were left as target-fallback gaps.
+    #[test]
+    fn quantified_count_before_card_noun_parses_as_zone_filter() {
+        let expected = TargetFilter::Typed(
+            TypedFilter::card()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                }]),
+        );
+        for word in ["seven", "eight", "nine", "ten", "eleven", "twelve"] {
+            let phrase = format!("{word} cards from your graveyard");
+            let (f, rest) = parse_target(&phrase);
+            assert_eq!(f, expected, "filter mismatch for {phrase:?}");
+            assert_eq!(rest, "", "count prefix not stripped for {phrase:?}");
+        }
+        // Collision guard (CR 201.2): the count strip is anchored to the generic
+        // "card(s)" noun, so a number-named card used as a copy/target source is
+        // NOT mis-stripped into its trailing subtype. "Seven Dwarves" must be left
+        // whole for name resolution (Princess Snowfall: "a copy of Seven Dwarves"),
+        // not consumed as a Dwarf-subtype target.
+        let (f, rest) = parse_target("Seven Dwarves");
+        assert_eq!(
+            f,
+            TargetFilter::Any,
+            "\"Seven Dwarves\" must not be stripped into a Dwarf-subtype filter"
+        );
+        assert_eq!(
+            rest, "Seven Dwarves",
+            "\"Seven Dwarves\" must be left unconsumed"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -17309,3 +17309,68 @@ fn banner_of_kinship_composes_choose_and_chosen_dependent_counters() {
         } if name == "fellowship"
     ));
 }
+
+/// CR 107.1 + CR 400.7 + CR 608.2b: Ultimecia, Time Sorceress — "you may pay
+/// {4}{U}{U}{B}{B} and exile eight cards from your graveyard. If you do,
+/// transform Ultimecia." The `exile eight cards from your graveyard` recipient
+/// previously fell through `QUANTIFIED_PREFIXES` (which stopped at "six") to a
+/// bare `TargetFilter::Any` with the count phrase left unconsumed — a
+/// target-fallback gap. With "seven".."ten" added, the recipient now strips its
+/// count and parses to the same graveyard-card zone filter as the already
+/// supported five-card siblings (Kroxa and Kunoros, Young Necromancer), so the
+/// whole card is gap-free and the exile is not silently retargeted to "any".
+/// (Emeritus of Ideation — "exile eight cards from your graveyard. If you do,
+/// this creature becomes prepared." — is unlocked by the same seam.)
+#[test]
+fn ultimecia_exile_eight_from_graveyard_recipient_not_dropped() {
+    use crate::types::ability::{ControllerRef, Effect, FilterProp, TargetFilter, TypedFilter};
+    use crate::types::zones::Zone;
+    let face = oracle_face_for(
+        "Ultimecia, Time Sorceress",
+        "At the beginning of your end step, you may pay {4}{U}{U}{B}{B} and exile eight cards from your graveyard. If you do, transform Ultimecia.",
+        &["Legendary", "Creature"],
+        &[],
+    );
+    let gaps = crate::game::coverage::card_face_gaps(&face);
+    assert!(
+        gaps.is_empty(),
+        "Ultimecia must be fully supported, gaps: {gaps:?}"
+    );
+    let expected_recipient = TargetFilter::Typed(
+        TypedFilter::card()
+            .controller(ControllerRef::You)
+            .properties(vec![FilterProp::InZone {
+                zone: Zone::Graveyard,
+            }]),
+    );
+    // Find the exile ChangeZone anywhere in the end-step trigger effect tree
+    // (top effect is a PayCost whose sub-ability is the graveyard exile).
+    let exec = face
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_ref())
+        .expect("end-step trigger must carry an effect");
+    let mut node: Option<&crate::types::ability::AbilityDefinition> = Some(exec.as_ref());
+    let mut recipient = None;
+    while let Some(a) = node {
+        if let Effect::ChangeZone {
+            origin,
+            destination,
+            target,
+            ..
+        } = &*a.effect
+        {
+            if *origin == Some(Zone::Graveyard) && *destination == Zone::Exile {
+                recipient = Some(target.clone());
+                break;
+            }
+        }
+        node = a.sub_ability.as_deref();
+    }
+    assert_eq!(
+        recipient,
+        Some(expected_recipient),
+        "the \"exile eight cards from your graveyard\" recipient must be the \
+         graveyard-card zone filter, not a dropped `Any`"
+    );
+}


### PR DESCRIPTION
## Summary

**Ultimecia, Time Sorceress** and **Emeritus of Ideation** both read *"…exile eight cards from your graveyard. If you do, …"*, but the exile recipient was silently dropped to `TargetFilter::Any` (a `target-fallback`), so the "eight cards from your graveyard" zone filter was lost.

Cause: `parse_target`'s `QUANTIFIED_PREFIXES` list (which strips a leading spelled-out/numeric count so the underlying noun phrase parses) only covers bare numbers up to `"six "`. `"five cards from your graveyard"` (Kroxa, Aegis Sculptor, Young Necromancer) already works — this is a pure parser gap; runtime is unchanged.

## Change

Rather than extend the bare-number prefix list (a **trap** — a bare `"seven "` prefix would strip the leading word of a *number-named card* used as a copy source, mis-parsing **Princess Snowfall**'s "copy of **Seven Dwarves**"), add an **anchored** recognizer ahead of `QUANTIFIED_PREFIXES` (`crates/engine/src/parser/oracle_target.rs`): a `parse_number` immediately followed by the generic `"card"/"cards"` noun. The count discard is thus scoped to genuine "N cards" quantities, and number-named cards stay whole.

After the fix, the exile target parses to `Typed(Card, controller = You, [InZone Graveyard])` — byte-identical to the supported "five cards from your graveyard" sibling.

## Tests

- `quantified_count_before_card_noun_parses_as_zone_filter` — seven..twelve strip to the graveyard filter; includes a **Seven Dwarves collision guard** (number-named card must stay `Any`/unconsumed).
- `ultimecia_exile_eight_from_graveyard_recipient_not_dropped` — real card; asserts the exile recipient is the graveyard filter, not a dropped `Any`.

Fails-before / passes-after confirmed. Green: rustfmt, parser-combinator (Rule Zero) gate, `clippy -D warnings`, full engine suite (14580 passed / 0 failed). Corpus (built against a fresh origin/main baseline): **net +2** (Ultimecia, Time Sorceress; Emeritus of Ideation gained), **0 regressions**, `target-fallback` 53→51, Princess Snowfall confirmed still an honest fallback (not mis-parsed).
