### PR TITLE
fix(engine): Tomb of Annihilation "Veils of Fear" is a life-loss punisher, not a creature sacrifice

### DIFF
--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -417,19 +417,17 @@ pub fn room_effects(
             ability.player_scope = Some(PlayerFilter::All);
             (ability, vec![])
         }
-        // 1: Veils of Fear — "Each player sacrifices a creature"
+        // 1: Veils of Fear — "Each player loses 2 life unless they discard a card."
+        // CR 118.12a: a punisher — each player either discards a card or loses
+        // 2 life. Parsed from the Oracle text so the base life loss, the
+        // each-player scope, and the unless-discard payment all come from the
+        // shared punisher parser (the payer binds to the per-iteration
+        // ScopedPlayer). The room was wrongly implemented as "each player
+        // sacrifices a creature".
         (DungeonId::TombOfAnnihilation, 1) => {
-            let mut ability = simple(
-                Effect::Sacrifice {
-                    target: TargetFilter::Typed(TypedFilter::creature()),
-                    count: QuantityExpr::Fixed { value: 1 },
-                    min_count: 0,
-                },
-                source_id,
-                controller,
-            );
-            ability.player_scope = Some(PlayerFilter::All);
-            (ability, vec![])
+            const ORACLE: &str = "Each player loses 2 life unless they discard a card.";
+            let def = parse_effect_chain(ORACLE, AbilityKind::Spell);
+            (build_resolved_from_def(&def, source_id, controller), vec![])
         }
         // 2: Oubliette — "Discard a card"
         (DungeonId::TombOfAnnihilation, 2) => (

--- a/crates/engine/tests/tomb_veils_of_fear_life_loss_runtime.rs
+++ b/crates/engine/tests/tomb_veils_of_fear_life_loss_runtime.rs
@@ -1,0 +1,80 @@
+//! Runtime (engine-path) regression for Tomb of Annihilation "Veils of Fear".
+//!
+//! Oracle: "Each player loses 2 life unless they discard a card." The room was
+//! wrongly implemented as "each player sacrifices a creature" — the wrong
+//! keyword action entirely, never touching life. This drives the real venture
+//! pipeline: with the marker in Trapped Entry (room 0 → branch to [1 Veils of
+//! Fear, 2 Oubliette]), a venture + room choice enters Veils of Fear. Each
+//! player is then offered the CR 118.12a punisher choice ("discard a card" or
+//! lose 2 life); with empty hands both decline and lose 2 life. On the old code
+//! the room sacrificed a creature and never touched life, so the assertions
+//! below fail — this discriminates the real behavior.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+#[test]
+fn tomb_veils_of_fear_each_player_loses_two_life_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    scenario.with_life(P1, 20);
+    // Both hands are empty (GameScenario::new deals no opening hand), so neither
+    // player can pay the "discard a card" alternative and each must take the
+    // life loss when prompted.
+    let mut runner = scenario.build();
+
+    // Marker in Trapped Entry (Tomb room 0 → [1 Veils of Fear, 2 Oubliette]).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::TombOfAnnihilation);
+        prog.current_room = 0;
+    }
+
+    // Venture → branch → choose Veils of Fear (room 1).
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    runner
+        .act(GameAction::ChooseDungeonRoom { room_index: 1 })
+        .expect("choosing Veils of Fear must succeed");
+    assert_eq!(
+        runner.state().dungeon_progress[&P0].current_room,
+        1,
+        "venture must enter Veils of Fear (room 1)"
+    );
+
+    // Resolve the room ability. It puts a per-player "loses 2 life unless they
+    // discard a card" punisher on the stack (CR 118.12a). Resolve it, then
+    // decline each player's discard-or-lose-life prompt so the life loss lands.
+    for _ in 0..12 {
+        if matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }) {
+            runner
+                .act(GameAction::PayUnlessCost { pay: false })
+                .expect("declining the discard alternative must succeed");
+        } else if !runner.state().stack.is_empty() {
+            runner.resolve_top();
+        } else {
+            break;
+        }
+    }
+
+    assert_eq!(
+        runner.state().players[0].life,
+        18,
+        "the venturing player loses 2 life (declined the discard); the old room \
+         sacrificed a creature and never touched life"
+    );
+    assert_eq!(
+        runner.state().players[1].life,
+        18,
+        "each other player also loses 2 life (the room affects each player)"
+    );
+}


### PR DESCRIPTION
## Problem

Tomb of Annihilation's **Veils of Fear** room has this Oracle text (Scryfall):

> Veils of Fear â€” Each player loses 2 life unless they discard a card.

The engine implemented a completely different effect â€” a mandatory creature sacrifice:

```rust
(DungeonId::TombOfAnnihilation, 1) => {
    let mut ability = simple(Effect::Sacrifice { target: creature, count: 1, min_count: 0 }, ..);
    ability.player_scope = Some(PlayerFilter::All);
    (ability, vec![])
}
```

So venturing into Veils of Fear never cost any life and instead demanded a creature â€” the wrong keyword action entirely.

## Fix

Build the room from its Oracle text via the shared parser (the same `parse_effect_chain` + `build_resolved_from_def` path several other rooms already use, e.g. Throne of the Dead Three). The parser yields the correct punisher shape:

- base effect `LoseLife { amount: 2 }`
- `player_scope: All` (each player)
- `unless_pay: { cost: Discard { count: 1 }, payer: ScopedPlayer }`

**CR 118.12a**: "Some spells, activated abilities, and triggered abilities read, '[Do something] unless [a player does something else].' This means the same thing as '[A player may do something else]. If [that player doesn't], [do something].'"

## Test

- **Runtime** (`tests/tomb_veils_of_fear_life_loss_runtime.rs`): drives the real venture pipeline â€” ventures Trapped Entry â†’ Veils of Fear with both players holding no cards, declines each player's discard-or-lose-life prompt (`PayUnlessCost { pay: false }`), and asserts both players lose 2 life. **Fails on the old sacrifice room** (revert-probed locally: with the old code both players stay at 20 life â€” no life loss and no unless-payment prompt).

Scope is limited to Veils of Fear.
