### PR TITLE
fix(engine): Tomb of Annihilation "Sandfall Cell" is a life-loss punisher, not a fabricated Zombie token

### DIFF
--- a/crates/engine/src/game/dungeon.rs
+++ b/crates/engine/src/game/dungeon.rs
@@ -461,19 +461,20 @@ pub fn room_effects(
             .sub_ability(sac_creature);
             (discard, vec![])
         }
-        // 3: Sandfall Cell — "You lose 2 life and create a 2/2 black Zombie creature token"
+        // 3: Sandfall Cell — "Each player loses 2 life unless they sacrifice a
+        //    creature, artifact, or land of their choice."
+        // CR 118.12a: a punisher — each player either sacrifices a creature,
+        // artifact, or land, or loses 2 life. Parsed from the Oracle text so the
+        // base life loss, the each-player scope, and the unless-sacrifice
+        // payment all come from the shared punisher parser (the payer binds to
+        // the per-iteration ScopedPlayer). The room was wrongly implemented as
+        // "you lose 2 life and create a 2/2 black Zombie token" — a fabricated
+        // effect that appears nowhere on the card.
         (DungeonId::TombOfAnnihilation, 3) => {
-            let mut lose = simple(
-                Effect::LoseLife { amount: fixed(2), target: None },
-                source_id,
-                controller,
-            );
-            lose.sub_ability = Some(Box::new(simple(
-                creature_token("Zombie", 2, 2, &["Zombie"], &[ManaColor::Black], &[], 1),
-                source_id,
-                controller,
-            )));
-            (lose, vec![])
+            const ORACLE: &str =
+                "Each player loses 2 life unless they sacrifice a creature, artifact, or land of their choice.";
+            let def = parse_effect_chain(ORACLE, AbilityKind::Spell);
+            (build_resolved_from_def(&def, source_id, controller), vec![])
         }
         // 4: Cradle of the Death God — "Create The Atropal, a legendary 4/4 black God Horror
         //    creature token with deathtouch."

--- a/crates/engine/tests/tomb_sandfall_cell_life_loss_runtime.rs
+++ b/crates/engine/tests/tomb_sandfall_cell_life_loss_runtime.rs
@@ -1,0 +1,86 @@
+//! Runtime (engine-path) regression for Tomb of Annihilation "Sandfall Cell".
+//!
+//! Oracle: "Each player loses 2 life unless they sacrifice a creature, artifact,
+//! or land of their choice." The room was wrongly implemented as "you lose 2
+//! life and create a 2/2 black Zombie creature token" — a fabricated token that
+//! appears nowhere on the card, and it only touched the controller. This drives
+//! the real venture pipeline: with the marker in Veils of Fear (room 1 → [3]
+//! Sandfall Cell), a venture enters Sandfall Cell. Each player is offered the CR
+//! 118.12a punisher choice; with no permanents to sacrifice, both decline and
+//! lose 2 life. On the old code only the controller lost life and a bogus token
+//! was created, so the assertions below fail — this discriminates the real
+//! behavior.
+
+use engine::game::dungeon::DungeonId;
+use engine::game::effects::venture;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{Effect, ResolvedAbility};
+use engine::types::actions::{GameAction, UnlessCostBranch};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+#[test]
+fn tomb_sandfall_cell_each_player_loses_two_life_at_runtime() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    scenario.with_life(P1, 20);
+    // Neither player controls any permanent, so neither can pay the "sacrifice a
+    // creature, artifact, or land" alternative and each must take the life loss.
+    let mut runner = scenario.build();
+
+    // Marker in Veils of Fear (Tomb room 1 → [3] Sandfall Cell, a single exit).
+    {
+        let prog = runner.state_mut().dungeon_progress.entry(P0).or_default();
+        prog.current_dungeon = Some(DungeonId::TombOfAnnihilation);
+        prog.current_room = 1;
+    }
+
+    // Venture → single exit → Sandfall Cell (room 3).
+    let venture_ability =
+        ResolvedAbility::new(Effect::VentureIntoDungeon, vec![], ObjectId(99), P0);
+    let mut events = Vec::new();
+    venture::resolve(runner.state_mut(), &venture_ability, &mut events).unwrap();
+    assert_eq!(
+        runner.state().dungeon_progress[&P0].current_room,
+        3,
+        "venture must enter Sandfall Cell (room 3)"
+    );
+
+    // Resolve: each player is prompted (single UnlessPayment or a disjunctive
+    // UnlessPaymentChooseCost). With no permanents, decline so the life loss
+    // lands.
+    for _ in 0..12 {
+        match &runner.state().waiting_for {
+            WaitingFor::UnlessPayment { .. } => {
+                runner
+                    .act(GameAction::PayUnlessCost { pay: false })
+                    .expect("declining must succeed");
+            }
+            WaitingFor::UnlessPaymentChooseCost { .. } => {
+                runner
+                    .act(GameAction::ChooseUnlessCostBranch {
+                        choice: UnlessCostBranch::Decline,
+                    })
+                    .expect("declining the disjunctive cost must succeed");
+            }
+            _ if !runner.state().stack.is_empty() => {
+                runner.resolve_top();
+            }
+            _ => break,
+        }
+    }
+
+    assert_eq!(
+        runner.state().players[0].life,
+        18,
+        "the venturing player loses 2 life (declined the sacrifice); the old room \
+         only touched the controller and created a bogus Zombie token"
+    );
+    assert_eq!(
+        runner.state().players[1].life,
+        18,
+        "each other player also loses 2 life (the room affects each player)"
+    );
+}


### PR DESCRIPTION
## Problem

Tomb of Annihilation's **Sandfall Cell** room has this Oracle text (Scryfall):

> Sandfall Cell â€” Each player loses 2 life unless they sacrifice a creature, artifact, or land of their choice.

The engine implemented a fabricated effect â€” a life loss for the controller plus a **Zombie token that does not exist on the card**:

```rust
(DungeonId::TombOfAnnihilation, 3) => {
    let mut lose = simple(Effect::LoseLife { amount: 2, target: None }, ..); // controller only
    lose.sub_ability = Some(Box::new(simple(
        creature_token("Zombie", 2, 2, &["Zombie"], &[ManaColor::Black], &[], 1), .. // not on the card
    )));
    (lose, vec![])
}
```

So venturing into Sandfall Cell made only the venturing player lose life, created a bogus 2/2 Zombie, and never offered the sacrifice alternative to any player.

## Fix

Build the room from its Oracle text via the shared parser (the same `parse_effect_chain` + `build_resolved_from_def` path other rooms use). The parser yields the correct punisher shape (verified against the resolved ability):

- base effect `LoseLife { amount: 2 }`
- `player_scope: All` (each player)
- `unless_pay: { cost: Sacrifice one permanent matching creature/artifact/land you control (Or-filter, count 1), payer: ScopedPlayer }`

**CR 118.12a**: "Some spells, activated abilities, and triggered abilities read, '[Do something] unless [a player does something else].'"

## Test

- **Runtime** (`tests/tomb_sandfall_cell_life_loss_runtime.rs`): drives the real venture pipeline â€” ventures Veils of Fear â†’ Sandfall Cell with both players controlling no permanents, declines each player's sacrifice-or-lose-life prompt (`PayUnlessCost { pay: false }`), and asserts both players lose 2 life. **Fails on the old room** (revert-probed locally: the non-controller player stays at 20, since the old code only made the controller lose life and created a bogus token).

Scope is limited to Sandfall Cell.
