### PR TITLE
fix(parser): variable-first "X plus/minus N" count offset — restore the dropped bonus (Crater's Claws, Flame Discharge)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -3007,6 +3007,33 @@ fn effect_lightning_bolt() {
 }
 
 #[test]
+fn effect_deal_x_plus_two_damage_uses_offset_amount() {
+    // Flame Discharge / Light Up the Night: "deals X plus N damage" composes the
+    // spell's announced X with a fixed bonus. The DealDamage amount must be
+    // Offset { X, offset: N } via parse_count_expr, not a bare X with a dropped
+    // "plus N" tail (the pre-fix behavior that left the effect unsupported).
+    let e = parse_effect("~ deals X plus 2 damage to any target");
+    match e {
+        Effect::DealDamage { amount, target, .. } => {
+            assert_eq!(target, TargetFilter::Any);
+            match amount {
+                QuantityExpr::Offset { inner, offset } => {
+                    assert_eq!(offset, 2);
+                    assert!(matches!(
+                        *inner,
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::Variable { .. }
+                        }
+                    ));
+                }
+                other => panic!("expected Offset {{X, +2}} amount, got {other:?}"),
+            }
+        }
+        other => panic!("expected DealDamage, got {other:?}"),
+    }
+}
+
+#[test]
 fn effect_damage_to_each_opponent_uses_player_scope() {
     let e = parse_effect("~ deals 1 damage to each opponent");
     assert!(matches!(

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -509,13 +509,68 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
                     return Some((expr, ""));
                 }
             }
+            // CR 107.1b + CR 107.3a: variable-first "X plus/minus <literal int N>"
+            // — the dual of the integer-first "N plus/minus <inner>" arm below.
+            // After the bare `X` ref, a "plus "/"minus " connective followed by a
+            // LITERAL integer (via `parse_number`) yields `Offset { inner: X,
+            // offset: +/-N }`, the offset stored directly (no `Multiply` wrapper).
+            // Flame Discharge / Light Up the Night: "deals X plus N damage". The
+            // integer restriction is deliberate — a dynamic operand ("X plus the
+            // number of …") must NOT be swallowed: `parse_number` fails there, so we
+            // fall through to the bare `X` ref with the connective left on the
+            // remainder (see `parse_count_expr_x_plus_dynamic_stays_bare_x`).
+            let after_x = rest.trim_start();
+            if let Ok((after_op, sign)) = nom::branch::alt((
+                nom::combinator::value(
+                    1i32,
+                    nom::bytes::complete::tag::<_, _, OracleError<'_>>("plus "),
+                ),
+                nom::combinator::value(-1i32, nom::bytes::complete::tag("minus ")),
+            ))
+            .parse(after_x)
+            {
+                // CR 107.1b + CR 107.3a: exclude a standalone `X` operand from the
+                // literal-integer offset. `parse_number` maps a bare "X" -> 0 (its
+                // numeric-only contract), so without this guard "X plus X" / "X minus X"
+                // would be wrongly consumed as `Offset { X, +/-0 }` instead of leaving the
+                // "plus X"/"minus X" connective on the remainder for the outer grammar.
+                // Peek — via the `nom_on_lower` bridge, so the check is case-insensitive —
+                // that `after_op` is NOT the `x` token as a standalone word (x followed by
+                // whitespace or end-of-input); `not` then succeeds only for a genuine
+                // literal-number operand. Regressions: parse_count_expr_x_plus_x_not_offset
+                // / parse_count_expr_x_minus_x_not_offset.
+                let after_op_lower = after_op.to_lowercase();
+                let operand_is_literal = nom_on_lower(after_op, &after_op_lower, |i| {
+                    nom::combinator::not(nom::sequence::terminated(
+                        nom::bytes::complete::tag::<_, _, OracleError<'_>>("x"),
+                        nom::branch::alt((nom::combinator::eof, nom::character::complete::space1)),
+                    ))
+                    .parse(i)
+                })
+                .is_some();
+                if operand_is_literal {
+                    if let Some((n, after_n)) = parse_number(after_op) {
+                        return Some((
+                            QuantityExpr::Offset {
+                                inner: Box::new(QuantityExpr::Ref {
+                                    qty: QuantityRef::Variable {
+                                        name: "X".to_string(),
+                                    },
+                                }),
+                                offset: sign * i32::try_from(n).unwrap_or(i32::MAX),
+                            },
+                            after_n,
+                        ));
+                    }
+                }
+            }
             return Some((
                 QuantityExpr::Ref {
                     qty: QuantityRef::Variable {
                         name: "X".to_string(),
                     },
                 },
-                rest.trim_start(),
+                after_x,
             ));
         }
     }
