### PR TITLE
fix(parser): bind anaphoric "equal to the difference" counter count to the trigger's power comparison (Drizzt Do'Urden)

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -3117,6 +3117,102 @@ mod tests {
         );
     }
 
+    /// CR 122.1 + CR 603.4 + CR 603.10a: Drizzt Do'Urden — "Whenever a creature
+    /// dies, if it had power greater than Drizzt's power, put a number of +1/+1
+    /// counters on Drizzt equal to the difference." End-to-end through the real
+    /// parser: a larger-power creature dying gates the trigger on and puts
+    /// `dyingPower - drizztPower` counters (read from LKI, CR 603.10a); an
+    /// equal/smaller creature fails the gate and adds none. Fails on revert
+    /// (parser leaves the effect Unimplemented / drops the gate → 0 counters).
+    #[test]
+    fn drizzt_difference_counters_from_dying_creature_lki_power() {
+        use crate::game::stack::resolve_top;
+        use crate::game::triggers::process_triggers;
+        use crate::types::triggers::TriggerMode;
+
+        // Parse Drizzt's dies trigger from Oracle text (real pipeline).
+        let parsed = crate::parser::parse_oracle_text(
+            "Double strike\n\
+             Whenever a creature dies, if it had power greater than Drizzt's power, \
+             put a number of +1/+1 counters on Drizzt equal to the difference.",
+            "Drizzt Do'Urden",
+            &[],
+            &["Creature".to_string()],
+            &["Elf".to_string(), "Ranger".to_string()],
+        );
+        let dies_trigger = parsed
+            .triggers
+            .iter()
+            .find(|t| {
+                matches!(t.mode, TriggerMode::ChangesZone)
+                    && t.execute
+                        .as_ref()
+                        .is_some_and(|e| matches!(&*e.effect, Effect::PutCounter { .. }))
+            })
+            .unwrap_or_else(|| panic!("Drizzt dies PutCounter trigger not parsed: {parsed:#?}"))
+            .clone();
+
+        // Run the dies scenario with a creature of the given power; return the
+        // number of +1/+1 counters Drizzt ends up with.
+        let run = |dying_power: i32| -> u32 {
+            let mut state = GameState::new_two_player(42);
+
+            let drizzt_id = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Drizzt Do'Urden".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let d = state.objects.get_mut(&drizzt_id).unwrap();
+                d.power = Some(2);
+                d.toughness = Some(3);
+                d.card_types.core_types.push(CoreType::Creature);
+                d.trigger_definitions.push(dies_trigger.clone());
+            }
+
+            let dying_id = create_object(
+                &mut state,
+                CardId(2),
+                PlayerId(1),
+                "Hill Giant".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let g = state.objects.get_mut(&dying_id).unwrap();
+                g.power = Some(dying_power);
+                g.toughness = Some(3);
+                g.card_types.core_types.push(CoreType::Creature);
+            }
+
+            let mut events = Vec::new();
+            crate::game::zones::move_to_zone(&mut state, dying_id, Zone::Graveyard, &mut events);
+            process_triggers(&mut state, &events);
+            while !state.stack.is_empty() {
+                let mut resolve_events = Vec::new();
+                resolve_top(&mut state, &mut resolve_events);
+            }
+
+            state.objects[&drizzt_id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0)
+        };
+
+        // Larger power (5) than Drizzt (2): gate passes, +1/+1 counters = 5 - 2 = 3.
+        assert_eq!(
+            run(5),
+            3,
+            "5-power creature dying should give Drizzt 3 (=5-2) +1/+1 counters"
+        );
+        // Equal power (2): strict GT gate fails, no counters.
+        assert_eq!(run(2), 0, "equal-power creature must not add counters");
+        // Smaller power (1): gate fails, no counters.
+        assert_eq!(run(1), 0, "smaller-power creature must not add counters");
+    }
+
     /// Regression test: MoveCounters must use LKI when the source has changed zones.
     /// Simulates Essence Channeler's "When this creature dies, put its counters on
     /// target creature you control" — the source is in the graveyard with no counters,

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -2,7 +2,7 @@ use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till, take_until};
 use nom::character::complete::space1;
-use nom::combinator::{eof, opt, peek, value};
+use nom::combinator::{all_consuming, eof, opt, peek, value};
 use nom::sequence::terminated;
 use nom::Parser;
 
