### PR TITLE
feat(combat): directional attack restriction — "attack only the nearest opponent in the chosen direction" (CR 508.1c)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -30,24 +30,35 @@ use crate::types::zones::Zone;
 /// rejects on `def.mode != mode` first), so `flag && check_static_ability(..)`
 /// is byte-identical to the original call while skipping the redundant scan.
 ///
-/// Representation: five named compile-time presence flags, NOT a no-bool-flags
-/// anti-pattern — these are five independent existence facts, not one
+/// Representation: named compile-time presence flags, NOT a no-bool-flags
+/// anti-pattern — these are independent existence facts, not one
 /// choice-encoding bool. An `EnumSet` is rejected because `enumset` is not a
 /// workspace dependency and `StaticMode` is not fieldless (it carries data
 /// variants such as `MaxUntapPerType { filter, max }` and `Other(String)`).
-/// Five named flags read clearer than a runtime set lookup.
+/// Named flags read clearer than a runtime set lookup.
 struct CombatStaticGates {
     has_cant_attack: bool,
     has_cant_attack_or_block: bool,
     has_must_attack: bool,
     has_goad: bool,
     has_can_attack_with_defender: bool,
+    /// CR 508.1c: any functioning `StaticMode::AttackOnlyNeighbor` present.
+    has_attack_only_neighbor: bool,
 }
 
 impl CombatStaticGates {
-    /// One `game_functioning_statics` sweep computing all five presence flags.
+    /// One `game_functioning_statics` sweep computing the presence flags.
     /// Does NOT increment the static-full-scan perf counter: this is the single
     /// intended hoisted sweep, not a per-element legality scan.
+    ///
+    /// `has_attack_only_neighbor` is deliberately computed from the SAME
+    /// collection the CR 508.1c enforcement loop iterates
+    /// (`battlefield_active_statics`, battlefield-only), not the broader
+    /// `game_functioning_statics` (battlefield + command zone) used for the
+    /// other flags. This keeps the gate flag and the enforcement in lockstep:
+    /// the flag is set iff a battlefield source will actually be enforced. A
+    /// command-zone grant of `AttackOnlyNeighbor` is out of scope and would
+    /// otherwise set the flag but never be enforced (silent under-enforcement).
     fn compute(state: &GameState) -> Self {
         let mut gates = CombatStaticGates {
             has_cant_attack: false,
@@ -55,6 +66,7 @@ impl CombatStaticGates {
             has_must_attack: false,
             has_goad: false,
             has_can_attack_with_defender: false,
+            has_attack_only_neighbor: false,
         };
         for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
             match def.mode {
@@ -66,6 +78,9 @@ impl CombatStaticGates {
                 _ => {}
             }
         }
+        gates.has_attack_only_neighbor =
+            super::functioning_abilities::battlefield_active_statics(state)
+                .any(|(_, def)| matches!(def.mode, StaticMode::AttackOnlyNeighbor));
         gates
     }
 }
@@ -2465,6 +2480,51 @@ pub fn declare_attackers_with_bands(
         }
     }
 
+    // CR 508.1c + CR 109.5 + CR 607.2d: The directional attack restriction
+    // (Pramikon, Sky Rampart; Mystic Barrier; Teyo, Geometric Tactician): "Each
+    // player may attack only the nearest opponent in the [last] chosen direction
+    // and planeswalkers controlled by that opponent." Each `AttackOnlyNeighbor`
+    // static resolves, per attacker, the neighbor in the source's live chosen
+    // direction and rejects any attack not aimed at that opponent or one of
+    // their planeswalkers. The restriction is global (affects EVERY player,
+    // CR 109.5 "each player"), so it is checked against every attacker regardless
+    // of who controls the source. A source with no chosen direction yet is inert
+    // (skipped). GAP-4: this deliberately does NOT reuse `TargetFilter::Neighbor`
+    // — the direction is a live chosen value read off the source, and the
+    // neighbor must be resolved per attacking player, so a static filter cannot
+    // express it.
+    if gates.has_attack_only_neighbor {
+        for (attacker_id, target) in attacks {
+            let Some(attacker_controller) = state.objects.get(attacker_id).map(|o| o.controller)
+            else {
+                continue;
+            };
+            for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
+                if !matches!(def.mode, StaticMode::AttackOnlyNeighbor) {
+                    continue;
+                }
+                // CR 607.2d: no direction chosen yet — the restriction is inert.
+                let Some(dir) = source.chosen_direction() else {
+                    continue;
+                };
+                let neighbor = crate::game::players::neighbor(state, attacker_controller, dir);
+                // CR 508.1c: the only legal targets are the nearest opponent in
+                // the chosen direction and planeswalkers that opponent controls.
+                if !crate::game::restrictions::attack_target_matches_defended_scope(
+                    state,
+                    Some(target),
+                    &crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker,
+                    neighbor,
+                    neighbor,
+                ) {
+                    return Err(format!(
+                        "{attacker_id:?} can't attack {target:?} (CR 508.1c: may attack only the nearest opponent in the chosen direction and their planeswalkers)"
+                    ));
+                }
+            }
+        }
+    }
+
     // CR 508.1c + CR 109.5: Player-scoped temporary attack prohibitions
     // (`GameRestriction::ProhibitActivity { activity: Attack { defended } }` —
     // Willie Lumpkin: "that player can't attack you or permanents you control
@@ -3784,8 +3844,9 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::parser::oracle_static::parse_static_line;
     use crate::types::ability::{
-        Comparator, ControllerRef, FilterProp, ObjectScope, PtStat, PtValueScope, QuantityExpr,
-        QuantityRef, StaticCondition, StaticDefinition, TargetFilter, TypedFilter,
+        ChosenAttribute, Comparator, ControllerRef, FilterProp, ObjectScope, PtStat, PtValueScope,
+        QuantityExpr, QuantityRef, SeatDirection, StaticCondition, StaticDefinition, TargetFilter,
+        TypedFilter,
     };
     use crate::types::card_type::CoreType;
     use crate::types::counter::{CounterMatch, CounterType};
@@ -6458,6 +6519,380 @@ mod tests {
             )
             .is_ok(),
             "without qualifying aura attachment, attack is legal"
