### PR TITLE
fix(parser): route printed "all creatures able to block ~ do so" to a permanent forced-block static (Ochran Assassin)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -7304,6 +7304,60 @@ mod tests {
         assert!(validate_blockers(&state, &[(blocker_a, attacker), (blocker_b, attacker)]).is_ok());
     }
 
+    /// CR 509.1c (issue #4949): END-TO-END proof that the PARSED Ochran Assassin
+    /// forced-block static enforces at combat. We parse the printed "All creatures
+    /// able to block Ochran Assassin do so" line via `parse_oracle_text`, install
+    /// the resulting static on the attacker, and drive real block-declaration
+    /// validation. Revert-discriminating: before the parser fix the line
+    /// misclassifies to a one-shot effect, so `parse_oracle_text` yields NO
+    /// `MustBeBlockedByAll` static and the `.expect(...)` below fails.
+    #[test]
+    fn parsed_ochran_assassin_lure_forces_every_able_blocker() {
+        let parsed = crate::parser::parse_oracle_text(
+            "Deathtouch\nAll creatures able to block Ochran Assassin do so.",
+            "Ochran Assassin",
+            &["Deathtouch".to_string()],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Assassin".to_string()],
+        );
+        let lure = parsed
+            .statics
+            .into_iter()
+            .find(|s| s.mode == StaticMode::MustBeBlockedByAll)
+            .expect(
+                "parser must produce a permanent MustBeBlockedByAll static for Ochran Assassin",
+            );
+
+        let mut state = setup();
+        let attacker = create_creature(&mut state, PlayerId(0), "Ochran Assassin", 1, 1);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .static_definitions
+            .push(lure);
+        let blocker_a = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        let blocker_b = create_creature(&mut state, PlayerId(1), "Elf", 1, 1);
+        state.combat = Some(CombatState {
+            attackers: vec![AttackerInfo::attacking_player(attacker, PlayerId(1))],
+            ..Default::default()
+        });
+
+        // The parsed lure forces EVERY able blocker onto Ochran.
+        assert!(
+            validate_blockers(&state, &[]).is_err(),
+            "no blockers must be illegal under the parsed lure"
+        );
+        assert!(
+            validate_blockers(&state, &[(blocker_a, attacker)]).is_err(),
+            "leaving one able blocker idle must be illegal"
+        );
+        assert!(
+            validate_blockers(&state, &[(blocker_a, attacker), (blocker_b, attacker)]).is_ok(),
+            "assigning every able blocker must be legal"
+        );
+    }
+
     #[test]
     fn must_be_blocked_by_all_exempts_unable_blockers() {
         // CR 509.1c "able to": a tapped creature carries no block requirement, so

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -483,6 +483,14 @@ pub(crate) fn is_static_pattern(lower: &str) -> bool {
         return true;
     }
 
+    // CR 509.1c: A printed permanent forced-block ("lure") static, "All creatures
+    // able to block <self/enchanted creature> do so" (Ochran Assassin, Breaker of
+    // Armies, Lure), routes to the static parser — NOT the one-shot spell form
+    // "… target creature this turn do so", which stays an effect.
+    if super::oracle_static::is_forced_block_static_candidate(lower) {
+        return true;
+    }
+
     if STATIC_CONTAINS_PATTERNS
         .iter()
         .any(|pattern| scan_contains(lower, pattern))

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2861,6 +2861,15 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // --- CR 509.1c: "All creatures able to block <self/enchanted creature> do so"
+    // — printed permanent forced-block ("lure") static (Ochran Assassin, Breaker
+    // of Armies, Prized Unicorn, Lure). The one-shot "… target creature this turn
+    // do so" spell form is left to `try_parse_mass_forced_block` in the effect
+    // parser. ---
+    if let Some(def) = parse_forced_block_static(&text) {
+        return Some(def);
+    }
+
     // --- "play any number of lands" / counted additional land-drop grants ---
     // The ordinary +1 phrase ("play an additional land") is handled by the
     // rule-static subject/predicate shell so embedded subjects such as

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -517,6 +517,54 @@ pub(crate) fn is_extra_blockers_static_candidate(lower: &str) -> bool {
     parse_extra_blockers_static(lower).is_some()
 }
 
+/// CR 509.1c + CR 611.3a: A printed permanent forced-block ("lure") static —
+/// "All creatures able to block `<subject>` do so" — where `<subject>` is a
+/// rule-static subject (a self-reference `~`, or "enchanted creature" for the
+/// Aura form). This is the PERMANENT static class (Ochran Assassin, Breaker of
+/// Armies, Prized Unicorn, Lure), distinct from the one-shot spell/activated
+/// form "… target creature this turn do so" (Alluring Scent), which
+/// `try_parse_mass_forced_block` lowers to a duration-bounded `GenericEffect`.
+/// Misclassifying the printed static as that one-shot effect leaves it as a
+/// never-resolving ability, so the lure never applies (issue #4949). Emitting a
+/// permanent `StaticMode::MustBeBlockedByAll` static routes it through the combat
+/// enforcement that already exists (`game/combat.rs`, CR 509.1c). The subject is
+/// resolved by `parse_rule_static_subject_filter`, which returns `None` for a
+/// `target …` subject so a genuine spell/effect form still falls through to the
+/// effect parser.
+pub(crate) fn parse_forced_block_static(text: &str) -> Option<StaticDefinition> {
+    let lower = text.to_lowercase();
+    // Grammar: "all creatures able to block <subject> do so[.]". The subject is
+    // taken up to the " do so" imperative, then classified by
+    // `parse_rule_static_subject_filter`. A one-shot spell form ("… target
+    // creature this turn do so", Alluring Scent) has a `target …` subject, which
+    // is not a rule-static subject, so this returns `None` and the line falls
+    // through to `try_parse_mass_forced_block` — no separate duration/target check
+    // is needed.
+    let (rest, _) = tag::<_, _, OracleError<'_>>("all creatures able to block ")
+        .parse(lower.as_str())
+        .ok()?;
+    let (_, subject_lower) = all_consuming(terminated(
+        take_until::<_, _, OracleError<'_>>(" do so"),
+        (tag(" do so"), opt(tag(".")), space0),
+    ))
+    .parse(rest)
+    .ok()?;
+    // The lowercasing is ASCII-length-preserving, so the subject occupies the same
+    // byte span in the original-cased `text`.
+    let start = lower.len() - rest.len();
+    let subject = text.get(start..start + subject_lower.len())?.trim();
+    let affected = parse_rule_static_subject_filter(subject)?;
+    Some(
+        StaticDefinition::new(StaticMode::MustBeBlockedByAll)
+            .affected(affected)
+            .description(text.to_string()),
+    )
+}
+
+pub(crate) fn is_forced_block_static_candidate(lower: &str) -> bool {
+    parse_forced_block_static(lower).is_some()
+}
+
 /// CR 702.3b + CR 611.3a + CR 613: Decompose `"<predicate_1> and can attack
 /// as though <pronoun> didn't have defender[ as long as <cond>]"` into two
 /// independent `StaticDefinition`s sharing the same `affected` + `condition`.

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -139,7 +139,9 @@ pub(crate) use cost_mod::{
     parse_alternative_keyword_cost, parse_cast_spells_alternative_cost_multi,
     parse_collect_evidence_alt_cost, parse_spells_alternative_cost,
 };
-pub(crate) use evasion::{classify_block_exception, is_extra_blockers_static_candidate};
+pub(crate) use evasion::{
+    classify_block_exception, is_extra_blockers_static_candidate, is_forced_block_static_candidate,
+};
 pub(crate) use grammar::map_keyword;
 pub(crate) use keyword_grant::{
     classify_quoted_inner, parse_chosen_qualifier_subject, parse_continuous_modifications,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -838,6 +838,56 @@ fn as_foretold_free_cast_line_is_unsupported() {
     );
 }
 
+/// CR 509.1c (issue #4949): Ochran Assassin's printed "All creatures able to
+/// block ~ do so" is a PERMANENT forced-block ("lure") static, not a one-shot
+/// effect. It must land as a `StaticMode::MustBeBlockedByAll` in `r.statics`
+/// (affected = the source itself), with NO leftover one-shot `GenericEffect`
+/// ability — that form has no trigger/cost and never resolves, so the lure never
+/// applies. Revert-discriminating: before the fix the line misclassifies to the
+/// effect parser and `r.statics` carries no MustBeBlockedByAll. Same printed line
+/// fixes Breaker of Armies / Prized Unicorn / Lure as a class.
+#[test]
+fn ochran_assassin_forced_block_is_permanent_static() {
+    use crate::types::ability::TargetFilter;
+    let r = parse(
+        "Deathtouch\nAll creatures able to block Ochran Assassin do so.",
+        "Ochran Assassin",
+        &[Keyword::Deathtouch],
+        &["Creature"],
+        &["Human", "Assassin"],
+    );
+
+    let lure = r
+        .statics
+        .iter()
+        .find(|s| s.mode == StaticMode::MustBeBlockedByAll)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a permanent MustBeBlockedByAll static, got {:?}",
+                r.statics
+            )
+        });
+    assert_eq!(
+        lure.affected,
+        Some(TargetFilter::SelfRef),
+        "the lure must affect the source creature itself"
+    );
+
+    // No leftover one-shot GenericEffect ability carrying MustBeBlockedByAll — that
+    // form never resolves (the pre-fix bug).
+    assert!(
+        !r.abilities.iter().any(|a| matches!(
+            &*a.effect,
+            Effect::GenericEffect { static_abilities, .. }
+                if static_abilities
+                    .iter()
+                    .any(|s| s.mode == StaticMode::MustBeBlockedByAll)
+        )),
+        "no one-shot GenericEffect MustBeBlockedByAll ability should remain, got {:?}",
+        r.abilities
+    );
+}
+
 /// Cavernous Maw (std BATCH 12): the `{2}` activated ability animates the
 /// land into a 3/3 Elemental creature, and the confirmatory "It's still a
 /// Cave land" sentence (CR 205.1b, CR 305.7) must NOT remain


