### PR TITLE
ENGINE: Scope counter replacements through type phrases

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::parser::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::{char, multispace1};
+use nom::character::complete::{char, multispace0, multispace1};
 use nom::combinator::{all_consuming, eof, map_opt, opt, peek, rest, value};
 use nom::multi::separated_list1;
 use nom::sequence::{pair, preceded, terminated};
@@ -7021,14 +7021,8 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
     let mut def = ReplacementDefinition::new(ReplacementEvent::AddCounter)
         .quantity_modification(modification)
         .description(original_text.to_string());
-    if nom_primitives::scan_contains(lower, "permanent you control") {
-        def = def.valid_card(TargetFilter::Typed(
-            TypedFilter::permanent().controller(ControllerRef::You),
-        ));
-    } else if nom_primitives::scan_contains(lower, "creature you control") {
-        def = def.valid_card(TargetFilter::Typed(
-            TypedFilter::creature().controller(ControllerRef::You),
-        ));
+    if let Some(valid_card) = parse_counter_replacement_valid_card(lower) {
+        def = def.valid_card(valid_card);
     }
     if nom_primitives::scan_contains(lower, "an opponent would put")
         || nom_primitives::scan_contains(lower, "opponent would put")
@@ -7047,6 +7041,57 @@ fn parse_counter_replacement(lower: &str, original_text: &str) -> Option<Replace
     }
 
     Some(def)
+}
+
+fn parse_counter_replacement_valid_card(lower: &str) -> Option<TargetFilter> {
+    let (_, (), after_anchor) =
+        nom_primitives::scan_preceded(lower, parse_counter_replacement_scope_anchor)?;
+    let (filter, rest) = parse_type_phrase(after_anchor);
+    if !is_counter_replacement_object_scope(&filter)
+        || parse_counter_replacement_scope_tail(rest).is_err()
+    {
+        return None;
+    }
+    Some(filter)
+}
+
+fn is_counter_replacement_object_scope(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(_) => true,
+        TargetFilter::Not { filter } => is_counter_replacement_object_scope(filter),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().all(is_counter_replacement_object_scope)
+        }
+        _ => false,
+    }
+}
+
+fn parse_counter_replacement_scope_anchor(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag::<_, _, OracleError<'_>>("counters would be put on "),
+            tag("counter would be put on "),
+            tag("an effect would put one or more counters on "),
+            tag("an effect would put a counter on "),
+        )),
+    )
+    .parse(input)
+}
+
+fn parse_counter_replacement_scope_tail(input: &str) -> OracleResult<'_, ()> {
+    preceded(
+        multispace0,
+        value(
+            (),
+            alt((
+                tag::<_, _, OracleError<'_>>(", that many"),
+                tag(", twice that many"),
+                tag(", it puts"),
+            )),
+        ),
+    )
+    .parse(input)
 }
 
 /// CR 614.17 + CR 614.6 + CR 122.1: Parse "Players can't get counters."
@@ -14051,6 +14096,84 @@ mod tests {
         ));
     }
 
