### PR TITLE
fix(engine): clamp negative mill and exile-top counts to zero (CR 107.1b)

### DIFF
--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -18,7 +18,11 @@ pub fn resolve(
         } => (
             // Use resolve_quantity_with_targets so that TargetZoneCardCount (and
             // DivideRounded wrapping it) can resolve against the targeted player.
-            resolve_quantity_with_targets(state, count, ability) as usize,
+            // CR 107.1b: clamp a negative result to zero before the `as usize`
+            // cast — a subtractive count would otherwise wrap huge, and the
+            // downstream library-size `min` would exile the entire library
+            // instead of nothing. Mirrors the guard in `draw.rs` / `discard.rs`.
+            resolve_quantity_with_targets(state, count, ability).max(0) as usize,
             player.clone(),
             *face_down,
         ),
@@ -764,6 +768,87 @@ mod tests {
         assert!(
             !obj.face_down,
             "face-up ExileTop must not flip the object's `face_down` flag",
+        );
+    }
+
+    /// CR 107.1b: an exile-top count that resolves negative must clamp to 0, not
+    /// wrap through the `as usize` cast and exile the whole library. Revert-probe:
+    /// without the `.max(0)` the downstream library-size `min` exiles the target's
+    /// entire library instead of nothing.
+    #[test]
+    fn exile_top_negative_count_clamps_to_zero() {
+        use crate::types::ability::PlayerScope;
+
+        let mut state = GameState::new_two_player(7);
+        // Controller (P0): 1 card in hand, 2 in library. Opponent (P1): 3 in hand.
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Hand".into(),
+            Zone::Hand,
+        );
+        create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "LibA".into(),
+            Zone::Library,
+        );
+        create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "LibB".into(),
+            Zone::Library,
+        );
+        for i in 0..3u64 {
+            create_object(
+                &mut state,
+                CardId(10 + i),
+                PlayerId(1),
+                "Theirs".into(),
+                Zone::Hand,
+            );
+        }
+
+        // count = HandSize{You} − HandSize{Opponent} = 1 − 3 = −2.
+        let count = QuantityExpr::Sum {
+            exprs: vec![
+                QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Opponent {
+                                aggregate: AggregateFunction::Sum,
+                            },
+                        },
+                    }),
+                },
+            ],
+        };
+        let ability = ResolvedAbility::new(
+            Effect::ExileTop {
+                player: TargetFilter::Controller,
+                count,
+                face_down: false,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.players[0].library.len(),
+            2,
+            "CR 107.1b: a negative exile-top count must exile 0, not the whole library"
         );
     }
 }

