### PR TITLE
Parse unless-pay mana costs strictly

### DIFF
--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7171,6 +7171,7 @@ fn parse_counter_unless_pay(
     match super::parse_unless_payment(rest) {
         Some(cost) => Some(Some(super::counter_unless_pay_modifier(cost))),
         None if counter_unless_has_partial_where_x_quantity(rest) => None,
+        None if super::has_unless_clause(rest) => None,
         None => Some(None),
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -84,7 +84,6 @@ use super::oracle_util::{
     contains_possessive, has_unconsumed_conditional, parse_count_expr, parse_mana_symbols,
     parse_number, split_around, starts_with_possessive, strip_after, TextPair,
 };
-use crate::database::mtgjson::parse_mtgjson_mana_cost;
 use crate::game::triggers;
 use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
@@ -544,6 +543,11 @@ fn parse_dealt_damage_this_way_dies_trigger(
 /// Delegates to the shared word-boundary scanning primitive in `oracle_nom::primitives`.
 fn scan_contains_phrase(text: &str, phrase: &str) -> bool {
     nom_primitives::scan_contains(text, phrase)
+}
+
+fn has_unless_clause(text: &str) -> bool {
+    nom_primitives::scan_preceded(text, |i| tag::<_, _, OracleError<'_>>("unless ").parse(i))
+        .is_some()
 }
 
 /// Windows that terminate the condition of an inline delayed trigger and
@@ -4862,6 +4866,29 @@ fn parsed_unless_unsupported_clause(full_text: &str, rider: &str) -> ParsedEffec
     ))
 }
 
+fn counter_unless_payment_is_unsupported(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let Some((_, rest_original)) = nom_on_lower(text, &lower, |i| {
+        value(
+            (),
+            alt((
+                tag::<_, _, OracleError<'_>>("counter all "),
+                tag("counter each "),
+                tag("counter "),
+            )),
+        )
+        .parse(i)
+    }) else {
+        return false;
+    };
+    let rest_lower = &lower[lower.len() - rest_original.len()..];
+    has_unless_clause(rest_lower) && parse_unless_payment(rest_lower).is_none()
+}
+
+fn parsed_unless_payment_unsupported_clause(full_text: &str) -> ParsedEffectClause {
+    parsed_clause(Effect::unimplemented("unless_payment", full_text))
+}
+
 fn attach_unless_slots(
     mut clause: ParsedEffectClause,
     unless_condition: Option<AbilityCondition>,
@@ -4891,6 +4918,8 @@ fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedEffectClause
             if unless_pay.is_some() {
                 unless_pay_deferred = unless_pay;
                 (None, stripped)
+            } else if counter_unless_payment_is_unsupported(text) {
+                return parsed_unless_payment_unsupported_clause(text);
             } else if unless_rider_defers_to_body_parser(text) {
                 (None, clause_text)
             } else {
@@ -5585,6 +5614,9 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
             name: "empty".to_string(),
             description: None,
         });
+    }
+    if counter_unless_payment_is_unsupported(text) {
+        return parsed_unless_payment_unsupported_clause(text);
     }
     // CR 608.2c: Self-ref continuation adverb. "also" after a self-ref subject
     // is a natural-language additive connector with no semantic weight — it
@@ -11825,7 +11857,7 @@ fn try_parse_verb_and_target<'a>(
             parsed_target
         };
         let unless_pay = parse_unless_payment(rest_lower).map(counter_unless_pay_modifier);
