### PR TITLE
fix: redact draft secrets (tokens, password, rng seed) from admin GET

### DIFF
--- a/crates/phase-server/src/admin.rs
+++ b/crates/phase-server/src/admin.rs
@@ -52,7 +52,11 @@ pub async fn admin_get_draft(
     let drafts = app_state.draft_sessions.lock().await;
     match drafts.sessions.get(&code) {
         Some(session) => {
-            let persisted = session.to_persisted();
+            // Use the secret-redacted snapshot: this endpoint is reachable
+            // unauthenticated (nginx proxies `/`), so it must never disclose
+            // per-seat `player_tokens` or the lobby password, which would let a
+            // caller impersonate any seat.
+            let persisted = session.to_admin_snapshot();
             match serde_json::to_value(&persisted) {
                 Ok(val) => Json(val).into_response(),
                 Err(_) => {

--- a/crates/phase-server/src/admin.rs
+++ b/crates/phase-server/src/admin.rs
@@ -54,8 +54,7 @@ pub async fn admin_get_draft(
         Some(session) => {
             // Use the secret-redacted snapshot: this endpoint is reachable
             // unauthenticated (nginx proxies `/`), so it must never disclose
-            // per-seat `player_tokens` or the lobby password, which would let a
-            // caller impersonate any seat.
+            // per-seat `player_tokens`, the lobby password, or the draft RNG seed.
             let persisted = session.to_admin_snapshot();
             match serde_json::to_value(&persisted) {
                 Ok(val) => Json(val).into_response(),

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -58,6 +58,12 @@ impl DraftSession {
     }
 
     /// Create a serializable snapshot for disk persistence.
+    ///
+    /// Includes secrets (`player_tokens`, `lobby_meta.password`) because they
+    /// must survive a restart. This snapshot is for trusted local disk only —
+    /// never serialize it onto a client-reachable transport. Use
+    /// [`DraftSession::to_admin_snapshot`] for the unauthenticated admin/HTTP
+    /// inspection surface.
     pub fn to_persisted(&self) -> PersistedDraftSession {
         PersistedDraftSession {
             draft_code: self.draft_code.clone(),
@@ -69,6 +75,21 @@ impl DraftSession {
             lobby_meta: self.lobby_meta.clone(),
             timer_remaining_ms: self.timer_remaining_ms,
         }
+    }
+
+    /// Snapshot for admin / HTTP inspection with every session secret stripped.
+    ///
+    /// Unlike [`to_persisted`](Self::to_persisted), this NEVER exposes per-seat
+    /// `player_tokens` (which authorize a client into a seat via
+    /// [`seat_for_token`](Self::seat_for_token)) or the lobby `password`, so it
+    /// is safe to serialize over an unauthenticated endpoint. Seat occupancy is
+    /// preserved: a claimed seat's token becomes a fixed placeholder and an
+    /// unclaimed seat stays empty, so operators still see which seats are taken
+    /// without learning any credential.
+    pub fn to_admin_snapshot(&self) -> PersistedDraftSession {
+        let mut snapshot = self.to_persisted();
+        redact_persisted_draft_secrets(&mut snapshot);
+        snapshot
     }
 
     /// Restore a draft session from a persisted snapshot.
@@ -96,6 +117,31 @@ impl DraftSession {
         let mut view = draft_core::view::filter_for_player(&self.session, seat as u8);
         view.timer_remaining_ms = self.timer_remaining_ms;
         view
+    }
+}
+
+/// Placeholder written in place of any redacted session secret. A single fixed
+/// marker for every claimed seat leaks nothing (all claimed seats look
+/// identical) while keeping the snapshot's shape intact.
+pub const REDACTED_SECRET: &str = "<redacted>";
+
+/// Strip session secrets from a persisted draft snapshot in place so it is safe
+/// to expose over an unauthenticated transport.
+///
+/// - Each non-empty per-seat `player_token` (a seat-authorizing credential) is
+///   replaced with [`REDACTED_SECRET`]; empty (unclaimed) seats are left empty
+///   so seat occupancy is still observable.
+/// - Any lobby `password` is replaced with [`REDACTED_SECRET`].
+pub fn redact_persisted_draft_secrets(snapshot: &mut PersistedDraftSession) {
+    for token in &mut snapshot.player_tokens {
+        if !token.is_empty() {
+            *token = REDACTED_SECRET.to_string();
+        }
+    }
+    if let Some(meta) = snapshot.lobby_meta.as_mut() {
+        if meta.password.is_some() {
+            meta.password = Some(REDACTED_SECRET.to_string());
+        }
     }
 }
 
@@ -916,6 +962,66 @@ mod tests {
         assert_eq!(restored.player_tokens, persisted.player_tokens);
         assert_eq!(restored.display_names, persisted.display_names);
         assert_eq!(restored.timer_remaining_ms, persisted.timer_remaining_ms);
+    }
+
+    #[test]
+    fn to_admin_snapshot_redacts_player_tokens_but_preserves_occupancy() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, host_token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+        // Claim a few more seats so we have real tokens to protect.
+        for i in 1..4 {
+            mgr.join_draft(&code, format!("Player {i}"), None).unwrap();
+        }
+
+        let session = &mgr.sessions[&code];
+        let real = session.to_persisted();
+        let admin = session.to_admin_snapshot();
+
+        // Same shape (one entry per seat), so occupancy stays observable.
+        assert_eq!(admin.player_tokens.len(), real.player_tokens.len());
+        for (admin_tok, real_tok) in admin.player_tokens.iter().zip(&real.player_tokens) {
+            if real_tok.is_empty() {
+                assert!(admin_tok.is_empty(), "unclaimed seat must stay empty");
+            } else {
+                assert_eq!(admin_tok, REDACTED_SECRET, "claimed seat must be redacted");
+                assert_ne!(admin_tok, real_tok, "raw token must never survive");
+            }
+        }
+
+        // The real credential must not appear anywhere in the serialized admin
+        // payload (defense against nested/duplicated exposure).
+        let admin_json = serde_json::to_string(&admin).expect("serialize admin snapshot");
+        assert!(
+            !admin_json.contains(&host_token),
+            "admin snapshot must not leak any real player token"
+        );
+
+        // Persistence snapshot is unchanged — real tokens survive for disk.
+        assert!(real.player_tokens.iter().any(|t| t == &host_token));
+    }
+
+    #[test]
+    fn redact_persisted_draft_secrets_clears_lobby_password() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, _token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+
+        let mut snapshot = mgr.sessions[&code].to_persisted();
+        snapshot.lobby_meta = Some(PersistedLobbyMeta {
+            host_name: "Alice".to_string(),
+            public: true,
+            password: Some("hunter2".to_string()),
+            timer_seconds: None,
+            start_when_full: true,
+            ranked: false,
+        });
+
+        redact_persisted_draft_secrets(&mut snapshot);
+
+        assert_eq!(
+            snapshot.lobby_meta.as_ref().unwrap().password.as_deref(),
+            Some(REDACTED_SECRET),
+            "lobby password must be redacted"
+        );
     }
 
     #[test]

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -59,9 +59,9 @@ impl DraftSession {
 
     /// Create a serializable snapshot for disk persistence.
     ///
-    /// Includes secrets (`player_tokens`, `lobby_meta.password`) because they
-    /// must survive a restart. This snapshot is for trusted local disk only —
-    /// never serialize it onto a client-reachable transport. Use
+    /// Includes secrets (`player_tokens`, `lobby_meta.password`, `config.rng_seed`)
+    /// because they must survive a restart. This snapshot is for trusted local
+    /// disk only — never serialize it onto a client-reachable transport. Use
     /// [`DraftSession::to_admin_snapshot`] for the unauthenticated admin/HTTP
     /// inspection surface.
     pub fn to_persisted(&self) -> PersistedDraftSession {
@@ -81,11 +81,8 @@ impl DraftSession {
     ///
     /// Unlike [`to_persisted`](Self::to_persisted), this NEVER exposes per-seat
     /// `player_tokens` (which authorize a client into a seat via
-    /// [`seat_for_token`](Self::seat_for_token)) or the lobby `password`, so it
-    /// is safe to serialize over an unauthenticated endpoint. Seat occupancy is
-    /// preserved: a claimed seat's token becomes a fixed placeholder and an
-    /// unclaimed seat stays empty, so operators still see which seats are taken
-    /// without learning any credential.
+    /// [`seat_for_token`](Self::seat_for_token)), the lobby `password`, or
+    /// `config.rng_seed` (which seeds deterministic pack generation).
     pub fn to_admin_snapshot(&self) -> PersistedDraftSession {
         let mut snapshot = self.to_persisted();
         redact_persisted_draft_secrets(&mut snapshot);
@@ -132,6 +129,7 @@ pub const REDACTED_SECRET: &str = "<redacted>";
 ///   replaced with [`REDACTED_SECRET`]; empty (unclaimed) seats are left empty
 ///   so seat occupancy is still observable.
 /// - Any lobby `password` is replaced with [`REDACTED_SECRET`].
+/// - `config.rng_seed` is zeroed so pack order cannot be predicted from the wire.
 pub fn redact_persisted_draft_secrets(snapshot: &mut PersistedDraftSession) {
     for token in &mut snapshot.player_tokens {
         if !token.is_empty() {
@@ -143,6 +141,7 @@ pub fn redact_persisted_draft_secrets(snapshot: &mut PersistedDraftSession) {
             meta.password = Some(REDACTED_SECRET.to_string());
         }
     }
+    snapshot.config.rng_seed = 0;
 }
 
 /// Seats that still owe a pick this round and have not yet submitted one.
@@ -998,6 +997,43 @@ mod tests {
 
         // Persistence snapshot is unchanged — real tokens survive for disk.
         assert!(real.player_tokens.iter().any(|t| t == &host_token));
+    }
+
+    #[test]
+    fn to_admin_snapshot_redacts_rng_seed() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, _token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+        mgr.sessions.get_mut(&code).unwrap().config.rng_seed = 0xDEAD_BEEF;
+
+        let session = &mgr.sessions[&code];
+        assert_eq!(session.to_persisted().config.rng_seed, 0xDEAD_BEEF);
+        assert_eq!(session.to_admin_snapshot().config.rng_seed, 0);
+    }
+
+    #[test]
+    fn redact_persisted_draft_secrets_clears_lobby_password_and_rng_seed() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, _token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+
+        let mut snapshot = mgr.sessions[&code].to_persisted();
+        snapshot.config.rng_seed = 0x1234_5678;
+        snapshot.lobby_meta = Some(PersistedLobbyMeta {
+            host_name: "Alice".to_string(),
+            public: true,
+            password: Some("hunter2".to_string()),
+            timer_seconds: None,
+            start_when_full: true,
+            ranked: false,
+        });
+
+        redact_persisted_draft_secrets(&mut snapshot);
+
+        assert_eq!(
+            snapshot.lobby_meta.as_ref().unwrap().password.as_deref(),
+            Some(REDACTED_SECRET),
+            "lobby password must be redacted"
+        );
+        assert_eq!(snapshot.config.rng_seed, 0, "rng_seed must be redacted");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Root cause:** `GET /admin/drafts/{code}` serialized `DraftSession::to_persisted()` including per-seat `player_tokens`, lobby `password`, and `config.rng_seed`. Admin routes have no authentication and nginx proxies `/` to the server.
- **Impact:** Unauthenticated callers could impersonate any seat (submit picks/decks), read lobby passwords, or predict draft pack order from the RNG seed.
- **Fix:** Add `to_admin_snapshot()` / `redact_persisted_draft_secrets()` to strip tokens, passwords, and zero `rng_seed` before the admin HTTP response. `to_persisted()` unchanged for trusted disk persistence.

## Review feedback addressed

- **[HIGH]** `config.rng_seed` is now zeroed in `redact_persisted_draft_secrets()` with tests confirming `to_admin_snapshot()` redacts it while `to_persisted()` preserves the real seed.

## Test plan

- [x] Unit tests: `to_admin_snapshot` redacts tokens, password, and `rng_seed`
- [x] Unit tests: `to_persisted` still preserves secrets for disk restore
- [ ] CI green