### PR TITLE
fix(engine): Lost Mine of Phandelver room fidelity (Storeroom target, Fungi Cavern duration)

### DIFF
--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -203,15 +203,15 @@ pub fn room_effects(
             simple(treasure_token(), source_id, controller),
             vec![],
         ),
-        // 3: Storeroom — "Put a +1/+1 counter on target creature you control"
+        // 3: Storeroom — "Put a +1/+1 counter on target creature"
+        // (any creature; the Oracle text is unrestricted, matching the sibling
+        // counter-rooms Undercity "Forge" / "Throne of the Dead Three").
         (DungeonId::LostMineOfPhandelver, 3) => (
             simple(
                 Effect::PutCounter {
                     counter_type: CounterType::Plus1Plus1,
                     count: fixed(1),
-                    target: TargetFilter::Typed(
-                        TypedFilter::creature().controller(ControllerRef::You),
-                    ),
+                    target: TargetFilter::Typed(TypedFilter::creature()),
                 },
                 source_id,
                 controller,
@@ -237,7 +237,9 @@ pub fn room_effects(
             )));
             (lose, vec![])
         }
-        // 5: Fungi Cavern — "Target creature gets -4/-0 until end of turn"
+        // 5: Fungi Cavern — "Target creature gets -4/-0 until your next turn"
+        // CR 514.2 + CR 611.2a: the debuff persists until the *beginning* of the
+        // controller's next turn, not just end of turn.
         (DungeonId::LostMineOfPhandelver, 5) => (
             ResolvedAbility::new(
                 Effect::Pump {
@@ -249,7 +251,9 @@ pub fn room_effects(
                 source_id,
                 controller,
             )
-            .duration(Duration::UntilEndOfTurn),
+            .duration(Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            }),
             vec![],
         ),
         // 6: Temple of Dumathoin — "Draw a card"
@@ -1495,6 +1499,48 @@ mod tests {
         assert_eq!(next_rooms(DungeonId::LostMineOfPhandelver, 3), &[6]);
         // Temple of Dumathoin has 0 exits (bottommost)
         assert!(next_rooms(DungeonId::LostMineOfPhandelver, 6).is_empty());
+    }
+
+    /// Oracle fidelity: Lost Mine of Phandelver "Storeroom" is "Put a +1/+1
+    /// counter on target creature" — ANY creature, no controller restriction
+    /// (matching the sibling unrestricted counter-rooms). Revert-probe: the old
+    /// `.controller(You)` sets `tf.controller = Some(You)`.
+    #[test]
+    fn lost_mine_storeroom_targets_any_creature() {
+        let (ability, _) =
+            room_effects(DungeonId::LostMineOfPhandelver, 3, ObjectId(1), PlayerId(0));
+        match &ability.effect {
+            Effect::PutCounter {
+                target: TargetFilter::Typed(tf),
+                counter_type,
+                ..
+            } => {
+                assert_eq!(*counter_type, CounterType::Plus1Plus1);
+                assert!(
+                    tf.controller.is_none(),
+                    "Storeroom targets ANY creature (Oracle: 'target creature'), got controller {:?}",
+                    tf.controller
+                );
+            }
+            other => panic!("expected PutCounter, got {other:?}"),
+        }
+    }
+
+    /// Oracle fidelity: Lost Mine of Phandelver "Fungi Cavern" is "-4/-0 until
+    /// your next turn" (CR 514.2 + CR 611.2a) — the debuff persists to the
+    /// controller's next turn, not just end of turn. Revert-probe: the old
+    /// `Duration::UntilEndOfTurn`.
+    #[test]
+    fn lost_mine_fungi_cavern_lasts_until_your_next_turn() {
+        let (ability, _) =
+            room_effects(DungeonId::LostMineOfPhandelver, 5, ObjectId(1), PlayerId(0));
+        assert_eq!(
+            ability.duration,
+            Some(Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            }),
+            "Fungi Cavern's -4/-0 lasts until your next turn, not end of turn"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/lost_mine_fungi_cavern_duration_runtime.rs
+++ b/crates/engine/tests/lost_mine_fungi_cavern_duration_runtime.rs
@@ -1,0 +1,125 @@
+//! Runtime (engine-path) regression for Lost Mine of Phandelver "Fungi Cavern".
+//!
+//! Oracle: "Target creature gets -4/-0 until your next turn." The room used
+//! `Duration::UntilEndOfTurn`, ending the debuff a full turn early. This drives
+//! the venture pipeline and the REAL turn machinery to prove the -4/-0:
+//!   1. applies when the room resolves,
+//!   2. SURVIVES the controller's end-of-turn cleanup (into the opponent's
+//!      turn) — the discriminator vs the old until-end-of-turn behavior,
+//!   3. EXPIRES at the beginning of the controller's next turn.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+fn power_of(runner: &GameRunner, obj: ObjectId) -> Option<i32> {
+    runner.state().objects[&obj].power
+}
+
+/// Drive the REAL turn machinery until `turn_number` reaches `target_turn`
+/// (declaring no attackers/blockers, draining trigger ordering, no-op cleanup
+/// discards). Mirrors the cross-turn harness in
+/// `momir_token_firebreathing_duration.rs`.
+fn advance_to_turn(runner: &mut GameRunner, target_turn: u32) {
+    for _ in 0..400 {
+        if runner.state().turn_number >= target_turn {
+            return;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declaring no attackers must be accepted");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declaring no blockers must be accepted");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::DiscardChoice { .. } => {
+                runner
+                    .act(GameAction::SelectCards { cards: vec![] })
+                    .expect("no-op cleanup discard must be accepted");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            other => panic!("unexpected WaitingFor while advancing turns: {other:?}"),
+        }
+    }
+    panic!("failed to reach turn {target_turn}");
+}
+
+#[test]
+fn fungi_cavern_debuff_survives_end_of_turn_and_expires_next_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Libraries so neither player decks out while advancing across turns.
+    scenario.with_library_top(P0, &["L0a", "L0b", "L0c", "L0d", "L0e"]);
+    scenario.with_library_top(
+        engine::game::scenario::P1,
+        &["L1a", "L1b", "L1c", "L1d", "L1e"],
+    );
+    // The only creature (so Fungi Cavern auto-targets it): a 4/4 → 0/4 under -4/-0.
+    let creature = scenario.add_creature(P0, "Big Bear", 4, 4).id();
+    let mut runner = scenario.build();
+    let start_turn = runner.state().turn_number;
+
+    // Marker in Mine Tunnels (Lost Mine room 2 → [4 Dark Pool, 5 Fungi Cavern]).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::LostMineOfPhandelver);
+        prog.current_room = 2;
+    }
+
+    // Venture → choose Fungi Cavern (room 5); its -4/-0 ability auto-targets the
+    // only creature and goes on the stack. Resolve it.
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    runner
+        .act(GameAction::ChooseDungeonRoom { room_index: 5 })
+        .expect("choosing Fungi Cavern must succeed");
+    assert_eq!(runner.state().dungeon_progress[&P0].current_room, 5);
+    runner.resolve_top();
+
+    // -4/-0 applied: power 4 → 0.
+    assert_eq!(
+        power_of(&runner, creature),
+        Some(0),
+        "-4/-0 applies (4 - 4 = 0)"
+    );
+
+    // Survives the controller's own end-of-turn cleanup, into the opponent's
+    // turn. The old `Duration::UntilEndOfTurn` would restore the power to 4 here.
+    advance_to_turn(&mut runner, start_turn + 1);
+    assert_eq!(
+        power_of(&runner, creature),
+        Some(0),
+        "the -4/-0 persists through end of turn ('until your next turn')"
+    );
+
+    // Expires at the beginning of the controller's next turn.
+    advance_to_turn(&mut runner, start_turn + 2);
+    assert_eq!(
+        power_of(&runner, creature),
+        Some(4),
+        "the -4/-0 expires at the controller's next turn"
+    );
+}