@@ -515,9 +515,32 @@ fn parse_counter_equal_to(
     // table. Isolate the phrase up to the first clause boundary so trailing
     // ", then …" clauses stay in the remainder.
     let (after_equal, _) = tag("equal to ").parse(input)?;
-    let (_, phrase) =
+    let (rest, phrase_raw) =
         take_till::<_, _, OracleError<'_>>(|c| c == ',' || c == '.').parse(after_equal)?;
-    let phrase = phrase.trim_end();
+
+    // CR 122.1 + CR 603.4 + CR 603.10a: bare anaphoric "the difference" — the
+    // count is the difference established by the enclosing trigger's
+    // intervening-if comparison ("if it had power greater than ~'s power, put a
+    // number of +1/+1 counters on ~ equal to the difference" — Drizzt
+    // Do'Urden). The two operands live on the hoisted trigger condition, not in
+    // this clause, so emit the deferred placeholder that the trigger-level
+    // difference binding in `lower_trigger_ir` (oracle_trigger.rs) resolves
+    // against the `QuantityComparison` operands. Distinct from the
+    // `parse_cda_quantity` "the difference between A and B" form below, which
+    // carries its own operands. Match on the fully-trimmed phrase (both ends) so
+    // stray leading whitespace ("equal to  the difference") still binds, and
+    // return `take_till`'s own remainder to preserve any trailing ", …" clause.
+    if all_consuming(tag::<_, _, OracleError<'_>>("the difference"))
+        .parse(phrase_raw.trim())
+        .is_ok()
+    {
+        return Ok((
+            rest,
+            crate::parser::oracle_effect::difference_anaphor_placeholder(),
+        ));
+    }
+
+    let phrase = phrase_raw.trim_end();
     if let Some(expr) = crate::parser::oracle_quantity::parse_cda_quantity(phrase) {
         return Ok((&after_equal[phrase.len()..], expr));
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19333,6 +19333,40 @@ pub(crate) fn rewrite_event_player_quantity_refs_to_scoped(def: &mut AbilityDefi
     }
 }
 
+/// CR 122.1 + CR 603.4 + CR 603.10a: The deferred count placeholder emitted for
+/// a bare anaphoric "the difference" whose two operands live on the trigger's
+/// hoisted intervening-if comparison rather than the effect clause ("Whenever a
+/// creature dies, if it had power greater than ~'s power, put a number of +1/+1
+/// counters on ~ equal to the difference" — Drizzt Do'Urden). The put-counter
+/// parser cannot see the comparison operands, so it emits this placeholder and
+/// the trigger-level difference binding in `lower_trigger_ir` (oracle_trigger.rs)
+/// replaces it with the `QuantityExpr::Difference` of the condition's two
+/// operands (alongside the sibling draw/lose bindings). Left unbound
+/// (a card with the anaphor but no comparison), a `Variable` ref resolves to 0
+/// in `quantity::resolve_ref`, so the effect is inert rather than wrong.
+pub(crate) const DIFFERENCE_ANAPHOR_VARIABLE: &str = "difference";
+
+/// Construct the deferred "the difference" count placeholder (see
+/// [`DIFFERENCE_ANAPHOR_VARIABLE`]).
+pub(crate) fn difference_anaphor_placeholder() -> QuantityExpr {
+    QuantityExpr::Ref {
+        qty: QuantityRef::Variable {
+            name: DIFFERENCE_ANAPHOR_VARIABLE.to_string(),
+        },
+    }
+}
+
+/// True when `expr` is the deferred "the difference" count placeholder awaiting
+/// a trigger-level bind (see [`DIFFERENCE_ANAPHOR_VARIABLE`]).
+pub(crate) fn is_difference_anaphor_placeholder(expr: &QuantityExpr) -> bool {
+    matches!(
+        expr,
+        QuantityExpr::Ref {
+            qty: QuantityRef::Variable { name },
+        } if name == DIFFERENCE_ANAPHOR_VARIABLE
+    )
+}
+
 /// True when a trigger's intervening-if references the controller gaining life
 /// this turn (Lathiel / Ocelot Pride class).
 pub(crate) fn trigger_condition_references_controller_life_gained(

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -94,6 +94,11 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         // wins over the fixed-N "its power is N or greater" combinator inside
         // that group (which only matches numeric thresholds).
         parse_subject_property_superlative_comparison,
+        // CR 208.1 + CR 603.4 + CR 603.10a: "it had power greater than ~'s power"
+        // — triggering object's LKI stat vs the source's stat (Drizzt Do'Urden).
+        // Placed before `parse_source_state_conditions` so the "it had <stat>"
+        // subject is not mistaken for a source-subject fixed-threshold form.
+        parse_event_object_pt_vs_source_comparison,
         parse_attached_object_is_filter_condition,
         parse_recipient_is_filter_condition,
         parse_source_state_conditions,
@@ -1804,6 +1809,58 @@ pub(crate) fn parse_source_power_toughness_condition(
             rhs: QuantityExpr::Fixed { value: n as i32 },
         },
     ))
+}
+
+/// CR 208.1 + CR 603.4 + CR 603.10a: Intervening-if comparing the *triggering*
+/// object's last-known stat against the ability source's stat — "it had power
+/// greater than ~'s power" (Drizzt Do'Urden's dies trigger). The subject "it" is
+/// the object referenced by the trigger event (the creature that died); "had"
+/// is past tense because CR 603.10a's look-back reads the dying creature's
+/// last-known power from the graveyard at resolution. "~'s power" is the ability
+/// source's current power.
+///
+/// Distinct from [`parse_source_power_toughness_condition`] ("its power is N",
+/// which compares the *source's* stat against a fixed threshold): here BOTH
+/// operands are dynamic P/T refs on two *different* objects — `EventSource` (the
+/// dying creature, resolved via LKI) and `Source` (the ability's own permanent).
+/// Emits a `QuantityComparison` so `static_condition_to_trigger_condition`
+/// bridges it onto the trigger's `condition`, and so the trigger-level
+/// difference binding in `lower_trigger_ir` (oracle_trigger.rs) can read the two
+/// operands for a paired "put ... counters equal to the difference" count.
+fn parse_event_object_pt_vs_source_comparison(input: &str) -> OracleResult<'_, StaticCondition> {
+    // Subject: "it had " — the triggering-event object, past tense (LKI look-back).
+    let (rest, _) = tag("it had ").parse(input)?;
+    let (rest, lhs) = parse_pt_ref_scoped(rest, ObjectScope::EventSource)?;
+    // Comparator between the two stats. Longer phrases precede their prefixes so
+    // "greater than or equal to" wins over "greater than".
+    let (rest, comparator) = alt((
+        value(Comparator::GE, tag(" greater than or equal to ")),
+        value(Comparator::LE, tag(" less than or equal to ")),
+        value(Comparator::GT, tag(" greater than ")),
+        value(Comparator::LT, tag(" less than ")),
+    ))
+    .parse(rest)?;
+    // RHS: "~'s <stat>" — the ability source's stat.
+    let (rest, _) = tag("~'s ").parse(rest)?;
+    let (rest, rhs) = parse_pt_ref_scoped(rest, ObjectScope::Source)?;
+    Ok((
+        rest,
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref { qty: lhs },
+            comparator,
+            rhs: QuantityExpr::Ref { qty: rhs },
+        },
+    ))
+}
+
+/// CR 208.1: Parse the bare stat word "power"/"toughness" into a P/T
+/// `QuantityRef` under the given object scope.
+fn parse_pt_ref_scoped(input: &str, scope: ObjectScope) -> OracleResult<'_, QuantityRef> {
+    alt((
+        value(QuantityRef::Power { scope }, tag("power")),
+        value(QuantityRef::Toughness { scope }, tag("toughness")),
+    ))
+    .parse(input)
 }
 
 /// Possessive-subject form: `<possessive> <property> is `, leaving the threshold

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -17500,3 +17500,206 @@ fn banner_of_kinship_composes_choose_and_chosen_dependent_counters() {
         } if name == "fellowship"
     ));
 }
