### PR TITLE
fix(parser): split "then any number of target players each ..." after a compound (Singularity Rupture)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1240,6 +1240,7 @@ fn split_comma_clause_boundary(current: &str, remainder: &str) -> Option<(Clause
         if starts_clause_text_or_conjugated(after_then)
             || starts_you_control_subject_predicate(after_then_lower)
             || starts_with_damage_clause(after_then_lower)
+            || starts_target_players_subject_clause(after_then_lower)
         {
             return Some((ClauseBoundary::Then, whitespace_len + "then ".len()));
         }
@@ -1515,6 +1516,23 @@ fn starts_you_control_subject_predicate(s: &str) -> bool {
         tag("has "),
     ))
     .parse(predicate)
+    .is_ok()
+}
+
+/// CR 115.1d + CR 608.2c: True when `s` is a distributive "any number of target
+/// player(s) [each] <verb>" clause (Singularity Rupture: "Destroy all creatures,
+/// then any number of target players each mill half their library, rounded
+/// down."). The leading token is a player *subject*, not an imperative verb, so
+/// `starts_clause_text_or_conjugated` misses it and the whole tail is dropped —
+/// even though `parse_subject_application` lowers it to a per-player targeted
+/// effect on its own. Recognize it so the `, then …` splitter peels it off as a
+/// standalone continuation.
+fn starts_target_players_subject_clause(s: &str) -> bool {
+    preceded(
+        tag::<_, _, OracleError<'_>>("any number of target player"),
+        alt((tag("s each "), tag(" each "), tag("s "), tag(" "))),
+    )
+    .parse(s)
     .is_ok()
 }
 
@@ -7123,6 +7141,40 @@ mod tests {
         // "Each player discards their hand, then draws seven cards."
         let chunks = clause_texts("discards their hand, then draws seven cards");
         assert_eq!(chunks, vec!["discards their hand", "draws seven cards"]);
+    }
+
+    #[test]
+    fn any_number_of_target_players_each_splits_after_then() {
+        // #4783 Singularity Rupture: "Destroy all creatures, then any number of
+        // target players each mill half their library, rounded down." The
+        // subject-led "any number of target players each …" tail lowers to a
+        // per-player Mill, so it must split off as its own clause after ", then"
+        // rather than being dropped.
+        let chunks = clause_texts(
+            "destroy all creatures, then any number of target players each mill half their library, rounded down",
+        );
+        assert_eq!(
+            chunks,
+            vec![
+                "destroy all creatures",
+                "any number of target players each mill half their library, rounded down",
+            ]
+        );
+    }
+
+    #[test]
+    fn starts_target_players_subject_clause_recognizes_distributive() {
+        assert!(starts_target_players_subject_clause(
+            "any number of target players each mill half their library"
+        ));
+        assert!(starts_target_players_subject_clause(
+            "any number of target players mill two cards"
+        ));
+        // Not a player-subject distributive clause.
+        assert!(!starts_target_players_subject_clause("draw a card"));
+        assert!(!starts_target_players_subject_clause(
+            "any number of target creatures"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #4783.

## Problem

**Singularity Rupture** — "Destroy all creatures, then any number of target players each mill half their library, rounded down." — dropped its **entire second clause**: only `DestroyAll` parsed, so the mill never happened and (as reported) no target prompt appeared.

## Cause

The `, then <clause>` boundary detector (`oracle_effect/sequence.rs`) recognized imperative-verb continuations, "`<subject>` you control …" predicates, and damage clauses — but **not a player-*subject*-led clause**. "any number of target players each mill …" begins with a *subject*, not a verb, so `starts_clause_text_or_conjugated` missed it and the tail was silently dropped.

Notably, the second clause parses correctly **on its own** (`parse_effect("Any number of target players each mill half their library, rounded down.")` → `Mill { count: DivideRounded(library ÷ 2, Down), target: Player }`); it was only lost in the `then`-continuation position.

## Fix

Add a targeted `starts_target_players_subject_clause` recognizer for the distributive "any number of target player(s) [each] …" form and include it in the `Then`-boundary check. Scoped to that exact subject so it can't over-split (a "then deal damage to any number of target players" tail still matches on the leading verb, unaffected).

Result — Singularity Rupture now chains:
- primary `DestroyAll` creatures
- sub `Mill { DivideRounded(TargetZoneCardCount(Library) ÷ 2, Down), target: Player }`

## Tests

New `any_number_of_target_players_each_splits_after_then` (the `, then` split) and `starts_target_players_subject_clause_recognizes_distributive` (recognizer unit, incl. negative cases).

`cargo test -p engine --lib` → **14,676 passed / 0 failed**; `fmt --check`, `clippy -p engine --all-targets -- -D warnings`, and `check-parser-combinators.sh` all clean.

CR 115.1d + CR 608.2c.