--- a/crates/engine/tests/lost_mine_storeroom_targeting_runtime.rs
+++ b/crates/engine/tests/lost_mine_storeroom_targeting_runtime.rs
@@ -1,0 +1,68 @@
+//! Runtime (engine-path) regression for Lost Mine of Phandelver "Storeroom".
+//!
+//! Oracle: "Put a +1/+1 counter on target creature" — ANY creature. The room
+//! was wrongly restricted to "creature you control", so when the venturing
+//! player controlled no creatures the ability had no legal target (removed on
+//! resolution, CR 608.2b). This drives the venture pipeline with the controller
+//! controlling NO creatures and the opponent controlling one, and proves the
+//! opponent's creature is targeted and receives the counter — behavior the old
+//! restriction made impossible.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+#[test]
+fn lost_mine_storeroom_counters_opponent_creature_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // P0 (venturing) controls NO creatures; the opponent P1 controls one.
+    let opp = scenario.add_creature(P1, "Opponent Bear", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // Marker in Goblin Lair (Lost Mine room 1 → [3 Storeroom, 4 Dark Pool]).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::LostMineOfPhandelver);
+        prog.current_room = 1;
+    }
+
+    // Venture → branch → choose Storeroom (room 3).
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    runner
+        .act(GameAction::ChooseDungeonRoom { room_index: 3 })
+        .expect("choosing Storeroom must succeed");
+    assert_eq!(
+        runner.state().dungeon_progress[&P0].current_room,
+        3,
+        "venture must enter Storeroom (room 3)"
+    );
+
+    // "+1/+1 counter on target creature" auto-targets the only legal creature —
+    // the opponent's (the controller has none) — and is on the stack. Under the
+    // old "creature you control" restriction there is no legal target, so the
+    // ability is removed on resolution (CR 608.2b) and no counter is placed.
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "Storeroom's targeted ability must be on the stack with the opponent's creature chosen"
+    );
+    runner.resolve_top();
+
+    assert_eq!(
+        runner.state().objects[&opp]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "the opponent's creature must receive Storeroom's +1/+1 counter"
+    );
+}


