### PR TITLE
perf(engine): eliminate O(N²) full-battlefield static scans via StaticModePresence index

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1269,7 +1269,12 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
 pub fn get_ai_action(difficulty: &str, player_id: u8) -> Result<JsValue, JsValue> {
     let ai_difficulty = AiDifficulty::from_label(difficulty);
 
-    with_state(|state| {
+    with_state_mut(|state| {
+        // Freshly-restored states carry `layers_dirty = Full` and a conservative
+        // all-present `static_mode_presence`; flush before read-only candidate
+        // generation so derived state and the presence index are precise
+        // (mirrors `get_legal_actions_js`). No-op when layers are clean.
+        engine::game::layers::flush_layers(state);
         let config =
             create_config_for_players(ai_difficulty, Platform::Wasm, state.players.len() as u8);
 
@@ -1298,6 +1303,11 @@ pub fn get_ai_scored_candidates(
     let ai_difficulty = AiDifficulty::from_label(difficulty);
 
     with_state_mut(|state| {
+        // Pool workers restore a deserialized state per decision: `layers_dirty =
+        // Full`, presence index conservatively all-present. Flush before scoring so
+        // candidate generation runs on precise derived state (mirrors
+        // `get_legal_actions_js`). No-op when layers are clean.
+        engine::game::layers::flush_layers(state);
         // Re-seed the state RNG so each parallel worker explores different
         // beam-search rollout paths and tie-breaking orders.
         state.rng = ChaCha20Rng::seed_from_u64(rng_seed);
@@ -1369,6 +1379,10 @@ fn resolve_all_inner(
     max_resolutions: u32,
     rng: &mut impl Rng,
 ) -> BatchResolveResult {
+    // The first AI decision in the fast-forward loop can run before any
+    // `apply()` (which would flush internally); flush up front so it sees
+    // precise derived state + presence index. No-op when layers are clean.
+    engine::game::layers::flush_layers(state);
     let session = ai_session_for(state);
     resolve_all_fast_forward(state, requester, max_resolutions, |state, actor| {
         if let Some(seat) = ai_seats

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -24,7 +24,7 @@ use crate::types::player::PlayerId;
 use crate::types::statics::{
     ActivationExemption, AdditionalCostTaxAction, CastFreeOrigin, CastFrequency,
     CastingProhibitionCondition, CostModifyMode, ExileCardPool, ExileCastCost, ExileCastTiming,
-    ProhibitionScope, StaticMode,
+    ProhibitionScope, StaticMode, StaticModeKind,
 };
 use crate::types::zones::{ExileCostSourceZone, Zone};
 
@@ -41,7 +41,7 @@ use super::ability_utils::{
 };
 use super::casting_costs::{self, check_additional_cost_or_pay};
 use super::engine::EngineError;
-use super::functioning_abilities::active_static_definitions;
+use super::functioning_abilities::{active_static_definitions, static_kind_present};
 use super::game_object::{GameObject, PreparedState, PrototypeFormState};
 use super::mana_payment;
 use super::priority;
@@ -5726,6 +5726,11 @@ fn collect_battlefield_cost_modifiers(
     // a reduction's `saturating_sub` floor can never clamp generic to 0 ahead of a
     // later increase (which would overcharge the spell, order-dependently).
     let mut collected = Vec::new();
+    // CR 604.1: O(1) presence gate — no ModifyCost static means no cost modifiers.
+    if !static_kind_present(state, StaticModeKind::ModifyCost) {
+        return collected;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     for (src_obj, def) in super::functioning_abilities::game_functioning_statics(state) {
         let bf_id = src_obj.id;
         let source_controller = src_obj.controller;
@@ -5851,6 +5856,11 @@ pub(super) fn collect_imposed_additional_cast_costs(
     use crate::types::ability::ControllerRef;
 
     let mut costs = Vec::new();
+    // CR 604.1: O(1) presence gate — no ImposeAdditionalCost static means no imposed costs.
+    if !static_kind_present(state, StaticModeKind::ImposeAdditionalCost) {
+        return costs;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     for (src_obj, def) in super::functioning_abilities::game_functioning_statics(state) {
         let bf_id = src_obj.id;
         let source_controller = src_obj.controller;
@@ -5973,6 +5983,11 @@ fn apply_cost_floor_inner(
     target_sensitive_only: bool,
     mana_cost: &mut ManaCost,
 ) {
+    // CR 604.1: O(1) presence gate — no ModifyCost static means no cost floor to apply.
+    if !static_kind_present(state, StaticModeKind::ModifyCost) {
+        return;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_functioning_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_functioning_statics(state) {
         let bf_id = bf_obj.id;
@@ -14513,6 +14528,11 @@ fn apply_static_activated_ability_cost_reduction(
     player: PlayerId,
     source_id: ObjectId,
 ) {
+    // CR 604.1: O(1) presence gate — no ReduceAbilityCost static means no reduction.
+    if !static_kind_present(state, StaticModeKind::ReduceAbilityCost) {
+        return;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 601.2f: A `ReduceAbilityCost` static keyed on a keyword (e.g. "power-up")
     // also reduces a tagged activated ability whose tag matches that keyword
     // (Hulk reduces other creatures' power-up abilities). Read the activating
@@ -14752,6 +14772,11 @@ fn is_blocked_from_casting_from_zone(
     }
 
     let object_id = obj.id;
+    // CR 604.1: O(1) presence gate — no CantCastFrom static means no restriction.
+    if !static_kind_present(state, StaticModeKind::CantCastFrom) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::CantCastFrom { ref who } = def.mode else {
@@ -14802,6 +14827,11 @@ pub(super) fn is_blocked_by_cant_be_activated(
     activating_source_id: ObjectId,
     activating_ability: &AbilityDefinition,
 ) -> bool {
+    // CR 604.1: O(1) presence gate — no CantBeActivated static means no prohibition.
+    if !static_kind_present(state, StaticModeKind::CantBeActivated) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let bf_id = bf_obj.id;
@@ -14896,6 +14926,11 @@ fn evaluate_casting_prohibition_condition(
 /// E.g., Dosan, the Falling Leaf (`who=AllPlayers, when=NotDuringAffectedPlayersTurn`):
 ///   each player can only cast on their own turn.
 fn is_blocked_by_cant_cast_during(state: &GameState, caster: PlayerId) -> bool {
+    // CR 604.1: O(1) presence gate — no CantCastDuring static means no restriction.
+    if !static_kind_present(state, StaticModeKind::CantCastDuring) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::CantCastDuring { ref who, ref when } = def.mode else {
@@ -14932,6 +14967,11 @@ pub(super) fn is_blocked_by_cant_activate_during(
     activator: PlayerId,
     activating_ability: &AbilityDefinition,
 ) -> bool {
+    // CR 604.1: O(1) presence gate — no CantActivateDuring static means no restriction.
+    if !static_kind_present(state, StaticModeKind::CantActivateDuring) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::CantActivateDuring {
@@ -14970,6 +15010,11 @@ fn is_blocked_by_cant_be_cast(
     caster: PlayerId,
     spell_obj: &super::game_object::GameObject,
 ) -> bool {
+    // CR 604.1: O(1) presence gate — no CantBeCast static means no restriction.
+    if !static_kind_present(state, StaticModeKind::CantBeCast) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`
     // — including the per-static `condition` check; no inline duplication needed.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
@@ -15063,6 +15108,11 @@ fn is_blocked_by_per_turn_cast_limit(
     caster: PlayerId,
     spell_obj: &super::game_object::GameObject,
 ) -> bool {
+    // CR 604.1: O(1) presence gate — no PerTurnCastLimit static means no limit.
+    if !static_kind_present(state, StaticModeKind::PerTurnCastLimit) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: Functioning gate owned by `battlefield_active_statics`.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::game::functioning_abilities::static_kind_present;
 use crate::types::ability::{
     is_chosen_remove_counter_cost_count, AbilityCondition, AbilityCost, AbilityDefinition,
     AbilityKind, AdditionalCost, AdditionalCostInstance, AdditionalCostOrigin, AggregateFunction,
@@ -21,7 +22,7 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaCost, ManaCostShard, ManaType, PaymentContext};
 use crate::types::player::PlayerId;
 use crate::types::replacements::ReplacementEvent;
-use crate::types::statics::{CostModifyMode, StaticMode};
+use crate::types::statics::{CostModifyMode, StaticMode, StaticModeKind};
 use crate::types::zones::{ExileCostSourceZone, Zone};
 
 use super::casting::emit_targeting_events;
@@ -3976,6 +3977,11 @@ fn find_defiler_reduction(
         return None;
     }
 
+    // CR 604.1: O(1) presence gate — no DefilerCostReduction static means no reduction.
+    if !static_kind_present(state, StaticModeKind::DefilerCostReduction) {
+        return None;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 702.26b + CR 604.1: `battlefield_active_statics` owns the gating.
     for (bf_obj, def) in super::functioning_abilities::battlefield_active_statics(state) {
         if bf_obj.controller != caster {

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -15487,6 +15487,10 @@ fn only_once_each_turn_without_modify_limit_static_avoids_exact_scan() {
     let mut events = Vec::new();
     handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events).unwrap();
 
+    // Flush makes the `StaticModePresence` index PRECISE (no ModifyActivationLimit static).
+    // Production reaches activation legality post-flush; the pre-flush `all_present` default
+    // would conservatively fall through to the exact per-candidate static scan.
+    crate::game::layers::evaluate_layers(&mut state);
     crate::game::perf_counters::reset();
     let second = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events);
 
@@ -15506,6 +15510,7 @@ fn only_once_each_turn_without_modify_limit_static_avoids_exact_scan() {
     );
     handle_activate_ability(&mut state, PlayerId(0), untagged, 0, &mut events).unwrap();
 
+    crate::game::layers::evaluate_layers(&mut state);
     crate::game::perf_counters::reset();
     let untagged_second =
         handle_activate_ability(&mut state, PlayerId(0), untagged, 0, &mut events);
@@ -15545,6 +15550,10 @@ fn priority_activation_candidates_share_activation_restriction_static_gate() {
         ),
     ];
 
+    // Flush makes the presence index PRECISE (no ModifyActivationLimit static). Production
+    // reaches candidate production post-flush; the pre-flush `all_present` default would
+    // conservatively fall through to the exact per-candidate static scan.
+    crate::game::layers::evaluate_layers(&mut state);
     crate::game::perf_counters::reset();
     let actions = crate::ai_support::candidate_actions_broad(&state);
     let offered = actions
@@ -15587,6 +15596,8 @@ fn only_once_without_modify_limit_static_avoids_exact_scan() {
     let mut events = Vec::new();
     handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events).unwrap();
 
+    // Flush makes the presence index PRECISE (no ModifyActivationLimit static).
+    crate::game::layers::evaluate_layers(&mut state);
     crate::game::perf_counters::reset();
     let second = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut events);
 
@@ -31271,6 +31282,10 @@ mod loyalty_gate {
         );
         set_opponent_combat_priority(&mut state);
 
+        // Flush makes the presence index PRECISE (no ActivateAsInstant static). Production
+        // reaches activation legality post-flush; the pre-flush `all_present` default would
+        // conservatively fall through to the exact permission scan.
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         assert!(
             !can_activate_ability_now(&state, PlayerId(0), pw, 0),

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::game_object::GameObject;
 use super::players;
 use crate::game::filter::{matches_target_filter, FilterContext};
+use crate::game::functioning_abilities::static_kind_present;
 use crate::types::ability::{StaticDefinition, TargetRef};
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::events::GameEvent;
@@ -15,6 +16,7 @@ use crate::types::mana::ManaColor;
 use crate::types::player::PlayerId;
 use crate::types::statics::{
     AttackDefenderScope, BlockExceptionKind, CombatAloneAction, CombatAloneRequirement, StaticMode,
+    StaticModeKind,
 };
 use crate::types::zones::Zone;
 
@@ -47,36 +49,34 @@ struct CombatStaticGates {
 }
 
 impl CombatStaticGates {
-    /// One `game_functioning_statics` sweep computing the presence flags.
-    /// Does NOT increment the static-full-scan perf counter: this is the single
-    /// intended hoisted sweep, not a per-element legality scan.
+    /// Reads all six presence flags from the O(1) `StaticModePresence` index
+    /// (Unit 1) instead of sweeping `game_functioning_statics`. Each flag mirrors
+    /// the discriminant its consumers gate `check_static_ability` behind; the
+    /// index is a post-flush-precise superset of the sweep, so a spurious `true`
+    /// merely falls through to the exact per-permanent scan.
     ///
-    /// `has_attack_only_neighbor` is computed from the SAME
-    /// `game_functioning_statics` (battlefield + command zone) sweep the CR
-    /// 508.1c enforcement loop iterates, so the flag and the enforcement stay in
-    /// lockstep AND a command-zone emblem granting `AttackOnlyNeighbor` is both
-    /// detected and enforced (CR 113.6: command-zone static abilities function).
+    /// `has_attack_only_neighbor` (CR 508.1c) is read from the SAME index; the
+    /// enforcement loop still sweeps `game_functioning_statics`, and the index is
+    /// precise post-flush (a spurious `true` merely runs that loop, which finds no
+    /// `AttackOnlyNeighbor` static and is inert), so the flag and the enforcement
+    /// stay consistent while the per-combat sweep is eliminated. CR 113.6:
+    /// command-zone statics function and are included in the refresh sweep.
+    /// Does NOT increment the static-full-scan perf counter: no scan occurs here.
     fn compute(state: &GameState) -> Self {
-        let mut gates = CombatStaticGates {
-            has_cant_attack: false,
-            has_cant_attack_or_block: false,
-            has_must_attack: false,
-            has_goad: false,
-            has_can_attack_with_defender: false,
-            has_attack_only_neighbor: false,
-        };
-        for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
-            match def.mode {
-                StaticMode::CantAttack => gates.has_cant_attack = true,
-                StaticMode::CantAttackOrBlock => gates.has_cant_attack_or_block = true,
-                StaticMode::MustAttack => gates.has_must_attack = true,
-                StaticMode::Goaded => gates.has_goad = true,
-                StaticMode::CanAttackWithDefender => gates.has_can_attack_with_defender = true,
-                StaticMode::AttackOnlyNeighbor => gates.has_attack_only_neighbor = true,
-                _ => {}
-            }
+        CombatStaticGates {
+            has_cant_attack: static_kind_present(state, StaticModeKind::CantAttack),
+            has_cant_attack_or_block: static_kind_present(state, StaticModeKind::CantAttackOrBlock),
+            has_must_attack: static_kind_present(state, StaticModeKind::MustAttack),
+            has_goad: static_kind_present(state, StaticModeKind::Goaded),
+            has_can_attack_with_defender: static_kind_present(
+                state,
+                StaticModeKind::CanAttackWithDefender,
+            ),
+            has_attack_only_neighbor: static_kind_present(
+                state,
+                StaticModeKind::AttackOnlyNeighbor,
+            ),
         }
-        gates
     }
 }
 
@@ -680,6 +680,15 @@ fn defending_player_for_target(state: &GameState, target: AttackTarget) -> Playe
 /// battlefield for every attacker. Mirrors the filter in
 /// `block_restriction_statics_against`.
 pub fn collect_block_restriction_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    // CR 509.1b: O(1) presence gate — no CantBeBlocked* discriminant present means the
+    // filtered sweep yields nothing, so return empty without walking the battlefield.
+    if !(static_kind_present(state, StaticModeKind::CantBeBlocked)
+        || static_kind_present(state, StaticModeKind::CantBeBlockedExceptBy)
+        || static_kind_present(state, StaticModeKind::CantBeBlockedBy)
+        || static_kind_present(state, StaticModeKind::CantBeBlockedByMoreThan))
+    {
+        return Vec::new();
+    }
     super::functioning_abilities::battlefield_functioning_statics(state)
         .filter(|(_, def)| {
             matches!(
@@ -698,6 +707,12 @@ pub fn collect_block_restriction_statics(state: &GameState) -> Vec<(ObjectId, St
 /// once per legality pass. Mirrors the filter in
 /// `blocker_restriction_statics_for`.
 pub fn collect_blocker_restriction_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    // CR 509.1b: O(1) presence gate — skip the sweep when neither discriminant is present.
+    if !(static_kind_present(state, StaticModeKind::CantBlock)
+        || static_kind_present(state, StaticModeKind::CantAttackOrBlock))
+    {
+        return Vec::new();
+    }
     super::functioning_abilities::game_functioning_statics(state)
         .filter(|(_, def)| {
             matches!(
@@ -713,6 +728,10 @@ pub fn collect_blocker_restriction_statics(state: &GameState) -> Vec<(ObjectId, 
 /// <filter>") static once per legality pass. Mirrors the filter in
 /// `blocker_block_allowed_statics_for`.
 pub fn collect_blocker_allowed_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    // CR 509.1b: O(1) presence gate — no BlockRestriction static means an empty result.
+    if !static_kind_present(state, StaticModeKind::BlockRestriction) {
+        return Vec::new();
+    }
     super::functioning_abilities::game_functioning_statics(state)
         .filter(|(_, def)| matches!(def.mode, StaticMode::BlockRestriction { .. }))
         .map(|(src, def)| (src.id, def.clone()))
@@ -723,6 +742,12 @@ pub fn collect_blocker_allowed_statics(state: &GameState) -> Vec<(ObjectId, Stat
 /// static once per legality pass. Mirrors the filter in
 /// `must_be_blocked_statics_for_attacker`.
 pub fn collect_must_be_blocked_statics(state: &GameState) -> Vec<(ObjectId, StaticDefinition)> {
+    // CR 509.1c: O(1) presence gate — skip the sweep when neither discriminant is present.
+    if !(static_kind_present(state, StaticModeKind::MustBeBlocked)
+        || static_kind_present(state, StaticModeKind::MustBeBlockedByAll))
+    {
+        return Vec::new();
+    }
     super::functioning_abilities::battlefield_functioning_statics(state)
         .filter(|(_, def)| {
             matches!(
@@ -1007,10 +1032,7 @@ pub fn validate_blockers_for_player(
     // 509.1b/609.4/702.28b). Hoisted once so the per-blocker shadow scan below
     // and every `can_block_pair_with_precomputed` call skip the O(N)
     // `check_static_ability` sweep when no `CanBlockShadow` static exists.
-    let can_block_shadow_exists =
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::CanBlockShadow)
-        });
+    let can_block_shadow_exists = static_kind_present(state, StaticModeKind::CanBlockShadow);
 
     // Group assignments by attacker for menace validation and by blocker for
     // per-creature block-capacity checks.
@@ -1476,10 +1498,7 @@ pub fn validate_blockers_for_player(
         // CR 604.1: hoist the MustBlock existence gate once before iterating N
         // permanents so the per-permanent `check_static_ability` re-scan is
         // skipped when no functioning MustBlock static exists (O(N^2) -> O(N)).
-        let has_must_block_static =
-            super::functioning_abilities::any_functioning_static_mode(state, |m| {
-                matches!(m, StaticMode::MustBlock)
-            });
+        let has_must_block_static = static_kind_present(state, StaticModeKind::MustBlock);
         for &obj_id in &state.battlefield {
             let Some(obj) = state.objects.get(&obj_id) else {
                 continue;
@@ -2779,9 +2798,7 @@ pub(crate) fn goading_players_for_creature(
     goading_players_for_creature_gated(
         state,
         creature_id,
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::Goaded)
-        }),
+        static_kind_present(state, StaticModeKind::Goaded),
     )
 }
 
@@ -3186,10 +3203,7 @@ pub fn can_block_pair(state: &GameState, blocker_id: ObjectId, attacker_id: Obje
     let block_restriction = collect_block_restriction_statics(state);
     let blocker_allowed = collect_blocker_allowed_statics(state);
     // CR 604.1: shadow block-lift existence gate (CR 509.1b/609.4/702.28b).
-    let can_block_shadow_exists =
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::CanBlockShadow)
-        });
+    let can_block_shadow_exists = static_kind_present(state, StaticModeKind::CanBlockShadow);
     can_block_pair_with_precomputed(
         state,
         blocker_id,
@@ -3385,10 +3399,7 @@ pub fn get_valid_block_targets(state: &GameState) -> HashMap<ObjectId, Vec<Objec
     let blocker_allowed = collect_blocker_allowed_statics(state);
     // CR 604.1: shadow block-lift existence gate (CR 509.1b/609.4/702.28b),
     // hoisted once for the whole O(blockers × attackers) sweep.
-    let can_block_shadow_exists =
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::CanBlockShadow)
-        });
+    let can_block_shadow_exists = static_kind_present(state, StaticModeKind::CanBlockShadow);
 
     let mut result = HashMap::new();
     for &blocker_id in &valid_blockers {
@@ -3940,6 +3951,10 @@ mod tests {
             .map(|i| create_creature(&mut state, PlayerId(0), &format!("Bear {i}"), 2, 2))
             .collect();
 
+        // Flush makes the `StaticModePresence` index PRECISE (no combat-restriction
+        // statics). Production reaches combat with a flushed index; the pre-flush
+        // `all_present` default would conservatively fall through to the O(K) scan.
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let valid = get_valid_attacker_ids(&state);
         let scans = crate::game::perf_counters::snapshot().static_full_scans;
@@ -3960,6 +3975,8 @@ mod tests {
             create_creature(&mut state, PlayerId(0), &format!("Bear {i}"), 2, 2);
         }
 
+        // Flush makes the presence index PRECISE (production reaches combat post-flush).
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let any = has_potential_attackers(&state);
         let scans = crate::game::perf_counters::snapshot().static_full_scans;
@@ -3988,6 +4005,8 @@ mod tests {
             .map(|id| (*id, AttackTarget::Player(PlayerId(1))))
             .collect();
 
+        // Flush makes the presence index PRECISE (production reaches combat post-flush).
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let mut events = Vec::new();
         let result = declare_attackers_with_bands(&mut state, &attacks, &[], &mut events);
@@ -5569,6 +5588,10 @@ mod tests {
             ..Default::default()
         });
 
+        // Flush makes the presence index PRECISE (no CanBlockShadow static). Production
+        // reaches block declaration post-flush; the pre-flush `all_present` default would
+        // conservatively fall through to the O(K) per-blocker shadow scan.
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let targets = get_valid_block_targets(&state);
         let scans = crate::game::perf_counters::snapshot().combat_shadow_block_scans;

--- a/crates/engine/src/game/effects/exchange_life.rs
+++ b/crates/engine/src/game/effects/exchange_life.rs
@@ -270,6 +270,13 @@ mod tests {
                 )),
             );
 
+        // Flush after installing the CantGainLife static so the `StaticModePresence`
+        // index (consulted by `check_static_ability` via `player_has_cant_gain_life`)
+        // reflects it. In production a static entering the battlefield always triggers a
+        // layers flush; this test mutates `static_definitions` directly, so it must flush
+        // to reproduce the production invariant.
+        evaluate_layers(&mut state);
+
         let ability = ResolvedAbility::new(
             Effect::ExchangeLifeWithStat {
                 player: TargetFilter::Controller,

--- a/crates/engine/src/game/effects/suspect.rs
+++ b/crates/engine/src/game/effects/suspect.rs
@@ -1,10 +1,11 @@
+use crate::game::functioning_abilities::static_kind_present;
 use crate::types::ability::{
     Effect, EffectError, EffectKind, EffectScope, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{StaticMode, StaticModeKind};
 
 /// Resolve the object subjects of a Suspect / Unsuspect effect.
 ///
@@ -80,6 +81,14 @@ fn can_become_suspected(state: &GameState, object_id: ObjectId) -> bool {
     if obj.is_suspected {
         return false;
     }
+    // CR 701.60a: O(1) presence gate — with no CantBecomeSuspected static present the
+    // designation is unprohibited, so return `true`. This gate MUST sit BELOW the CR
+    // 701.60d `is_suspected` early-return above: placing it higher would let the
+    // resolver double-suspect an already-suspected permanent.
+    if !static_kind_present(state, StaticModeKind::CantBecomeSuspected) {
+        return true;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 701.60a: an active `CantBecomeSuspected` static (e.g. Airtight Alibi's
     // "can't become suspected") prohibits the designation even while unsuspected.
     !crate::game::functioning_abilities::game_functioning_statics(state).any(|(src, def)| {
@@ -470,6 +479,109 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, GameEvent::CreatureSuspected { .. })),
             "no CreatureSuspected event when the prohibition gate fires"
+        );
+    }
+
+    /// Unit 2, site #20: `can_become_suspected` gates its O(N) whole-battlefield
+    /// `CantBecomeSuspected` scan behind the O(1) `StaticModePresence` index. Driven
+    /// through the real `resolve` (Suspect) production path on a large board with the
+    /// index precise (post-flush) and zero `CantBecomeSuspected` statics, the
+    /// designation succeeds with ZERO recorded full scans. Reverting the
+    /// `if !static_kind_present(..) { return true }` gate makes the fall-through
+    /// `record_static_full_scan()` fire, flipping the counter. The anchor half proves
+    /// the counter is wired: with a `CantBecomeSuspected` static present the scan runs.
+    #[test]
+    fn suspect_gate_zero_scans() {
+        let mut state = GameState::new_two_player(42);
+        let target = setup_creature(&mut state);
+        for i in 0..600u64 {
+            create_object(
+                &mut state,
+                CardId(2000 + i),
+                PlayerId((i % 2) as u8),
+                format!("Bear {i}"),
+                Zone::Battlefield,
+            );
+        }
+        // Flush makes the presence index PRECISE (CantBecomeSuspected absent).
+        evaluate_layers(&mut state);
+
+        let ability = ResolvedAbility::new(
+            Effect::Suspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(target)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        crate::game::perf_counters::reset();
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            state.objects[&target].is_suspected,
+            "unsuspected creature with no prohibition must become suspected"
+        );
+        assert_eq!(
+            scans, 0,
+            "the O(1) presence gate must skip the CantBecomeSuspected scan (revert-failing)"
+        );
+
+        // Non-vacuous anchor: install a CantBecomeSuspected static (source-only, no
+        // affected filter), reflush, and suspect a DIFFERENT creature — the gate
+        // falls through and the scan runs exactly once (finding no match for the
+        // other creature, so the designation still succeeds).
+        let other = create_object(
+            &mut state,
+            CardId(3000),
+            PlayerId(0),
+            "Other".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&other)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(crate::types::card_type::CoreType::Creature);
+        let alibi = create_object(
+            &mut state,
+            CardId(3001),
+            PlayerId(0),
+            "Airtight Alibi".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&alibi)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantBecomeSuspected));
+        evaluate_layers(&mut state);
+
+        let ability = ResolvedAbility::new(
+            Effect::Suspect {
+                target: TargetFilter::Any,
+                scope: EffectScope::Single,
+            },
+            vec![TargetRef::Object(other)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        crate::game::perf_counters::reset();
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+        assert!(
+            state.objects[&other].is_suspected,
+            "the source-only prohibition does not cover a different creature"
+        );
+        assert_eq!(
+            scans, 1,
+            "present index falls through to exactly one recorded scan"
         );
     }
 

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -44,7 +44,7 @@ use crate::game::game_object::GameObject;
 use crate::game::layers::evaluate_condition;
 use crate::types::ability::{ReplacementDefinition, StaticDefinition, TriggerDefinition};
 use crate::types::game_state::GameState;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{StaticMode, StaticModeKind};
 use crate::types::zones::Zone;
 
 /// CR 905.4a + CR 113.6b: Face-down hidden-agenda conspiracies do not function
@@ -219,6 +219,21 @@ pub fn any_functioning_static_mode(
     predicate: impl Fn(&StaticMode) -> bool,
 ) -> bool {
     game_functioning_statics(state).any(|(_, def)| predicate(&def.mode))
+}
+
+/// O(1) existence query over FUNCTIONING statics: "does any functioning static have
+/// mode discriminant `kind`?" Reads the [`GameState::static_mode_presence`] cache, which
+/// is rebuilt wholesale from `game_functioning_statics` by the layers pipeline
+/// (`layers::refresh_static_mode_presence`), so it has IDENTICAL scoping to
+/// `game_functioning_statics`: condition unevaluated (CR 604.1 / CR 613.1 — this is a
+/// conservative superset, exactly like `any_functioning_static_mode`); phased-out
+/// permanents excluded (CR 702.26b); command-zone statics included per-def opt-in only
+/// (CR 114.4 / CR 113.6b). A `true` result is a superset gate — callers MUST fall through
+/// to their exact per-object check; a `false` result is precise post-flush and lets the
+/// caller short-circuit the O(battlefield) scan. This is the Unit 2/3 migration target for
+/// discriminant-only scan gates.
+pub fn static_kind_present(state: &GameState, kind: StaticModeKind) -> bool {
+    state.static_mode_presence.contains(kind)
 }
 
 /// Like `battlefield_active_statics` but WITHOUT condition filtering.

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -1914,6 +1914,11 @@ pub fn evaluate_layers(state: &mut GameState) {
     // fresh cache for the next incremental flush's truth-delta consult.
     refresh_static_gate_truth(state);
 
+    // Rebuild the O(1) `StaticModeKind` presence index from the fully-derived board,
+    // immediately after the gate-truth cache and before `layers_dirty = Clean`, so a full
+    // eval always leaves a precise presence index for the next scan-gate consult.
+    refresh_static_mode_presence(state);
+
     // CR 603.6a + CR 611.2e: Layer evaluation just finalized post-layer
     // trigger sets on every battlefield permanent (granted triggers from
     // sliver lords, Changeling, Bramble Sovereign, suppress-triggers statics).
@@ -2193,6 +2198,12 @@ pub fn flush_layers(state: &mut GameState) {
             if let Some(prepared) = prepare_incremental_flush(state, &ids) {
                 super::perf_counters::record_layers_incremental();
                 apply_layers_incremental(state, prepared);
+                // Rebuild the presence index so the incremental arm leaves a PRECISE index
+                // (not a conservative superset). The incremental path is already
+                // O(battlefield): `prepare_incremental_flush` unconditionally calls
+                // `StaticSourceIndex::rebuild_from_state`, so a full presence rebuild here is
+                // DRY, matches the sibling-cache convention, and adds no asymptotic cost.
+                refresh_static_mode_presence(state);
                 for id in &ids {
                     super::public_state::mark_public_state_object_dirty(state, *id);
                 }
@@ -2501,6 +2512,19 @@ fn refresh_static_gate_truth(state: &mut GameState) {
         }
     });
     state.static_gate_truth = next;
+}
+
+/// Rebuild the O(1) `StaticModeKind` presence index wholesale from the same
+/// `game_functioning_statics` iterator its consumers would otherwise scan, so the index is
+/// exactly `.any(|(_, d)| d.mode.kind() == kind)` for every kind — no false negatives. The
+/// fold accumulates into a local `StaticModePresence` first (the iterator borrows `state`),
+/// then assigns.
+fn refresh_static_mode_presence(state: &mut GameState) {
+    let mut presence = crate::types::statics::StaticModePresence::empty();
+    for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
+        presence.insert(def.mode.kind());
+    }
+    state.static_mode_presence = presence;
 }
 
 /// CR 613.1: Continuous effects are applied in layers to determine object characteristics.
@@ -16141,6 +16165,124 @@ mod tests {
         assert_eq!(
             ctrl.name, "Secret Bear",
             "the controller still sees the real back-face identity"
+        );
+    }
+
+    // ── StaticModePresence refresh tests (Verification Matrix D/F) ──
+
+    /// Test D — incremental-arm refresh. A battlefield entrant carrying an `IgnoreHexproof`
+    /// static (a non-`Continuous` static, so the flush takes the incremental fast path) must
+    /// still leave the presence index PRECISE. Advisory A: establish a precise presence=false
+    /// baseline via a FULL flush FIRST, so assertion (2) cannot pass vacuously.
+    #[test]
+    fn incremental_flush_refreshes_static_mode_presence() {
+        use crate::types::statics::StaticModeKind;
+        let mut state = setup();
+        // Baseline: full flush with NO IgnoreHexproof static => precise presence = false.
+        evaluate_layers(&mut state);
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::IgnoreHexproof
+            ),
+            "baseline: no IgnoreHexproof static means presence is precisely false"
+        );
+
+        // Entrant carries an object-scoped IgnoreHexproof static (mode != Continuous => the
+        // incremental fast path handles it, no full escalation).
+        let entrant = make_creature(&mut state, "Nowhere to Run", 2, 2, PlayerId(0));
+        state.objects.get_mut(&entrant).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::IgnoreHexproof).affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::Opponent),
+                )),
+            ]
+            .into();
+
+        crate::game::perf_counters::reset();
+        state.layers_dirty = LayersDirty::EnteredObjects([entrant].into());
+        flush_layers(&mut state);
+        let counters = crate::game::perf_counters::snapshot();
+
+        // (1) Branch proof: the incremental arm ran (NOT a Full escalation).
+        assert_eq!(
+            counters.layers_incremental, 1,
+            "must take the incremental arm, not escalate"
+        );
+        assert_eq!(counters.layers_full_eval, 0, "must not escalate to full");
+        // (2) Revert guard: presence now reports IgnoreHexproof present. Removing the
+        //     Step 4c refresh_static_mode_presence call leaves this stale-false.
+        assert!(
+            crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::IgnoreHexproof
+            ),
+            "incremental flush must refresh the presence index"
+        );
+        // (3) A kind absent from the board still reports false — the incremental arm builds a
+        //     PRECISE index, not a conservative all-present one.
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::Shroud
+            ),
+            "incremental refresh must remain precise for absent kinds"
+        );
+    }
+
+    /// Test F — building-block equivalence (the Unit 2/3 contract). After a full flush on a
+    /// mixed board (a phased-out static, plus plain battlefield statics of distinct kinds),
+    /// the presence index must equal `game_functioning_statics().any(kind == K)` for EVERY
+    /// kind. `StaticModePresence: PartialEq` compares the whole discriminant array, so a
+    /// single `assert_eq!` IS the "for every K" check.
+    #[test]
+    fn static_mode_presence_equals_functioning_statics_fold() {
+        use crate::types::statics::{StaticModeKind, StaticModePresence};
+        let mut state = setup();
+        // Plain battlefield statics of two distinct kinds.
+        let a = make_creature(&mut state, "Ignore Hexproof Source", 1, 1, PlayerId(0));
+        state.objects.get_mut(&a).unwrap().static_definitions =
+            vec![StaticDefinition::new(StaticMode::IgnoreHexproof)].into();
+        let b = make_creature(&mut state, "CantBeTargeted Source", 1, 1, PlayerId(0));
+        state.objects.get_mut(&b).unwrap().static_definitions =
+            vec![StaticDefinition::new(StaticMode::CantBeTargeted)].into();
+        // Phased-out permanent carrying a Shroud static — CR 702.26b excludes it from
+        // game_functioning_statics, so its kind must NOT appear in presence.
+        let phased = make_creature(&mut state, "Phased Shroud Source", 1, 1, PlayerId(0));
+        {
+            let obj = state.objects.get_mut(&phased).unwrap();
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::Shroud)].into();
+            obj.phase_status = crate::game::game_object::PhaseStatus::PhasedOut {
+                cause: crate::game::game_object::PhaseOutCause::Directly,
+            };
+        }
+
+        evaluate_layers(&mut state);
+
+        // Whole-array equivalence: recompute from the same iterator the consumers scan.
+        let mut expected = StaticModePresence::empty();
+        for (_, def) in crate::game::functioning_abilities::game_functioning_statics(&state) {
+            expected.insert(def.mode.kind());
+        }
+        assert_eq!(
+            expected, state.static_mode_presence,
+            "presence index must equal the game_functioning_statics fold for every kind"
+        );
+        // Explicit spot-checks of the interesting scopings.
+        assert!(crate::game::functioning_abilities::static_kind_present(
+            &state,
+            StaticModeKind::IgnoreHexproof
+        ));
+        assert!(crate::game::functioning_abilities::static_kind_present(
+            &state,
+            StaticModeKind::CantBeTargeted
+        ));
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::Shroud
+            ),
+            "phased-out static (CR 702.26b) must not appear in presence"
         );
     }
 }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1,3 +1,4 @@
+use crate::game::functioning_abilities::static_kind_present;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ChoiceValue, CostPaidObjectSnapshot, Effect,
     ManaProduction, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter,
@@ -14,6 +15,7 @@ use crate::types::mana::{ManaColor, ManaCost, ManaPool, ManaType, PaymentContext
 #[cfg(test)]
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
+use crate::types::statics::StaticModeKind;
 use crate::types::zones::Zone;
 use std::collections::HashSet;
 
@@ -1056,27 +1058,17 @@ pub struct ManaActivationGates {
 }
 
 impl ManaActivationGates {
-    /// One `game_functioning_statics` sweep computing both presence flags.
+    /// Reads both presence flags from the O(1) `StaticModePresence` index (Unit 1)
+    /// instead of sweeping `game_functioning_statics`. A post-flush-precise superset:
+    /// a spurious `true` falls through to the exact per-source scan.
     pub fn compute(state: &GameState) -> Self {
-        let mut gates = ManaActivationGates {
-            has_cant_be_activated: false,
-            has_cant_activate_during: false,
-        };
-        for (_, def) in super::functioning_abilities::game_functioning_statics(state) {
-            match def.mode {
-                crate::types::statics::StaticMode::CantBeActivated { .. } => {
-                    gates.has_cant_be_activated = true
-                }
-                crate::types::statics::StaticMode::CantActivateDuring { .. } => {
-                    gates.has_cant_activate_during = true
-                }
-                _ => {}
-            }
-            if gates.has_cant_be_activated && gates.has_cant_activate_during {
-                break;
-            }
+        ManaActivationGates {
+            has_cant_be_activated: static_kind_present(state, StaticModeKind::CantBeActivated),
+            has_cant_activate_during: static_kind_present(
+                state,
+                StaticModeKind::CantActivateDuring,
+            ),
         }
-        gates
     }
 }
 

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -92,6 +92,12 @@ pub fn record_state_clone_for_legality() {
 /// (each `check_static_ability` call). Combat/untap legality loops hoist a
 /// once-computed existence gate to drive this toward zero, collapsing O(N^2)
 /// per-loop scans to O(N).
+///
+/// Also incremented at the two hexproof scan gates in `static_abilities`
+/// (`player_ignores_hexproof`, `target_ignores_hexproof`), which each guard their
+/// O(battlefield) `.any()` behind the O(1) `static_kind_present(IgnoreHexproof)`
+/// presence index — so on a board with zero functioning `IgnoreHexproof` statics this
+/// counter stays at 0 across an entire target enumeration.
 pub fn record_static_full_scan() {
     with_mut(|s| s.static_full_scans += 1);
 }

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -11,11 +11,12 @@ use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{StaticMode, StaticModeKind};
 use crate::types::zones::Zone;
 use crate::types::SpellCastRecord;
 
 use super::engine::EngineError;
+use crate::game::functioning_abilities::static_kind_present;
 use crate::types::identifiers::ObjectId;
 
 /// CR 602.5b / CR 602.5d: loop-invariant existence gates for rare static modes
@@ -31,23 +32,16 @@ pub struct ActivationRestrictionStaticGates {
 impl ActivationRestrictionStaticGates {
     pub fn compute(state: &crate::types::game_state::GameState) -> Self {
         crate::game::perf_counters::record_restriction_static_mode_gate_scan();
-        let mut gates = ActivationRestrictionStaticGates {
-            has_modify_activation_limit: false,
-            has_activate_as_instant: false,
-        };
-        for (_, def) in crate::game::functioning_abilities::game_functioning_statics(state) {
-            match def.mode {
-                StaticMode::ModifyActivationLimit { .. } => {
-                    gates.has_modify_activation_limit = true
-                }
-                StaticMode::ActivateAsInstant { .. } => gates.has_activate_as_instant = true,
-                _ => {}
-            }
-            if gates.has_modify_activation_limit && gates.has_activate_as_instant {
-                break;
-            }
+        // Read the two discriminants from the O(1) `StaticModePresence` index (Unit 1)
+        // instead of sweeping `game_functioning_statics`. A post-flush-precise superset:
+        // a spurious `true` falls through to the exact per-ability `check_static_ability`.
+        ActivationRestrictionStaticGates {
+            has_modify_activation_limit: static_kind_present(
+                state,
+                StaticModeKind::ModifyActivationLimit,
+            ),
+            has_activate_as_instant: static_kind_present(state, StaticModeKind::ActivateAsInstant),
         }
-        gates
     }
 }
 

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::game::functioning_abilities::static_kind_present;
 use crate::game::layers;
 use crate::game::replacement::{self, ReplacementResult};
 use crate::game::zone_pipeline::{
@@ -14,7 +15,7 @@ use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::ProposedEvent;
-use crate::types::statics::StaticMode;
+use crate::types::statics::{StaticMode, StaticModeKind};
 use crate::types::zones::Zone;
 
 use super::speed::{controls_start_your_engines_in, set_speed};
@@ -387,11 +388,17 @@ fn ascend_status_in(
 /// (`analysis::loop_check::live_mandatory_loop_winner`, CR 101.2) can reuse the same
 /// SBA-layer predicate rather than re-deriving the can't-lose check.
 pub(crate) fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
-    let from_permanent =
+    // CR 604.1: O(1) presence gate on the battlefield-static authority only. The
+    // transient-continuous-effect path below is a separate authority the index does
+    // NOT fold, so gate the `.any()` with a short-circuit conjunction rather than an
+    // early return.
+    let from_permanent = static_kind_present(state, StaticModeKind::CantLoseTheGame) && {
+        crate::game::perf_counters::record_static_full_scan();
         super::functioning_abilities::battlefield_active_statics(state).any(|(obj, def)| {
             def.mode == StaticMode::CantLoseTheGame
                 && static_affects_player(obj.controller, &def.affected, player_id)
-        });
+        })
+    };
     if from_permanent {
         return true;
     }
@@ -857,9 +864,10 @@ pub fn legend_rule_exempt(
 
 fn legend_rule_exemption_static_present(state: &GameState) -> bool {
     crate::game::perf_counters::record_legend_rule_mode_gate_scan();
-    super::functioning_abilities::any_functioning_static_mode(state, |m| {
-        matches!(m, StaticMode::LegendRuleDoesntApply)
-    })
+    // Read the discriminant from the O(1) `StaticModePresence` index (Unit 1) instead of
+    // sweeping `game_functioning_statics`. A post-flush-precise superset: a spurious `true`
+    // falls through to the exact per-permanent exemption check.
+    static_kind_present(state, StaticModeKind::LegendRuleDoesntApply)
 }
 
 fn legend_rule_exempt_with_gate(
@@ -4443,6 +4451,62 @@ mod tests {
              eliminated by draw-from-empty SBA"
         );
         assert!(!state.eliminated_players.contains(&PlayerId(0)));
+    }
+
+    /// Unit 2, site #19 (multi-authority): `player_has_cant_lose` gates ONLY its
+    /// battlefield `CantLoseTheGame` scan behind the O(1) presence index, via a
+    /// short-circuit conjunction, and leaves the `transient_grants_static_mode_to_player`
+    /// authority below untouched. With the index PRECISE and absent (post-flush, zero
+    /// battlefield statics) but an active TCE granting CantLoseTheGame to P0, the
+    /// predicate must still return `true` — proving the gate did NOT early-return and
+    /// suppress the transient authority. A wrong `if !static_kind_present { return false }`
+    /// flips this. The battlefield scan is skipped (0 recorded full scans), and the
+    /// negative reach-guard (P1, no grant) proves the positive is non-vacuous.
+    #[test]
+    fn cant_lose_tce_survives_precise_battlefield_gate() {
+        use crate::types::ability::{ContinuousModification, Duration};
+        let mut state = setup();
+        state.add_transient_continuous_effect(
+            crate::types::identifiers::ObjectId(999),
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            TargetFilter::SpecificPlayer { id: PlayerId(0) },
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::CantLoseTheGame,
+            }],
+            None,
+        );
+        // Flush makes the presence index PRECISE: no battlefield CantLoseTheGame static
+        // exists, so `static_kind_present` is false and the battlefield scan is skipped.
+        layers::evaluate_layers(&mut state);
+
+        crate::game::perf_counters::reset();
+        let p0_cant_lose = player_has_cant_lose(&state, PlayerId(0));
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            p0_cant_lose,
+            "transient-granted CantLoseTheGame must survive the battlefield-static gate (revert-failing)"
+        );
+        assert_eq!(
+            scans, 0,
+            "the precise-absent index must skip the battlefield scan; only the TCE authority answers"
+        );
+        // Negative reach-guard: a player with no grant is not protected — the true above
+        // is a real grant, not a blanket pass.
+        assert!(
+            !player_has_cant_lose(&state, PlayerId(1)),
+            "a player with neither authority is not protected"
+        );
+
+        // Production path: draw-from-empty SBA must not eliminate the TCE-covered player.
+        state.players[0].drew_from_empty_library = true;
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+        assert!(
+            !state.players[0].is_eliminated,
+            "TCE-covered player must not be eliminated by the draw-from-empty SBA"
+        );
     }
 
     // --- CR 702.131b: Ascend / city's blessing grant SBA ---

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 use crate::game::combat::AttackTarget;
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::functioning_abilities::{
-    battlefield_active_statics, game_active_statics, game_functioning_statics,
+    battlefield_active_statics, game_active_statics, game_functioning_statics, static_kind_present,
 };
 use crate::game::layers::{evaluate_condition, evaluate_condition_with_recipient};
 use crate::types::ability::{ContinuousModification, Duration, TargetFilter, TypedFilter};
@@ -13,7 +13,7 @@ use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::statics::{
     CombatAloneAction, CombatAloneRequirement, CostPaymentProhibition, CrewAction,
-    CrewContributionKind, ProhibitionScope, StaticMode,
+    CrewContributionKind, ProhibitionScope, StaticMode, StaticModeKind,
 };
 
 /// Handler function type for static ability modes.
@@ -1157,20 +1157,28 @@ pub fn player_has_cant_lose_life(state: &GameState, player_id: PlayerId) -> bool
 /// widen the bypass to every target `player_id` chooses. Those are evaluated
 /// per-target by [`target_ignores_hexproof`].
 pub fn player_ignores_hexproof(state: &GameState, player_id: PlayerId) -> bool {
-    let player_scoped_grant = game_functioning_statics(state).any(|(obj, def)| {
-        matches!(def.mode, StaticMode::IgnoreHexproof)
-            && def.affected.is_none()
-            && static_condition_matches_context(
-                state,
-                obj.id,
-                obj.controller,
-                def,
-                &StaticCheckContext {
-                    player_id: Some(player_id),
-                    ..Default::default()
-                },
-            )
-    });
+    // CR 702.11b + CR 702.11e existence gate: with no functioning `IgnoreHexproof`
+    // static on the board, no player-scoped hexproof-bypass grant is possible, so skip the
+    // O(battlefield) scan entirely (the O(1) presence index is precise post-flush; before
+    // the first flush it is conservatively all-present and this falls through to the exact
+    // scan below). Verdict-identical to the un-gated `.any()` for all inputs.
+    let player_scoped_grant = static_kind_present(state, StaticModeKind::IgnoreHexproof) && {
+        crate::game::perf_counters::record_static_full_scan();
+        game_functioning_statics(state).any(|(obj, def)| {
+            matches!(def.mode, StaticMode::IgnoreHexproof)
+                && def.affected.is_none()
+                && static_condition_matches_context(
+                    state,
+                    obj.id,
+                    obj.controller,
+                    def,
+                    &StaticCheckContext {
+                        player_id: Some(player_id),
+                        ..Default::default()
+                    },
+                )
+        })
+    };
     player_scoped_grant
         || transient_grants_static_mode_to_player(state, player_id, &StaticMode::IgnoreHexproof)
 }
@@ -1197,6 +1205,14 @@ pub fn player_ignores_hexproof(state: &GameState, player_id: PlayerId) -> bool {
 /// Detection Tower form (`affected = None`) is handled by
 /// [`player_ignores_hexproof`].
 pub fn target_ignores_hexproof(state: &GameState, target_id: ObjectId) -> bool {
+    // CR 702.11b + CR 702.11e existence gate: with no functioning `IgnoreHexproof`
+    // static on the board, no object-scoped hexproof-bypass grant is possible — skip the O(battlefield)
+    // scan. Precise post-flush; conservatively all-present before the first flush, where it
+    // falls through to the exact scan below. Verdict-identical to the un-gated `.any()`.
+    if !static_kind_present(state, StaticModeKind::IgnoreHexproof) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     game_functioning_statics(state).any(|(source_obj, def)| {
         matches!(def.mode, StaticMode::IgnoreHexproof)
             && def.affected.as_ref().is_some_and(|filter| {

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -442,6 +442,11 @@ pub(crate) fn triggered_cause_sacrifice_or_exile_muzzled(
     if acting_player != ability.controller {
         return false;
     }
+    // CR 604.1: O(1) presence gate — no CantCauseSacrificeOrExile static means no muzzle.
+    if !static_kind_present(state, StaticModeKind::CantCauseSacrificeOrExile) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     for (bf_obj, def) in crate::game::functioning_abilities::battlefield_active_statics(state) {
         let StaticMode::CantCauseSacrificeOrExile { ref cause } = def.mode else {
             continue;
@@ -679,6 +684,11 @@ pub fn check_static_ability(
     // Perf: this is the O(N) whole-battlefield sweep that combat/untap legality
     // loops hoist an existence gate in front of (see
     // `functioning_abilities::any_functioning_static_mode`).
+    // CR 604.1: static abilities are always on; when the O(1) presence index reports
+    // zero statics of this discriminant, no fall-through scan can match — return false.
+    if !static_kind_present(state, mode.kind()) {
+        return false;
+    }
     crate::game::perf_counters::record_static_full_scan();
     // CR 114.4: Abilities of emblems function in the command zone.
     // Check both battlefield objects and command zone emblems. The functioning
@@ -1037,6 +1047,11 @@ pub fn player_life_payment_colors(
         ..Default::default()
     };
     let mut colors = LifePaymentColors::EMPTY;
+    // CR 604.1: O(1) presence gate — no PayLifeAsColoredMana static means no grant.
+    if !static_kind_present(state, StaticModeKind::PayLifeAsColoredMana) {
+        return colors;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     // CR 604.1 + CR 702.26b: `battlefield_active_statics` owns the
     // phased-out / command-zone / condition gate.
     for (obj, def) in battlefield_active_statics(state) {
@@ -1243,6 +1258,11 @@ pub fn target_ignores_hexproof(state: &GameState, target_id: ObjectId) -> bool {
 /// also prevents damage/life-loss events. Paying 0 life remains legal under
 /// CR 119.4b and is handled by callers before consulting this predicate.
 pub fn player_cant_pay_life_as_cost(state: &GameState, player_id: PlayerId) -> bool {
+    // CR 604.1: O(1) presence gate — no CantPayCost static means no prohibition.
+    if !static_kind_present(state, StaticModeKind::CantPayCost) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     battlefield_active_statics(state).any(|(source_obj, def)| {
         matches!(
             &def.mode,
@@ -1265,6 +1285,11 @@ pub fn player_cant_sacrifice_as_cost(
     player_id: PlayerId,
     object_id: ObjectId,
 ) -> bool {
+    // CR 604.1: O(1) presence gate — no CantPayCost static means no prohibition.
+    if !static_kind_present(state, StaticModeKind::CantPayCost) {
+        return false;
+    }
+    crate::game::perf_counters::record_static_full_scan();
     battlefield_active_statics(state).any(|(source_obj, def)| {
         let StaticMode::CantPayCost {
             who,
@@ -1368,60 +1393,75 @@ pub fn player_protection_from(
         player_id: Some(player_id),
         ..Default::default()
     };
-    // CR 114.4: Abilities of emblems function in the command zone.
-    for (src_obj, def) in game_functioning_statics(state) {
-        let StaticMode::PlayerProtection(ref target) = def.mode else {
-            continue;
-        };
-        if let Some(ref affected) = def.affected {
-            if !static_filter_matches(state, &context, affected, src_obj.id) {
+    // CR 702.16: O(1) presence gate on the battlefield/command-zone PlayerProtection
+    // authority ONLY. The `Everything` transient-effect authority is handled by the
+    // short-circuit above (a separate authority the index does not fold), so wrap the
+    // loop rather than early-returning.
+    if static_kind_present(state, StaticModeKind::PlayerProtection) {
+        crate::game::perf_counters::record_static_full_scan();
+        // CR 114.4: Abilities of emblems function in the command zone.
+        for (src_obj, def) in game_functioning_statics(state) {
+            let StaticMode::PlayerProtection(ref target) = def.mode else {
+                continue;
+            };
+            if let Some(ref affected) = def.affected {
+                if !static_filter_matches(state, &context, affected, src_obj.id) {
+                    continue;
+                }
+            }
+            if !static_condition_matches_context(
+                state,
+                src_obj.id,
+                src_obj.controller,
+                def,
+                &context,
+            ) {
                 continue;
             }
-        }
-        if !static_condition_matches_context(state, src_obj.id, src_obj.controller, def, &context) {
-            continue;
-        }
-        let protects = match target {
-            // CR 702.16j: handled by the short-circuit above.
-            ProtectionTarget::Everything => false,
-            // CR 702.16 + CR 205.2: protection from the card type
-            // chosen as the granting permanent (e.g. Serra's Emissary) entered.
-            ProtectionTarget::ChosenCardType => state.objects.get(&source_id).is_some_and(|src| {
-                src_obj
-                    .chosen_card_type()
-                    .and_then(|ct| ct.protection_quality_str())
-                    .is_some_and(|quality| source_matches_card_type(src, quality))
-            }),
-            // CR 702.16k: "Protection from [a player]" at the player level — the
-            // protected player has protection from each object the specified
-            // player(s) control. "Each of your opponents" (CR 702.16i) → the
-            // `Opponent` scope: any source NOT controlled by the protected
-            // player is an opponent's object in 1v1 and free-for-all. Mirrors the
-            // object-level arm in `game/keywords.rs::source_matches_protection_target`.
-            ProtectionTarget::FromPlayer(scope) => {
-                state
-                    .objects
-                    .get(&source_id)
-                    .is_some_and(|src| match scope {
-                        ControllerRef::Opponent => src.controller != player_id,
-                        ControllerRef::You => src.controller == player_id,
-                        // Target/chosen player refs have no static context here —
-                        // fail closed (the parser never emits them for protection).
-                        _ => false,
+            let protects = match target {
+                // CR 702.16j: handled by the short-circuit above.
+                ProtectionTarget::Everything => false,
+                // CR 702.16 + CR 205.2: protection from the card type
+                // chosen as the granting permanent (e.g. Serra's Emissary) entered.
+                ProtectionTarget::ChosenCardType => {
+                    state.objects.get(&source_id).is_some_and(|src| {
+                        src_obj
+                            .chosen_card_type()
+                            .and_then(|ct| ct.protection_quality_str())
+                            .is_some_and(|quality| source_matches_card_type(src, quality))
                     })
+                }
+                // CR 702.16k: "Protection from [a player]" at the player level — the
+                // protected player has protection from each object the specified
+                // player(s) control. "Each of your opponents" (CR 702.16i) → the
+                // `Opponent` scope: any source NOT controlled by the protected
+                // player is an opponent's object in 1v1 and free-for-all. Mirrors the
+                // object-level arm in `game/keywords.rs::source_matches_protection_target`.
+                ProtectionTarget::FromPlayer(scope) => {
+                    state
+                        .objects
+                        .get(&source_id)
+                        .is_some_and(|src| match scope {
+                            ControllerRef::Opponent => src.controller != player_id,
+                            ControllerRef::You => src.controller == player_id,
+                            // Target/chosen player refs have no static context here —
+                            // fail closed (the parser never emits them for protection).
+                            _ => false,
+                        })
+                }
+                // Truly inert at the player level — no card grants these qualities to
+                // a player; object-level grants of these qualities flow through the
+                // `AddKeyword(Protection)` continuous path, not `PlayerProtection`.
+                ProtectionTarget::ChosenColor
+                | ProtectionTarget::Color(_)
+                | ProtectionTarget::Multicolored
+                | ProtectionTarget::Quality(_)
+                | ProtectionTarget::CardType(_)
+                | ProtectionTarget::Filter(_) => false,
+            };
+            if protects {
+                return true;
             }
-            // Truly inert at the player level — no card grants these qualities to
-            // a player; object-level grants of these qualities flow through the
-            // `AddKeyword(Protection)` continuous path, not `PlayerProtection`.
-            ProtectionTarget::ChosenColor
-            | ProtectionTarget::Color(_)
-            | ProtectionTarget::Multicolored
-            | ProtectionTarget::Quality(_)
-            | ProtectionTarget::CardType(_)
-            | ProtectionTarget::Filter(_) => false,
-        };
-        if protects {
-            return true;
         }
     }
     false
@@ -1447,28 +1487,35 @@ pub fn player_protection_from(
 /// constructing `StaticMode::Other(name.to_string())` on every call would
 /// allocate in potentially hot paths (damage resolution, sacrifice loops).
 fn check_static_other_by_name(state: &GameState, name: &str, context: &StaticCheckContext) -> bool {
-    // CR 114.4: Abilities of emblems function in the command zone.
-    // Functioning gate is applied before context-specific condition evaluation.
-    for (source_obj, def) in game_functioning_statics(state) {
-        match &def.mode {
-            StaticMode::Other(s) if s == name => {}
-            _ => continue,
-        }
-        if let Some(ref affected) = def.affected {
-            if !static_filter_matches(state, context, affected, source_obj.id) {
+    // CR 604.1: O(1) presence gate on the battlefield/command-zone `Other` static
+    // authority ONLY. The `transient_grants_other_static_to_context` fall-through below
+    // is a separate authority the index does not fold, so wrap the loop rather than
+    // early-returning.
+    if static_kind_present(state, StaticModeKind::Other) {
+        crate::game::perf_counters::record_static_full_scan();
+        // CR 114.4: Abilities of emblems function in the command zone.
+        // Functioning gate is applied before context-specific condition evaluation.
+        for (source_obj, def) in game_functioning_statics(state) {
+            match &def.mode {
+                StaticMode::Other(s) if s == name => {}
+                _ => continue,
+            }
+            if let Some(ref affected) = def.affected {
+                if !static_filter_matches(state, context, affected, source_obj.id) {
+                    continue;
+                }
+            }
+            if !static_condition_matches_context(
+                state,
+                source_obj.id,
+                source_obj.controller,
+                def,
+                context,
+            ) {
                 continue;
             }
+            return true;
         }
-        if !static_condition_matches_context(
-            state,
-            source_obj.id,
-            source_obj.controller,
-            def,
-            context,
-        ) {
-            continue;
-        }
-        return true;
     }
     transient_grants_other_static_to_context(state, name, context)
 }
@@ -1873,6 +1920,93 @@ mod tests {
             ..Default::default()
         };
         assert!(check_static_ability(&state, StaticMode::CantAttack, &ctx));
+    }
+
+    /// Unit 2, site #1: `check_static_ability` gates its O(N) whole-battlefield
+    /// scan behind the O(1) `StaticModePresence` index. On a large board with zero
+    /// functioning statics of the queried mode (index precise after a layers flush),
+    /// the call must run ZERO recorded full scans and return `false`. Reverting the
+    /// `if !static_kind_present(..) { return false }` gate makes the
+    /// `record_static_full_scan()` on the fall-through path fire, flipping the
+    /// counter assertion. The anchor half proves the counter is wired: with a
+    /// matching static present, the scan runs exactly once.
+    #[test]
+    fn check_static_ability_gate_zero_scans() {
+        let mut state = setup();
+        // Large vanilla board, no CantAttack static anywhere. Capture the first
+        // creature (controlled by P0) as the query target.
+        let mut target = None;
+        for i in 0..600u64 {
+            let id = create_object(
+                &mut state,
+                CardId(1000 + i),
+                PlayerId(0),
+                format!("Bear {i}"),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+            if target.is_none() {
+                target = Some(id);
+            }
+        }
+        let target = target.unwrap();
+        // Flush makes the presence index PRECISE (CantAttack absent => gate short-circuits).
+        crate::game::layers::evaluate_layers(&mut state);
+
+        let ctx = StaticCheckContext {
+            target_id: Some(target),
+            ..Default::default()
+        };
+        crate::game::perf_counters::reset();
+        let blocked = check_static_ability(&state, StaticMode::CantAttack, &ctx);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+
+        assert!(
+            !blocked,
+            "no CantAttack static means the check returns false"
+        );
+        assert_eq!(
+            scans, 0,
+            "the O(1) presence gate must skip the whole-battlefield scan (revert-failing)"
+        );
+
+        // Non-vacuous anchor: install a matching static (source controlled by P1,
+        // affecting opponents' creatures => matches the P0 target), reflush, and
+        // confirm the fall-through scan runs exactly once and the check now matches.
+        let source = create_object(
+            &mut state,
+            CardId(9999),
+            PlayerId(1),
+            "Pacifism Source".to_string(),
+            Zone::Battlefield,
+        );
+        let affected =
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantAttack).affected(affected));
+        crate::game::layers::evaluate_layers(&mut state);
+
+        crate::game::perf_counters::reset();
+        let blocked = check_static_ability(&state, StaticMode::CantAttack, &ctx);
+        let scans = crate::game::perf_counters::snapshot().static_full_scans;
+        assert!(
+            blocked,
+            "the installed CantAttack static must match the P0 target on fall-through"
+        );
+        assert_eq!(
+            scans, 1,
+            "present index falls through to exactly one recorded scan"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -244,6 +244,12 @@ fn find_legal_targets_with_context(
         }
     }
 
+    // Target-invariant player-scoped hexproof bypass (CR 702.11b, Detection Tower):
+    // hoisted ONCE per enumeration and threaded into every `can_target` call below, so the
+    // O(battlefield) player-scoped scan runs once rather than once per candidate target.
+    let source_ignores_hexproof =
+        crate::game::static_abilities::player_ignores_hexproof(state, source_controller);
+
     let explicit_zones = extract_explicit_zones(filter);
 
     if !explicit_zones.is_empty() {
@@ -257,7 +263,13 @@ fn find_legal_targets_with_context(
                                 Some(o) => o,
                                 None => continue,
                             };
-                            if can_target(obj, source_controller, source_id, state) {
+                            if can_target(
+                                obj,
+                                source_controller,
+                                source_id,
+                                source_ignores_hexproof,
+                                state,
+                            ) {
                                 targets.push(TargetRef::Object(obj_id));
                             }
                         }
@@ -350,7 +362,13 @@ fn find_legal_targets_with_context(
                     Some(o) => o,
                     None => continue,
                 };
-                if can_target(obj, source_controller, source_id, state) {
+                if can_target(
+                    obj,
+                    source_controller,
+                    source_id,
+                    source_ignores_hexproof,
+                    state,
+                ) {
                     targets.push(TargetRef::Object(obj_id));
                 }
             }
@@ -380,6 +398,12 @@ fn has_legal_target_with_context(
         });
     }
 
+    // Target-invariant player-scoped hexproof bypass (CR 702.11b) hoisted ONCE per
+    // enumeration and threaded into every `can_target` below (mirrors
+    // `find_legal_targets_with_context`).
+    let source_ignores_hexproof =
+        crate::game::static_abilities::player_ignores_hexproof(state, source_controller);
+
     let explicit_zones = extract_explicit_zones(filter);
     if !explicit_zones.is_empty() {
         if explicit_zones.contains(&Zone::Battlefield) {
@@ -388,7 +412,13 @@ fn has_legal_target_with_context(
                     let Some(obj) = state.objects.get(&obj_id) else {
                         continue;
                     };
-                    if can_target(obj, source_controller, source_id, state) {
+                    if can_target(
+                        obj,
+                        source_controller,
+                        source_id,
+                        source_ignores_hexproof,
+                        state,
+                    ) {
                         return true;
                     }
                 }
@@ -409,7 +439,13 @@ fn has_legal_target_with_context(
             let Some(obj) = state.objects.get(&obj_id) else {
                 continue;
             };
-            if can_target(obj, source_controller, source_id, state) {
+            if can_target(
+                obj,
+                source_controller,
+                source_id,
+                source_ignores_hexproof,
+                state,
+            ) {
                 return true;
             }
         }
@@ -1558,6 +1594,12 @@ fn add_zone_targets(
     let source_controller = target_ctx
         .source_controller
         .expect("target enumeration context must include a source controller");
+    // Target-invariant player-scoped hexproof bypass (CR 702.11b) hoisted ONCE per
+    // enumeration. Only the `require_full_targeting` arm consults `can_target`, so the scan
+    // is skipped entirely when full targeting isn't required (the else-arm uses only the
+    // per-object `is_protected_from`).
+    let source_ignores_hexproof = require_full_targeting
+        && crate::game::static_abilities::player_ignores_hexproof(state, source_controller);
     for obj_id in object_ids {
         if super::filter::matches_target_filter(state, obj_id, filter, target_ctx) {
             let obj = match state.objects.get(&obj_id) {
@@ -1565,7 +1607,13 @@ fn add_zone_targets(
                 None => continue,
             };
             if require_full_targeting {
-                if can_target(obj, source_controller, source_id, state) {
+                if can_target(
+                    obj,
+                    source_controller,
+                    source_id,
+                    source_ignores_hexproof,
+                    state,
+                ) {
                     targets.push(TargetRef::Object(obj_id));
                 }
             } else if !is_protected_from(obj, source_id, state) {
@@ -1583,6 +1631,10 @@ fn add_stack_spells(
     target_ctx: &super::filter::FilterContext,
     targets: &mut Vec<TargetRef>,
 ) {
+    // Target-invariant player-scoped hexproof bypass (CR 702.11b) hoisted ONCE per
+    // enumeration and threaded into every `can_target` below.
+    let source_ignores_hexproof =
+        crate::game::static_abilities::player_ignores_hexproof(state, source_controller);
     for entry in &state.stack {
         // CR 601.2c: A spell choosing stack targets during its own cast cannot
         // select itself — targeting the counterspell removes only the counter
@@ -1599,7 +1651,13 @@ fn add_stack_spells(
             Some(o) => o,
             None => continue,
         };
-        if can_target(obj, source_controller, source_id, state) {
+        if can_target(
+            obj,
+            source_controller,
+            source_id,
+            source_ignores_hexproof,
+            state,
+        ) {
             targets.push(TargetRef::Object(entry.id));
         }
     }
@@ -1841,6 +1899,7 @@ fn can_target(
     obj: &crate::game::game_object::GameObject,
     source_controller: PlayerId,
     source_id: ObjectId,
+    source_ignores_hexproof: bool,
     state: &GameState,
 ) -> bool {
     // CR 702.18a: Shroud prevents targeting by any player.
@@ -1850,14 +1909,16 @@ fn can_target(
     // CR 702.11b: An "ignore hexproof" effect bypasses Hexproof / Hexproof from
     // [quality] only — never Shroud. Two distinct scopings:
     //   - player-scoped (Detection Tower): the targeting source's controller may
-    //     target any permanent "as though it didn't have hexproof";
+    //     target any permanent "as though it didn't have hexproof". This half is
+    //     target-invariant, so callers hoist it ONCE per enumeration and thread the
+    //     result in as `source_ignores_hexproof`.
     //   - object-scoped (Nowhere to Run): specific permanents matching a static's
     //     `affected` filter may be targeted as though they had no hexproof, by
     //     ANY player — the card carries no "you control" qualifier on the spells
-    //     or abilities, which is the multiplayer-correct reading.
-    let ignores_hexproof =
-        crate::game::static_abilities::player_ignores_hexproof(state, source_controller)
-            || crate::game::static_abilities::target_ignores_hexproof(state, obj.id);
+    //     or abilities, which is the multiplayer-correct reading. This half is
+    //     per-object and stays inside the loop.
+    let ignores_hexproof = source_ignores_hexproof
+        || crate::game::static_abilities::target_ignores_hexproof(state, obj.id);
     // CR 702.11b: Hexproof on a permanent prevents targeting by opponents.
     if !ignores_hexproof
         && obj.has_keyword(&Keyword::Hexproof)
@@ -1876,6 +1937,7 @@ fn can_target(
             }
         }
     }
+    // Per-object (depends on `obj`) — correctly NOT hoisted out of the enumeration loop.
     if is_protected_from(obj, source_id, state) {
         return false;
     }
@@ -1887,6 +1949,7 @@ fn can_target(
     // — see `static_mode_needs_grant_propagation`). The opponent-scoped variant
     // ("... your opponents control") is parsed as `Keyword::Hexproof` instead, so
     // it is handled by the Hexproof branch above rather than here.
+    // Per-object (reads `obj`'s own static definitions) — correctly NOT hoisted.
     if super::functioning_abilities::active_static_definitions(state, obj)
         .any(|def| matches!(def.mode, crate::types::statics::StaticMode::CantBeTargeted))
     {
@@ -2348,6 +2411,7 @@ mod tests {
             state.objects.get(&c1).unwrap(),
             PlayerId(0),
             source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
             &state
         ));
 
@@ -2366,6 +2430,7 @@ mod tests {
             state.objects.get(&c1).unwrap(),
             PlayerId(0),
             source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
             &state
         ));
     }
@@ -2477,6 +2542,7 @@ mod tests {
                 state.objects.get(&p1_creature).unwrap(),
                 PlayerId(2),
                 p2_source,
+                crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(2)),
                 &state
             ),
             "scoped IgnoreHexproof must let a third player target the static controller's opponent's creature"
@@ -2489,6 +2555,7 @@ mod tests {
                 state.objects.get(&p0_creature).unwrap(),
                 PlayerId(1),
                 p1_source,
+                crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(1)),
                 &state
             ),
             "the static controller's own creature is outside the bypass scope and keeps hexproof"
@@ -2576,6 +2643,7 @@ mod tests {
             state.objects.get(&target).unwrap(),
             PlayerId(2),
             source,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(2)),
             &state,
         );
         assert!(
@@ -2594,6 +2662,7 @@ mod tests {
             state.objects.get(&target).unwrap(),
             PlayerId(2),
             source,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(2)),
             &state,
         );
         assert!(
@@ -3739,7 +3808,13 @@ mod tests {
 
         // Player 0 (opponent) targeting c1 with a red source — should fail
         let obj = state.objects.get(&c1).unwrap();
-        assert!(!can_target(obj, PlayerId(0), source_id, &state));
+        assert!(!can_target(
+            obj,
+            PlayerId(0),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     #[test]
@@ -3772,7 +3847,13 @@ mod tests {
 
         // Player 0 targeting c1 with a blue source — should succeed
         let obj = state.objects.get(&c1).unwrap();
-        assert!(can_target(obj, PlayerId(0), source_id, &state));
+        assert!(can_target(
+            obj,
+            PlayerId(0),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     #[test]
@@ -3805,7 +3886,13 @@ mod tests {
 
         // Controller targeting own creature — should succeed regardless
         let obj = state.objects.get(&c1).unwrap();
-        assert!(can_target(obj, PlayerId(1), source_id, &state));
+        assert!(can_target(
+            obj,
+            PlayerId(1),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(1)),
+            &state
+        ));
     }
 
     #[test]
@@ -3837,7 +3924,13 @@ mod tests {
             .push(CoreType::Artifact);
 
         let obj = state.objects.get(&c1).unwrap();
-        assert!(!can_target(obj, PlayerId(0), source_id, &state));
+        assert!(!can_target(
+            obj,
+            PlayerId(0),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     #[test]
@@ -3870,7 +3963,13 @@ mod tests {
             .push(ManaColor::Red);
 
         let obj = state.objects.get(&c1).unwrap();
-        assert!(!can_target(obj, PlayerId(0), source_id, &state));
+        assert!(!can_target(
+            obj,
+            PlayerId(0),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
 
         // Multicolored source — NOT blocked by "hexproof from monocolored"
         let multi_id = create_object(
@@ -3886,7 +3985,13 @@ mod tests {
             multi.color.push(ManaColor::Blue);
         }
         let obj = state.objects.get(&c1).unwrap();
-        assert!(can_target(obj, PlayerId(0), multi_id, &state));
+        assert!(can_target(
+            obj,
+            PlayerId(0),
+            multi_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     #[test]
@@ -3917,7 +4022,13 @@ mod tests {
             .push(CoreType::Instant);
 
         let obj = state.objects.get(&c1).unwrap();
-        assert!(!can_target(obj, PlayerId(0), source_id, &state));
+        assert!(!can_target(
+            obj,
+            PlayerId(0),
+            source_id,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     #[test]
@@ -3962,8 +4073,20 @@ mod tests {
             };
 
         let obj = state.objects.get(&c1).unwrap();
-        assert!(!can_target(obj, PlayerId(0), low_mv_source, &state));
-        assert!(can_target(obj, PlayerId(0), high_mv_source, &state));
+        assert!(!can_target(
+            obj,
+            PlayerId(0),
+            low_mv_source,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
+        assert!(can_target(
+            obj,
+            PlayerId(0),
+            high_mv_source,
+            crate::game::static_abilities::player_ignores_hexproof(&state, PlayerId(0)),
+            &state
+        ));
     }
 
     /// CR 702.16b + CR 702.16j: A player with protection from everything
@@ -4548,5 +4671,139 @@ mod tests {
             kind: crate::types::events::ActivatedAbilityKind::Normal,
         };
         assert_eq!(extract_player_from_event(&event, &state), Some(PlayerId(1)));
+    }
+
+    // ── StaticModePresence hexproof scan-gate tests (Verification Matrix A/B/C) ──
+
+    /// Test A — token-storm counter guard. On a ~1000-token board with zero functioning
+    /// `IgnoreHexproof` statics, a full target enumeration must run ZERO whole-battlefield
+    /// static scans (the profiler-confirmed O(targets × battlefield) hang). Non-vacuous
+    /// anchor: every token is still returned as a legal target.
+    #[test]
+    fn token_storm_target_enumeration_does_no_static_full_scans() {
+        let mut state = GameState::new_two_player(42);
+        const TOKENS: usize = 1000;
+        let mut token_ids = Vec::with_capacity(TOKENS);
+        for i in 0..TOKENS {
+            let id = create_object(
+                &mut state,
+                CardId(1000 + i as u64),
+                PlayerId(1),
+                format!("Token{i}"),
+                Zone::Battlefield,
+            );
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+            token_ids.push(id);
+        }
+        // Full layers flush makes the presence index PRECISE (IgnoreHexproof absent => the
+        // gates short-circuit before any full scan).
+        crate::game::layers::evaluate_layers(&mut state);
+
+        crate::game::perf_counters::reset();
+        let targets = find_legal_targets(&state, &creature_filter(), PlayerId(0), ObjectId(99));
+        let counters = crate::game::perf_counters::snapshot();
+
+        // (1) Counter guard — reverting the presence gate makes this non-zero.
+        assert_eq!(
+            counters.static_full_scans, 0,
+            "token-storm target enumeration must not run any whole-battlefield static scan"
+        );
+        // (2) Standalone correctness anchor — every token is a legal target.
+        assert_eq!(targets.len(), TOKENS, "every token must be a legal target");
+        assert!(targets.contains(&TargetRef::Object(token_ids[0])));
+        assert!(targets.contains(&TargetRef::Object(token_ids[TOKENS - 1])));
+    }
+
+    /// Test B — positive control (multi-authority). With BOTH a player-scoped
+    /// (`affected = None`, Detection Tower) and an object-scoped (`affected = Some`,
+    /// Nowhere to Run) `IgnoreHexproof` static present, a hexproof creature IS targetable.
+    /// Proves the presence gate does not suppress a real grant (the index reports present,
+    /// so the exact scan runs). Test C shares this fixture minus the statics as the
+    /// reach-guard.
+    #[test]
+    fn multi_authority_ignore_hexproof_keeps_hexproof_creature_targetable() {
+        use crate::types::ability::{ControllerRef, StaticDefinition};
+        let (mut state, _c0, c1) = setup_with_creatures();
+        state
+            .objects
+            .get_mut(&c1)
+            .unwrap()
+            .keywords
+            .push(Keyword::Hexproof);
+        // Player-scoped IgnoreHexproof (Detection Tower form), controlled by P0.
+        let tower = create_object(
+            &mut state,
+            CardId(50),
+            PlayerId(0),
+            "Detection Tower".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&tower).unwrap().static_definitions =
+            vec![StaticDefinition::new(StaticMode::IgnoreHexproof)].into();
+        // Object-scoped IgnoreHexproof (Nowhere to Run form), controlled by P0.
+        let nowhere = create_object(
+            &mut state,
+            CardId(51),
+            PlayerId(0),
+            "Nowhere to Run".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&nowhere).unwrap().static_definitions =
+            vec![
+                StaticDefinition::new(StaticMode::IgnoreHexproof).affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::Opponent),
+                )),
+            ]
+            .into();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        assert!(
+            find_legal_targets(&state, &creature_filter(), PlayerId(0), tower)
+                .contains(&TargetRef::Object(c1)),
+            "hexproof creature must stay targetable when IgnoreHexproof authorities are present"
+        );
+    }
+
+    /// Test C — hexproof negative + controller positive (reach-guard for Test B). With NO
+    /// `IgnoreHexproof` static (precise presence = false), an opponent CANNOT target a
+    /// hexproof creature, but the creature's own controller CAN (CR 702.11b — hexproof only
+    /// blocks opponents). The negative assertion is the revert guard for the hoisted
+    /// `source_ignores_hexproof` threading.
+    #[test]
+    fn hexproof_blocks_opponent_but_not_controller_with_precise_presence() {
+        let (mut state, _c0, c1) = setup_with_creatures();
+        state
+            .objects
+            .get_mut(&c1)
+            .unwrap()
+            .keywords
+            .push(Keyword::Hexproof);
+        crate::game::layers::evaluate_layers(&mut state);
+        // Precise presence: IgnoreHexproof absent.
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                crate::types::statics::StaticModeKind::IgnoreHexproof
+            ),
+            "no IgnoreHexproof static means presence is precisely false"
+        );
+        // (neg) P0 (opponent of P1) cannot target P1's hexproof creature.
+        assert!(
+            !find_legal_targets(&state, &creature_filter(), PlayerId(0), ObjectId(99))
+                .contains(&TargetRef::Object(c1)),
+            "hexproof blocks the opponent"
+        );
+        // (pos) P1 (its own controller) CAN target it.
+        assert!(
+            find_legal_targets(&state, &creature_filter(), PlayerId(1), ObjectId(99))
+                .contains(&TargetRef::Object(c1)),
+            "hexproof does not block the controller (CR 702.11b)"
+        );
     }
 }

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -14,12 +14,13 @@ use crate::types::identifiers::ObjectId;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::ProposedEvent;
-use crate::types::statics::{HandSizeModification, StaticMode};
+use crate::types::statics::{HandSizeModification, StaticMode, StaticModeKind};
 use crate::types::zones::Zone;
 
 use super::combat;
 use super::combat_damage;
 use super::day_night;
+use super::functioning_abilities::static_kind_present;
 use super::priority;
 use super::turn_control;
 use super::zones;
@@ -875,10 +876,7 @@ pub fn execute_untap_with_choices(
     // per-permanent scan so the O(N) `check_static_ability` re-scan is skipped
     // for every permanent when no functioning CantUntap static exists
     // (O(N^2) -> O(N) on the every-turn untap step).
-    let has_cant_untap_static =
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::CantUntap)
-        });
+    let has_cant_untap_static = static_kind_present(state, StaticModeKind::CantUntap);
     let intrinsic_cant_untap: HashSet<ObjectId> = state
         .battlefield
         .iter()
@@ -1144,10 +1142,7 @@ fn untap_excluded_ids(state: &GameState, player: PlayerId) -> HashSet<ObjectId> 
         .collect();
     // CR 502.3 + CR 604.1: hoist the CantUntap existence gate once before the
     // per-permanent scan (O(N^2) -> O(N) when no functioning CantUntap exists).
-    let has_cant_untap_static =
-        super::functioning_abilities::any_functioning_static_mode(state, |m| {
-            matches!(m, StaticMode::CantUntap)
-        });
+    let has_cant_untap_static = static_kind_present(state, StaticModeKind::CantUntap);
     for id in state.battlefield.iter().copied() {
         let Some(obj) = state.objects.get(&id) else {
             continue;
@@ -4049,6 +4044,10 @@ mod tests {
             .map(|i| create_tapped_creature(&mut state, 100 + i, &format!("Bear {i}")))
             .collect();
 
+        // Flush makes the `StaticModePresence` index PRECISE (CantUntap absent). In
+        // production the index is always flushed before the untap step; the pre-flush
+        // `all_present` default would conservatively fall through to the O(N) scan.
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let mut events = Vec::new();
         execute_untap(&mut state, &mut events);
@@ -4083,6 +4082,10 @@ mod tests {
         create_tapped_creature(&mut state, 2, "Bear A");
         create_tapped_creature(&mut state, 3, "Bear B");
 
+        // Flush makes the `StaticModePresence` index PRECISE (CantUntap absent, only the
+        // MaxUntapPerType cap present). Production reaches this path with a flushed index;
+        // the pre-flush `all_present` default would conservatively fall through.
+        crate::game::layers::evaluate_layers(&mut state);
         crate::game::perf_counters::reset();
         let prompt = max_untap_subset_prompt(&state, PlayerId(0), &HashSet::new());
         let scans = crate::game::perf_counters::snapshot().static_full_scans;

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -761,20 +761,26 @@ fn viewer_may_look_at_face_down(
     can_view_private_for_player: &impl Fn(PlayerId) -> bool,
 ) -> bool {
     use crate::types::ability::{ContinuousModification, Duration};
-    use crate::types::statics::StaticMode;
-    for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
-        if !matches!(def.mode, StaticMode::MayLookAtFaceDown) {
-            continue;
-        }
-        if !can_view_private_for_player(source.controller) {
-            continue;
-        }
-        let Some(filter) = def.affected.as_ref() else {
-            continue;
-        };
-        let ctx = super::filter::FilterContext::from_source(state, source.id);
-        if super::filter::matches_target_filter(state, obj_id, filter, &ctx) {
-            return true;
+    use crate::types::statics::{StaticMode, StaticModeKind};
+    // CR 708.5: O(1) presence gate covers ONLY the battlefield-static authority. The
+    // duration-bound `transient_continuous_effects` scan below is a separate authority
+    // the index does not track, so wrap the loop rather than early-returning `false`.
+    if super::functioning_abilities::static_kind_present(state, StaticModeKind::MayLookAtFaceDown) {
+        crate::game::perf_counters::record_static_full_scan(); // counter fires only on real scan
+        for (source, def) in super::functioning_abilities::battlefield_active_statics(state) {
+            if !matches!(def.mode, StaticMode::MayLookAtFaceDown) {
+                continue;
+            }
+            if !can_view_private_for_player(source.controller) {
+                continue;
+            }
+            let Some(filter) = def.affected.as_ref() else {
+                continue;
+            };
+            let ctx = super::filter::FilterContext::from_source(state, source.id);
+            if super::filter::matches_target_filter(state, obj_id, filter, &ctx) {
+                return true;
+            }
         }
     }
 
@@ -1261,6 +1267,113 @@ mod tests {
             filtered.objects.get(&card_id).map(|obj| obj.name.as_str()),
             Some("Hidden Card"),
             "re-drawn card must not inherit prior reveal state — it is a new object per CR 400.7"
+        );
+    }
+
+    /// Unit 2, site #21 (multi-authority): `viewer_may_look_at_face_down` gates ONLY
+    /// its battlefield `MayLookAtFaceDown` scan behind the O(1) presence index (wrap,
+    /// not early-return), and falls through UNCHANGED to the duration-bound
+    /// `transient_continuous_effects` authority the index does not track. Three cases:
+    /// (a) a TCE grant with the index PRECISE-absent still permits the look — proving
+    /// the wrap did not early-`return false` and suppress the TCE (revert-failing);
+    /// (b) neither authority => no look; (c) a battlefield static (index present) falls
+    /// through and permits the look.
+    #[test]
+    fn face_down_look_tce_survives_precise_battlefield_gate() {
+        use crate::types::ability::{
+            ContinuousModification, ControllerRef, Duration, StaticDefinition, TargetFilter,
+            TypedFilter,
+        };
+        use crate::types::statics::{StaticMode, StaticModeKind};
+
+        // Viewer P0; face-down creature controlled by opponent P1.
+        let mut state = GameState::new_two_player(42);
+        let face_down = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Face Down".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&face_down).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.face_down = true;
+        }
+        // Viewer P0 can see only their own private information.
+        let can_view = |p: PlayerId| p == PlayerId(0);
+        let opp_creature =
+            || TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent));
+
+        // (b) Neither authority present, index precise => no look.
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::MayLookAtFaceDown
+            ),
+            "precondition: no battlefield MayLookAtFaceDown static"
+        );
+        assert!(
+            !viewer_may_look_at_face_down(&state, face_down, &can_view),
+            "no authority => the viewer may not look"
+        );
+
+        // (a) TCE grant (controller P0) with the battlefield index still absent.
+        state.add_transient_continuous_effect(
+            ObjectId(999),
+            PlayerId(0),
+            Duration::UntilEndOfTurn,
+            opp_creature(),
+            vec![ContinuousModification::AddStaticMode {
+                mode: StaticMode::MayLookAtFaceDown,
+            }],
+            None,
+        );
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            !crate::game::functioning_abilities::static_kind_present(
+                &state,
+                StaticModeKind::MayLookAtFaceDown
+            ),
+            "the TCE authority must NOT flip the battlefield-static presence index"
+        );
+        assert!(
+            viewer_may_look_at_face_down(&state, face_down, &can_view),
+            "TCE-granted look must survive the battlefield-static gate (revert-failing)"
+        );
+
+        // (c) Battlefield static (index present) — presence-positive fall-through.
+        let mut state = GameState::new_two_player(42);
+        let face_down = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(1),
+            "Face Down".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&face_down).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.face_down = true;
+        }
+        let looker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Found Footage".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&looker)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::MayLookAtFaceDown).affected(opp_creature()));
+        crate::game::layers::evaluate_layers(&mut state);
+        assert!(
+            viewer_may_look_at_face_down(&state, face_down, &can_view),
+            "a battlefield MayLookAtFaceDown static permits the look on fall-through"
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6027,6 +6027,24 @@ pub struct GameState {
     /// must not break AI-search dedup on semantically-identical positions.
     #[serde(skip)]
     pub static_source_index: StaticSourceIndex,
+    /// O(1) presence index over `StaticModeKind` discriminants — "does any functioning
+    /// static of kind K exist on the board?" Rebuilt wholesale from `game_functioning_statics`
+    /// as a byproduct of the layers pipeline (`layers::refresh_static_mode_presence`), so it is
+    /// exactly `.any(kind)` for every kind. Lets discriminant-only scan gates (e.g. the
+    /// hexproof scans in `static_abilities`) skip an O(battlefield) `.any()` when zero statics
+    /// of that kind exist.
+    ///
+    /// DERIVED CACHE — `#[serde(skip)]` with an `all_present` default: before the first flush
+    /// makes the index precise, every consumer must fall through to its exact per-object check,
+    /// so the conservative all-true default can only cost a redundant scan, never miss a grant.
+    /// INTENTIONALLY omitted from `impl PartialEq for GameState` — CR 104.4b loop detection
+    /// compares semantic board state; derived caches must not perturb loop-detection equality
+    /// (like `static_source_index`/`static_gate_truth`).
+    #[serde(
+        skip,
+        default = "crate::types::statics::StaticModePresence::all_present"
+    )]
+    pub static_mode_presence: crate::types::statics::StaticModePresence,
     /// CR 732.2a loop-shortcut detection ring (PR-3). A bounded FIFO of recent
     /// post-resolution NORMALIZED board snapshots, captured at the post-pipeline frame
     /// of `game::engine::pass_priority_once_with_pipeline` (after
@@ -7888,6 +7906,7 @@ impl GameState {
             trigger_index: TriggerIndex::default(),
             replacement_index: ReplacementIndex::default(),
             static_source_index: StaticSourceIndex::default(),
+            static_mode_presence: crate::types::statics::StaticModePresence::all_present(),
             loop_detect_ring: std::collections::VecDeque::new(),
             next_timestamp: 1,
             public_state_dirty: PublicStateDirty::all_dirty(),
@@ -8434,6 +8453,9 @@ impl PartialEq for GameState {
             // static_definitions). Including it would break AI-search dedup on
             // semantically-identical positions whose caches differ only in
             // freshness.
+            // `static_mode_presence` is INTENTIONALLY excluded for the same reason
+            // (CR 104.4b) — a derived O(1) presence cache rebuilt from
+            // `game_functioning_statics`; it must not perturb loop-detection equality.
             && self.next_timestamp == other.next_timestamp
             && self.public_state_dirty == other.public_state_dirty
             && self.state_revision == other.state_revision
@@ -9089,6 +9111,61 @@ mod tests {
         // Reconstruct RNG from seed since it's skipped in serde
         deserialized.rng = ChaCha20Rng::seed_from_u64(deserialized.rng_seed);
         assert_eq!(state, deserialized);
+    }
+
+    /// Test E — deserialize-before-flush. `static_mode_presence` is `#[serde(skip)]` with an
+    /// `all_present` default, so a freshly-deserialized state (before any layers flush) has a
+    /// conservative all-present index. Gated consumers must stay CORRECT under that default by
+    /// falling through to their exact per-object scan; a full flush then makes the index
+    /// precise (a kind absent from the board reports false).
+    #[test]
+    fn static_mode_presence_defaults_all_present_after_deserialize() {
+        use crate::game::zones::create_object;
+        use crate::types::ability::StaticDefinition;
+        use crate::types::statics::{StaticMode, StaticModeKind};
+
+        let mut state = GameState::new_two_player(42);
+        let src = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Detection Tower".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&src).unwrap().static_definitions =
+            vec![StaticDefinition::new(StaticMode::IgnoreHexproof)].into();
+        crate::game::layers::evaluate_layers(&mut state);
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: GameState = serde_json::from_str(&json).unwrap();
+
+        // Before any flush: the conservative all-present default (a board-absent kind still
+        // reports present).
+        assert!(restored
+            .static_mode_presence
+            .contains(StaticModeKind::IgnoreHexproof));
+        assert!(restored
+            .static_mode_presence
+            .contains(StaticModeKind::Shroud));
+        // Gated-consumer correctness under the all-present default: the Detection Tower grant
+        // is found because the consumer falls through to its exact scan, not the index.
+        assert!(crate::game::static_abilities::player_ignores_hexproof(
+            &restored,
+            PlayerId(0)
+        ));
+
+        // After a full flush the index is precise: a board-absent kind reports false.
+        let mut flushed = restored;
+        flushed.layers_dirty = LayersDirty::full();
+        crate::game::layers::flush_layers(&mut flushed);
+        assert!(!crate::game::functioning_abilities::static_kind_present(
+            &flushed,
+            StaticModeKind::Shroud
+        ));
+        assert!(crate::game::functioning_abilities::static_kind_present(
+            &flushed,
+            StaticModeKind::IgnoreHexproof
+        ));
     }
 
     #[test]

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -3,6 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use strum::EnumCount;
 
 use super::ability::{
     AbilityCost, CardPlayMode, CastTimingPermission, CostCategory, PlayerFilter, QuantityExpr,
@@ -1835,6 +1836,311 @@ pub enum StaticMode {
     },
     /// Fallback for unrecognized static mode strings.
     Other(String),
+}
+
+/// Fieldless discriminant mirror of [`StaticMode`], used for O(1) discriminant-only
+/// existence queries (see [`StaticModePresence`]) without touching each variant's payload.
+///
+/// No-wildcard contract: every [`StaticMode`] variant MUST have a matching arm here and in
+/// [`StaticMode::kind`]. The exhaustive, wildcard-free match in `kind()` is the compile-time
+/// gate — adding a `StaticMode` variant without a `StaticModeKind` arm fails to compile.
+/// Precedent: `KeywordKind` / `Keyword::kind` (types/keywords.rs) — a hand-authored fieldless
+/// mirror plus a manual match is the established idiom here (not `strum::EnumDiscriminants`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumCount)]
+pub enum StaticModeKind {
+    Continuous,
+    DamageNotRemovedDuringCleanup,
+    CantAttack,
+    CantBlock,
+    CantAttackOrBlock,
+    CantBecomeSuspected,
+    MaxAttackersEachCombat,
+    MaxBlockersEachCombat,
+    CantBeTargeted,
+    CantBeCast,
+    CantBeActivated,
+    CantSearchLibrary,
+    RestrictLibrarySearchToTop,
+    CantCauseSacrificeOrExile,
+    CastWithFlash,
+    GrantsExtraVote,
+    GrantsExtraVillainousChoice,
+    CastWithKeyword,
+    CastWithAlternativeCost,
+    AlternativeKeywordCost,
+    ModifyCost,
+    ImposeAdditionalCost,
+    ReduceAbilityCost,
+    ReduceActionCost,
+    ModifyActivationLimit,
+    ActivateAsInstant,
+    CantPayCost,
+    CantGainLife,
+    CantLoseLife,
+    PlayerProtection,
+    MustAttack,
+    MustAttackPlayer,
+    MustBlock,
+    MustBlockAttacker,
+    CantDraw,
+    DrawFromBottom,
+    DoubleTriggers,
+    IgnoreHexproof,
+    ExtraBlockers,
+    RevealTopOfLibrary,
+    RevealHand,
+    GraveyardCastPermission,
+    TopOfLibraryCastPermission,
+    TopOfLibraryHasPlot,
+    TopOfLibraryPlotPermission,
+    CastFromHandFree,
+    ExileCastPermission,
+    LinkedCollectionCounterPlayPermission,
+    CountersPersistAcrossZones,
+    CantBeCountered,
+    CantBeCopied,
+    CantEnterBattlefieldFrom,
+    CantCastFrom,
+    CantCastDuring,
+    CantActivateDuring,
+    PerTurnCastLimit,
+    PerTurnDrawLimit,
+    SuppressTriggers,
+    CantBeBlocked,
+    CantBeBlockedExceptBy,
+    CantBeBlockedBy,
+    CantBeBlockedByMoreThan,
+    AttachmentRestriction,
+    Protection,
+    Indestructible,
+    CantBeDestroyed,
+    CantBeRegenerated,
+    FlashBack,
+    Shroud,
+    Hexproof,
+    Vigilance,
+    Menace,
+    Reach,
+    Flying,
+    Trample,
+    Deathtouch,
+    Lifelink,
+    CantTap,
+    CantUntap,
+    MustBeBlocked,
+    MustBeBlockedByAll,
+    Goaded,
+    CombatAlone,
+    CantCrew,
+    CantPhaseIn,
+    CrewContribution,
+    MayLookAtTopOfLibrary,
+    MayLookAtFaceDown,
+    CantBeTurnedFaceUp,
+    MayChooseNotToUntap,
+    AdditionalLandDrop,
+    EmblemStatic,
+    BlockRestriction,
+    NoMaximumHandSize,
+    MaximumHandSize,
+    MayPlayAdditionalLand,
+    CantHaveKeyword,
+    CantWinTheGame,
+    CantLoseTheGame,
+    LegendRuleDoesntApply,
+    SpeedCanIncreaseBeyondFour,
+    DefilerCostReduction,
+    SkipStep,
+    SpendManaAsAnyColor,
+    PayLifeAsColoredMana,
+    StepEndUnspentMana,
+    CanAttackWithDefender,
+    IgnoreLandwalkForBlocking,
+    CanActivateAbilitiesAsThoughHaste,
+    CanBlockShadow,
+    AssignNoCombatDamage,
+    UntapsDuringEachOtherPlayersUntapStep,
+    MaxUntapPerType,
+    EntersWithAdditionalCounters,
+    Other,
+}
+
+impl StaticMode {
+    /// Maps this [`StaticMode`] to its fieldless [`StaticModeKind`] discriminant.
+    ///
+    /// Wildcard-free exhaustive match — see the no-wildcard contract on [`StaticModeKind`].
+    pub fn kind(&self) -> StaticModeKind {
+        match self {
+            StaticMode::Continuous => StaticModeKind::Continuous,
+            StaticMode::DamageNotRemovedDuringCleanup => {
+                StaticModeKind::DamageNotRemovedDuringCleanup
+            }
+            StaticMode::CantAttack => StaticModeKind::CantAttack,
+            StaticMode::CantBlock => StaticModeKind::CantBlock,
+            StaticMode::CantAttackOrBlock => StaticModeKind::CantAttackOrBlock,
+            StaticMode::CantBecomeSuspected => StaticModeKind::CantBecomeSuspected,
+            StaticMode::MaxAttackersEachCombat { .. } => StaticModeKind::MaxAttackersEachCombat,
+            StaticMode::MaxBlockersEachCombat { .. } => StaticModeKind::MaxBlockersEachCombat,
+            StaticMode::CantBeTargeted => StaticModeKind::CantBeTargeted,
+            StaticMode::CantBeCast { .. } => StaticModeKind::CantBeCast,
+            StaticMode::CantBeActivated { .. } => StaticModeKind::CantBeActivated,
+            StaticMode::CantSearchLibrary { .. } => StaticModeKind::CantSearchLibrary,
+            StaticMode::RestrictLibrarySearchToTop { .. } => {
+                StaticModeKind::RestrictLibrarySearchToTop
+            }
+            StaticMode::CantCauseSacrificeOrExile { .. } => {
+                StaticModeKind::CantCauseSacrificeOrExile
+            }
+            StaticMode::CastWithFlash => StaticModeKind::CastWithFlash,
+            StaticMode::GrantsExtraVote => StaticModeKind::GrantsExtraVote,
+            StaticMode::GrantsExtraVillainousChoice => StaticModeKind::GrantsExtraVillainousChoice,
+            StaticMode::CastWithKeyword { .. } => StaticModeKind::CastWithKeyword,
+            StaticMode::CastWithAlternativeCost { .. } => StaticModeKind::CastWithAlternativeCost,
+            StaticMode::AlternativeKeywordCost { .. } => StaticModeKind::AlternativeKeywordCost,
+            StaticMode::ModifyCost { .. } => StaticModeKind::ModifyCost,
+            StaticMode::ImposeAdditionalCost { .. } => StaticModeKind::ImposeAdditionalCost,
+            StaticMode::ReduceAbilityCost { .. } => StaticModeKind::ReduceAbilityCost,
+            StaticMode::ReduceActionCost { .. } => StaticModeKind::ReduceActionCost,
+            StaticMode::ModifyActivationLimit { .. } => StaticModeKind::ModifyActivationLimit,
+            StaticMode::ActivateAsInstant { .. } => StaticModeKind::ActivateAsInstant,
+            StaticMode::CantPayCost { .. } => StaticModeKind::CantPayCost,
+            StaticMode::CantGainLife => StaticModeKind::CantGainLife,
+            StaticMode::CantLoseLife => StaticModeKind::CantLoseLife,
+            StaticMode::PlayerProtection(..) => StaticModeKind::PlayerProtection,
+            StaticMode::MustAttack => StaticModeKind::MustAttack,
+            StaticMode::MustAttackPlayer { .. } => StaticModeKind::MustAttackPlayer,
+            StaticMode::MustBlock => StaticModeKind::MustBlock,
+            StaticMode::MustBlockAttacker { .. } => StaticModeKind::MustBlockAttacker,
+            StaticMode::CantDraw { .. } => StaticModeKind::CantDraw,
+            StaticMode::DrawFromBottom { .. } => StaticModeKind::DrawFromBottom,
+            StaticMode::DoubleTriggers { .. } => StaticModeKind::DoubleTriggers,
+            StaticMode::IgnoreHexproof => StaticModeKind::IgnoreHexproof,
+            StaticMode::ExtraBlockers { .. } => StaticModeKind::ExtraBlockers,
+            StaticMode::RevealTopOfLibrary { .. } => StaticModeKind::RevealTopOfLibrary,
+            StaticMode::RevealHand { .. } => StaticModeKind::RevealHand,
+            StaticMode::GraveyardCastPermission { .. } => StaticModeKind::GraveyardCastPermission,
+            StaticMode::TopOfLibraryCastPermission { .. } => {
+                StaticModeKind::TopOfLibraryCastPermission
+            }
+            StaticMode::TopOfLibraryHasPlot => StaticModeKind::TopOfLibraryHasPlot,
+            StaticMode::TopOfLibraryPlotPermission => StaticModeKind::TopOfLibraryPlotPermission,
+            StaticMode::CastFromHandFree { .. } => StaticModeKind::CastFromHandFree,
+            StaticMode::ExileCastPermission { .. } => StaticModeKind::ExileCastPermission,
+            StaticMode::LinkedCollectionCounterPlayPermission => {
+                StaticModeKind::LinkedCollectionCounterPlayPermission
+            }
+            StaticMode::CountersPersistAcrossZones { .. } => {
+                StaticModeKind::CountersPersistAcrossZones
+            }
+            StaticMode::CantBeCountered => StaticModeKind::CantBeCountered,
+            StaticMode::CantBeCopied => StaticModeKind::CantBeCopied,
+            StaticMode::CantEnterBattlefieldFrom => StaticModeKind::CantEnterBattlefieldFrom,
+            StaticMode::CantCastFrom { .. } => StaticModeKind::CantCastFrom,
+            StaticMode::CantCastDuring { .. } => StaticModeKind::CantCastDuring,
+            StaticMode::CantActivateDuring { .. } => StaticModeKind::CantActivateDuring,
+            StaticMode::PerTurnCastLimit { .. } => StaticModeKind::PerTurnCastLimit,
+            StaticMode::PerTurnDrawLimit { .. } => StaticModeKind::PerTurnDrawLimit,
+            StaticMode::SuppressTriggers { .. } => StaticModeKind::SuppressTriggers,
+            StaticMode::CantBeBlocked => StaticModeKind::CantBeBlocked,
+            StaticMode::CantBeBlockedExceptBy { .. } => StaticModeKind::CantBeBlockedExceptBy,
+            StaticMode::CantBeBlockedBy { .. } => StaticModeKind::CantBeBlockedBy,
+            StaticMode::CantBeBlockedByMoreThan { .. } => StaticModeKind::CantBeBlockedByMoreThan,
+            StaticMode::AttachmentRestriction { .. } => StaticModeKind::AttachmentRestriction,
+            StaticMode::Protection => StaticModeKind::Protection,
+            StaticMode::Indestructible => StaticModeKind::Indestructible,
+            StaticMode::CantBeDestroyed => StaticModeKind::CantBeDestroyed,
+            StaticMode::CantBeRegenerated => StaticModeKind::CantBeRegenerated,
+            StaticMode::FlashBack => StaticModeKind::FlashBack,
+            StaticMode::Shroud => StaticModeKind::Shroud,
+            StaticMode::Hexproof => StaticModeKind::Hexproof,
+            StaticMode::Vigilance => StaticModeKind::Vigilance,
+            StaticMode::Menace => StaticModeKind::Menace,
+            StaticMode::Reach => StaticModeKind::Reach,
+            StaticMode::Flying => StaticModeKind::Flying,
+            StaticMode::Trample => StaticModeKind::Trample,
+            StaticMode::Deathtouch => StaticModeKind::Deathtouch,
+            StaticMode::Lifelink => StaticModeKind::Lifelink,
+            StaticMode::CantTap => StaticModeKind::CantTap,
+            StaticMode::CantUntap => StaticModeKind::CantUntap,
+            StaticMode::MustBeBlocked => StaticModeKind::MustBeBlocked,
+            StaticMode::MustBeBlockedByAll => StaticModeKind::MustBeBlockedByAll,
+            StaticMode::Goaded => StaticModeKind::Goaded,
+            StaticMode::CombatAlone { .. } => StaticModeKind::CombatAlone,
+            StaticMode::CantCrew => StaticModeKind::CantCrew,
+            StaticMode::CantPhaseIn => StaticModeKind::CantPhaseIn,
+            StaticMode::CrewContribution { .. } => StaticModeKind::CrewContribution,
+            StaticMode::MayLookAtTopOfLibrary => StaticModeKind::MayLookAtTopOfLibrary,
+            StaticMode::MayLookAtFaceDown => StaticModeKind::MayLookAtFaceDown,
+            StaticMode::CantBeTurnedFaceUp => StaticModeKind::CantBeTurnedFaceUp,
+            StaticMode::MayChooseNotToUntap => StaticModeKind::MayChooseNotToUntap,
+            StaticMode::AdditionalLandDrop { .. } => StaticModeKind::AdditionalLandDrop,
+            StaticMode::EmblemStatic => StaticModeKind::EmblemStatic,
+            StaticMode::BlockRestriction { .. } => StaticModeKind::BlockRestriction,
+            StaticMode::NoMaximumHandSize => StaticModeKind::NoMaximumHandSize,
+            StaticMode::MaximumHandSize { .. } => StaticModeKind::MaximumHandSize,
+            StaticMode::MayPlayAdditionalLand => StaticModeKind::MayPlayAdditionalLand,
+            StaticMode::CantHaveKeyword { .. } => StaticModeKind::CantHaveKeyword,
+            StaticMode::CantWinTheGame => StaticModeKind::CantWinTheGame,
+            StaticMode::CantLoseTheGame => StaticModeKind::CantLoseTheGame,
+            StaticMode::LegendRuleDoesntApply => StaticModeKind::LegendRuleDoesntApply,
+            StaticMode::SpeedCanIncreaseBeyondFour => StaticModeKind::SpeedCanIncreaseBeyondFour,
+            StaticMode::DefilerCostReduction { .. } => StaticModeKind::DefilerCostReduction,
+            StaticMode::SkipStep { .. } => StaticModeKind::SkipStep,
+            StaticMode::SpendManaAsAnyColor { .. } => StaticModeKind::SpendManaAsAnyColor,
+            StaticMode::PayLifeAsColoredMana { .. } => StaticModeKind::PayLifeAsColoredMana,
+            StaticMode::StepEndUnspentMana { .. } => StaticModeKind::StepEndUnspentMana,
+            StaticMode::CanAttackWithDefender => StaticModeKind::CanAttackWithDefender,
+            StaticMode::IgnoreLandwalkForBlocking { .. } => {
+                StaticModeKind::IgnoreLandwalkForBlocking
+            }
+            StaticMode::CanActivateAbilitiesAsThoughHaste => {
+                StaticModeKind::CanActivateAbilitiesAsThoughHaste
+            }
+            StaticMode::CanBlockShadow => StaticModeKind::CanBlockShadow,
+            StaticMode::AssignNoCombatDamage => StaticModeKind::AssignNoCombatDamage,
+            StaticMode::UntapsDuringEachOtherPlayersUntapStep => {
+                StaticModeKind::UntapsDuringEachOtherPlayersUntapStep
+            }
+            StaticMode::MaxUntapPerType { .. } => StaticModeKind::MaxUntapPerType,
+            StaticMode::EntersWithAdditionalCounters { .. } => {
+                StaticModeKind::EntersWithAdditionalCounters
+            }
+            StaticMode::Other(..) => StaticModeKind::Other,
+        }
+    }
+}
+
+/// O(1) presence index over [`StaticModeKind`] discriminants, populated as a byproduct of the
+/// layers pipeline. Answers "does any functioning static of kind K exist?" without an
+/// O(battlefield) scan. Backed by a fixed-size `bool` array indexed by `kind as usize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaticModePresence([bool; StaticModeKind::COUNT]);
+
+impl StaticModePresence {
+    /// All-false. Only used inside the layers-pipeline refresh fold, which rebuilds the index
+    /// wholesale from the same iterator its consumers would scan.
+    pub fn empty() -> Self {
+        StaticModePresence([false; StaticModeKind::COUNT])
+    }
+
+    /// All-true conservative default. Used before the first layers flush makes the index
+    /// precise (e.g. immediately after `GameState::new` or deserialize). Every consumer falls
+    /// through to its exact per-object check when a kind reports present, so a false positive
+    /// costs at most one redundant scan; a false negative would be a correctness bug and is
+    /// impossible in the all-true state.
+    pub fn all_present() -> Self {
+        StaticModePresence([true; StaticModeKind::COUNT])
+    }
+
+    /// Marks `kind` as present.
+    pub fn insert(&mut self, kind: StaticModeKind) {
+        self.0[kind as usize] = true;
+    }
+
+    /// Returns whether any functioning static of `kind` is currently indexed as present.
+    pub fn contains(&self, kind: StaticModeKind) -> bool {
+        self.0[kind as usize]
+    }
 }
 
 /// Manual Hash impl because `ModifyCost` contains `TargetFilter` and `QuantityRef`

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1955,6 +1955,7 @@ pub enum StaticModeKind {
     PayLifeAsColoredMana,
     StepEndUnspentMana,
     CanAttackWithDefender,
+    AttackOnlyNeighbor,
     IgnoreLandwalkForBlocking,
     CanActivateAbilitiesAsThoughHaste,
     CanBlockShadow,
@@ -2090,6 +2091,7 @@ impl StaticMode {
             StaticMode::PayLifeAsColoredMana { .. } => StaticModeKind::PayLifeAsColoredMana,
             StaticMode::StepEndUnspentMana { .. } => StaticModeKind::StepEndUnspentMana,
             StaticMode::CanAttackWithDefender => StaticModeKind::CanAttackWithDefender,
+            StaticMode::AttackOnlyNeighbor => StaticModeKind::AttackOnlyNeighbor,
             StaticMode::IgnoreLandwalkForBlocking { .. } => {
                 StaticModeKind::IgnoreLandwalkForBlocking
             }

--- a/crates/engine/tests/token_storm_scaling_gate.rs
+++ b/crates/engine/tests/token_storm_scaling_gate.rs
@@ -1,0 +1,255 @@
+//! Token-storm scaling CI gate (engine tier).
+//!
+//! Permanent regression guard proving the `StaticModePresence` O(1) index keeps
+//! whole-battlefield static scans out of the two highest-fanout production
+//! enumeration paths — target legality (`find_legal_targets`) and combat
+//! declaration (`get_valid_attacker_ids` / `legal_actions_full`) — at 1000-object
+//! scale, INCLUDING the production serde-restore → `flush_layers` seam that the AI
+//! search and saved-state loader hit. Locks in the Unit 1/Unit 2 perf work
+//! (commits a7ea537, dd8fe5d, 48861f8) against silent regression.
+//!
+//! DB-free by construction: `GameState::new_two_player` + `create_object` only,
+//! never loading `client/public/card-data.json` (mirrors the
+//! `targeting.rs:4683` unit test; `scripts/check-test-card-data-load.sh` guards
+//! this). Under `cargo nextest` each test runs in its own process, so the
+//! `thread_local!` perf counters cannot bleed across tests and the exact `== 0`
+//! assertions are sound. When run locally with plain `cargo test` the counters
+//! are still per-thread; nextest (Tilt `test-engine`) is the authoritative
+//! process-per-test harness.
+
+use engine::ai_support::legal_actions_full;
+use engine::game::combat::{get_valid_attack_targets, get_valid_attacker_ids};
+use engine::game::layers;
+use engine::game::perf_counters;
+use engine::game::targeting::find_legal_targets;
+use engine::game::zones::create_object;
+use engine::types::ability::{StaticDefinition, TargetFilter, TargetRef, TypedFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::statics::{StaticMode, StaticModeKind};
+use engine::types::zones::Zone;
+
+const TOKENS: usize = 1000;
+
+/// Combat-declaration board size. `token_storm_declare_attackers_gate` drives
+/// `legal_actions_full`, which enumerates the declare-attackers action
+/// cross-product (O(attackers)) — at 1000 tokens that runs ~13s in a debug
+/// build, too slow for an always-on gate. 300 keeps the discrimination margin
+/// intact while staying fast: legitimate per-attacker work is O(N) (a few
+/// hundred to low-thousands of scan increments), whereas a reverted presence
+/// gate makes each of the N attackers force a whole-battlefield scan → O(N²) =
+/// 90_000 at N=300. The `< 20_000` bound sits orders of magnitude clear of both
+/// sides (≈10²–10³ legit ≪ 20_000 ≪ 90_000 pathological), so it still flips red
+/// on a gate revert. 1a/1c/2a stay at `TOKENS` (1000) because `find_legal_targets`
+/// and the direct combat enumerator are fast at that scale.
+const DECLARE_TOKENS: usize = 300;
+
+/// `TargetFilter` matching every creature. Round-2 amendment: the private
+/// `#[cfg(test)]` helper at `targeting.rs:2200` is not reachable from an
+/// integration-test crate, so define the equivalent locally from public API
+/// (`TypedFilter::creature()` is pub at `types/ability.rs:3410`; idiom mirrors
+/// `aurora_awakener_reveal_until_n_permanents.rs:318`).
+fn creature_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature())
+}
+
+/// `count` vanilla creature tokens controlled by `owner`, plus one bare global
+/// Vigilance static so the presence index is provably non-empty yet does NOT
+/// touch the `IgnoreHexproof` bit the target-enumeration gate consults.
+///
+/// The Vigilance seed uses the proven bare-global idiom (no `.affected()`):
+/// `obj.static_definitions = vec![StaticDefinition::new(StaticMode::Vigilance)].into();`
+/// — identical to `targeting.rs:4748` / `game_state.rs:9136`. After a flush this
+/// leaves `StaticModeKind::Vigilance` PRESENT and `IgnoreHexproof` precisely
+/// ABSENT, which is what makes the index discriminate kinds (not "all-empty").
+fn token_storm_board(owner: PlayerId, count: usize) -> (GameState, Vec<ObjectId>) {
+    let mut state = GameState::new_two_player(42);
+    let mut ids = Vec::with_capacity(count);
+    for i in 0..count {
+        let id = create_object(
+            &mut state,
+            CardId(1000 + i as u64),
+            owner,
+            format!("Token{i}"),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        ids.push(id);
+    }
+    let src = create_object(
+        &mut state,
+        CardId(9999),
+        owner,
+        "Vigilance Anthem".to_string(),
+        Zone::Battlefield,
+    );
+    state.objects.get_mut(&src).unwrap().static_definitions =
+        vec![StaticDefinition::new(StaticMode::Vigilance)].into();
+    (state, ids)
+}
+
+/// Serde round-trip: drops every `#[serde(skip)]` field, so the restored state
+/// has `static_mode_presence = all_present` and `layers_dirty = LayersDirty::full()`
+/// — exactly the production shape an AI-search / saved-game restore produces.
+fn restore(state: &GameState) -> GameState {
+    serde_json::from_str(&serde_json::to_string(state).unwrap()).unwrap()
+}
+
+/// Test 1a — target enumeration does no full scan at 1000-object scale after a
+/// FULL-FLUSH serde restore (class a AND class b).
+///
+/// Overlap note (A4): the class-a signal on a hand-built board is already covered
+/// by `token_storm_target_enumeration_does_no_static_full_scans` (`targeting.rs:4683`),
+/// which refreshes via `evaluate_layers`. This test's UNIQUE contribution is the
+/// production-shaped serde-restore + `flush_layers` seam: `flush_layers` dispatches
+/// `LayersDirty::Full => evaluate_layers` (`layers.rs:1968`) → `refresh_static_mode_presence`
+/// (`layers.rs:1920`), additionally exercising the `flush_layers` dispatch +
+/// `mark_public_state_all_dirty` seam that production (AI restore, saved-game load) hits.
+#[test]
+fn token_storm_scaling_gate_absent_modes() {
+    let (state, ids) = token_storm_board(PlayerId(1), TOKENS);
+    let mut restored = restore(&state);
+    // Pre-flush the restored state carries the all-present serde default.
+    assert!(
+        restored
+            .static_mode_presence
+            .contains(StaticModeKind::IgnoreHexproof),
+        "restored state must start with the conservative all-present index"
+    );
+
+    // Full arm → evaluate_layers → refresh_static_mode_presence → PRECISE index.
+    layers::flush_layers(&mut restored);
+
+    // The index discriminates kinds: Vigilance present, IgnoreHexproof absent.
+    assert!(
+        restored
+            .static_mode_presence
+            .contains(StaticModeKind::Vigilance),
+        "the seeded Vigilance static must be indexed present after flush"
+    );
+    assert!(
+        !restored
+            .static_mode_presence
+            .contains(StaticModeKind::IgnoreHexproof),
+        "no IgnoreHexproof static exists — the index must report it absent after flush"
+    );
+
+    perf_counters::reset();
+    let targets = find_legal_targets(&restored, &creature_filter(), PlayerId(0), ObjectId(99));
+    let counters = perf_counters::snapshot();
+
+    // Revert guard (class a): removing the `can_target` presence gate makes this
+    // non-zero. Revert guard (class b): removing the `flush_layers` call above
+    // leaves the all-present index, and every token forces a scan → non-zero.
+    assert_eq!(
+        counters.static_full_scans, 0,
+        "token-storm target enumeration must not run any whole-battlefield static scan \
+         after a full-flush restore"
+    );
+    // Reach-guard: the 0-scan is not from an empty result — every token is legal.
+    assert_eq!(targets.len(), TOKENS, "every token must be a legal target");
+    assert!(targets.contains(&TargetRef::Object(ids[0])));
+    assert!(targets.contains(&TargetRef::Object(ids[TOKENS - 1])));
+}
+
+/// Test 1b — combat declaration is bounded after a full-flush restore (class-a
+/// composite only).
+///
+/// `legal_actions_full` self-heals (`ai_support/mod.rs:948-951`, `:960-966`): it
+/// re-flushes a dirty state before enumerating. This test therefore asserts the
+/// class-a index-precision composite only — the combat enumerators used to BUILD
+/// the state carry no class-b guard here (that guard is Test 1c's direct-drive).
+///
+/// Non-vacuousness: `get_valid_attacker_ids` scans only creatures controlled by
+/// `state.active_player` (`combat.rs:2929`), so the board is built UNDER the active
+/// player. With `new_two_player`, `active_player == PlayerId(0)`; building
+/// `DECLARE_TOKENS` tokens under it yields that many valid attackers, so the
+/// per-attacker O(N) work is real and reverting a combat presence gate blows the
+/// `< 20_000` bound (see the `DECLARE_TOKENS` margin justification).
+#[test]
+fn token_storm_declare_attackers_gate() {
+    let probe = GameState::new_two_player(42);
+    let active = probe.active_player;
+    let (state, _ids) = token_storm_board(active, DECLARE_TOKENS);
+    let mut restored = restore(&state);
+    layers::flush_layers(&mut restored);
+
+    // Mirror combat.rs:2996-3006 — build the declare-attackers payload from the
+    // real enumerators.
+    let valid_attacker_ids = get_valid_attacker_ids(&restored);
+    let valid_attack_targets = get_valid_attack_targets(&restored);
+    assert_eq!(
+        valid_attacker_ids.len(),
+        DECLARE_TOKENS,
+        "all active-player tokens must be valid attackers (non-vacuous fixture)"
+    );
+    restored.waiting_for = WaitingFor::DeclareAttackers {
+        player: active,
+        valid_attacker_ids,
+        valid_attack_targets,
+    };
+
+    perf_counters::reset();
+    let (actions, _costs, _grouped) = legal_actions_full(&restored);
+    let counters = perf_counters::snapshot();
+
+    assert_eq!(
+        counters.combat_shadow_block_scans, 0,
+        "combat declaration must not run a shadow-block full scan after a full-flush restore"
+    );
+    assert!(
+        counters.static_full_scans < 20_000,
+        "combat declaration static scans must stay bounded (legitimate per-attacker O(N) \
+         work only); got {}",
+        counters.static_full_scans
+    );
+    assert!(
+        !actions.is_empty(),
+        "declare-attackers enumeration must offer at least one legal action"
+    );
+}
+
+/// Test 1c — missing flush ⇒ explosion (class-b positive control), for BOTH the
+/// target path and the combat enumerator path.
+///
+/// This is the paired positive control that proves 1a/1b's `== 0` / bounded
+/// assertions are reachable (not short-circuited on an empty result) and guards
+/// them against a future self-heal of the read-only enumerators making the 0
+/// vacuous. On an UNFLUSHED restored state the index is all-present, so every
+/// token forces a whole-battlefield scan.
+#[test]
+fn token_storm_missing_flush_explodes() {
+    // Target path: unflushed all-present index → per-token scan.
+    let (state, _) = token_storm_board(PlayerId(1), TOKENS);
+    let unflushed = restore(&state); // SKIP flush.
+    perf_counters::reset();
+    let _ = find_legal_targets(&unflushed, &creature_filter(), PlayerId(0), ObjectId(99));
+    assert!(
+        perf_counters::snapshot().static_full_scans >= TOKENS as u64,
+        "unflushed all-present index must force a whole-battlefield scan per token \
+         (target path)"
+    );
+
+    // Combat direct-drive: `get_valid_attacker_ids` takes `&GameState` and CANNOT
+    // self-heal (combat.rs:2918). Build tokens under the active player so the
+    // per-creature scan branch (combat.rs:2929, controller == active) is reached.
+    let probe = GameState::new_two_player(42);
+    let active = probe.active_player;
+    let (state, _) = token_storm_board(active, TOKENS);
+    let unflushed = restore(&state); // SKIP flush.
+    perf_counters::reset();
+    let _ = get_valid_attacker_ids(&unflushed);
+    assert!(
+        perf_counters::snapshot().static_full_scans >= TOKENS as u64,
+        "unflushed all-present index forces a per-creature combat static scan \
+         (combat direct-drive; non-self-healing &GameState)"
+    );
+}

--- a/crates/phase-ai/src/saved_state.rs
+++ b/crates/phase-ai/src/saved_state.rs
@@ -11,7 +11,16 @@ struct Saved {
 pub fn load_saved_game_state(raw: &str) -> Result<GameState, serde_json::Error> {
     let mut value = serde_json::from_str(raw)?;
     migrate_saved_state(&mut value);
-    serde_json::from_value::<Saved>(value).map(|saved| saved.game_state)
+    serde_json::from_value::<Saved>(value).map(|saved| {
+        let mut state = saved.game_state;
+        // A deserialized state carries `layers_dirty = Full` and a conservative
+        // all-present `static_mode_presence`. `choose_action` takes `&GameState`
+        // and cannot flush, so flush here — otherwise every presence-gated scan
+        // falls through and read-only AI consumers pay full O(battlefield) scans
+        // per query (mirrors the WASM bridge's flush-before-enumeration idiom).
+        engine::game::layers::flush_layers(&mut state);
+        state
+    })
 }
 
 fn migrate_saved_state(value: &mut Value) {

--- a/crates/phase-ai/tests/token_storm_restore_flush_gate.rs
+++ b/crates/phase-ai/tests/token_storm_restore_flush_gate.rs
@@ -1,0 +1,150 @@
+//! Token-storm restore-flush CI gate (phase-ai tier).
+//!
+//! Companion to `crates/engine/tests/token_storm_scaling_gate.rs`, guarding the
+//! phase-ai side of the `StaticModePresence` O(1) index: the production
+//! serde-restore → `flush_layers` seam that `load_saved_game_state`
+//! (`saved_state.rs`) and the AI search hit. A deserialized `GameState` arrives
+//! with `static_mode_presence = all_present` (the conservative `#[serde(skip,
+//! default)]` value) and `layers_dirty = Full`; `load_saved_game_state` flushes
+//! on load so read-only AI consumers (`choose_action` takes `&GameState` and
+//! cannot flush) pay O(1) presence reads instead of O(battlefield) scans.
+//!
+//! DB-free by construction: `GameState::new_two_player` + `create_object` only,
+//! never loading `client/public/card-data.json`
+//! (`scripts/check-test-card-data-load.sh` guards this). Under `cargo nextest`
+//! each test runs in its own process, so the `thread_local!` perf counters
+//! cannot bleed across tests and the exact `== 0` assertion is sound.
+
+use engine::game::perf_counters;
+use engine::game::targeting::find_legal_targets;
+use engine::game::zones::create_object;
+use engine::types::ability::{StaticDefinition, TargetFilter, TypedFilter};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::statics::{StaticMode, StaticModeKind};
+use engine::types::zones::Zone;
+use phase_ai::choose_action;
+use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
+use phase_ai::saved_state::load_saved_game_state;
+use rand::rngs::SmallRng;
+use rand::SeedableRng;
+
+const TOKENS: usize = 1000;
+
+/// `TargetFilter` matching every creature (built from public API — the private
+/// `#[cfg(test)]` helper in engine is not reachable here).
+fn creature_filter() -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature())
+}
+
+/// 1000 vanilla creature tokens controlled by `owner`, plus one bare global
+/// Vigilance static (no `.affected()`) so the presence index is provably
+/// non-empty yet leaves `IgnoreHexproof` precisely absent after a flush. Mirrors
+/// the engine-tier `token_storm_board` DB-free idiom exactly.
+fn token_storm_board(owner: PlayerId) -> GameState {
+    let mut state = GameState::new_two_player(42);
+    for i in 0..TOKENS {
+        let id = create_object(
+            &mut state,
+            CardId(1000 + i as u64),
+            owner,
+            format!("Token{i}"),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+    }
+    let src = create_object(
+        &mut state,
+        CardId(9999),
+        owner,
+        "Vigilance Anthem".to_string(),
+        Zone::Battlefield,
+    );
+    state.objects.get_mut(&src).unwrap().static_definitions =
+        vec![StaticDefinition::new(StaticMode::Vigilance)].into();
+    state
+}
+
+/// Wrap a state in the saved-game envelope `{"gameState": <state-json>}` that
+/// `load_saved_game_state` (`saved_state.rs`) expects.
+fn saved_envelope(state: &GameState) -> String {
+    serde_json::json!({ "gameState": state }).to_string()
+}
+
+/// Test 2a — `load_saved_game_state` flushes the presence index (always-on backbone).
+///
+/// Revert-failing assertion: if the `flush_layers` call in `saved_state.rs` (the
+/// load-time flush) is deleted, the loaded state keeps the all-present serde
+/// default → `contains(IgnoreHexproof)` stays true AND target enumeration runs a
+/// whole-battlefield scan per token. Both assertions below flip.
+#[test]
+fn load_saved_game_state_flushes_presence_index() {
+    let state = token_storm_board(PlayerId(1));
+    let envelope = saved_envelope(&state);
+
+    let loaded = load_saved_game_state(&envelope).expect("load saved game state");
+
+    // The load-time flush made the index PRECISE: Vigilance present (discrimination
+    // guard — proves it is not "all-empty"), IgnoreHexproof absent (the revert guard).
+    assert!(
+        loaded
+            .static_mode_presence
+            .contains(StaticModeKind::Vigilance),
+        "the seeded Vigilance static must be indexed present after the load-time flush"
+    );
+    assert!(
+        !loaded
+            .static_mode_presence
+            .contains(StaticModeKind::IgnoreHexproof),
+        "load_saved_game_state must flush the index so IgnoreHexproof reads absent \
+         (trips if the saved_state.rs load-time flush is deleted)"
+    );
+
+    perf_counters::reset();
+    let targets = find_legal_targets(&loaded, &creature_filter(), PlayerId(0), ObjectId(99));
+    let counters = perf_counters::snapshot();
+
+    assert_eq!(
+        counters.static_full_scans, 0,
+        "target enumeration on a loaded saved game must not run any whole-battlefield \
+         static scan (trips if the load-time flush is deleted)"
+    );
+    // Reach-guard: the 0-scan is not from an empty result.
+    assert_eq!(targets.len(), TOKENS, "every token must be a legal target");
+}
+
+/// Test 2b — full AI search stays bounded on a restored board (`#[ignore]`
+/// defense-in-depth backstop; 2a is the always-on gate).
+///
+/// `perf_counters` is `thread_local`; nextest's process-per-test isolates it, but
+/// `choose_action` drives real search work, so the bound is deliberately loose
+/// and the test is `#[ignore]`. Covers the `search.rs` `choose_action(&GameState,
+/// …)` consumer, which relies on `load_saved_game_state` having flushed the index.
+#[test]
+#[ignore = "opt-in perf backstop; 2a is the always-on gate"]
+fn choose_action_on_restored_board_is_bounded() {
+    let state = token_storm_board(PlayerId(1));
+    let envelope = saved_envelope(&state);
+    let loaded = load_saved_game_state(&envelope).expect("load saved game state");
+
+    let cfg = create_config_for_players(AiDifficulty::VeryEasy, Platform::Native, 2);
+    let mut rng = SmallRng::seed_from_u64(42);
+
+    perf_counters::reset();
+    let _ = choose_action(&loaded, PlayerId(0), &cfg, &mut rng);
+    let counters = perf_counters::snapshot();
+
+    assert!(
+        counters.static_full_scans < 200_000,
+        "full AI search on a restored token-storm board must stay bounded; got {}",
+        counters.static_full_scans
+    );
+}


### PR DESCRIPTION
## Systemic O(N²) static-scan elimination

Eliminates the full-battlefield static-ability scans that made AI decisions on
large boards (e.g. the ~1400-token Court of Grace state) hang, replacing them
with an O(1) `StaticModePresence` index maintained by the layers pipeline.

### Commits
1. **`StaticModePresence` O(1) index** — a `[bool; StaticModeKind::COUNT]` bitset on
   `GameState` (`#[serde(skip)]`, `all_present` default, excluded from the manual
   `PartialEq` per CR 104.4b), rebuilt by `refresh_static_mode_presence` in the
   layers flush. `static_kind_present()` is the O(1) choke point; migrates
   `can_target` hexproof scans as the first consumer.
2. **Flush activation** — flush layers at the AI state-restore seams
   (`engine-wasm`, `phase-ai::saved_state`) so the index is precise before the
   first gated read.
3. **36 gated sites** — every remaining quadratic full-battlefield static scan
   now early-returns / short-circuits on the index. Second-authority sites
   (protection, cant-lose, face-down look) wrap rather than early-return so a
   `transient_continuous_effects` grant is never missed.
4. **Token-storm scaling CI gate** — integration tests that serde-restore a
   1000-token board, flush, and assert `static_full_scans == 0` through the
   non-self-healing seams (`find_legal_targets`, `get_valid_attacker_ids`), plus
   an unflushed positive control proving the ≥N-scan explosion signature.

### Rebase integration with #5003
`main` advanced with #5003 (`AttackOnlyNeighbor`, CR 508.1c directional attack)
while this work was local. That added a 6th `CombatStaticGates` flag computed via
the old sweep. Reconciled by: adding `StaticModeKind::AttackOnlyNeighbor` (variant
+ `kind()` arm — the exhaustive match is the compile-time gate), and reading the
6th flag from the index like the other five. The generic `refresh` populates the
new bit automatically. #5003's eight `attack_only_neighbor_*` CR 508.1c tests pass
unchanged through the index-gated path (no false-negative in enforcement).

The index is a post-flush-precise **superset** of the sweep — a spurious `true`
falls through to the exact per-object check, and a false negative is impossible in
the pre-flush `all_present` state, so every gate is correctness-preserving.
