### PR TITLE
ship/local hotseat resolve all

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -7,6 +7,7 @@ import { dispatchAction, dispatchResolveAll } from "../../game/dispatch.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { usePhaseInfo } from "../../hooks/usePhaseInfo.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { DRAFT_BOT_AI_SEAT, useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore.ts";
 import { useMultiplayerStore } from "../../stores/multiplayerStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { buildAttacks, hasMultipleAttackTargets, getValidAttackTargets } from "../../utils/combat.ts";
@@ -377,21 +378,28 @@ export function ActionButton() {
               aria-busy={isResolvingAll}
               onClick={() => {
                 const { gameState: gs, gameMode } = useGameStore.getState();
-                // Only claim seats as AI-driven when an AI actually drives them
-                // ("ai" always; "draft-match" when the opponent is an AI — the
-                // vs-human case has no batch resolveAll, so the list is ignored).
-                // In "local" hotseat every seat is a human: an empty list makes
-                // dispatchResolveAll fall back to the per-seat engine auto-yield
-                // instead of handing the users' seats to the AI (#4978).
-                const aiDriven = gameMode === "ai" || gameMode === "draft-match";
-                const playerCount = gs?.players?.length ?? 2;
-                const aiSeats = usePreferencesStore.getState().aiSeats;
-                const seats = aiDriven
-                  ? Array.from({ length: playerCount - 1 }, (_, i) => ({
-                      playerId: i + 1,
-                      difficulty: aiSeats[i]?.difficulty ?? "Medium",
-                    }))
-                  : [];
+                // Only claim seats as AI-driven when an AI actually drives them,
+                // mirroring the controller each mode installs. "ai": every
+                // non-local seat (same prefs sourcing as scheduleBatchResolve).
+                // Draft matches: only a Bot pairing has an AI seat, and it uses
+                // the same binding installMatchRuntime gives the live controller.
+                // Everything else — "local" hotseat above all (#4978) — gets an
+                // empty list so dispatchResolveAll falls back to the per-seat
+                // engine auto-yield instead of handing human seats to the AI.
+                let seats: { playerId: number; difficulty: string }[] = [];
+                if (gameMode === "ai") {
+                  const playerCount = gs?.players?.length ?? 2;
+                  const aiSeats = usePreferencesStore.getState().aiSeats;
+                  seats = Array.from({ length: playerCount - 1 }, (_, i) => ({
+                    playerId: i + 1,
+                    difficulty: aiSeats[i]?.difficulty ?? "Medium",
+                  }));
+                } else if (
+                  gameMode === "draft-match" &&
+                  useMultiplayerDraftStore.getState().matchPairing?.type === "Bot"
+                ) {
+                  seats = [DRAFT_BOT_AI_SEAT];
+                }
                 dispatchResolveAll(playerId, seats);
               }}
               aria-describedby={resolveAllTooltipId}

--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -376,12 +376,22 @@ export function ActionButton() {
               disabled={actionBlocked}
               aria-busy={isResolvingAll}
               onClick={() => {
-                const playerCount = useGameStore.getState().gameState?.players?.length ?? 2;
+                const { gameState: gs, gameMode } = useGameStore.getState();
+                // Only claim seats as AI-driven when an AI actually drives them
+                // ("ai" always; "draft-match" when the opponent is an AI — the
+                // vs-human case has no batch resolveAll, so the list is ignored).
+                // In "local" hotseat every seat is a human: an empty list makes
+                // dispatchResolveAll fall back to the per-seat engine auto-yield
+                // instead of handing the users' seats to the AI (#4978).
+                const aiDriven = gameMode === "ai" || gameMode === "draft-match";
+                const playerCount = gs?.players?.length ?? 2;
                 const aiSeats = usePreferencesStore.getState().aiSeats;
-                const seats = Array.from({ length: playerCount - 1 }, (_, i) => ({
-                  playerId: i + 1,
-                  difficulty: aiSeats[i]?.difficulty ?? "Medium",
-                }));
+                const seats = aiDriven
+                  ? Array.from({ length: playerCount - 1 }, (_, i) => ({
+                      playerId: i + 1,
+                      difficulty: aiSeats[i]?.difficulty ?? "Medium",
+                    }))
+                  : [];
                 dispatchResolveAll(playerId, seats);
               }}
               aria-describedby={resolveAllTooltipId}

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameState, WaitingFor } from "../../../adapter/types";
-import { dispatchAction } from "../../../game/dispatch.ts";
+import { dispatchAction, dispatchResolveAll } from "../../../game/dispatch.ts";
 import { useGameStore } from "../../../stores/gameStore";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore";
 import { useUiStore } from "../../../stores/uiStore";
@@ -174,6 +174,60 @@ describe("ActionButton", () => {
     expect(screen.getByRole("button", { name: /^Resolve Pass priority/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^Resolve All Keep passing priority/ })).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("passes an empty AI-seat list in local hotseat so Resolve All auto-yields instead of AI-driving human seats (#4978)", () => {
+    useGameStore.setState({
+      gameMode: "local",
+      gameState: {
+        ...createGameState({ type: "Priority", data: { player: 0 } }),
+        phase: "PostCombatMain",
+        auto_pass: {},
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 0,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
+      },
+      waitingFor: { type: "Priority", data: { player: 0 } },
+      legalActions: [],
+    });
+
+    render(<ActionButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Resolve All/ }));
+    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, []);
+  });
+
+  it("builds the AI seat list for Resolve All when the other seats are AI-driven", () => {
+    useGameStore.setState({
+      gameMode: "ai",
+      gameState: {
+        ...createGameState({ type: "Priority", data: { player: 0 } }),
+        phase: "PostCombatMain",
+        auto_pass: {},
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 0,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
+      },
+      waitingFor: { type: "Priority", data: { player: 0 } },
+      legalActions: [],
+    });
+
+    render(<ActionButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Resolve All/ }));
+    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, [
+      { playerId: 1, difficulty: "Medium" },
+    ]);
   });
 
   it("surfaces an armed UntilStackEmpty session with a cancel affordance while an opponent holds priority", () => {

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GameState, WaitingFor } from "../../../adapter/types";
 import { dispatchAction, dispatchResolveAll } from "../../../game/dispatch.ts";
 import { useGameStore } from "../../../stores/gameStore";
+import { DRAFT_BOT_AI_SEAT, useMultiplayerDraftStore } from "../../../stores/multiplayerDraftStore";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore";
 import { useUiStore } from "../../../stores/uiStore";
 import { ActionButton } from "../ActionButton";
@@ -102,6 +103,7 @@ describe("ActionButton", () => {
       combatClickHandler: null,
     });
     useMultiplayerStore.setState({ actionPending: false });
+    useMultiplayerDraftStore.setState({ matchPairing: null });
   });
 
   afterEach(() => {
@@ -228,6 +230,60 @@ describe("ActionButton", () => {
     expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, [
       { playerId: 1, difficulty: "Medium" },
     ]);
+  });
+
+  it("uses the live controller's bot seat binding for a Bot draft match", () => {
+    useGameStore.setState({
+      gameMode: "draft-match",
+      gameState: {
+        ...createGameState({ type: "Priority", data: { player: 0 } }),
+        phase: "PostCombatMain",
+        auto_pass: {},
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 0,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
+      },
+      waitingFor: { type: "Priority", data: { player: 0 } },
+      legalActions: [],
+    });
+    useMultiplayerDraftStore.setState({ matchPairing: { type: "Bot" } as never });
+
+    render(<ActionButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Resolve All/ }));
+    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, [DRAFT_BOT_AI_SEAT]);
+  });
+
+  it("claims no AI seats for a vs-human draft match", () => {
+    useGameStore.setState({
+      gameMode: "draft-match",
+      gameState: {
+        ...createGameState({ type: "Priority", data: { player: 0 } }),
+        phase: "PostCombatMain",
+        auto_pass: {},
+        stack: [
+          {
+            id: 1,
+            source_id: 1,
+            controller: 0,
+            kind: { type: "Spell", data: { card_id: 1 } },
+          },
+        ],
+      },
+      waitingFor: { type: "Priority", data: { player: 0 } },
+      legalActions: [],
+    });
+    useMultiplayerDraftStore.setState({ matchPairing: { type: "HumanHost" } as never });
+
+    render(<ActionButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Resolve All/ }));
+    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, []);
   });
 
   it("surfaces an armed UntilStackEmpty session with a cancel affordance while an opponent holds priority", () => {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -71,7 +71,9 @@ describe("dispatchResolveAll progress", () => {
       } as never,
     });
 
-    await dispatchResolveAll(0, []);
+    // Non-empty AI seat list = the "ai"-mode shape; an empty list would route
+    // to the SetAutoPass fallback instead of the batch drain under test.
+    await dispatchResolveAll(0, [{ playerId: 1, difficulty: "Medium" }]);
 
     // Three progress updates: total latched at 200 throughout; resolved
     // accumulates 80 -> 160 -> clamped 200.
@@ -107,10 +109,38 @@ describe("dispatchResolveAll progress", () => {
       } as never,
     });
 
