### PR TITLE
fix(engine): clamp negative discard counts to zero (CR 107.1b)

### DIFF
--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -141,8 +141,13 @@ pub fn resolve(
         } => {
             let (inner, up_to) = count.peel_up_to();
             (
-                // CR 107.1b: Use ability context so X resolves against the caster's chosen value.
-                resolve_quantity_with_targets(state, inner, ability) as u32,
+                // CR 107.1b: a calculation that would yield a negative number
+                // uses zero instead. Clamp before the `as u32` cast — a
+                // subtractive count ("discard cards equal to A minus B" when
+                // B > A) would otherwise wrap to ~4 billion and let the player
+                // discard their whole hand. Ability context also resolves X
+                // against the caster's chosen value. Mirrors `draw.rs`.
+                resolve_quantity_with_targets(state, inner, ability).max(0) as u32,
                 up_to,
                 unless_filter.clone(),
                 target.clone(),
@@ -622,6 +627,88 @@ mod tests {
             .any(|e| matches!(e, GameEvent::Discarded { object_id, .. } if *object_id == card)));
         // CR 702.187b: the Mayhem marker is NOT stamped when the card was redirected.
         assert_eq!(state.objects[&card].discarded_turn, None);
+    }
+
+    /// CR 107.1b: a discard count that resolves negative must clamp to 0, not
+    /// wrap through the `as u32` cast to ~4 billion. "Discard up to (cards in
+    /// your hand − cards in an opponent's hand)" with the opponent holding more
+    /// cards yields a negative count; the player must be offered a discard of 0,
+    /// never their whole hand. This mirrors the clamp `draw.rs` already applies
+    /// for the analogous Mr. Foxglove subtractive-draw shape. Revert-probe:
+    /// without the `.max(0)` the presented count is `u32::MAX - 1`.
+    #[test]
+    fn discard_negative_count_clamps_to_zero() {
+        use crate::types::ability::{
+            AggregateFunction, CardSelectionMode, PlayerScope, QuantityRef,
+        };
+
+        let mut state = GameState::new_two_player(7);
+        // Caster (P0) hand: 1 card. Opponent (P1) hand: 3 cards.
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mine".into(),
+            Zone::Hand,
+        );
+        for i in 0..3u64 {
+            create_object(
+                &mut state,
+                CardId(10 + i),
+                PlayerId(1),
+                "Theirs".into(),
+                Zone::Hand,
+            );
+        }
+
+        // count = up to (HandSize{You} − HandSize{Opponent}) = 1 − 3 = −2.
+        let count = QuantityExpr::up_to(QuantityExpr::Sum {
+            exprs: vec![
+                QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Opponent {
+                                aggregate: AggregateFunction::Sum,
+                            },
+                        },
+                    }),
+                },
+            ],
+        });
+
+        let ability = ResolvedAbility::new(
+            Effect::Discard {
+                count,
+                target: TargetFilter::Controller,
+                selection: CardSelectionMode::Chosen,
+                unless_filter: None,
+                filter: None,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        match &state.waiting_for {
+            WaitingFor::DiscardChoice { count, player, .. } => {
+                assert_eq!(*player, PlayerId(0));
+                assert_eq!(
+                    *count,
+                    0,
+                    "CR 107.1b: a negative discard count must clamp to 0, not wrap to {}",
+                    u32::MAX - 1
+                );
+            }
+            other => panic!("expected a DiscardChoice of up-to-0, got {other:?}"),
+        }
     }
 
     /// D1 double-consult guard: the madness class (a Discard-level definition


### PR DESCRIPTION
## Summary

The discard resolver cast the resolved count `as u32` with no lower bound (`discard.rs`, the `Effect::Discard` arm). A subtractive count — "discard cards equal to [A] minus [B]" (`Sum[A, Multiply{-1, B}]`) — resolves negative when `B > A`, and `-2 as u32` wraps to `4_294_967_294`. In the **"up to"** path that wrapped count is passed **uncapped** into `WaitingFor::DiscardChoice`, so the player is offered a discard of ~4 billion and may legally dump their **entire hand**, when CR 107.1b requires discarding **zero**.

Every sibling resolver already clamps this exact hazard — `draw.rs` (whose comment names the Mr. Foxglove subtractive shape), `sacrifice.rs`, `adapt.rs`, `token.rs`, etc. `discard.rs` was the lone unclamped one. The fix is the same one-liner:

```rust
resolve_quantity_with_targets(state, inner, ability).max(0) as u32,
```

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> One-line resolver fix that restores an invariant every sibling resolver already holds (`.max(0)` before the `as u32` cast), plus a regression test. No new pattern, variant, or AST. A final `/review-impl` self-check was run.

## CR references

- `CR 107.1b` — "If a calculation that would determine the result of an effect yields a negative number, zero is used instead."

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib game::effects::discard::tests` — 29 passed.
- New `discard_negative_count_clamps_to_zero` resolves `Effect::Discard { count: UpTo(HandSize{You} − HandSize{Opponent}) }` with the opponent holding more cards, and asserts the presented `DiscardChoice` count is `0`. Revert-probe: **without** the `.max(0)` the presented count is `u32::MAX - 1` (`4294967294`) and the test fails — proving the wrap is real and reachable, and the assertion is non-vacuous (both fixed and buggy paths produce a `DiscardChoice`, differing only in the count).