### PR TITLE
fix(parser): parse dynamic pump "for each ... on the battlefield with <keyword>" (Radiant Archangel, Pride of the Clouds)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2941,6 +2941,11 @@ fn parse_for_each_clause_ref_with_they_controller(
         parse_for_each_attacking_controller_type,
         parse_for_each_blocking_source_type,
         parse_for_each_recipient_shared_quality,
+        // CR 613.4c + CR 604.3: "<type> on the battlefield with <keyword>" —
+        // must precede `parse_for_each_battlefield_type`, whose shorter
+        // " on the battlefield" tag would otherwise match first and strand
+        // " with <keyword>" as an unconsumed remainder.
+        parse_for_each_battlefield_type_with_keyword,
         parse_for_each_battlefield_type,
         parse_for_each_commander_cast_count,
         parse_mana_spent_to_cast_ref,
@@ -3942,6 +3947,46 @@ fn parse_for_each_battlefield_type(input: &str) -> OracleResult<'_, QuantityRef>
     ))
 }
 
+/// CR 613.4c + CR 604.3: Parse "[other] <type> on the battlefield with
+/// <keyword>" in a "for each" clause -> a battlefield-wide (any-controller)
+/// population count of permanents of the given type that have the named
+/// keyword, with an optional "other"/"another" exclusion of the source object.
+///
+/// "for each" sibling of `parse_number_of_type_on_battlefield_with_keyword`
+/// (the "the number of" form of the same CR 604.3 grammar) and of
+/// `parse_for_each_battlefield_type` (the keyword-less bare form, which this
+/// arm must precede — its shorter `tag(" on the battlefield")` would otherwise
+/// match first and strand " with <keyword>" as an unconsumed remainder).
+/// Backs dynamic P/T anthems such as Radiant, Archangel and Pride of the
+/// Clouds ("~ gets +1/+1 for each other creature on the battlefield with
+/// flying"). Generalized over every evergreen keyword via `parse_keyword_name`
+/// + `FilterProp::WithKeyword`, so it covers the whole class, not one card.
+fn parse_for_each_battlefield_type_with_keyword(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, has_other) =
+        opt(alt((value((), tag("other ")), value((), tag("another "))))).parse(input)?;
+    let (rest, tf) = parse_type_filter_word(rest)?;
+    let (rest, _) = tag(" on the battlefield with ").parse(rest)?;
+    let (rest, keyword_name) = parse_keyword_name(rest)?;
+    let keyword: Keyword = keyword_name.parse().unwrap();
+
+    let mut properties = Vec::new();
+    if has_other.is_some() {
+        properties.push(FilterProp::Another);
+    }
+    properties.push(FilterProp::WithKeyword { value: keyword });
+
+    Ok((
+        rest,
+        QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![tf],
+                controller: None,
+                properties,
+            }),
+        },
+    ))
+}
+
 fn parse_for_each_controlled_type(input: &str) -> OracleResult<'_, QuantityRef> {
     // CR 109.4: Only objects on the stack or on the battlefield have a
     // controller, so a "you control" count is over battlefield permanents
@@ -4325,6 +4370,54 @@ mod tests {
                     );
                 }
                 other => panic!("{text:?}: expected ObjectCount, got {other:?}"),
+            }
+        }
+    }
+
+    /// CR 613.4c + CR 604.3: "for each" sibling of
+    /// `parse_number_of_type_on_battlefield_with_keyword_global_count` — the
+    /// dynamic-pump grammar backing Radiant, Archangel / Pride of the Clouds
+    /// ("~ gets +1/+1 for each other creature on the battlefield with
+    /// flying"), generalized over the KEYWORDS table and the optional
+    /// "other"/"another" exclusion.
+    #[test]
+    fn parse_for_each_battlefield_type_with_keyword_global_count() {
+        for (clause, other, kw) in [
+            (
+                "other creature on the battlefield with flying",
+                true,
+                Keyword::Flying,
+            ),
+            (
+                "another creature on the battlefield with shadow",
+                true,
+                Keyword::Shadow,
+            ),
+            (
+                "creature on the battlefield with flying",
+                false,
+                Keyword::Flying,
+            ),
+        ] {
+            let (rest, q) = parse_for_each_clause_ref(clause).unwrap();
+            assert_eq!(rest, "", "{clause:?} should fully consume");
+            match q {
+                QuantityRef::ObjectCount {
+                    filter: TargetFilter::Typed(tf),
+                } => {
+                    assert_eq!(tf.controller, None, "{clause:?}: counts every controller");
+                    assert_eq!(
+                        tf.properties.contains(&FilterProp::Another),
+                        other,
+                        "{clause:?}: Another presence must match the other/another prefix"
+                    );
+                    assert!(
+                        tf.properties
+                            .contains(&FilterProp::WithKeyword { value: kw }),
+                        "{clause:?}: must gate on the named keyword"
+                    );
+                }
+                other => panic!("{clause:?}: expected ObjectCount, got {other:?}"),
             }
         }
     }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2941,10 +2941,10 @@ fn parse_for_each_clause_ref_with_they_controller(
         parse_for_each_attacking_controller_type,
         parse_for_each_blocking_source_type,
         parse_for_each_recipient_shared_quality,
-        // CR 613.4c + CR 604.3: "<type> on the battlefield with <keyword>" —
-        // must precede `parse_for_each_battlefield_type`, whose shorter
-        // " on the battlefield" tag would otherwise match first and strand
-        // " with <keyword>" as an unconsumed remainder.
+        // CR 604.1 + CR 611.3a + CR 613.4c: "<type> on the battlefield with
+        // <keyword>" — must precede `parse_for_each_battlefield_type`, whose
+        // shorter " on the battlefield" tag would otherwise match first and
+        // strand " with <keyword>" as an unconsumed remainder.
         parse_for_each_battlefield_type_with_keyword,
         parse_for_each_battlefield_type,
         parse_for_each_commander_cast_count,
@@ -3947,16 +3947,21 @@ fn parse_for_each_battlefield_type(input: &str) -> OracleResult<'_, QuantityRef>
     ))
 }
 
