### PR TITLE
feat(parser): supertype-defining statics "[subject] is/are [no longer] [supertype]" (Leyline of Singularity, Melting)

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -1223,6 +1223,16 @@ pub(crate) fn parse_static_line_inner(
         return Some(def);
     }
 
+    // CR 205.4b + CR 613.1d (Layer 4): "[subject] is/are [no longer] [supertype]"
+    // — supertype sibling of the color path (Leyline of Singularity "All nonland
+    // permanents are legendary", Melting "All lands are no longer snow"). The
+    // supertype predicate (legendary/basic/snow) is disjoint from color and
+    // land-type words, so this is order-safe here; it precedes `parse_land_type_change`
+    // so "All lands are basic" (supertype) is not probed as a land-type line.
+    if let Some(def) = parse_subject_is_supertype(&tp, &text) {
+        return Some(def);
+    }
+
     // CR 508.1d / CR 509.1c: Subject-scoped "attack/block each combat if able" patterns.
     // These apply MustAttack/MustBlock to a class of creatures (not just self).
     // Compound forms ("attacks or blocks") produce multiple statics; return the first here.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15982,8 +15982,8 @@ fn static_all_creatures_are_black() {
 /// CR 205.4b + CR 613.1d (Layer 4): "[subject] is/are [no longer] [supertype]"
 /// supertype-defining statics — the supertype sibling of the color path. Adds a
 /// supertype (Leyline of Singularity, Sixth Stage of Magic Design) or removes one
-/// via a "no longer"/"not" negation (Melting). Reuses the shared subject grammar
-/// + `parse_supertype_word` + the existing `AddSupertype`/`RemoveSupertype`
+/// via a "no longer"/"not" negation (Melting). Reuses the shared subject grammar,
+/// `parse_supertype_word`, and the existing `AddSupertype`/`RemoveSupertype`
 /// runtime; the color/land-type paths are unchanged (disjoint predicates).
 #[test]
 fn static_subject_are_supertype_adds_and_removes() {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -16037,6 +16037,36 @@ fn static_subject_are_supertype_adds_and_removes() {
         }]
     );
 
+    // CR 205.4a: the path is general over the full standard supertype set, not
+    // just legendary/basic/snow — "world" and "ongoing" resolve through the same
+    // shared `parse_supertype_word` token and the generic AddSupertype/
+    // RemoveSupertype runtime (no per-supertype special-casing).
+    assert_eq!(
+        parse_static_line("All enchantments are world.")
+            .unwrap()
+            .modifications,
+        vec![ContinuousModification::AddSupertype {
+            supertype: Supertype::World
+        }]
+    );
+    assert_eq!(
+        parse_static_line("All permanents are ongoing.")
+            .unwrap()
+            .modifications,
+        vec![ContinuousModification::AddSupertype {
+            supertype: Supertype::Ongoing
+        }]
+    );
+    // Removal negation is likewise general across the set.
+    assert_eq!(
+        parse_static_line("All enchantments are no longer world.")
+            .unwrap()
+            .modifications,
+        vec![ContinuousModification::RemoveSupertype {
+            supertype: Supertype::World
+        }]
+    );
+
     // Color sibling is unchanged (disjoint predicate — no regression).
     assert_eq!(
         parse_static_line("All creatures are white.")

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -15979,6 +15979,86 @@ fn static_all_creatures_are_black() {
     );
 }
 