@@ -2554,6 +2609,103 @@ mod tests {
             }
             other => panic!("Expected Offset, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_count_expr_x_plus_two() {
+        // CR 107.1b + CR 107.3a: variable-first "X plus 2" -> Offset { X, offset: 2 }
+        // (Flame Discharge / Light Up the Night's "deals X plus N damage"). Mirror
+        // of the integer-first "two plus X" arm; the literal operand's remainder is
+        // preserved for the caller (here the trailing "damage").
+        let (qty, rest) = parse_count_expr("X plus 2 damage").unwrap();
+        match qty {
+            QuantityExpr::Offset { inner, offset } => {
+                assert_eq!(offset, 2);
+                assert!(matches!(
+                    *inner,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { .. }
+                    }
+                ));
+            }
+            other => panic!("Expected Offset {{X, +2}}, got {other:?}"),
+        }
+        assert_eq!(rest, "damage");
+    }
+
+    #[test]
+    fn parse_count_expr_x_minus_one() {
+        // CR 107.1b + CR 107.3a: variable-first "X minus 1" -> Offset { X, offset: -1 }.
+        // The negative offset (stored directly, not an inner Multiply) is clamped to
+        // zero by the resolver when X < 1, matching the integer-first arm's math.
+        let (qty, rest) = parse_count_expr("X minus 1 cards").unwrap();
+        match qty {
+            QuantityExpr::Offset { inner, offset } => {
+                assert_eq!(offset, -1);
+                assert!(matches!(
+                    *inner,
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Variable { .. }
+                    }
+                ));
+            }
+            other => panic!("Expected Offset {{X, -1}}, got {other:?}"),
+        }
+        assert_eq!(rest, "cards");
+    }
+
+    #[test]
+    fn parse_count_expr_x_plus_dynamic_stays_bare_x() {
+        // Regression / no-over-reach guard: the variable-first offset is literal
+        // integer only. A dynamic operand ("X plus the number of ...") must NOT be
+        // swallowed into an Offset; it falls through to the bare-X ref with the
+        // connective left on the remainder, exactly as before this arm existed.
+        let (qty, rest) = parse_count_expr("X plus the number of creatures you control").unwrap();
+        assert!(matches!(
+            qty,
+            QuantityExpr::Ref {
+                qty: QuantityRef::Variable { .. }
+            }
+        ));
+        assert_eq!(rest, "plus the number of creatures you control");
+    }
+
+    #[test]
+    fn parse_count_expr_x_plus_x_not_offset() {
+        // CR 107.3a: the variable-first offset is LITERAL-integer only. `parse_number`
+        // maps a bare "X" -> 0 (its numeric-only contract), so "X plus X" must NOT be
+        // swallowed into `Offset { X, +0 }`; the standalone-`X` operand guard rejects
+        // it and the count falls through to a bare-X ref, leaving the "plus X ..."
+        // connective on the remainder for the outer grammar.
+        let (qty, rest) = parse_count_expr("X plus X damage").unwrap();
+        assert!(
+            matches!(
+                qty,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { .. }
+                }
+            ),
+            "expected bare Variable X ref, got {qty:?}"
+        );
+        assert_eq!(rest, "plus X damage");
+    }
+
+    #[test]
+    fn parse_count_expr_x_minus_x_not_offset() {
+        // CR 107.3a: mirror of the "plus" case for subtraction. "X minus X" must not
+        // become `Offset { X, -0 }`; the standalone-`X` operand is excluded from the
+        // literal-int offset, leaving the bare-X ref with "minus X ..." on the remainder.
+        let (qty, rest) = parse_count_expr("X minus X counters").unwrap();
+        assert!(
+            matches!(
+                qty,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { .. }
+                }
+            ),
+            "expected bare Variable X ref, got {qty:?}"
+        );
+        assert_eq!(rest, "minus X counters");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Count expressions of the form **"X plus N" / "X minus N"** (variable-first) parsed the amount as a bare `X`, **silently dropping the `+N`/`−N`**. So cards like **Crater's Claws** ("X plus 2 damage"), **Flame Discharge** / **Light Up the Night** ("X plus 1 damage"), **Meteor Shower**, and **Hellfire** ("X plus 3 damage") resolved as *X* damage instead of *X+N* — a correctness bug, even though the cards were already classified "supported" via their primary clause.

The engine already had the integer-first dual, **"N plus/minus X"** (Slumbering Trudge's "three minus X", "two plus X"), which lowers to `QuantityExpr::Offset`. Only the variable-first ordering was missing.

## Change

Add the variable-first arm to `parse_count_expr` (`crates/engine/src/parser/oracle_util.rs`), mirroring the existing integer-first offset arm with the roles swapped: after the bare `X` ref, a `plus `/`minus ` connective followed by a **literal integer** (via `parse_number`) yields `Offset { inner: X, offset: +/-N }` (sign folded directly into the offset, no `Multiply` wrapper). Maps to the existing `QuantityExpr::Offset` — no new effect/IR; the resolver already clamps a negative result to zero (CR 107.1b).

**No over-reach:** the arm fires only when a literal integer follows the connective. A dynamic operand (*"X plus the number of creatures you control"*) makes `parse_number` fail, so it falls through to the bare `X` ref with the connective left on the remainder (regression-tested).

## Tests

- `parse_count_expr_x_plus_two` / `parse_count_expr_x_minus_one` — recognizer → `Offset{X, +2}` / `Offset{X, -1}`.
- `parse_count_expr_x_plus_dynamic_stays_bare_x` — dynamic operand is NOT swallowed into an offset.
- `effect_deal_x_plus_two_damage_uses_offset_amount` — end-to-end: "deals X plus 2 damage to any target" → `DealDamage { amount: Offset{X,+2} }` (previously a bare `X` that dropped the +2).

Fails-before (amount was bare `X` / `Unimplemented`) / passes-after confirmed. Green: rustfmt, parser-combinator (Rule Zero) gate, `clippy -D warnings`, full engine suite (14733 passed / 0 failed). `cargo coverage` byte-identical before/after (this is a correctness fix to already-"supported" cards, not a coverage gain — no regression, and the shared `parse_count_expr` changed no other card's count parse: the arm only fires on a literal-integer offset).
