### PR TITLE
Configure multiplayer default server for self-hosted builds

### DIFF
--- a/client/src/components/lobby/ServerPicker.tsx
+++ b/client/src/components/lobby/ServerPicker.tsx
@@ -124,7 +124,7 @@ export function ServerPicker({ onClose, onApply }: ServerPickerProps) {
                       className="h-3.5 w-auto rounded-[2px] shadow-sm ring-1 ring-black/20"
                     />
                   )}
-                  {preset.label}
+                  {t(preset.labelKey)}
                 </span>
                 <span className="min-w-0 truncate pl-2 font-mono text-[10px] text-slate-500">
                   {preset.url.replace(/^wss?:\/\//, "")}

--- a/client/src/components/lobby/ServerPicker.tsx
+++ b/client/src/components/lobby/ServerPicker.tsx
@@ -118,10 +118,12 @@ export function ServerPicker({ onClose, onApply }: ServerPickerProps) {
                 }
               >
                 <span className="flex min-w-0 items-center gap-2 font-medium">
-                  <ServerFlag
-                    flag={preset.flag}
-                    className="h-3.5 w-auto rounded-[2px] shadow-sm ring-1 ring-black/20"
-                  />
+                  {preset.flag && (
+                    <ServerFlag
+                      flag={preset.flag}
+                      className="h-3.5 w-auto rounded-[2px] shadow-sm ring-1 ring-black/20"
+                    />
+                  )}
                   {preset.label}
                 </span>
                 <span className="min-w-0 truncate pl-2 font-mono text-[10px] text-slate-500">

--- a/client/src/config/multiplayerServer.ts
+++ b/client/src/config/multiplayerServer.ts
@@ -1,0 +1,15 @@
+export const OFFICIAL_MULTIPLAYER_SERVER_URL = "wss://lobby.phase-rs.dev/ws";
+export const DEFAULT_MULTIPLAYER_SERVER_URL = __DEFAULT_MULTIPLAYER_SERVER_URL__;
+
+const OFFICIAL_MULTIPLAYER_SERVER_HOSTS = new Set([
+  "lobby.phase-rs.dev",
+  "us.phase-rs.dev",
+]);
+
+export function isOfficialMultiplayerServerUrl(value: string): boolean {
+  try {
+    return OFFICIAL_MULTIPLAYER_SERVER_HOSTS.has(new URL(value).hostname);
+  } catch {
+    return false;
+  }
+}

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Wähle eine Region oder verbinde dich mit einer selbst gehosteten Instanz.",
     "noneLabel": "Keiner (nur P2P)",
     "directCodes": "direkte Codes",
+    "official": "Offiziell",
     "selfHosted": "Selbst gehostet",
     "customUrlPlaceholder": "wss://dein-server.beispiel/ws",
     "test": "Testen",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Pick a region, or connect to a self-hosted instance.",
     "noneLabel": "None (P2P only)",
     "directCodes": "direct codes",
+    "official": "Official",
     "selfHosted": "Self-hosted",
     "customUrlPlaceholder": "wss://your-server.example/ws",
     "test": "Test",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Elige una región o conéctate a una instancia autoalojada.",
     "noneLabel": "Ninguno (solo P2P)",
     "directCodes": "códigos directos",
+    "official": "Oficial",
     "selfHosted": "Autoalojado",
     "customUrlPlaceholder": "wss://tu-servidor.ejemplo/ws",
     "test": "Probar",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Choisissez une région, ou connectez-vous à une instance auto-hébergée.",
     "noneLabel": "Aucun (P2P uniquement)",
     "directCodes": "codes directs",
+    "official": "Officiel",
     "selfHosted": "Auto-hébergé",
     "customUrlPlaceholder": "wss://votre-serveur.exemple/ws",
     "test": "Tester",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Scegli una regione, o connettiti a un'istanza self-hosted.",
     "noneLabel": "Nessuno (solo P2P)",
     "directCodes": "codici diretti",
+    "official": "Ufficiale",
     "selfHosted": "Self-hosted",
     "customUrlPlaceholder": "wss://tuo-server.esempio/ws",
     "test": "Testa",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Wybierz region lub połącz się z własną instancją.",
     "noneLabel": "Brak (tylko P2P)",
     "directCodes": "bezpośrednie kody",
+    "official": "Oficjalny",
     "selfHosted": "Własny hosting",
     "customUrlPlaceholder": "wss://twoj-serwer.example/ws",
     "test": "Testuj",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -110,6 +110,7 @@
     "subtitle": "Escolha uma região ou conecte-se a uma instância auto-hospedada.",
     "noneLabel": "Nenhum (apenas P2P)",
     "directCodes": "códigos diretos",
+    "official": "Oficial",
     "selfHosted": "Auto-hospedado",
     "customUrlPlaceholder": "wss://seu-servidor.exemplo/ws",
     "test": "Testar",

--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_MULTIPLAYER_SERVER_URL,
+  OFFICIAL_MULTIPLAYER_SERVER_URL,
+} from "../../config/multiplayerServer";
+import {
   DEFAULT_SERVER,
   SERVER_PRESETS,
   formatJoinShare,
@@ -9,8 +13,17 @@ import {
 } from "../serverDetection";
 
 describe("server defaults", () => {
-  it("uses the first server preset as the default multiplayer server", () => {
+  it("uses the configured build default as the first server preset", () => {
+    expect(DEFAULT_SERVER).toBe(DEFAULT_MULTIPLAYER_SERVER_URL);
     expect(DEFAULT_SERVER).toBe(SERVER_PRESETS[0].url);
+    expect(SERVER_PRESETS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labelKey: "serverPicker.official",
+          url: OFFICIAL_MULTIPLAYER_SERVER_URL,
+        }),
+      ]),
+    );
   });
 });
 

