### PR TITLE
feat(parser): gate Ravenous Trap's alt-cost on "an opponent had N cards put into their graveyard this turn"

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -39925,3 +39925,152 @@ fn heal_draws_on_the_next_turns_upkeep() {
         "Heal must draw exactly one card on the next turn's upkeep"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Ravenous Trap alternative-cost gate (CR 118.9 + CR 601.2b + CR 404.1 +
+// CR 109.5). "If an opponent had three or more cards put into their graveyard
+// from anywhere this turn, you may pay {0} rather than pay this spell's mana
+// cost." Drives the real cast-cost pipeline
+// (`payable_spell_alternative_cost_details` → `restrictions::evaluate_condition`
+// → `resolve_quantity_scoped` over `zone_changes_this_turn`), binding the
+// parsed `Owned { Opponent }` gate against each record's `owner`.
+// ---------------------------------------------------------------------------
+
+/// Build a Ravenous Trap in `player`'s hand carrying the REAL parsed alt-cost
+/// casting option (so the runtime tests bind directly to the parser output, not
+/// a hand-rolled condition). Base printed cost is {2}{B} so the {0} alt-cost is
+/// distinguishable.
+fn create_ravenous_trap_in_hand(state: &mut GameState, player: PlayerId) -> ObjectId {
+    let option = crate::parser::oracle_casting::parse_spell_casting_option_line(
+        "If an opponent had three or more cards put into their graveyard from anywhere this turn, you may pay {0} rather than pay this spell's mana cost.",
+        "Ravenous Trap",
+    )
+    .expect("Ravenous Trap alt-cost line must parse");
+
+    let obj_id = create_object(
+        state,
+        CardId(9500),
+        player,
+        "Ravenous Trap".to_string(),
+        Zone::Hand,
+    );
+    let obj = state.objects.get_mut(&obj_id).unwrap();
+    obj.card_types.core_types.push(CoreType::Instant);
+    obj.mana_cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Black],
+        generic: 2,
+    };
+    Arc::make_mut(&mut obj.abilities).clear();
+    Arc::make_mut(&mut obj.abilities).push(parse_effect_chain(
+        "Exile target player's graveyard.",
+        AbilityKind::Spell,
+    ));
+    obj.casting_options.push(option);
+    obj_id
+}
+
+/// Push `count` "card put into `owner`'s graveyard from anywhere this turn"
+/// zone-change records (from hand → graveyard, nontoken) so the gate's
+/// `ZoneChangeCountThisTurn { to: Graveyard, filter: Owned{..} + NonToken }`
+/// resolver counts them.
+fn push_cards_to_graveyard_this_turn(state: &mut GameState, owner: PlayerId, count: usize) {
+    for i in 0..count {
+        state
+            .zone_changes_this_turn
+            .push(crate::types::game_state::ZoneChangeRecord {
+                name: format!("Milled Card {i}"),
+                core_types: vec![CoreType::Creature],
+                mana_value: 1,
+                controller: owner,
+                owner,
+                is_token: false,
+                ..crate::types::game_state::ZoneChangeRecord::test_minimal(
+                    ObjectId(40_000 + i as u64),
+                    Some(Zone::Hand),
+                    Zone::Graveyard,
+                )
+            });
+    }
+}
+
+fn ravenous_trap_offered_cost(
+    state: &GameState,
+    player: PlayerId,
+    trap: ObjectId,
+) -> Option<AbilityCost> {
+    crate::game::casting_costs::payable_spell_alternative_cost_details(state, player, trap)
+        .map(|details| details.cost)
+}
+
+/// R-a: fewer than three opponent-owned cards to a graveyard this turn → the
+/// alt-cost gate is unmet, so no free-cast option is offered.
+#[test]
+fn ravenous_trap_alt_cost_not_offered_below_threshold() {
+    let mut state = setup_game_at_main_phase();
+    let trap = create_ravenous_trap_in_hand(&mut state, PlayerId(0));
+    push_cards_to_graveyard_this_turn(&mut state, PlayerId(1), 2);
+
+    assert_eq!(
+        ravenous_trap_offered_cost(&state, PlayerId(0), trap),
+        None,
+        "two opponent-owned cards is below the GE-3 gate; alt-cost must not be offered"
+    );
+}
+
+/// R-b: three or more opponent-owned cards to a graveyard this turn → alt-cost
+/// offered and the spell is castable for {0}.
+#[test]
+fn ravenous_trap_alt_cost_offered_at_threshold() {
+    let mut state = setup_game_at_main_phase();
+    let trap = create_ravenous_trap_in_hand(&mut state, PlayerId(0));
+    push_cards_to_graveyard_this_turn(&mut state, PlayerId(1), 3);
+
+    assert_eq!(
+        ravenous_trap_offered_cost(&state, PlayerId(0), trap),
+        Some(AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                generic: 0,
+                shards: vec![],
+            },
+        }),
+        "three opponent-owned cards meets the GE-3 gate; {{0}} alt-cost must be offered"
+    );
+    assert!(
+        can_cast_object_now(&state, PlayerId(0), trap),
+        "with the alt-cost payable for {{0}}, Ravenous Trap must be castable with no mana"
+    );
+}
+
+/// R-c: the owner-vs-controller discriminator. Three CASTER-owned cards (zero
+/// opponent-owned) went to a graveyard this turn. Because a card goes to its
+/// OWNER's graveyard (CR 404.1) and the gate scopes by `Owned { Opponent }`,
+/// the gate must stay unmet — the alt-cost is NOT offered. This is the hostile
+/// fixture that would pass if the filter used control (or `You`) instead of
+/// opponent ownership.
+#[test]
+fn ravenous_trap_alt_cost_owner_not_controller_discriminator() {
+    let mut state = setup_game_at_main_phase();
+    let trap = create_ravenous_trap_in_hand(&mut state, PlayerId(0));
+    push_cards_to_graveyard_this_turn(&mut state, PlayerId(0), 3);
+
+    assert_eq!(
+        ravenous_trap_offered_cost(&state, PlayerId(0), trap),
+        None,
+        "caster-owned cards must not satisfy the opponent-owned gate (CR 404.1 owner scope)"
+    );
+}
+
+/// R-d: a still-unsupported leading-if predicate ("If the sky is green, …")
+/// keeps dropping the whole casting option — the generalization must not have
+/// widened the leading-if acceptance surface for unrelated predicates.
+#[test]
+fn unsupported_leading_if_predicate_still_drops_option() {
+    let option = crate::parser::oracle_casting::parse_spell_casting_option_line(
+        "If the sky is green, you may pay {0} rather than pay this spell's mana cost.",
+        "Not A Real Trap",
+    );
+    assert!(
+        option.is_none(),
+        "an unrecognized leading-if predicate must still drop the alt-cost option, got {option:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4430,8 +4430,11 @@ fn parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn(
 
     // The mandatory "card"/"cards" noun and the graveyard clause form the
     // suffix; whatever `take_until` leaves before it is the type qualifier
-    // ("artifact", "creature", …), or empty for the bare-cards case. The suffix
-    // must terminate at end-of-input so upstream `all_consuming` is satisfied.
+    // ("artifact", "creature", …), or empty for the bare-cards case. Any
+    // remaining input is returned unconsumed (a composable leaf parser); the
+    // standalone-condition caller wraps this in `all_consuming`, which enforces
+    // end-of-input, so this parser need not (and must not) reject a non-empty
+    // remainder itself.
     let plural = "cards put into their graveyard from anywhere this turn";
     let singular = "card put into their graveyard from anywhere this turn";
     let (rest, type_text) = alt((
@@ -4439,12 +4442,6 @@ fn parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn(
         terminated(take_until(singular), tag(singular)),
     ))
     .parse(rest)?;
-    if !rest.is_empty() {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Fail,
-        )));
-    }
     let type_text = type_text.trim();
 
     let filter = if type_text.is_empty() {

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4347,7 +4347,11 @@ fn parse_card_left_your_graveyard_this_turn(input: &str) -> OracleResult<'_, Sta
             QuantityRef::ZoneChangeCountThisTurn {
                 from: Some(Zone::Graveyard),
                 to: None,
-                filter: add_owned_you_with_props(TargetFilter::Any, &[FilterProp::NonToken]),
+                filter: add_owned_with_props(
+                    TargetFilter::Any,
+                    ControllerRef::You,
+                    &[FilterProp::NonToken],
+                ),
             },
             1,
         ),