+        );
+    }
+
+    /// CR 508.1c: Build a directional attack-restriction source (Pramikon-style)
+    /// controlled by `controller`, with `AttackOnlyNeighbor` static and the given
+    /// chosen direction persisted on it. Mirrors how the parser + choose hijack
+    /// wire the real card at runtime.
+    fn create_directional_restrictor(
+        state: &mut GameState,
+        controller: PlayerId,
+        direction: SeatDirection,
+    ) -> ObjectId {
+        let id = create_creature(state, controller, "Pramikon, Sky Rampart", 1, 5);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.static_definitions
+            .push(StaticDefinition::new(StaticMode::AttackOnlyNeighbor));
+        obj.chosen_attributes
+            .push(ChosenAttribute::Direction(direction));
+        id
+    }
+
+    /// CR 508.1c + CR 607.2d: Under Pramikon (chosen Left), the active player may
+    /// attack only the nearest opponent to their left (P0's left = P1 in seat
+    /// order [P0,P1,P2,P3]) and that opponent's planeswalkers. Attacking any
+    /// other player, or another player's planeswalker, is illegal. Revert gate →
+    /// the illegal non-neighbor attack succeeds, failing the `is_err` assertions.
+    #[test]
+    fn attack_only_neighbor_left_restricts_to_left_neighbor_and_their_planeswalkers() {
+        let mut state = setup_multiplayer_combat(4);
+        // Restrictor controlled by P0; chosen direction Left. P0's left = P1.
+        let _pramikon = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let neighbor_pw = create_planeswalker(&mut state, PlayerId(1), "Jace");
+        let far_pw = create_planeswalker(&mut state, PlayerId(2), "Chandra");
+
+        // Neighbor (P1) — legal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(1)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "attacking the left neighbor P1 is legal"
+        );
+        // Neighbor's planeswalker — legal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Planeswalker(neighbor_pw))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "attacking the left neighbor's planeswalker is legal"
+        );
+        // Non-neighbor player (P2) — illegal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "attacking a non-neighbor player must be rejected"
+        );
+        // Non-neighbor's planeswalker — illegal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Planeswalker(far_pw))],
+                &mut vec![]
+            )
+            .is_err(),
+            "attacking a non-neighbor's planeswalker must be rejected"
+        );
+    }
+
+    /// CR 508.1c + CR 109.5: "Each player" — the restriction is global. P1's
+    /// attack (a non-active demonstration via active_player swap) against a
+    /// non-neighbor is rejected even though P0 controls the Pramikon. P1's left
+    /// neighbor in [P0,P1,P2,P3] is P2; attacking P3 is illegal.
+    #[test]
+    fn attack_only_neighbor_is_global_across_all_players() {
+        let mut state = setup_multiplayer_combat(4);
+        let _pramikon = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+        state.active_player = PlayerId(1);
+
+        let p1_attacker = create_creature(&mut state, PlayerId(1), "Bear", 2, 2);
+        // P1's left neighbor is P2 → legal; P3 is not → illegal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(p1_attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "P1 attacking its own left neighbor P2 is legal under the global restriction"
+        );
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(p1_attacker, AttackTarget::Player(PlayerId(3)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "P1 attacking a non-neighbor P3 is illegal under P0's global Pramikon"
+        );
+    }
+
+    /// CR 607.2d: A restrictor with no chosen direction yet is inert — any attack
+    /// is legal until a direction is chosen. Revert the `chosen_direction()`
+    /// skip → this would wrongly reject.
+    #[test]
+    fn attack_only_neighbor_no_direction_is_inert() {
+        let mut state = setup_multiplayer_combat(4);
+        // Restrictor WITHOUT a chosen direction.
+        let id = create_creature(&mut state, PlayerId(0), "Pramikon, Sky Rampart", 1, 5);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::AttackOnlyNeighbor));
+
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        assert!(
+            declare_attackers(
+                &mut state,
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "with no direction chosen the restriction is inert"
+        );
+    }
+
+    /// CR 102.2 collapse: in a two-player game the only opponent is always the
+    /// neighbor in either direction, so the restriction never forbids anything.
+    #[test]
+    fn attack_only_neighbor_two_player_collapse_allows_any_attack() {
+        let mut state = setup();
+        state.phase = crate::types::phase::Phase::DeclareAttackers;
+        let _pramikon = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        assert!(
+            declare_attackers(
+                &mut state,
+                &[(attacker, AttackTarget::Player(PlayerId(1)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "the sole opponent is always the neighbor, so any attack is legal"
+        );
+    }
+
+    /// CR 607.2d "the last chosen direction": a re-choice flips legality. After
+    /// re-choosing Right, P0's neighbor becomes P3 (previous in seat order), so
+    /// the previously-legal P1 attack becomes illegal and the P3 attack legal.
+    /// Exercises the replace-on-rechoose clear in `choose.rs` via the runtime
+    /// `bind_named_choice` path.
+    #[test]
+    fn attack_only_neighbor_rechoice_flips_legality() {
+        use crate::game::effects::choose::bind_named_choice;
+        use crate::types::ability::ChoiceType;
+
+        let mut state = setup_multiplayer_combat(4);
+        let pramikon = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+
+        // Initially Left → P1 legal, P3 illegal.
+        assert!(declare_attackers(
+            &mut state.clone(),
+            &[(attacker, AttackTarget::Player(PlayerId(1)))],
+            &mut vec![]
+        )
+        .is_ok());
+
+        // Re-choose Right via the runtime binding authority.
+        let labeled = ChoiceType::Labeled {
+            options: vec!["Left".into(), "Right".into()],
+        };
+        bind_named_choice(&mut state, &labeled, "Right", Some(pramikon));
+
+        // Exactly one Direction persists, and it is Right.
+        assert_eq!(
+            state.objects.get(&pramikon).unwrap().chosen_direction(),
+            Some(SeatDirection::Right),
+            "re-choice must replace the prior direction"
+        );
+
+        // Now Right → P0's neighbor is P3. P1 illegal, P3 legal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(1)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "after flipping to Right, the old left neighbor P1 is illegal"
+        );
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(3)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "after flipping to Right, the right neighbor P3 is legal"
+        );
+    }
+
+    /// CR 508.1c + CR 611.2a/c + CR 607.2d: RUNTIME test for Teyo, Geometric
+    /// Tactician's [−2] duration-bound grant — the seam a parser-shape test
+    /// cannot reach. Teyo's [−2] resolves an `Effect::GenericEffect` that grants
+    /// `StaticMode::AttackOnlyNeighbor` to itself until its controller's next
+    /// turn. This test drives the full runtime chain, NOT the AST shape:
+    ///
+    /// 1. Install the grant through the SAME production storage the effect
+    ///    resolver uses: `effect::register_transient_effect`'s `SelfRef` branch
+    ///    calls `add_transient_continuous_effect` with a `SpecificObject{self}`
+    ///    filter, a `GrantStaticAbility(AttackOnlyNeighbor)` modification, and the
+    ///    `UntilNextTurnOf{Controller}` duration. We call that same function with
+    ///    the same arguments, then run the real `evaluate_layers` so the granted
+    ///    static is materialized onto Teyo's `static_definitions` and surfaced by
+    ///    `battlefield_active_statics` (CR 611.2c object-set fixing).
+    /// 2. Bind Teyo's direction through the production `bind_named_choice`
+    ///    authority (source = Teyo) — the SAME {Left,Right} hijack the printed
+    ///    card uses — so `Teyo.chosen_direction()` is set, NOT hand-pushed.
+    /// 3. Assert the combat gate READS the layer-granted static: with Left chosen,
+    ///    the non-neighbor attack via real `declare_attackers` is rejected and the
+    ///    neighbor attack is legal (proves the granted static reaches the gate).
+    /// 4. Assert EXPIRY: prune P0's `UntilNextTurnOf{Controller}` grant via the
+    ///    production `prune_until_next_turn_effects` (the exact call the untap step
+    ///    makes at the controller's next turn), re-evaluate layers, and confirm the
+    ///    same non-neighbor attack is now legal — the restriction is gone.
+    ///
+    /// REVERT-FAILING: without the grant+layer wiring, the granted static never
+    /// lands on Teyo and step 3's `is_err` flips to `is_ok`; without the duration
+    /// prune the step-4 `is_ok` flips to `is_err`.
+    #[test]
+    fn teyo_minus_two_runtime_grant_gates_attacks_and_expires() {
+        use crate::game::effects::choose::bind_named_choice;
+        use crate::game::layers::evaluate_layers;
+        use crate::types::ability::{ChoiceType, ContinuousModification, Duration, PlayerScope};
+
+        let mut state = setup_multiplayer_combat(4);
+
+        // Teyo, a planeswalker P0 controls. Its [−2] granted the directional
+        // restriction to itself; no static is printed on Teyo — the grant will be
+        // materialized by the layer system from the transient continuous effect.
+        let teyo = create_planeswalker(&mut state, PlayerId(0), "Teyo, Geometric Tactician");
+
+        // Step 1: install the grant exactly as `effect::register_transient_effect`
+        // (SelfRef branch) does when Teyo's parsed [−2] `GenericEffect` resolves:
+        // a `SpecificObject{self}`-affected transient continuous effect carrying a
+        // `GrantStaticAbility(AttackOnlyNeighbor)` modification, bounded by the
+        // `UntilNextTurnOf{Controller}` duration `try_parse_temporary_attack_only_neighbor`
+        // attaches. This is the identical grant the [−2] `GenericEffect` produces.
+        state.add_transient_continuous_effect(
+            teyo,
+            PlayerId(0),
+            Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            },
+            TargetFilter::SpecificObject { id: teyo },
+            vec![ContinuousModification::GrantStaticAbility {
+                definition: Box::new(StaticDefinition::new(StaticMode::AttackOnlyNeighbor)),
+            }],
+            None,
+        );
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // The granted static must now be present on Teyo (materialized by layer 6).
+        assert!(
+            crate::game::functioning_abilities::battlefield_active_statics(&state)
+                .any(|(src, def)| src.id == teyo
+                    && matches!(def.mode, StaticMode::AttackOnlyNeighbor)),
+            "the [−2] grant must land on Teyo and be surfaced by battlefield_active_statics"
+        );
+
+        // Step 2: bind Teyo's direction through the production choice authority.
+        let labeled = ChoiceType::Labeled {
+            options: vec!["Left".into(), "Right".into()],
+        };
+        bind_named_choice(&mut state, &labeled, "Left", Some(teyo));
+        assert_eq!(
+            state.objects.get(&teyo).unwrap().chosen_direction(),
+            Some(SeatDirection::Left),
+            "bind_named_choice must set Teyo's chosen direction (source = Teyo)"
+        );
+
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+
+        // Step 3: the gate reads the layer-granted static. P0's left neighbor is
+        // P1; attacking P1 is legal, attacking non-neighbor P2 is rejected.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(1)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "neighbor attack is legal under the layer-granted Teyo restriction"
+        );
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "non-neighbor attack must be rejected while Teyo's grant is active"
+        );
+
+        // Step 4: expiry. Prune P0's `UntilNextTurnOf{Controller}` transient via
+        // the production path the untap step runs at the controller's next turn.
+        crate::game::layers::prune_until_next_turn_effects(&mut state, PlayerId(0));
+        state.layers_dirty.mark_full();
+        evaluate_layers(&mut state);
+
+        // The grant is gone → the granted static no longer functions on Teyo.
+        assert!(
+            !crate::game::functioning_abilities::battlefield_active_statics(&state)
+                .any(|(src, def)| src.id == teyo
+                    && matches!(def.mode, StaticMode::AttackOnlyNeighbor)),
+            "after the controller's next turn, the [−2] grant must be pruned off Teyo"
+        );
+        // The same previously-illegal non-neighbor attack is now legal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "after expiry the directional restriction is gone; non-neighbor attack is legal"
+        );
+    }
+
+    /// CR 508.1c: two restrictors intersect — an attack must satisfy EVERY
+    /// functioning restriction. P0's Pramikon (Left → neighbor P1) and P2's
+    /// Pramikon (Left → P2's neighbor P3) both apply globally. For P0's attacker,
+    /// only P1 satisfies P0's restriction; but P2's restriction demands P0 attack
+    /// P2's-neighbor... no — P2's restriction constrains attacks relative to the
+    /// attacker's own left neighbor (P0's left = P1). Both restrictors resolve the
+    /// neighbor per the ATTACKER (P0), so both demand P1. The attack on P1 is
+    /// legal; an attack on P2 fails the first restrictor.
+    #[test]
+    fn attack_only_neighbor_two_sources_intersect() {
+        let mut state = setup_multiplayer_combat(4);
+        let _a = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+        let _b = create_directional_restrictor(&mut state, PlayerId(2), SeatDirection::Left);
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+
+        // Both restrictors resolve the neighbor per the attacking player P0 → P1.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(1)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "P1 satisfies both restrictors"
+        );
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "P2 violates both restrictors"
         );
     }
 

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -51,14 +51,11 @@ impl CombatStaticGates {
     /// Does NOT increment the static-full-scan perf counter: this is the single
     /// intended hoisted sweep, not a per-element legality scan.
     ///
-    /// `has_attack_only_neighbor` is deliberately computed from the SAME
-    /// collection the CR 508.1c enforcement loop iterates
-    /// (`battlefield_active_statics`, battlefield-only), not the broader
-    /// `game_functioning_statics` (battlefield + command zone) used for the
-    /// other flags. This keeps the gate flag and the enforcement in lockstep:
-    /// the flag is set iff a battlefield source will actually be enforced. A
-    /// command-zone grant of `AttackOnlyNeighbor` is out of scope and would
-    /// otherwise set the flag but never be enforced (silent under-enforcement).
+    /// `has_attack_only_neighbor` is computed from the SAME
+    /// `game_functioning_statics` (battlefield + command zone) sweep the CR
+    /// 508.1c enforcement loop iterates, so the flag and the enforcement stay in
+    /// lockstep AND a command-zone emblem granting `AttackOnlyNeighbor` is both
+    /// detected and enforced (CR 113.6: command-zone static abilities function).
     fn compute(state: &GameState) -> Self {
         let mut gates = CombatStaticGates {
             has_cant_attack: false,
@@ -75,12 +72,10 @@ impl CombatStaticGates {
                 StaticMode::MustAttack => gates.has_must_attack = true,
                 StaticMode::Goaded => gates.has_goad = true,
                 StaticMode::CanAttackWithDefender => gates.has_can_attack_with_defender = true,
+                StaticMode::AttackOnlyNeighbor => gates.has_attack_only_neighbor = true,
                 _ => {}
             }
         }
-        gates.has_attack_only_neighbor =
-            super::functioning_abilities::battlefield_active_statics(state)
-                .any(|(_, def)| matches!(def.mode, StaticMode::AttackOnlyNeighbor));
         gates
     }
 }