+
+/// CR 122.1 + CR 603.4 + CR 603.10a: Drizzt Do'Urden's dies trigger — "Whenever
+/// a creature dies, if it had power greater than Drizzt's power, put a number of
+/// +1/+1 counters on Drizzt equal to the difference." The bare anaphoric "the
+/// difference" has no operands in its own clause; they live on the
+/// intervening-if comparison. The trigger must (1) carry the comparison as its
+/// gate and (2) resolve the count to `QuantityExpr::Difference` of the two power
+/// operands — NOT leave the effect `Unimplemented`.
+#[test]
+fn drizzt_dies_trigger_puts_difference_counters_gated_by_power_comparison() {
+    use crate::types::ability::{
+        Comparator, ObjectScope, QuantityExpr, QuantityRef, TriggerCondition,
+    };
+    use crate::types::counter::CounterType;
+
+    let r = parse(
+        "Double strike\n\
+         When Drizzt enters, create Guenhwyvar, a legendary 4/1 green Cat creature token with trample.\n\
+         Whenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt equal to the difference.",
+        "Drizzt Do'Urden",
+        &[],
+        &["Creature"],
+        &["Elf", "Ranger"],
+    );
+
+    // Locate the dies trigger (the one whose body puts counters).
+    let dies = r
+        .triggers
+        .iter()
+        .find(|t| {
+            t.execute
+                .as_ref()
+                .is_some_and(|e| matches!(&*e.effect, Effect::PutCounter { .. }))
+        })
+        .unwrap_or_else(|| panic!("no dies PutCounter trigger parsed: {r:#?}"));
+
+    let execute = dies.execute.as_ref().expect("dies trigger has a body");
+    assert!(
+        !has_unimplemented(execute),
+        "dies trigger body must not be Unimplemented: {execute:#?}"
+    );
+
+    // (1) Effect: PutCounter of +1/+1 counters on ~ with a Difference count over
+    // the dying creature's (EventSource, LKI) power and the source's power.
+    match &*execute.effect {
+        Effect::PutCounter {
+            counter_type,
+            count: QuantityExpr::Difference { left, right },
+            target,
+        } => {
+            assert_eq!(*counter_type, CounterType::Plus1Plus1);
+            assert_eq!(*target, TargetFilter::SelfRef, "counters go on ~ (Drizzt)");
+            assert_eq!(
+                **left,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::EventSource,
+                    },
+                },
+                "left operand is the dying creature's (LKI) power"
+            );
+            assert_eq!(
+                **right,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Source,
+                    },
+                },
+                "right operand is the source's power"
+            );
+        }
+        other => panic!("expected PutCounter with Difference count, got {other:#?}"),
+    }
+
+    // (2) Intervening-if gate: the trigger only fires when the dying creature's
+    // power exceeded the source's power.
+    fn find_power_gt(cond: &TriggerCondition) -> Option<(&QuantityExpr, &QuantityExpr)> {
+        match cond {
+            TriggerCondition::QuantityComparison {
+                lhs,
+                comparator: Comparator::GT,
+                rhs,
+            } => Some((lhs, rhs)),
+            TriggerCondition::And { conditions } | TriggerCondition::Or { conditions } => {
+                conditions.iter().find_map(find_power_gt)
+            }
+            _ => None,
+        }
+    }
+    let condition = dies
+        .condition
+        .as_ref()
+        .unwrap_or_else(|| panic!("dies trigger must carry the power-comparison gate: {dies:#?}"));
+    let (lhs, rhs) = find_power_gt(condition)
+        .unwrap_or_else(|| panic!("gate must be a GT power comparison: {condition:#?}"));
+    assert_eq!(
+        *lhs,
+        QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::EventSource,
+            },
+        }
+    );
+    assert_eq!(
+        *rhs,
+        QuantityExpr::Ref {
+            qty: QuantityRef::Power {
+                scope: ObjectScope::Source,
+            },
+        }
+    );
+}
+
+/// CR 122.1 coverage-honesty: a "put ... counters equal to the difference" whose
+/// enclosing trigger has NO "if it had <stat> greater than ~'s <stat>"
+/// comparison has nothing to bind the anaphor to. It must surface as a loud
+/// `Unimplemented` residual (mirroring the draw/lose difference siblings), NOT a
+/// silently-zero `PutCounter` that would read as coverage-supported. Fails on
+/// revert of the unbound-placeholder guard in `lower_trigger_ir`.
+#[test]
+fn difference_counter_anaphor_without_comparison_stays_unimplemented() {
+    let r = parse(
+        "Whenever a creature dies, put a number of +1/+1 counters on ~ equal to the difference.",
+        "Test Card",
+        &[],
+        &["Creature"],
+        &[],
+    );
+    let dies = r
+        .triggers
+        .iter()
+        .find(|t| t.execute.is_some())
+        .unwrap_or_else(|| panic!("no dies trigger parsed: {r:#?}"));
+    let execute = dies.execute.as_ref().expect("dies trigger has a body");
+    assert!(
+        !matches!(&*execute.effect, Effect::PutCounter { .. }),
+        "an unbindable 'the difference' must not survive as a silently-zero PutCounter: {execute:#?}"
+    );
+    assert!(
+        has_unimplemented(execute),
+        "an unbindable difference anaphor must be a loud Unimplemented residual: {execute:#?}"
+    );
+}
+
+/// CR 122.1 + CR 603.4: Conformer Shuriken class — the "equal to the difference"
+/// put-counter sits under a CLAUSE-LEVEL conditional continuation (a
+/// `sub_ability`), not the trigger's hoisted intervening-if, so there is no
+/// `QuantityComparison` on `def.condition` to bind against. The deferred
+/// placeholder is nested one level below the top-level effect, where the
+/// top-level-only `count_expr_mut` guard cannot see it. The recursive resolver
+/// must still downgrade it to an honest Unimplemented so the card does NOT
+/// appear falsely supported (no surviving `PutCounter { Variable{"difference"} }`
+/// anywhere in the tree).
+#[test]
+fn nested_conditional_difference_anaphor_downgrades_to_unimplemented() {
+    use crate::types::ability::QuantityRef;
+
+    fn surviving_difference_placeholder(def: &crate::types::ability::AbilityDefinition) -> bool {
+        let here = matches!(
+            &*def.effect,
+            Effect::PutCounter {
+                count: QuantityExpr::Ref { qty: QuantityRef::Variable { name } },
+                ..
+            } | Effect::PutCounterAll {
+                count: QuantityExpr::Ref { qty: QuantityRef::Variable { name } },
+                ..
+            } if name == "difference"
+        );
+        here || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(surviving_difference_placeholder)
+            || def
+                .else_ability
+                .as_deref()
+                .is_some_and(surviving_difference_placeholder)
+    }
+
+    let r = parse(
+        "Whenever this creature attacks, tap target creature defending player controls. \
+         If that creature has power greater than this creature's power, put a number of \
+         +1/+1 counters on this creature equal to the difference.",
+        "Conformer Shuriken",
+        &[],
+        &["Artifact"],
+        &["Equipment"],
+    );
+    let trig = r
+        .triggers
+        .iter()
+        .find(|t| t.execute.is_some())
+        .unwrap_or_else(|| panic!("no attacks trigger parsed: {r:#?}"));
+    let execute = trig.execute.as_ref().expect("trigger has a body");
+
+    assert!(
+        !surviving_difference_placeholder(execute),
+        "nested unbindable 'the difference' must not survive as a PutCounter placeholder: {execute:#?}"
+    );
+    assert!(
+        has_unimplemented(execute),
+        "nested unbindable difference anaphor must become a loud Unimplemented residual: {execute:#?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -521,6 +521,77 @@ fn quantity_comparison_operands(cond: &TriggerCondition) -> Option<(&QuantityExp
     }
 }
 
