### PR TITLE
fix(engine): consume filtered one-shot spell cost reductions (CR 601.2f)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -6269,13 +6269,30 @@ fn apply_pending_spell_cost_reductions(
     }
 }
 
-/// CR 601.2f: Consume (remove) a one-shot pending cost reduction after a spell is cast.
-pub(super) fn consume_pending_spell_cost_reduction(state: &mut GameState, caster: PlayerId) {
-    if let Some(idx) = state
-        .pending_spell_cost_reductions
-        .iter()
-        .position(|r| r.player == caster && r.spell_filter.is_none())
-    {
+/// CR 601.2f: Consume (remove) the one-shot pending cost reduction a cast spell
+/// used. Removes the first entry for this caster that the cast spell matches —
+/// whether unfiltered OR filter-matched (e.g. "the next face-down creature spell
+/// you cast this turn costs {3} less", Kadena) — mirroring the single entry that
+/// [`apply_pending_spell_cost_reductions`] applied (it also stops at the first
+/// match). The previous predicate removed only *unfiltered* entries, so a
+/// filtered reduction was never consumed and kept discounting every matching
+/// spell for the rest of the turn instead of just the next one. Mirrors
+/// [`consume_pending_next_spell_modifiers`].
+pub(super) fn consume_pending_spell_cost_reduction(
+    state: &mut GameState,
+    caster: PlayerId,
+    spell_id: ObjectId,
+) {
+    let matched = state.pending_spell_cost_reductions.iter().position(|r| {
+        r.player == caster
+            && match &r.spell_filter {
+                None => true,
+                Some(filter) => {
+                    spell_matches_cost_filter(state, caster, spell_id, filter, spell_id)
+                }
+            }
+    });
+    if let Some(idx) = matched {
         state.pending_spell_cost_reductions.remove(idx);
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6200,7 +6200,7 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
     restrictions::record_spell_cast_from_zone(state, player, &obj, source_zone, casting_variant);
 
     // CR 601.2f: Consume any one-shot pending cost reductions now that the spell is finalized.
-    super::casting::consume_pending_spell_cost_reduction(state, player);
+    super::casting::consume_pending_spell_cost_reduction(state, player, object_id);
 
     // CR 601.2f: Stamp and consume one-shot "the next spell …" modifiers.
     super::casting::apply_pending_next_spell_stack_grants(state, player, object_id);

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -22915,6 +22915,77 @@ fn spell_matches_cost_filter_fail_closed_for_unrecognized_variants() {
     ));
 }
 
+/// CR 601.2f: a *filtered* one-shot cost reduction ("the next [type] spell you
+/// cast this turn costs {N} less" — Kadena, Slinking Sorcerer) must be consumed
+/// once the matching spell is cast, not left to discount every matching spell
+/// for the rest of the turn. The consumer previously removed only *unfiltered*
+/// entries. Revert-probe: with the old `spell_filter.is_none()` predicate the
+/// filtered entry survives and the length-0 assertion below fails.
+#[test]
+fn consume_filtered_pending_cost_reduction_removes_the_matching_entry() {
+    use crate::types::game_state::PendingSpellCostReduction;
+
+    let mut state = GameState::new_two_player(1);
+    // A creature spell cast by P0.
+    let spell = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Creature Spell".to_string(),
+        Zone::Stack,
+    );
+    {
+        let obj = state.objects.get_mut(&spell).unwrap();
+        obj.card_types.core_types = vec![CoreType::Creature];
+        obj.base_card_types = obj.card_types.clone();
+    }
+
+    // 1. A filtered (creature-spell) reduction that matches is consumed.
+    state
+        .pending_spell_cost_reductions
+        .push(PendingSpellCostReduction {
+            player: PlayerId(0),
+            amount: 2,
+            spell_filter: Some(TargetFilter::Typed(TypedFilter::creature())),
+        });
+    consume_pending_spell_cost_reduction(&mut state, PlayerId(0), spell);
+    assert!(
+        state.pending_spell_cost_reductions.is_empty(),
+        "a matching filtered reduction must be consumed (previously it persisted \
+         and re-discounted every creature spell for the rest of the turn)"
+    );
+
+    // 2. Regression: an unfiltered reduction is still consumed.
+    state
+        .pending_spell_cost_reductions
+        .push(PendingSpellCostReduction {
+            player: PlayerId(0),
+            amount: 1,
+            spell_filter: None,
+        });
+    consume_pending_spell_cost_reduction(&mut state, PlayerId(0), spell);
+    assert!(
+        state.pending_spell_cost_reductions.is_empty(),
+        "an unfiltered reduction is still consumed"
+    );
+
+    // 3. Precision: a reduction belonging to a different player is NOT consumed
+    //    by this player's cast.
+    state
+        .pending_spell_cost_reductions
+        .push(PendingSpellCostReduction {
+            player: PlayerId(1),
+            amount: 2,
+            spell_filter: Some(TargetFilter::Typed(TypedFilter::creature())),
+        });
+    consume_pending_spell_cost_reduction(&mut state, PlayerId(0), spell);
+    assert_eq!(
+        state.pending_spell_cost_reductions.len(),
+        1,
+        "another player's reduction must not be consumed by P0's cast"
+    );
+}
+
 // -----------------------------------------------------------------------
 // Flashback (CR 702.34)
 // -----------------------------------------------------------------------

--- a/crates/engine/tests/filtered_cost_reduction_only_first_cast.rs
+++ b/crates/engine/tests/filtered_cost_reduction_only_first_cast.rs
@@ -1,0 +1,77 @@
+//! CR 601.2f regression (runtime cast pipeline): a filtered one-shot "the next
+//! [type] spell you cast this turn costs {N} less" reduction (Kadena, Slinking
+//! Sorcerer) must be consumed by the first matching cast and must not discount
+//! later matching spells that turn.
+//!
+//! This drives the real cast pipeline — `GameScenario` → `cast().resolve()` →
+//! finalize (`apply_pending_spell_cost_reductions` during cost calculation, then
+//! `consume_pending_spell_cost_reduction` at finalize) — casting two {2} creature
+//! spells with a creature-filtered {1} reduction and proving only the first is
+//! discounted. On the old consumer (which removed only *unfiltered* entries) the
+//! second cast is also discounted and this test fails.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{TargetFilter, TypedFilter};
+use engine::types::game_state::PendingSpellCostReduction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+#[test]
+fn filtered_reduction_discounts_only_the_first_matching_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let c1 = scenario
+        .add_creature_to_hand(P0, "Bear One", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let c2 = scenario
+        .add_creature_to_hand(P0, "Bear Two", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let mut runner = scenario.build();
+
+    // 3 colorless mana: enough for the reduced first cast ({1}) plus the full
+    // second cast ({2}).
+    for _ in 0..3 {
+        runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+
+    // A creature-filtered one-shot {1} reduction ("the next creature spell you
+    // cast this turn costs {1} less").
+    runner
+        .state_mut()
+        .pending_spell_cost_reductions
+        .push(PendingSpellCostReduction {
+            player: P0,
+            amount: 1,
+            spell_filter: Some(TargetFilter::Typed(TypedFilter::creature())),
+        });
+
+    // Cast 1: {2} - {1} = {1} spent, and the reduction is consumed.
+    let before1 = runner.state().players[0].mana_pool.total();
+    runner.cast(c1).resolve();
+    let spent1 = before1 - runner.state().players[0].mana_pool.total();
+    assert_eq!(
+        spent1, 1,
+        "the first creature spell is discounted by {{1}} (2 - 1)"
+    );
+    assert!(
+        runner.state().pending_spell_cost_reductions.is_empty(),
+        "the filtered reduction must be consumed by the first matching cast"
+    );
+
+    // Cast 2: full {2} — the one-shot reduction is already gone.
+    let before2 = runner.state().players[0].mana_pool.total();
+    runner.cast(c2).resolve();
+    let spent2 = before2 - runner.state().players[0].mana_pool.total();
+    assert_eq!(
+        spent2, 2,
+        "the second creature spell pays full cost (reduction already consumed)"
+    );
+}


### PR DESCRIPTION
## Summary

"The next [type] spell you cast this turn costs {N} less" (**Kadena, Slinking Sorcerer**; **Slinking Sorcerer**) kept discounting **every** matching spell for the rest of the turn, not just the next one.

`apply_pending_spell_cost_reductions` (`casting.rs`) matches filtered entries via `spell_matches_cost_filter` and applies the **first** (it `break`s), but `consume_pending_spell_cost_reduction` only removed entries whose `spell_filter` was `None`. So a filtered `PendingSpellCostReduction` was applied on every matching cast and never consumed until the end-of-turn `clear()` — a class-level over-reduction for the whole "next … spell costs {N} less" family.

The fix consumes the **same** entry `apply` used: the first for this caster that the cast spell matches (unfiltered **or** filter-matched), threading the finalized spell's `object_id` through the single call site. This mirrors the already-correct sibling `consume_pending_next_spell_modifiers` (the parallel one-shot "next spell has convoke / can't be countered" system), which was the source of the asymmetry.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> A few-line fix that aligns the consumer's predicate with the applier's (and with the sibling `consume_pending_next_spell_modifiers`), plus its call site and a unit revert-probe test. No new pattern/variant/AST. A `/review-impl` self-check was run.

## CR references

- `CR 601.2f` — total cost is the mana cost "minus all cost reductions"; a one-shot "next spell" reduction applies to exactly one spell.

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib cost_reduction` — 98 passed.
- New `consume_filtered_pending_cost_reduction_removes_the_matching_entry`: pushes a filtered (creature-spell) reduction, casts a creature spell, and asserts the entry is consumed; plus an unfiltered-still-consumed regression and a different-player-not-consumed precision check. **Revert-probe:** with the old `spell_filter.is_none()` predicate the filtered entry survives and the test fails — proving the class-level over-reduction and a non-vacuous assertion.