### PR TITLE
fix(parser): gate self keyword-grants on trailing "unless <source state>" (Tadeas, Juniper Ascendant)

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -799,6 +799,47 @@ pub(crate) fn parse_continuous_gets_has(
         }
     }
 
+    // CR 611.3a: Split a trailing " unless [condition]" gate, mirroring the
+    // " as long as " form above. An "unless <cond>" rider grants the modification
+    // precisely when <cond> is FALSE, so the parsed condition is wrapped in `Not`
+    // (Tadeas, Juniper Ascendant: "has hexproof unless it's attacking" → AddKeyword
+    // gated on Not(SourceIsAttacking)). Only peel when the split sits OUTSIDE a
+    // quoted granted ability — a granted ability's own inner "unless" (e.g. "gains
+    // 'counter target spell unless its controller pays {1}'") must stay with the
+    // quoted text; balanced double quotes in the body signal the split is outside
+    // any "...". As with the " as long as " form, the self-pronoun condition
+    // subject ("it's attacking"/"it's tapped") is resolved to the source only for
+    // SelfRef grants — an attached-subject "it" keeps its enchanted/equipped
+    // binding and stays an honest gap.
+    if let Some((before_cond, after_cond)) = tp
+        .split_around(" unless ")
+        .filter(|(body, _)| body.original.chars().filter(|&c| c == '"').count() % 2 == 0)
+    {
+        let continuous_text = before_cond.original;
+        let condition_text = after_cond.original.trim().trim_end_matches('.');
+        if let Some(mut def) =
+            parse_continuous_gets_has(continuous_text, affected.clone(), description)
+        {
+            let typed = if matches!(affected, TargetFilter::SelfRef) {
+                parse_static_condition(&rewrite_self_pronoun_subject(condition_text))
+            } else {
+                parse_static_condition(condition_text)
+            };
+            let condition = match typed {
+                Some(inner) => StaticCondition::Not {
+                    condition: Box::new(inner),
+                },
+                None => StaticCondition::Not {
+                    condition: Box::new(StaticCondition::Unrecognized {
+                        text: format!("unless {condition_text}"),
+                    }),
+                },
+            };
+            def.condition = Some(condition);
+            return Some(def);
+        }
+    }
+
     // CR 613.4c: Handle repeated dynamic pump terms — "gets +N/+M for each X and
     // +P/+Q for each Y" (Eidolon of Countless Battles) — where each term scales
     // by its own count. Try this before the single-"for each" path so the second

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -714,7 +714,9 @@ pub(crate) fn parse_typed_you_control_subject_filter(
 ///    enchanted/equipped creature) the pronoun is not the source.
 /// 2. Only the bare source-STATE predicates that `~ is …` already resolves to a
 ///    typed condition are rewritten — the tapped/untapped pair plus their
-///    combat-state siblings "attacking"/"blocking"/"blocked"
+///    combat-state siblings "attacking"/"blocking"/"blocked" and the compound
+///    "attacking or blocking" (which `~ is …` lowers to
+///    `Or([SourceIsAttacking, SourceIsBlocking])`)
 ///    (CR 508.1k / 509.1g / 509.1h). "it" is otherwise overloaded: "it's your
 ///    turn" is impersonal (a turn reference, not the source); "it's a Wall" /
 ///    "it's red" / "it's legendary" are type/characteristic gates with their own
@@ -744,6 +746,7 @@ fn rewrite_self_pronoun_subject(condition: &str) -> String {
                 | "attacking"
                 | "blocking"
                 | "blocked"
+                | "attacking or blocking"
                 | "modified"
                 | "equipped"
                 | "enchanted"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1636,6 +1636,41 @@ fn self_keyword_grant_unless_source_combat_state_gate() {
         "no static_structure gap should remain; abilities = {:?}",
         parsed.abilities
     );
+
+    // CR 509.1g + CR 508.1k: the compound "attacking or blocking" self-state must
+    // resolve to Not(Or([SourceIsAttacking, SourceIsBlocking])) — NOT a partial
+    // Not(Unrecognized) — via the same self-pronoun normalization axis (Tromokratis:
+    // "~ has hexproof unless it's attacking or blocking.").
+    let tromokratis = crate::parser::oracle::parse_oracle_text(
+        "~ has hexproof unless it's attacking or blocking.",
+        "Tromokratis",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let def = tromokratis
+        .statics
+        .iter()
+        .find(|d| d.mode == StaticMode::Continuous)
+        .expect("expected a Continuous hexproof grant");
+    match &def.condition {
+        Some(StaticCondition::Not { condition }) => match &**condition {
+            StaticCondition::Or { conditions } => assert!(
+                conditions.len() == 2
+                    && conditions.contains(&StaticCondition::SourceIsAttacking)
+                    && conditions.contains(&StaticCondition::SourceIsBlocking),
+                "expected Or([SourceIsAttacking, SourceIsBlocking]), got {conditions:?}"
+            ),
+            other => panic!("expected Not(Or([...])), got Not({other:?})"),
+        },
+        other => panic!("expected Not(Or([...])) condition, got {other:?}"),
+    }
+    assert!(
+        !serde_json::to_string(&tromokratis)
+            .unwrap()
+            .contains("Unrecognized"),
+        "the compound combat-state gate must not leave an Unrecognized condition"
+    );
 }
 
 /// CR 509.1b + CR 506.2 + CR 108.3: The compound "+N/+N and can't be blocked

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1585,6 +1585,59 @@ fn cant_be_blocked_static_split_keeps_trailing_condition() {
     );
 }
 
+/// CR 611.3a + CR 508.1k: A self-referential keyword grant gated by a trailing
+/// "unless it's <source combat/tap state>" rider (Tadeas, Juniper Ascendant:
+/// "~ has hexproof unless it's attacking.") must attach the negated source
+/// condition, not be dropped as an unparsed static. The self keyword-grant path
+/// handled the "as long as" and "if" gate forms, but "unless <source state>"
+/// fell through — `parse_continuous_gets_has` split "as long as" (with the
+/// self-pronoun rewrite that resolves "it's attacking" → `SourceIsAttacking`)
+/// but had no "unless" split, so the whole grant failed to a `static_structure`
+/// gap. "unless X" grants precisely when X is FALSE, so the condition is
+/// `Not(SourceIsAttacking)`.
+#[test]
+fn self_keyword_grant_unless_source_combat_state_gate() {
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        "~ has hexproof unless it's attacking.",
+        "Tadeas, Juniper Ascendant",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let def = parsed
+        .statics
+        .iter()
+        .find(|d| d.mode == StaticMode::Continuous)
+        .expect("expected a Continuous hexproof grant");
+    assert!(
+        def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Hexproof
+            }
+        )),
+        "expected an AddKeyword(Hexproof) modification, got {:?}",
+        def.modifications
+    );
+    assert!(
+        matches!(
+            &def.condition,
+            Some(StaticCondition::Not { condition })
+                if matches!(**condition, StaticCondition::SourceIsAttacking)
+        ),
+        "the 'unless it's attacking' rider must gate on Not(SourceIsAttacking), got {:?}",
+        def.condition
+    );
+    assert!(
+        parsed.parse_warnings.is_empty()
+            && !serde_json::to_string(&parsed.abilities)
+                .unwrap()
+                .contains("static_structure"),
+        "no static_structure gap should remain; abilities = {:?}",
+        parsed.abilities
+    );
+}
+
 /// CR 509.1b + CR 506.2 + CR 108.3: The compound "+N/+N and can't be blocked
 /// unless it's attacking its owner or a permanent its owner controls" must
 /// decompose into BOTH the P/T grant AND a `CantBeBlocked` static whose