+/// CR 122.1 + CR 603.4 + CR 603.10a: Resolve every deferred "the difference"
+/// counter-anaphor placeholder anywhere in an ability's effect tree.
+///
+/// The put-counter parser emits a `Variable { "difference" }` count placeholder
+/// for a bare "equal to the difference" because the two operands live on the
+/// trigger's hoisted intervening-if, not the effect clause. `Effect::count_expr_mut`
+/// only reaches the top-level effect, so a placeholder nested under a
+/// clause-level conditional `sub_ability` (Conformer Shuriken: "tap target
+/// creature …; if that creature has power greater than ~'s power, put a number
+/// of +1/+1 counters on ~ equal to the difference") would otherwise escape both
+/// the bind and the guard. This walks the full tree — `sub_ability`,
+/// `else_ability`, and single-`Box<Effect>` wrappers — so that:
+///   * with a hoisted `QuantityComparison` (`bound = Some`), each placeholder
+///     binds to that `Difference` (Drizzt Do'Urden), and
+///   * with none to bind (`bound = None`), the carrying counter effect is
+///     downgraded to an explicit `Effect::Unimplemented` — an honest coverage
+///     gap rather than a silently-zero `PutCounter` that reads as supported.
+fn resolve_difference_anaphor_in_ability(
+    def: &mut AbilityDefinition,
+    bound: Option<&QuantityExpr>,
+) {
+    resolve_difference_anaphor_in_effect(&mut def.effect, bound);
+    if let Some(sub) = def.sub_ability.as_deref_mut() {
+        resolve_difference_anaphor_in_ability(sub, bound);
+    }
+    if let Some(els) = def.else_ability.as_deref_mut() {
+        resolve_difference_anaphor_in_ability(els, bound);
+    }
+}
+
+fn resolve_difference_anaphor_in_effect(effect: &mut Effect, bound: Option<&QuantityExpr>) {
+    // Recurse into the single-`Box<Effect>` wrapper (the draw-replacement
+    // substitute) so a placeholder nested inside it is reached. This is the only
+    // `Effect` variant that wraps a heterogeneous sub-`Effect`; every other
+    // nesting is via `AbilityDefinition` (`sub_ability`/`else_ability`), walked
+    // by the caller.
+    if let Effect::CreateDrawReplacement {
+        replacement_effect: inner,
+    } = effect
+    {
+        resolve_difference_anaphor_in_effect(inner, bound);
+    }
+
+    // Only counter effects ever carry the deferred placeholder (it is emitted
+    // solely by the put-counter parser), so restrict both bind and downgrade to
+    // them — this keeps the downgrade's `Effect::Unimplemented` name/description
+    // honest without depending on `count_expr_mut` being counter-specific.
+    if !matches!(
+        effect,
+        Effect::PutCounter { .. } | Effect::PutCounterAll { .. }
+    ) {
+        return;
+    }
+    let is_placeholder = effect
+        .count_expr_mut()
+        .is_some_and(|slot| crate::parser::oracle_effect::is_difference_anaphor_placeholder(slot));
+    if !is_placeholder {
+        return;
+    }
+    match bound {
+        Some(count) => {
+            if let Some(slot) = effect.count_expr_mut() {
+                *slot = count.clone();
+            }
+        }
+        None => {
+            *effect = Effect::unimplemented("put", "counters equal to the difference");
+        }
+    }
+}
+
 pub(crate) fn parse_trigger_lines_at_index(
     text: &str,
     card_name: &str,
@@ -1281,7 +1352,7 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             left: Box::new(lhs.clone()),
             right: Box::new(rhs.clone()),
         });
