### PR TITLE
fix(parser): recognize "unless that player has ~ deal N damage to them" (Skullscorch)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24028,8 +24028,17 @@ fn parse_unless_have_deal_damage_cost(after_unless: &str) -> Option<AbilityCost>
     ))
     .parse(after_unless)
     .ok()?;
+    parse_have_deal_damage_to_them_cost(rest)
+}
+
+/// CR 118.12a: the shared `"[~] deal N damage to them"` tail of an
+/// unless-have-deal-damage cost — the `"<who> has "` prefix is consumed by the
+/// caller (`its controller has …`, `that player has …`, etc.). The damage is
+/// dealt to the payer (`TargetFilter::Player`); the caller selects which player
+/// pays via `UnlessPayModifier::payer`.
+fn parse_have_deal_damage_to_them_cost(after_has: &str) -> Option<AbilityCost> {
     let (rest, _) = take_until::<_, _, OracleError<'_>>(" deal ")
-        .parse(rest)
+        .parse(after_has)
         .ok()?;
     // `take_until` leaves the matched delimiter on the input (" deal N ...").
     let (rest, _) = tag::<_, _, OracleError<'_>>(" deal ").parse(rest).ok()?;
@@ -24096,6 +24105,29 @@ fn extract_resolution_unless_pay_modifier(
                 Some(UnlessPayModifier {
                     cost,
                     payer: TargetFilter::AllPlayers,
+                }),
+            );
+        }
+    }
+
+    // CR 118.12a: "[Effect] unless that player has [~] deal N damage to them"
+    // (Skullscorch) — the TARGETED player may have the source deal the damage
+    // instead of taking the primary effect, so the payer is that player
+    // (`TargetFilter::Player`), unlike the object-controller forms below whose
+    // payer resolves through `ParentTargetController`. Checked before the generic
+    // "unless " scan so the player-have-deal shape is not misclassified.
+    if let Some((before_unless, _, after_unless_lower)) =
+        nom_primitives::scan_preceded(&lower, |i| {
+            tag::<_, _, OracleError<'_>>("unless that player has ").parse(i)
+        })
+    {
+        if let Some(cost) = parse_have_deal_damage_to_them_cost(after_unless_lower) {
+            let cleaned = text[..before_unless.trim_end().len()].trim().to_string();
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost,
+                    payer: TargetFilter::Player,
                 }),
             );
         }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -37868,3 +37868,35 @@ fn ents_fury_keeps_cost_paid_object_scope() {
         "Ent's Fury must keep Power{{CostPaidObject}} GE 4, got {condition:?}"
     );
 }
+
+/// #4921 / CR 118.12a: "[Effect] unless that player has [~] deal N damage to
+/// them" (Skullscorch) — the targeted player may have the source deal the damage
+/// instead of taking the primary effect. Mirrors the `its controller has …`
+/// forms, but the payer is the targeted player itself (`TargetFilter::Player`),
+/// not an object's controller.
+#[test]
+fn unless_that_player_has_source_deal_damage() {
+    let def = parse_effect_chain(
+        "Target player discards two cards at random unless that player has ~ deal 4 damage to them.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(*def.effect, Effect::Discard { .. }),
+        "primary effect must be a Discard, got {:?}",
+        def.effect
+    );
+    let unless_pay = def
+        .unless_pay
+        .expect("the `that player has … deal N damage` unless must attach");
+    assert_eq!(unless_pay.payer, TargetFilter::Player);
+    assert_eq!(
+        unless_pay.cost,
+        AbilityCost::EffectCost {
+            effect: Box::new(Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 4 },
+                target: TargetFilter::Player,
+                damage_source: None,
+            }),
+        }
+    );
+}


### PR DESCRIPTION
Closes #4921.

## Problem

The resolution-time unless extractor recognized `unless [that object's|its] controller has ~ deal N damage to them` (Blazing Salvo, Lava Blister, Molten Influence) but **not** the player-targeted form `unless that player has ~ deal N damage to them`. So **Skullscorch** —

> Target player discards two cards at random unless that player has Skullscorch deal 4 damage to them.

— dropped the unless clause to an `Unimplemented`/unsupported node.

## Fix

- Extracted the shared `[~] deal N damage to them` tail of the cost into `parse_have_deal_damage_to_them_cost` (the `"<who> has "` prefix is consumed by the caller).
- Added a dedicated `unless that player has …` branch to `extract_resolution_unless_pay_modifier`. Unlike the object-controller forms (payer resolves through `ParentTargetController`), the payer here is the **targeted player itself** (`TargetFilter::Player`) — that player may have the source deal the damage instead of taking the primary effect.

Skullscorch now parses to exactly the expected shape:

1. Primary → `Discard` two cards at random targeting `Player`.
2. `unless_pay` → `EffectCost(DealDamage 4 → Player)` with payer `TargetFilter::Player`.

No parse warnings; no card-parse regressions.

## Tests

New `unless_that_player_has_source_deal_damage` asserts the `Discard` primary + the `unless_pay` cost/payer.

`cargo test -p engine --lib` → **14,677 passed / 0 failed**; `fmt --check`, `clippy -p engine --all-targets -- -D warnings`, and `check-parser-combinators.sh` all clean.

CR 118.12a.