### PR TITLE
feat(client): attachment fan for in-place targeting of a permanent + its attachments

### DIFF
--- a/client/src/components/board/AttachmentFan.tsx
+++ b/client/src/components/board/AttachmentFan.tsx
@@ -1,0 +1,334 @@
+import { type CSSProperties, useCallback, useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+
+import type { GameAction, ObjectId } from "../../adapter/types.ts";
+import { dispatchAction } from "../../game/dispatch.ts";
+import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+import { collectObjectActions } from "../../viewmodel/cardActionChoice.ts";
+import {
+  boardChoiceMaxSelection,
+  buildBoardChoiceAction,
+  canConfirmBoardChoice,
+  getBoardChoiceView,
+  isBoardChoiceImmediate,
+} from "../../viewmodel/gameStateView.ts";
+import { CardImage } from "../card/CardImage.tsx";
+import { fanGeometry, spreadFactor } from "../card/fanGeometry.ts";
+
+// Card sizing for the centered fan. Cards render at near card-preview size so
+// oracle text / P-T are readable at rest (no separate preview needed), and scale
+// down ONLY IF NEEDED to fit the viewport. The width is:
+//
+//   min( clamp(11rem, 26vh, 24rem) ,  ${WIDTH_BUDGET_VW}vw / spreadFactor(n) )
+//        └────── desired size ──────┘  └──────── width-fit cap ────────────┘
+//
+//   • Desired size is height-driven (`26vh`; `* 1.4` is the standard card aspect)
+//     so it's generous on a tall screen — but FLOORED at `11rem` so a SHORT screen
+//     (landscape phone, where `26vh` collapses to ~100px) still gets a big card.
+//     Ceiling keeps a 2-card fan from ballooning on an ultrawide monitor.
+//   • Width-fit cap is an OUTER `min`, so it can pull the card BELOW the 11rem
+//     floor when the whole overlapped fan (`cardW * spreadFactor`) would otherwise
+//     overflow — i.e. a narrow PORTRAIT phone with several attachments. It never
+//     binds on a roomy screen, so those sizes are unchanged. Budget is generous
+//     (96vw) so the common 1–2 card case is never shrunk.
+//
+// The floor lives INSIDE the desired term (not as an outer clamp) precisely so it
+// rescues short screens without re-inflating a correctly width-shrunk card.
+const WIDTH_BUDGET_VW = 96;
+function fanCardSizingStyle(cardCount: number): CSSProperties {
+  const widthCapVw = (WIDTH_BUDGET_VW / spreadFactor(cardCount)).toFixed(1);
+  const cardW = `min(clamp(11rem, 26vh, 24rem), ${widthCapVw}vw)`;
+  return {
+    "--fan-card-w": cardW,
+    "--fan-card-h": `calc(${cardW} * 1.4)`,
+  } as CSSProperties;
+}
+
+/**
+ * Per-object selection state for one card in the fan, derived once by the
+ * parent from the live prompt so each card knows exactly which engine action
+ * (if any) its click should dispatch. Target > board-choice > activation is
+ * the same precedence PermanentCard uses on the battlefield.
+ */
+interface CardChoice {
+  isTarget: boolean;
+  boardEligible: boolean;
+  isSelected: boolean;
+  activationActions: GameAction[];
+}
+
+/**
+ * Centered spread of a host permanent plus every permanent attached to it
+ * (Aura / Equipment / Fortification), fanned out at HAND size using the SAME
+ * `fanGeometry` the player's hand uses — so it reads as a familiar held hand of
+ * large, legible cards rather than a bespoke overlay. Solves the reachability
+ * problem where an attached Equipment/Aura renders only as a narrow peek behind
+ * its host: during a target or board-choice prompt the overlapping objects are
+ * all legal picks (CR 301.5 / 303.4: an attached permanent is its own
+ * independent object), and the fan lets the player choose which one without
+ * hunting the peek.
+ *
+ * The fan NEVER invents a choice — each card lights up (cyan) and dispatches
+ * only what the engine's live prompt actually offers for that object. Terminal
+ * picks (a target, an immediate board-choice, an activation) close the fan;
+ * a multi-select board-choice toggles and is finished via the Confirm button.
+ * Direct clicking on the battlefield still works — this fan is an opt-in
+ * convenience opened from the "⧉" badge, not a forced modal.
+ */
+export function AttachmentFan() {
+  const { t } = useTranslation("game");
+  const playerId = usePlayerId();
+  const hostId = useUiStore((s) => s.attachmentFanHostId);
+  const setAttachmentFanHost = useUiStore((s) => s.setAttachmentFanHost);
+  const dismissPreview = useUiStore((s) => s.dismissPreview);
+  const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
+  const toggleSelectedCard = useUiStore((s) => s.toggleSelectedCard);
+  const selectedCardIds = useUiStore((s) => s.selectedCardIds);
+
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+
+  const host = hostId != null ? objects?.[hostId] : undefined;
+
+  const cardIds = useMemo<ObjectId[]>(
+    () => (host ? [host.id, ...host.attachments] : []),
+    [host],
+  );
+
+  const boardChoice = useMemo(() => {
+    const choice = getBoardChoiceView(waitingFor, objects);
+    return choice && choice.player === playerId ? choice : null;
+  }, [waitingFor, objects, playerId]);
+
+  // Engine's live target legal-set for the current prompt, as a plain id set.
+  const targetIds = useMemo(() => {
+    const set = new Set<ObjectId>();
+    if (
+      (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
+      && waitingFor.data.player === playerId
+    ) {
+      for (const target of waitingFor.data.selection?.current_legal_targets ?? []) {
+        if ("Object" in target) set.add(target.Object);
+      }
+    }
+    if (waitingFor?.type === "EquipTarget" && waitingFor.data.player === playerId) {
+      for (const id of waitingFor.data.valid_targets) set.add(id);
+    }
+    return set;
+  }, [waitingFor, playerId]);
+
+  const close = useCallback(() => {
+    setAttachmentFanHost(null);
+    // The fan is opened from a hovered card, so a card preview may still be up
+    // (CardPreview `z-[100]`); tear it down so it doesn't linger over the board.
+    dismissPreview();
+  }, [setAttachmentFanHost, dismissPreview]);
+
+  // Esc closes, mirroring every other dismissible overlay.
+  useEffect(() => {
+    if (hostId == null) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [hostId, close]);
+
+  const choiceFor = useCallback(
+    (id: ObjectId): CardChoice => ({
+      isTarget: targetIds.has(id),
+      boardEligible: boardChoice?.objectIds.includes(id) ?? false,
+      isSelected: selectedCardIds.includes(id),
+      activationActions: legalActionsByObject ? collectObjectActions(legalActionsByObject, id) : [],
+    }),
+    [targetIds, boardChoice, selectedCardIds, legalActionsByObject],
+  );
+
+  const handlePick = useCallback(
+    (id: ObjectId, choice: CardChoice) => {
+      if (choice.isTarget) {
+        dispatchAction({ type: "ChooseTarget", data: { target: { Object: id } } });
+        close();
+        return;
+      }
+      if (choice.boardEligible && boardChoice) {
+        if (isBoardChoiceImmediate(boardChoice)) {
+          dispatchAction(buildBoardChoiceAction(boardChoice, [id]));
+          close();
+          return;
+        }
+        // Multi-select: toggle within the engine's max, then Confirm finishes.
+        const max = boardChoiceMaxSelection(boardChoice);
+        const selectedForChoice = selectedCardIds.filter((s) => boardChoice.objectIds.includes(s));
+        if (choice.isSelected || max == null || selectedForChoice.length < max) {
+          toggleSelectedCard(id);
+        }
+        return;
+      }
+      if (choice.activationActions.length > 0) {
+        if (choice.activationActions.length === 1) {
+          dispatchAction(choice.activationActions[0]);
+        } else {
+          setPendingAbilityChoice({ objectId: id, actions: choice.activationActions });
+        }
+        close();
+      }
+    },
+    [boardChoice, selectedCardIds, close, toggleSelectedCard, setPendingAbilityChoice],
+  );
+
+  const confirmSelection = useMemo(() => {
+    if (!boardChoice || isBoardChoiceImmediate(boardChoice)) return null;
+    const selectedForChoice = selectedCardIds.filter((s) => boardChoice.objectIds.includes(s));
+    if (selectedForChoice.length === 0) return null;
+    return {
+      enabled: canConfirmBoardChoice(boardChoice, selectedForChoice, objects),
+      selected: selectedForChoice,
+      choice: boardChoice,
+    };
+  }, [boardChoice, selectedCardIds, objects]);
+
+  if (hostId == null || !host || cardIds.length === 0) return null;
+
+  // Same whole-row fan the hand uses — sized by the total card count so the
+  // host + its attachments tuck into the identical overlap / tilt / arc curve.
+  // The overlap basis is `--fan-card-w` (the fan's larger card width) so the
+  // spread stays proportional to the bigger cards.
+  const fan = fanGeometry(cardIds.length, "--fan-card-w");
+
+  return createPortal(
+    // Portaled above the card preview (`z-[100]`) so the fan and its cyan
+    // affordances are never veiled. Backdrop click / Esc dismiss.
+    <div
+      className="fixed inset-0 z-[120] flex flex-col items-center justify-center bg-black/60 backdrop-blur-[2px]"
+      onClick={close}
+      data-attachment-fan
+    >
+      {/* `items-end` + `perspective` mirror the hand container so the cards fan
+          up from a shared baseline with the same held-hand feel. The sizing style
+          defines `--fan-card-w/h` — big by default, scaling down only if the fan
+          would overflow a narrow screen (portrait mobile with several cards). */}
+      <div
+        className="flex items-end justify-center"
+        style={{ perspective: "800px", ...fanCardSizingStyle(cardIds.length) }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {cardIds.map((id, i) => (
+          <FanCard
+            key={id}
+            objectId={id}
+            choice={choiceFor(id)}
+            marginLeft={i === 0 ? 0 : fan.overlap}
+            rotation={fan.rotation(i)}
+            arcOffset={fan.arc(i)}
+            zIndex={i}
+            onPick={handlePick}
+          />
+        ))}
+      </div>
+
+      {confirmSelection && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            dispatchAction(buildBoardChoiceAction(confirmSelection.choice, confirmSelection.selected));
+            close();
+          }}
+          disabled={!confirmSelection.enabled}
+          className="mt-8 rounded-full bg-cyan-500 px-5 py-2 text-sm font-bold text-cyan-950 shadow-[0_2px_10px_rgba(34,211,238,0.5)] transition hover:bg-cyan-400 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300 disabled:shadow-none"
+        >
+          {t("permanent.fanConfirm", { count: confirmSelection.selected.length })}
+        </button>
+      )}
+    </div>,
+    document.body,
+  );
+}
+
+function FanCard({
+  objectId,
+  choice,
+  marginLeft,
+  rotation,
+  arcOffset,
+  zIndex,
+  onPick,
+}: {
+  objectId: ObjectId;
+  choice: CardChoice;
+  marginLeft: string | number;
+  rotation: number;
+  arcOffset: number;
+  zIndex: number;
+  onPick: (id: ObjectId, choice: CardChoice) => void;
+}) {
+  const { t } = useTranslation("game");
+  const obj = useGameStore((s) => s.gameState?.objects[objectId]);
+  if (!obj) return null;
+
+  const lookup = cardImageLookup(obj);
+  const isToken = obj.display_source === "Token";
+  const selectable = choice.isTarget || choice.boardEligible || choice.activationActions.length > 0;
+
+  // The whole fan speaks one "pick me" color — cyan — so a spread of a host and
+  // its attachments reads as a single chooser regardless of whether the engine
+  // is asking for a target, a board choice, or an activation. Selected (a
+  // toggled multi-select board choice) brightens and adds a check.
+  const ring = choice.isSelected
+    ? "ring-4 ring-cyan-300 shadow-[0_0_22px_7px_rgba(34,211,238,0.7),inset_0_0_18px_5px_rgba(34,211,238,0.35)]"
+    : selectable
+      ? "ring-2 ring-cyan-400 shadow-[0_0_16px_5px_rgba(34,211,238,0.55)]"
+      : "";
+
+  // Mirror the hand card's resting animation (arc + tilt) and hover lift so the
+  // attachment fan feels identical to picking a card out of hand.
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 40 }}
+      animate={{ opacity: 1, y: 30 + arcOffset, rotate: rotation }}
+      whileHover={{ y: arcOffset - 12, scale: 1.12, zIndex: 999 }}
+      transition={{ duration: 0.2 }}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (selectable) onPick(objectId, choice);
+      }}
+      aria-label={obj.name}
+      className={`relative leading-[0] select-none ${selectable ? "cursor-pointer" : "cursor-default"}`}
+      style={{ marginLeft, zIndex }}
+    >
+      <div className={`relative overflow-hidden rounded-lg ${ring} ${selectable ? "" : "opacity-60"}`}>
+        <CardImage
+          cardName={lookup.name}
+          faceIndex={lookup.faceIndex}
+          oracleId={lookup.oracleId}
+          faceName={lookup.faceName}
+          size="large"
+          isToken={isToken}
+          tokenFilters={isToken ? tokenFiltersForObject(obj) : undefined}
+          tokenImageRef={isToken ? obj.token_image_ref : undefined}
+          oracleText={isToken ? obj.token_rules_text : undefined}
+          faceDown={obj.face_down}
+          className="!w-[var(--fan-card-w)] !h-[var(--fan-card-h)]"
+        />
+      </div>
+      {choice.isSelected && (
+        <span className="pointer-events-none absolute left-1 top-1 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-cyan-400 text-sm font-black text-cyan-950 ring-2 ring-cyan-950/60 shadow">
+          ✓
+        </span>
+      )}
+      {selectable && !choice.isSelected && (
+        <span className="pointer-events-none absolute left-1 top-1 z-10 rounded bg-cyan-400 px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-normal text-cyan-950 ring-1 ring-cyan-950/50 shadow">
+          {t("permanent.fanPick")}
+        </span>
+      )}
+    </motion.div>
+  );
+}

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -304,6 +304,8 @@ export const PermanentCard = memo(function PermanentCard({
     : [];
 
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
+  const setAttachmentFanHost = useUiStore((s) => s.setAttachmentFanHost);
+  const dismissPreview = useUiStore((s) => s.dismissPreview);
   const cardRef = useRef<HTMLDivElement | null>(null);
 
   // On compact-height (landscape phones), use a subtler 12° rotation:
@@ -503,6 +505,13 @@ export const PermanentCard = memo(function PermanentCard({
     // to activate Equip and reattach it. Stop the bubble so the attachment's
     // own intent (target / activate / select) wins cleanly.
     if (obj.attached_to !== null) e.stopPropagation();
+    // A permanent and its attachments are each independently clickable in place
+    // — the host by its face, an attached Equipment/Aura by its right-edge peek
+    // (CR 301.5 / 303.4: an attachment is its own legal object). We deliberately
+    // do NOT hijack an ambiguous click into the AttachmentFan here: direct
+    // targeting must always work. When the peek is an awkward click target the
+    // player can open the fan explicitly via the "⧉" badge instead of being
+    // forced through it.
     // A PayCost TapCreatures prompt is mid-cost resolution — check before combat
     // mode so clicks land even when DeclareAttackers combat mode is active.
     if (isSelectableForBoardChoice && boardChoice) {
@@ -873,6 +882,52 @@ export const PermanentCard = memo(function PermanentCard({
           aria-hidden
           className="pointer-events-none absolute inset-[-4px] z-40 rounded-xl ring-4 ring-fuchsia-400 shadow-[0_0_22px_6px_rgba(232,121,249,0.7),inset_0_0_18px_4px_rgba(232,121,249,0.45)] animate-pulse"
         />
+      )}
+
+      {/* View-attachments affordance. Attached permanents (Equipment / Aura /
+          Fortification) render only as a narrow right-edge peek behind their
+          host, so their own click/hover handlers — including an Equipment's
+          re-Equip activation (CR 301.5: the Equipment is an independent object
+          and activation source) — are hard to reach. This badge opens the
+          AttachmentsDialog for the host, where each attachment is shown at full
+          size and is independently interactive (target-select / activate). Only
+          the host carries attachments, so it never appears on the peeked cards
+          themselves. Revealed on hover on pointer devices; always shown on
+          touch (no hover) since the dialog is the only reliable reach there.
+
+          Mirrors GroupedPermanent's expand/collapse badge — a circular corner
+          affordance sticking out past the card. Placed top-LEFT so it clears
+          the right-edge attachment peeks and the `hiddenAttachments` +N badge.
+
+          Two interaction traps this must sidestep, both from the host motion.div:
+          1. `useLongPress` calls `setPointerCapture` on pointerdown, which would
+             capture the pointer to the host and retarget this button's click to
+             the host (firing card selection, not the badge). Stopping pointerdown
+             propagation keeps capture from ever engaging — the same reason the
+             group badge works: it lives OUTSIDE the capturing element.
+          2. The hover preview (CardPreview `z-[100]`) paints above the dialog
+             (`z-50`); clearing it on click makes the opened dialog visible. */}
+      {obj.attachments.length > 0 && (isHovered || isInHoveredAttachmentTree || isInspected || isSelected || !canHover) && (
+        <button
+          type="button"
+          aria-label={t("permanent.viewAttachments", { count: obj.attachments.length })}
+          title={t("permanent.viewAttachments", { count: obj.attachments.length })}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            // dismissPreview (not inspectObject(null), which only schedules a
+            // deferred 50ms clear) tears the preview down synchronously so the
+            // z-[100] preview never veils the fan.
+            dismissPreview();
+            setAttachmentFanHost(objectId);
+          }}
+          className="absolute -left-3 -top-3 z-40 flex h-6 min-w-6 items-center justify-center gap-0.5 rounded-full bg-black px-1.5 text-[11px] font-extrabold leading-none text-amber-200 ring-2 ring-amber-200/80 shadow-[0_2px_8px_rgba(0,0,0,0.65)] transition-transform hover:scale-105"
+        >
+          <span aria-hidden className="text-[12px] leading-none">⧉</span>
+          {obj.attachments.length > 1 && (
+            <span className="tabular-nums">{obj.attachments.length}</span>
+          )}
+        </button>
       )}
     </motion.div>
   );

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -269,6 +269,39 @@ describe("PermanentCard attachments", () => {
     expect(container.querySelector('[data-object-id="4"]')).not.toBeNull();
   });
 
+  it("opens the attachment fan for the host via the hover badge", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, inspectedObjectId: null });
+    });
+
+    const { container } = renderPermanent();
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    // On a pointer device the view-attachments badge is hover-revealed, so it
+    // is absent until the host is hovered. (The nested attachment cards never
+    // render a badge here — only the host owns attachments.)
+    expect(container.querySelector("button")).toBeNull();
+
+    // Hovering reveals the badge AND raises the card preview (inspectedObjectId).
+    fireEvent.mouseEnter(host);
+    expect(useUiStore.getState().inspectedObjectId).toBe(1);
+    const button = container.querySelector("button") as HTMLButtonElement;
+    expect(button).not.toBeNull();
+
+    // pointerdown must be stopped so the host motion.div never captures the
+    // pointer (useLongPress.setPointerCapture) and retargets the click to the
+    // host — which would fire card selection instead of opening the fan.
+    fireEvent.pointerDown(button);
+    fireEvent.click(button);
+
+    // Routes to the fan-host state (uiStore), clears the covering card preview
+    // so the z-[100] preview never veils the fan, and never selects the host
+    // (the click stayed on the badge).
+    expect(useUiStore.getState().attachmentFanHostId).toBe(1);
+    expect(useUiStore.getState().selectedObjectId).toBeNull();
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
   it("auto-expands collapsed attachments when one is a valid target", () => {
     // Regression: Moira Brown's "put a quest counter on target nonland
     // permanent you control" offers the host's attached Equipment/Auras as
@@ -479,6 +512,26 @@ describe("PermanentCard attachments", () => {
     fireEvent.click(permanent);
 
     expect(staleBlockerHandler).not.toHaveBeenCalled();
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "ChooseTarget",
+      data: { target: { Object: 1 } },
+    });
+  });
+
+  it("directly targets the host (not the fan) when host and attachment are both legal targets", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null });
+    });
+    // Both the host (1) and its attached Equipment (2) are legal targets. A
+    // click on the host targets the host DIRECTLY — the fan is never forced.
+    // (The attachment stays independently reachable via its peek, and the fan
+    // is available on demand from the "⧉" badge — covered by the badge test.)
+    const { container } = renderPermanent(new Set([1, 2]));
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.click(host);
+
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
     expect(dispatchAction).toHaveBeenCalledWith({
       type: "ChooseTarget",
       data: { target: { Object: 1 } },

--- a/client/src/components/card/fanGeometry.ts
+++ b/client/src/components/card/fanGeometry.ts
@@ -1,0 +1,86 @@
+// Shared card-fan geometry — the overlap / tilt / arc math that lays a row of
+// cards out as a held "hand". Extracted from PlayerHand so any centered spread
+// of cards (the player's hand, a host permanent + its attachments) fans with
+// identical proportions instead of each surface re-deriving the curve.
+
+// Signed overlap FRACTION of one card width by which each card slides over the
+// previous one (negative == leftward). Tightens continuously as the row grows so
+// a Commander-sized hand (up to ~20 cards) still fits on screen. Single source of
+// truth for both the CSS margin (`getHandOverlap`) and the fan's total-width
+// budget (`spreadFactor`), so a caller sizing cards to fit a viewport can never
+// drift out of sync with the margin the cards actually render with.
+function overlapFraction(rowSize: number): number {
+  if (rowSize <= 5) return -0.25;
+  if (rowSize <= 7) return -0.45;
+  // For 8+ cards: target total width ≈ 4× card width.
+  // First card occupies 1w; remaining (n-1) each contribute (1 + overlap)w.
+  // (n-1)(1 + overlap) = 3  =>  overlap = 3/(n-1) - 1, clamped to [-0.85, -0.6].
+  return Math.max(-0.85, Math.min(-0.6, 3 / (rowSize - 1) - 1));
+}
+
+// Total width of the whole fan, in units of ONE card width: the first card
+// occupies 1w and each of the remaining (n-1) cards adds its visible fraction
+// `(1 + overlap)`. A caller sizing cards to fit a viewport divides its width
+// budget by this factor. Never below 1 (a single card is 1w).
+export function spreadFactor(rowSize: number): number {
+  if (rowSize <= 1) return 1;
+  return 1 + (rowSize - 1) * (1 + overlapFraction(rowSize));
+}
+
+// Horizontal overlap between adjacent fanned cards, as a CSS margin-left. The
+// margin is a fraction of the card's OWN rendered width var (`cardWidthVar` —
+// `--hand-card-w` for the hand, `--fan-card-w` for the attachment fan). This
+// MUST match the width the cards actually render at: using a different basis
+// (e.g. base `--card-w` while cards render 1.14–1.4× larger) leaves the real
+// overlap off by the scale factor, spreading the fan ~40% too wide with the
+// error compounding as the row grows.
+export function getHandOverlap(rowSize: number, cardWidthVar = "--hand-card-w"): string {
+  return `calc(var(${cardWidthVar}) * ${overlapFraction(rowSize)})`;
+}
+
+// Quadratic arc lift coefficient. Scales down as the row grows so the parabola
+// stays inside the band instead of pushing edge cards off-screen.
+export function getArcCoefficient(rowSize: number): number {
+  if (rowSize <= 7) return 6;
+  // Keep max arc lift (at the edges) roughly constant at ~54px.
+  const maxDist = (rowSize - 1) / 2;
+  return 54 / (maxDist * maxDist);
+}
+
+/** Per-card fan placement functions, all sized by the total card count so a
+ *  small row and a large row tuck into the same angle-clamped arc. `k` is a
+ *  card's 0-based position across the row. */
+export interface FanGeometry {
+  /** Negative CSS margin-left overlapping each card over the previous one. */
+  overlap: string;
+  /** Signed tilt (deg) for the card at position `k`. */
+  rotation: (k: number) => number;
+  /** Downward-parabola vertical offset (px) for the card at position `k`. */
+  arc: (k: number) => number;
+}
+
+// Geometry for a whole displayed row as one fan. Overlap, per-card tilt and arc
+// are all sized by the TOTAL number of displayed cards, so a 3-card row tucks
+// into the same tight, angle-clamped arc a 16-card row would, instead of
+// inheriting loose 3-card spacing and spilling off-screen with near-sideways
+// edge cards.
+export function fanGeometry(totalCards: number, cardWidthVar = "--hand-card-w"): FanGeometry {
+  const center = (totalCards - 1) / 2;
+  // Size the SHAPE (tilt + arc) from at least two cards so a lone card still
+  // fans (a raw delta of 0 would render flat).
+  const shape = Math.max(2, totalCards);
+  const delta = Math.min(6, 36 / (shape - 1));
+  const arcCoeff = getArcCoefficient(shape);
+  // Downward parabola (edges drop, center rides highest), clamped at the row's
+  // own edges so the outermost cards rest level with the band instead of
+  // sinking below it and clipping.
+  const edgeLift = center * center * arcCoeff;
+  return {
+    overlap: getHandOverlap(totalCards, cardWidthVar),
+    rotation: (k: number) => (k - center) * delta,
+    arc: (k: number) => {
+      const d = k - center;
+      return Math.min(d * d * arcCoeff, edgeLift);
+    },
+  };
+}

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -32,71 +32,20 @@ import { ZONE_THEME, type ZoneTheme } from "../../viewmodel/zoneAffordance.ts";
 import { useCardOrganizer } from "../modal/cardChoice/useCardOrganizer.ts";
 import { CardOrganizerToolbar } from "../modal/cardChoice/CardOrganizerToolbar.tsx";
 import { PopoverMenu } from "../menu/PopoverMenu.tsx";
+import { fanGeometry } from "../card/fanGeometry.ts";
 
 // Stable empty lookup so an undefined `objects` (pre-game) never busts the
 // organizer's filter memo with a fresh `{}` each render.
 const EMPTY_OBJECTS: Record<string, GameObject> = {};
 
-// Horizontal overlap between adjacent hand cards. Negative margin pulls each
-// card leftward over the previous one. Tightens continuously as the hand grows
-// so a Commander-sized hand (up to ~20 cards) still fits on screen.
-//
-// The margin is a fraction of `--hand-card-w` — the SAME basis the cards are
-// rendered at (CardImage below). Using the base `--card-w` here while the cards
-// render at `--hand-card-w` (1.14–1.4× larger) left the real overlap off by the
-// scale factor, so the fan spread ~40% wider than the formula intends and the
-// error compounded with hand size, pushing the fan off-center to the right.
-function getHandOverlap(handSize: number): string {
-  if (handSize <= 5) return "calc(var(--hand-card-w) * -0.25)";
-  if (handSize <= 7) return "calc(var(--hand-card-w) * -0.45)";
-  // For 8+ cards: target total width ≈ 4× card width.
-  // First card occupies 1w; remaining (n-1) each contribute (1 + overlap)w.
-  // (n-1)(1 + overlap) = 3  =>  overlap = 3/(n-1) - 1, clamped to [-0.85, -0.6].
-  const overlap = Math.max(-0.85, Math.min(-0.6, 3 / (handSize - 1) - 1));
-  return `calc(var(--hand-card-w) * ${overlap})`;
-}
-
-// Quadratic arc lift coefficient. Scales down as the hand grows so the parabola
-// stays inside the hand band instead of pushing edge cards off-screen.
-function getArcCoefficient(handSize: number): number {
-  if (handSize <= 7) return 6;
-  // Keep max arc lift (at the edges) roughly constant at ~54px.
-  const maxDist = (handSize - 1) / 2;
-  return 54 / (maxDist * maxDist);
-}
-
-// Geometry for the WHOLE displayed row — hand cards plus the castable exile
-// (left) and graveyard (right) "wings" — as one fan. Overlap, per-card tilt and
-// arc are all sized by the TOTAL number of displayed cards, so a 3-card hand
-// shown alongside 13 graveyard delve-candidates tucks into the same tight,
-// angle-clamped arc a 16-card hand would, instead of inheriting the loose
-// 3-card spacing and spilling off-screen with near-sideways edge cards.
-//
-// `k` is a card's absolute position across the row: exile cards occupy [0, E),
-// hand cards [E, E + H), graveyard cards [E + H, N). When there are no wings
-// (N === H, E === 0) a hand card at index i sits at k === i, so the hand keeps
-// its familiar standalone fan; wings only ever shift the shared center, never
-// the hand's reorder bookkeeping (index/handSize stay hand-local).
-function fanGeometry(totalCards: number) {
-  const center = (totalCards - 1) / 2;
-  // Size the SHAPE (tilt + arc) from at least two cards so a lone card / wing
-  // still fans (a raw delta of 0 would render flat).
-  const shape = Math.max(2, totalCards);
-  const delta = Math.min(6, 36 / (shape - 1));
-  const arcCoeff = getArcCoefficient(shape);
-  // Downward parabola (edges drop, center rides highest), clamped at the row's
-  // own edges so the outermost cards rest level with the band instead of sinking
-  // below it and clipping.
-  const edgeLift = center * center * arcCoeff;
-  return {
-    overlap: getHandOverlap(totalCards),
-    rotation: (k: number) => (k - center) * delta,
-    arc: (k: number) => {
-      const d = k - center;
-      return Math.min(d * d * arcCoeff, edgeLift);
-    },
-  };
-}
+// The whole-row fan geometry — the overlap / tilt / arc that lays hand cards
+// (plus the castable exile / graveyard "wings") out as one held hand — now
+// lives in the shared `card/fanGeometry` module so the attachment fan curves
+// identically. `k` is a card's absolute position across the row: exile cards
+// occupy [0, E), hand cards [E, E + H), graveyard [E + H, N). With no wings
+// (E === 0, N === H) a hand card at index i sits at k === i, so the hand keeps
+// its familiar standalone fan; wings only shift the shared center, never the
+// hand's reorder bookkeeping (index/handSize stay hand-local).
 
 // Rendered size (px) of the bouncing drop-arrow's square box. Fixed (not
 // card-relative) so the imperative center / above-slot offsets stay exact in px.

--- a/client/src/components/hud/AttachmentsDialog.tsx
+++ b/client/src/components/hud/AttachmentsDialog.tsx
@@ -66,7 +66,12 @@ export function AttachmentsDialog({ isOpen, onClose, host, attachmentIds }: Prop
     >
       <div className="flex flex-wrap content-start justify-center gap-3 px-4 py-4 lg:px-6 lg:py-5">
         {attachmentIds.map((id) => (
-          <DialogAttachmentCard key={id} objectId={id} widthPx={ATTACHMENT_W_PX} />
+          <DialogAttachmentCard
+            key={id}
+            objectId={id}
+            widthPx={ATTACHMENT_W_PX}
+            onDismiss={onClose}
+          />
         ))}
       </div>
     </DialogShell>

--- a/client/src/components/hud/DialogAttachmentCard.tsx
+++ b/client/src/components/hud/DialogAttachmentCard.tsx
@@ -18,6 +18,18 @@ interface Props {
    *  ratio. Caller controls so the dialog can pick a size that suits its
    *  available width budget without DialogAttachmentCard guessing. */
   widthPx: number;
+  /** Close the enclosing AttachmentsDialog. Called after any interaction that
+   *  advances engine state to a prompt the player resolves on the BOARD rather
+   *  than in this dialog — target-select (the enchant/equip target is a
+   *  battlefield object, not a dialog card) and activation (e.g. Equip
+   *  transitions to `EquipTarget`, which needs the board visible). The
+   *  multi-ability picker is the one exception: it floats above independently,
+   *  so the dialog closes only after the picker itself dispatches.
+   *
+   *  Optional: the non-interactive `AurasHoverPreview` (a `pointer-events-none`
+   *  glance panel) renders these cards purely for display, so no interaction —
+   *  hence no dismiss — is ever possible there and it omits the callback. */
+  onDismiss?: () => void;
 }
 
 /**
@@ -41,7 +53,7 @@ interface Props {
  *     would be blank anyway. Reading directly from gameStore.waitingFor /
  *     legalActionsByObject is the right source here.
  */
-export function DialogAttachmentCard({ objectId, widthPx }: Props) {
+export function DialogAttachmentCard({ objectId, widthPx, onDismiss }: Props) {
   const { t } = useTranslation("game");
   const playerId = usePlayerId();
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
@@ -73,7 +85,6 @@ export function DialogAttachmentCard({ objectId, widthPx }: Props) {
   const isActivatable = objectActions.length > 0;
 
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
-  const setEnchantmentsDialogPlayer = useUiStore((s) => s.setEnchantmentsDialogPlayer);
 
   const { handlers, firedRef } = useCardHover(objectId);
 
@@ -101,17 +112,23 @@ export function DialogAttachmentCard({ objectId, widthPx }: Props) {
       // Auto-close on target select: the user's intent was decisive ("I
       // picked this target"). The engine moves to the next prompt; leaving
       // the dialog mounted would obscure that next prompt for no reason.
-      setEnchantmentsDialogPlayer(null);
+      onDismiss?.();
       return;
     }
     if (isActivatable) {
       if (objectActions.length === 1) {
         dispatchAction(objectActions[0]);
+        // Close so the board is reachable for whatever the activation asks
+        // next — e.g. Equip transitions to `EquipTarget`, whose creature
+        // target is picked on the battlefield, not in this dialog.
+        onDismiss?.();
       } else {
-        // Multi-ability picker takes over; our dialog stays mounted so the
-        // user can see what they activated against (the modal stacks above
-        // via DialogHost z-ordering — both signals trigger `wrapped`).
+        // Multi-ability picker takes over. Hand off to it and close this
+        // dialog: the picker floats independently (DialogHost z-ordering)
+        // and its own dispatch will drive the next board prompt, so keeping
+        // the attachments dialog mounted behind it only obscures the board.
         setPendingAbilityChoice({ objectId, actions: objectActions });
+        onDismiss?.();
       }
     }
   };

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -19,6 +19,7 @@ export function clearPromptOverlayState(): void {
   });
   useUiStore.getState().setPendingAbilityChoice(null);
   useUiStore.getState().setEnchantmentsDialogPlayer(null);
+  useUiStore.getState().setAttachmentFanHost(null);
   // The per-game "Manual mana" toggle must never leak into the next game.
   useUiStore.getState().setManualManaOverride(false);
   // The ephemeral hand hide-filter is a per-game focus aid — reset it too.

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Ring",
     "ringBearerTooltip": "Ringträger",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Wählen",
+    "fanConfirm": "Bestätigen ({{count}})",
+    "viewAttachments_one": "Angelegte Karte ansehen",
+    "viewAttachments_other": "{{count}} angelegte Karten ansehen",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -180,6 +180,10 @@
     "ringBearer": "Ring",
     "ringBearerTooltip": "Ring-bearer",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Pick",
+    "fanConfirm": "Confirm ({{count}})",
+    "viewAttachments_one": "View attached card",
+    "viewAttachments_other": "View {{count}} attached cards",
     "hiddenExileCards": "+{{count}} more exiled",
     "boardChoiceBadges": {
       "sacrifice": "Sac",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Anillo",
     "ringBearerTooltip": "Portador del Anillo",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Elegir",
+    "fanConfirm": "Confirmar ({{count}})",
+    "viewAttachments_one": "Ver carta anexada",
+    "viewAttachments_other": "Ver {{count}} cartas anexadas",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Anneau",
     "ringBearerTooltip": "Porteur de l'Anneau",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Choisir",
+    "fanConfirm": "Confirmer ({{count}})",
+    "viewAttachments_one": "Voir la carte attachée",
+    "viewAttachments_other": "Voir {{count}} cartes attachées",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Anello",
     "ringBearerTooltip": "Portatore dell'Anello",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Scegli",
+    "fanConfirm": "Conferma ({{count}})",
+    "viewAttachments_one": "Mostra carta assegnata",
+    "viewAttachments_other": "Mostra {{count}} carte assegnate",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Pierścień",
     "ringBearerTooltip": "Powiernik Pierścienia",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Wybierz",
+    "fanConfirm": "Potwierdź ({{count}})",
+    "viewAttachments_one": "Pokaż dołączoną kartę",
+    "viewAttachments_other": "Pokaż dołączone karty ({{count}})",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -179,6 +179,10 @@
     "ringBearer": "Anel",
     "ringBearerTooltip": "Portador do Anel",
     "hiddenAttachments": "+{{count}} more attached",
+    "fanPick": "Escolher",
+    "fanConfirm": "Confirmar ({{count}})",
+    "viewAttachments_one": "Ver carta anexada",
+    "viewAttachments_other": "Ver {{count}} cartas anexadas",
     "hiddenExileCards": "+{{count}} more exiled",
     "sacrifice": "Sacrifice",
     "boardChoiceBadges": {

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -109,6 +109,7 @@ import { ResolutionProgressOverlay } from "../components/board/ResolutionProgres
 import { LobbyProgress } from "../components/multiplayer/LobbyProgress.tsx";
 import { DisconnectChoiceDialog } from "../components/hud/DisconnectChoiceDialog.tsx";
 import { PlayerEnchantmentsDialog } from "../components/hud/PlayerEnchantmentsDialog.tsx";
+import { AttachmentFan } from "../components/board/AttachmentFan.tsx";
 import { PausedBanner } from "../components/chrome/PausedBanner.tsx";
 import type { P2PAdapterEvent } from "../adapter/p2p-adapter.ts";
 import { WebSocketAdapter } from "../adapter/ws-adapter.ts";
@@ -1617,6 +1618,14 @@ function GamePageContent({
             so the dialog's `fixed inset-0` shell anchors to the viewport
             instead of HudPlate's transform-CB bounding box. */}
         <PlayerEnchantmentsDialog />
+
+        {/* Permanent-attachment fan (Equipment / Aura / Fortification on a
+            battlefield object): a centered spread of the host + attachments,
+            each with its live selection affordance. Opened by clicking a
+            permanent-with-attachments during a target/board-choice prompt or by
+            the host's ⧉ badge. Self-portals to document.body, so its mount point
+            here is incidental. */}
+        <AttachmentFan />
 
         {/* Optional additional cost choice (kicker, blight, "or pay") */}
         {waitingFor?.type === "OptionalCostChoice" &&

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -142,6 +142,15 @@ interface UiStoreState {
    *  inherit Tailwind's `transform` containing block and shrink the
    *  dialog. See DialogHost.tsx:113-122 for the contract. */
   enchantmentsDialogPlayer: number | null;
+  /** When non-null, the AttachmentFan is open: a centered spread of this host
+   *  plus every permanent (Aura / Equipment / Fortification) attached to it,
+   *  each card carrying its own live selection affordance. Opened by clicking
+   *  a permanent-with-attachments during a target / board-choice prompt (so an
+   *  attached Equipment that overlaps its host is reachable) and by the host's
+   *  ⧉ badge for out-of-prompt viewing / re-equip. The object-host counterpart
+   *  to `enchantmentsDialogPlayer` (player-attached Aura curses, which still
+   *  use the modal AttachmentsDialog). Cleared by `clearPromptOverlayState`. */
+  attachmentFanHostId: ObjectId | null;
   mobileHandOpen: boolean;
   /** Ephemeral hide-filter for the player's own hand (display-only). Lives here
    *  rather than in `preferencesStore` so it resets each game (cleared by
@@ -222,6 +231,7 @@ interface UiStoreActions {
   setFocusedOpponent: (id: number | null) => void;
   setPendingAbilityChoice: (choice: { objectId: ObjectId; actions: GameAction[] } | null) => void;
   setEnchantmentsDialogPlayer: (id: number | null) => void;
+  setAttachmentFanHost: (id: ObjectId | null) => void;
   setMobileHandOpen: (open: boolean) => void;
   setHandFilter: (filter: FilterKey) => void;
   toggleDebugPanel: () => void;
@@ -274,6 +284,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   focusedOpponent: null,
   pendingAbilityChoice: null,
   enchantmentsDialogPlayer: null,
+  attachmentFanHostId: null,
   mobileHandOpen: false,
   handFilter: "none",
   debugPanelOpen: false,
@@ -523,6 +534,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   setFocusedOpponent: (id) => set({ focusedOpponent: id }),
   setPendingAbilityChoice: (choice) => set({ pendingAbilityChoice: choice }),
   setEnchantmentsDialogPlayer: (id) => set({ enchantmentsDialogPlayer: id }),
+  setAttachmentFanHost: (id) => set({ attachmentFanHostId: id }),
   setMobileHandOpen: (open) => set({ mobileHandOpen: open }),
   setHandFilter: (filter) => set({ handFilter: filter }),
   toggleDebugPanel: () => set((state) => ({ debugPanelOpen: !state.debugPanelOpen })),


### PR DESCRIPTION
During a target or board-choice prompt, a permanent and each of its attached
Auras/Equipment/Fortifications (CR 301.5 / 303.4: independent objects) are now
directly selectable in place — the host by its face, an attachment by its
right-edge peek. When the peek is an awkward click target, a '⧉' badge opens
a centered fan (AttachmentFan) spreading the host + attachments at readable size,
each card dispatching only what the engine's live prompt offers for that object
(target / board-choice / activation). The fan is opt-in, never forced.

The fan reuses the player hand's fan geometry, extracted to a shared
components/card/fanGeometry module (getHandOverlap parameterized by the card
width var so hand and fan overlap correctly at their own sizes). Fan cards are
big by default and scale down only if needed to fit the viewport:
min(clamp(11rem, 26vh, 24rem), 96vw / spreadFactor(n)) — the height-driven
desired size is floored so short/landscape screens stay large, while an outer
width-cap shrinks a many-attachment fan on a narrow portrait phone so nothing
clips off-screen.