--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { formatJoinShare, mixedContentBlockReason, parseJoinCode } from "../serverDetection";
+import {
+  DEFAULT_SERVER,
+  SERVER_PRESETS,
+  formatJoinShare,
+  mixedContentBlockReason,
+  parseJoinCode,
+} from "../serverDetection";
+
+describe("server defaults", () => {
+  it("uses the first server preset as the default multiplayer server", () => {
+    expect(DEFAULT_SERVER).toBe(SERVER_PRESETS[0].url);
+  });
+});
 
 describe("parseJoinCode", () => {
   it("returns just the code when no server address is present", () => {

--- a/client/src/services/serverDetection.ts
+++ b/client/src/services/serverDetection.ts
@@ -1,5 +1,9 @@
 import { isTauri } from "./sidecar";
 import { useMultiplayerStore } from "../stores/multiplayerStore";
+import {
+  DEFAULT_MULTIPLAYER_SERVER_URL,
+  OFFICIAL_MULTIPLAYER_SERVER_URL,
+} from "../config/multiplayerServer";
 
 const DEFAULT_PORT = 9374;
 
@@ -10,18 +14,20 @@ export type FlagCode = "us";
 export interface ServerPreset {
   label: string;
   url: string;
-  flag: FlagCode;
+  flag?: FlagCode;
 }
 
 /**
- * User-pickable canonical regions. The official deployment is a single global
- * lobby, so there is intentionally one entry — additional regional lobbies would
- * fragment the matchmaking pool, defeating the broker's purpose. Self-hosted
- * servers are entered via the custom-URL field, not here. See
- * .planning/lobby-failover-federation-plan.md.
+ * User-pickable canonical endpoints. The official deployment is a single global
+ * lobby; a self-hosted build may prepend its configured default so the picker
+ * clearly shows where this static bundle connects by default. Additional
+ * one-off self-hosted servers are still entered through the custom URL field.
  */
 export const SERVER_PRESETS: ServerPreset[] = [
-  { label: "Official", url: "wss://lobby.phase-rs.dev/ws", flag: "us" },
+  ...(DEFAULT_MULTIPLAYER_SERVER_URL === OFFICIAL_MULTIPLAYER_SERVER_URL
+    ? []
+    : [{ label: "Self-hosted", url: DEFAULT_MULTIPLAYER_SERVER_URL }]),
+  { label: "Official", url: OFFICIAL_MULTIPLAYER_SERVER_URL, flag: "us" },
 ];
 
 /** The default region's URL — first entry in {@link SERVER_PRESETS}. */

--- a/client/src/services/serverDetection.ts
+++ b/client/src/services/serverDetection.ts
@@ -12,7 +12,7 @@ const DEFAULT_PORT = 9374;
 export type FlagCode = "us";
 
 export interface ServerPreset {
-  label: string;
+  labelKey: string;
   url: string;
   flag?: FlagCode;
 }
@@ -26,8 +26,12 @@ export interface ServerPreset {
 export const SERVER_PRESETS: ServerPreset[] = [
   ...(DEFAULT_MULTIPLAYER_SERVER_URL === OFFICIAL_MULTIPLAYER_SERVER_URL
     ? []
-    : [{ label: "Self-hosted", url: DEFAULT_MULTIPLAYER_SERVER_URL }]),
-  { label: "Official", url: OFFICIAL_MULTIPLAYER_SERVER_URL, flag: "us" },
+    : [{ labelKey: "serverPicker.selfHosted", url: DEFAULT_MULTIPLAYER_SERVER_URL }]),
+  {
+    labelKey: "serverPicker.official",
+    url: OFFICIAL_MULTIPLAYER_SERVER_URL,
+    flag: "us",
+  },
 ];
 
 /** The default region's URL — first entry in {@link SERVER_PRESETS}. */

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PlayerSlot } from "../../multiplayer/seatTypes";
 import { formatMetadata } from "../../data/formatRegistry";
-import { FORMAT_DEFAULTS, type HostingSettings, useMultiplayerStore } from "../multiplayerStore";
+import {
+  FORMAT_DEFAULTS,
+  migrateOfficialServerAddress,
+  type HostingSettings,
+  useMultiplayerStore,
+} from "../multiplayerStore";
 
 const p2pMocks = vi.hoisted(() => ({
   hostDestroy: vi.fn(),
@@ -131,6 +136,30 @@ describe("multiplayerStore", () => {
         formatMetadata(metadata.format)?.default_config,
       );
     }
+  });
+
+  it("migrates official persisted server addresses to the configured deployment default", () => {
+    expect(
+      migrateOfficialServerAddress(
+        "wss://lobby.phase-rs.dev/ws",
+        "wss://selfhost.example/ws",
+      ),
+    ).toBe("wss://selfhost.example/ws");
+    expect(
+      migrateOfficialServerAddress(
+        "wss://us.phase-rs.dev/ws",
+        "wss://selfhost.example/ws",
+      ),
+    ).toBe("wss://selfhost.example/ws");
+  });
+
+  it("does not migrate custom self-hosted server addresses", () => {
+    expect(
+      migrateOfficialServerAddress(
+        "wss://play.example.com/ws",
+        "wss://selfhost.example/ws",
+      ),
+    ).toBe("wss://play.example.com/ws");
   });
 
   it("strips AI seats from team-based server host settings", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -36,6 +36,10 @@ import {
   type ReconnectHandle,
 } from "../services/openPhaseSocket";
 import { isValidWebSocketUrl } from "../services/serverDetection";
+import {
+  DEFAULT_MULTIPLAYER_SERVER_URL,
+  isOfficialMultiplayerServerUrl,
+} from "../config/multiplayerServer";
 import { saveActiveGame, useGameStore } from "./gameStore";
 import type { P2PHostAdapter } from "../adapter/p2p-adapter";
 import {
@@ -498,22 +502,36 @@ export const FORMAT_DEFAULTS: Record<GameFormat, FormatConfig> = Object.fromEntr
   FORMAT_REGISTRY.map((m) => [m.format, m.default_config]),
 ) as Record<GameFormat, FormatConfig>;
 
-/**
- * Canonical official lobby URL, mirroring `DEFAULT_SERVER` in serverDetection.
- * Kept as a local literal (not imported) because this constant is read at the
- * top level during `create()`, and serverDetection ↔ multiplayerStore form an
- * import cycle — a top-level read of the imported value could hit a TDZ crash
- * depending on bundler load order. The migration below uses the same constant
- * to retire the decommissioned regional host from persisted state.
- */
-const OFFICIAL_LOBBY_URL = "wss://lobby.phase-rs.dev/ws";
+export function migrateOfficialServerAddress(
+  address: unknown,
+  targetAddress: string,
+): unknown {
+  return typeof address === "string" && isOfficialMultiplayerServerUrl(address)
+    ? targetAddress
+    : address;
+}
+
+export function migratePersistedMultiplayerState(
+  persisted: unknown,
+  version: number,
+): unknown {
+  if (!persisted || typeof persisted !== "object") return persisted;
+  const migrated = persisted as Record<string, unknown>;
+  if (version < 2) {
+    migrated.serverAddress = migrateOfficialServerAddress(
+      migrated.serverAddress,
+      DEFAULT_MULTIPLAYER_SERVER_URL,
+    );
+  }
+  return migrated;
+}
 
 export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>()(
   persist(
     (set, get) => ({
       playerId: crypto.randomUUID(),
       displayName: "",
-      serverAddress: OFFICIAL_LOBBY_URL,
+      serverAddress: DEFAULT_MULTIPLAYER_SERVER_URL,
       connectionStatus: "disconnected",
       activePlayerId: null,
       opponentDisplayName: null,
@@ -1325,24 +1343,12 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
     }),
     {
       name: "phase-multiplayer",
-      version: 1,
-      // v0 → v1: the regional "us.phase-rs.dev" lobby was retired in favour of
-      // the single global broker at "lobby.phase-rs.dev". A returning user's
-      // persisted serverAddress overrides the in-code default on rehydrate, so
-      // without this rewrite they stay pinned to the dead host forever. Only the
-      // old official host is rewritten — custom self-hosted addresses are left
-      // untouched.
-      migrate: (persisted: unknown, version: number) => {
-        if (!persisted || typeof persisted !== "object") return persisted;
-        const migrated = persisted as Record<string, unknown>;
-        if (version < 1) {
-          const addr = migrated.serverAddress;
-          if (typeof addr === "string" && addr.includes("us.phase-rs.dev")) {
-            migrated.serverAddress = OFFICIAL_LOBBY_URL;
-          }
-        }
-        return migrated;
-      },
+      version: 2,
+      // v0/v1 → v2: official hosted lobby addresses are deployment defaults,
+      // not user intent. A self-hosted build must move returning browsers from
+      // the official lobby to its configured default while preserving explicit
+      // custom/self-hosted addresses.
+      migrate: migratePersistedMultiplayerState,
       partialize: (state) => ({
         playerId: state.playerId,
         displayName: state.displayName,

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 declare const __APP_VERSION__: string;
 declare const __BUILD_HASH__: string;
+declare const __DEFAULT_MULTIPLAYER_SERVER_URL__: string;
 declare const __CARD_DATA_URL__: string;
 declare const __CARD_DATA_LOCALE_URL_TEMPLATE__: string;
 declare const __CARD_NAMES_URL__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -10,6 +10,8 @@ import { VitePWA } from "vite-plugin-pwa";
 import { compression } from "vite-plugin-compression2";
 import type { Plugin } from "vite";
 
+const OFFICIAL_MULTIPLAYER_SERVER_URL = "wss://lobby.phase-rs.dev/ws";
+
 // wasm-bindgen emits `import * as importN from "env"` for WASM host-environment
 // imports (LLVM intrinsics). These are provided at instantiation time by the JS
 // glue code and are never loaded as ES modules. Resolve them to an empty shim
@@ -81,6 +83,9 @@ function dataFileDefines(mode: string): Record<string, string> {
     __AUDIO_BASE_URL__: JSON.stringify(process.env.AUDIO_BASE_URL || ""),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
     __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
+    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
+      process.env.DEFAULT_MULTIPLAYER_SERVER_URL || OFFICIAL_MULTIPLAYER_SERVER_URL,
+    ),
     // True only for tagged production releases (release.yml sets RELEASE_BUILD).
     // The staging deploy (deploy.yml) is also a production Vite build, so we
     // cannot key off import.meta.env.PROD — that would surface the "try the

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -84,7 +84,7 @@ function dataFileDefines(mode: string): Record<string, string> {
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
     __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
     __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
-      process.env.DEFAULT_MULTIPLAYER_SERVER_URL || OFFICIAL_MULTIPLAYER_SERVER_URL,
+      envVar("DEFAULT_MULTIPLAYER_SERVER_URL") || OFFICIAL_MULTIPLAYER_SERVER_URL,
     ),
     // True only for tagged production releases (release.yml sets RELEASE_BUILD).
     // The staging deploy (deploy.yml) is also a production Vite build, so we

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -49,6 +49,9 @@ export default defineConfig({
     __CHANGELOG_META_URL__: JSON.stringify("/changelog-meta.json"),
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
     __BUILD_HASH__: JSON.stringify("testhash"),
+    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
+      process.env.DEFAULT_MULTIPLAYER_SERVER_URL || "wss://lobby.phase-rs.dev/ws",
+    ),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
   },
   test: {


### PR DESCRIPTION
## Summary

Makes the multiplayer lobby server default configurable at build time so self-hosted client bundles can default to their own broker while still keeping the official lobby available in the server picker.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Frontend-only client configuration and persistence migration change; this does not touch engine/parser logic or `crates/engine/` rules behavior.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

None.

## Verification

- `git diff --check origin/main...HEAD` — passed
- `NODE_OPTIONS=--no-experimental-webstorage npx --yes pnpm@10.23.0 exec vitest run src/services/__tests__/serverDetection.test.ts src/stores/__tests__/multiplayerStore.test.ts` — passed, 32 tests
- `npx --yes pnpm@10.23.0 type-check` — passed
- `npx --yes pnpm@10.23.0 exec eslint . --quiet` — passed
- `DEFAULT_MULTIPLAYER_SERVER_URL=wss://selfhost.example/ws node --input-type=module ...` Vite config-load assertion — passed; `__DEFAULT_MULTIPLAYER_SERVER_URL__` resolved to the supplied self-host URL