-/// CR 613.4c + CR 604.3: Parse "[other] <type> on the battlefield with
-/// <keyword>" in a "for each" clause -> a battlefield-wide (any-controller)
-/// population count of permanents of the given type that have the named
-/// keyword, with an optional "other"/"another" exclusion of the source object.
+/// CR 604.1 + CR 611.3a + CR 613.4c: Parse "[other] <type> on the
+/// battlefield with <keyword>" in a "for each" clause -> a battlefield-wide
+/// (any-controller) population count of permanents of the given type that
+/// have the named keyword, with an optional "other"/"another" exclusion of
+/// the source object. This is a static ability (CR 604.1) whose continuous
+/// effect isn't locked in — it applies at any given moment to whatever the
+/// count currently is (CR 611.3a) — as a layer 7c power/toughness
+/// modification (CR 613.4c), not a characteristic-defining ability.
 ///
 /// "for each" sibling of `parse_number_of_type_on_battlefield_with_keyword`
-/// (the "the number of" form of the same CR 604.3 grammar) and of
-/// `parse_for_each_battlefield_type` (the keyword-less bare form, which this
-/// arm must precede — its shorter `tag(" on the battlefield")` would otherwise
-/// match first and strand " with <keyword>" as an unconsumed remainder).
+/// (the "the number of" CR 604.3 CDA form of the same "on the battlefield
+/// with <keyword>" grammar) and of `parse_for_each_battlefield_type` (the
+/// keyword-less bare form, which this arm must precede — its shorter
+/// `tag(" on the battlefield")` would otherwise match first and strand
+/// " with <keyword>" as an unconsumed remainder).
 /// Backs dynamic P/T anthems such as Radiant, Archangel and Pride of the
 /// Clouds ("~ gets +1/+1 for each other creature on the battlefield with
 /// flying"). Generalized over every evergreen keyword via `parse_keyword_name`
@@ -4374,7 +4379,7 @@ mod tests {
         }
     }
 
-    /// CR 613.4c + CR 604.3: "for each" sibling of
+    /// CR 604.1 + CR 611.3a + CR 613.4c: "for each" sibling of
     /// `parse_number_of_type_on_battlefield_with_keyword_global_count` — the
     /// dynamic-pump grammar backing Radiant, Archangel / Pride of the Clouds
     /// ("~ gets +1/+1 for each other creature on the battlefield with

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22964,12 +22964,13 @@ fn static_self_and_enchanted_each_repeated_dynamic_pump() {
     assert!(counts_auras, "the other term must count Auras you control");
 }
 
-/// CR 613.4c + CR 604.3: Radiant, Archangel / Pride of the Clouds — "~ gets
-/// +1/+1 for each other creature on the battlefield with flying." The zone
-/// qualifier ("on the battlefield") and the keyword qualifier ("with flying")
-/// both trail the type word, a combination the "for each" grammar had no
-/// combinator for (only the "the number of ... on the battlefield with
-/// <keyword>" CDA form did); the dynamic pump previously failed to parse.
+/// CR 604.1 + CR 611.3a + CR 613.4c: Radiant, Archangel / Pride of the
+/// Clouds — "~ gets +1/+1 for each other creature on the battlefield with
+/// flying." The zone qualifier ("on the battlefield") and the keyword
+/// qualifier ("with flying") both trail the type word, a combination the
+/// "for each" grammar had no combinator for (only the "the number of ... on
+/// the battlefield with <keyword>" CR 604.3 CDA form did); the dynamic pump
+/// previously failed to parse.
 #[test]
 fn static_self_dynamic_pump_for_each_other_creature_on_battlefield_with_keyword() {
     let def =

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22963,3 +22963,48 @@ fn static_self_and_enchanted_each_repeated_dynamic_pump() {
     );
     assert!(counts_auras, "the other term must count Auras you control");
 }
