### PR TITLE
ship/mp resolve all auto yield

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -250,6 +250,11 @@ export function ActionButton() {
   // Read auto-pass state from engine
   const autoPass = gameState?.auto_pass?.[playerId];
   const isEndingTurn = autoPass?.type === "UntilEndOfTurn";
+  // Armed Arena-style "Resolve All" session (multiplayer): the engine is
+  // auto-passing this seat's priority windows until the stack empties or
+  // grows. Surfaced with the same pulsing cancel affordance as UntilEndOfTurn
+  // so the player can revoke it between opponents' windows.
+  const isResolvingStack = autoPass?.type === "UntilStackEmpty";
   const canActDuringAutoPass = mode === "combat-blockers";
 
   const actionPending = useMultiplayerStore((s) => s.actionPending);
@@ -390,7 +395,7 @@ export function ActionButton() {
           </>
         )}
 
-        {(mode === "priority-empty" || idle) && !isEndingTurn && (
+        {(mode === "priority-empty" || idle) && !isEndingTurn && !isResolvingStack && (
           <>
             {canCompanionToHand && !idle && (
               <button
@@ -443,7 +448,7 @@ export function ActionButton() {
           </>
         )}
 
-        {isEndingTurn && !canActDuringAutoPass && (
+        {(isEndingTurn || isResolvingStack) && !canActDuringAutoPass && (
           <button
             disabled={actionBlocked}
             onClick={() => dispatchAction({ type: "CancelAutoPass" })}
@@ -453,7 +458,7 @@ export function ActionButton() {
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 animate-spin">
                 <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.451a.75.75 0 0 0 0-1.5H4.5a.75.75 0 0 0-.75.75v3.75a.75.75 0 0 0 1.5 0v-2.033l.364.363a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.39Zm-10.624-2.85a5.5 5.5 0 0 1 9.201-2.465l.312.31H11.75a.75.75 0 0 0 0 1.5h3.75a.75.75 0 0 0 .75-.75V3.42a.75.75 0 0 0-1.5 0v2.033l-.364-.364A7 7 0 0 0 3.074 8.227a.75.75 0 0 0 1.449.39l.165-.044Z" clipRule="evenodd" />
               </svg>
-              {t("actionButton.autoPassing")}
+              {isEndingTurn ? t("actionButton.autoPassing") : t("actionButton.resolvingStack")}
             </span>
           </button>
         )}

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -1,7 +1,8 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameState, WaitingFor } from "../../../adapter/types";
+import { dispatchAction } from "../../../game/dispatch.ts";
 import { useGameStore } from "../../../stores/gameStore";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore";
 import { useUiStore } from "../../../stores/uiStore";
@@ -173,6 +174,36 @@ describe("ActionButton", () => {
     expect(screen.getByRole("button", { name: /^Resolve Pass priority/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("surfaces an armed UntilStackEmpty session with a cancel affordance while an opponent holds priority", () => {
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: {
+        ...createGameState({ type: "Priority", data: { player: 1 } }),
+        phase: "PostCombatMain",
+        auto_pass: { 0: { type: "UntilStackEmpty", initial_stack_len: 1 } },
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 1,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
+      },
+      waitingFor: { type: "Priority", data: { player: 1 } },
+      legalActions: [],
+      isResolvingAll: false,
+    });
+    useMultiplayerStore.setState({ activePlayerId: 0, actionPending: false });
+
+    render(<ActionButton />);
+
+    const cancel = screen.getByRole("button", { name: "Resolving Stack..." });
+    expect(cancel).toBeEnabled();
+    fireEvent.click(cancel);
+    expect(vi.mocked(dispatchAction)).toHaveBeenCalledWith({ type: "CancelAutoPass" });
   });
 
   it("shows blocker controls when turn decision controller differs from blocking player (issue #1199)", () => {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -112,6 +112,33 @@ describe("dispatchResolveAll progress", () => {
     expect(resolveAll).toHaveBeenCalledTimes(1);
     expect(useGameStore.getState().isResolvingAll).toBe(false);
   });
+
+  it("falls back to an engine-side UntilStackEmpty auto-pass when the adapter has no batch resolveAll (multiplayer)", async () => {
+    const submitAction = vi
+      .fn<(action: unknown, actor: number) => Promise<{ events: never[] }>>()
+      .mockResolvedValue({ events: [] });
+
+    useGameStore.setState({
+      gameState: stateWithStack(3),
+      adapter: {
+        submitAction,
+        getState: vi.fn().mockResolvedValue(stateWithStack(2)),
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+      } as never,
+    });
+
+    await dispatchResolveAll(0, []);
+
+    // Arena semantics: yield THIS seat's priority windows via the engine's
+    // auto-pass session — never a host-driven batch drain over human seats.
+    expect(submitAction).toHaveBeenCalledTimes(1);
+    expect(submitAction).toHaveBeenCalledWith(
+      { type: "SetAutoPass", data: { mode: { type: "UntilStackEmpty" } } },
+      0,
+    );
+    // The batch busy-state must stay untouched — there is no local drain loop.
+    expect(useGameStore.getState().isResolvingAll).toBe(false);
+  });
 });
 
 type EngineResolveAll = (

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -136,13 +136,10 @@ function isStateLost(err: unknown): boolean {
 }
 
 /**
- * True when a gameplay round-trip to the engine worker timed out (the worker
- * wedged and never replied — see `ENGINE_REQUEST_TIMEOUT_MS`). Unlike
- * STATE_LOST this is NOT rehydratable in place: the worker itself is
- * unresponsive, so retrying or restoring through it would hang again. Surface
- * the Layer 3 reload prompt and let the error propagate so the dispatch mutex
- * is released (the alternative is an infinite freeze with a silently-held mutex
- * that drops every later click).
+ * Legacy adapter failure for an engine worker that has already been classified
+ * as unrecoverably unresponsive. Current worker watchdogs do not reject at 60s;
+ * they notify the UI and keep the request alive so the user can continue
+ * waiting for a late response.
  */
 function isEngineUnresponsive(err: unknown): boolean {
   return err instanceof AdapterError && err.code === AdapterErrorCode.ENGINE_UNRESPONSIVE;
@@ -714,8 +711,22 @@ export async function dispatchResolveAll(
 ): Promise<void> {
   if (batchResolveInProgress) return;
   const { adapter } = useGameStore.getState();
-  if (!adapter || !adapter.resolveAll) {
-    debugLog("dispatchResolveAll: adapter missing or no resolveAll support");
+  if (!adapter) {
+    debugLog("dispatchResolveAll: no adapter");
+    return;
+  }
+  if (!adapter.resolveAll) {
+    // Multiplayer transports have no batch drain: the other seats are humans,
+    // and CR 117.4 entitles each of them to their own priority window before
+    // anything resolves — the engine must not pass on their behalf. Arena-style
+    // "Resolve All" instead: an engine-side auto-yield for THIS seat only
+    // (AutoPassMode::UntilStackEmpty), which auto-passes whenever this player
+    // receives priority and clears itself when the stack empties or grows
+    // (an opponent responded).
+    await dispatchAction(
+      { type: "SetAutoPass", data: { mode: { type: "UntilStackEmpty" } } },
+      requester,
+    );
     return;
   }
 

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { isMultiplayerMode, useGameStore } from "../stores/gameStore";
 import { useUiStore } from "../stores/uiStore";
 import { dispatchAction } from "../game/dispatch";
+import { getPlayerId } from "./usePlayerId";
 import { useAltToggle } from "./useAltToggle";
 import { useShiftHeld } from "./useShiftHeld";
 import {
@@ -105,9 +106,10 @@ export function useKeyboardShortcuts(): void {
 
         case "Enter": {
           e.preventDefault();
-          // Toggle auto-pass: if any auto-pass is active, cancel it; otherwise set UntilEndOfTurn
-          const playerId = gameState?.active_player ?? 0;
-          const currentAutoPass = gameState?.auto_pass?.[playerId];
+          // Toggle auto-pass: if any auto-pass is active, cancel it; otherwise set UntilEndOfTurn.
+          // Read the LOCAL seat's entry — auto_pass is keyed by the player who
+          // armed it, and in multiplayer the local seat is rarely the active player.
+          const currentAutoPass = gameState?.auto_pass?.[getPlayerId()];
           if (currentAutoPass) {
             dispatchAction({ type: "CancelAutoPass" });
           } else {
@@ -157,8 +159,8 @@ export function useKeyboardShortcuts(): void {
 
         case "Escape": {
           e.preventDefault();
-          const escPlayerId = gameState?.active_player ?? 0;
-          if (gameState?.auto_pass?.[escPlayerId]) {
+          // Local seat's own session — see the Enter handler note.
+          if (gameState?.auto_pass?.[getPlayerId()]) {
             dispatchAction({ type: "CancelAutoPass" });
           } else if (waitingFor?.type === "ManaPayment") {
             dispatch({ type: "CancelCast" });

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Priorität abgeben. Wenn der Stapel leer ist, rückt dies durch das aktuelle Prioritätsfenster vor. Tastenkürzel: Leertaste.",
     "pass": "Abgeben",
     "passToEndTooltip": "Bis zum Endschritt automatisch abgeben, sofern keine Wahl, kein Stopp oder die volle Kontrolle unterbricht. Tastenkürzel: Eingabe.",
-    "autoPassing": "Automatisch bis zum Endschritt abgeben..."
+    "autoPassing": "Automatisch bis zum Endschritt abgeben...",
+    "resolvingStack": "Stapel wird aufgelöst..."
   },
   "board": {
     "regroupCreatures": "Doppelte Kreaturengruppen neu gruppieren",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Pass priority. If the stack is empty, this advances through the current priority window. Shortcut: Space.",
     "pass": "Pass",
     "passToEndTooltip": "Auto-pass until the end step unless a choice, stop, or Full Control interrupts. Shortcut: Enter.",
-    "autoPassing": "Auto-Passing to End Step..."
+    "autoPassing": "Auto-Passing to End Step...",
+    "resolvingStack": "Resolving Stack..."
   },
   "board": {
     "regroupCreatures": "Regroup duplicate creature groups",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Pasa la prioridad. Si la pila está vacía, esto avanza por la ventana de prioridad actual. Atajo: Espacio.",
     "pass": "Pasar",
     "passToEndTooltip": "Pasar automáticamente hasta el paso final a menos que lo interrumpa una elección, una parada o el Control total. Atajo: Intro.",
-    "autoPassing": "Pasando automáticamente al paso final..."
+    "autoPassing": "Pasando automáticamente al paso final...",
+    "resolvingStack": "Resolviendo la pila..."
   },
   "board": {
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Passez la priorité. Si la pile est vide, cela avance dans la fenêtre de priorité actuelle. Raccourci : Espace.",
     "pass": "Passer",
     "passToEndTooltip": "Passage automatique jusqu'à l'étape de fin sauf si un choix, un arrêt ou le Contrôle total interrompt. Raccourci : Entrée.",
-    "autoPassing": "Passage automatique jusqu'à l'étape de fin..."
+    "autoPassing": "Passage automatique jusqu'à l'étape de fin...",
+    "resolvingStack": "Résolution de la pile..."
   },
   "board": {
     "regroupCreatures": "Regrouper les groupes de créatures en double",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Passa la priorità. Se la pila è vuota, questo avanza attraverso la finestra di priorità corrente. Scorciatoia: Spazio.",
     "pass": "Passa",
     "passToEndTooltip": "Passa automaticamente fino al passo finale a meno che una scelta, uno stop o il Controllo totale non interrompa. Scorciatoia: Invio.",
-    "autoPassing": "Passaggio automatico fino al passo finale..."
+    "autoPassing": "Passaggio automatico fino al passo finale...",
+    "resolvingStack": "Risoluzione della pila..."
   },
   "board": {
     "regroupCreatures": "Raggruppa i gruppi di creature duplicate",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Przekaż priorytet. Jeśli stos jest pusty, spowoduje to przejście przez bieżące okno priorytetu. Skrót: Spacja.",
     "pass": "Przekaż",
     "passToEndTooltip": "Automatycznie przekazuj priorytet aż do kroku końcowego, chyba że przerwie to wybór, zatrzymanie lub Pełna kontrola. Skrót: Enter.",
-    "autoPassing": "Automatyczne przekazywanie do kroku końcowego..."
+    "autoPassing": "Automatyczne przekazywanie do kroku końcowego...",
+    "resolvingStack": "Rozpatrywanie stosu..."
   },
   "board": {
     "regroupCreatures": "Pogrupuj zduplikowane grupy stworów",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -77,7 +77,8 @@
     "priorityTooltip": "Passe a prioridade. Se a pilha estiver vazia, isso avança pela janela de prioridade atual. Atalho: Espaço.",
     "pass": "Passar",
     "passToEndTooltip": "Passe automaticamente até a etapa final, a menos que uma escolha, parada ou o Controle Total interrompa. Atalho: Enter.",
-    "autoPassing": "Passando Automaticamente até a Etapa Final..."
+    "autoPassing": "Passando Automaticamente até a Etapa Final...",
+    "resolvingStack": "Resolvendo a Pilha..."
   },
   "board": {
     "regroupCreatures": "Reagrupar grupos de criaturas duplicadas",

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -103,8 +103,8 @@ export function get_ai_action(difficulty: string, player_id: number): any;
  * Score all candidate actions and return `[GameAction, score]` tuples.
  * Used by AI workers for root parallelism — each worker scores independently,
  * then results are merged on the main thread.
- * `rng_seed` seeds the game state's RNG so each worker's MCTS explores
- * different paths through the search tree, producing diverse score vectors.
+ * `rng_seed` seeds the game state's RNG so each worker's beam search explores
+ * different orderings, producing diverse score vectors.
  */
 export function get_ai_scored_candidates(difficulty: string, player_id: number, rng_seed: bigint): any;
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -421,12 +421,14 @@ fn remember_public_reveals(state: &mut GameState, events: &[GameEvent]) {
 /// - `Concede` self-authenticates via its own `player_id` field — but we still
 ///   require it to match `actor` so a player cannot concede someone else on
 ///   their behalf (CR 104.3a).
-/// - **Preference actions** (SetPhaseStops, SetAutoPass, CancelAutoPass) are
-///   per-player UI settings. They have no CR semantics, mutate only the
-///   submitter's own preference slot, and may legitimately fire at any time —
-///   e.g. the human toggles a phase stop while the AI holds priority. The
-///   downstream handlers route by `actor`, so any seat may set its own
-///   preferences regardless of `WaitingFor`.
+/// - **Preference actions** (SetPhaseStops, CancelAutoPass) are per-player UI
+///   settings. They have no CR semantics, mutate only the submitter's own
+///   preference slot, and may legitimately fire at any time — e.g. the human
+///   toggles a phase stop while the AI holds priority. The downstream handlers
+///   route by `actor`, so any seat may set its own preferences regardless of
+///   `WaitingFor`. `SetAutoPass` is deliberately NOT exempt: its handler
+///   stores the mode for the `WaitingFor::Priority` player and immediately
+///   passes that priority, so it must come from the authorized submitter.
 fn check_actor_authorization(
     state: &GameState,
     actor: PlayerId,


### PR DESCRIPTION
- **feat(client): Arena-style Resolve All in multiplayer via engine auto-yield**
- **fix(client): surface + cancel armed UntilStackEmpty session; key auto-pass shortcuts to local seat**