-    if let Some(count) = difference_count {
+    if let Some(count) = difference_count.as_ref() {
         if let Some(execute) = def.execute.as_deref_mut() {
             let is_difference_draw = matches!(
                 execute.effect.as_ref(),
@@ -1312,11 +1383,24 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             );
             if is_difference_lose {
                 *execute.effect = Effect::LoseLife {
-                    amount: count,
+                    amount: count.clone(),
                     target: Some(TargetFilter::ParentTarget),
                 };
             }
         }
+    }
+
+    // CR 122.1 + CR 603.4 + CR 603.10a coverage-honesty: bind — or, when there is
+    // no hoisted comparison to bind, downgrade to an honest `Unimplemented` —
+    // every deferred "the difference" counter anaphor placeholder in the FULL
+    // effect tree. Recursing (not the top-level-only `count_expr_mut`) catches a
+    // placeholder nested under a clause-level conditional `sub_ability`: Drizzt
+    // Do'Urden's binds at the top level, while Conformer Shuriken's put-counter
+    // sits under the tap's conditional continuation with no hoisted comparison,
+    // so it must become an explicit unsupported residual rather than survive as a
+    // silently-zero, false-green `PutCounter`.
+    if let Some(execute) = def.execute.as_deref_mut() {
+        resolve_difference_anaphor_in_ability(execute, difference_count.as_ref());
     }
 
     // CR 603.4: Intervening-if life-gain triggers check the gained-life


### PR DESCRIPTION
## Problem

Drizzt Do'Urden's dies trigger — "Whenever a creature dies, if it had power greater than Drizzt's power, put a number of +1/+1 counters on Drizzt **equal to the difference**" — was a no-op: the intervening-if parsed to nothing and the bare anaphoric "the difference" count fell to `Effect::Unimplemented`. This was a **deliberately-documented gap** (`oracle_effect/counter.rs` returns `None` for the bare "the difference" rather than emit a wrong 0-count placeholder that would swallow the trailing clause).

## Fix (parser-only)

- **`parse_event_object_pt_vs_source_comparison`** (`oracle_nom/condition.rs`): a nom combinator parsing "it had `<stat>` {greater/less than\[ or equal to\]} ~'s `<stat>`" — the *triggering* object's last-known stat (`ObjectScope::EventSource`, CR 603.10a graveyard look-back) vs the ability source's stat — into a `StaticCondition::QuantityComparison`, bridged onto the trigger's `condition` by the existing `static_condition_to_trigger_condition`.
- **`parse_counter_equal_to`** (`counter.rs`): recognizes the bare "the difference" (via `all_consuming(tag("the difference"))`) and emits a deferred count placeholder, so the effect parses to a well-formed `PutCounter` (counter type + placement target intact) instead of `Unimplemented`.
- **`lower_trigger_ir`** (`oracle_trigger.rs`): binds that placeholder to `QuantityExpr::Difference{ comparison.lhs, comparison.rhs }` through the **existing draw/lose difference-binding block** (`Effect::count_expr_mut`, effect-agnostic). A placeholder that no comparison could bind is downgraded to an explicit `Unimplemented` residual — **coverage-honesty parity with the draw/lose siblings**, never a silently-zero `PutCounter` that would read as supported.

No runtime changes — the runtime already resolves `Difference{Power{EventSource}, Power{Source}}` from the dying creature's last-known power (`quantity.rs` LKI; LKI is snapshotted on the battlefield→graveyard zone change). Built for the **class** "if it had `<stat>` greater than ~'s `<stat>` … equal to the difference" — no name special-case, no new enum variants.

## Anchored on
- `crates/engine/src/parser/oracle_trigger.rs:1276` — the existing `difference_count` / `is_difference_draw` / `is_difference_lose` block that binds "equal to the difference" for the Draw and LoseLife classes (Kozilek, Damia, …). This fix extends that same block, effect-agnostically via `Effect::count_expr_mut()`, to the PutCounter class, and gives the counter path the same unbound→`Unimplemented` loud-gap behavior.
- `crates/engine/src/parser/oracle_nom/condition.rs:1785` — `parse_source_power_toughness_condition` (source stat vs a fixed threshold): the new `parse_event_object_pt_vs_source_comparison` (`:1830`) is its two-object sibling (EventSource stat vs Source stat), placed ahead of the source-state group so "it had `<stat>`" isn't mistaken for the source-subject form.

## Gate A
```
$ ./scripts/check-parser-combinators.sh   (verified via git diff vs origin/main)
CLEAN — no forbidden string-method dispatch in the added parser lines
```

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --tests -- -D warnings` — clean (exit 0). Full-workspace `clippy-strict` needs OpenSSL/`pkg-config` (unavailable in my sandbox); CI **Rust lint** is the green run.
- Combinator gate — verified by `git diff origin/main -- 'crates/engine/src/parser/**' | grep '^+' | grep -E '<forbidden methods>'` → no matches.
- `cargo test -p engine --lib -- parser:: game::triggers:: game::quantity:: game::effects::counters::` — **7746 passed / 0 failed**. Full sharded `cargo test -p engine` runs green in CI.
- wasm-dev check (`cargo check -p engine-wasm --target wasm32-unknown-unknown` with `-D warnings`) — clean.
- Card-data / coverage / semantic-audit run green in CI (**Card data** job); the local pipeline needs an MTGJSON download unavailable in my sandbox.

## Tests (drive the real pipeline; fail on revert)
- `drizzt_dies_trigger_puts_difference_counters_gated_by_power_comparison` (`parser/oracle_tests.rs`) — full `parse_oracle_text`: the dies trigger's effect is `PutCounter` with a `Difference{ Power{EventSource}, Power{Source} }` count (NOT `Unimplemented`), and the trigger carries the strict-GT power gate.
- `drizzt_difference_counters_from_dying_creature_lki_power` (`game/effects/counters.rs`) — **end-to-end runtime** off the real parsed trigger: a 5-power creature dies → Drizzt (power 2) gains 3 (=5−2) counters; equal (2) and smaller (1) → 0 (strict-GT gate).
- `difference_counter_anaphor_without_comparison_stays_unimplemented` — coverage-honesty: an unbindable "the difference" (no comparison) surfaces as a loud `Unimplemented`, not a silent-0 `PutCounter`.

## CR
CR 122.1 (counters) + CR 208.1 (P/T) + CR 603.4 (intervening-if) + CR 603.10a (last-known-information look-back for a creature that has left the battlefield). Verified against `docs/MagicCompRules.txt`.

Closes #4967

Tier: Frontier
Model: claude-opus-4-8
Thinking: high