### PR DESCRIPTION
## Problem

The printed lure line "All creatures able to block `<self / enchanted creature>` do so" — Ochran Assassin, Breaker of Armies, Prized Unicorn, and the Aura **Lure** — was misclassified as the one-shot spell/activated form and lowered to a duration-bounded `Effect::GenericEffect` ability. That ability has no trigger and no activation cost, so it never resolves — the lure never applied (issue #4949).

## Fix (parser-only)

- **`parse_forced_block_static`** (`oracle_static/evasion.rs`): recognizes the permanent form — the `"do so"` imperative with a rule-static subject (a self-reference `~` or `"enchanted creature"`) and **no** trailing duration — and emits a permanent `StaticMode::MustBeBlockedByAll` static (no `Duration`).
- **`is_forced_block_static_candidate`** is wired into `is_static_pattern` (mirroring `is_extra_blockers_static_candidate`) so the line routes to the static parser; `parse_forced_block_static` is invoked in the static lowering (`oracle_static/dispatch.rs`).
- The one-shot `"… target creature this turn do so"` form (Alluring Scent) stays with `try_parse_mass_forced_block`: a `target …` subject is not a rule-static subject (`parse_rule_static_subject_filter` returns `None`) and a trailing duration forces the effect path.

No runtime changes — combat enforcement of `MustBeBlockedByAll` (`game/combat.rs`, CR 509.1c) already exists and is tested. Fixes the whole printed-lure class.

## Anchored on
- `crates/engine/src/parser/oracle_static/evasion.rs:488` — `parse_extra_blockers_static` / `is_extra_blockers_static_candidate` (`:516`): the sibling static-candidate helper, wired into `is_static_pattern` (`oracle_classifier.rs:482`) and invoked in the static lowering the exact same way. `parse_forced_block_static` mirrors its shape, its `is_*_candidate` wrapper, and its dispatch registration.
- `crates/engine/src/parser/oracle_effect/mod.rs:7642` — `try_parse_mass_forced_block`: the one-shot `MustBeBlockedByAll` effect form (target + duration) that the new permanent-static form complements and deliberately leaves intact.

## Gate A
```
$ ./scripts/check-parser-combinators.sh
(no output; exit 0 — no combinator-purity violations)
```

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine` — clean (`-D warnings`). Full-workspace `clippy-strict` needs OpenSSL/`pkg-config` (unavailable in my sandbox); CI **Rust lint** is the green run.
- `./scripts/check-parser-combinators.sh` — clean (exit 0) — see **Gate A**
- `cargo test -p engine --lib -- parser:: game::combat::` — **7382 passed / 0 failed**. Full sharded `cargo test -p engine` runs green in CI (**Rust tests**).
- wasm-dev check (`cargo check -p engine-wasm --target wasm32-unknown-unknown` with `-D warnings`) — clean.
- Card-data / coverage / semantic-audit run green in CI (**Card data** job); the local pipeline needs an MTGJSON download unavailable in my sandbox.

## Tests (both fail on revert)
- `ochran_assassin_forced_block_is_permanent_static` (`parser/oracle_tests.rs`) — full-dispatch `parse_oracle_text`: Ochran yields a permanent `MustBeBlockedByAll` static (`affected = SelfRef`) and **no** leftover one-shot `GenericEffect` ability.
- `parsed_ochran_assassin_lure_forces_every_able_blocker` (`game/combat.rs`) — **end-to-end runtime**: parses Ochran, installs the parsed static on the attacker, and drives real `validate_blockers` — every able blocker is forced onto Ochran and leaving one idle is illegal. Fails on revert (the parser yields no static to enforce).

## CR
CR 509.1c (block requirements — "effects that say a creature must block") + CR 611.3a (continuous static). Verified against `docs/MagicCompRules.txt`.

Closes #4949

Tier: Frontier
Model: claude-opus-4-8
Thinking: high
