### PR TITLE
fix(parser): resolve "an opponent's graveyard" target to a graveyard card

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1102,6 +1102,31 @@ pub fn parse_target_with_syntax<'a>(
         );
     }
 
+    // CR 108.3 + CR 404.1: an opponent's graveyard as a target resolves to a
+    // card in that graveyard. This more-specific possessive phrase MUST be tried
+    // before the bare opponent-player references below: the un-bounded
+    // `tag("an opponent")` arm would otherwise match the "an opponent" prefix of
+    // "an opponent's graveyard" and return a bare Opponent-player filter, leaving
+    // "'s graveyard" as an unconsumed remainder. The no-"an" sibling
+    // ("opponent's graveyard") is unaffected either way (no opponent-player tag
+    // matches "opponent's"), so both possessive forms now agree.
+    for phrase in ["opponent's graveyard", "an opponent's graveyard"] {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(phrase).parse(lower.as_str()) {
+            return (
+                TargetFilter::Typed(TypedFilter::card().properties(vec![
+                    FilterProp::Owned {
+                        controller: ControllerRef::Opponent,
+                    },
+                    FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    },
+                ])),
+                &text[lower.len() - rest.len()..],
+                syntax,
+            );
+        }
+    }
+
     // CR 115.1 + CR 102.2: Opponent player references — "each opponent",
     // "opponents", and the bare "an opponent" form used by postnominal
     // random-selection patterns (Zaffai — "an opponent chosen at random")
@@ -1127,23 +1152,6 @@ pub fn parse_target_with_syntax<'a>(
         .parse(input)
     }) {
         return (filter, rest, syntax);
-    }
-
-    for phrase in ["opponent's graveyard", "an opponent's graveyard"] {
-        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>(phrase).parse(lower.as_str()) {
-            return (
-                TargetFilter::Typed(TypedFilter::card().properties(vec![
-                    FilterProp::Owned {
-                        controller: ControllerRef::Opponent,
-                    },
-                    FilterProp::InZone {
-                        zone: Zone::Graveyard,
-                    },
-                ])),
-                &text[lower.len() - rest.len()..],
-                syntax,
-            );
-        }
     }
 
     // CR 610.3 / CR 406.6: "each card exiled with this <type>" is a linked-
@@ -13470,6 +13478,40 @@ mod tests {
             ]))
         );
         assert_eq!(rest, "");
+    }
+
+    /// Regression: the "an" possessive form must agree with the no-"an" sibling
+    /// above. Before the graveyard branch was ordered ahead of the opponent-
+    /// player references, the un-bounded `tag("an opponent")` arm matched the
+    /// "an opponent" prefix of "an opponent's graveyard" and returned a bare
+    /// Opponent-player filter, leaving "'s graveyard" as an unconsumed remainder.
+    #[test]
+    fn parse_target_an_opponents_graveyard_is_graveyard_filter() {
+        let (filter, rest) = parse_target("an opponent's graveyard");
+        assert_eq!(
+            filter,
+            TargetFilter::Typed(TypedFilter::card().properties(vec![
+                FilterProp::Owned {
+                    controller: ControllerRef::Opponent,
+                },
+                FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                },
+            ]))
+        );
+        assert_eq!(rest, "");
+    }
+
+    /// Guard: reordering the graveyard branch above the opponent-player arm must
+    /// not disturb the bare "an opponent" player reference (Zaffai — "an opponent
+    /// chosen at random"), which contains no "graveyard" token.
+    #[test]
+    fn parse_target_bare_an_opponent_still_player() {
+        let (filter, _rest) = parse_target("an opponent chosen at random");
+        assert_eq!(
+            filter,
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`parse_target("an opponent's graveyard")` returned a bare Opponent-**player** filter and left `"'s graveyard"` as an unconsumed remainder, instead of a card-in-graveyard filter. The un-bounded `tag("an opponent")` arm of the opponent-player references matched the `"an opponent"` prefix of `"an opponent's graveyard"` *before* the more-specific graveyard-phrase branch could run — leaving that branch (which already lists `"an opponent's graveyard"`) as dead code.

This reorders the graveyard-phrase branch ahead of the opponent-player references, so the possessive form resolves to `Owned{Opponent} + InZone{Graveyard}` — matching the already-correct **no-"an"** sibling (`"opponent's graveyard"`), which was never shadowed and has a passing test. The two possessive forms now agree.

Why reorder rather than word-bound the `"an opponent"` tag: the graveyard-phrase branch is the specific downstream handler for this possessive form, and reordering restores its evidently-intended precedence with zero blast radius. Bare opponent-player references (`"an opponent chosen at random"`, `"each opponent"`, `"opponents"`) contain no `"graveyard"` token, so they still fall through unchanged — pinned by a new guard test.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> Minimal, surgical reordering of two adjacent branches within an existing `parse_target` dispatch cluster (no new pattern, variant, or matcher). A final `/review-impl` pass was run; the broader `"an opponent's <noun>"` shadowing class (the un-bounded tag as root cause) is intentionally left out of scope because graveyard is the only possessive form with a dedicated downstream handler — changing routing for the others has no correct destination and would risk regressions.

## CR references

- `CR 108.3` — owner of a card (the `Owned{Opponent}` property: a card in an opponent's graveyard is owned by that opponent).
- `CR 404.1` — a player's graveyard (the `InZone{Graveyard}` property).

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib parse_target_` — 41 passed, incl. two new tests:
  - `parse_target_an_opponents_graveyard_is_graveyard_filter` — the fix (revert-probe: **fails under the old ordering**, confirming nothing earlier catches the bare phrase and the assertion is non-vacuous).
  - `parse_target_bare_an_opponent_still_player` — guard proving the bare opponent-player reference is unaffected by the reorder.