--- a/crates/engine/src/game/effects/mill.rs
+++ b/crates/engine/src/game/effects/mill.rs
@@ -22,8 +22,14 @@ pub fn resolve(
             target,
         } => (
             // CR 107.1b: Resolve with full ability context so `QuantityRef::Variable { "X" }`
-            // reads the caster-chosen X from the resolving ability.
-            resolve_quantity_with_targets(state, count, ability) as usize,
+            // reads the caster-chosen X from the resolving ability, and clamp a
+            // negative result to zero before the `as usize` cast. Mill shares the
+            // Draw/Mill/Discard dynamic-count parser, so a subtractive count
+            // ("mill cards equal to A minus B" with B > A) resolves negative;
+            // without the clamp `-1 as usize` wraps huge and the downstream
+            // library-size `min` mills the entire library instead of nothing.
+            // Mirrors the guard in `draw.rs` / `discard.rs`.
+            resolve_quantity_with_targets(state, count, ability).max(0) as usize,
             *destination,
             // CR 701.17a + CR 115.1: Mirror Draw/Scry/Surveil — context-ref
             // target filters (Controller, PostReplacementSourceController,
@@ -804,6 +810,93 @@ mod tests {
         assert_eq!(
             state.players[0].life, life_before,
             "life must be unchanged — no Angel was milled this way"
+        );
+    }
+
+    /// CR 107.1b: a mill count that resolves negative must clamp to 0, not wrap
+    /// through the `as usize` cast and mill the whole library. Mill shares the
+    /// Draw/Mill/Discard dynamic-count parser, so "mill cards equal to A minus B"
+    /// (with B > A) resolves negative. Revert-probe: without the `.max(0)` the
+    /// downstream library-size `min` mills the target's entire library instead of
+    /// nothing.
+    #[test]
+    fn mill_negative_count_clamps_to_zero() {
+        use crate::types::ability::{AggregateFunction, PlayerScope};
+
+        let mut state = GameState::new_two_player(7);
+        // Controller (P0): 1 card in hand, 2 in library. Opponent (P1): 3 in hand.
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Hand".into(),
+            Zone::Hand,
+        );
+        create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "LibA".into(),
+            Zone::Library,
+        );
+        create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "LibB".into(),
+            Zone::Library,
+        );
+        for i in 0..3u64 {
+            create_object(
+                &mut state,
+                CardId(10 + i),
+                PlayerId(1),
+                "Theirs".into(),
+                Zone::Hand,
+            );
+        }
+
+        // count = HandSize{You} − HandSize{Opponent} = 1 − 3 = −2.
+        let count = QuantityExpr::Sum {
+            exprs: vec![
+                QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                QuantityExpr::Multiply {
+                    factor: -1,
+                    inner: Box::new(QuantityExpr::Ref {
+                        qty: QuantityRef::HandSize {
+                            player: PlayerScope::Opponent {
+                                aggregate: AggregateFunction::Sum,
+                            },
+                        },
+                    }),
+                },
+            ],
+        };
+        let ability = ResolvedAbility::new(
+            Effect::Mill {
+                count,
+                target: TargetFilter::Controller,
+                destination: Zone::Graveyard,
+            },
+            vec![],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.players[0].library.len(),
+            2,
+            "CR 107.1b: a negative mill count must mill 0, not the whole library"
+        );
+        assert!(
+            state.players[0].graveyard.is_empty(),
+            "no card may be milled"
         );
     }
 }


### PR DESCRIPTION
## Summary

The **mill** (`mill.rs`) and **exile-top** (`exile_top.rs`) resolvers cast their resolved count `as usize` with no lower bound. Mill shares the Draw/Mill/Discard dynamic-count parser (`oracle_effect/imperative.rs`: *"cross-verb dynamic-count idioms shared by Draw/Mill/Discard"*), so a subtractive count — "mill cards equal to A minus B" when `B > A` — resolves negative. `-2 as usize` wraps to a huge value, and the downstream library-size `min` (CR 701.17b, "a player can't mill/exile more than their library") then mills / exiles the target's **entire library** instead of nothing.

Both get the same one-liner every sibling count-resolver already applies (`draw.rs`, `discard.rs`, `sacrifice.rs`):

```rust
resolve_quantity_with_targets(state, count, ability).max(0) as usize,
```

Mill and exile-top were the two remaining unclamped count-casts among the effect resolvers; the counter/life resolvers already clamp (`.max(0)`) or use negatives as intentional "remove all" sentinels, so they are untouched.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> Two one-line resolver fixes restoring an invariant every sibling resolver already holds (`.max(0)` before the `as usize` cast), each with a resolver-level regression test. No new pattern, variant, or AST. A `/review-impl` self-check was run.

## CR references

- `CR 107.1b` — "If a calculation that would determine the result of an effect yields a negative number, zero is used instead."
- `CR 701.17b` — a player can't mill/exile more cards than are in their library (the downstream `min` that turns the wrap into a whole-library drain).

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib effects::mill::tests` (12) and `effects::exile_top::tests` (12) — all pass.
- Added `mill_negative_count_clamps_to_zero` and `exile_top_negative_count_clamps_to_zero`. Each resolves the effect with `count = HandSize{You} − HandSize{Opponent}` (opponent holds more) and asserts the target's library is untouched (0 milled/exiled). **Revert-probe:** without the `.max(0)`, each test fails because the target's entire library is drained — proving the wrap is real, reachable, and the assertions are non-vacuous.