### PR TITLE
fix(parser): count only creature cards for Dread Summons' token repeat

### DIFF
--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1390,7 +1390,6 @@ mod tests {
         // way, you create a … token." The token count must restrict to CREATURE
         // cards moved this way (`FilteredTrackedSetSize`), not every card
         // (`TrackedSetSize`, which would create X tokens for X cards milled).
-        use crate::types::ability::TargetFilter;
         let txt = "Create a tapped 2/2 black Zombie creature token for each creature card put into a graveyard this way.";
         let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
             .expect("expected Token effect");

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -10,7 +10,7 @@ use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_nom::error::OracleResult;
 use crate::types::ability::{
     ContinuousModification, ControllerRef, Effect, FilterProp, ObjectScope, PtValue, QuantityExpr,
-    QuantityRef, StaticDefinition, TargetFilter,
+    QuantityRef, StaticDefinition, TargetFilter, TypeFilter,
 };
 use crate::types::card_type::Supertype;
 use crate::types::keywords::Keyword;
@@ -328,6 +328,23 @@ pub(crate) fn parse_token_description(text: &str) -> Option<TokenDescription> {
     parse_token_description_with_context(text, &ParseContext::default())
 }
 
+/// True iff a `for each … this way` count restricts to a specific card type
+/// (Dread Summons' "creature card"), so it should override the unfiltered
+/// `TrackedSetSize`. A bare/generic "card" filter (e.g. "card discarded this
+/// way") is not restrictive and keeps `TrackedSetSize`.
+fn tracked_set_count_is_type_restricted(qty: &QuantityRef) -> bool {
+    let QuantityRef::FilteredTrackedSetSize { filter, .. } = qty else {
+        return false;
+    };
+    let TargetFilter::Typed(typed) = filter.as_ref() else {
+        return false;
+    };
+    typed
+        .type_filters
+        .iter()
+        .any(|type_filter| !matches!(type_filter, TypeFilter::Card))
+}
+
 fn parse_token_description_with_context(
     text: &str,
     ctx: &ParseContext,
@@ -609,6 +626,18 @@ fn parse_token_description_with_context(
                     .ok()
                     .filter(|(rest, _)| rest.is_empty())
                     .map(|(_, qty)| QuantityExpr::Ref { qty })
+                    // CR 609.3 + CR 205.2a: a TYPE-restricted "for each <type> card
+                    // <verb> this way" (Dread Summons: "for each creature card put
+                    // into a graveyard this way") counts only the matching cards
+                    // moved this way — `FilteredTrackedSetSize` — not every card
+                    // moved (`TrackedSetSize`, which would create X tokens). Only a
+                    // restrictive type overrides; a bare/"card" filter keeps
+                    // `TrackedSetSize`.
+                    .or_else(|| {
+                        crate::parser::oracle_quantity::parse_for_each_clause(clause)
+                            .filter(tracked_set_count_is_type_restricted)
+                            .map(|qty| QuantityExpr::Ref { qty })
+                    })
                 })
                 .unwrap_or(QuantityExpr::Ref {
                     qty: QuantityRef::TrackedSetSize,
@@ -1352,6 +1381,34 @@ mod tests {
                 qty: QuantityRef::TrackedSetSize,
             },
             "bare 'card discarded this way' must keep TrackedSetSize"
+        );
+    }
+
+    #[test]
+    fn for_each_creature_card_this_way_counts_only_creatures() {
+        // #4746 Dread Summons: "For each creature card put into a graveyard this
+        // way, you create a … token." The token count must restrict to CREATURE
+        // cards moved this way (`FilteredTrackedSetSize`), not every card
+        // (`TrackedSetSize`, which would create X tokens for X cards milled).
+        use crate::types::ability::TargetFilter;
+        let txt = "Create a tapped 2/2 black Zombie creature token for each creature card put into a graveyard this way.";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("expected Token effect");
+        let Effect::Token { count, .. } = effect else {
+            panic!("expected Effect::Token, got {effect:?}");
+        };
+        let QuantityExpr::Ref {
+            qty: QuantityRef::FilteredTrackedSetSize { filter, .. },
+        } = &count
+        else {
+            panic!("expected FilteredTrackedSetSize (creature-restricted), got {count:?}");
+        };
+        assert!(
+            matches!(
+                filter.as_ref(),
+                TargetFilter::Typed(typed) if typed.type_filters == vec![TypeFilter::Creature]
+            ),
+            "count must restrict to creature cards milled, got {filter:?}"
         );
     }
 


### PR DESCRIPTION
Closes #4746.

## Problem

**Dread Summons** — "Each player mills X cards. **For each creature card** put into a graveyard this way, you create a tapped 2/2 black Zombie creature token." — created **X** tokens (one per *card* milled) instead of one per **creature** card milled.

The token's repeat count parsed to the **unfiltered `TrackedSetSize`** (every card moved this way = X), dropping the "creature" qualifier.

## Cause

In `oracle_effect/token.rs`, the "for each `<thing>` this way" token-count arm only routed the *distinct-card-types* shape (Occult Epiphany's "for each card type among cards … this way") to a filtered count; **every other form** — including "for each **creature** card … this way" — fell back to `TrackedSetSize`.

## Fix

Fall back to the shared `parse_for_each_clause` (which already restricts the tracked set by a leading type phrase → `FilteredTrackedSetSize`), and adopt its result **only when it restricts to a specific card type**. A bare/generic "card … this way" (e.g. "card discarded this way") stays `TrackedSetSize`, preserving existing behavior.

Verified:

| Clause | Token count |
|---|---|
| `for each creature card put into a graveyard this way` | `FilteredTrackedSetSize{Creature}` ✅ |
| `for each card put into a graveyard this way` (bare) | `TrackedSetSize` (unchanged) |
| `for each card discarded this way` (bare) | `TrackedSetSize` (unchanged) |
| `for each card type among cards discarded this way` (Occult Epiphany) | `DistinctCardTypes` (unchanged) |

## Tests

New `for_each_creature_card_this_way_counts_only_creatures`; the existing `bare_for_each_card_discarded_this_way_keeps_tracked_set_size` and Occult Epiphany tests still pass.

`cargo test -p engine --lib` → **14,676 passed / 0 failed**; `fmt --check`, `clippy -p engine --all-targets -- -D warnings`, and `check-parser-combinators.sh` all clean.

CR 609.3 + CR 205.2a.