### PR TITLE
fix(engine): implement Dungeon of the Mad Mage "Lost Level" as Scry 2 (was a wrong stub)

### DIFF
--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -320,14 +320,12 @@ pub fn room_effects(
             });
             (ability, vec![])
         }
-        // 4: Lost Level — "Destroy target creature of an opponent's choice"
+        // 4: Lost Level — "Scry 2"
         (DungeonId::DungeonOfTheMadMage, 4) => (
             simple(
-                Effect::Unimplemented {
-                    name: "Room: Lost Level".to_string(),
-                    description: Some(
-                        "Destroy target creature of an opponent's choice".to_string(),
-                    ),
+                Effect::Scry {
+                    count: fixed(2),
+                    target: TargetFilter::Controller,
                 },
                 source_id,
                 controller,
@@ -1541,6 +1539,23 @@ mod tests {
             }),
             "Fungi Cavern's -4/-0 lasts until your next turn, not end of turn"
         );
+    }
+
+    /// Oracle fidelity: Dungeon of the Mad Mage "Lost Level" is "Scry 2". It was
+    /// stubbed as `Effect::Unimplemented` with fabricated text ("Destroy target
+    /// creature of an opponent's choice"), so venturing into it did nothing.
+    /// Revert-probe: the old stub is not `Effect::Scry`.
+    #[test]
+    fn mad_mage_lost_level_is_scry_two() {
+        let (ability, _) =
+            room_effects(DungeonId::DungeonOfTheMadMage, 4, ObjectId(1), PlayerId(0));
+        match &ability.effect {
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 2 },
+                target: TargetFilter::Controller,
+            } => {}
+            other => panic!("expected 'Scry 2' targeting the controller, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/tests/mad_mage_lost_level_scry_runtime.rs
+++ b/crates/engine/tests/mad_mage_lost_level_scry_runtime.rs
@@ -1,0 +1,59 @@
+//! Runtime (engine-path) regression for Dungeon of the Mad Mage "Lost Level".
+//!
+//! The room was stubbed as `Effect::Unimplemented`, so venturing into it did
+//! nothing. Its real Oracle effect is "Scry 2". This drives the actual venture
+//! pipeline: with the marker in Goblin Bazaar (room 2 → [4] Lost Level), a
+//! venture advances into Lost Level, its room ability goes on the stack, and
+//! resolving it produces a Scry over the top TWO library cards
+//! (`WaitingFor::ScryChoice`). On the old stub no scry happens and the match
+//! below fails — so this discriminates the real game behavior, not just the AST.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+#[test]
+fn mad_mage_lost_level_scries_two_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A library to scry (needs at least 2 cards).
+    scenario.with_library_top(P0, &["Top A", "Top B", "Top C"]);
+    let mut runner = scenario.build();
+
+    // Marker already in Mad Mage at Goblin Bazaar (room 2 → [4] Lost Level).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::DungeonOfTheMadMage);
+        prog.current_room = 2;
+    }
+
+    // Venture: advance into Lost Level (room 4); its Scry 2 ability goes on the stack.
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    assert_eq!(
+        runner.state().dungeon_progress[&P0].current_room,
+        4,
+        "venture must advance the marker into Lost Level (room 4)"
+    );
+
+    // Resolve the room ability — a real Scry 2 asks the controller to arrange the
+    // top TWO cards of their library.
+    runner.resolve_top();
+    match &runner.state().waiting_for {
+        WaitingFor::ScryChoice { player, cards } => {
+            assert_eq!(*player, P0, "the venturing player scries");
+            assert_eq!(
+                cards.len(),
+                2,
+                "Lost Level scries 2 (the old Unimplemented stub scried nothing)"
+            );
+        }
+        other => panic!("expected a Scry-2 ScryChoice after resolving Lost Level, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

The **"Lost Level"** room of Dungeon of the Mad Mage (room 4) was stubbed as `Effect::Unimplemented` with **fabricated** text â€” `"Destroy target creature of an opponent's choice"` â€” so venturing into it did nothing.

The printed Oracle text is simply **"Scry 2"** (Scryfall, Dungeon of the Mad Mage: `Lost Level â€” Scry 2.`), a fully-supported effect. This implements it as `Effect::Scry { count: 2, target: Controller }`, mirroring the Scry rooms already coded correctly in the same table (this dungeon's "Dungeon Level", Lost Mine's "Cave Entrance").

Dungeon room text is hard-coded in `dungeon.rs` with no card-data cross-check, hence the Scryfall citation.

## Implementation method (required)

- [ ] Produced via the `/engine-implementer` pipeline
- [x] **Not** `/engine-implementer` â€” explain why below

> Replaces a single wrong `Effect::Unimplemented` stub with the correct existing `Effect::Scry` (no new pattern/variant), plus an AST test. A `/review-impl` self-check was run.

## CR references

- `CR 309.4c` â€” a room's triggered ability. `CR 701.22` â€” Scry. (Effect itself is already implemented; this is a fidelity/coverage fix.)

## Verification

Tilt not running in this environment; toolchain used directly.

- `cargo fmt --all` â€” clean.
- `cargo clippy -p engine --lib` â€” clean (0 warnings).
- `cargo test -p engine --lib dungeon::tests` â€” passes, incl. new `mad_mage_lost_level_is_scry_two` asserting the room resolves to `Effect::Scry { count: Fixed(2), target: Controller }`. Revert-probe: the old `Effect::Unimplemented` stub fails the match.