### PR TITLE
fix(client): scope mobile dock redesign to portrait, restoring landscape layout

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -258,9 +258,9 @@ export function ActionButton() {
   const idle = mode === "hidden" && !isEndingTurn;
   const blocked = idle || actionBlocked;
   const panelClassName =
-    "flex max-w-[min(32rem,calc(100vw-1.25rem))] flex-row flex-wrap items-center justify-end gap-1.5 rounded-[22px] border border-white/10 bg-slate-950/72 p-2 shadow-[0_24px_64px_rgba(15,23,42,0.52)] backdrop-blur-xl max-lg:w-full max-lg:max-w-none max-lg:flex-col max-lg:flex-nowrap max-lg:gap-1 max-lg:p-1.5 lg:max-w-none [@media(max-height:500px)]:gap-1 [@media(max-height:500px)]:p-1 [@media(max-height:500px)]:rounded-[14px]";
-  const primaryButtonClass = "min-w-[10.5rem] max-lg:w-full max-lg:!min-w-0 lg:min-w-[12rem] [@media(max-height:500px)]:!min-w-[5.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
-  const secondaryButtonClass = "min-w-[8rem] max-lg:w-full max-lg:!min-w-0 [@media(max-height:500px)]:!min-w-[4.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
+    "flex max-w-[min(32rem,calc(100vw-1.25rem))] flex-row flex-wrap items-center justify-end gap-1.5 rounded-[22px] border border-white/10 bg-slate-950/72 p-2 shadow-[0_24px_64px_rgba(15,23,42,0.52)] backdrop-blur-xl max-lg:portrait:w-full max-lg:portrait:max-w-none max-lg:portrait:flex-col max-lg:portrait:flex-nowrap max-lg:portrait:gap-1 max-lg:portrait:p-1.5 lg:max-w-none [@media(max-height:500px)]:gap-1 [@media(max-height:500px)]:p-1 [@media(max-height:500px)]:rounded-[14px]";
+  const primaryButtonClass = "min-w-[10.5rem] max-lg:portrait:w-full max-lg:portrait:!min-w-0 lg:min-w-[12rem] [@media(max-height:500px)]:!min-w-[5.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
+  const secondaryButtonClass = "min-w-[8rem] max-lg:portrait:w-full max-lg:portrait:!min-w-0 [@media(max-height:500px)]:!min-w-[4.5rem] [@media(max-height:500px)]:!min-h-7 [@media(max-height:500px)]:!px-2 [@media(max-height:500px)]:!py-0.5 [@media(max-height:500px)]:!text-[10px]";
 
   return (
     <>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -500,9 +500,12 @@ select.select-dark option {
   }
 }
 
-/* Mobile: lift the fanned hand above the fixed bottom action rail. Row height
-   is unchanged — cards still peek off the bottom edge. Desktop (lg+) untouched. */
-@media (max-width: 1023px) {
+/* Mobile PORTRAIT only: lift the fanned hand above the fixed bottom action
+   rail and split the dock into left/right clusters. Landscape (<lg) keeps the
+   desktop-style right-anchored rail; short landscape viewports are handled by
+   the existing max-height:500px compact styles. `width < 64rem` matches
+   Tailwind v4's `max-lg:` boundary exactly (strict <, rem-based). */
+@media (width < 64rem) and (orientation: portrait) {
   :root {
     --game-mobile-hand-lift: 1rem;
     --game-mobile-pile-lift: 16rem;
@@ -576,7 +579,7 @@ select.select-dark option {
   }
 }
 
-@media (max-width: 1023px) and (max-aspect-ratio: 10/11) {
+@media (width < 64rem) and (max-aspect-ratio: 10/11) {
   :root {
     --game-mobile-hand-lift: 3.25rem;
     --game-mobile-pile-lift: 18.5rem;
@@ -586,7 +589,10 @@ select.select-dark option {
   }
 }
 
-@media (max-width: 1023px) and (max-height: 500px) {
+/* Portrait-short windows (e.g. 400×480 desktop slivers): soften the lifts the
+   aspect-ratio block above would otherwise apply. Orientation-scoped so
+   landscape phones — which no longer receive the dock at all — are untouched. */
+@media (width < 64rem) and (orientation: portrait) and (max-height: 500px) {
   :root {
     --game-mobile-hand-lift: 0.75rem;
     --game-mobile-pile-lift: 12.5rem;

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1327,7 +1327,7 @@ function GamePageContent({
         flexZone="actionRail"
         scaleKey="actionRail"
         resizeCorner="bl"
-        className="fixed z-30 flex flex-col items-end gap-1.5 max-lg:w-full max-lg:flex-row max-lg:items-end max-lg:justify-between max-lg:gap-2"
+        className="fixed z-30 flex flex-col items-end gap-1.5 max-lg:portrait:w-full max-lg:portrait:flex-row max-lg:portrait:items-end max-lg:portrait:justify-between max-lg:portrait:gap-2"
         style={{
           bottom: "calc(env(safe-area-inset-bottom) + var(--action-btn-bottom))",
           right: "calc(env(safe-area-inset-right) + var(--game-edge-right) + var(--game-right-rail-offset, 0px))",
@@ -1338,7 +1338,7 @@ function GamePageContent({
         {!isSpectatorMode && (
           <div
             data-mobile-action-left
-            className="flex flex-col gap-1 max-lg:min-w-0 lg:hidden"
+            className="hidden flex-col gap-1 max-lg:portrait:flex max-lg:portrait:min-w-0"
           >
             <div className="flex flex-col gap-1 max-lg:gap-1">
               <CombatPhaseIndicator />
@@ -1349,21 +1349,21 @@ function GamePageContent({
         )}
         <div
           data-mobile-action-right
-          className="flex flex-col items-end gap-1.5 max-lg:min-w-0 max-lg:items-stretch lg:items-end"
+          className="flex flex-col items-end gap-1.5 max-lg:min-w-0 max-lg:portrait:items-stretch lg:items-end"
         >
           {showFlowHelpNudge && <FlowHelpNudge />}
           {showSandboxToolsNudge && <SandboxToolsNudge />}
-          <div className="hidden lg:block">
+          <div className="hidden max-lg:landscape:block lg:block">
             <CombatPhaseIndicator />
           </div>
           {isSpectatorMode ? (
             <TurnStatusLine />
           ) : (
             <>
-              <div className="max-lg:w-full lg:hidden">
+              <div className="hidden max-lg:portrait:block max-lg:portrait:w-full">
                 <TurnStatusLine />
               </div>
-              <div className="hidden flex-row items-center gap-1.5 lg:flex">
+              <div className="hidden flex-row items-center gap-1.5 max-lg:landscape:flex lg:flex">
                 <TurnStatusLine />
                 <HandBadge />
                 <FullControlToggle />


### PR DESCRIPTION
PR #4177 gated the portrait action-dock redesign on viewport width alone
(max-width:1023px / max-lg:), so landscape phones and small tablets got a
portrait-shaped layout: zone piles hoisted 200px off the bottom-left, the
player HUD pushed up by the forced 0.24 player-row height, and full-width
stacked action buttons.

Scope the index.css mobile block to (width < 64rem) and (orientation:
portrait) — the width < 64rem form matches Tailwind v4's max-lg boundary
exactly — and portrait-scope the Tailwind rail/ActionButton classes, with
max-lg:landscape visibility restoring the pre-#4177 inline status row and
combat phase indicator. Landscape falls back to the pre-existing
max-height:500px compact styling; portrait keeps the #4177 dock unchanged,
including the height<=500 var softening, now orientation-scoped.