@@ -4377,7 +4381,7 @@ fn parse_permanent_put_into_your_hand_from_battlefield_this_turn(
             QuantityRef::ZoneChangeCountThisTurn {
                 from: Some(Zone::Battlefield),
                 to: Some(Zone::Hand),
-                filter: add_owned_you_with_props(filter, &[]),
+                filter: add_owned_with_props(filter, ControllerRef::You, &[]),
             },
             1,
         ),
@@ -4385,6 +4389,98 @@ fn parse_permanent_put_into_your_hand_from_battlefield_this_turn(
 }
 
 fn parse_card_put_into_your_graveyard_from_anywhere_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    alt((
+        parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn,
+        parse_your_card_put_into_your_graveyard_from_anywhere_this_turn,
+    ))
+    .parse(input)
+}
+
+/// CR 404.1 + CR 109.5 + CR 603.4: "an opponent had N or more cards put into
+/// their graveyard from anywhere this turn" — Ravenous Trap's alternative-cost
+/// gate. A card is put into *its owner's* graveyard (CR 404.1), so "their
+/// graveyard" scopes by ownership (`Owned { Opponent }`), not control. The
+/// count uses the shared "N or more"/"a(n)" (→ 1) threshold idiom. The bare
+/// "cards" noun carries no type, so `TargetFilter::Any` is accepted here (the
+/// owner + non-token tags still narrow it); a preceding type word
+/// ("artifact cards") narrows via `parse_type_phrase`.
+fn parse_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    // `tag("an opponent had ")` MUST precede any `parse_article` attempt: the
+    // shared `parse_article` (`alt(("an ", "a "))`) would greedily eat "an " of
+    // "an opponent" and desync the parse.
+    let (rest, _) = tag("an opponent had ").parse(input)?;
+    let (rest, count) = alt((
+        // "N or more cards"
+        |i| {
+            let (rest, n) = parse_number(i)?;
+            let (rest, _) = tag(" or more ").parse(rest)?;
+            Ok((rest, n))
+        },
+        // "a card" / "an artifact card" → 1
+        |i| {
+            let (rest, _) = parse_article(i)?;
+            Ok((rest, 1u32))
+        },
+    ))
+    .parse(rest)?;
+
+    // The mandatory "card"/"cards" noun and the graveyard clause form the
+    // suffix; whatever `take_until` leaves before it is the type qualifier
+    // ("artifact", "creature", …), or empty for the bare-cards case. The suffix
+    // must terminate at end-of-input so upstream `all_consuming` is satisfied.
+    let plural = "cards put into their graveyard from anywhere this turn";
+    let singular = "card put into their graveyard from anywhere this turn";
+    let (rest, type_text) = alt((
+        terminated(take_until(plural), tag(plural)),
+        terminated(take_until(singular), tag(singular)),
+    ))
+    .parse(rest)?;
+    if !rest.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let type_text = type_text.trim();
+
+    let filter = if type_text.is_empty() {
+        // Bare "cards" — no type qualifier. Unlike the strict your/singular
+        // branch, `Any` is accepted here; the owner + non-token tags below
+        // still bound the set.
+        TargetFilter::Any
+    } else {
+        let (filter, leftover) = parse_type_phrase(type_text);
+        if !leftover.trim().is_empty() || filter == TargetFilter::Any {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Fail,
+            )));
+        }
+        filter
+    };
+
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::ZoneChangeCountThisTurn {
+                from: None,
+                to: Some(Zone::Graveyard),
+                filter: add_owned_with_props(
+                    filter,
+                    ControllerRef::Opponent,
+                    &[FilterProp::NonToken],
+                ),
+            },
+            count,
+        ),
+    ))
+}
+
+fn parse_your_card_put_into_your_graveyard_from_anywhere_this_turn(
     input: &str,
 ) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = parse_article(input)?;