+/// CR 205.4b + CR 613.1d (Layer 4): "[subject] is/are [no longer] [supertype]"
+/// supertype-defining statics — the supertype sibling of the color path. Adds a
+/// supertype (Leyline of Singularity, Sixth Stage of Magic Design) or removes one
+/// via a "no longer"/"not" negation (Melting). Reuses the shared subject grammar
+/// + `parse_supertype_word` + the existing `AddSupertype`/`RemoveSupertype`
+/// runtime; the color/land-type paths are unchanged (disjoint predicates).
+#[test]
+fn static_subject_are_supertype_adds_and_removes() {
+    use crate::types::card_type::Supertype;
+
+    // AddSupertype on a nonland-permanent subject (Leyline of Singularity).
+    let leyline = parse_static_line("All nonland permanents are legendary.").unwrap();
+    assert_eq!(leyline.mode, StaticMode::Continuous);
+    assert_eq!(
+        leyline.modifications,
+        vec![ContinuousModification::AddSupertype {
+            supertype: Supertype::Legendary
+        }]
+    );
+    let TargetFilter::Typed(ref tf) = leyline.affected.as_ref().unwrap() else {
+        panic!("expected Typed filter, got {:?}", leyline.affected);
+    };
+    assert!(
+        tf.type_filters.contains(&TypeFilter::Permanent)
+            && tf
+                .type_filters
+                .contains(&TypeFilter::Non(Box::new(TypeFilter::Land))),
+        "expected nonland-permanent filter, got {:?}",
+        tf.type_filters
+    );
+
+    // AddSupertype on a bare creature subject (Sixth Stage of Magic Design).
+    let sixth = parse_static_line("All creatures are legendary.").unwrap();
+    assert_eq!(
+        sixth.modifications,
+        vec![ContinuousModification::AddSupertype {
+            supertype: Supertype::Legendary
+        }]
+    );
+
+    // "no longer" negation → RemoveSupertype (Melting).
+    let melting = parse_static_line("All lands are no longer snow.").unwrap();
+    assert_eq!(
+        melting.modifications,
+        vec![ContinuousModification::RemoveSupertype {
+            supertype: Supertype::Snow
+        }]
+    );
+
+    // "basic" supertype must NOT be mis-claimed by the land-type-change branch.
+    let basic = parse_static_line("All lands are basic.").unwrap();
+    assert_eq!(
+        basic.modifications,
+        vec![ContinuousModification::AddSupertype {
+            supertype: Supertype::Basic
+        }]
+    );
+
+    // Color sibling is unchanged (disjoint predicate — no regression).
+    assert_eq!(
+        parse_static_line("All creatures are white.")
+            .unwrap()
+            .modifications,
+        vec![ContinuousModification::SetColor {
+            colors: vec![ManaColor::White]
+        }]
+    );
+    // A subtype predicate must NOT be parsed as a supertype static.
+    assert!(
+        !parse_static_line("All creatures are Zombies.")
+            .map(|d| d.modifications.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddSupertype { .. }
+                    | ContinuousModification::RemoveSupertype { .. }
+            )))
+            .unwrap_or(false),
+        "a subtype predicate must not be parsed as a supertype static"
+    );
+}
+
 #[test]
 fn static_all_permanents_are_colorless() {
     // CR 613.1e + CR 105.2c: Thran Lens — "All permanents are colorless."

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1419,7 +1419,8 @@ pub(crate) fn parse_subject_is_color(
 ///
 /// Reuses the shared subject grammar (`parse_continuous_subject_filter`, which
 /// handles "All"/"Each", "nonland permanents", controller suffixes), the shared
-/// `parse_supertype_word` token (legendary/basic/snow), and the existing
+/// `parse_supertype_word` token (the full CR 205.4a set: legendary/basic/snow/
+/// world/ongoing), and the existing
 /// `ContinuousModification::AddSupertype`/`RemoveSupertype` runtime (applied at
 /// Layer 4 in `game/layers.rs`) — no new variant or runtime. Dispatched after the
 /// color/land-type branches; the supertype predicate is disjoint from color and
@@ -1442,6 +1443,21 @@ pub(crate) fn parse_subject_is_supertype(
     // CR 604.3: a self-referential line would be a CDA, not a Layer-4 static.
     if matches!(affected, TargetFilter::SelfRef) {
         return None;
+    }
+    // CR 613 dispatch ownership: the attached "Enchanted/Equipped [type] is
+    // [supertype]" Aura/Equipment form is owned by the predicate seam
+    // (`parse_supertype_grant` via `parse_continuous_gets_has` — Glittering Frost,
+    // In Bolas's Clutches). Decline an attached-subject filter here so this general
+    // "[subject] is/are [supertype]" static path owns only the standalone-subject
+    // form and never double-handles an attached-subject grant.
+    if let TargetFilter::Typed(ref tf) = affected {
+        if tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::EnchantedBy | FilterProp::EquippedBy))
+        {
+            return None;
+        }
     }
 
     // CR 205.4b: an object can gain or lose a supertype ("When an object gains or

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1444,8 +1444,9 @@ pub(crate) fn parse_subject_is_supertype(
         return None;
     }
 
-    // CR 205.4b + CR 707.9b: an optional "no longer"/"not" negation flips this to
-    // a supertype REMOVAL.
+    // CR 205.4b: an object can gain or lose a supertype ("When an object gains or
+    // loses a supertype…") — an optional "no longer"/"not" negation flips this
+    // parse to a supertype REMOVAL.
     let predicate_lower = predicate.to_lowercase();
     let (supertype_input, is_remove) = match opt(alt((
         tag::<_, _, OracleError<'_>>("no longer "),

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -1410,6 +1410,69 @@ pub(crate) fn parse_subject_is_color(
     )
 }
 
+/// CR 205.4b + CR 613.1d (Layer 4): Parse a supertype-defining static of the form
+/// "[subject] is/are [no longer|not] [supertype]." — the supertype sibling of
+/// [`parse_subject_is_color`]. Adds a supertype (Leyline of Singularity: "All
+/// nonland permanents are legendary"; Sixth Stage of Magic Design: "All creatures
+/// are legendary") or removes one via a "no longer"/"not" negation (Melting: "All
+/// lands are no longer snow").
+///
+/// Reuses the shared subject grammar (`parse_continuous_subject_filter`, which
+/// handles "All"/"Each", "nonland permanents", controller suffixes), the shared
+/// `parse_supertype_word` token (legendary/basic/snow), and the existing
+/// `ContinuousModification::AddSupertype`/`RemoveSupertype` runtime (applied at
+/// Layer 4 in `game/layers.rs`) — no new variant or runtime. Dispatched after the
+/// color/land-type branches; the supertype predicate is disjoint from color and
+/// land-type words, so no branch is stolen. `all_consuming` on the supertype word
+/// keeps this to the BARE form ("… are legendary."): a trailing tail ("… in
+/// addition to their other types") or unrecognized predicate leaves the line
+/// unsupported (returns `None`) rather than being mis-claimed. A self-referential
+/// subject is declined — it would be a CDA, not a plain Layer-4 static.
+pub(crate) fn parse_subject_is_supertype(
+    tp: &TextPair<'_>,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let (subject_tp, predicate_tp) = tp
+        .split_around(" is ")
+        .or_else(|| tp.split_around(" are "))?;
+    let subject = subject_tp.original.trim();
+    let predicate = predicate_tp.original.trim().trim_end_matches('.').trim();
+
+    let affected = parse_continuous_subject_filter(subject)?;
+    // CR 604.3: a self-referential line would be a CDA, not a Layer-4 static.
+    if matches!(affected, TargetFilter::SelfRef) {
+        return None;
+    }
+
+    // CR 205.4b + CR 707.9b: an optional "no longer"/"not" negation flips this to
+    // a supertype REMOVAL.
+    let predicate_lower = predicate.to_lowercase();
+    let (supertype_input, is_remove) = match opt(alt((
+        tag::<_, _, OracleError<'_>>("no longer "),
+        tag("not "),
+    )))
+    .parse(predicate_lower.as_str())
+    {
+        Ok((rest, negation)) => (rest, negation.is_some()),
+        Err(_) => (predicate_lower.as_str(), false),
+    };
+    let (_, supertype) = all_consuming(nom_target::parse_supertype_word)
+        .parse(supertype_input)
+        .ok()?;
+
+    let modification = if is_remove {
+        ContinuousModification::RemoveSupertype { supertype }
+    } else {
+        ContinuousModification::AddSupertype { supertype }
+    };
+    Some(
+        StaticDefinition::continuous()
+            .affected(affected)
+            .modifications(vec![modification])
+            .description(description.to_string()),
+    )
+}
+
 /// CR 305.7: Parse "[Subject] lands are [type]" land type-changing static abilities.
 /// Handles replacement ("Nonbasic lands are Mountains"), additive ("Each land is a
 /// Swamp in addition to its other land types"), and all-basic-types ("Lands you control


### PR DESCRIPTION
## Problem

Global supertype-setting statics were unimplemented — they dropped to an `Unimplemented` gap even though the **color sibling** (`All creatures are white` → `SetColor`) and the `AddSupertype`/`RemoveSupertype` **runtime** already existed:

- **Leyline of Singularity** — `All nonland permanents are legendary.`
- **Sixth Stage of Magic Design** — `All creatures are legendary.`
- **Rimefeather Owl** — `Permanents with ice counters on them are snow.`
- **Melting** — `All lands are no longer snow.`

## Fix

Add `parse_subject_is_supertype` in the test-free `oracle_static/type_change.rs` — the supertype mirror of the existing `parse_subject_is_color`. **No new engine variant, no new runtime.** It reuses:

- the shared subject grammar `parse_continuous_subject_filter` (handles `All`/`Each`, `nonland permanents`, controller suffixes, and counter-filtered subjects — Rimefeather's `with ice counters on them` is preserved as a `Counters(ice) ≥ 1` filter);
- the shared `nom_target::parse_supertype_word` token (legendary / basic / snow);
- the existing `ContinuousModification::AddSupertype` / `RemoveSupertype` runtime, applied at Layer 4 (**CR 613.1d / CR 205.4b**) in `game/layers.rs`.

An optional `no longer`/`not` negation flips it to `RemoveSupertype` (**CR 707.9b**). `all_consuming` on the supertype word keeps this to the bare form — a trailing tail or unrecognized predicate leaves the line unsupported rather than being mis-claimed. A self-referential subject is declined (it would be a CDA).

**Order-safety:** dispatched immediately after the color path and **before** `parse_land_type_change`, so `All lands are basic` (supertype) is not probed as a land-type line. The supertype predicate is disjoint from color and land-type words, so no sibling branch is stolen — the color and land-type paths are unchanged.

## Tests

- New `static_subject_are_supertype_adds_and_removes`: add (nonland-permanent + creature subjects), remove (`no longer snow`), `basic` supertype vs land-type, color-sibling unchanged, and a subtype predicate (`are Zombies`) NOT claimed as a supertype.
- 960 `oracle_static` tests pass; `cargo fmt` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)