### PR TITLE
fix(parser): gate extra-blocker grants on trailing "as long as/if" conditions (Entourage of Trest)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2860,23 +2860,20 @@ pub(crate) fn parse_static_line_inner(
     // CR 509.1c + CR 611.3a: an extra-blocker grant may carry a trailing "as long
     // as <cond>" / "if <cond>" gate (Entourage of Trest: "This creature can block
     // an additional creature each combat as long as you're the monarch"). The bare
-    // form is parsed directly; when a trailing gate is present, peel it so the
-    // condition-free body reaches `parse_extra_blockers_static`, then attach the
-    // parsed condition (IsMonarch, etc.) via `parse_static_condition`.
+    // form is parsed directly; a trailing gate is peeled via the shared gate
+    // authority (`split_trailing_gate_condition_with_body`, which owns the
+    // `as long as` > last-valid-`if` > `as if`-exclusion rules) so the
+    // condition-free body reaches `parse_extra_blockers_static`, then the parsed
+    // condition attaches. CR 611.3a: fail CLOSED — an unrecognized condition leaves
+    // the whole line unsupported (`parse_static_condition` returns `None` → `?`)
+    // rather than enforcing the extra-block grant unconditionally (an `Unrecognized`
+    // gate evaluates as always-true in the layer system).
     if let Some(def) = parse_extra_blockers_static(&text) {
         return Some(def);
     }
-    if let Some((body_tp, condition_tp)) = tp
-        .split_around(" as long as ")
-        .or_else(|| tp.split_around(" if "))
-    {
-        if let Some(mut def) = parse_extra_blockers_static(body_tp.original) {
-            let condition_text = condition_tp.original.trim().trim_end_matches('.');
-            def.condition = Some(parse_static_condition(condition_text).unwrap_or(
-                StaticCondition::Unrecognized {
-                    text: condition_text.to_string(),
-                },
-            ));
+    if let Some((body, condition_text)) = split_trailing_gate_condition_with_body(&tp) {
+        if let Some(mut def) = parse_extra_blockers_static(body) {
+            def.condition = Some(parse_static_condition(condition_text)?);
             return Some(def);
         }
     }

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2856,9 +2856,29 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
-    // --- "can block an additional creature" / "can block any number" ---
+    // --- "can block an additional creature [as long as|if <cond>]" / "can block any number" ---
+    // CR 509.1c + CR 611.3a: an extra-blocker grant may carry a trailing "as long
+    // as <cond>" / "if <cond>" gate (Entourage of Trest: "This creature can block
+    // an additional creature each combat as long as you're the monarch"). The bare
+    // form is parsed directly; when a trailing gate is present, peel it so the
+    // condition-free body reaches `parse_extra_blockers_static`, then attach the
+    // parsed condition (IsMonarch, etc.) via `parse_static_condition`.
     if let Some(def) = parse_extra_blockers_static(&text) {
         return Some(def);
+    }
+    if let Some((body_tp, condition_tp)) = tp
+        .split_around(" as long as ")
+        .or_else(|| tp.split_around(" if "))
+    {
+        if let Some(mut def) = parse_extra_blockers_static(body_tp.original) {
+            let condition_text = condition_tp.original.trim().trim_end_matches('.');
+            def.condition = Some(parse_static_condition(condition_text).unwrap_or(
+                StaticCondition::Unrecognized {
+                    text: condition_text.to_string(),
+                },
+            ));
+            return Some(def);
+        }
     }
 
     // --- CR 509.1c: "All creatures able to block <self/enchanted creature> do so"

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2124,6 +2124,36 @@ pub(crate) fn split_trailing_gate_condition(lower: &str) -> Option<&str> {
     split_trailing_as_long_as(lower).or_else(|| split_trailing_if_condition(lower))
 }
 
+/// Body-preserving sibling of [`split_trailing_gate_condition`] for callers that
+/// must re-parse the pre-gate body as its own static (e.g. an extra-blocker grant
+/// gated on "… as long as you're the monarch"). Returns `(body, condition)` in
+/// ORIGINAL case from the SAME authority — `as long as` is tried first, then the
+/// last valid `if` marker (excluding `as if`) — so trailing-gate splitting is not
+/// re-implemented per call site. `body` is the line with the trailing gate
+/// removed (trailing separator whitespace trimmed); `condition` is the gate's
+/// condition text for [`parse_static_condition`]. The word-boundary scan yields
+/// the marker's byte offset, so the original-case body/condition are recovered by
+/// slicing `tp.original` (mirroring `split_trailing_if_condition_tp`).
+pub(crate) fn split_trailing_gate_condition_with_body<'a>(
+    tp: &'a TextPair<'a>,
+) -> Option<(&'a str, &'a str)> {
+    let (marker_offset, _, tail_lower) =
+        nom_primitives::scan_last_at_word_boundaries_with_offset(tp.lower, |i| {
+            tag::<_, _, OracleError<'_>>("as long as ").parse(i)
+        })
+        .or_else(|| {
+            nom_primitives::scan_last_valid_at_word_boundaries_with_offset(
+                tp.lower,
+                |i| tag::<_, _, OracleError<'_>>("if ").parse(i),
+                |if_offset| !is_as_if_gate_marker(tp.lower, if_offset),
+            )
+        })?;
+    let condition_start = tp.lower.len().checked_sub(tail_lower.len())?;
+    let condition = tp.original.get(condition_start..)?.trim_start();
+    let body = tp.original.get(..marker_offset)?.trim_end();
+    Some((body, condition))
+}
+
 /// CR 508.1c / CR 509.1b: Parse the trailing " if [condition]" clause of a
 /// combat-restriction static ("~ can't attack if defending player controls an
 /// untapped land"; "~ can't block if you control an untapped land"). Mirrors

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1032,6 +1032,26 @@ fn extra_blockers_static_gated_on_trailing_as_long_as_condition() {
         bare.condition.is_none(),
         "bare form must carry no condition"
     );
+
+    // CR 611.3a: the "if" branch of the shared gate authority must also attach.
+    let if_gated = parse_static_line("~ can block an additional creature if you control a Forest.")
+        .expect("extra-blockers grant with a trailing `if` condition must parse");
+    assert_eq!(if_gated.mode, StaticMode::ExtraBlockers { count: Some(1) });
+    assert!(
+        matches!(if_gated.condition, Some(StaticCondition::IsPresent { .. })),
+        "the 'if you control a Forest' rider must gate on IsPresent, got {:?}",
+        if_gated.condition
+    );
+
+    // CR 611.3a: an UNRECOGNIZED trailing condition must fail CLOSED — the line is
+    // left unsupported rather than producing an unconditionally-active
+    // `ExtraBlockers` static (an `Unrecognized` gate evaluates as always-true).
+    assert!(
+        parse_static_line("~ can block an additional creature as long as the omens are dire.")
+            .is_none(),
+        "an unrecognized trailing condition must leave the extra-block line unsupported, \
+         not grant ExtraBlockers unconditionally"
+    );
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1003,6 +1003,37 @@ fn extra_blockers_static_self_reference_stays_selfref() {
     assert_eq!(def.affected, Some(TargetFilter::SelfRef));
 }
 
+/// CR 509.1c + CR 611.3a: An extra-blocker grant may carry a trailing "as long
+/// as <condition>" (or "if <condition>") gate (Entourage of Trest: "This creature
+/// can block an additional creature each combat as long as you're the monarch").
+/// Without peeling the rider the whole line failed to parse (it fell through to a
+/// failed effect); the bare body must reach the extra-blockers parser and the
+/// parsed condition attach to the static. Regression for the dropped gate.
+#[test]
+fn extra_blockers_static_gated_on_trailing_as_long_as_condition() {
+    let def = parse_static_line(
+        "~ can block an additional creature each combat as long as you're the monarch.",
+    )
+    .expect("extra-blockers grant with a trailing monarch condition must parse");
+    assert_eq!(def.mode, StaticMode::ExtraBlockers { count: Some(1) });
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::IsMonarch),
+        "the 'as long as you're the monarch' rider must gate the extra-block grant, got {:?}",
+        def.condition
+    );
+
+    // The bare (unconditional) form must still parse with no condition (no regression).
+    let bare = parse_static_line("~ can block an additional creature each combat.")
+        .expect("bare extra-blockers grant must still parse");
+    assert_eq!(bare.mode, StaticMode::ExtraBlockers { count: Some(1) });
+    assert!(
+        bare.condition.is_none(),
+        "bare form must carry no condition"
+    );
+}
+
 #[test]
 fn extra_blockers_count_phrase_handles_hyphenated_and_any() {
     assert_eq!(


### PR DESCRIPTION
## Problem

An extra-blocker grant carrying a trailing `as long as <cond>` / `if <cond>` gate failed to parse **entirely**:

- Entourage of Trest: `This creature can block an additional creature each combat **as long as you're the monarch**.`

The rider left non-empty remainder in `parse_extra_blockers_static` (which requires the line to end after the extra-block predicate), so the whole line fell through to a failed effect and the extra-block grant was **silently dropped**.

## Fix

Peel the trailing condition in the `dispatch.rs` arm **before** delegating to `parse_extra_blockers_static`: split on ` as long as ` / ` if `, parse the condition-free body as the extra-block static, and attach the parsed condition via `parse_static_condition` (**CR 611.3a**).

`you're the monarch` resolves to `StaticCondition::IsMonarch` through the existing shared condition authority — **no new condition parsing**. The bare (unconditional) form is unchanged.

### Before / after

```
before: (no static — line failed to a dropped effect, extra-block grant lost)
after:  ExtraBlockers{ count: 1 }  condition: IsMonarch
```

## Tests

- New `extra_blockers_static_gated_on_trailing_as_long_as_condition` regression: asserts the `ExtraBlockers{1}` grant carries the `IsMonarch` gate, plus the bare form still parses with no condition.
- 961 `oracle_static` tests pass; `cargo fmt` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)