### PR DESCRIPTION
## Summary

Two **Lost Mine of Phandelver** room effects in `dungeon.rs` diverged from the printed Oracle text. (Dungeon room text is hard-coded in `dungeon.rs` and has no card-data cross-check, so I verified both against Scryfall — quoted below.)

**Storeroom** — Oracle: *"Put a +1/+1 counter on target creature."*
The code restricted the target to `TypedFilter::creature().controller(You)` (creature *you control*). Fixed to any creature. Beyond forbidding the legal choice of an opponent's creature, the restriction made the room's triggered ability (CR 309.4c) find **no legal target** — removed on resolution (CR 608.2b) — when the venturing player controlled no creatures but an opponent did. This also matches the sibling unrestricted counter-rooms Undercity **Forge** and **Throne of the Dead Three**, which already use plain `TypedFilter::creature()`.

**Fungi Cavern** — Oracle: *"Target creature gets -4/-0 until your next turn."*
The code used `Duration::UntilEndOfTurn`, ending the debuff a full turn early. Fixed to `Duration::UntilNextTurnOf { Controller }` (CR 514.2 + CR 611.2a).

(Scryfall, Lost Mine of Phandelver: `Storeroom — Put a +1/+1 counter on target creature.` / `Fungi Cavern — Target creature gets -4/-0 until your next turn.`)

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` — explain why below

> Two one-line Oracle-fidelity corrections to a hard-coded room-effect table (a target-filter and a duration), plus AST tests. No new pattern/variant. A `/review-impl` self-check was run.

## CR references

- `CR 309.4c` — a room's triggered ability. `CR 608.2b` — a spell/ability with no legal targets is removed on resolution.
- `CR 514.2` + `CR 611.2a` — "until your next turn" duration (Fungi Cavern).

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --lib` — clean (0 warnings).
- `cargo test -p engine --lib dungeon::tests` — passes, incl. two new AST tests: `lost_mine_storeroom_targets_any_creature` (asserts `tf.controller.is_none()`) and `lost_mine_fungi_cavern_lasts_until_your_next_turn` (asserts `UntilNextTurnOf { Controller }`). Each directly asserts the corrected AST field, so reverting either fix flips its assertion (the old values were `Some(You)` / `UntilEndOfTurn`).