### PR TITLE
fix(engine): grant The Atropal deathtouch (Tomb of Annihilation "Cradle of the Death God")

### DIFF
--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -460,7 +460,8 @@ pub fn room_effects(
             (lose, vec![])
         }
         // 4: Cradle of the Death God — "Create The Atropal, a legendary 4/4 black God Horror
-        //    creature token"
+        //    creature token with deathtouch."
+        // CR 702.2a: Deathtouch is a static ability granted to the token.
         (DungeonId::TombOfAnnihilation, 4) => (
             simple(
                 Effect::Token {
@@ -473,7 +474,7 @@ pub fn room_effects(
                         "Horror".to_string(),
                     ],
                     colors: vec![ManaColor::Black],
-                    keywords: vec![],
+                    keywords: vec![Keyword::Deathtouch],
                     tapped: false,
                     count: fixed(1),
                     owner: TargetFilter::Controller,
@@ -1669,6 +1670,46 @@ mod tests {
     #[test]
     fn room_effects_undercity_throne_of_dead_three() {
         assert_throne_room_chain(&undercity_effect(8));
+    }
+
+    fn tomb_effect(room: u8) -> ResolvedAbility {
+        room_effects(
+            DungeonId::TombOfAnnihilation,
+            room,
+            ObjectId(1),
+            PlayerId(0),
+        )
+        .0
+    }
+
+    /// Oracle fidelity: Tomb of Annihilation "Cradle of the Death God" creates
+    /// The Atropal, a legendary 4/4 black God Horror creature token *with
+    /// deathtouch* (CR 702.2a). The token was created with no keywords, dropping
+    /// the deathtouch. Revert-probe: the old `keywords: vec![]` has no Deathtouch.
+    #[test]
+    fn tomb_cradle_atropal_has_deathtouch() {
+        let ability = tomb_effect(4);
+        match &ability.effect {
+            Effect::Token {
+                name,
+                power: PtValue::Fixed(4),
+                toughness: PtValue::Fixed(4),
+                keywords,
+                supertypes,
+                ..
+            } => {
+                assert_eq!(name, "The Atropal");
+                assert!(
+                    keywords.contains(&Keyword::Deathtouch),
+                    "The Atropal is created with deathtouch, got keywords {keywords:?}"
+                );
+                assert!(
+                    supertypes.contains(&Supertype::Legendary),
+                    "The Atropal is legendary"
+                );
+            }
+            other => panic!("expected a 4/4 Atropal Token, got {other:?}"),
+        }
     }
 
     fn mad_mage_effect(room: u8) -> ResolvedAbility {

--- a/crates/engine/tests/tomb_cradle_atropal_deathtouch_runtime.rs
+++ b/crates/engine/tests/tomb_cradle_atropal_deathtouch_runtime.rs
@@ -1,0 +1,63 @@
+//! Runtime (engine-path) regression for Tomb of Annihilation "Cradle of the
+//! Death God".
+//!
+//! The room creates "The Atropal, a legendary 4/4 black God Horror creature
+//! token with deathtouch" (CR 702.2a). The token was built with an empty
+//! keyword list, silently dropping the deathtouch. This drives the real venture
+//! pipeline: with the marker in Oubliette (room 2 → [4] Cradle of the Death
+//! God), a venture advances into Cradle, its room ability goes on the stack, and
+//! resolving it creates the Atropal on the battlefield. On the old code the
+//! token has no deathtouch and the assertion below fails — so this discriminates
+//! the real game behavior, not just the AST shape.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+#[test]
+fn tomb_cradle_atropal_enters_with_deathtouch_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    // Marker already in Tomb of Annihilation at Oubliette (room 2 → [4] Cradle).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::TombOfAnnihilation);
+        prog.current_room = 2;
+    }
+
+    // Venture: advance into Cradle of the Death God (room 4); its token ability
+    // goes on the stack.
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    assert_eq!(
+        runner.state().dungeon_progress[&P0].current_room,
+        4,
+        "venture must advance the marker into Cradle of the Death God (room 4)"
+    );
+
+    // Resolve the room ability — creates The Atropal on the battlefield.
+    runner.resolve_top();
+
+    let atropal = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .find(|obj| obj.is_token && obj.name == "The Atropal")
+        .expect("Cradle of the Death God creates The Atropal token");
+
+    assert!(
+        atropal.keywords.contains(&Keyword::Deathtouch),
+        "CR 702.2a: The Atropal enters with deathtouch (the old empty keyword \
+         list dropped it), got keywords {:?}",
+        atropal.keywords
+    );
+}


### PR DESCRIPTION
## Problem

Tomb of Annihilation's final room, **Cradle of the Death God**, creates *The Atropal*. Its Oracle text (Scryfall):

> Cradle of the Death God â€” Create The Atropal, a legendary 4/4 black God Horror creature token **with deathtouch**.

The engine built the token with an empty keyword list, silently dropping the deathtouch:

```rust
Effect::Token { name: "The Atropal", power: 4, toughness: 4, colors: [Black], keywords: vec![], .. }
```

So the Atropal's combat damage was not treated as lethal to creatures with toughness > 1 â€” a visible gameplay difference whenever the token blocks or attacks.

## Fix

Grant `Keyword::Deathtouch` to the token.

- **CR 702.2a**: "Deathtouch is a static ability."
- **CR 702.2c**: "Any nonzero amount of combat damage assigned to a creature by a source with deathtouch is considered to be lethal damageâ€¦"

## Tests

- **AST** (`dungeon.rs::tomb_cradle_atropal_has_deathtouch`): `room_effects` for Cradle produces a 4/4 legendary Atropal `Token` whose `keywords` contain `Deathtouch`.
- **Runtime** (`tests/tomb_cradle_atropal_deathtouch_runtime.rs`): drives the real venture pipeline â€” ventures into Cradle of the Death God, resolves the room ability, and asserts the created battlefield token has deathtouch. **Fails on the old empty keyword list** (revert-probed locally: the test panics with `got keywords []` when the fix is reverted).

Scope is intentionally limited to this one token's missing keyword.