-    await dispatchResolveAll(0, []);
+    await dispatchResolveAll(0, [{ playerId: 1, difficulty: "Medium" }]);
 
     expect(resolveAll).toHaveBeenCalledTimes(1);
     expect(useGameStore.getState().isResolvingAll).toBe(false);
+  });
+
+  it("falls back to the auto-yield when there are no AI seats to drive the drain, even with a batch-capable adapter (local hotseat, #4978)", async () => {
+    const resolveAll = vi.fn<EngineResolveAll>();
+    const submitAction = vi
+      .fn<(action: unknown, actor: number) => Promise<{ events: never[] }>>()
+      .mockResolvedValue({ events: [] });
+
+    useGameStore.setState({
+      gameState: stateWithStack(3),
+      adapter: {
+        resolveAll,
+        submitAction,
+        getState: vi.fn().mockResolvedValue(stateWithStack(2)),
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+      } as never,
+    });
+
+    await dispatchResolveAll(0, []);
+
+    // The batch drain needs an AI decider for every non-requester seat; with
+    // none, those seats are humans (local hotseat) and CR 117.4 entitles each
+    // to their own priority window — never engage the worker drain.
+    expect(resolveAll).not.toHaveBeenCalled();
+    expect(submitAction).toHaveBeenCalledWith(
+      { type: "SetAutoPass", data: { mode: { type: "UntilStackEmpty" } } },
+      0,
+    );
   });
 
   it("falls back to an engine-side UntilStackEmpty auto-pass when the adapter has no batch resolveAll (multiplayer)", async () => {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -157,7 +157,11 @@ describe("dispatchResolveAll progress", () => {
       } as never,
     });
 
-    await dispatchResolveAll(0, []);
+    // A NON-empty seat list pins the `!adapter.resolveAll` half of the
+    // fallback gate on its own: even when a caller claims AI seats exist
+    // (draft-match vs a human would, if its pairing were misread), a
+    // transport with no batch drain must still take the auto-yield path.
+    await dispatchResolveAll(0, [{ playerId: 1, difficulty: "Medium" }]);
 
     // Arena semantics: yield THIS seat's priority windows via the engine's
     // auto-pass session — never a host-driven batch drain over human seats.

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -715,14 +715,15 @@ export async function dispatchResolveAll(
     debugLog("dispatchResolveAll: no adapter");
     return;
   }
-  if (!adapter.resolveAll) {
-    // Multiplayer transports have no batch drain: the other seats are humans,
-    // and CR 117.4 entitles each of them to their own priority window before
-    // anything resolves — the engine must not pass on their behalf. Arena-style
-    // "Resolve All" instead: an engine-side auto-yield for THIS seat only
-    // (AutoPassMode::UntilStackEmpty), which auto-passes whenever this player
-    // receives priority and clears itself when the stack empties or grows
-    // (an opponent responded).
+  if (!adapter.resolveAll || aiSeats.length === 0) {
+    // No batch drain (multiplayer transports), or no AI deciders for the other
+    // seats (local hotseat — every seat is a human, #4978): those seats are
+    // humans, and CR 117.4 entitles each of them to their own priority window
+    // before anything resolves — the engine must not pass on their behalf.
+    // Arena-style "Resolve All" instead: an engine-side auto-yield for THIS
+    // seat only (AutoPassMode::UntilStackEmpty), which auto-passes whenever
+    // this player receives priority and clears itself when the stack empties
+    // or grows (an opponent responded).
     await dispatchAction(
       { type: "SetAutoPass", data: { mode: { type: "UntilStackEmpty" } } },
       requester,

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -23,6 +23,7 @@ import type {
 } from "../adapter/draft-adapter";
 import type { EngineAdapter, GameEvent, GameLogEntry, MatchScore, SubmitResult } from "../adapter/types";
 import type { DraftMatchLaunch, DraftPauseReason } from "../network/draftProtocol";
+import type { AISeatBinding } from "../game/controllers/aiController";
 import { createGameLoopController, type GameLoopController } from "../game/controllers/gameLoopController";
 import { processRemoteUpdate } from "../game/dispatch";
 import { legalResultState, useGameStore } from "./gameStore";
@@ -272,6 +273,12 @@ function disposeMatchController(): void {
   activeMatchController = null;
 }
 
+/** The engine-side AI seat for a Bot draft match (the local player is game
+ *  player 0, the bot is 1). Single authority shared by the live game-loop
+ *  controller and the Resolve All batch drain, so the drain can never play
+ *  the bot at a different difficulty than the controller driving it. */
+export const DRAFT_BOT_AI_SEAT: AISeatBinding = { playerId: 1, difficulty: "Medium" };
+
 async function installMatchRuntime(
   gameId: string,
   adapter: EngineAdapter,
@@ -304,8 +311,8 @@ async function installMatchRuntime(
   disposeMatchController();
   activeMatchController = createGameLoopController({
     mode: controllerMode,
-    difficulty: "Medium",
-    aiSeats: controllerMode === "ai" ? [{ playerId: 1, difficulty: "Medium" }] : undefined,
+    difficulty: DRAFT_BOT_AI_SEAT.difficulty,
+    aiSeats: controllerMode === "ai" ? [DRAFT_BOT_AI_SEAT] : undefined,
     playerCount: 2,
   });
   activeMatchController.start();

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,28 +3,32 @@ import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
 /**
- * Resolves @wasm/engine to the real WASM build artifact when present,
- * otherwise to a virtual empty module. This allows vi.mock("@wasm/engine", factory)
- * to work on CI where WASM build artifacts are absent (gitignored).
+ * Resolves the @wasm/* aliases to the real WASM build artifacts when present,
+ * otherwise to a virtual empty module. Vitest does not inherit vite.config.ts
+ * aliases, and the artifacts are gitignored (absent on CI), so without this
+ * any test whose import graph reaches a `import("@wasm/...")` fails at
+ * transform time. The stub also lets vi.mock("@wasm/engine", factory) work.
  */
 function wasmStubPlugin(): Plugin {
-  const resolved = path.resolve(__dirname, "src/wasm/engine_wasm.js");
-  const virtualId = "\0@wasm/engine-stub";
+  const artifacts: Record<string, string> = {
+    "@wasm/engine": path.resolve(__dirname, "src/wasm/engine_wasm.js"),
+    "@wasm/draft": path.resolve(__dirname, "src/wasm/draft_wasm.js"),
+  };
   return {
     name: "wasm-stub",
     enforce: "pre",
     async resolveId(id) {
-      if (id === "@wasm/engine") {
-        try {
-          await import("node:fs/promises").then((fs) => fs.access(resolved));
-          return resolved;
-        } catch {
-          return virtualId;
-        }
+      const artifact = artifacts[id];
+      if (!artifact) return;
+      try {
+        await import("node:fs/promises").then((fs) => fs.access(artifact));
+        return artifact;
+      } catch {
+        return `\0${id}-stub`;
       }
     },
     load(id) {
-      if (id === virtualId) {
+      if (id.startsWith("\0@wasm/") && id.endsWith("-stub")) {
         return "export default function init() {}";
       }
     },


### PR DESCRIPTION
- **fix(client): Resolve All in local hotseat auto-yields instead of AI-driving human seats**
- **fix(client): derive draft-match Resolve All seats from the Bot pairing; pin the no-batch-drain gate**