-        if unless_pay.is_none() && scan_contains_phrase(rest_lower, "unless") {
+        if unless_pay.is_none() && has_unless_clause(rest_lower) {
             return None;
         }
         return Some((
@@ -11863,7 +11895,7 @@ fn try_parse_verb_and_target<'a>(
         };
         // CR 118.12: Parse "unless its controller pays {X}" for conditional counters
         let unless_pay = parse_unless_payment(rest_lower).map(counter_unless_pay_modifier);
-        if unless_pay.is_none() && scan_contains_phrase(rest_lower, "unless") {
+        if unless_pay.is_none() && has_unless_clause(rest_lower) {
             return None;
         }
         return Some((
@@ -23886,6 +23918,12 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
         if let Some(cost) = parse_unless_mana_or_energy_payment(cost_str) {
             return Some(cost);
         }
+        if tag::<_, _, OracleError<'_>>("{")
+            .parse(cost_str.trim_start())
+            .is_ok()
+        {
+            return None;
+        }
     }
     // CR 118.12a: "unless [target's controller] has [~] deal N damage to them"
     // (Molten Influence and other counter spells with damage alternatives).
@@ -23913,20 +23951,13 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
 /// the "pays " verb. Returns `None` for non-mana shapes (life / sacrifice /
 /// discard), which the caller routes to the shared non-mana authority.
 fn parse_unless_mana_or_energy_payment(cost_str: &str) -> Option<AbilityCost> {
+    let cost_str = cost_str.trim_start();
     // CR 107.14 + CR 202.3: dynamic energy unless-cost — checked before the
     // brace-run truncation below, which collapses "an amount of {e} …" to "an".
     if let Some(amount) = parse_dynamic_energy_unless_cost(cost_str) {
         return Some(AbilityCost::PayEnergy { amount });
     }
-    // Extract the mana cost (brace-delimited symbols)
-    let cost_end = cost_str
-        .find(|c: char| c != '{' && c != '}' && !c.is_alphanumeric())
-        .unwrap_or(cost_str.len());
-    let cost_text = cost_str[..cost_end].trim();
-    if cost_text.is_empty() || !cost_text.contains('{') {
-        return None;
-    }
-    if let Some((amount, rest)) = parse_fixed_energy_unless_cost(cost_text) {
+    if let Some((amount, rest)) = parse_fixed_energy_unless_cost(cost_str) {
         if rest.trim().is_empty() {
             return Some(AbilityCost::PayEnergy {
                 amount: QuantityExpr::Fixed {
@@ -23936,35 +23967,57 @@ fn parse_unless_mana_or_energy_payment(cost_str: &str) -> Option<AbilityCost> {
         }
     }
     // Check for dynamic {X} with "where X is" clause
-    if cost_text == "{X}" || cost_text == "{x}" {
-        let after_cost = &cost_str[cost_end..];
-        if let Some(quantity) = parse_where_x_is(after_cost) {
-            return Some(AbilityCost::ManaDynamic { quantity });
-        }
-        if tag::<_, _, OracleError<'_>>("where x is ")
-            .parse(after_cost.trim().trim_start_matches(',').trim())
-            .is_ok()
+    if let Ok((after_cost, _)) = tag::<_, _, OracleError<'_>>("{x}").parse(cost_str) {
+        if tag::<_, _, OracleError<'_>>("{")
+            .parse(after_cost.trim_start())
+            .is_err()
         {
-            return None;
-        }
-        // CR 107.3a + CR 118.12: bare {X} unless-cost references the announced X
-        // of the spell carrying this counter.
-        return Some(AbilityCost::ManaDynamic {
-            quantity: QuantityExpr::Ref {
-                qty: QuantityRef::Variable {
-                    name: "X".to_string(),
+            if let Some(quantity) = parse_where_x_is(after_cost) {
+                return Some(AbilityCost::ManaDynamic { quantity });
+            }
+            if tag::<_, _, OracleError<'_>>("where x is ")
+                .parse(after_cost.trim().trim_start_matches(',').trim())
+                .is_ok()
+            {
+                return None;
+            }
+            // CR 107.3a + CR 118.12: bare {X} unless-cost references the announced X
+            // of the spell carrying this counter.
+            return Some(AbilityCost::ManaDynamic {
+                quantity: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
                 },
-            },
-        });
+            });
+        }
     }
-    let cost = parse_mtgjson_mana_cost(cost_text);
-    if let Some(unless_cost) = parse_unless_for_each_payment(&cost_str[cost_end..], &cost) {
+    let (cost, after_cost) = parse_unless_mana_cost_prefix(cost_str)?;
+    if let Some(unless_cost) = parse_unless_for_each_payment(after_cost, &cost) {
         return Some(unless_cost);
     }
     if cost == ManaCost::NoCost || cost == ManaCost::zero() {
         return None;
     }
     Some(AbilityCost::Mana { cost })
+}
+
+pub(crate) fn parse_unless_mana_cost_prefix(input: &str) -> Option<(ManaCost, &str)> {
+    let input = input.trim_start();
+    // Oracle text is lowercased before these unless-cost paths, while mana
+    // symbol parsing is case-sensitive. ASCII uppercasing preserves byte length,
+    // so the consumed prefix still maps back onto the original input slice.
+    let normalized = input.to_ascii_uppercase();
+    let (normalized_rest, cost) = nom_primitives::parse_mana_cost(&normalized).ok()?;
+    let consumed = normalized.len().checked_sub(normalized_rest.len())?;
+    let rest = &input[consumed..];
+    if tag::<_, _, OracleError<'_>>("{")
+        .parse(rest.trim_start())
+        .is_ok()
+    {
+        return None;
+    }
+    Some((cost, rest))
 }
 
 /// Winternight Stories shape: primary Discard with "unless you discard a [type]"
@@ -24288,20 +24341,22 @@ fn parse_resolution_unless_cost(cost_text: &str) -> Option<AbilityCost> {
     // CR 107.3a: extract_resolution_unless_pay_modifier lowercased the text; the
     // case-sensitive X mana symbol no longer matches, so handle bare {x}
     // explicitly. The announced X of the carrying effect drives the cost.
-    if tag::<_, _, OracleError<'_>>("{x}")
-        .parse(cost_text.trim_start())
-        .is_ok()
-    {
-        return Some(AbilityCost::ManaDynamic {
-            quantity: QuantityExpr::Ref {
-                qty: QuantityRef::Variable {
-                    name: "X".to_string(),
+    if let Ok((after_cost, _)) = tag::<_, _, OracleError<'_>>("{x}").parse(cost_text.trim_start()) {
+        if tag::<_, _, OracleError<'_>>("{")
+            .parse(after_cost.trim_start())
+            .is_err()
+        {
+            return Some(AbilityCost::ManaDynamic {
+                quantity: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
                 },
-            },
-        });
+            });
+        }
     }
 
-    if let Ok((rest, cost)) = nom_primitives::parse_mana_cost(cost_text.trim_start()) {
+    if let Some((cost, rest)) = parse_unless_mana_cost_prefix(cost_text) {
         if let Some(unless_cost) = parse_unless_for_each_payment(rest, &cost) {
             return Some(unless_cost);
         }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::parser::parse_oracle_text;
 use crate::types::ability::AttachmentKind;
 use crate::types::card_type::CoreType;
+use crate::types::mana::ManaCostShard;
 
 /// CR 615.5: `each_target_filter_mut` must NEVER visit `Effect::Shuffle`.
 /// Several callers rewrite `TriggeringPlayer` / `ParentTargetController` /
@@ -5503,6 +5504,92 @@ fn effect_counter_unless_pays_flat_generic_stays_static() {
         ),
         "flat unless-cost should stay static Mana{{generic:3}}, got {:?}",
         unless_pay.cost
+    );
+}
+
+#[test]
+fn effect_counter_unless_rejects_unrecognized_mana_symbol() {
+    let text = "Counter target spell unless its controller pays {3}{½}";
+    let lower = text.to_lowercase();
+    assert!(
+        parse_unless_payment(&lower).is_none(),
+        "unrecognized mana symbol must not parse as an unless payment"
+    );
+    assert!(
+        crate::parser::oracle_trigger::parse_unless_they_alt_cost_chain("they pay {3}{½}")
+            .is_none(),
+        "shared trigger-side unless-cost parser must not reinterpret malformed mana as life"
+    );
+    assert!(
+        imperative::parse_counter_ast(text, &lower).is_none(),
+        "counter AST must decline an unparsed unless-payment rider"
+    );
+    let def = parse_effect_chain(text, AbilityKind::Spell);
+    let Effect::Unimplemented { name, .. } = def.effect.as_ref() else {
+        panic!(
+            "unrecognized mana symbol must leave the counter unsupported, got {:?}",
+            def.effect
+        );
+    };
+    assert_eq!(name, "unless_payment");
+    assert!(
+        def.unless_pay.is_none(),
+        "unknown mana symbols must not collapse to a partial unless-pay cost: {:?}",
+        def.unless_pay
+    );
+}
+
+#[test]
+fn effect_counter_unless_rejects_unparsed_dynamic_x_tail() {
+    let text = "Counter target spell unless its controller pays {X}, where X is the number of words in the name with the most words among permanents you control.";
+    let def = parse_effect_chain(text, AbilityKind::Spell);
+    let Effect::Unimplemented { name, .. } = def.effect.as_ref() else {
+        panic!(
+            "unparsed dynamic X unless rider must not become a plain counter: {:?}",
+            def.effect
+        );
+    };
+    assert_eq!(name, "unless_payment");
+    assert!(
+        def.unless_pay.is_none(),
+        "unparsed dynamic X unless rider must not attach a partial cost: {:?}",
+        def.unless_pay
+    );
+}
+
+#[test]
+fn effect_counter_unless_rejects_that_player_unparsed_dynamic_x_tail() {
+    let text = "counter that spell unless that player pays {X}, where X is the number of cards in all graveyards with the same name as the spell";
+    let def = parse_effect_chain(text, AbilityKind::Spell);
+    let Effect::Unimplemented { name, .. } = def.effect.as_ref() else {
+        panic!(
+            "unparsed trigger-relative X unless rider must not become a plain counter: {:?}",
+            def.effect
+        );
+    };
+    assert_eq!(name, "unless_payment");
+    assert!(
+        def.unless_pay.is_none(),
+        "unparsed trigger-relative X unless rider must not attach a partial cost: {:?}",
+        def.unless_pay
+    );
+}
+
+#[test]
+fn effect_unless_pays_colored_mana_preserves_shards_after_lowercase() {
+    let lower = "prevent all combat damage that would be dealt by that creature this turn unless its controller pays {2}{r}";
+    let cost = parse_unless_payment(lower).expect("colored unless mana must parse");
+    assert!(
+        matches!(
+            cost,
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    ref shards,
+                    generic: 2
+                }
+            } if shards.as_slice() == [ManaCostShard::Red]
+        ),
+        "colored unless mana must preserve the red shard, got {cost:?}"
     );
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1754,16 +1754,7 @@ fn parse_unless_mana_payment(cost_str: &str) -> Option<AbilityCost> {
         });
     }
 
-    let cost_end = trimmed
-        .find(|c: char| c != '{' && c != '}' && !c.is_alphanumeric())
-        .unwrap_or(trimmed.len());
-    let cost_text = trimmed[..cost_end].trim();
-
-    if cost_text.is_empty() || !cost_text.contains('{') {
-        return None;
-    }
-
-    if let Some((amount, rest)) = super::oracle_effect::parse_fixed_energy_unless_cost(cost_text) {
+    if let Some((amount, rest)) = super::oracle_effect::parse_fixed_energy_unless_cost(trimmed) {
         if !rest.trim().is_empty() {
             return None;
         }
@@ -1774,36 +1765,39 @@ fn parse_unless_mana_payment(cost_str: &str) -> Option<AbilityCost> {
         });
     }
 
-    if cost_text == "{x}" || cost_text == "{X}" {
-        let after_cost = &trimmed[cost_end..];
-        if let Some(quantity) = super::oracle_effect::parse_where_x_is(after_cost) {
-            return Some(AbilityCost::ManaDynamic { quantity });
-        }
-        let after_x = after_cost.trim().trim_start_matches(',').trim();
-        let after_x_lower = after_x.to_lowercase();
-        if tag::<_, _, OracleError<'_>>("where x is ")
-            .parse(after_x_lower.as_str())
-            .is_ok()
+    if let Ok((after_cost, _)) = tag::<_, _, OracleError<'_>>("{x}").parse(trimmed) {
+        if tag::<_, _, OracleError<'_>>("{")
+            .parse(after_cost.trim_start())
+            .is_err()
         {
-            return None;
-        }
-        return Some(AbilityCost::ManaDynamic {
-            quantity: QuantityExpr::Ref {
-                qty: QuantityRef::Variable {
-                    name: "X".to_string(),
+            if let Some(quantity) = super::oracle_effect::parse_where_x_is(after_cost) {
+                return Some(AbilityCost::ManaDynamic { quantity });
+            }
+            let after_x = after_cost.trim().trim_start_matches(',').trim();
+            let after_x_lower = after_x.to_lowercase();
+            if tag::<_, _, OracleError<'_>>("where x is ")
+                .parse(after_x_lower.as_str())
+                .is_ok()
+            {
+                return None;
+            }
+            return Some(AbilityCost::ManaDynamic {
+                quantity: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
                 },
-            },
-        });
+            });
+        }
     }
 
-    let mana_cost = crate::database::mtgjson::parse_mtgjson_mana_cost(cost_text);
+    let (mana_cost, after_cost) = super::oracle_effect::parse_unless_mana_cost_prefix(trimmed)?;
     if mana_cost == crate::types::mana::ManaCost::NoCost
         || mana_cost == crate::types::mana::ManaCost::zero()
     {
         return None;
     }
-    if let Some(cost) =
-        super::oracle_effect::parse_unless_for_each_payment(&trimmed[cost_end..], &mana_cost)
+    if let Some(cost) = super::oracle_effect::parse_unless_for_each_payment(after_cost, &mana_cost)
     {
         return Some(cost);
     }

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -42,7 +42,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 28 | Trigger/activation timing or ordinal restriction dropped | 20 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 29 | Disjunctive mana ability split into two Fixed abilities | 18 | oracle parser mana-ability handling — emit AnyOneColor{color_options} for 'Add A or B' |
 | 30 | Token/named-card name corrupted by normalization or overrun | 18 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
-| 31 | Other / uncategorized misparse | 7 | manual triage |
+| 31 | Other / uncategorized misparse | 3 | manual triage |
 | 32 | Static pay/action-to-ignore-effect clause dropped | 1 | add-static-ability / add-interactive-effect — model "ignore this effect until end of turn" exceptions |
 
 > The top **5** root causes cover ~50% of all misparse appearances; the top 10 cover the overwhelming majority. Fix these first.
@@ -5219,7 +5219,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 31. Other / uncategorized misparse  (4 cards)
+### 31. Other / uncategorized misparse  (3 cards)
 
 **Signature.** Cluster did not match a canonical signature class.
 
@@ -5227,7 +5227,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 <details><summary>Cards</summary>
 
-- Flaccify
 - Merfolk Falconer
 - Rush of Dread
 - The Goose Mother


### PR DESCRIPTION
## Summary

- make unless-payment mana parsing strict so unknown trailing brace symbols fail closed instead of becoming partial costs
- share the strict mana-cost prefix helper across effect and trigger unless-payment paths
- label unsupported counter unless-payment riders as `unless_payment` instead of a lost `counter` handler
- remove Flaccify from the parser misparse backlog

## Parsed-output guardrail

Saved before/after guardrail corpus:

- before: `/tmp/phase-unless-pays-brace-before-ship.json`
- first after: `/tmp/phase-unless-pays-brace-after-ship.json`
- both snapshots: 532 cards
- changed card keys in the first pass: `busted!`, `flaccify`, `heroism`

After the CI-label fix, I regenerated a fresh full export and projected it onto the same saved 532-key corpus:

- projected after: `/tmp/phase-unless-pays-brace-after-ship-v2-oldkeys.json`
- changed keys vs original before: `busted!`, `cephalid shrine`, `flaccify`, `heroism`
- changed keys vs first after: `busted!`, `cephalid shrine`, `flaccify`

Intentional changes:

- `flaccify`: no longer parses `{3}{½}` as a supported `{3}` unless-pay counter; it is now honestly `Unimplemented { name: "unless_payment" }`.
- `busted!`: no longer drops the text-defined `{X}` unless rider and claims a plain counter; now `unless_payment`.
- `cephalid shrine`: same text-defined `{X}` counter-unless class as Busted!, now labeled `unless_payment` instead of the generic unsupported-unless label.
- `heroism`: `{2}{R}` now preserves the red mana shard instead of collapsing to generic `{2}`.

## Checks

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `./scripts/check-parser-combinators.sh`
- `git diff --check`
- `./scripts/check-skill-doc.sh`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/home/ntindle/code/phase/target cargo test -p engine --lib effect_counter_unless -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/home/ntindle/code/phase/target cargo test -p engine --lib effect_unless_pays_colored_mana_preserves_shards_after_lowercase -- --nocapture`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/home/ntindle/code/phase/target cargo clippy -p engine --lib -- -D warnings`