+
+/// CR 613.4c + CR 604.3: Radiant, Archangel / Pride of the Clouds — "~ gets
+/// +1/+1 for each other creature on the battlefield with flying." The zone
+/// qualifier ("on the battlefield") and the keyword qualifier ("with flying")
+/// both trail the type word, a combination the "for each" grammar had no
+/// combinator for (only the "the number of ... on the battlefield with
+/// <keyword>" CDA form did); the dynamic pump previously failed to parse.
+#[test]
+fn static_self_dynamic_pump_for_each_other_creature_on_battlefield_with_keyword() {
+    let def =
+        parse_static_line("~ gets +1/+1 for each other creature on the battlefield with flying.")
+            .expect("Radiant, Archangel's dynamic pump must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(def.affected, Some(TargetFilter::SelfRef));
+
+    let expected = QuantityExpr::Ref {
+        qty: QuantityRef::ObjectCount {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: None,
+                properties: vec![
+                    FilterProp::Another,
+                    FilterProp::WithKeyword {
+                        value: Keyword::Flying,
+                    },
+                ],
+            }),
+        },
+    };
+
+    assert!(def.modifications.iter().any(
+        |m| matches!(m, ContinuousModification::AddDynamicPower { value } if value == &expected)
+    ));
+    assert!(def.modifications.iter().any(
+        |m| matches!(m, ContinuousModification::AddDynamicToughness { value } if value == &expected)
+    ));
+    assert!(
+        !def.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddPower { .. } | ContinuousModification::AddToughness { .. }
+        )),
+        "must not emit flat P/T modifications alongside dynamic ones: {:?}",
+        def.modifications
+    );
+}


### PR DESCRIPTION
## Problem (#5007)

Radiant, Archangel and Pride of the Clouds's static —

> This creature gets +1/+1 for each other creature on the battlefield with flying.

— failed to parse its dynamic pump. The for-each clause combines a zone
qualifier ("on the battlefield") with a trailing keyword qualifier ("with
flying"), and neither existing `oracle_nom` for-each combinator covers that
combination:

- `parse_for_each_battlefield_type` only handles the bare `<type> on the
  battlefield` form (no trailing predicate) — it matches the zone phrase
  and stops, stranding " with flying" as an unconsumed remainder.
- `parse_for_each_recipient_shared_quality` only handles a shared-quality
  clause after `on the battlefield ` ("... that shares a creature type with
  it") — a different predicate shape.

The sibling "the number of ..." CDA grammar already has this exact
combinator (`parse_number_of_type_on_battlefield_with_keyword`, backing
Dauthi Warlord's "the number of creatures on the battlefield with shadow"),
but the "for each" grammar never got its counterpart, so the quantity
clause never fully consumed and the whole dynamic pump was dropped.

## Fix (`oracle_nom/quantity.rs`)

- Add `parse_for_each_battlefield_type_with_keyword`, the "for each" sibling
  of `parse_number_of_type_on_battlefield_with_keyword`: `[other] <type> on
  the battlefield with <keyword>`, generalized over the full `KEYWORDS`
  table (not just flying) via `parse_keyword_name` + `FilterProp::WithKeyword`,
  with the optional "other"/"another" exclusion prefix mirrored from
  `parse_for_each_recipient_shared_quality`.
- Register it in the for-each combinator `alt()` immediately before
  `parse_for_each_battlefield_type`, since the bare arm's shorter
  `" on the battlefield"` tag would otherwise match first and strand the
  keyword clause.

## Result

Radiant, Archangel and Pride of the Clouds now parse to a continuous static
on `SelfRef` with dynamic `+1/+1` per other creature with flying on the
battlefield (any controller), matching CR 613.4c. The combinator covers the
whole class — any `<type> on the battlefield with <keyword>` for-each
clause, not just these two cards.

## Testing

- New nom-level regression test `parse_for_each_battlefield_type_with_keyword_global_count`
  (`oracle_nom/quantity.rs`), covering the keyword table generalization and
  the "other"/"another"/bare prefix variants.
- New end-to-end regression test
  `static_self_dynamic_pump_for_each_other_creature_on_battlefield_with_keyword`
  (`oracle_static/tests.rs`), mirroring the existing Alpha Status /
  Eidolon-style dynamic-pump regression tests.
- `cargo fmt -p engine --check` clean.
- `cargo check -p engine --lib --tests` and `cargo clippy -p engine --lib --tests -- -D warnings` both clean.

**Note:** this environment has no local MSVC/mingw linker available (verified: no
`link.exe`/`cl.exe` under any Visual Studio or Windows SDK install, and no
mingw `gcc` on PATH), so I could not link and run `cargo test`/`cargo
nextest` locally — only `cargo check`/`cargo clippy` (which don't invoke the
linker) were run. The new tests are written to the same conventions as the
existing passing suite and reuse only already-evaluated `FilterProp`/`QuantityRef`
shapes (`FilterProp::WithKeyword`, `FilterProp::Another`,
`QuantityRef::ObjectCount`), so risk is low, but please let CI's
`cargo nextest run` be the actual gate here.

Closes #5007