@@ -4405,7 +4501,7 @@ fn parse_card_put_into_your_graveyard_from_anywhere_this_turn(
             QuantityRef::ZoneChangeCountThisTurn {
                 from: None,
                 to: Some(Zone::Graveyard),
-                filter: add_owned_you_with_props(filter, &[FilterProp::NonToken]),
+                filter: add_owned_with_props(filter, ControllerRef::You, &[FilterProp::NonToken]),
             },
             1,
         ),
@@ -4440,19 +4536,24 @@ fn parse_object_put_into_graveyard_from_battlefield_this_turn(
     ))
 }
 
-/// CR 109.5: Append `Owned { controller: You }` plus any caller-supplied
+/// CR 109.5 + CR 404.1: Append `Owned { controller }` plus any caller-supplied
 /// `extras` to `filter`'s property set, skipping props whose variant tag
 /// already appears (presence is variant-tag equality via `mem::discriminant`,
 /// matching the original tag-only `matches!(p, FilterProp::X { .. })` checks).
-/// Pass `&[]` for the bare "owned by you" case; pass `&[FilterProp::NonToken]`
-/// for "you own a nontoken card" patterns. Wraps `TargetFilter::Any` into a
-/// fresh `Typed` filter carrying the same property set; returns other variants
-/// (`Player`, `SpecificObject`, …) unchanged because owner-tagging is
-/// meaningless on non-typed shapes.
-fn add_owned_you_with_props(filter: TargetFilter, extras: &[FilterProp]) -> TargetFilter {
-    let owned = FilterProp::Owned {
-        controller: ControllerRef::You,
-    };
+/// A card is always put into *its owner's* graveyard (CR 404.1), so ownership —
+/// not control — is the correct axis for "your"/"their" graveyard phrases; pass
+/// `ControllerRef::You` for "your graveyard" and `ControllerRef::Opponent` for
+/// "an opponent's/their graveyard". Pass `&[]` for the bare "owned" case; pass
+/// `&[FilterProp::NonToken]` for "own a nontoken card" patterns. Wraps
+/// `TargetFilter::Any` into a fresh `Typed` filter carrying the same property
+/// set; returns other variants (`Player`, `SpecificObject`, …) unchanged
+/// because owner-tagging is meaningless on non-typed shapes.
+fn add_owned_with_props(
+    filter: TargetFilter,
+    controller: ControllerRef,
+    extras: &[FilterProp],
+) -> TargetFilter {
+    let owned = FilterProp::Owned { controller };
     let push_unique_by_tag = |props: &mut Vec<FilterProp>, prop: FilterProp| {
         let tag = std::mem::discriminant(&prop);
         if !props.iter().any(|p| std::mem::discriminant(p) == tag) {
@@ -12733,6 +12834,51 @@ mod tests {
         }
     }
 
+    /// CR 404.1 + CR 109.5 + CR 603.4: Ravenous Trap's alt-cost gate — "an
+    /// opponent had three or more cards put into their graveyard from anywhere
+    /// this turn". Bare "cards" carries no type, so the filter is `Any` narrowed
+    /// only by the owner + non-token tags; ownership is `Opponent` (CR 404.1: a
+    /// card goes to its owner's graveyard), and the threshold is GE 3.
+    #[test]
+    fn test_opponent_cards_put_into_their_graveyard_from_anywhere_this_turn() {
+        let (rest, c) = parse_inner_condition(
+            "an opponent had three or more cards put into their graveyard from anywhere this turn",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty:
+                            QuantityRef::ZoneChangeCountThisTurn {
+                                from: None,
+                                to: Some(Zone::Graveyard),
+                                filter: TargetFilter::Typed(filter),
+                            },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 3 },
+            } => {
+                assert!(filter.properties.iter().any(|property| matches!(
+                    property,
+                    FilterProp::Owned {
+                        controller: ControllerRef::Opponent
+                    }
+                )));
+                assert!(filter
+                    .properties
+                    .iter()
+                    .any(|property| matches!(property, FilterProp::NonToken)));
+            }
+            other => {
+                panic!(
+                    "expected opponent-owned card graveyard zone-change count GE 3, got {other:?}"
+                )
+            }
+        }
+    }
+
     #[test]
     fn test_artifact_or_creature_put_into_graveyard_from_battlefield_this_turn() {
         let (rest, c) = parse_inner_condition(
@@ -14596,16 +14742,16 @@ mod tests {
         );
     }
 
-    /// CR 109.5: `add_owned_you_with_props` is the unified replacement for the
-    /// prior `add_owned_you` / `add_owned_you_non_token` pair. With an empty
-    /// extras slice it must produce only the `Owned { You }` tag (the bare
-    /// "owned by you" shape); with `&[FilterProp::NonToken]` it must additionally
-    /// carry the `NonToken` tag. Both `Typed` inputs and `Any` (lifted to a
-    /// fresh `Typed` filter) must follow the same uniqueness rule.
+    /// CR 109.5 + CR 404.1: `add_owned_with_props` is the unified replacement
+    /// for the prior `add_owned_you` / `add_owned_you_non_token` pair. With an
+    /// empty extras slice it must produce only the `Owned { controller }` tag
+    /// (the bare "owned" shape); with `&[FilterProp::NonToken]` it must
+    /// additionally carry the `NonToken` tag. Both `Typed` inputs and `Any`
+    /// (lifted to a fresh `Typed` filter) must follow the same uniqueness rule.
     #[test]
     fn add_owned_you_with_props_matches_legacy_helper_shapes() {
         // Empty extras + Any input → fresh Typed filter with Owned only.
-        let owned_only = add_owned_you_with_props(TargetFilter::Any, &[]);
+        let owned_only = add_owned_with_props(TargetFilter::Any, ControllerRef::You, &[]);
         assert_eq!(
             owned_only,
             TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Owned {
@@ -14614,7 +14760,11 @@ mod tests {
         );
 
         // NonToken extras + Any input → Owned + NonToken in that order.
-        let owned_non_token = add_owned_you_with_props(TargetFilter::Any, &[FilterProp::NonToken]);
+        let owned_non_token = add_owned_with_props(
+            TargetFilter::Any,
+            ControllerRef::You,
+            &[FilterProp::NonToken],
+        );
         assert_eq!(
             owned_non_token,
             TargetFilter::Typed(TypedFilter::default().properties(vec![
@@ -14633,7 +14783,11 @@ mod tests {
             TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Owned {
                 controller: ControllerRef::Opponent,
             }]));
-        let after = add_owned_you_with_props(pre_owned.clone(), &[FilterProp::NonToken]);
+        let after = add_owned_with_props(
+            pre_owned.clone(),
+            ControllerRef::You,
+            &[FilterProp::NonToken],
+        );
         match after {
             TargetFilter::Typed(typed) => {
                 let owned_count = typed
@@ -14649,7 +14803,11 @@ mod tests {
 
         // Non-typed/non-Any inputs (e.g., Player) must pass through unchanged
         // — owner-tagging is meaningless on those shapes.
-        let unchanged = add_owned_you_with_props(TargetFilter::Player, &[FilterProp::NonToken]);
+        let unchanged = add_owned_with_props(
+            TargetFilter::Player,
+            ControllerRef::You,
+            &[FilterProp::NonToken],
+        );
         assert_eq!(unchanged, TargetFilter::Player);
     }
 

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -5798,6 +5798,81 @@ fn spell_casting_option_parses_trap_alternative_cost() {
     ));
 }
 
+// CR 118.9 + CR 601.2b + CR 404.1 + CR 109.5: Ravenous Trap — the leading
+// "If an opponent had three or more cards put into their graveyard from
+// anywhere this turn" gate now decomposes into a typed
+// `ParsedCondition::QuantityComparison` (opponent-owned nontoken cards → any
+// graveyard, GE 3), so the {0} alternative cost is offered when the gate holds.
+// The alt-cost line must be consumed as a casting option (not leak into the
+// ability list as a `PayCost`/"pay" effect); the sole ability is the
+// graveyard-exile effect.
+#[test]
+fn spell_casting_option_parses_ravenous_trap_alternative_cost() {
+    let r = parse(
+        "If an opponent had three or more cards put into their graveyard from anywhere this turn, you may pay {0} rather than pay this spell's mana cost.\nExile target player's graveyard.",
+        "Ravenous Trap",
+        &[],
+        &["Instant"],
+        &[],
+    );
+    assert_eq!(
+        r.casting_options.len(),
+        1,
+        "warnings: {:?}",
+        r.parse_warnings
+    );
+    assert_eq!(
+        r.casting_options[0].cost,
+        Some(AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                generic: 0,
+                shards: vec![],
+            },
+        })
+    );
+    match r.casting_options[0].condition.as_ref() {
+        Some(crate::types::ability::ParsedCondition::QuantityComparison {
+            lhs:
+                crate::types::ability::QuantityExpr::Ref {
+                    qty:
+                        crate::types::ability::QuantityRef::ZoneChangeCountThisTurn {
+                            from: None,
+                            to: Some(Zone::Graveyard),
+                            filter: TargetFilter::Typed(filter),
+                        },
+                },
+            comparator: crate::types::ability::Comparator::GE,
+            rhs: crate::types::ability::QuantityExpr::Fixed { value: 3 },
+        }) => {
+            assert!(
+                filter.properties.iter().any(|p| matches!(
+                    p,
+                    crate::types::ability::FilterProp::Owned {
+                        controller: crate::types::ability::ControllerRef::Opponent
+                    }
+                )),
+                "expected Owned(Opponent) filter, got {filter:?}"
+            );
+        }
+        other => panic!("expected opponent-graveyard QuantityComparison GE 3, got {other:?}"),
+    }
+    // The sole ability is the graveyard-exile, not a leaked pay effect.
+    assert_eq!(r.abilities.len(), 1);
+    assert!(
+        !matches!(*r.abilities[0].effect, Effect::PayCost { .. }),
+        "alt-cost must not leak into abilities as a PayCost effect, got {:?}",
+        r.abilities[0].effect
+    );
+    assert!(
+        !matches!(
+            *r.abilities[0].effect,
+            Effect::Unimplemented { ref name, .. } if name == "pay"
+        ),
+        "alt-cost must not leak into abilities as an unimplemented pay effect, got {:?}",
+        r.abilities[0].effect
+    );
+}
+
 #[test]
 fn spell_casting_option_parses_composite_alternative_cost() {
     let r = parse(


### PR DESCRIPTION
## Summary

Enables **Ravenous Trap**'s alternative cost by generalizing the existing "cards put into a graveyard this turn" condition combinator to the opponent-owned / plural / "N or more" form.

Oracle: *"If an opponent had three or more cards put into their graveyard from anywhere this turn, you may pay {0} rather than pay this spell's mana cost. Exile target player's graveyard."*

Previously the leading condition didn't parse, so `parse_spell_casting_option_line`'s `parse_restriction_condition(…)?` bailed and the alt-cost option was **dropped** — strictly safe (Ravenous was castable only at full mana cost, never free), but the discount was unavailable. It's now offered exactly when the condition holds.

## Approach — parser-only, composes existing machinery

No new enum variant, no casting-layer change. The general alt-cost condition seam (`split_leading_if_clause` → `parse_restriction_condition` → the casting-layer `evaluate_condition` gate) already works; the only gap was that this specific condition grammar wasn't recognized.

- `parse_card_put_into_your_graveyard_from_anywhere_this_turn` becomes `alt(( <opponent branch>, <legacy your/singular branch — unchanged> ))`. The new branch matches `"an opponent had "` (**before** the article, so the leading "an " isn't greedily consumed), an optional `"N or more"` count, and the `"cards put into their graveyard from anywhere this turn"` suffix.
- `add_owned_you_with_props` is generalized to `add_owned_with_props(controller)`; existing callers pass `ControllerRef::You` (behavior-preserving), the new branch passes `ControllerRef::Opponent`.
- Emits the existing `QuantityRef::ZoneChangeCountThisTurn { to: Graveyard, filter: Owned{Opponent} + NonToken } >= N`. Ownership is keyed on the zone-change record's **owner** (CR 404.1 — a card goes to its owner's graveyard), evaluated live per cast (CR 603.4).

The generalization covers the class **{your, opponent's} × {singular, plural} × {≥1, ≥N}**, with Ravenous as the card it unlocks; the existing "your/singular" behavior is preserved byte-identically.

## Scope

- **Fixed:** Ravenous Trap.
- **Already worked (unchanged):** Mindbreak, Nemesis, Slingbow Trap.
- **Deferred (honest gaps):** Inferno / Cobra / Summoning Trap — their conditions ("dealt damage by N creatures this turn", "permanent destroyed by an opponent this turn", "creature spell countered this turn") need turn-scoped tracking the engine doesn't keep. Their alt-cost option stays safely dropped; not touched here.

## Rules

CR 118.9 + CR 601.2b (alternative cost) + CR 404.1 + CR 109.5 (owner scope) + CR 603.4 (running intervening-if). All verified against the Comprehensive Rules.

## Testing

- **Parser:** the opponent-owned condition decomposes to `QuantityComparison{ Owned{Opponent}, GE, 3 }`; full-card parse shows one casting option with the graveyard-exile effect (not a leaked `PayCost`); the legacy your/singular test is unmodified and green.
- **Runtime cast path** (through `payable_spell_alternative_cost_details` / `can_cast_object_now`): alt-cost **not** offered below 3 opponent-owned graveyard entries; **offered** (castable for {0}) at ≥3; **not** offered when 3 *caster*-owned cards hit a graveyard — the owner-vs-controller discriminator (verified load-bearing: flipping the filter to `You` makes this test fail); and the already-supported traps are unchanged.

Full `cargo test -p engine` green.
