### PR TITLE
fix(parser): require a word boundary after English number words

### DIFF
--- a/crates/engine/src/parser/oracle_nom/primitives.rs
+++ b/crates/engine/src/parser/oracle_nom/primitives.rs
@@ -72,7 +72,7 @@ fn parse_digit_number(input: &str) -> OracleResult<'_, u32> {
 fn parse_english_number(input: &str) -> OracleResult<'_, u32> {
     // Longest-match-first ordering within shared prefixes (e.g. "fourteen" before "four").
     // Split into multiple alt groups to stay within nom's 21-element tuple limit.
-    alt((
+    let (rest, matched) = alt((
         value(100u32, tag("one hundred")),
         parse_hyphenated_english_number,
         parse_english_tens,
@@ -101,7 +101,22 @@ fn parse_english_number(input: &str) -> OracleResult<'_, u32> {
         value(1, tag("one")),
         parse_article_number,
     )))
-    .parse(input)
+    .parse(input)?;
+
+    // Require a word boundary after the number word so a cardinal isn't matched
+    // inside a longer word ("sixth" → "six", "tenfold" → "ten", "nineteenth" →
+    // "nineteen"). This mirrors the boundary guard `parse_article_number` already
+    // applies to "a"/"an"; the multi-character number words previously lacked it
+    // because the `oracle_util::parse_number` wrapper only guards matches of ≤2
+    // characters. A following ASCII alphanumeric means the token continues, so
+    // the match was a spurious substring.
+    match rest.chars().next() {
+        Some(c) if c.is_ascii_alphanumeric() => Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        ))),
+        _ => Ok((rest, matched)),
+    }
 }
 
 fn parse_english_tens(input: &str) -> OracleResult<'_, u32> {
@@ -1176,6 +1191,43 @@ mod tests {
         assert_eq!(parse_number("ninety-nine").unwrap().1, 99);
         assert_eq!(parse_number("ninety").unwrap().1, 90);
         assert_eq!(parse_number("one hundred").unwrap().1, 100);
+    }
+
+    /// A cardinal number word must not be matched inside a longer word (e.g.
+    /// the ordinal "sixth" or "tenfold"). The multi-character words previously
+    /// lacked the word-boundary guard that `parse_article_number` applies to
+    /// "a"/"an", and the `oracle_util::parse_number` wrapper only guarded
+    /// matches of ≤2 characters — so "sixth" parsed as 6, "tenth" as 10, etc.
+    #[test]
+    fn test_parse_english_number_requires_word_boundary() {
+        // Longer words that merely start with a cardinal must NOT parse.
+        for embedded in [
+            "sixth",
+            "tenth",
+            "tenfold",
+            "threefold",
+            "nineteenth",
+            "fourteener",
+        ] {
+            assert!(
+                parse_number(embedded).is_err(),
+                "{embedded:?} must not parse as an embedded cardinal"
+            );
+        }
+        // Genuine cardinals with a trailing boundary still parse, remainder intact.
+        assert_eq!(parse_number("six cards").unwrap(), (" cards", 6));
+        assert_eq!(parse_number("ten").unwrap(), ("", 10));
+        assert_eq!(
+            parse_number("nineteen creatures").unwrap(),
+            (" creatures", 19)
+        );
+        assert_eq!(
+            parse_number("three, then draw").unwrap(),
+            (", then draw", 3)
+        );
+        // Distinct number words that merely share a prefix are unaffected.
+        assert_eq!(parse_number("sixteen").unwrap(), ("", 16));
+        assert_eq!(parse_number("sixty").unwrap(), ("", 60));
     }
 
     /// `parse_strict_counter_type` accepts recognized counter tokens (keyword


### PR DESCRIPTION
## Summary

`parse_english_number` matched multi-character cardinals with bare `tag()`s and no trailing word-boundary check, so a number word was matched *inside* a longer word:

| input | before | after |
|-------|--------|-------|
| `sixth` | `Ok(("th", 6))` | `Err` |
| `tenth` | `Ok(("th", 10))` | `Err` |
| `tenfold` | `Ok(("fold", 10))` | `Err` |
| `nineteenth` | `Ok(("th", 19))` | `Err` |

The `oracle_util::parse_number` wrapper only applies its boundary guard to matches of ≤2 characters (i.e. `"a"`/`"an"`), so every real number word (≥3 chars) slipped through unguarded.

This adds the same word-boundary guard `parse_article_number` already applies to `"a"`/`"an"`: reject the match when the next character is ASCII-alphanumeric (the token continues, so the cardinal was a spurious substring). Distinct number words that merely share a prefix — `"sixteen"`, `"sixty"` — are matched by their own longer/earlier `alt` arms and are unaffected.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> Small, self-contained parser primitive fix: a word-boundary guard on one `nom` combinator, mirroring the existing `parse_article_number` guard one function above it. No new pattern, variant, or game logic — it's lexical parsing plumbing, so no CR annotation applies. A final `/review-impl` pass was run.

## CR references

None — this is lexical number-word tokenization, not a game rule.

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib parser::` — **7203 passed, 0 failed** (no regression across the whole parser suite).
- New test `test_parse_english_number_requires_word_boundary` is a revert-probe: it **fails without the guard** (`"sixth"` parses as 6) and passes with it, while genuine cardinals with a trailing boundary (`"six cards"`, `"nineteen creatures"`, `"three, then draw"`) and prefix-sharing words (`"sixteen"`, `"sixty"`) still parse correctly.