+    fn controlled_or_branch_types(valid_card: Option<TargetFilter>) -> Vec<Vec<TypeFilter>> {
+        let Some(TargetFilter::Or { filters }) = valid_card else {
+            panic!("expected controlled Or target filter");
+        };
+        filters
+            .into_iter()
+            .map(|filter| match filter {
+                TargetFilter::Typed(TypedFilter {
+                    type_filters,
+                    controller: Some(ControllerRef::You),
+                    ..
+                }) => type_filters,
+                other => panic!("expected controlled typed branch, got {other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn counter_plus_one_replacement_artifact_or_creature_scope() {
+        let def = parse_replacement_line(
+            "If one or more +1/+1 counters would be put on an artifact or creature you control, that many plus one +1/+1 counters are put on it instead.",
+            "Ozolith-style test card",
+        )
+        .unwrap();
+
+        assert_eq!(
+            controlled_or_branch_types(def.valid_card),
+            vec![vec![TypeFilter::Artifact], vec![TypeFilter::Creature]]
+        );
+    }
+
+    #[test]
+    fn counter_doubling_replacement_comma_type_list_scope() {
+        let def = parse_replacement_line(
+            "If one or more counters would be put on a creature, Spacecraft, or Planet you control, twice that many of each of those kinds of counters are put on it instead.",
+            "Loading Zone",
+        )
+        .unwrap();
+
+        assert_eq!(def.counter_match, None);
+        assert_eq!(
+            controlled_or_branch_types(def.valid_card),
+            vec![
+                vec![TypeFilter::Creature],
+                vec![TypeFilter::Subtype("Spacecraft".to_string())],
+                vec![TypeFilter::Subtype("Planet".to_string())],
+            ]
+        );
+    }
+
+    #[test]
+    fn counter_plus_one_replacement_mauhur_scope() {
+        // CR 614.1a + CR 122.1a: Mauhur only changes +1/+1 counters put on
+        // Armies, Goblins, and Orcs you control.
+        let def = parse_replacement_line(
+            "If one or more +1/+1 counters would be put on an Army, Goblin, or Orc you control, that many plus one +1/+1 counters are put on it instead.",
+            "Mauhur, Uruk-hai Captain",
+        )
+        .unwrap();
+        assert_eq!(def.event, ReplacementEvent::AddCounter);
+        assert_eq!(
+            def.quantity_modification,
+            Some(QuantityModification::Plus { value: 1 })
+        );
+        assert_eq!(
+            def.counter_match,
+            Some(CounterMatch::OfType(CounterType::Plus1Plus1))
+        );
+        assert_eq!(
+            controlled_or_branch_types(def.valid_card),
+            vec![
+                vec![TypeFilter::Subtype("Army".to_string())],
+                vec![TypeFilter::Subtype("Goblin".to_string())],
+                vec![TypeFilter::Subtype("Orc".to_string())],
+            ]
+        );
+    }
+
     #[test]
     fn counter_minus_one_replacement_vizier_of_remedies() {
         // CR 614.1a + CR 122.1a: Vizier of Remedies — "-1/-1 counters"
@@ -15546,6 +15669,7 @@ mod tests {
         .expect("halving season");
         assert_eq!(def.quantity_modification, Some(QuantityModification::Half));
         assert_eq!(def.valid_player, Some(ReplacementPlayerScope::Opponent));
+        assert_eq!(def.valid_card, None);
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -486,6 +486,7 @@ mod mana_drain_refund;
 mod maraxus_team_pump_anthem;
 mod mass_phase_out_1792_repro;
 mod master_of_ceremonies;
+mod mauhur_swarming_of_moria;
 mod memory_plunder_free_cast_2884;
 mod militant_angel_attacked_opponents;
 mod mill_double_redirect_choice_continuation;

--- a/crates/engine/tests/integration/mauhur_swarming_of_moria.rs
+++ b/crates/engine/tests/integration/mauhur_swarming_of_moria.rs
@@ -1,0 +1,90 @@
+//! Regression for Mauhur, Uruk-hai Captain with Swarming of Moria.
+//!
+//! CR 701.47a: amass Orcs puts counters on the chosen Army. Mauhur does not
+//! move those counters to itself; it increases the number put on that Army.
+
+use engine::game::effects::counters::add_counter_with_replacement;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const MAUHUR: &str = "Menace\n\
+If one or more +1/+1 counters would be put on an Army, Goblin, or Orc you control, \
+that many plus one +1/+1 counters are put on it instead.";
+
+const SWARMING_OF_MORIA: &str = "Create a Treasure token.\nAmass Orcs 2.";
+
+fn plus_one_counters(runner: &GameRunner, object_id: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&object_id)
+        .and_then(|obj| obj.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+fn controlled_army(runner: &GameRunner) -> Option<ObjectId> {
+    runner.state().battlefield.iter().copied().find(|id| {
+        runner.state().objects.get(id).is_some_and(|obj| {
+            obj.controller == P0 && obj.card_types.subtypes.iter().any(|s| s == "Army")
+        })
+    })
+}
+
+#[test]
+fn swarming_of_moria_puts_mauhurs_extra_counter_on_the_army() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mauhur = scenario
+        .add_creature_from_oracle(P0, "Mauhur, Uruk-hai Captain", 2, 2, MAUHUR)
+        .with_subtypes(vec!["Orc", "Soldier"])
+        .id();
+    let swarming = scenario
+        .add_spell_to_hand_from_oracle(P0, "Swarming of Moria", false, SWARMING_OF_MORIA)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(swarming).resolve();
+
+    let army = controlled_army(&runner).expect("Swarming of Moria should create an Army");
+    assert_eq!(
+        plus_one_counters(&runner, army),
+        3,
+        "amass Orcs 2 should put 3 counters on the Army while Mauhur is controlled"
+    );
+    assert_eq!(
+        plus_one_counters(&runner, mauhur),
+        0,
+        "Mauhur modifies the Army's counter event; it does not receive those counters"
+    );
+}
+
+#[test]
+fn mauhur_does_not_add_counters_to_unlisted_creature_types() {
+    let mut scenario = GameScenario::new();
+    let _mauhur = scenario
+        .add_creature_from_oracle(P0, "Mauhur, Uruk-hai Captain", 2, 2, MAUHUR)
+        .with_subtypes(vec!["Orc", "Soldier"])
+        .id();
+    let bear = scenario.add_creature(P0, "Bear", 2, 2).id();
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    assert!(add_counter_with_replacement(
+        runner.state_mut(),
+        P0,
+        bear,
+        CounterType::Plus1Plus1,
+        1,
+        &mut events,
+    ));
+
+    assert_eq!(
+        plus_one_counters(&runner, bear),
+        1,
+        "Mauhur only modifies counters put on Armies, Goblins, and Orcs you control"
+    );
+}


### PR DESCRIPTION
## Summary

Fix counter replacement parsing so effects like Mauhur, Uruk-hai Captain scope modified counters to the affected Army/Goblin/Orc instead of applying broadly to any counter event from the replacement source. The parser now derives object-only valid-card scope from the existing type-phrase parser, covering artifact-or-creature and comma-separated type/subtype lists without expanding actor-scoped opponent replacement semantics.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [ ] Produced via the `/engine-implementer` pipeline (plan -> review-plan -> implement -> review-impl -> commit)
- [x] **Not** `/engine-implementer` — explain why below

If you did **not** use `/engine-implementer`, state why (e.g. frontend-only
change, docs/CI/tooling change, release chore, or a fix too small to warrant
the pipeline):

> Initial code was produced directly in a Codex debugging session before `/engine-implementer` was invoked, so I am not claiming the full pipeline authored the commit. Follow-up validation used fresh-context `/engine-planner`, `/review-engine-plan`, and final `/review-impl` passes against the diff. The plan review caught the actor-scoped `opponent would put` boundary, and the final implementation review reported zero findings against the updated diff plus parse-diff evidence.

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

- CR 614.1a / CR 614.16: replacement effects, including effects that modify counters put on permanents.
- CR 122.1a: +1/+1 counters modify power/toughness.
- CR 701.47a: amass chooses an Army creature and puts the counters on that creature.

## Verification

- `cargo fmt --all --check` — passed.
- `./scripts/check-parser-combinators.sh` — passed.
- Parser string-dispatch grep from the `/engine-implementer` executor instructions — passed, no added parser `.contains`/`.starts_with`/`.find`/`.split*` dispatch.
- CR diff grep against `docs/MagicCompRules.txt` — passed, no unverified added/changed CR annotations.
- `CARGO_INCREMENTAL=0 cargo test -p engine --lib counter_plus_one_replacement --jobs 2` — passed: 3 tests.
- `CARGO_INCREMENTAL=0 cargo test -p engine --lib counter_doubling_replacement_current_oracle_wording --jobs 2` — passed: 1 test.
- `CARGO_INCREMENTAL=0 cargo test -p engine --lib parses_halving_season_opponent_counter_replacement --jobs 2` — passed: 1 test.
- `CARGO_INCREMENTAL=0 cargo test -p engine --test integration mauhur --jobs 2` — passed: 2 tests.
- `./scripts/gen-card-data.sh` — passed; generated coverage data for parse-diff evidence.
- `cargo run --profile tool --features cli --bin coverage-parse-diff -- /tmp/pr5027-coverage-base.json client/public/coverage-data.json --base-sha 910a4385355244500e31d2bf5d25a9f0377befba --markdown /tmp/pr5027-parse-diff.md --json /tmp/pr5027-parse-diff.json` — passed; parse-diff reports 0 card(s), 0 signature(s).