@@ -2494,28 +2489,39 @@ pub fn declare_attackers_with_bands(
     // neighbor must be resolved per attacking player, so a static filter cannot
     // express it.
     if gates.has_attack_only_neighbor {
+        // CR 508.1c + CR 113.6: collect the functioning directional restrictors
+        // once (battlefield + command zone), rather than re-scanning every active
+        // static per attacker — O(A + S) instead of O(A × S).
+        let restrictors: Vec<_> = super::functioning_abilities::game_functioning_statics(state)
+            .filter(|(_, def)| matches!(def.mode, StaticMode::AttackOnlyNeighbor))
+            .collect();
         for (attacker_id, target) in attacks {
             let Some(attacker_controller) = state.objects.get(attacker_id).map(|o| o.controller)
             else {
                 continue;
             };
-            for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
-                if !matches!(def.mode, StaticMode::AttackOnlyNeighbor) {
-                    continue;
-                }
+            for &(source, _def) in &restrictors {
                 // CR 607.2d: no direction chosen yet — the restriction is inert.
                 let Some(dir) = source.chosen_direction() else {
                     continue;
                 };
-                let neighbor = crate::game::players::neighbor(state, attacker_controller, dir);
-                // CR 508.1c: the only legal targets are the nearest opponent in
-                // the chosen direction and planeswalkers that opponent controls.
+                // CR 508.1c + CR 102.2: the legal target is the nearest OPPONENT
+                // in the chosen direction — skipping living teammates in team
+                // formats (2HG, CR 810), not merely the next seat — and
+                // planeswalkers that opponent controls.
+                let Some(nearest) =
+                    crate::game::players::nearest_opponent(state, attacker_controller, dir)
+                else {
+                    // No opponent in that direction (e.g. attacker is the sole
+                    // survivor) — no restriction target to enforce; inert.
+                    continue;
+                };
                 if !crate::game::restrictions::attack_target_matches_defended_scope(
                     state,
                     Some(target),
                     &crate::types::triggers::AttackTargetFilter::PlayerOrPlaneswalker,
-                    neighbor,
-                    neighbor,
+                    nearest,
+                    nearest,
                 ) {
                     return Err(format!(
                         "{attacker_id:?} can't attack {target:?} (CR 508.1c: may attack only the nearest opponent in the chosen direction and their planeswalkers)"
@@ -6538,6 +6544,51 @@ mod tests {
         obj.chosen_attributes
             .push(ChosenAttribute::Direction(direction));
         id
+    }
+
+    /// CR 508.1c + CR 102.2 + CR 810: In Two-Headed Giant the seat adjacent to
+    /// the attacker can be a TEAMMATE. The directional restriction must resolve
+    /// the nearest OPPONENT (skipping teammates), not merely the next seat —
+    /// otherwise the real legal target (the next opponent) is rejected and no
+    /// legal attack exists. Regression for the team-format finding: P0's left
+    /// neighbor P1 is a teammate; the nearest opponent is P2.
+    #[test]
+    fn attack_only_neighbor_skips_teammate_in_two_headed_giant() {
+        // 2HG teams {P0,P1} and {P2,P3}, seat order [P0,P1,P2,P3].
+        let mut state = GameState::new(
+            crate::types::format::FormatConfig::two_headed_giant(),
+            4,
+            42,
+        );
+        state.turn_number = 2;
+        state.active_player = PlayerId(0);
+        state.phase = crate::types::phase::Phase::DeclareAttackers;
+
+        let _pramikon = create_directional_restrictor(&mut state, PlayerId(0), SeatDirection::Left);
+        let attacker = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+
+        // The nearest opponent past teammate P1 is P2 — legal. Before the fix the
+        // gate required attacking teammate P1 (an illegal target), leaving P0 with
+        // no legal attack at all.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(2)))],
+                &mut vec![]
+            )
+            .is_ok(),
+            "attacking the nearest opponent P2 (past teammate P1) must be legal"
+        );
+        // The far opponent P3 is not the nearest in the Left direction — illegal.
+        assert!(
+            declare_attackers(
+                &mut state.clone(),
+                &[(attacker, AttackTarget::Player(PlayerId(3)))],
+                &mut vec![]
+            )
+            .is_err(),
+            "attacking the far opponent P3 must be rejected (P2 is the nearest)"
+        );
     }
 
     /// CR 508.1c + CR 607.2d: Under Pramikon (chosen Left), the active player may

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -7945,6 +7945,10 @@ fn audit_card_lines(oracle_text: &str, face: &CardFace) -> Vec<SemanticFinding> 
             StaticMode::CantAttack => effective_lower.contains("can't attack"),
             StaticMode::CantBlock => effective_lower.contains("can't block"),
             StaticMode::CantAttackOrBlock => effective_lower.contains("can't attack or block"),
+            // CR 508.1c: Pramikon/Mystic Barrier/Teyo directional restriction.
+            StaticMode::AttackOnlyNeighbor => {
+                effective_lower.contains("attack only the nearest opponent")
+            }
             // CR 701.60a + CR 701.60d: Airtight Alibi's "can't become suspected".
             StaticMode::CantBecomeSuspected => effective_lower.contains("can't become suspected"),
             StaticMode::CantCrew => {

--- a/crates/engine/src/game/effects/choose.rs
+++ b/crates/engine/src/game/effects/choose.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use crate::game::players;
 use crate::types::ability::{
     ChoiceType, ChoiceValue, ChosenAttribute, Effect, EffectError, EffectKind, ResolvedAbility,
-    TargetSelectionMode,
+    SeatDirection, TargetSelectionMode,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -219,6 +219,34 @@ pub(crate) fn bind_named_choice(
                     )
                 })
                 .collect(),
+            // CR 607.2d + CR 508.1c: The directional "choose left or right"
+            // prompt (Pramikon, Sky Rampart; Mystic Barrier; Teyo, Geometric
+            // Tactician) arrives as a two-option `ChoiceType::Labeled`. Hijack
+            // ONLY the exact 2-option {left, right} set (case-insensitive, both
+            // present) into a typed `ChosenAttribute::Direction` so the CR
+            // 508.1c gate can read the seat direction. A Labeled choice that
+            // merely includes "Left" among other options (e.g.
+            // ["Left", "Center", "Right"]) is NOT a directional choice — it
+            // falls through to the generic `Label` path below.
+            ChoiceType::Labeled { options }
+                if options.len() == 2
+                    && options
+                        .iter()
+                        .all(|o| SeatDirection::from_choice_label(o).is_some())
+                    && options.iter().any(|o| {
+                        SeatDirection::from_choice_label(o) == Some(SeatDirection::Left)
+                    })
+                    && options.iter().any(|o| {
+                        SeatDirection::from_choice_label(o) == Some(SeatDirection::Right)
+                    }) =>
+            {
+                match SeatDirection::from_choice_label(choice) {
+                    Some(dir) => vec![ChosenAttribute::Direction(dir)],
+                    None => ChosenAttribute::from_choice(choice_type.clone(), choice)
+                        .into_iter()
+                        .collect(),
+                }
+            }
             _ => ChosenAttribute::from_choice(choice_type.clone(), choice)
                 .into_iter()
                 .collect(),
@@ -240,6 +268,17 @@ pub(crate) fn bind_named_choice(
                 if matches!(choice_type, ChoiceType::Keyword { .. }) {
                     obj.chosen_attributes
                         .retain(|a| !matches!(a, ChosenAttribute::Keyword(_)));
+                }
+                // CR 607.2d "the last chosen direction": a re-choice (Mystic
+                // Barrier's upkeep re-selection) REPLACES the prior direction.
+                // Clear only `ChosenAttribute::Direction`, mirroring the Keyword
+                // retain above, so exactly one direction (the last) survives.
+                if attrs
+                    .iter()
+                    .any(|a| matches!(a, ChosenAttribute::Direction(_)))
+                {
+                    obj.chosen_attributes
+                        .retain(|a| !matches!(a, ChosenAttribute::Direction(_)));
                 }
                 for attr in attrs {
                     obj.chosen_attributes.push(attr);
@@ -1117,5 +1156,105 @@ mod tests {
             "the FIRST choice (First Strike) must NO LONGER be granted — a keyword \
              choice represents the current answer set, not an accumulation"
         );
+    }
+
+    /// Create a bare battlefield object to receive a bound choice.
+    #[cfg(test)]
+    fn seed_source(state: &mut GameState) -> ObjectId {
+        use crate::types::identifiers::CardId;
+        crate::game::zones::create_object(
+            state,
+            CardId(state.next_object_id),
+            PlayerId(0),
+            "Pramikon, Sky Rampart".to_string(),
+            crate::types::zones::Zone::Battlefield,
+        )
+    }
+
+    /// CR 607.2d: The {Left,Right} hijack fires ONLY for the exact 2-option
+    /// {left,right} set. A Labeled prompt that merely INCLUDES "Left" among other
+    /// options (["Left","Center","Right"]) is an ordinary anchor-word Label, not
+    /// a direction — it must persist as a `Label` and `chosen_direction()` stays
+    /// `None`. Revert the `options.len() == 2` guard → this stores a Direction.
+    #[test]
+    fn labeled_three_options_including_left_stays_a_label() {
+        use crate::types::ability::SeatDirection;
+
+        let mut state = GameState::new_two_player(42);
+        let src = seed_source(&mut state);
+        let choice_type = ChoiceType::Labeled {
+            options: vec!["Left".into(), "Center".into(), "Right".into()],
+        };
+        bind_named_choice(&mut state, &choice_type, "Left", Some(src));
+
+        let obj = &state.objects[&src];
+        assert_eq!(
+            obj.chosen_direction(),
+            None,
+            "a 3-option labeled choice must NOT be hijacked into a Direction"
+        );
+        assert_eq!(
+            obj.chosen_label(),
+            Some("Left"),
+            "it must persist as an ordinary anchor-word Label"
+        );
+        // Sanity: SeatDirection typing still recognises the token in isolation.
+        assert_eq!(
+            SeatDirection::from_choice_label("Left"),
+            Some(SeatDirection::Left)
+        );
+    }
+
+    /// CR 607.2d: The exact 2-option {left,right} set is hijacked into a typed
+    /// `Direction` (case-insensitive), and NO `Label` is stored. Revert the
+    /// hijack branch → this stores a `Label` and `chosen_direction()` is `None`.
+    #[test]
+    fn labeled_left_right_binds_direction_not_label() {
+        use crate::types::ability::SeatDirection;
+
+        let mut state = GameState::new_two_player(42);
+        let src = seed_source(&mut state);
+        let choice_type = ChoiceType::Labeled {
+            options: vec!["Left".into(), "Right".into()],
+        };
+        // Lowercase answer proves case-insensitive typing via from_choice_label.
+        bind_named_choice(&mut state, &choice_type, "left", Some(src));
+
+        let obj = &state.objects[&src];
+        assert_eq!(obj.chosen_direction(), Some(SeatDirection::Left));
+        assert_eq!(
+            obj.chosen_label(),
+            None,
+            "the directional choice must NOT also leave a Label"
+        );
+    }
+
+    /// CR 607.2d "the last chosen direction": re-choosing Right after Left leaves
+    /// exactly one `Direction(Right)` — the prior direction is cleared. Revert the
+    /// Direction retain-clear → both directions accumulate and the count is 2.
+    #[test]
+    fn rechoosing_direction_replaces_prior() {
+        use crate::types::ability::{ChosenAttribute, SeatDirection};
+
+        let mut state = GameState::new_two_player(42);
+        let src = seed_source(&mut state);
+        let choice_type = ChoiceType::Labeled {
+            options: vec!["Left".into(), "Right".into()],
+        };
+        bind_named_choice(&mut state, &choice_type, "Left", Some(src));
+        bind_named_choice(&mut state, &choice_type, "Right", Some(src));
+
+        let obj = &state.objects[&src];
+        let directions: Vec<_> = obj
+            .chosen_attributes
+            .iter()
+            .filter(|a| matches!(a, ChosenAttribute::Direction(_)))
+            .collect();
+        assert_eq!(
+            directions.len(),
+            1,
+            "exactly one Direction must survive a re-choice, got {directions:?}"
+        );
+        assert_eq!(obj.chosen_direction(), Some(SeatDirection::Right));
     }
 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -8,7 +8,7 @@ use crate::types::ability::{
     AbilityDefinition, AdditionalCost, AdditionalCostInstancePayment, AdditionalCostOrigin,
     BasicLandType, CastTimingPermission, CastVariantPaid, CastingPermission, CastingRestriction,
     ChosenAttribute, ChosenSubtypeKind, CostPaidObjectSnapshot, ModalChoice, ReplacementDefinition,
-    SolveCondition, SpellCastingOption, StaticDefinition, TriggerDefinition,
+    SeatDirection, SolveCondition, SpellCastingOption, StaticDefinition, TriggerDefinition,
 };
 use crate::types::card::{LayoutKind, PrintedCardRef, TokenImageRef};
 use crate::types::card_type::{CardType, CoreType};
@@ -1785,6 +1785,18 @@ impl GameObject {
     pub fn chosen_label(&self) -> Option<&str> {
         self.chosen_attributes.iter().find_map(|a| match a {
             ChosenAttribute::Label(s) => Some(s.as_str()),
+            _ => None,
+        })
+    }
+
+    /// CR 607.2d + CR 508.1c: Look up the persisted chosen seat direction
+    /// (left/right) for a directional attack-restriction source (Pramikon,
+    /// Sky Rampart; Mystic Barrier; Teyo, Geometric Tactician). Returns `None`
+    /// until a direction has been chosen, in which case the restriction is
+    /// inert. Read by the CR 508.1c attacker-declaration gate in `combat.rs`.
+    pub fn chosen_direction(&self) -> Option<SeatDirection> {
+        self.chosen_attributes.iter().find_map(|a| match a {
+            ChosenAttribute::Direction(d) => Some(*d),
             _ => None,
         })
     }

--- a/crates/engine/src/game/players.rs
+++ b/crates/engine/src/game/players.rs
@@ -80,6 +80,31 @@ pub fn neighbor(state: &GameState, controller: PlayerId, direction: SeatDirectio
     }
 }
 
+/// CR 102.2 + CR 508.1c: The nearest *opponent* in the given seating direction,
+/// skipping living teammates. In a free-for-all every other seat is an opponent
+/// so this equals [`neighbor`], but in team formats (Two-Headed Giant, CR 810)
+/// an adjacent teammate is not the "nearest opponent" — the walk continues past
+/// them to the first living opponent in that direction.
+///
+/// Walks the seat ring one living player at a time via [`neighbor`]; returns
+/// `None` only if the walk returns to `controller` without finding an opponent
+/// (e.g. `controller` is the sole living player). Termination is guaranteed:
+/// each step advances deterministically around the finite living-seat ring.
+pub fn nearest_opponent(
+    state: &GameState,
+    controller: PlayerId,
+    direction: SeatDirection,
+) -> Option<PlayerId> {
+    let mut candidate = neighbor(state, controller, direction);
+    while candidate != controller {
+        if is_opponent(state, controller, candidate) {
+            return Some(candidate);
+        }
+        candidate = neighbor(state, candidate, direction);
+    }
+    None
+}
+
 /// CR 102.2 / CR 102.3: Opponents in two-player and multiplayer games.
 ///
 /// Returns all living players not on the given player's team, in seat order.
@@ -357,6 +382,61 @@ mod tests {
             p.is_eliminated = true;
         }
         state.eliminated_players.push(player);
+    }
+
+    // --- nearest_opponent ---
+
+    #[test]
+    fn nearest_opponent_equals_neighbor_in_free_for_all() {
+        // Individual seats: every other player is an opponent, so the nearest
+        // opponent is just the adjacent seat.
+        let state = make_state(4, FormatConfig::free_for_all());
+        for dir in [SeatDirection::Left, SeatDirection::Right] {
+            assert_eq!(
+                nearest_opponent(&state, PlayerId(0), dir),
+                Some(neighbor(&state, PlayerId(0), dir)),
+                "free-for-all nearest opponent is the adjacent seat ({dir:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn nearest_opponent_skips_teammate_in_two_headed_giant() {
+        // 2HG: teams {P0,P1} and {P2,P3}, seat order [P0,P1,P2,P3]. P0's left
+        // neighbor P1 is a TEAMMATE; the nearest opponent to the left is P2.
+        let state = make_state(4, FormatConfig::two_headed_giant());
+        assert!(
+            !is_opponent(&state, PlayerId(0), PlayerId(1)),
+            "P1 is P0's teammate in 2HG"
+        );
+        assert_eq!(
+            neighbor(&state, PlayerId(0), SeatDirection::Left),
+            PlayerId(1),
+            "the adjacent left seat is the teammate"
+        );
+        assert_eq!(
+            nearest_opponent(&state, PlayerId(0), SeatDirection::Left),
+            Some(PlayerId(2)),
+            "nearest opponent skips the teammate to the first opponent P2"
+        );
+        assert_eq!(
+            nearest_opponent(&state, PlayerId(0), SeatDirection::Right),
+            Some(PlayerId(3)),
+            "to the right, P3 is the first opponent"
+        );
+    }
+
+    #[test]
+    fn nearest_opponent_none_when_sole_survivor() {
+        let mut state = make_state(4, FormatConfig::free_for_all());
+        for p in [PlayerId(1), PlayerId(2), PlayerId(3)] {
+            eliminate(&mut state, p);
+        }
+        assert_eq!(
+            nearest_opponent(&state, PlayerId(0), SeatDirection::Left),
+            None,
+            "no living opponent in any direction → None"
+        );
     }
 
     // --- is_alive ---

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -67,6 +67,9 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     registry.insert(StaticMode::CantAttack, handle_rule_mod);
     registry.insert(StaticMode::CantBlock, handle_rule_mod);
     registry.insert(StaticMode::CantAttackOrBlock, handle_rule_mod);
+    // CR 508.1c: The directional attack restriction is a passive rule-modifying
+    // marker; enforcement lives in `combat.rs`'s attacker-declaration gate.
+    registry.insert(StaticMode::AttackOnlyNeighbor, handle_rule_mod);
     registry.insert(StaticMode::CantBeTargeted, handle_rule_mod);
     // Note: CantBeCast is a data-carrying variant — runtime enforcement is in
     // casting.rs::is_blocked_by_cant_be_cast(). Coverage support is via is_data_carrying_static().

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -2661,6 +2661,52 @@ fn try_parse_temporary_spell_cost_modification(tp: TextPair<'_>) -> Option<Parse
     })
 }
 
+/// CR 508.1c + CR 611.2a + CR 611.2c: Teyo, Geometric Tactician's [−2]: "Until
+/// your next turn, each player may attack only the nearest opponent in the last
+/// chosen direction and planeswalkers controlled by that opponent." A
+/// duration-bound directional attack restriction — grant the same
+/// `StaticMode::AttackOnlyNeighbor` static that Pramikon/Mystic Barrier print,
+/// but only until the controller's next turn (CR 611.2a: a continuous effect
+/// from a resolving ability lasts as long as stated by that ability, here the
+/// specified "until your next turn" duration — NOT a cleanup-step "until end of
+/// turn" effect, so CR 514.2 does not govern its expiry; CR 611.2c fixes the
+/// affected object set at the time the effect begins). The prefix strip
+/// discriminates the temporary grant from a printed static; the shared static
+/// authority (`parse_static_line`) does the actual line recognition so both
+/// wordings ("the chosen" / "the last chosen") flow through one parser.
+fn try_parse_temporary_attack_only_neighbor(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    let (_, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
+        value((), tag::<_, _, OracleError<'_>>("until your next turn, ")).parse(input)
+    })?;
+
+    let static_def = super::oracle_static::parse_static_line(rest_orig)?;
+    if !matches!(static_def.mode, StaticMode::AttackOnlyNeighbor) {
+        return None;
+    }
+
+    let duration = Duration::UntilNextTurnOf {
+        player: PlayerScope::Controller,
+    };
+    Some(ParsedEffectClause {
+        effect: Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::GrantStaticAbility {
+                    definition: Box::new(static_def),
+                }])],
+            duration: Some(duration.clone()),
+            target: Some(TargetFilter::SelfRef),
+        },
+        distribute: None,
+        multi_target: None,
+        duration: Some(duration),
+        sub_ability: None,
+        condition: None,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
 /// CR 101.2: "Your opponents can't cast spells this turn" / "Players can't cast spells this turn."
 /// Handles blanket "can't cast spells" prohibitions from instant/sorcery effects (e.g., Silence).
 /// Must be called AFTER try_parse_cast_only_from_zones_restriction (which handles the more
@@ -6087,6 +6133,13 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // (Rowan/Will, Scion of …). Tried after the "next spell" handlers since
     // those are the more specific one-spell forms.
     if let Some(clause) = try_parse_temporary_spell_cost_modification(tp) {
+        return clause;
+    }
+
+    // CR 508.1c + CR 611.2c: "Until your next turn, each player may attack only
+    // the nearest opponent in the last chosen direction ..." (Teyo, Geometric
+    // Tactician [−2]) — a duration-bound directional attack restriction.
+    if let Some(clause) = try_parse_temporary_attack_only_neighbor(tp) {
         return clause;
     }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -37955,3 +37955,45 @@ fn ents_fury_keeps_cost_paid_object_scope() {
         "Ent's Fury must keep Power{{CostPaidObject}} GE 4, got {condition:?}"
     );
 }
+
+/// CR 508.1c + CR 611.2c: Teyo, Geometric Tactician's [−2] must lower to a
+/// duration-bound grant of the `AttackOnlyNeighbor` static onto the source,
+/// ending at the controller's next turn. Reverting the temporary-grant arm
+/// leaves this as `Effect::Unimplemented`, failing the `GenericEffect` match.
+#[test]
+fn teyo_minus_two_grants_temporary_attack_only_neighbor() {
+    let effect = parse_effect(
+        "Until your next turn, each player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.",
+    );
+
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        ..
+    } = &effect
+    else {
+        panic!("expected a GenericEffect grant, got {effect:?}");
+    };
+
+    assert_eq!(
+        duration.as_ref(),
+        Some(&Duration::UntilNextTurnOf {
+            player: PlayerScope::Controller,
+        }),
+        "Teyo's grant must last until the controller's next turn, got {duration:?}"
+    );
+
+    let grants_neighbor = static_abilities.iter().any(|s| {
+        s.modifications.iter().any(|m| {
+            matches!(
+                m,
+                ContinuousModification::GrantStaticAbility { definition }
+                    if definition.mode == StaticMode::AttackOnlyNeighbor
+            )
+        })
+    });
+    assert!(
+        grants_neighbor,
+        "expected a GrantStaticAbility(AttackOnlyNeighbor); got {static_abilities:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -558,6 +558,12 @@ pub(crate) fn parse_static_line_inner(
         return Some(StaticDefinition::new(mode).description(text.to_string()));
     }
 
+    // CR 508.1c: The directional attack restriction (Pramikon, Sky Rampart;
+    // Mystic Barrier; Teyo, Geometric Tactician).
+    if let Some(mode) = parse_attack_only_neighbor_static(&lower) {
+        return Some(StaticDefinition::new(mode).description(text.to_string()));
+    }
+
     if let Some(defs) = parse_cost_payment_prohibition_statics(&tp, &text) {
         return defs.into_iter().next();
     }

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -257,6 +257,33 @@ pub(crate) fn parse_max_combat_creatures_static(lower: &str) -> Option<StaticMod
     Some(mode)
 }
 
+/// CR 508.1c: The directional attack restriction (Pramikon, Sky Rampart;
+/// Mystic Barrier; Teyo, Geometric Tactician): "Each player may attack only the
+/// nearest opponent in the [last] chosen direction and planeswalkers controlled
+/// by that opponent." The `opt(tag("last "))` tolerates both the base wording
+/// ("the chosen direction") and Mystic Barrier's re-choosable phrasing ("the
+/// last chosen direction"). The chosen direction is bound separately by the
+/// linked "choose left or right" ability (CR 607.2d); this static is the nullary
+/// marker read by the CR 508.1c attacker-declaration gate in `combat.rs`.
+pub(crate) fn parse_attack_only_neighbor_static(lower: &str) -> Option<StaticMode> {
+    let (rest, _) =
+        tag::<_, _, OracleError<'_>>("each player may attack only the nearest opponent in the ")
+            .parse(lower)
+            .ok()?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>("last "))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>(
+        "chosen direction and planeswalkers controlled by that opponent",
+    )
+    .parse(rest)
+    .ok()?;
+    let (_, _) = all_consuming(opt(tag::<_, _, OracleError<'_>>(".")))
+        .parse(rest)
+        .ok()?;
+    Some(StaticMode::AttackOnlyNeighbor)
+}
+
 pub(crate) fn parse_compound_subject_rule_static(
     text: &str,
     lower: &str,

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -12638,6 +12638,26 @@ fn static_no_more_than_one_creature_can_block_each_combat() {
 }
 
 #[test]
+fn static_attack_only_neighbor_chosen_direction() {
+    // CR 508.1c: Pramikon, Sky Rampart — base "the chosen direction" wording.
+    let def = parse_static_line(
+        "Each player may attack only the nearest opponent in the chosen direction and planeswalkers controlled by that opponent.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::AttackOnlyNeighbor);
+}
+
+#[test]
+fn static_attack_only_neighbor_last_chosen_direction() {
+    // CR 508.1c: Mystic Barrier — re-choosable "the last chosen direction".
+    let def = parse_static_line(
+        "Each player may attack only the nearest opponent in the last chosen direction and planeswalkers controlled by that opponent.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::AttackOnlyNeighbor);
+}
+
+#[test]
 fn static_attacks_or_blocks_each_combat_if_able_emits_both_defs() {
     let direct = try_parse_scoped_must_attack_block(
         "this creature attacks or blocks each combat if able.",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -905,6 +905,14 @@ pub enum ChosenAttribute {
     /// changes zones (CR 400.7), which is exactly the lifetime Koh's grant needs.
     /// Replace-on-rechoose: `RememberCard` removes any prior `Card` before pushing.
     Card(ObjectId),
+    /// CR 607.2d: The chosen seat direction (left/right) for a directional
+    /// "choose left or right" ability linked to a "the [last] chosen direction"
+    /// static (Pramikon, Sky Rampart; Mystic Barrier; Teyo, Geometric
+    /// Tactician). Stored on the source's `chosen_attributes` and read by
+    /// `GameObject::chosen_direction()` during the CR 508.1c attacker gate.
+    /// Replace-on-rechoose: the {Left,Right} hijack in `choose.rs` removes any
+    /// prior `Direction` before pushing, so only the "last chosen" survives.
+    Direction(SeatDirection),
 }
 
 impl ChosenAttribute {
@@ -950,6 +958,12 @@ impl ChosenAttribute {
             // spurious object-choice category.
             Self::Card(_) => ChoiceType::Labeled {
                 options: Vec::new(),
+            },
+            // CR 607.2d: The directional choice is a two-option labeled prompt.
+            // The {Left,Right} hijack in `choose.rs` recognises exactly this
+            // option set to persist a typed `Direction` rather than a `Label`.
+            Self::Direction(_) => ChoiceType::Labeled {
+                options: vec!["Left".into(), "Right".into()],
             },
         }
     }
@@ -5040,6 +5054,20 @@ pub enum SeatDirection {
     /// The living player seated immediately to the controller's right — the
     /// previous player in turn order. Backward through `seat_order`.
     Right,
+}
+
+impl SeatDirection {
+    /// CR 607.2d: The single typed authority for mapping a chosen "left"/"right"
+    /// option label to a `SeatDirection`. Used by the {Left,Right} hijack in
+    /// `game/effects/choose.rs` so no call site ever string-matches "Left"
+    /// verbatim. Case-insensitive and whitespace-tolerant.
+    pub fn from_choice_label(label: &str) -> Option<Self> {
+        match label.trim().to_ascii_lowercase().as_str() {
+            "left" => Some(Self::Left),
+            "right" => Some(Self::Right),
+            _ => None,
+        }
+    }
 }
 
 /// CR 102.1 / CR 102.2 / CR 109.5: Relative player set for player filters that

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -745,6 +745,14 @@ pub enum StaticMode {
     CantAttack,
     CantBlock,
     CantAttackOrBlock,
+    /// CR 508.1c: Directional attack restriction (Pramikon, Sky Rampart; Mystic
+    /// Barrier; Teyo, Geometric Tactician). "Each player may attack only the
+    /// nearest opponent in the [last] chosen direction and planeswalkers
+    /// controlled by that opponent." A nullary marker static — the chosen
+    /// direction is stored on the source's `chosen_attributes`
+    /// (`ChosenAttribute::Direction`, CR 607.2d linked ability) and runtime
+    /// enforcement is the attacker-declaration gate in `combat.rs`.
+    AttackOnlyNeighbor,
     /// CR 701.60a + CR 701.60d: The affected permanent can't become suspected
     /// (Airtight Alibi: "Enchanted creature ... can't become suspected"). A
     /// nullary marker static — the `affected` filter scopes which permanents are
@@ -1998,6 +2006,7 @@ impl StaticMode {
             | StaticMode::CantAttack
             | StaticMode::CantBlock
             | StaticMode::CantAttackOrBlock
+            | StaticMode::AttackOnlyNeighbor
             | StaticMode::CantBecomeSuspected
             | StaticMode::MaxAttackersEachCombat { .. }
             | StaticMode::MaxBlockersEachCombat { .. }
@@ -2113,6 +2122,7 @@ impl fmt::Display for StaticMode {
             StaticMode::CantAttack => write!(f, "CantAttack"),
             StaticMode::CantBlock => write!(f, "CantBlock"),
             StaticMode::CantAttackOrBlock => write!(f, "CantAttackOrBlock"),
+            StaticMode::AttackOnlyNeighbor => write!(f, "AttackOnlyNeighbor"),
             StaticMode::CantBecomeSuspected => write!(f, "CantBecomeSuspected"),
             StaticMode::MaxAttackersEachCombat { max, defender } => match defender {
                 None => write!(f, "MaxAttackersEachCombat({max})"),
@@ -2501,6 +2511,7 @@ impl FromStr for StaticMode {
             "CantAttack" => StaticMode::CantAttack,
             "CantBlock" => StaticMode::CantBlock,
             "CantAttackOrBlock" => StaticMode::CantAttackOrBlock,
+            "AttackOnlyNeighbor" => StaticMode::AttackOnlyNeighbor,
             "CantBecomeSuspected" => StaticMode::CantBecomeSuspected,
             "LinkedCollectionCounterPlayPermission" => {
                 StaticMode::LinkedCollectionCounterPlayPermission
@@ -3380,6 +3391,7 @@ mod tests {
             // Pre-existing variants
             StaticMode::Continuous,
             StaticMode::CantAttack,
+            StaticMode::AttackOnlyNeighbor,
             StaticMode::ExtraBlockers { count: None },
             StaticMode::ExtraBlockers { count: Some(1) },
             StaticMode::MaxAttackersEachCombat {


### PR DESCRIPTION
## Summary

Implements the **CR 508.1c** global directional attack restriction — "Each player may attack only the nearest opponent in the [last] chosen direction and planeswalkers controlled by that opponent" — unlocking three previously-unsupported cards:

- **Pramikon, Sky Rampart** — `As Pramikon enters, choose left or right.`
- **Mystic Barrier** — `When this enchantment enters and at the beginning of your upkeep, choose left or right.`
- **Teyo, Geometric Tactician** — `[−2]: Choose left or right. Until your next turn, …` (duration-bound)

## Approach — compose existing primitives, no new subsystem

The restriction and its linked "choose left or right" are built from existing building blocks; there is **no new AI, frontend, or serialization surface** (the choice UI, layer grant, and combat-declaration machinery are all reused).

- **`StaticMode::AttackOnlyNeighbor`** (nullary, peer of `MustAttackPlayer`). The direction is **not** a parse-time field — it's read live from the source's chosen direction — so all present and future printings share one variant and one combat gate.
- **`ChosenAttribute::Direction(SeatDirection)`** (peer of `Label`), with a typed `SeatDirection::from_choice_label` helper and a `chosen_direction()` accessor. `bind_named_choice` hijacks the **exact two-option `{Left, Right}`** `Labeled` choice into a typed `Direction` (CR 607.2d linked choice), replacing the prior direction on re-choose ("last chosen"). A `Labeled` choice that merely *includes* "Left" among other options stays a `Label` — so nothing else regresses.
- **Combat gate** in `declare_attackers_with_bands`: for every attacker, the direction is read from each active `AttackOnlyNeighbor` source (CR 109.5), the nearest opponent is resolved **per attacker** via `players::neighbor` (skips eliminated players, wraps, 2-player collapses to the sole opponent), and an attack is rejected unless it targets that neighbor or a planeswalker they control. Existence-gated (a no-op when no such static is on the battlefield); multiple sources **intersect** (each is an independent CR 508.1c check).
- **Teyo's `[−2]`** parses to a duration-bound `GrantStaticAbility` (CR 611.2a "until your next turn"); the granted static lands on Teyo and reads Teyo's chosen direction, and expires at the controller's next turn. Teyo's ETB Wall token and `[+1]` are out of scope (parse independently).

Coverage is via registry membership (`handle_rule_mod` marker); enforcement is **solely** the combat gate (no double enforcement).

## Rules

CR 508.1c (governing) + CR 109.5 (source-controller "you") + CR 102.1 / 103.1 (seating / neighbor order) + CR 607.2d (linked choose ↔ chosen) + CR 611.2a / 611.2c (Teyo duration) + CR 400.7 (chosen attribute cleared on zone change). All verified against the Comprehensive Rules.

## Testing

**10 runtime combat tests** through the real `declare_attackers` path:
- non-neighbor attack rejected / neighbor + their planeswalker allowed,
- global scope (every player restricted, not just the source's controller),
- 2-player collapse (any attack legal),
- no-direction-yet is inert,
- "last chosen" re-choice flips legality,
- two-source intersection,
- **Teyo's grant gates attacks and expires at the controller's next turn** (installed via the real transient-grant → layer-materialization → `bind_named_choice` → prune path, revert-failing).

Plus the `{Left, Right}` hijack hostile fixtures (a 3-option `{Left, Center, Right}` choice stays a `Label`; re-choose replaces the prior direction) and static/effect parser tests. Full `cargo test -p engine` green; clippy clean.
