### PR TITLE
fix(client): attach Manual mana toggle and Undo button to player HUD

### DIFF
--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
-import { isMultiplayerMode, useGameStore } from "../../stores/gameStore.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { sortCreaturesForBlockers } from "../../viewmodel/blockerSorting.ts";
@@ -19,7 +19,6 @@ import {
 import { BoardInteractionContext } from "./BoardInteractionContext.tsx";
 import { ArchenemyPanel } from "./ArchenemyPanel.tsx";
 import { CombatLine } from "./CombatLine.tsx";
-import { ManualManaToggle } from "./ManualManaToggle.tsx";
 import { PlayerArea } from "./PlayerArea.tsx";
 import { PlanechasePanel } from "./PlanechasePanel.tsx";
 import { DraggableWidget } from "../flexlayout/DraggableWidget.tsx";
@@ -34,12 +33,6 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
   const gameState = useGameStore((s) => s.gameState);
   const waitingFor = useGameStore((s) => s.waitingFor);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
-  // Undo is a single-player affordance only — multiplayer games have
-  // authoritative shared state and can't safely rewind one client.
-  const canUndo = useGameStore(
-    (s) => s.stateHistory.length > 0 && !isMultiplayerMode(s.gameMode),
-  );
-  const undo = useGameStore((s) => s.undo);
   const blockerAssignments = useUiStore((s) => s.blockerAssignments);
   const localPlayerId = usePlayerId();
   const myId = usePerspectivePlayerId();
@@ -235,30 +228,6 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
   // OpponentHud rail into PlayerArea's small `hud` slot.
   const is1v1 = isOneOnOne(gameState);
 
-  // Undo button for the player's land column
-  const undoButton = canUndo ? (
-    <button
-      onClick={undo}
-      className="mt-auto mx-auto flex items-center gap-1 rounded-md bg-gray-800/80 px-2.5 py-1 text-[11px] font-medium text-gray-400 transition-colors hover:bg-gray-700/80 hover:text-gray-200"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
-        <path fillRule="evenodd" d="M14 8a6 6 0 1 1-12 0 6 6 0 0 1 12 0ZM7.72 4.22a.75.75 0 0 0-1.06 0L4.97 5.91a.75.75 0 0 0 0 1.06l1.69 1.69a.75.75 0 1 0 1.06-1.06l-.47-.47h1.63a1.25 1.25 0 0 1 0 2.5H7.5a.75.75 0 0 0 0 1.5h1.38a2.75 2.75 0 0 0 0-5.5H7.25l.47-.47a.75.75 0 0 0 0-1.06Z" clipRule="evenodd" />
-      </svg>
-      {t("board.undo")}
-    </button>
-  ) : null;
-
-  // Land-column stack: the per-game "Manual mana" toggle above the undo button.
-  // `landColumnExtra` is an absolutely-positioned single-child overlay that
-  // stacks upward from `bottom-0` (see PlayerArea), where the undo button's
-  // `mt-auto` is inert — so use an explicit `gap-1` flex column for spacing.
-  const landColumnExtra = (
-    <div className="flex flex-col items-center gap-1">
-      <ManualManaToggle />
-      {undoButton}
-    </div>
-  );
-
   return (
     <BoardInteractionContext.Provider value={boardInteractionState}>
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
@@ -313,7 +282,6 @@ export const GameBoard = memo(function GameBoard({ oppHud, playerHud }: GameBoar
           battlefieldView={playerBattlefieldView}
           playerId={myId}
           mode="full"
-          landColumnExtra={landColumnExtra}
           creatureOverride={sortedPlayerCreatures}
           hud={playerHud}
         />

--- a/client/src/components/board/ManualManaToggle.tsx
+++ b/client/src/components/board/ManualManaToggle.tsx
@@ -7,8 +7,8 @@ import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
  * Thin pill that forces Manual mana payment for the current game only. Toggles
  * the ephemeral `manualManaOverride` in uiStore (reset on every game boundary by
  * `clearPromptOverlayState`) — it never touches the persisted `spellPaymentMode`
- * preference. Pure display + dispatch leaf; rendered in the local player's land
- * column beside the undo button.
+ * preference. Pure display + dispatch leaf; rendered attached to the local
+ * player's HUD beside the undo button.
  */
 export function ManualManaToggle() {
   const { t } = useTranslation("game");

--- a/client/src/components/board/PlayerArea.tsx
+++ b/client/src/components/board/PlayerArea.tsx
@@ -148,8 +148,6 @@ interface PlayerAreaProps {
   onFocus?: () => void;
   /** Whether this compact strip is the currently focused opponent */
   isActive?: boolean;
-  /** Extra content to render in the land column (e.g. undo button) */
-  landColumnExtra?: React.ReactNode;
   /** Override creature groups with pre-sorted list (for blocker alignment) */
   creatureOverride?: GroupedPermanent[];
   battlefieldView?: PlayerBattlefieldView;
@@ -162,7 +160,6 @@ export function PlayerArea({
   mode,
   onFocus,
   isActive,
-  landColumnExtra,
   creatureOverride,
   battlefieldView,
   hud,
@@ -413,21 +410,6 @@ export function PlayerArea({
     </div>
   ) : null;
 
-  const landColumnExtraOverlay = landColumnExtra ? (
-    // The stack anchors at the middle-row bottom and grows upward, so at bottom-0
-    // it rides up over the lowest lands / the collapsed land tile. Drop it into
-    // the outer column's reserved `pb-8` gutter (full, non-compact only — compact
-    // height has no bottom padding to borrow) so it clears the land row.
-    <div
-      className={`pointer-events-none absolute bottom-0 left-2 z-30 ${
-        isCompactHeight ? "" : "translate-y-8"
-      }`}
-      data-testid="land-column-extra"
-    >
-      <div className="pointer-events-auto">{landColumnExtra}</div>
-    </div>
-  ) : null;
-
   return (
     <div
       className={`relative flex min-h-0 min-w-0 flex-1 overflow-visible ${
@@ -451,7 +433,6 @@ export function PlayerArea({
             <div className={`relative ${isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}`}>
               {middleRow}
               {hudBand}
-              {landColumnExtraOverlay}
             </div>
             <div className="flex min-h-0 flex-1 items-end px-2" data-debug-label="Opp Creatures">
               <BattlefieldZoneOverflow
@@ -474,7 +455,6 @@ export function PlayerArea({
             <div className={`relative ${isCompactHeight ? "min-h-0 max-h-[40%]" : "shrink-0"}`}>
               {middleRow}
               {hudBand}
-              {landColumnExtraOverlay}
             </div>
             <BattlefieldRow groups={partitioned?.other ?? []} rowType="other" />
           </>

--- a/client/src/components/board/UndoButton.tsx
+++ b/client/src/components/board/UndoButton.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from "react-i18next";
+
+import { isMultiplayerMode, useGameStore } from "../../stores/gameStore.ts";
+
+/**
+ * Undo button for the local player, rendered attached to the player HUD beside
+ * the Manual mana toggle. Undo is a single-player affordance only — multiplayer
+ * games have authoritative shared state and can't safely rewind one client.
+ */
+export function UndoButton() {
+  const { t } = useTranslation("game");
+  const canUndo = useGameStore(
+    (s) => s.stateHistory.length > 0 && !isMultiplayerMode(s.gameMode),
+  );
+  const undo = useGameStore((s) => s.undo);
+
+  if (!canUndo) return null;
+  return (
+    <button
+      onClick={undo}
+      className="flex items-center gap-1 rounded-md bg-gray-800/80 px-2.5 py-1 text-[11px] font-medium text-gray-400 transition-colors hover:bg-gray-700/80 hover:text-gray-200"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
+        <path fillRule="evenodd" d="M14 8a6 6 0 1 1-12 0 6 6 0 0 1 12 0ZM7.72 4.22a.75.75 0 0 0-1.06 0L4.97 5.91a.75.75 0 0 0 0 1.06l1.69 1.69a.75.75 0 1 0 1.06-1.06l-.47-.47h1.63a1.25 1.25 0 0 1 0 2.5H7.5a.75.75 0 0 0 0 1.5h1.38a2.75 2.75 0 0 0 0-5.5H7.25l.47-.47a.75.75 0 0 0 0-1.06Z" clipRule="evenodd" />
+      </svg>
+      {t("board.undo")}
+    </button>
+  );
+}

--- a/client/src/components/board/__tests__/UndoButton.test.tsx
+++ b/client/src/components/board/__tests__/UndoButton.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { GameState } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { UndoButton } from "../UndoButton.tsx";
+
+describe("UndoButton", () => {
+  afterEach(() => {
+    cleanup();
+    useGameStore.setState({ stateHistory: [], gameMode: null });
+  });
+
+  it("renders when single-player history exists", () => {
+    useGameStore.setState({
+      stateHistory: [{} as GameState],
+      gameMode: "ai",
+    });
+
+    render(<UndoButton />);
+
+    expect(screen.getByRole("button", { name: /undo/i })).toBeInTheDocument();
+  });
+
+  it("does not render without history", () => {
+    useGameStore.setState({ stateHistory: [], gameMode: "ai" });
+
+    render(<UndoButton />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("never renders in multiplayer, even with history", () => {
+    // Multiplayer state is authoritative and shared — a client-side rewind
+    // would desync, so the affordance must stay hidden regardless of history.
+    useGameStore.setState({
+      stateHistory: [{} as GameState],
+      gameMode: "online",
+    });
+
+    render(<UndoButton />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -10,6 +10,8 @@ import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getPlayerDisplayName, useMultiplayerStore } from "../../stores/multiplayerStore.ts";
 import { ScoreBadge } from "../draft/ScoreBadge.tsx";
+import { ManualManaToggle } from "../board/ManualManaToggle.tsx";
+import { UndoButton } from "../board/UndoButton.tsx";
 import { LifeTotal } from "../controls/LifeTotal.tsx";
 import { ManaPoolSummary } from "./ManaPoolSummary.tsx";
 import { PhaseIndicatorLeft, PhaseIndicatorRight } from "../controls/PhaseStopBar.tsx";
@@ -147,6 +149,16 @@ export function PlayerHud() {
         </div>
       </HudPlate>
       <PhaseIndicatorRight />
+      {/* Manual mana + undo ride the HUD (drag offsets and the mobile portrait
+          shift included) instead of overlaying the land column, where they
+          collided with land stacks and the zone piles. Absolutely positioned
+          off the right edge so the plate keeps its centered anchor. The
+          pointer-events split keeps the column's empty bounding-box regions
+          (chip gap, short-chip gutter) tappable through to fanned hand cards. */}
+      <div className="pointer-events-none absolute left-full top-1/2 z-20 ml-1 flex -translate-y-1/2 flex-col items-start gap-1 [&>*]:pointer-events-auto">
+        <ManualManaToggle />
+        <UndoButton />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The Manual toggle and Undo button lived in an absolutely-positioned overlay
anchored to the land column's bottom-left corner (landColumnExtra), which
chronically collided with land stacks, the lifted zone piles, and other
bottom-left UI as layouts shifted around it.

Extract the undo affordance into a self-contained UndoButton leaf (same
stateHistory + single-player gating) and render both chips inside PlayerHud,
absolutely anchored off the plate's right edge so they ride HUD drags and
the mobile portrait shift as one positioned unit. The pointer-events split
keeps the column's empty bounding-box regions tappable through to fanned
hand cards. Deletes the landColumnExtra plumbing from GameBoard/PlayerArea.