### PR DESCRIPTION
## Problem

A self-referential keyword grant gated by a trailing `unless it's <attacking|blocking|tapped|…>` rider parsed to a `static_structure` gap and silently lost its gate:

- Tadeas, Juniper Ascendant: `~ has hexproof **unless it's attacking**.` → no static (dropped)

The self keyword-grant dispatch had `if` and `as long as` arms but **no `unless` arm**, and `parse_continuous_gets_has` split ` as long as ` (resolving the self-pronoun `it's attacking` → `SourceIsAttacking` via `rewrite_self_pronoun_subject`) but had **no ` unless ` split**. So `unless <source state>` reached `parse_continuous_gets_has` with the rider intact and nothing handled it → the whole grant failed.

Confirmed the whole class was affected, not just Tadeas: `~ has hexproof unless it's tapped`, `~ has flying unless it's blocking`, etc. all failed identically, while `unless you control X` (board condition) and `as long as it's attacking` already worked.

## Fix

Add an ` unless ` split to `parse_continuous_gets_has` (test-free `oracle_static/anthem.rs`) mirroring the existing ` as long as ` block (**CR 611.3a**): recurse on the body, parse the condition — applying the SelfRef-only self-pronoun rewrite so `it's attacking` binds to the source — and wrap it in `Not` (an `unless X` grant applies precisely when X is **false**).

A balanced-double-quote guard keeps a granted ability's own inner `unless` (`gains "counter target spell unless its controller pays {1}"`) with its quoted text.

### Before / after (Tadeas)

```
before: (no static — static_structure gap, hexproof gate dropped)
after:  Continuous / AddKeyword(Hexproof)  condition: Not(SourceIsAttacking)
```

## Scope / safety

- Covers the whole self keyword/pump-grant `unless <source state>` class (attacking / blocking / blocked / tapped / etc.).
- **Unchanged:** board-condition `unless` (`Not(IsPresent)`), `as long as`, plain grants, attached-subject (`enchanted creature … unless it's attacking` correctly keeps its host binding as an honest gap rather than a wrong self-rewrite), and quoted granted-ability inner `unless`.

## Tests

- New `self_keyword_grant_unless_source_combat_state_gate` regression: asserts the Continuous `AddKeyword(Hexproof)` gate is `Not(SourceIsAttacking)` with no `static_structure` residue.
- 949 `oracle_static` tests pass; `cargo fmt` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)