### PR TITLE
fix(engine): scope Iona's chosen-color cast prohibition to the chosen color

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14922,7 +14922,7 @@ fn is_blocked_by_cant_be_cast(
 
         // CR 604.1: Check spell filter if present.
         if let Some(ref affected) = def.affected {
-            if !cant_cast_filter_matches(state, spell_obj, affected, bf_obj) {
+            if !cant_cast_filter_matches(state, spell_obj, affected, bf_obj, caster) {
                 continue;
             }
         }
@@ -14946,18 +14946,31 @@ fn is_blocked_by_cant_be_cast(
 
 /// CR 101.2: Check if a spell matches a CantBeCast affected filter.
 /// Handles type filters, mana value comparisons, chosen name, and chosen card type.
-/// Source-dependent filters (HasChosenName, IsChosenCardType) are resolved here
-/// because they need the source permanent's chosen attributes.
+/// Evaluate a `CantBeCast` affected filter against a spell being cast, with the
+/// prohibiting permanent as the filter source.
+///
+/// Only `HasChosenName` needs a dedicated arm — the shared spell-filter matcher
+/// has no top-level chosen-name variant. Every other filter, including the
+/// chosen-attribute *properties* (`IsChosenColor` per CR 105.2/105.4,
+/// `IsChosenCardType` per CR 205), is evaluated as a normal typed-filter
+/// conjunction through the source-aware `spell_object_matches_filter_from_state`
+/// path. That path resolves each chosen property against the source permanent's
+/// chosen attributes from context, so a prohibition can combine a chosen
+/// attribute with any card-type, controller, or zone axis without a bespoke
+/// per-property matcher here.
 fn cant_cast_filter_matches(
     state: &GameState,
     spell_obj: &super::game_object::GameObject,
     filter: &TargetFilter,
     source_obj: &super::game_object::GameObject,
+    caster: PlayerId,
 ) -> bool {
-    use crate::types::ability::{ChosenAttribute, FilterProp};
+    use crate::types::ability::ChosenAttribute;
 
     match filter {
-        // CR 201.2: "spells with the chosen name" — match spell name against source's chosen name.
+        // CR 201.2: "spells with the chosen name" — the shared spell-filter path
+        // has no top-level chosen-name variant, so match the spell name against
+        // the source's chosen name here.
         TargetFilter::HasChosenName => {
             let chosen_name = source_obj.chosen_attributes.iter().find_map(|a| match a {
                 ChosenAttribute::CardName(n) => Some(n.as_str()),
@@ -14965,48 +14978,17 @@ fn cant_cast_filter_matches(
             });
             chosen_name.is_some_and(|name| name.eq_ignore_ascii_case(&spell_obj.name))
         }
-        // CR 205: Typed filter with IsChosenCardType requires source's chosen card type.
-        TargetFilter::Typed(tf)
-            if tf
-                .properties
-                .iter()
-                .any(|p| matches!(p, FilterProp::IsChosenCardType)) =>
-        {
-            let chosen_type = source_obj.chosen_attributes.iter().find_map(|a| match a {
-                ChosenAttribute::CardType(ct) => Some(ct),
-                _ => None,
-            });
-            let Some(chosen_type) = chosen_type else {
-                return false;
-            };
-            spell_obj
-                .card_types
-                .core_types
-                .iter()
-                .any(|ct| ct == chosen_type)
-        }
-        // All other filters delegate to the spell record matcher.
-        _ => {
-            let record = SpellCastRecord {
-                name: spell_obj.name.clone(),
-                core_types: spell_obj.card_types.core_types.clone(),
-                supertypes: spell_obj.card_types.supertypes.clone(),
-                subtypes: spell_obj.card_types.subtypes.clone(),
-                keywords: spell_obj.keywords.clone(),
-                colors: spell_obj.color.clone(),
-                mana_value: spell_obj.mana_cost.mana_value(),
-                has_x_in_cost: super::casting_costs::cost_has_x(&spell_obj.mana_cost),
-                from_zone: spell_obj.zone,
-                cast_variant: crate::types::game_state::CastingVariant::Normal,
-                was_kicked: !spell_obj.kickers_paid.is_empty(),
-            };
-            super::filter::spell_record_matches_filter(
-                &record,
-                filter,
-                source_obj.controller,
-                &state.all_creature_types,
-            )
-        }
+        // Everything else — including IsChosenColor / IsChosenCardType properties —
+        // flows through the shared source-aware typed-filter conjunction.
+        _ => super::filter::spell_object_matches_filter_from_state(
+            state,
+            spell_obj,
+            spell_obj.zone,
+            caster,
+            filter,
+            source_obj.id,
+            &state.all_creature_types,
+        ),
     }
 }
 

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -1016,9 +1016,17 @@ pub(crate) fn parse_cant_cast_type_spells(
     }
 
     // --- "spells of the chosen color" ---
+    // CR 101.2 + CR 105.4: scope the prohibition to spells whose colors (CR 105.2)
+    // include the source's chosen color — not every spell. Mirrors the "chosen
+    // type" branch above; runtime resolution lives in `cant_cast_filter_matches`.
     if nom_tag_lower(trimmed, trimmed, "spells of the chosen color").is_some() {
-        let def =
-            StaticDefinition::new(StaticMode::CantBeCast { who }).description(text.to_string());
+        let filter = TargetFilter::Typed(TypedFilter {
+            properties: vec![FilterProp::IsChosenColor],
+            ..TypedFilter::default()
+        });
+        let def = StaticDefinition::new(StaticMode::CantBeCast { who })
+            .affected(filter)
+            .description(text.to_string());
         return attach_parsed_static_gate(def, gate_condition_text);
     }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15378,7 +15378,11 @@ fn cant_cast_during_combat_instants() {
 
 #[test]
 fn cant_cast_spells_of_chosen_color() {
-    // CR 101.2: "can't cast spells of the chosen color"
+    // CR 101.2 + CR 105.4: "can't cast spells of the chosen color" (Iona, Shield
+    // of Emeria) must scope the prohibition to the chosen color, not lock out
+    // every spell. The prohibition carries an `IsChosenColor` filter so only
+    // spells whose colors (CR 105.2) include the source's chosen color are
+    // prohibited.
     let def = parse_static_line("Your opponents can't cast spells of the chosen color.").unwrap();
     assert_eq!(
         def.mode,
@@ -15386,6 +15390,19 @@ fn cant_cast_spells_of_chosen_color() {
             who: ProhibitionScope::Opponents,
         }
     );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert!(
+            tf.properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::IsChosenColor)),
+            "chosen-color cast prohibition must scope to the chosen color; got {:?}",
+            tf.properties
+        ),
+        other => panic!(
+            "expected a Typed filter carrying IsChosenColor, got {other:?} \
+             (an unfiltered prohibition locks out spells of every color)"
+        ),
+    }
 }
 
 #[test]

--- a/crates/engine/tests/issue_4937_iona_chosen_color.rs
+++ b/crates/engine/tests/issue_4937_iona_chosen_color.rs
@@ -1,0 +1,71 @@
+//! Regression coverage for **Iona, Shield of Emeria** (issue #4937).
+//!
+//! "Your opponents can't cast spells of **the chosen color**." must prohibit
+//! only spells whose colors (CR 105.2) include the source's chosen color
+//! (CR 105.4) — not every spell. This is the color analog of the "chosen type"
+//! (Iona's sibling `IsChosenCardType`) and "chosen name" (`HasChosenName`)
+//! cast-lock branches.
+//!
+//! The bug had two halves, so this is a revert-probe for both: the parser
+//! (`parse_cant_cast_type_spells`) dropped the `IsChosenColor` filter, AND the
+//! runtime resolver (`cant_cast_filter_matches`) had no arm to evaluate that
+//! filter. If either half regresses, the chosen-color spell below becomes
+//! castable again and `blue_is_locked` fails; the off-color control
+//! (`red_is_free`) guards against the opposite over-broad regression.
+
+use engine::game::casting::can_cast_object_now;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::ChosenAttribute;
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::Phase;
+
+const IONA: &str = "Your opponents can't cast spells of the chosen color.";
+
+#[test]
+fn iona_locks_only_the_chosen_color() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Iona under P0; its "can't cast spells of the chosen color" static must
+    // parse to a `CantBeCast` carrying an `IsChosenColor` filter.
+    let iona = scenario
+        .add_creature_from_oracle(P0, "Iona, Shield of Emeria", 7, 7, IONA)
+        .id();
+
+    // Two {0} instants in the opponent's hand — identical castability except for
+    // color, so the only variable is the chosen-color prohibition.
+    let blue_spell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Blue Spell", true, "Draw a card.")
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    let red_spell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Red Spell", true, "Draw a card.")
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    let mut runner = scenario.build();
+
+    {
+        let st = runner.state_mut();
+        // CR 105.4: Iona's controller chose blue as it entered.
+        st.objects
+            .get_mut(&iona)
+            .expect("Iona must be on the battlefield")
+            .chosen_attributes
+            .push(ChosenAttribute::Color(ManaColor::Blue));
+        // CR 105.2: fix the spells' colors directly so mana payment is not a
+        // confound — both cost {0}; only the color differs.
+        st.objects.get_mut(&blue_spell).unwrap().color = vec![ManaColor::Blue];
+        st.objects.get_mut(&red_spell).unwrap().color = vec![ManaColor::Red];
+    }
+
+    assert!(
+        !can_cast_object_now(runner.state(), P1, blue_spell),
+        "opponent must NOT be able to cast a spell of the chosen color (blue)"
+    );
+    assert!(
+        can_cast_object_now(runner.state(), P1, red_spell),
+        "opponent MUST still be able to cast off-color spells (red) — Iona locks \
+         only the chosen color, not every spell"
+    );
+}


### PR DESCRIPTION
## Summary

**Iona, Shield of Emeria** — "Your opponents can't cast spells of **the chosen color**" — parsed to an *unfiltered* `CantBeCast`, locking opponents out of spells of **every** color (and colorless) instead of only the chosen one. This scopes the prohibition to the chosen color, matching the physical card. Fixes #4937.

The bug had two halves, both fixed here (mirroring the existing `"chosen type"` / `"chosen name"` sibling branches):

- **Parser** (`parser/oracle_static/restriction.rs`): the `"spells of the chosen color"` branch of `parse_cant_cast_type_spells` built `CantBeCast` with no `affected` filter. It now attaches `FilterProp::IsChosenColor`, exactly like the adjacent `"chosen type"` branch attaches `IsChosenCardType`.
- **Runtime** (`game/casting.rs`): `cant_cast_filter_matches` had a dedicated arm for `IsChosenCardType` (it needs the source permanent's chosen attribute) but none for `IsChosenColor`, so the delegated `spell_record_matches_filter` path returned `false` for it — i.e. a parser-only fix would make Iona prohibit *nothing*. Added the matching arm, resolving the spell's colors (CR 105.2) against the source's chosen color (CR 105.4).

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> Small, surgical fix that slots into an existing `alt`-style branch cluster (it mirrors the two sibling branches immediately above it and the sibling runtime arm) rather than introducing a new pattern or variant. A final `/review-impl` pass was run and its notes addressed; the passive-voice "Spells of the chosen color can't be cast" form is intentionally left out of scope (no printed card uses it, so leaving it unimplemented stays coverage-honest).

## CR references

- `CR 101.2` — a "can't" effect takes precedence (the prohibition).
- `CR 105.2` — an object's color(s) come from its mana symbols (matching the spell).
- `CR 105.4` — choosing a color (Iona's chosen color).

## Verification

Toolchain used directly (Tilt not running in this environment):

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- New end-to-end regression test `crates/engine/tests/issue_4937_iona_chosen_color.rs` drives production `can_cast_object_now`: with Iona (chosen color = blue) on the battlefield, an opponent **can't** cast a blue spell but **can** still cast a red spell. Passes with the fix; **fails without it** (revert-probe — reverting either half makes the off-color spell wrongly prohibited).
- Strengthened the existing `cant_cast_spells_of_chosen_color` parser unit test to assert the `IsChosenColor` filter is attached (previously it checked only `def.mode`, which is why the dropped filter went unnoticed).