### PR TITLE
feat(ai): Wave-1 legality vetoes + x_cast_gate search-depth perf fix

### DIFF
--- a/.claude/skills/add-ai-feature-policy/SKILL.md
+++ b/.claude/skills/add-ai-feature-policy/SKILL.md
@@ -74,6 +74,25 @@ All scoring scalars come from `AiConfig::policy_penalties` / `PolicyPenalties` w
 | **No bool fields.** Use existing typed enums (`ControllerRef`, `Comparator`, `TurnOrder`, etc.). | Booleans aren't composable; an enum is self-documenting. | If you need a "your-vs-opponent" distinction, use `ControllerRef::You/Opponent`. If you need on-play vs on-draw, use the existing `TurnOrder`. |
 | **Use `crate::ability_chain::collect_chain_effects`.** | Single source of truth for ability-chain walking. | Never re-implement `collect_chain_effects`. If you need to walk a `ResolvedAbility` chain in a policy, use `policies/context.rs::collect_ability_effects` (handles `sub_ability` chain). |
 | **No `git add -A` or `git add .`.** | Pre-existing untracked files at the repo root (e.g., `parser-batch-plan.md`) get accidentally committed. | Use explicit `git add path1 path2 ...`. |
+| **No unguarded board-wide / affordability engine calls in `activation()`/`verdict()`.** | Policies run per-candidate at every AI search node; a board-wide sweep there is a wall-clock landmine that `cargo ai-gate` cannot see. | Order predicates cheap-to-expensive: card-local AST checks first, `max_x_value` / `find_legal_targets` / mana sweeps last and only once the class is confirmed. See the **Performance** section. |
+
+---
+
+## Performance — `verdict()` runs in the AI search inner loop
+
+`PolicyRegistry::verdicts()` (`registry.rs:375-433`) runs **every** policy whose `decision_kinds()` matches the candidate's `DecisionKind`, calling `activation()` then `verdict()`, **for every candidate action, at every node the AI search expands.** On a large late-game board that is thousands of `verdict()` calls per decision. Treat `verdict()` and everything it transitively calls as an inner-loop function — the same discipline you would apply to code inside the engine's search.
+
+**The trap that shipped (`x_cast_gate`, commit `3de827350d`).** `XCastGatePolicy::verdict()` calls `engine::game::max_x_value` per candidate. `max_x_value` (`casting_costs.rs:7592`) walks the whole battlefield calling `feasible_mana_capacity` per permanent, and for a spell adds a per-X `concrete_cost_for_x` cost-orchestration loop — a board-wide affordability sweep. Run per candidate per search node on a turn-41 board, it regressed the Court of Grace decision from ~2.1s to ~5.7s (isolated A/B). The policy was rules-correct and passed `cargo ai-gate` with 0 win-rate flips; the entire cost was wall-clock.
+
+Rules:
+
+1. **Order predicates cheap-to-expensive; short-circuit on card-local AST before anything board-wide.** Check the candidate's own `ManaCost` / `AbilityCost` / effect chain (a handful of `matches!` over one card's AST) first, and reach for a board-wide or affordability engine call only after the card-local checks prove the candidate is even a member of the class you gate. `x_cast_gate` correctly gates `max_x_value` behind an `{X}`-shard check — but any predicate that ANDs a board-wide call with a card-local one must run the card-local one FIRST. AND is commutative, so the ordering is free latency. (For `x_cast_gate` specifically, the card-local `no_op_at_x_zero` payoff walk should precede the board-wide `max_x_value` — it spares the sweep for every `{X}` card whose payoff has a fixed residual or does not scale with X.)
+
+2. **These engine calls are board-wide or state-cloning — never call them unguarded in `activation()`/`verdict()`:** `max_x_value` / `feasible_mana_capacity` (affordability sweep), `find_legal_targets` (self-heals to a full scan), any `SimulationFilter`-cloning path, and mana-availability sweeps (the pass-priority mana clone storm and declare-attackers mana sweep are documented quadratic hot paths). Prefer a `*_for_simulation` variant where one exists. If you must call one, gate it behind the cheapest structural discriminator and push it as late in the predicate as the logic allows.
+
+3. **`activation()` is the free opt-out; use it.** It receives only `(features, state, player)` — not the candidate — so it cannot inspect the specific card, but it CAN switch the whole policy off for decks/states the policy never fires on (`if features.<feat>.commitment < FLOOR { None }`). A policy that returns `Some(1.0)` unconditionally (an `activation-constant` backstop, like `x_cast_gate`) pays full `verdict()` cost on every matching candidate — acceptable only when `verdict()` itself short-circuits cheaply per rule 1.
+
+4. **`cargo ai-gate` is blind to latency, and `cargo ai-perf-gate` is blind to un-instrumented calls.** `ai-gate` measures win-rate only. `ai-perf-gate` (`crates/phase-ai/src/bin/ai_perf_gate.rs`) field-wise sums engine `PerfCounterSnapshot` fields (`crates/engine/src/game/perf_counters.rs`) against `crates/phase-ai/baselines/perf-baseline.json` — but it only sees paths that bump a counter. `max_x_value` / `feasible_mana_capacity` bump none, so BOTH gates missed the regression above; a manual wall-clock A/B caught it. Therefore, if your policy adds a board-wide/affordability engine call that is not already counter-instrumented, EITHER add a `PerfCounterSnapshot` field for it (and refresh the perf baseline) so `ai-perf-gate` can see it, OR run and attach a wall-clock A/B on a large late-game board showing no material regression. A 0-flip `ai-gate` is necessary but NOT sufficient.
 
 ---
 
@@ -314,6 +333,7 @@ Every feature MUST have:
 
 **Measurement evidence:**
 - New-policy PRs attach a `rtk cargo ai-gate` paired-seed report. No flips is acceptable for narrow policies, but the run must exist.
+- If the policy calls any board-wide or affordability engine function (`max_x_value`, `find_legal_targets`, mana-availability / `SimulationFilter` sweeps), ALSO attach `cargo ai-perf-gate` (or a wall-clock A/B on a large late-game board). `ai-gate` measures win-rate only and is structurally blind to per-decision latency; `ai-perf-gate` is blind to any call that bumps no `PerfCounterSnapshot` field. See the **Performance** section.
 
 ---
 

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -2192,4 +2192,107 @@ mod tests {
             other => panic!("expected ChangeZone, got {other:?}"),
         }
     }
+
+    /// Cluster J3 (delayed-trigger provenance lock-in): Saheeli's "Sacrifice it
+    /// at the beginning of the next end step" must bind the specific token
+    /// created THIS resolution, not "whatever token was created most recently"
+    /// at firing time. The token id is SNAPSHOTTED from `last_created_token_ids`
+    /// into `delayed_triggers[0].ability.targets` at `CreateDelayedTrigger`
+    /// resolution — before any later token exists.
+    ///
+    /// CR 603.7c: A delayed triggered ability that refers to information from
+    /// its creation event keeps that creation-time binding for later resolution.
+    ///
+    /// Hostile multi-authority fixture: after the snapshot, a SECOND unrelated
+    /// token is created (mutating `last_created_token_ids`). The discriminating
+    /// assertion is that the snapshot equals the FIRST token's id — a live
+    /// re-read at firing would instead point at the second token. Firing the
+    /// stored ability then sacrifices the FIRST token and leaves the second
+    /// untouched, confirming the snapshot is what production consumes.
+    #[test]
+    fn delayed_sacrifice_it_snapshots_first_token_not_later_token() {
+        let mut state = GameState::new_two_player(42);
+
+        // The token created by this resolution (Saheeli's 5/5 copy).
+        let first_token = crate::game::zones::create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Saheeli Token".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&first_token)
+            .unwrap()
+            .card_types
+            .core_types = vec![crate::types::card_type::CoreType::Creature];
+        // CopyTokenOf records the created token id here; the snapshot reads it.
+        state.last_created_token_ids = vec![first_token];
+
+        // "Sacrifice it at the beginning of the next end step" — the anaphoric
+        // "it" parses to `TargetFilter::LastCreated`.
+        let inner = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Sacrifice {
+                target: crate::types::ability::TargetFilter::LastCreated,
+                count: QuantityExpr::Fixed { value: 1 },
+                min_count: 0,
+            },
+        );
+        let create = ResolvedAbility::new(
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                effect: Box::new(inner),
+                uses_tracked_set: false,
+            },
+            vec![],
+            ObjectId(100), // Saheeli's source id
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &create, &mut events).expect("CreateDelayedTrigger resolves");
+
+        // Discriminating assertion: the snapshot captured the FIRST token at
+        // creation. A live re-read at firing would instead read the second.
+        assert_eq!(
+            state.delayed_triggers[0].ability.targets,
+            vec![crate::types::ability::TargetRef::Object(first_token)],
+            "CR 603.7c: the delayed 'sacrifice it' must snapshot the just-created \
+             token's id at creation time"
+        );
+
+        // A SECOND, unrelated token is created before the end step fires,
+        // mutating `last_created_token_ids`.
+        let second_token = crate::game::zones::create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Later Token".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&second_token)
+            .unwrap()
+            .card_types
+            .core_types = vec![crate::types::card_type::CoreType::Creature];
+        state.last_created_token_ids = vec![second_token];
+
+        // Fire the stored delayed ability through the effect dispatcher.
+        let fired = state.delayed_triggers[0].ability.clone();
+        let mut fire_events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &fired, &mut fire_events, 0)
+            .expect("delayed sacrifice resolves");
+
+        assert!(
+            state.players[0].graveyard.contains(&first_token),
+            "the FIRST (snapshotted) token is sacrificed at the end step"
+        );
+        assert!(
+            state.battlefield.contains(&second_token),
+            "the later, unrelated token must survive — the snapshot did not drift to it"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -561,6 +561,71 @@ mod tests {
         }
     }
 
+    /// Cluster J1 (building-block companion to the Disciple of Bolas
+    /// cast-pipeline guard): "sacrifice **another** creature" as an EFFECT must
+    /// exclude the ability's source from the eligible pool. With exactly one
+    /// OTHER creature, the mandatory sacrifice auto-resolves onto it and the
+    /// source survives.
+    ///
+    /// CR 701.21a: sacrifice moves the chosen permanent to its owner's
+    /// graveyard. `FilterProp::Another` is evaluated via
+    /// `FilterContext::from_ability` (source excluded). The paired negative
+    /// (source survives) is made non-vacuous by asserting the OTHER creature was
+    /// actually moved to the graveyard.
+    #[test]
+    fn sacrifice_another_creature_effect_excludes_source_from_pool() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Disciple".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        let other = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Hill Giant".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&other).unwrap().card_types.core_types = vec![CoreType::Creature];
+
+        let ability = ResolvedAbility::new(
+            Effect::Sacrifice {
+                target: TargetFilter::Typed(
+                    TypedFilter::creature().properties(vec![FilterProp::Another]),
+                ),
+                count: QuantityExpr::Fixed { value: 1 },
+                min_count: 0,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(
+            state.battlefield.contains(&source),
+            "FilterProp::Another must exclude the source — it survives"
+        );
+        assert!(
+            state.players[0].graveyard.contains(&other),
+            "the OTHER creature is the sole eligible target and is sacrificed"
+        );
+        assert!(
+            !state.battlefield.contains(&other),
+            "non-vacuous: the other creature actually left the battlefield"
+        );
+    }
+
     #[test]
     fn sacrifice_moves_to_graveyard() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -4869,6 +4869,101 @@ fn disciple_of_bolas_uses_sacrificed_creature_power_for_life_and_draw() {
     assert!(state.players[0].graveyard.contains(&hill_giant));
 }
 
+/// Cluster J1 (headline `/card-test` regression guard): "When this creature
+/// enters, sacrifice **another** creature." must exclude the source. Casting
+/// Disciple of Bolas through the full cast → trigger → stack → apply() → chain
+/// → `sacrifice::resolve` pipeline with exactly one OTHER creature must
+/// sacrifice that other creature and leave Disciple on the battlefield.
+///
+/// CR 701.21a: sacrifice moves the chosen permanent to its owner's graveyard.
+/// The `another` qualifier parses to `FilterProp::Another`; the effect resolver
+/// builds its eligible pool via `FilterContext::from_ability` (source excluded
+/// at `filter.rs` `FilterProp::Another => object_id != source.id`).
+///
+/// COST/EFFECT CLASS REDUNDANCY (fix-constraint #2): the sibling cost path
+/// (`find_eligible_sacrifice_targets` → `FilterContext::from_source`) sets
+/// `recipient_id: None` identically to `from_ability`, so both paths hit the
+/// same `FilterProp::Another` exclusion site with an identical source id. This
+/// one effect-path guard therefore substantiates the whole "sacrifice another"
+/// class (effect + cost forms) — no separate cost-path integration test needed.
+///
+/// The positive Hill-Giant sacrifice plus the +3 life / +3 draw deltas prove
+/// the sacrifice machinery actually ran (non-vacuous), and the paired sibling
+/// test `sacrifice_a_creature_without_another_includes_sole_source` proves the
+/// exclusion is `Another`-driven, not an empty-pool artifact.
+#[test]
+fn disciple_of_bolas_sacrifices_another_creature_not_itself() {
+    use crate::game::scenario::{GameScenario, P0};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The entering creature carries the verbatim Oracle text (parser branch
+    // fidelity — a paraphrase could take a different branch). Mana is elided
+    // (default zero cost) so the test isolates the sacrifice-exclusion seam.
+    let disciple = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Disciple of Bolas",
+            2,
+            1,
+            "When this creature enters, sacrifice another creature. You gain X life and draw X cards, where X is that creature's power.",
+        )
+        .id();
+
+    // Exactly one OTHER creature: the sole eligible sacrifice, so the effect
+    // auto-resolves (no EffectZoneChoice) onto it. Power 3 → X = 3.
+    let hill_giant = scenario.add_creature(P0, "Hill Giant", 3, 3).id();
+
+    // Three library cards so the "draw X" (X = 3) has cards to draw.
+    scenario.with_library_top(P0, &["Card A", "Card B", "Card C"]);
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(disciple).resolve();
+
+    // Source excluded: Disciple survives on the battlefield.
+    outcome.assert_zone(&[disciple], Zone::Battlefield);
+    // The OTHER creature was sacrificed (positive, non-vacuous reach-guard).
+    outcome.assert_zone(&[hill_giant], Zone::Graveyard);
+    // X = Hill Giant's power (3): +3 life and 3 cards drawn.
+    outcome.assert_life_delta(P0, 3);
+    outcome.assert_hand_drawn(P0, 3);
+}
+
+/// Cluster J1 (paired sibling reach-guard): the same ETB shape WITHOUT the
+/// `another` qualifier ("sacrifice a creature") DOES include the sole source,
+/// sacrificing the entering creature itself. This proves the exclusion in
+/// `disciple_of_bolas_sacrifices_another_creature_not_itself` is driven by
+/// `FilterProp::Another`, not by a vacuously empty eligible pool.
+///
+/// CR 701.21a: with the source as the only eligible creature, the mandatory
+/// sacrifice auto-resolves onto it.
+#[test]
+fn sacrifice_a_creature_without_another_includes_sole_source() {
+    use crate::game::scenario::{GameScenario, P0};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // No "another" — the source is a legal sacrifice target. It is the ONLY
+    // creature on the battlefield when the ETB resolves.
+    let reaper = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Test Reaper",
+            1,
+            1,
+            "When this creature enters, sacrifice a creature.",
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(reaper).resolve();
+
+    // Sole eligible creature is the source itself → it sacrifices itself.
+    outcome.assert_zone(&[reaper], Zone::Graveyard);
+}
+
 const SQUADRON_HAWK_ORACLE: &str = "Flying\nWhen this creature enters, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle.";
 
 fn add_squadron_hawk_to_library(state: &mut GameState, card_id: u64) -> ObjectId {

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -166,6 +166,13 @@ pub use bracket_estimate::{
     estimate_bracket, BracketAxis, BracketAxisCounts, BracketContributingCards, BracketEstimate,
     BracketViolation, CommanderBracketTier,
 };
+// Plumbing: read-only re-export of the X-affordability authority
+// (`max_x_value`) so the `phase-ai` consumer crate can price "the only legal X
+// is 0" without duplicating the cost machinery. `casting_costs` is otherwise
+// `pub(crate)`; this exposes exactly that one function from it. The governing
+// rule annotation lives on the function definition in `casting_costs.rs`, not
+// on this visibility re-export.
+pub use casting_costs::max_x_value;
 pub use deck_loading::{
     create_commander_from_card_face, load_and_hydrate_decks, load_deck_into_state,
     resolve_deck_list, resolve_player_deck_list, DeckEntry, DeckList, DeckPayload, PlayerDeckList,

--- a/crates/engine/src/game/planeswalker.rs
+++ b/crates/engine/src/game/planeswalker.rs
@@ -1183,4 +1183,78 @@ mod tests {
             on_stack.ability().map(|a| &a.effect)
         );
     }
+
+    /// Cluster J2 (legal-action-seam regression guard): a planeswalker's
+    /// negative-loyalty ability must NOT be offered when the permanent lacks
+    /// enough loyalty counters to pay it. An Ob-Nixilis-shaped planeswalker
+    /// (loyalty abilities +2 / -2 / -8) at 1 loyalty offers ONLY the +2 at the
+    /// `can_activate_ability_now` legal-action seam — the exact layer whose
+    /// leak the report ("Ob Nixilis used -2 at 1 loyalty") alleged.
+    ///
+    /// CR 606.6: A loyalty ability with a negative loyalty cost can't be
+    /// activated unless the permanent has at least that many loyalty counters on
+    /// it. The +2 reach-guard proves the enumerator reaches each ability and the
+    /// gate is loyalty-sensitive (not blanket-false for negatives), and the
+    /// 2-loyalty boundary case proves -2 flips to payable at exactly 2 (2 >= 2).
+    #[test]
+    fn negative_loyalty_ability_not_offered_below_cost() {
+        use crate::game::casting::can_activate_ability_now;
+
+        fn draw(n: i32) -> Effect {
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: n },
+                target: TargetFilter::Controller,
+            }
+        }
+
+        fn ob_nixilis_abilities() -> Vec<AbilityDefinition> {
+            vec![
+                make_loyalty_ability(2, draw(1)),
+                make_loyalty_ability(-2, draw(2)),
+                make_loyalty_ability(-8, draw(7)),
+            ]
+        }
+
+        let mut state = setup();
+
+        // At 1 loyalty: +2 is always payable; -2 and -8 are not (CR 606.6).
+        let pw = create_planeswalker(
+            &mut state,
+            PlayerId(0),
+            "Ob Nixilis of the Black Oath",
+            1,
+            ob_nixilis_abilities(),
+        );
+
+        assert!(
+            can_activate_ability_now(&state, PlayerId(0), pw, 0),
+            "+2 must be offered at 1 loyalty (reach-guard: the enumerator reaches this ability)"
+        );
+        assert!(
+            !can_activate_ability_now(&state, PlayerId(0), pw, 1),
+            "CR 606.6: -2 must NOT be offered at 1 loyalty (1 < 2)"
+        );
+        assert!(
+            !can_activate_ability_now(&state, PlayerId(0), pw, 2),
+            "CR 606.6: -8 must NOT be offered at 1 loyalty (1 < 8)"
+        );
+
+        // Boundary: at exactly 2 loyalty, -2 becomes payable (2 >= 2), proving
+        // the gate is loyalty-sensitive rather than blanket-false for negatives.
+        let pw2 = create_planeswalker(
+            &mut state,
+            PlayerId(0),
+            "Ob Nixilis of the Black Oath",
+            2,
+            ob_nixilis_abilities(),
+        );
+        assert!(
+            can_activate_ability_now(&state, PlayerId(0), pw2, 1),
+            "CR 606.6 boundary: -2 becomes payable at exactly 2 loyalty (2 >= 2)"
+        );
+        assert!(
+            !can_activate_ability_now(&state, PlayerId(0), pw2, 2),
+            "CR 606.6: -8 still not payable at 2 loyalty (2 < 8)"
+        );
+    }
 }

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -410,6 +410,20 @@ pub struct PolicyPenalties {
     /// urgency advantage over waiting. Consumed by `AntiSelfHarmPolicy`.
     #[serde(default = "default_tapped_removal_no_urgency_penalty")]
     pub tapped_removal_no_urgency_penalty: f64,
+    /// CR 119.4: Per-point cost of a self-inflicted pay-life activation cost,
+    /// before runtime life-pressure scaling. Mirrors the `player_impact`
+    /// GainLife/LoseLife weight (0.15). Consumed by `SelfCostValuePolicy`.
+    #[serde(default = "default_self_cost_pay_life_per_point")]
+    pub self_cost_pay_life_per_point: f64,
+    /// CR 701.9a: Per-card cost of a self-inflicted discard activation cost (one
+    /// card ≈ one unit of expected value). Consumed by `SelfCostValuePolicy`.
+    #[serde(default = "default_self_cost_discard_per_card")]
+    pub self_cost_discard_per_card: f64,
+    /// CR 701.13a: Per-card cost of exiling a card from the AI's own graveyard
+    /// as an activation cost — cheap unless the deck is graveyard-committed.
+    /// Consumed by `SelfCostValuePolicy`.
+    #[serde(default = "default_self_cost_exile_graveyard_per_card")]
+    pub self_cost_exile_graveyard_per_card: f64,
 }
 
 impl Default for PolicyPenalties {
@@ -468,6 +482,9 @@ impl Default for PolicyPenalties {
             untap_opponent_tapped_penalty: default_untap_opponent_tapped_penalty(),
             untap_untapped_penalty: default_untap_untapped_penalty(),
             tapped_removal_no_urgency_penalty: default_tapped_removal_no_urgency_penalty(),
+            self_cost_pay_life_per_point: default_self_cost_pay_life_per_point(),
+            self_cost_discard_per_card: default_self_cost_discard_per_card(),
+            self_cost_exile_graveyard_per_card: default_self_cost_exile_graveyard_per_card(),
         }
     }
 }
@@ -486,6 +503,15 @@ fn default_untap_untapped_penalty() -> f64 {
 }
 fn default_tapped_removal_no_urgency_penalty() -> f64 {
     -5.0
+}
+fn default_self_cost_pay_life_per_point() -> f64 {
+    0.15
+}
+fn default_self_cost_discard_per_card() -> f64 {
+    1.0
+}
+fn default_self_cost_exile_graveyard_per_card() -> f64 {
+    0.15
 }
 
 fn default_lethality_tapout_penalty() -> f64 {
@@ -697,6 +723,18 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "tapped_removal_no_urgency_penalty",
         "AntiSelfHarmPolicy magnitude lifted from a raw literal (value-preserving); awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "self_cost_pay_life_per_point",
+        "new SelfCostValuePolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "self_cost_discard_per_card",
+        "new SelfCostValuePolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
+    ),
+    (
+        "self_cost_exile_graveyard_per_card",
+        "new SelfCostValuePolicy knob; awaiting a paired-seed ai-gate calibration before joining the CMA-ES vector",
     ),
 ];
 

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -18,7 +18,7 @@ use crate::config::{AiConfig, OpponentModel};
 use crate::eval::{
     evaluate_for_planner, evaluate_state, strategic_intent, threat_level, StrategicIntent,
 };
-use crate::policies::context::PolicyContext;
+use crate::policies::context::{PolicyContext, PriorsEnv, SearchDepth};
 use crate::policies::PolicyRegistry;
 
 #[derive(Debug, Clone)]
@@ -911,6 +911,7 @@ impl<'a> PlannerServices<'a> {
         ctx: &AiDecisionContext,
         candidate: &CandidateAction,
         scoring_player: PlayerId,
+        search_depth: SearchDepth,
     ) -> f64 {
         let cast_facts = cast_facts_for_action(state, &candidate.action, scoring_player);
         let mut score = should_play_now_with_facts(
@@ -928,6 +929,7 @@ impl<'a> PlannerServices<'a> {
             config: self.config,
             context: &self.context,
             cast_facts,
+            search_depth,
         };
         score += self.policies.score(&policy_ctx);
 
@@ -957,15 +959,17 @@ impl<'a> PlannerServices<'a> {
         ctx: &AiDecisionContext,
         candidates: &[CandidateAction],
         scoring_player: PlayerId,
+        search_depth: SearchDepth,
     ) -> Vec<PolicyPrior> {
-        self.policies.priors(
+        let env = PriorsEnv {
             state,
-            ctx,
-            candidates,
-            scoring_player,
-            self.config,
-            &self.context,
-        )
+            decision: ctx,
+            ai_player: scoring_player,
+            config: self.config,
+            context: &self.context,
+            search_depth,
+        };
+        self.policies.priors(&env, candidates)
     }
 
     pub fn planner_evaluation(&mut self, state: &GameState) -> PlannerEvaluation {
@@ -976,7 +980,15 @@ impl<'a> PlannerServices<'a> {
         let ctx = self.build_decision_context(state);
         let scoring_player = state.waiting_for.acting_player().unwrap_or(self.ai_player);
         PlannerEvaluation {
-            priors: self.policy_priors(state, &ctx, &ctx.candidates, scoring_player),
+            // Rollout leaf: every node reached here is deep lookahead, never the
+            // committed decision, so board-wide/affordability policies self-gate.
+            priors: self.policy_priors(
+                state,
+                &ctx,
+                &ctx.candidates,
+                scoring_player,
+                SearchDepth::Lookahead,
+            ),
             value: self.evaluate_for_planner(state),
         }
     }
@@ -1105,7 +1117,17 @@ impl BeamContinuationPlanner {
         let scoring_player = node_player.unwrap_or(services.ai_player);
         let ranked = rank_candidates(
             ctx.candidates.clone(),
-            |candidate| services.tactical_score(state, &ctx, candidate, scoring_player),
+            // Interior beam node: `search_value` is always entered ≥1 ply below
+            // the decision root, so move-ordering scoring runs in lookahead.
+            |candidate| {
+                services.tactical_score(
+                    state,
+                    &ctx,
+                    candidate,
+                    scoring_player,
+                    SearchDepth::Lookahead,
+                )
+            },
             services.config.search.max_branching as usize,
         );
 
@@ -1490,7 +1512,13 @@ mod tests {
             },
         ];
 
-        let priors = services.policy_priors(&state, &decision, &candidates, PlayerId(0));
+        let priors = services.policy_priors(
+            &state,
+            &decision,
+            &candidates,
+            PlayerId(0),
+            SearchDepth::Lookahead,
+        );
         assert_eq!(priors.len(), 2);
         assert!(priors.iter().all(|prior| prior.prior.is_finite()));
         assert!(priors.iter().any(|prior| prior.prior > 0.0));

--- a/crates/phase-ai/src/policies/aggro_pressure.rs
+++ b/crates/phase-ai/src/policies/aggro_pressure.rs
@@ -408,6 +408,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = AggroPressurePolicy.verdict(&ctx);
@@ -441,6 +442,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = AggroPressurePolicy.verdict(&ctx);
@@ -476,6 +478,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = AggroPressurePolicy.verdict(&ctx);
@@ -519,6 +522,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = AggroPressurePolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/anthem_priority.rs
+++ b/crates/phase-ai/src/policies/anthem_priority.rs
@@ -241,6 +241,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = AnthemPriorityPolicy.verdict(&ctx);
         match verdict {
@@ -271,6 +272,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = AnthemPriorityPolicy.verdict(&ctx);
         match verdict {
@@ -305,6 +307,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = AnthemPriorityPolicy.verdict(&ctx);
         match verdict {

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -1243,6 +1243,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -1282,6 +1283,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -1320,6 +1322,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1338,6 +1341,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1410,6 +1414,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1427,6 +1432,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1475,6 +1481,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1492,6 +1499,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1522,6 +1530,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1538,6 +1547,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1574,6 +1584,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1591,6 +1602,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1626,6 +1638,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -1643,6 +1656,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1680,6 +1694,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_self = AntiSelfHarmPolicy.score(&ctx_self);
 
@@ -1700,6 +1715,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -1771,6 +1787,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let opp_candidate = CandidateAction {
             action: GameAction::ChooseTarget {
@@ -1789,6 +1806,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let self_score = AntiSelfHarmPolicy.score(&self_ctx);
@@ -1860,6 +1878,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let opp_candidate = CandidateAction {
             action: GameAction::ChooseTarget {
@@ -1878,6 +1897,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let self_score = AntiSelfHarmPolicy.score(&self_ctx);
@@ -2063,6 +2083,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2125,6 +2146,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2223,6 +2245,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2286,6 +2309,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2348,6 +2372,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2410,6 +2435,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2474,6 +2500,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2537,6 +2564,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2599,6 +2627,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2749,6 +2778,7 @@ mod tests {
             config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         AntiSelfHarmPolicy.score(&ctx)
     }
@@ -2775,6 +2805,7 @@ mod tests {
             config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         AntiSelfHarmPolicy.score(&ctx)
     }
@@ -2815,6 +2846,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -2945,6 +2977,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -3103,6 +3136,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -3206,6 +3240,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -3258,6 +3293,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = AntiSelfHarmPolicy.score(&ctx);
@@ -3372,6 +3408,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let creature_score = AntiSelfHarmPolicy.score(&creature_ctx);
 
@@ -3393,6 +3430,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let token_score = AntiSelfHarmPolicy.score(&token_ctx);
 
@@ -3478,6 +3516,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let effects = ctx.effects();
@@ -3558,6 +3597,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict_self = AntiSelfHarmPolicy.verdict(&ctx_self);
 
@@ -3579,6 +3619,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -3600,6 +3641,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_player = AntiSelfHarmPolicy.score(&ctx_player);
 
@@ -3650,6 +3692,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_own = AntiSelfHarmPolicy.score(&ctx_own);
 
@@ -3668,6 +3711,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
 
@@ -3719,6 +3763,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_creature = AntiSelfHarmPolicy.score(&ctx_creature);
 
@@ -3737,6 +3782,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score_face = AntiSelfHarmPolicy.score(&ctx_face);
 
@@ -3783,6 +3829,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score = AntiSelfHarmPolicy.score(&ctx);
 
@@ -3842,6 +3889,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score = AntiSelfHarmPolicy.score(&ctx);
         assert!(
@@ -3885,6 +3933,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let lowest_score = AntiSelfHarmPolicy.score(&ctx_lowest);
 
@@ -3905,6 +3954,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let other_score = AntiSelfHarmPolicy.score(&ctx_other);
 
@@ -3953,6 +4003,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         AntiSelfHarmPolicy.score(&ctx)
     }
@@ -3969,6 +4020,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         AntiSelfHarmPolicy.verdict(&ctx)
     }
@@ -4305,6 +4357,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         AntiSelfHarmPolicy.verdict(&ctx)
     }
@@ -4349,6 +4402,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdicts = crate::policies::registry::PolicyRegistry::shared().verdicts(&ctx);

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -28,7 +28,9 @@ use engine::game::players;
 
 use super::activation::turn_only;
 use super::context::PolicyContext;
-use super::copy_value::{copy_target_penalties, score_legend_rule_keep};
+use super::copy_value::{
+    copy_effect_strips_legendary, copy_target_penalties, score_legend_rule_keep,
+};
 use super::effect_classify::{
     aggregate_player_impact, aura_polarity, effect_polarity, effect_targets_object,
     extract_target_filter, is_spell_beneficial, lethal_to_creature, targeted_object_impact,
@@ -705,13 +707,15 @@ fn score_target_object(ctx: &PolicyContext<'_>, object_id: ObjectId, beneficial:
         }
     }
 
-    if ctx
+    if let Some(copy_effect) = ctx
         .effects()
         .iter()
-        .any(|effect| matches!(effect, Effect::CopyTokenOf { .. }))
+        .find(|effect| matches!(effect, Effect::CopyTokenOf { .. }))
     {
         if let Some(source) = ctx.source_object() {
-            score -= copy_target_penalties(ctx.state, ctx.ai_player, Some(source.id), object);
+            let strips = copy_effect_strips_legendary(copy_effect);
+            score -=
+                copy_target_penalties(ctx.state, ctx.ai_player, Some(source.id), object, strips);
         }
     }
 
@@ -1345,6 +1349,155 @@ mod tests {
         assert!(
             score_opp < 0.0,
             "Opponent creature score should be negative"
+        );
+    }
+
+    #[test]
+    fn undying_malice_prefers_own_creature() {
+        // Undying Malice grants target creature "when this dies, return it to the
+        // battlefield" — GenericEffect{ Continuous{ GrantTrigger{ dies →
+        // ChangeZone→Battlefield } } }. Pre-fix `modification_polarity(GrantTrigger)`
+        // fell to `Contextual`, so `player_impact`/`is_spell_beneficial` read the
+        // spell as non-beneficial and `score_target_object` aimed it at an opponent
+        // creature. The fix classifies the grant Beneficial (via the executed
+        // ChangeZone→Battlefield), flipping the preference to the AI's own creature.
+        // Reverting the named `GrantTrigger` arm makes `score_own < score_opp`.
+        let mut state = make_state();
+        let own_id = add_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let opp_id = add_creature(&mut state, PlayerId(1), "Goblin", 2, 2);
+        let config = AiConfig::default();
+
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone);
+        trigger.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: Some(Zone::Graveyard),
+                destination: Zone::Battlefield,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        )));
+        let effect = Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::ParentTarget)
+                .modifications(vec![ContinuousModification::GrantTrigger {
+                    trigger: Box::new(trigger),
+                }])],
+            target: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature))),
+            duration: None,
+        };
+
+        let (decision, candidate) = make_target_selection_ctx(
+            &state,
+            effect.clone(),
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(own_id)),
+        );
+        let ctx_own = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        let score_own = AntiSelfHarmPolicy.score(&ctx_own);
+
+        let (decision, candidate) = make_target_selection_ctx(
+            &state,
+            effect,
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(opp_id)),
+        );
+        let ctx_opp = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
+
+        assert!(
+            score_own > score_opp,
+            "Undying grant should prefer own creature: own={score_own}, opp={score_opp}"
+        );
+        assert!(score_own > 0.0, "Own creature score should be positive");
+        assert!(
+            score_opp < 0.0,
+            "Opponent creature score should be negative"
+        );
+    }
+
+    #[test]
+    fn strength_of_tajuru_prefers_own_creature() {
+        // VERIFY-ONLY (expected to PASS on unmodified code): Strength of the Tajuru's
+        // payoff leaf is `PutCounterAll{ +1/+1 }`, which `counter_sign_polarity`
+        // already classifies Beneficial, so `is_spell_beneficial` is true and
+        // `score_target_object` prefers the AI's own creature. No code change backs
+        // this — it documents the reported "targets opponent" behavior as already
+        // correct for the counter payoff (the empty `Typed` target mirrors the real
+        // leaf AST). If this ever fails, it is a stop-and-return item, not a fix.
+        let mut state = make_state();
+        let own_id = add_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+        let opp_id = add_creature(&mut state, PlayerId(1), "Goblin", 2, 2);
+        let config = AiConfig::default();
+
+        let effect = Effect::PutCounterAll {
+            counter_type: CounterType::Plus1Plus1,
+            count: QuantityExpr::Fixed { value: 2 },
+            target: TargetFilter::Typed(TypedFilter::default()),
+        };
+
+        let (decision, candidate) = make_target_selection_ctx(
+            &state,
+            effect.clone(),
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(own_id)),
+        );
+        let ctx_own = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        let score_own = AntiSelfHarmPolicy.score(&ctx_own);
+
+        let (decision, candidate) = make_target_selection_ctx(
+            &state,
+            effect,
+            vec![TargetRef::Object(own_id), TargetRef::Object(opp_id)],
+            Some(TargetRef::Object(opp_id)),
+        );
+        let ctx_opp = PolicyContext {
+            state: &state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+        };
+        let score_opp = AntiSelfHarmPolicy.score(&ctx_opp);
+
+        assert!(
+            score_own > score_opp,
+            "PutCounterAll{{+1/+1}} should prefer own creature: own={score_own}, opp={score_opp}"
         );
     }
 

--- a/crates/phase-ai/src/policies/blight_value.rs
+++ b/crates/phase-ai/src/policies/blight_value.rs
@@ -176,6 +176,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let small_score = BlightValuePolicy.score(&small_ctx);
 
@@ -195,6 +196,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let big_score = BlightValuePolicy.score(&big_ctx);
 
@@ -259,6 +261,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         // The raw score must exceed the ceiling, proving the clamp is exercised.
@@ -309,6 +312,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = BlightValuePolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/board_wipe_telegraph.rs
+++ b/crates/phase-ai/src/policies/board_wipe_telegraph.rs
@@ -269,6 +269,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = BoardWipeTelegraphPolicy.score(&ctx);
@@ -352,6 +353,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = BoardWipeTelegraphPolicy.score(&ctx);
@@ -448,6 +450,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let base_score = BoardWipeTelegraphPolicy.score(&base_ctx);
 
@@ -473,6 +476,7 @@ mod tests {
             config: &config,
             context: &context_with_tokens,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let amp_score = BoardWipeTelegraphPolicy.score(&amp_ctx);
 

--- a/crates/phase-ai/src/policies/card_advantage.rs
+++ b/crates/phase-ai/src/policies/card_advantage.rs
@@ -167,6 +167,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = CardAdvantagePolicy.score(&ctx);
@@ -225,6 +226,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = CardAdvantagePolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/chalice_avoidance.rs
+++ b/crates/phase-ai/src/policies/chalice_avoidance.rs
@@ -324,6 +324,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         ChaliceAvoidancePolicy.score(&ctx)
     }
@@ -450,6 +451,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let registry = PolicyRegistry::default();
         let fired = registry.verdicts(&ctx).into_iter().any(|(id, v)| {

--- a/crates/phase-ai/src/policies/combo_line.rs
+++ b/crates/phase-ai/src/policies/combo_line.rs
@@ -225,6 +225,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = policy.verdict(&ctx);
         match verdict {
@@ -293,6 +294,7 @@ mod tests {
             config,
             context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         }
     }
 

--- a/crates/phase-ai/src/policies/condition_gated_activation.rs
+++ b/crates/phase-ai/src/policies/condition_gated_activation.rs
@@ -210,6 +210,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         ConditionGatedActivationPolicy.verdict(&ctx)
     }
@@ -289,6 +290,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         assert_score(
             ConditionGatedActivationPolicy.verdict(&ctx),

--- a/crates/phase-ai/src/policies/context.rs
+++ b/crates/phase-ai/src/policies/context.rs
@@ -16,6 +16,21 @@ use crate::eval::{strategic_intent, StrategicIntent};
 #[cfg(test)]
 use engine::types::game_state::CastPaymentMode;
 
+/// Position of the node being scored within the current AI decision's search
+/// tree. `Root` is the node the AI will actually commit an action at
+/// (`score_candidates_core`); `Lookahead` is any hypothetical node inside beam
+/// alpha-beta or rollout. Expensive policies (board-wide affordability sweeps,
+/// `find_legal_targets`, `SimulationFilter` clones) should run their full
+/// analysis only at `Root` via [`PolicyContext::at_root`] and return neutral in
+/// lookahead, where the resulting-state eval already accounts for the action.
+/// Mirrors the `deadline`/projection-budget self-gating precedent, but is a
+/// per-node field (not an `AiContext` value) because depth varies per node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchDepth {
+    Root,
+    Lookahead,
+}
+
 pub struct PolicyContext<'a> {
     pub state: &'a GameState,
     pub decision: &'a AiDecisionContext,
@@ -24,6 +39,24 @@ pub struct PolicyContext<'a> {
     pub config: &'a AiConfig,
     pub context: &'a crate::context::AiContext,
     pub cast_facts: Option<CastFacts<'a>>,
+    pub search_depth: SearchDepth,
+}
+
+/// Batch-constant scoring inputs for [`super::registry::PolicyRegistry::priors`] —
+/// every value that stays fixed across all candidates in a single `priors`
+/// call, as opposed to `candidates` itself (what's being scored). Grouping
+/// these keeps `priors` under clippy's argument-count limit; every field
+/// flows unchanged into the per-candidate [`PolicyContext`] built inside the
+/// scoring loop. `search_depth` stays a distinct field here (not folded into
+/// `AiContext`) for the same reason it's distinct on `PolicyContext`: it
+/// varies per search node, unlike the ambient `AiContext`.
+pub struct PriorsEnv<'a> {
+    pub state: &'a GameState,
+    pub decision: &'a AiDecisionContext,
+    pub ai_player: PlayerId,
+    pub config: &'a AiConfig,
+    pub context: &'a crate::context::AiContext,
+    pub search_depth: SearchDepth,
 }
 
 impl<'a> PolicyContext<'a> {
@@ -61,6 +94,14 @@ impl<'a> PolicyContext<'a> {
             .deadline
             .remaining()
             .is_none_or(|r| r.as_millis() >= floor)
+    }
+
+    /// True when this is the node the AI will commit an action at. Policies whose
+    /// only correctness role is stopping a *committed* action (and whose analysis
+    /// is board-wide/expensive) should gate that work behind this and return
+    /// neutral otherwise — the lookahead eval already dominates no-op lines.
+    pub fn at_root(&self) -> bool {
+        matches!(self.search_depth, SearchDepth::Root)
     }
 
     pub fn source_object(&self) -> Option<&'a GameObject> {
@@ -257,6 +298,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let effects = ctx.effects();
@@ -319,6 +361,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let effects = ctx.effects();
@@ -387,6 +430,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let effects = ctx.effects();
@@ -460,6 +504,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(ctx.effects().len(), 1);
@@ -483,6 +528,7 @@ mod tests {
             config,
             context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         }
     }
 

--- a/crates/phase-ai/src/policies/control_change_awareness.rs
+++ b/crates/phase-ai/src/policies/control_change_awareness.rs
@@ -300,6 +300,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         ControlChangeAwarenessPolicy.verdict(&ctx)
     }
@@ -329,6 +330,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         ControlChangeAwarenessPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -4,7 +4,7 @@ use engine::ai_support::{
 };
 use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::game_object::GameObject;
-use engine::types::ability::{AbilityDefinition, Effect, TargetRef};
+use engine::types::ability::{AbilityDefinition, ContinuousModification, Effect, TargetRef};
 use engine::types::actions::GameAction;
 use engine::types::card_type::{CoreType, Supertype};
 use engine::types::game_state::{GameState, PendingCast, WaitingFor};
@@ -57,7 +57,11 @@ impl CopyValuePolicy {
                 .any(|e| matches!(e, Effect::CopyTokenOf { .. })) =>
             {
                 let source_id = ctx.source_object().map(|source| source.id);
-                score_copy_token_target(ctx.state, ctx.ai_player, source_id, *target_id)
+                let strips = ctx
+                    .effects()
+                    .iter()
+                    .any(|e| copy_effect_strips_legendary(e));
+                score_copy_token_target(ctx.state, ctx.ai_player, source_id, *target_id, strips)
             }
             _ => 0.0,
         }
@@ -100,13 +104,47 @@ fn evaluate_legend_keep_permanent(state: &GameState, keep: ObjectId, object: &Ga
     (object.mana_cost.mana_value() as f64).min(6.0)
 }
 
+/// CR 707.9 + CR 205.4a: A copy inherits the copied object's supertypes
+/// (including Legendary) unless the copy effect includes an "except" clause that
+/// strips it (Miirym, Sentinel Wyrm / Helm of the Host: "except the token isn't
+/// legendary" → `RemoveSupertype { Legendary }`). Core-type modifications
+/// (`RemoveType`, `SetCardTypes`; CR 205.1a) act on card *types*, not
+/// supertypes, so they can never remove Legendary — a `RemoveSupertype {
+/// Legendary }` in `additional_modifications` is the sole legend-strip. Handles
+/// both the token-copy (`CopyTokenOf`) and enters-as-copy (`BecomeCopy`) forms,
+/// which share the field.
+pub(crate) fn copy_effect_strips_legendary(effect: &Effect) -> bool {
+    let mods = match effect {
+        Effect::CopyTokenOf {
+            additional_modifications,
+            ..
+        }
+        | Effect::BecomeCopy {
+            additional_modifications,
+            ..
+        } => additional_modifications,
+        _ => return false,
+    };
+    mods.iter().any(|m| {
+        matches!(
+            m,
+            ContinuousModification::RemoveSupertype {
+                supertype: Supertype::Legendary
+            }
+        )
+    })
+}
+
 /// Penalties for copy effects that would trigger a wasteful legend-rule loop
-/// (issue #2438 — Saheeli copying her own commander).
+/// (issue #2438 — Saheeli copying her own commander). `strips_legendary` is the
+/// copy effect's typed decision (from `copy_effect_strips_legendary`): a copy
+/// that makes its token non-legendary creates no legend-rule collision.
 pub(crate) fn copy_target_penalties(
     state: &GameState,
     ai_player: PlayerId,
     source_id: Option<ObjectId>,
     target: &GameObject,
+    strips_legendary: bool,
 ) -> f64 {
     let mut penalty = 0.0;
 
@@ -118,17 +156,15 @@ pub(crate) fn copy_target_penalties(
         penalty += 40.0;
     }
 
+    // CR 704.5j: copying your own legendary CREATES a same-name legend-rule
+    // collision (the copy is the duplicate that forces one into the graveyard).
+    // Penalize unless the copy makes the token non-legendary
+    // (`RemoveSupertype { Legendary }`) or the legend rule is switched off for
+    // the target (Mirror Gallery / Sakashima, `legend_rule_exempt`).
     if target.controller == ai_player
         && target.card_types.supertypes.contains(&Supertype::Legendary)
-        && state.battlefield.iter().any(|&id| {
-            id != target.id
-                && state.objects.get(&id).is_some_and(|other| {
-                    other.controller == ai_player
-                        && other.card_types.supertypes.contains(&Supertype::Legendary)
-                        && other.name == target.name
-                })
-                && !engine::game::sba::legend_rule_exempt(state, id)
-        })
+        && !strips_legendary
+        && !engine::game::sba::legend_rule_exempt(state, target.id)
     {
         penalty += 35.0;
     }
@@ -141,12 +177,13 @@ fn score_copy_token_target(
     ai_player: PlayerId,
     source_id: Option<ObjectId>,
     target_id: ObjectId,
+    strips_legendary: bool,
 ) -> f64 {
     let Some(target) = state.objects.get(&target_id) else {
         return -10.0;
     };
     let base = evaluate_creature(state, target_id);
-    let penalty = copy_target_penalties(state, ai_player, source_id, target);
+    let penalty = copy_target_penalties(state, ai_player, source_id, target, strips_legendary);
     base - penalty
 }
 
@@ -277,7 +314,8 @@ fn score_target_choice(
         copy_bonus += 0.06;
     }
 
-    copy_penalty += copy_target_penalties(state, ai_player, Some(source_id), target)
+    let strips = copy_effect_strips_legendary(&effect_def.effect);
+    copy_penalty += copy_target_penalties(state, ai_player, Some(source_id), target, strips)
         * COPY_SPELL_LOOP_PENALTY_SCALE;
 
     if base_creature_value < 3.0 {
@@ -365,13 +403,14 @@ mod tests {
     use engine::game::zones::create_object;
     use engine::types::ability::{
         AbilityKind, ContinuousModification, CopyManaValueLimit, Effect, QuantityExpr,
-        ReplacementDefinition, TargetFilter,
+        ReplacementDefinition, StaticDefinition, TargetFilter,
     };
     use engine::types::card_type::CoreType;
     use engine::types::game_state::PendingCast;
     use engine::types::identifiers::CardId;
     use engine::types::mana::{ManaCost, ManaCostShard};
     use engine::types::replacements::ReplacementEvent;
+    use engine::types::statics::StaticMode;
 
     fn make_state() -> GameState {
         let mut state = GameState::new_two_player(42);
@@ -669,7 +708,7 @@ mod tests {
             obj.is_commander = true;
         }
 
-        let score = score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli);
+        let score = score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli, false);
         assert!(
             score < -50.0,
             "self-commander copy must be strongly penalised, got {score}"
@@ -694,12 +733,123 @@ mod tests {
             obj.is_commander = true;
         }
 
-        let unknown_source_score = score_copy_token_target(&state, PlayerId(0), None, saheeli);
+        let unknown_source_score =
+            score_copy_token_target(&state, PlayerId(0), None, saheeli, false);
         let self_source_score =
-            score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli);
+            score_copy_token_target(&state, PlayerId(0), Some(saheeli), saheeli, false);
         assert!(
             unknown_source_score > self_source_score + 45.0,
             "unknown source must not be treated as self-copy: unknown={unknown_source_score}, self={self_source_score}"
+        );
+    }
+
+    fn legendary_creature(state: &mut GameState, card_id: u64, name: &str) -> ObjectId {
+        let id = add_creature(state, card_id, PlayerId(0), name, 3, 3, 4);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .supertypes
+            .push(Supertype::Legendary);
+        id
+    }
+
+    /// Mirror Gallery: a global `LegendRuleDoesntApply` static that exempts every
+    /// legendary permanent from the legend rule (CR 704.5j).
+    fn add_mirror_gallery(state: &mut GameState) {
+        let id = create_object(
+            state,
+            CardId(900),
+            PlayerId(0),
+            "Mirror Gallery".to_string(),
+            Zone::Battlefield,
+        );
+        let mut def = StaticDefinition::new(StaticMode::LegendRuleDoesntApply);
+        def.affected = None;
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .static_definitions
+            .push(def);
+    }
+
+    #[test]
+    fn copy_own_lone_legendary_is_penalised() {
+        // Step 4: copying your own legendary CREATES a same-name legend-rule
+        // collision (the copy is the duplicate), so a lone own legendary — with NO
+        // pre-existing same-name duplicate on the battlefield — must be penalised.
+        // The old same-name-duplicate branch returned 0 here; reverting to it
+        // flips this assertion.
+        let mut state = make_state();
+        let target_id = legendary_creature(&mut state, 1, "Adeline, Resplendent Cathar");
+        let target = &state.objects[&target_id];
+        let penalty = copy_target_penalties(&state, PlayerId(0), None, target, false);
+        assert!(
+            penalty >= 35.0,
+            "own legendary copy must be penalised even with no pre-existing duplicate, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn legendary_strip_copy_not_penalised() {
+        // Hostile fixture (i): a legend-stripping copy (Miirym: "except the token
+        // isn't legendary" → strips_legendary=true) creates a non-legendary token,
+        // so no collision → no legendary penalty.
+        let mut state = make_state();
+        let target_id = legendary_creature(&mut state, 1, "Adeline, Resplendent Cathar");
+        let target = &state.objects[&target_id];
+        let penalty = copy_target_penalties(&state, PlayerId(0), None, target, true);
+        assert_eq!(
+            penalty, 0.0,
+            "legend-stripping copy of own legendary must not be penalised, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn legend_exempt_copy_not_penalised() {
+        // Hostile fixture (iii): Mirror Gallery switches off the legend rule, so a
+        // duplicate legendary is legal → no penalty (`legend_rule_exempt`).
+        let mut state = make_state();
+        add_mirror_gallery(&mut state);
+        let target_id = legendary_creature(&mut state, 1, "Adeline, Resplendent Cathar");
+        let target = &state.objects[&target_id];
+        let penalty = copy_target_penalties(&state, PlayerId(0), None, target, false);
+        assert_eq!(
+            penalty, 0.0,
+            "legend-rule-exempt legendary (Mirror Gallery) must not be penalised, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn own_nonlegendary_copy_not_penalised() {
+        // Reach-guard: a non-legendary own target has no legend-rule concern → 0.
+        let mut state = make_state();
+        let target_id = add_creature(&mut state, 1, PlayerId(0), "Grizzly Bears", 2, 2, 2);
+        let target = &state.objects[&target_id];
+        let penalty = copy_target_penalties(&state, PlayerId(0), None, target, false);
+        assert_eq!(
+            penalty, 0.0,
+            "own non-legendary copy target must not be penalised, got {penalty}"
+        );
+    }
+
+    #[test]
+    fn own_nonlegendary_copy_target_outscores_own_legendary() {
+        // Hostile fixture (ii): given an own legendary and an own non-legendary of
+        // equal stats, the non-legendary target must outscore the legendary one
+        // (which eats the +35 legend-rule-collision penalty). A non-legendary copy
+        // merely outscores — the legendary is never hard-rejected.
+        let mut state = make_state();
+        let legendary = legendary_creature(&mut state, 1, "Adeline, Resplendent Cathar");
+        let vanilla = add_creature(&mut state, 2, PlayerId(0), "Adeline's Understudy", 3, 3, 4);
+
+        let legendary_score = score_copy_token_target(&state, PlayerId(0), None, legendary, false);
+        let vanilla_score = score_copy_token_target(&state, PlayerId(0), None, vanilla, false);
+        assert!(
+            vanilla_score > legendary_score,
+            "own non-legendary copy target must outscore own legendary: vanilla={vanilla_score}, legendary={legendary_score}"
         );
     }
 

--- a/crates/phase-ai/src/policies/copy_value.rs
+++ b/crates/phase-ai/src/policies/copy_value.rs
@@ -530,6 +530,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
         let score_two = CopyValuePolicy.score(&PolicyContext {
             state: &state,
@@ -545,6 +546,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
 
         assert!(score_zero > score_two);
@@ -599,6 +601,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
         let score_three = CopyValuePolicy.score(&PolicyContext {
             state: &state,
@@ -614,6 +617,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
 
         assert!(score_three > score_zero);
@@ -651,6 +655,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
         let score_large = CopyValuePolicy.score(&PolicyContext {
             state: &state,
@@ -668,6 +673,7 @@ mod tests {
             config: &crate::config::AiConfig::default(),
             context: &crate::context::AiContext::empty(&crate::eval::EvalWeightSet::default()),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
 
         assert!(score_large > score_small);

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -189,6 +189,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         DownsideAwarenessPolicy.score(&ctx)
     }
@@ -328,6 +329,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let score = DownsideAwarenessPolicy.score(&ctx);
         assert!(

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -2,7 +2,7 @@ use engine::game::filter::{matches_target_filter, FilterContext};
 use engine::game::game_object::GameObject;
 use engine::types::ability::{
     ContinuousModification, Effect, EffectScope, PtValue, QuantityExpr, TapStateChange,
-    TargetFilter, TypeFilter,
+    TargetFilter, TriggerDefinition, TypeFilter,
 };
 use engine::types::counter::CounterType;
 use engine::types::game_state::{CastingVariant, GameState, WaitingFor};
@@ -813,6 +813,23 @@ pub(crate) fn static_mode_polarity(mode: &StaticMode) -> EffectPolarity {
     }
 }
 
+/// CR 603.1: A `GrantTrigger` confers a triggered ability on its target. The
+/// benefit/harm to the bearer is the polarity of the effect that granted trigger
+/// *executes* — Undying Malice grants "when this dies, return it to the
+/// battlefield" (`ChangeZone`→Battlefield, Beneficial); a downside grant of "at
+/// the beginning of your upkeep, you lose 1 life" (`LoseLife`, Harmful) must NOT
+/// read Beneficial. Delegating to `effect_polarity` covers the whole class of
+/// grant-a-trigger buffs and downside curses (AI heuristic). The polarity is
+/// bound statically from the parsed `TriggerDefinition.execute.effect`; no live
+/// game-state lookup.
+fn granted_trigger_polarity(trigger: &TriggerDefinition) -> EffectPolarity {
+    trigger
+        .execute
+        .as_deref()
+        .map(|exec| effect_polarity(&exec.effect))
+        .unwrap_or(EffectPolarity::Contextual)
+}
+
 /// Classify a continuous modification as beneficial/harmful to its target.
 pub(crate) fn modification_polarity(m: &ContinuousModification) -> EffectPolarity {
     match m {
@@ -834,6 +851,7 @@ pub(crate) fn modification_polarity(m: &ContinuousModification) -> EffectPolarit
         | ContinuousModification::AddColor { .. }
         | ContinuousModification::AddType { .. }
         | ContinuousModification::AddSubtype { .. } => EffectPolarity::Beneficial,
+        ContinuousModification::GrantTrigger { trigger } => granted_trigger_polarity(trigger),
         ContinuousModification::RemoveKeyword { .. }
         | ContinuousModification::RemoveAllAbilities
         | ContinuousModification::RemoveType { .. }
@@ -1075,6 +1093,130 @@ mod suspect_scope_tests {
         assert!(
             extract_target_filter(&all_unsuspect).is_none(),
             "mass Unsuspect{{All}} (Absolving Lammasu) is a population effect, not target-filtered"
+        );
+    }
+}
+
+#[cfg(test)]
+mod grant_trigger_polarity_tests {
+    use super::*;
+    use engine::types::ability::{AbilityDefinition, AbilityKind, StaticDefinition, TypedFilter};
+    use engine::types::zones::EtbTapState;
+
+    /// Build a `GenericEffect` that grants its target a triggered ability whose
+    /// executed effect is `exec` — the Undying-Malice-shaped AST
+    /// (`GenericEffect{ Continuous{ GrantTrigger{ dies → exec } } }`).
+    fn grant_trigger_generic(exec: Effect) -> Effect {
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone);
+        trigger.execute = Some(Box::new(AbilityDefinition::new(AbilityKind::Spell, exec)));
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::ParentTarget)
+                .modifications(vec![ContinuousModification::GrantTrigger {
+                    trigger: Box::new(trigger),
+                }])],
+            target: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature))),
+            duration: None,
+        }
+    }
+
+    /// "When this dies, return it to the battlefield" — the Undying Malice grant.
+    fn return_to_battlefield() -> Effect {
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Battlefield,
+            target: TargetFilter::SelfRef,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+
+    #[test]
+    fn grant_return_trigger_reads_beneficial() {
+        // Undying Malice grants "when this dies, return it to the battlefield"
+        // (ChangeZone→Battlefield, Beneficial). Pre-fix `GrantTrigger` hit the
+        // `_ => Contextual` fallback, so the whole GenericEffect read Contextual.
+        let ge = grant_trigger_generic(return_to_battlefield());
+        assert_eq!(effect_polarity(&ge), EffectPolarity::Beneficial);
+    }
+
+    #[test]
+    fn harmful_grant_trigger_not_beneficial() {
+        // A downside grant ("at the beginning of your upkeep, you lose 1 life")
+        // must read Harmful, NOT a blanket Beneficial — this is the load-bearing
+        // discriminator that proves the arm reads the executed-effect polarity
+        // rather than labeling every grant beneficial.
+        let ge = grant_trigger_generic(Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            target: None,
+        });
+        assert_eq!(effect_polarity(&ge), EffectPolarity::Harmful);
+    }
+
+    #[test]
+    fn granted_trigger_without_execute_is_contextual() {
+        // A grant whose trigger has no executed effect carries no polarity
+        // signal — stays Contextual (the same as the pre-existing fallback).
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone);
+        trigger.execute = None;
+        assert_eq!(
+            modification_polarity(&ContinuousModification::GrantTrigger {
+                trigger: Box::new(trigger),
+            }),
+            EffectPolarity::Contextual
+        );
+    }
+
+    #[test]
+    fn parsed_undying_malice_grant_reads_beneficial() {
+        // Production-parser reach guard: the real Undying Malice Oracle text parses
+        // to `GenericEffect{ Continuous{ GrantTrigger{ dies → ChangeZone→Battlefield
+        // } } }`, so its polarity must read Beneficial through the same classifier
+        // the AI target-scorer uses. Guards the fix against future parser AST drift.
+        use engine::parser::oracle::parse_oracle_text;
+
+        let parsed = parse_oracle_text(
+            "Until end of turn, target creature gains \"When this creature dies, return it to the battlefield tapped under its owner's control with a +1/+1 counter on it.\"",
+            "Undying Malice",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        let spell = parsed
+            .abilities
+            .iter()
+            .find(|a| a.kind == AbilityKind::Spell)
+            .expect("Undying Malice parses to a spell ability");
+        assert_eq!(
+            effect_polarity(&spell.effect),
+            EffectPolarity::Beneficial,
+            "Undying Malice's granted return-to-battlefield trigger must read Beneficial"
+        );
+    }
+
+    #[test]
+    fn grant_ability_still_beneficial() {
+        // Sibling reach-guard: `GrantAbility` (a granted static/activated ability,
+        // no executed-trigger effect to inspect) stays in the Beneficial cluster,
+        // unchanged by the new GrantTrigger arm.
+        assert_eq!(
+            modification_polarity(&ContinuousModification::GrantAbility {
+                definition: Box::new(AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::TargetOnly {
+                        target: TargetFilter::Any,
+                    },
+                )),
+            }),
+            EffectPolarity::Beneficial
         );
     }
 }

--- a/crates/phase-ai/src/policies/effect_timing.rs
+++ b/crates/phase-ai/src/policies/effect_timing.rs
@@ -387,6 +387,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = combat_trick_score(&ctx);
@@ -432,6 +433,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = combat_trick_score(&ctx);
@@ -476,6 +478,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = combat_trick_score(&ctx);

--- a/crates/phase-ai/src/policies/equipment_priority.rs
+++ b/crates/phase-ai/src/policies/equipment_priority.rs
@@ -241,6 +241,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         EquipmentPriorityPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/evasion_removal_priority.rs
+++ b/crates/phase-ai/src/policies/evasion_removal_priority.rs
@@ -303,6 +303,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = EvasionRemovalPriorityPolicy.score(&ctx);
@@ -370,6 +371,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = EvasionRemovalPriorityPolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/fetch_land_patience.rs
+++ b/crates/phase-ai/src/policies/fetch_land_patience.rs
@@ -251,6 +251,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         FetchLandPatiencePolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/free_outlet_activation.rs
+++ b/crates/phase-ai/src/policies/free_outlet_activation.rs
@@ -11,15 +11,14 @@
 //! moves directly into its owner's graveyard — sacrifice is not destruction
 //! and bypasses regenerate / indestructible.
 
-use engine::game::game_object::GameObject;
 use engine::types::actions::GameAction;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
-use engine::types::zones::Zone;
 
 use super::context::PolicyContext;
 use super::effect_classify::{effect_polarity, EffectPolarity};
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use super::self_cost::count_death_triggers_on_board;
 use super::strategy_helpers::sacrifice_cost;
 use crate::features::aristocrats::{ability_is_sacrifice_outlet, is_free_outlet_ability};
 use crate::features::DeckFeatures;
@@ -166,26 +165,6 @@ fn cheapest_sacrificeable_cost(ctx: &PolicyContext<'_>) -> f64 {
             .then(|| sacrifice_cost(ctx.state, id, ctx.penalties()))
         })
         .fold(f64::INFINITY, f64::min)
-}
-
-/// Count AI-controlled death-trigger payoff objects currently on the battlefield.
-/// Uses `death_trigger_names` as an identity-lookup list — the structural
-/// classification already happened at deck-build time in `aristocrats::detect`.
-fn count_death_triggers_on_board(
-    state: &GameState,
-    player: PlayerId,
-    death_trigger_names: &[String],
-) -> usize {
-    if death_trigger_names.is_empty() {
-        return 0;
-    }
-    state
-        .battlefield
-        .iter()
-        .filter_map(|id| state.objects.get(id))
-        .filter(|obj: &&GameObject| obj.controller == player && obj.zone == Zone::Battlefield)
-        .filter(|obj| death_trigger_names.iter().any(|name| name == &obj.name))
-        .count()
 }
 
 #[cfg(test)]

--- a/crates/phase-ai/src/policies/free_outlet_activation.rs
+++ b/crates/phase-ai/src/policies/free_outlet_activation.rs
@@ -354,6 +354,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = FreeOutletActivationPolicy.verdict(&ctx);
@@ -399,6 +400,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = FreeOutletActivationPolicy.verdict(&ctx);
@@ -441,6 +443,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = FreeOutletActivationPolicy.verdict(&ctx);
@@ -475,6 +478,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = FreeOutletActivationPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/hand_disruption.rs
+++ b/crates/phase-ai/src/policies/hand_disruption.rs
@@ -322,6 +322,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert!(HandDisruptionPolicy.score(&ctx) < 0.0);
@@ -473,6 +474,7 @@ mod tests {
                 config: &config,
                 context: &context,
                 cast_facts: None,
+                search_depth: crate::policies::context::SearchDepth::Root,
             };
             HandDisruptionPolicy.score(&ctx)
         };
@@ -597,6 +599,7 @@ mod tests {
                 config: &config,
                 context: &context,
                 cast_facts: None,
+                search_depth: crate::policies::context::SearchDepth::Root,
             };
             HandDisruptionPolicy.score(&ctx)
         };
@@ -688,6 +691,7 @@ mod tests {
                 config: &config,
                 context: &context,
                 cast_facts: None,
+                search_depth: crate::policies::context::SearchDepth::Root,
             };
             HandDisruptionPolicy.score(&ctx)
         };

--- a/crates/phase-ai/src/policies/hold_mana_up.rs
+++ b/crates/phase-ai/src/policies/hold_mana_up.rs
@@ -352,6 +352,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = HoldManaUpForInteractionPolicy.verdict(&ctx);
@@ -389,6 +390,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = HoldManaUpForInteractionPolicy.verdict(&ctx);
@@ -422,6 +424,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = HoldManaUpForInteractionPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/land_animation.rs
+++ b/crates/phase-ai/src/policies/land_animation.rs
@@ -447,6 +447,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         LandAnimationPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/land_sequencing.rs
+++ b/crates/phase-ai/src/policies/land_sequencing.rs
@@ -220,6 +220,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         LandSequencingPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/landfall_timing.rs
+++ b/crates/phase-ai/src/policies/landfall_timing.rs
@@ -379,6 +379,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = LandfallTimingPolicy.verdict(&ctx);
@@ -414,6 +415,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = LandfallTimingPolicy.verdict(&ctx);
@@ -453,6 +455,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = LandfallTimingPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/lethality_awareness.rs
+++ b/crates/phase-ai/src/policies/lethality_awareness.rs
@@ -207,6 +207,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = LethalityAwarenessPolicy.score(&ctx);
@@ -262,6 +263,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = LethalityAwarenessPolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/life_total_resource.rs
+++ b/crates/phase-ai/src/policies/life_total_resource.rs
@@ -262,6 +262,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = LifeTotalResourcePolicy.score(&ctx);
@@ -324,6 +325,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = LifeTotalResourcePolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/mana_efficiency.rs
+++ b/crates/phase-ai/src/policies/mana_efficiency.rs
@@ -238,6 +238,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(
@@ -268,6 +269,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert!(
@@ -301,6 +303,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = ManaEfficiencyPolicy.score(&ctx);
@@ -344,6 +347,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let ctx_without = PolicyContext {
             state: &state_no_instant,
@@ -353,6 +357,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score_with = ManaEfficiencyPolicy.score(&ctx_with);
@@ -385,6 +390,7 @@ mod tests {
             config: &config_patient,
             context: &crate::context::AiContext::empty(&config_patient.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = ManaEfficiencyPolicy.score(&ctx);
@@ -433,6 +439,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = ManaEfficiencyPolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/mill_targeting.rs
+++ b/crates/phase-ai/src/policies/mill_targeting.rs
@@ -224,6 +224,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         MillTargetingPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/mill_targeting.rs
+++ b/crates/phase-ai/src/policies/mill_targeting.rs
@@ -13,6 +13,7 @@ use engine::types::ability::{Effect, TargetRef};
 use engine::types::actions::GameAction;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
 
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
@@ -107,13 +108,21 @@ fn has_mill_with_conditional_payoff(ctx: &PolicyContext<'_>) -> bool {
             obj.abilities.iter().any(|ability| {
                 let effects = crate::cast_facts::collect_definition_effects(ability);
                 let has_mill = effects.iter().any(|e| matches!(e, Effect::Mill { .. }));
-                let has_retrieval = effects.iter().any(|e| {
-                    matches!(
-                        e,
-                        Effect::Draw { .. }
-                            | Effect::ChangeZone { .. }
-                            | Effect::ChooseFromZone { .. }
-                    )
+                let has_retrieval = effects.iter().any(|e| match e {
+                    // CR 701.17a: milled cards go to the graveyard, so a payoff
+                    // that retrieves milled cards must source from the graveyard.
+                    // A bare library-top `Draw` (Thought Scour) is a cantrip, not
+                    // milled-card retrieval, and must not qualify.
+                    Effect::ChooseFromZone {
+                        zone,
+                        additional_zones,
+                        ..
+                    } => *zone == Zone::Graveyard || additional_zones.contains(&Zone::Graveyard),
+                    Effect::ChangeZone {
+                        origin: Some(Zone::Graveyard),
+                        ..
+                    } => true,
+                    _ => false,
                 });
                 has_mill && has_retrieval
             })
@@ -263,6 +272,78 @@ mod tests {
         );
 
         assert_eq!(delta, SELF_MILL_PENALTY);
+    }
+
+    fn draw_effect() -> Effect {
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        }
+    }
+
+    fn change_zone_from_graveyard_effect() -> Effect {
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Hand,
+            target: TargetFilter::Any,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+
+    fn mill_with_sub_effect(sub: Effect) -> AbilityDefinition {
+        let mut ability = AbilityDefinition::new(AbilityKind::Activated, mill_effect());
+        ability.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Activated,
+            sub,
+        )));
+        ability
+    }
+
+    #[test]
+    fn mill_plus_library_draw_is_not_conditional_payoff() {
+        // Thought Scour class: `Mill{Player}` + `Draw{Controller}` is a library-top
+        // cantrip, not milled-card retrieval (milled cards land in the graveyard,
+        // CR 701.17a). It must NOT qualify — reverting the tightening (re-adding the
+        // bare `Effect::Draw` arm) flips this to `mill_targeting_score`.
+        let mut state = GameState::new_two_player(42);
+        let source_id = add_source_with_ability(&mut state, mill_with_sub_effect(draw_effect()));
+        add_library_card(&mut state, OPP);
+
+        let delta = score_delta(
+            score_target(&state, source_id, TargetRef::Player(OPP)),
+            "mill_targeting_no_conditional",
+        );
+
+        assert_eq!(delta, 0.0);
+    }
+
+    #[test]
+    fn mill_plus_change_zone_from_graveyard_qualifies() {
+        // Positive reach-guard: a graveyard-sourced retrieval
+        // (`ChangeZone{ origin: Graveyard }`) after a mill IS milled-card retrieval,
+        // so it still qualifies for the opponent-target bonus.
+        let mut state = GameState::new_two_player(42);
+        let source_id = add_source_with_ability(
+            &mut state,
+            mill_with_sub_effect(change_zone_from_graveyard_effect()),
+        );
+        add_library_card(&mut state, OPP);
+
+        let delta = score_delta(
+            score_target(&state, source_id, TargetRef::Player(OPP)),
+            "mill_targeting_score",
+        );
+
+        assert_eq!(delta, TARGET_BONUS);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -57,6 +57,8 @@ mod tempo_curve;
 mod tokens_wide;
 mod tribal_lord_priority;
 pub(crate) mod tutor;
+mod x_cast_gate;
+mod x_reference;
 mod x_value;
 
 #[cfg(test)]

--- a/crates/phase-ai/src/policies/mod.rs
+++ b/crates/phase-ai/src/policies/mod.rs
@@ -43,6 +43,8 @@ mod redundancy_avoidance;
 pub mod registry;
 mod sacrifice_land_protection;
 mod sacrifice_value;
+mod self_cost;
+mod self_cost_value;
 mod self_protection_classify;
 mod separate_piles_timing;
 mod spellskite_priority;

--- a/crates/phase-ai/src/policies/payment_selection.rs
+++ b/crates/phase-ai/src/policies/payment_selection.rs
@@ -386,6 +386,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         PaymentSelectionPolicy.score(&ctx)
     }

--- a/crates/phase-ai/src/policies/planeswalker_loyalty.rs
+++ b/crates/phase-ai/src/policies/planeswalker_loyalty.rs
@@ -258,6 +258,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         PlaneswalkerLoyaltyPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/plus_one_counters.rs
+++ b/crates/phase-ai/src/policies/plus_one_counters.rs
@@ -418,6 +418,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);
@@ -455,6 +456,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);
@@ -501,6 +503,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);
@@ -538,6 +541,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);
@@ -589,6 +593,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);
@@ -664,6 +669,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = PlusOneCountersPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/ramp_timing.rs
+++ b/crates/phase-ai/src/policies/ramp_timing.rs
@@ -374,6 +374,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = RampTimingPolicy.verdict(&ctx);
@@ -427,6 +428,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = RampTimingPolicy.verdict(&ctx);
@@ -464,6 +466,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = RampTimingPolicy.verdict(&ctx);
@@ -507,6 +510,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = RampTimingPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/reactive_self_protection.rs
+++ b/crates/phase-ai/src/policies/reactive_self_protection.rs
@@ -167,6 +167,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         ReactiveSelfProtectionPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/recursion_awareness.rs
+++ b/crates/phase-ai/src/policies/recursion_awareness.rs
@@ -213,6 +213,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = RecursionAwarenessPolicy.score(&ctx);
@@ -306,6 +307,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = RecursionAwarenessPolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -1127,6 +1127,7 @@ mod tests {
             config,
             context: ai_ctx,
             cast_facts,
+            search_depth: crate::policies::context::SearchDepth::Root,
         }
     }
 

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -8,7 +8,7 @@ use super::board_development::BoardDevelopmentPolicy;
 use super::board_wipe_telegraph::BoardWipeTelegraphPolicy;
 use super::card_advantage::CardAdvantagePolicy;
 use super::chalice_avoidance::ChaliceAvoidancePolicy;
-use super::context::PolicyContext;
+use super::context::{PolicyContext, PriorsEnv};
 use super::copy_value::CopyValuePolicy;
 use super::effect_timing::EffectTimingPolicy;
 use super::etb_value::EtbValuePolicy;
@@ -43,11 +43,10 @@ use super::tutor::TutorPolicy;
 use super::x_cast_gate::XCastGatePolicy;
 use super::x_value::XValuePolicy;
 use crate::cast_facts::cast_facts_for_action;
-use crate::config::AiConfig;
 use crate::decision_kind::classify as classify_decision;
 use crate::features::DeckFeatures;
 use crate::planner::PolicyPrior;
-use engine::ai_support::{AiDecisionContext, CandidateAction};
+use engine::ai_support::CandidateAction;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 
@@ -454,15 +453,7 @@ impl PolicyRegistry {
         self.policies.iter().any(|p| p.id() == id)
     }
 
-    pub fn priors(
-        &self,
-        state: &GameState,
-        decision: &AiDecisionContext,
-        candidates: &[CandidateAction],
-        ai_player: PlayerId,
-        config: &AiConfig,
-        context: &crate::context::AiContext,
-    ) -> Vec<PolicyPrior> {
+    pub fn priors(&self, env: &PriorsEnv<'_>, candidates: &[CandidateAction]) -> Vec<PolicyPrior> {
         if candidates.is_empty() {
             return Vec::new();
         }
@@ -470,15 +461,16 @@ impl PolicyRegistry {
         let raw_scores: Vec<f64> = candidates
             .iter()
             .map(|candidate| {
-                let cast_facts = cast_facts_for_action(state, &candidate.action, ai_player);
+                let cast_facts = cast_facts_for_action(env.state, &candidate.action, env.ai_player);
                 self.score(&PolicyContext {
-                    state,
-                    decision,
+                    state: env.state,
+                    decision: env.decision,
                     candidate,
-                    ai_player,
-                    config,
-                    context,
+                    ai_player: env.ai_player,
+                    config: env.config,
+                    context: env.context,
                     cast_facts,
+                    search_depth: env.search_depth,
                 })
             })
             .collect();
@@ -540,6 +532,8 @@ impl PolicyRegistry {
 #[cfg(test)]
 mod shared_invariant_tests {
     use super::*;
+    use crate::config::AiConfig;
+    use crate::policies::context::SearchDepth;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::types::actions::GameAction;
     use engine::types::game_state::{GameState, WaitingFor};
@@ -651,14 +645,15 @@ mod shared_invariant_tests {
         let config = AiConfig::default();
         let context = crate::context::AiContext::empty(&config.weights);
 
-        let priors = prior_test_registry().priors(
-            &state,
-            &decision,
-            &candidates,
-            PlayerId(0),
-            &config,
-            &context,
-        );
+        let env = PriorsEnv {
+            state: &state,
+            decision: &decision,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &context,
+            search_depth: SearchDepth::Lookahead,
+        };
+        let priors = prior_test_registry().priors(&env, &candidates);
 
         assert_eq!(priors.len(), 2);
         assert_eq!(priors[0].prior, 0.0);
@@ -676,14 +671,15 @@ mod shared_invariant_tests {
         let config = AiConfig::default();
         let context = crate::context::AiContext::empty(&config.weights);
 
-        let priors = prior_test_registry().priors(
-            &state,
-            &decision,
-            &candidates,
-            PlayerId(0),
-            &config,
-            &context,
-        );
+        let env = PriorsEnv {
+            state: &state,
+            decision: &decision,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &context,
+            search_depth: SearchDepth::Lookahead,
+        };
+        let priors = prior_test_registry().priors(&env, &candidates);
 
         assert_eq!(priors.len(), 2);
         assert!(priors

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -40,6 +40,7 @@ use super::sweeper_timing::SweeperTimingPolicy;
 use super::tokens_wide::TokensWidePolicy;
 use super::tribal_lord_priority::TribalLordPriorityPolicy;
 use super::tutor::TutorPolicy;
+use super::x_cast_gate::XCastGatePolicy;
 use super::x_value::XValuePolicy;
 use crate::cast_facts::cast_facts_for_action;
 use crate::config::AiConfig;
@@ -124,6 +125,7 @@ pub enum PolicyId {
     ChaliceAvoidance,
     PaymentSelection,
     SeparatePilesTiming,
+    XCastGate,
 }
 
 /// Coarse routing kind for a candidate decision. Each policy declares which
@@ -331,6 +333,7 @@ impl Default for PolicyRegistry {
             Box::new(super::land_sequencing::LandSequencingPolicy),
             Box::new(super::condition_gated_activation::ConditionGatedActivationPolicy),
             Box::new(XValuePolicy),
+            Box::new(XCastGatePolicy),
             Box::new(super::control_change_awareness::ControlChangeAwarenessPolicy),
             Box::new(super::land_animation::LandAnimationPolicy),
             Box::new(super::mill_targeting::MillTargetingPolicy),

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -33,6 +33,7 @@ use super::recursion_awareness::RecursionAwarenessPolicy;
 use super::redundancy_avoidance::RedundancyAvoidancePolicy;
 use super::sacrifice_land_protection::SacrificeLandProtectionPolicy;
 use super::sacrifice_value::SacrificeValuePolicy;
+use super::self_cost_value::SelfCostValuePolicy;
 use super::separate_piles_timing::SeparatePilesTimingPolicy;
 use super::spellslinger_casting::SpellslingerCastingPolicy;
 use super::sweeper_timing::SweeperTimingPolicy;
@@ -105,6 +106,7 @@ pub enum PolicyId {
     CombatTaxPayment,
     ReactiveSelfProtection,
     SacrificeLandProtection,
+    SelfCostValue,
     ComboLineProgress,
     CedhKeepablesMulligan,
     FixedDeckKeepMulligan,
@@ -321,6 +323,7 @@ impl Default for PolicyRegistry {
             Box::new(super::combat_tax::CombatTaxPaymentPolicy),
             Box::new(ReactiveSelfProtectionPolicy),
             Box::new(SacrificeLandProtectionPolicy),
+            Box::new(SelfCostValuePolicy),
             Box::new(super::combo_line::ComboLinePolicy::new()),
             Box::new(super::planeswalker_loyalty::PlaneswalkerLoyaltyPolicy),
             Box::new(super::equipment_priority::EquipmentPriorityPolicy),

--- a/crates/phase-ai/src/policies/sacrifice_land_protection.rs
+++ b/crates/phase-ai/src/policies/sacrifice_land_protection.rs
@@ -215,6 +215,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         SacrificeLandProtectionPolicy.verdict(&ctx)
     }
@@ -498,6 +499,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         match ReactiveSelfProtectionPolicy.verdict(&ctx) {
             PolicyVerdict::Reject { reason } => {

--- a/crates/phase-ai/src/policies/sacrifice_value.rs
+++ b/crates/phase-ai/src/policies/sacrifice_value.rs
@@ -168,6 +168,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let creature_score = SacrificeValuePolicy.score(&creature_ctx);
 
@@ -187,6 +188,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let token_score = SacrificeValuePolicy.score(&token_ctx);
 
@@ -250,6 +252,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         // The raw score must exceed the ceiling, proving the clamp is exercised.
@@ -307,6 +310,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = SacrificeValuePolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/self_cost.rs
+++ b/crates/phase-ai/src/policies/self_cost.rs
@@ -1,0 +1,516 @@
+//! Net-value gate for self-cost ability activations.
+//!
+//! An activated ability whose *cost* spends the AI's own resources — it
+//! sacrifices a permanent, pays life, discards, or exiles cards from the AI's
+//! own hand/graveyard — should only be activated when its *effect* buys
+//! something worth the loss. The free-outlet policy only prices creature
+//! sacrifice for aristocrats outlets; land-sacrifice lifegain (Zuran Orb),
+//! pay-life pingers, discard-to-grant loops, and self-exile-from-graveyard
+//! grants all slip past it, so the AI cracks them every turn for nothing.
+//!
+//! This module is the single authority that (1) recognizes those four cost
+//! shapes on the `AbilityCost` tree, (2) prices the self-inflicted cost, and
+//! (3) decides whether the ability's immediate payoff is trivial. It is
+//! deliberately conservative: anything whose payoff scales or is ambiguous —
+//! mana production, land search, large or power-derived damage, beneficial
+//! counters — is treated as non-trivial, so ramp, fixing, burn finishers, and
+//! counter payoffs are never suppressed. Off-ability synergy (an aristocrats
+//! board that turns each death into value, a lifegain/reanimator shell that
+//! wants the resource spent) stands the gate down entirely.
+//!
+//! Only the *scoring* half lives here; the thin `SelfCostValuePolicy` adapter
+//! (`self_cost_value.rs`) fetches the activated ability and turns these
+//! predicates into a `PolicyVerdict`.
+
+use engine::game::bracket_estimate::CommanderBracketTier;
+use engine::game::filter::{matches_target_filter, FilterContext};
+use engine::game::game_object::GameObject;
+use engine::game::players;
+use engine::game::quantity::resolve_quantity;
+use engine::types::ability::{AbilityCost, AbilityDefinition, Effect, QuantityExpr, TargetFilter};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::config::PolicyPenalties;
+use crate::eval::board_stats;
+use crate::features::landfall::ability_searches_library_for_land;
+use crate::features::mana_ramp::target_filter_references_land;
+use crate::features::DeckFeatures;
+
+use super::effect_classify::lethal_to_creature;
+use super::self_protection_classify::{any_immediate_threat, is_self_protection_effect};
+use super::strategy_helpers::{sacrifice_cost, targetable_threat_value};
+
+/// A fixed face-damage payoff at or below this value is trivial — a 1- or
+/// 2-point ping for no board effect is not worth spending a real resource on.
+const FACE_DAMAGE_TRIVIAL_CEILING: i32 = 2;
+/// Gaining this much life or less, with the AI not under life pressure, is not
+/// worth a real self-cost (Zuran Orb's 2 is the flagship case).
+const TRIVIAL_LIFEGAIN_CEILING: i32 = 3;
+/// Multiplier applied to the per-point pay-life cost when the AI's life is a
+/// pressured resource (mirrors `LifeTotalResourcePolicy`'s criticality test).
+const PAY_LIFE_CRITICALITY_MULT: f64 = 4.0;
+/// Deck-commitment floor above which an off-ability synergy payoff (lifegain,
+/// reanimator) justifies paying the corresponding self-cost. Mirrors
+/// `FreeOutletActivationPolicy::COMMITMENT_FLOOR`.
+const SYNERGY_COMMITMENT_FLOOR: f32 = 0.1;
+
+/// True when the ability's cost spends one of the four self-resources this gate
+/// prices. Recurses `Composite`/`OneOf`. Only `Exile` from the AI's own hand or
+/// graveyard is in scope; the `ExileMaterials` / `CollectEvidence` /
+/// `ExileWithAggregate` / `Behold` cost siblings (and every other cost variant)
+/// deliberately do not fire the gate — they are structurally different payment
+/// shapes, so the catch-all is fail-open (a new cost variant simply gets no
+/// gate rather than a spurious veto).
+pub(crate) fn self_cost_in_scope(cost: &AbilityCost) -> bool {
+    match cost {
+        AbilityCost::Sacrifice(_) | AbilityCost::PayLife { .. } | AbilityCost::Discard { .. } => {
+            true
+        }
+        // Exile-as-cost: only the AI's own hand (a discard by another name) or
+        // graveyard is a self-resource loss. Library/other zones and a bare
+        // `None` zone are out of scope.
+        AbilityCost::Exile { zone, .. } => {
+            matches!(zone, Some(Zone::Graveyard) | Some(Zone::Hand))
+        }
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+            costs.iter().any(self_cost_in_scope)
+        }
+        _ => false,
+    }
+}
+
+/// Price the self-inflicted portion of `cost` in card-equivalent units.
+/// `Composite` sums its sub-costs (you pay them all); `OneOf` takes the minimum
+/// (the payer chooses the cheapest). Out-of-scope sub-costs (mana, tap) price 0.
+pub(crate) fn real_self_cost(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    cost: &AbilityCost,
+    penalties: &PolicyPenalties,
+) -> f64 {
+    match cost {
+        AbilityCost::Sacrifice(sacrifice) => {
+            sacrifice_leaf_cost(state, ai_player, source_id, &sacrifice.target, penalties)
+        }
+        // `amount` is a QuantityExpr — resolve it, then weight by the per-point
+        // life cost and by runtime life pressure.
+        AbilityCost::PayLife { amount } => {
+            let points = resolve_quantity(state, amount, ai_player, source_id).max(0) as f64;
+            points
+                * penalties.self_cost_pay_life_per_point
+                * pay_life_criticality_mult(state, ai_player)
+        }
+        // Discard `count` is a QuantityExpr (unlike `Exile.count`).
+        AbilityCost::Discard { count, .. } => {
+            let cards = resolve_quantity(state, count, ai_player, source_id).max(0) as f64;
+            cards * penalties.self_cost_discard_per_card
+        }
+        // `Exile.count` is a plain `u32` here, so multiply directly —
+        // `resolve_quantity` takes a `&QuantityExpr` and does not apply. Hand
+        // exile is priced as a discard; graveyard exile is cheap.
+        AbilityCost::Exile { count, zone, .. } => match zone {
+            Some(Zone::Graveyard) => (*count as f64) * penalties.self_cost_exile_graveyard_per_card,
+            Some(Zone::Hand) => (*count as f64) * penalties.self_cost_discard_per_card,
+            _ => 0.0,
+        },
+        AbilityCost::Composite { costs } => costs
+            .iter()
+            .map(|c| real_self_cost(state, ai_player, source_id, c, penalties))
+            .sum(),
+        AbilityCost::OneOf { costs } => {
+            let min = costs
+                .iter()
+                .map(|c| real_self_cost(state, ai_player, source_id, c, penalties))
+                .fold(f64::INFINITY, f64::min);
+            if min.is_finite() {
+                min
+            } else {
+                0.0
+            }
+        }
+        _ => 0.0,
+    }
+}
+
+/// Cost of the permanent(s) the sacrifice would consume. A `SelfRef` sacrifice
+/// is priced against the ability's own source (never the cheapest permanent);
+/// any other filter takes the cheapest AI-controlled match.
+fn sacrifice_leaf_cost(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    target: &TargetFilter,
+    penalties: &PolicyPenalties,
+) -> f64 {
+    if matches!(target, TargetFilter::SelfRef) {
+        return sacrifice_cost(state, source_id, penalties);
+    }
+    let filter_ctx = FilterContext::from_source(state, source_id);
+    let min = state
+        .battlefield
+        .iter()
+        .filter_map(|&id| {
+            let obj = state.objects.get(&id)?;
+            (obj.controller == ai_player && matches_target_filter(state, id, target, &filter_ctx))
+                .then(|| sacrifice_cost(state, id, penalties))
+        })
+        .fold(f64::INFINITY, f64::min);
+    if min.is_finite() {
+        min
+    } else {
+        0.0
+    }
+}
+
+/// True when every effect the ability produces is trivial — no meaningful
+/// immediate advantage that would justify the self-cost.
+pub(crate) fn benefit_is_trivial(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    ability: &AbilityDefinition,
+) -> bool {
+    collect_chain_effects(ability)
+        .iter()
+        .all(|effect| effect_is_trivial(state, ai_player, source_id, ability, effect))
+}
+
+fn effect_is_trivial(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    ability: &AbilityDefinition,
+    effect: &Effect,
+) -> bool {
+    match effect {
+        // Drawing a card is real card advantage.
+        Effect::Draw { count, .. } => resolve_quantity(state, count, ai_player, source_id) < 1,
+        // Damage is non-trivial if it is dynamic (power-derived, e.g. Fling),
+        // lethal to a player, kills a real creature, or exceeds the face-ping
+        // ceiling.
+        Effect::DealDamage { amount, target, .. } => {
+            deal_damage_is_trivial(state, ai_player, source_id, amount, target)
+        }
+        // Small lifegain is trivial unless the AI is under life pressure.
+        Effect::GainLife { amount, .. } => {
+            resolve_quantity(state, amount, ai_player, source_id) <= TRIVIAL_LIFEGAIN_CEILING
+                && !ai_life_critical(state, ai_player)
+        }
+        // Removal is non-trivial when a worthwhile opponent creature can be hit.
+        Effect::Destroy { target, .. } | Effect::Bounce { target, .. } => {
+            removal_is_trivial(state, ai_player, source_id, target)
+        }
+        Effect::ChangeZone {
+            destination: Zone::Exile | Zone::Graveyard,
+            target,
+            ..
+        } => removal_is_trivial(state, ai_player, source_id, target),
+        // A beneficial counter (e.g. an indestructible keyword counter) is
+        // non-trivial by default; a harmful counter is removal. The one trivial
+        // case is a self-counter that fizzles because paying the cost removes
+        // its only recipient (Carrion Feeder into an empty board).
+        Effect::PutCounter {
+            counter_type,
+            target,
+            ..
+        } => put_counter_is_trivial(state, ai_player, source_id, ability, counter_type, target),
+        // A mass counter mirrors the single-`PutCounter` classification: a
+        // harmful mass counter (e.g. "-1/-1 counter on each creature") is real
+        // board interaction and non-trivial whenever it wipes/shrinks a
+        // worthwhile opponent creature — only trivial when it has no worthwhile
+        // opponent-board impact. A beneficial mass counter is non-trivial by
+        // default (conservative), consistent with single `PutCounter`.
+        Effect::PutCounterAll {
+            counter_type,
+            target,
+            ..
+        } => {
+            if counter_is_harmful(counter_type) {
+                removal_is_trivial(state, ai_player, source_id, target)
+            } else {
+                false
+            }
+        }
+        // Mana production is ramp — never trivial (Ashnod's/Phyrexian Altar).
+        Effect::Mana { .. } => false,
+        // A library search for a land is ramp/fixing (sacrifice-a-land fetch
+        // chains) — non-trivial.
+        Effect::SearchLibrary { filter, .. } => {
+            !(ability_searches_library_for_land(ability) || target_filter_references_land(filter))
+        }
+        // A self-protection grant is only worth a cost when a threat is live.
+        effect if is_self_protection_effect(effect) => !any_immediate_threat(state, ai_player),
+        // No modeled board impact → trivial.
+        _ => true,
+    }
+}
+
+/// A fixed face ping at or below the ceiling, that neither kills a
+/// player nor a real creature, is trivial. Dynamic (non-`Fixed`) damage is
+/// power-derived (Fling and friends) and always treated as non-trivial so burn
+/// finishers are never suppressed.
+fn deal_damage_is_trivial(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    amount: &QuantityExpr,
+    target: &TargetFilter,
+) -> bool {
+    let QuantityExpr::Fixed { value } = amount else {
+        return false;
+    };
+    let value = *value;
+    if value > FACE_DAMAGE_TRIVIAL_CEILING {
+        return false;
+    }
+    if filter_can_target_player(target) && damage_lethal_to_opponent(state, ai_player, value) {
+        return false;
+    }
+    if damage_kills_creature(state, ai_player, source_id, target, value) {
+        return false;
+    }
+    true
+}
+
+fn filter_can_target_player(target: &TargetFilter) -> bool {
+    match target {
+        TargetFilter::Any | TargetFilter::Player => true,
+        // Typed filters select permanents, not players.
+        TargetFilter::Typed(_) => false,
+        // Unknown/compound filters: fail-open (assume a player could be hit).
+        _ => true,
+    }
+}
+
+fn damage_lethal_to_opponent(state: &GameState, ai_player: PlayerId, value: i32) -> bool {
+    players::opponents(state, ai_player).iter().any(|&opp| {
+        let player = &state.players[opp.0 as usize];
+        !player.is_eliminated && player.life <= value
+    })
+}
+
+/// True when `value` fixed damage would be lethal to at least one opponent
+/// creature the filter admits (via `lethal_to_creature`).
+fn damage_kills_creature(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    target: &TargetFilter,
+    value: i32,
+) -> bool {
+    let opponents = players::opponents(state, ai_player);
+    let filter_ctx = FilterContext::from_source(state, source_id);
+    let damage = Effect::DealDamage {
+        amount: QuantityExpr::Fixed { value },
+        target: TargetFilter::Any,
+        damage_source: None,
+    };
+    state.battlefield.iter().any(|&id| {
+        let Some(obj) = state.objects.get(&id) else {
+            return false;
+        };
+        opponents.contains(&obj.controller)
+            && obj.card_types.core_types.contains(&CoreType::Creature)
+            && matches_target_filter(state, id, target, &filter_ctx)
+            && lethal_to_creature(state, id, &[&damage]) == Some(true)
+    })
+}
+
+fn removal_is_trivial(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    target: &TargetFilter,
+) -> bool {
+    targetable_threat_value(state, ai_player, target, source_id) <= 0.0
+}
+
+/// A placed counter is beneficial-by-default (indestructible, +1/+1)
+/// unless its sign is negative. A harmful counter routes through removal
+/// semantics; a beneficial counter is trivial only when it fizzles.
+fn put_counter_is_trivial(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    ability: &AbilityDefinition,
+    counter_type: &CounterType,
+    target: &TargetFilter,
+) -> bool {
+    if counter_is_harmful(counter_type) {
+        return removal_is_trivial(state, ai_player, source_id, target);
+    }
+    put_counter_fizzles(state, ai_player, source_id, ability, target)
+}
+
+/// A self-targeted beneficial counter fizzles when paying the cost necessarily
+/// removes the source — sacrificing the only recipient (Carrion Feeder with no
+/// other creature to feed it).
+fn put_counter_fizzles(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    ability: &AbilityDefinition,
+    counter_target: &TargetFilter,
+) -> bool {
+    if !matches!(counter_target, TargetFilter::SelfRef) {
+        return false;
+    }
+    ability
+        .cost
+        .as_ref()
+        .is_some_and(|cost| sacrifice_must_remove_source(state, ai_player, source_id, cost))
+}
+
+/// True when paying `cost` necessarily sacrifices the ability's source — either
+/// a `SelfRef` sacrifice, or a filtered sacrifice whose only legal AI-controlled
+/// target is the source itself.
+fn sacrifice_must_remove_source(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    cost: &AbilityCost,
+) -> bool {
+    match cost {
+        AbilityCost::Sacrifice(sacrifice) => {
+            if matches!(sacrifice.target, TargetFilter::SelfRef) {
+                return true;
+            }
+            let filter_ctx = FilterContext::from_source(state, source_id);
+            let mut matched_any = false;
+            let mut matched_other = false;
+            for &id in &state.battlefield {
+                let Some(obj) = state.objects.get(&id) else {
+                    continue;
+                };
+                if obj.controller == ai_player
+                    && matches_target_filter(state, id, &sacrifice.target, &filter_ctx)
+                {
+                    matched_any = true;
+                    if id != source_id {
+                        matched_other = true;
+                    }
+                }
+            }
+            matched_any && !matched_other
+        }
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => costs
+            .iter()
+            .any(|c| sacrifice_must_remove_source(state, ai_player, source_id, c)),
+        _ => false,
+    }
+}
+
+/// Harmful counters are the negative-sign counters (`-1/-1`, negative
+/// power/toughness, or a generic counter whose name reads negative). Everything
+/// else — `+1/+1`, keyword counters (indestructible), and other typed counters —
+/// is treated as beneficial-by-default for the gate.
+fn counter_is_harmful(counter_type: &CounterType) -> bool {
+    match counter_type {
+        CounterType::Minus1Minus1 => true,
+        CounterType::PowerToughness { power, toughness } => *power < 0 || *toughness < 0,
+        CounterType::Generic(name) => name.starts_with('-'),
+        _ => false,
+    }
+}
+
+/// The AI's life is a pressured resource when it is at or
+/// below 5, or at or below the opponents' combined board power. Mirrors
+/// `LifeTotalResourcePolicy`'s `ai_critical` test.
+fn ai_life_critical(state: &GameState, ai_player: PlayerId) -> bool {
+    let ai_life = state.players[ai_player.0 as usize].life;
+    let opp_total_power: i32 = players::opponents(state, ai_player)
+        .iter()
+        .map(|&opp| board_stats(state, opp).1)
+        .sum();
+    ai_life <= 5 || ai_life <= opp_total_power
+}
+
+fn pay_life_criticality_mult(state: &GameState, ai_player: PlayerId) -> f64 {
+    if ai_life_critical(state, ai_player) {
+        PAY_LIFE_CRITICALITY_MULT
+    } else {
+        1.0
+    }
+}
+
+/// Whether off-ability deck synergy justifies paying this self-cost even though
+/// the ability's own effect is trivial. Complements the intrinsic-payoff check
+/// in [`benefit_is_trivial`] — it covers value that lands elsewhere (aristocrats
+/// death triggers, a lifegain/reanimator engine fed by the resource spent).
+pub(crate) fn synergy_justifies_self_cost(
+    features: &DeckFeatures,
+    state: &GameState,
+    ai_player: PlayerId,
+    ability: &AbilityDefinition,
+) -> bool {
+    // cEDH lists run tight combo/engine lines where routine self-costs are the
+    // intended fuel; never veto self-costs for a Cedh-bracket deck.
+    if features.bracket_tier == CommanderBracketTier::Cedh {
+        return true;
+    }
+    ability
+        .cost
+        .as_ref()
+        .is_some_and(|cost| synergy_justifies_cost(features, state, ai_player, cost))
+}
+
+fn synergy_justifies_cost(
+    features: &DeckFeatures,
+    state: &GameState,
+    ai_player: PlayerId,
+    cost: &AbilityCost,
+) -> bool {
+    match cost {
+        // Board-gated aristocrats payoff only. NO landfall stand-down: landfall
+        // triggers when a land ENTERS the battlefield, never when one is
+        // sacrificed, so "sacrifice a land" yields zero landfall value —
+        // including it would reopen Zuran Orb in landfall decks. Genuine
+        // sacrifice-a-land ramp is already non-trivial via the mana / land-search
+        // arms of `benefit_is_trivial`.
+        AbilityCost::Sacrifice(_) => {
+            count_death_triggers_on_board(
+                state,
+                ai_player,
+                &features.aristocrats.death_trigger_names,
+            ) > 0
+        }
+        AbilityCost::PayLife { .. } => features.lifegain.commitment >= SYNERGY_COMMITMENT_FLOOR,
+        AbilityCost::Discard { .. } => features.reanimator.commitment >= SYNERGY_COMMITMENT_FLOOR,
+        // Exile from the AI's own hand/graveyard: no synergy stand-down. Graveyard
+        // exile is a strict loss for a reanimator deck (it removes fuel), and no
+        // real card pairs a trivial payoff with a hand-exile self-cost.
+        AbilityCost::Exile { .. } => false,
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => costs
+            .iter()
+            .any(|c| synergy_justifies_cost(features, state, ai_player, c)),
+        _ => false,
+    }
+}
+
+/// Count AI-controlled death-trigger payoff objects currently on the battlefield.
+/// Uses `death_trigger_names` as an identity-lookup list — the structural
+/// classification already happened at deck-build time in `aristocrats::detect`.
+/// Shared with `FreeOutletActivationPolicy` (the aristocrats sac-outlet path).
+pub(crate) fn count_death_triggers_on_board(
+    state: &GameState,
+    player: PlayerId,
+    death_trigger_names: &[String],
+) -> usize {
+    if death_trigger_names.is_empty() {
+        return 0;
+    }
+    state
+        .battlefield
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .filter(|obj: &&GameObject| obj.controller == player && obj.zone == Zone::Battlefield)
+        .filter(|obj| death_trigger_names.iter().any(|name| name == &obj.name))
+        .count()
+}

--- a/crates/phase-ai/src/policies/self_cost.rs
+++ b/crates/phase-ai/src/policies/self_cost.rs
@@ -182,7 +182,10 @@ pub(crate) fn benefit_is_trivial(
         .all(|effect| effect_is_trivial(state, ai_player, source_id, ability, effect))
 }
 
-fn effect_is_trivial(
+/// Whether a single effect carries no meaningful immediate advantage. Shared
+/// with the X-cast no-op gate (`x_cast_gate.rs`) for pricing the *non-X*
+/// residual effects of an {X}-cost payoff whose only affordable X is 0.
+pub(crate) fn effect_is_trivial(
     state: &GameState,
     ai_player: PlayerId,
     source_id: ObjectId,

--- a/crates/phase-ai/src/policies/self_cost_value.rs
+++ b/crates/phase-ai/src/policies/self_cost_value.rs
@@ -1,0 +1,1261 @@
+//! Net-value gate policy for self-cost ability activations.
+//!
+//! Thin adapter over `self_cost.rs`: fetches the activated ability, confirms its
+//! cost spends a self-resource (sacrifice / pay-life / discard / self-exile),
+//! stands down when off-ability deck synergy justifies the cost, then prices the
+//! cost against the ability's immediate payoff. A real cost with a trivial
+//! payoff is rejected (scoring `-inf`, so Pass wins); a cheap cost is merely
+//! deprioritized; anything with a genuine payoff is left alone.
+
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::player::PlayerId;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use super::self_cost::{
+    benefit_is_trivial, real_self_cost, self_cost_in_scope, synergy_justifies_self_cost,
+};
+use crate::features::DeckFeatures;
+
+/// At or above this priced self-cost, a trivial-benefit activation is a real
+/// loss and is rejected. Below it, a trivial-benefit activation is only
+/// deprioritized (never hard-rejected) — but it is still never treated as a
+/// benefit-present play.
+const REAL_COST_FLOOR: f64 = 1.0;
+
+pub struct SelfCostValuePolicy;
+
+impl TacticalPolicy for SelfCostValuePolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::SelfCostValue
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // activation-constant: cost-axis backstop for every activated-ability candidate; scope gating happens in `verdict`.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        let GameAction::ActivateAbility {
+            source_id,
+            ability_index,
+        } = &ctx.candidate.action
+        else {
+            return PolicyVerdict::neutral(PolicyReason::new("self_cost_value_na"));
+        };
+
+        let Some(ability) = ctx
+            .state
+            .objects
+            .get(source_id)
+            .and_then(|object| object.abilities.get(*ability_index))
+        else {
+            return PolicyVerdict::neutral(PolicyReason::new("self_cost_value_na"));
+        };
+
+        let Some(cost) = ability.cost.as_ref() else {
+            return PolicyVerdict::neutral(PolicyReason::new("self_cost_value_na"));
+        };
+
+        if !self_cost_in_scope(cost) {
+            return PolicyVerdict::neutral(PolicyReason::new("self_cost_value_na"));
+        }
+
+        let features = ctx
+            .context
+            .session
+            .features
+            .get(&ctx.ai_player)
+            .cloned()
+            .unwrap_or_default();
+
+        if synergy_justifies_self_cost(&features, ctx.state, ctx.ai_player, ability) {
+            return PolicyVerdict::neutral(PolicyReason::new("self_cost_synergy_justified"));
+        }
+
+        let cost_value =
+            real_self_cost(ctx.state, ctx.ai_player, *source_id, cost, ctx.penalties());
+        let trivial = benefit_is_trivial(ctx.state, ctx.ai_player, *source_id, ability);
+
+        let cost_milli = (cost_value * 1000.0) as i64;
+
+        if trivial {
+            if cost_value >= REAL_COST_FLOOR {
+                return PolicyVerdict::reject(
+                    PolicyReason::new("self_cost_trivial_benefit")
+                        .with_fact("cost_milli", cost_milli)
+                        .with_fact("benefit", 0),
+                );
+            }
+            // Trivial payoff, but the priced self-cost is below the real-loss
+            // floor: deprioritize with an auto-banded negative delta. No trivial
+            // self-cost play may resolve to `self_cost_benefit_present`, and the
+            // `self_cost_marginal` reason deliberately does NOT claim a benefit.
+            return PolicyVerdict::score(
+                -cost_value,
+                PolicyReason::new("self_cost_marginal").with_fact("cost_milli", cost_milli),
+            );
+        }
+
+        PolicyVerdict::neutral(PolicyReason::new("self_cost_benefit_present"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+    use crate::features::aristocrats::AristocratsFeature;
+    use crate::features::landfall::LandfallFeature;
+    use crate::features::lifegain::LifegainFeature;
+    use crate::features::reanimator::ReanimatorFeature;
+    use crate::features::DeckFeatures;
+    use crate::session::AiSession;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::bracket_estimate::CommanderBracketTier;
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, ContinuousModification, ControllerRef, Effect,
+        ManaContribution, ManaProduction, ObjectScope, QuantityExpr, QuantityRef, SacrificeCost,
+        StaticDefinition, TargetFilter, TypeFilter, TypedFilter,
+    };
+    use engine::types::card_type::CoreType;
+    use engine::types::counter::CounterType;
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId};
+    use engine::types::keywords::{Keyword, KeywordKind};
+    use engine::types::player::PlayerId;
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    const AI: PlayerId = PlayerId(0);
+    const OPP: PlayerId = PlayerId(1);
+
+    // --- fixture builders -------------------------------------------------
+
+    fn activated(effect: Effect, cost: AbilityCost) -> AbilityDefinition {
+        let mut ability = AbilityDefinition::new(AbilityKind::Activated, effect);
+        ability.cost = Some(cost);
+        ability
+    }
+
+    fn sac_creature_cost() -> AbilityCost {
+        AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            1,
+        ))
+    }
+
+    fn sac_land_cost() -> AbilityCost {
+        AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+            1,
+        ))
+    }
+
+    fn gain_life(amount: i32) -> Effect {
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: amount },
+            player: TargetFilter::Controller,
+        }
+    }
+
+    fn draw(count: i32) -> Effect {
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: count },
+            target: TargetFilter::Controller,
+        }
+    }
+
+    fn deal_fixed(value: i32) -> Effect {
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value },
+            target: TargetFilter::Any,
+            damage_source: None,
+        }
+    }
+
+    fn deal_dynamic() -> Effect {
+        // Fling shape: damage equal to a creature's power (non-Fixed quantity).
+        Effect::DealDamage {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Source,
+                },
+            },
+            target: TargetFilter::Player,
+            damage_source: None,
+        }
+    }
+
+    fn add_two_colorless() -> Effect {
+        Effect::Mana {
+            produced: ManaProduction::Fixed {
+                colors: Vec::new(),
+                contribution: ManaContribution::Base,
+            },
+            restrictions: Vec::new(),
+            grants: Vec::new(),
+            expiry: None,
+            target: None,
+        }
+    }
+
+    fn search_for_land() -> Effect {
+        Effect::SearchLibrary {
+            source_zones: vec![Zone::Library],
+            filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+            count: QuantityExpr::Fixed { value: 1 },
+            reveal: false,
+            target_player: None,
+            selection_constraint: engine::types::ability::SearchSelectionConstraint::None,
+            split: None,
+        }
+    }
+
+    fn shroud_self_grant() -> Effect {
+        Effect::GenericEffect {
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Shroud,
+                }])],
+            target: Some(TargetFilter::SelfRef),
+            duration: None,
+        }
+    }
+
+    fn put_counter(counter: CounterType, target: TargetFilter) -> Effect {
+        Effect::PutCounter {
+            counter_type: counter,
+            count: QuantityExpr::Fixed { value: 1 },
+            target,
+        }
+    }
+
+    // --- state / context helpers -----------------------------------------
+
+    fn creature(
+        state: &mut GameState,
+        controller: PlayerId,
+        name: &str,
+        p: i32,
+        t: i32,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(next_id()),
+            controller,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(p);
+        obj.toughness = Some(t);
+        id
+    }
+
+    fn token_creature(state: &mut GameState, name: &str, p: i32, t: i32) -> ObjectId {
+        let id = creature(state, AI, name, p, t);
+        state.objects.get_mut(&id).unwrap().is_token = true;
+        id
+    }
+
+    fn artifact_token(state: &mut GameState, name: &str) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(next_id()),
+            AI,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.is_token = true;
+        id
+    }
+
+    fn sac_artifact_cost() -> AbilityCost {
+        AbilityCost::Sacrifice(SacrificeCost::count(
+            TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Artifact).controller(ControllerRef::You),
+            ),
+            1,
+        ))
+    }
+
+    fn put_counter_all(counter: CounterType, target: TargetFilter) -> Effect {
+        Effect::PutCounterAll {
+            counter_type: counter,
+            count: QuantityExpr::Fixed { value: 1 },
+            target,
+        }
+    }
+
+    fn land(state: &mut GameState, name: &str) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(next_id()),
+            AI,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Land);
+        id
+    }
+
+    fn source_with(
+        state: &mut GameState,
+        name: &str,
+        core: &[CoreType],
+        ability: AbilityDefinition,
+    ) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(next_id()),
+            AI,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        for &ct in core {
+            obj.card_types.core_types.push(ct);
+        }
+        Arc::make_mut(&mut obj.abilities).push(ability);
+        id
+    }
+
+    fn next_id() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(1000);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn features_with(
+        landfall: f32,
+        lifegain: f32,
+        reanimator: f32,
+        death_triggers: Vec<String>,
+        bracket: CommanderBracketTier,
+    ) -> DeckFeatures {
+        DeckFeatures {
+            landfall: LandfallFeature {
+                commitment: landfall,
+                ..Default::default()
+            },
+            lifegain: LifegainFeature {
+                commitment: lifegain,
+                ..Default::default()
+            },
+            reanimator: ReanimatorFeature {
+                commitment: reanimator,
+                ..Default::default()
+            },
+            aristocrats: AristocratsFeature {
+                death_trigger_count: death_triggers.len() as u32,
+                death_trigger_names: death_triggers,
+                ..Default::default()
+            },
+            bracket_tier: bracket,
+            ..DeckFeatures::default()
+        }
+    }
+
+    fn plain_features() -> DeckFeatures {
+        features_with(0.0, 0.0, 0.0, Vec::new(), CommanderBracketTier::Core)
+    }
+
+    fn verdict_for(
+        state: &GameState,
+        source_id: ObjectId,
+        features: DeckFeatures,
+    ) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let config = AiConfig::default();
+        let mut session = AiSession::empty();
+        session.features.insert(AI, features);
+        let mut context = AiContext::empty(&config.weights);
+        context.session = Arc::new(session);
+        context.player = AI;
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        SelfCostValuePolicy.verdict(&ctx)
+    }
+
+    fn assert_reject(verdict: &PolicyVerdict, kind: &str) {
+        match verdict {
+            PolicyVerdict::Reject { reason } => assert_eq!(reason.kind, kind, "reject kind"),
+            PolicyVerdict::Score { delta, reason } => {
+                panic!(
+                    "expected reject {kind}, got Score {{ delta: {delta}, kind: {} }}",
+                    reason.kind
+                )
+            }
+        }
+    }
+
+    fn assert_neutral(verdict: &PolicyVerdict, kind: &str) {
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, kind, "neutral kind");
+                assert_eq!(*delta, 0.0, "neutral delta");
+            }
+            PolicyVerdict::Reject { reason } => {
+                panic!("expected neutral {kind}, got Reject {}", reason.kind)
+            }
+        }
+    }
+
+    fn assert_not_reject(verdict: &PolicyVerdict) {
+        assert!(
+            matches!(verdict, PolicyVerdict::Score { .. }),
+            "expected a Score (not a hard veto)"
+        );
+    }
+
+    // --- Row 1: sac-creature trivial lifegain rejected --------------------
+
+    #[test]
+    fn sac_creature_for_small_lifegain_rejected() {
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "High Market",
+            &[CoreType::Land],
+            activated(gain_life(1), sac_creature_cost()),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn sac_creature_for_draw_reaches_scoring_and_is_allowed() {
+        // Positive reach-guard for row 1: identical cost, real payoff (a card) →
+        // the input passed self_cost_in_scope and the benefit walk flips it to
+        // a non-reject. If benefit detection were broken this would reject.
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "High Market",
+            &[CoreType::Land],
+            activated(draw(1), sac_creature_cost()),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    // --- Row 2: Fling-class dynamic damage NOT rejected -------------------
+
+    #[test]
+    fn dynamic_power_damage_not_rejected() {
+        let mut state = GameState::new_two_player(42);
+        state.players[OPP.0 as usize].life = 12;
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "Fling-like",
+            &[CoreType::Artifact],
+            activated(deal_dynamic(), sac_creature_cost()),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    #[test]
+    fn fixed_one_face_ping_rejected() {
+        // Hostile boundary for row 2: same sac cost, a fixed 1 to face with no
+        // kill is trivial → reject.
+        let mut state = GameState::new_two_player(42);
+        state.players[OPP.0 as usize].life = 12;
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "Pinger",
+            &[CoreType::Artifact],
+            activated(deal_fixed(1), sac_creature_cost()),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    // --- Row 3: burn above the ceiling NOT rejected, boundary at 2 --------
+
+    #[test]
+    fn fixed_three_face_damage_not_rejected() {
+        let mut state = GameState::new_two_player(42);
+        state.players[OPP.0 as usize].life = 20;
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "Burn",
+            &[CoreType::Artifact],
+            activated(deal_fixed(3), sac_creature_cost()),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    #[test]
+    fn fixed_two_face_damage_no_kill_rejected() {
+        let mut state = GameState::new_two_player(42);
+        state.players[OPP.0 as usize].life = 20;
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "Weak Burn",
+            &[CoreType::Artifact],
+            activated(deal_fixed(2), sac_creature_cost()),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    // --- Row 4 / 4b: Zuran Orb rejected, land-search allowed --------------
+
+    #[test]
+    fn zuran_orb_land_sac_lifegain_rejected() {
+        let mut state = GameState::new_two_player(42);
+        land(&mut state, "Forest");
+        let source = source_with(
+            &mut state,
+            "Zuran Orb",
+            &[CoreType::Artifact],
+            activated(gain_life(2), sac_land_cost()),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn zuran_orb_still_rejected_in_landfall_deck() {
+        // NEW-1 regression guard: landfall commitment above the synergy floor
+        // must NOT stand Zuran Orb down — landfall triggers on a land entering,
+        // never on one being sacrificed.
+        let mut state = GameState::new_two_player(42);
+        land(&mut state, "Forest");
+        let source = source_with(
+            &mut state,
+            "Zuran Orb",
+            &[CoreType::Artifact],
+            activated(gain_life(2), sac_land_cost()),
+        );
+        let features = features_with(0.9, 0.0, 0.0, Vec::new(), CommanderBracketTier::Core);
+        assert_reject(
+            &verdict_for(&state, source, features),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn land_sac_search_for_land_allowed_even_in_landfall_deck() {
+        // Reach-guard for 4b: a real "sacrifice a land: search a land" ramp line
+        // reaches scoring (in-scope land sacrifice) and is allowed via the
+        // SearchLibrary-for-land arm, NOT a synergy stand-down.
+        let mut state = GameState::new_two_player(42);
+        land(&mut state, "Forest");
+        let source = source_with(
+            &mut state,
+            "Ramp Land",
+            &[CoreType::Land],
+            activated(search_for_land(), sac_land_cost()),
+        );
+        let features = features_with(0.9, 0.0, 0.0, Vec::new(), CommanderBracketTier::Core);
+        assert_neutral(
+            &verdict_for(&state, source, features),
+            "self_cost_benefit_present",
+        );
+    }
+
+    // --- Row 5: Ashnod's Altar (mana) allowed, cEDH stand-down ------------
+
+    #[test]
+    fn sac_for_mana_not_rejected() {
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "Ashnod's Altar",
+            &[CoreType::Artifact],
+            activated(add_two_colorless(), sac_creature_cost()),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    #[test]
+    fn cedh_bracket_stands_down_self_cost() {
+        // Same trivial sac-for-lifegain that rejects in a Core deck is stood
+        // down at the Cedh bracket.
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let source = source_with(
+            &mut state,
+            "High Market",
+            &[CoreType::Land],
+            activated(gain_life(1), sac_creature_cost()),
+        );
+        let features = features_with(0.0, 0.0, 0.0, Vec::new(), CommanderBracketTier::Cedh);
+        assert_neutral(
+            &verdict_for(&state, source, features),
+            "self_cost_synergy_justified",
+        );
+    }
+
+    // --- Row 6: discard-to-grant no-threat rejected -----------------------
+
+    #[test]
+    fn discard_for_self_protection_no_threat_rejected() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        // Give the AI a spare card so the discard cost is meaningful context.
+        create_object(
+            &mut state,
+            CardId(next_id()),
+            AI,
+            "Filler".to_string(),
+            Zone::Hand,
+        );
+        let cost = AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: None,
+            selection: Default::default(),
+            self_scope: Default::default(),
+        };
+        let source = source_with(
+            &mut state,
+            "Loopy Creature",
+            &[CoreType::Creature],
+            activated(shroud_self_grant(), cost),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn discard_stands_down_in_reanimator_deck() {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        let cost = AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: None,
+            selection: Default::default(),
+            self_scope: Default::default(),
+        };
+        let source = source_with(
+            &mut state,
+            "Loopy Creature",
+            &[CoreType::Creature],
+            activated(shroud_self_grant(), cost),
+        );
+        let features = features_with(0.0, 0.0, 0.9, Vec::new(), CommanderBracketTier::Core);
+        assert_neutral(
+            &verdict_for(&state, source, features),
+            "self_cost_synergy_justified",
+        );
+    }
+
+    // --- Row 7: self-exile-graveyard priced cheap (marginal, not reject) --
+
+    #[test]
+    fn self_exile_graveyard_single_card_is_marginal_not_rejected() {
+        // DEVIATION from matrix row 7 ("reject"): the plan prices graveyard
+        // exile at 0.15/card, well below the 0.5 marginal floor, so a single
+        // self-exile is deprioritized, never hard-vetoed. Multi-card exiles
+        // (>=7 cards) would clear the reject floor.
+        let mut state = GameState::new_two_player(42);
+        let cost = AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Graveyard),
+            filter: Some(TargetFilter::SelfRef),
+        };
+        let source = source_with(
+            &mut state,
+            "Psychic Frog",
+            &[CoreType::Creature],
+            activated(shroud_self_grant(), cost),
+        );
+        let verdict = verdict_for(&state, source, plain_features());
+        assert_not_reject(&verdict);
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "self_cost_marginal");
+                assert!(delta < 0.0, "expected a deprioritizing nudge, got {delta}");
+            }
+            PolicyVerdict::Reject { .. } => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn self_exile_hand_is_in_scope_and_priced_as_discard() {
+        // Exile{Hand} is priced as a discard (1.0/card), so a trivial-benefit
+        // hand-exile clears the reject floor — proves Exile{Hand} reaches scoring.
+        let mut state = GameState::new_two_player(42);
+        let cost = AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Hand),
+            filter: None,
+        };
+        let source = source_with(
+            &mut state,
+            "Hand Exiler",
+            &[CoreType::Creature],
+            activated(shroud_self_grant(), cost),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    // --- Row 8: ExilesCards siblings never fire the gate ------------------
+
+    #[test]
+    fn exile_cost_siblings_out_of_scope() {
+        // CollectEvidence / ExileWithAggregate / Behold are structurally
+        // distinct from a self-resource exile — the gate must not fire.
+        assert!(!self_cost_in_scope(&AbilityCost::CollectEvidence {
+            amount: 3
+        }));
+        assert!(!self_cost_in_scope(&AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Library),
+            filter: None,
+        }));
+        assert!(!self_cost_in_scope(&AbilityCost::Exile {
+            count: 1,
+            zone: None,
+            filter: None,
+        }));
+        // A Composite of only out-of-scope costs stays out of scope.
+        assert!(!self_cost_in_scope(&AbilityCost::Composite {
+            costs: vec![AbilityCost::Tap, AbilityCost::CollectEvidence { amount: 2 },],
+        }));
+        // Selective, not blanket: a graveyard/hand exile IS in scope.
+        assert!(self_cost_in_scope(&AbilityCost::Exile {
+            count: 1,
+            zone: Some(Zone::Graveyard),
+            filter: None,
+        }));
+    }
+
+    #[test]
+    fn collect_evidence_cost_yields_na() {
+        let mut state = GameState::new_two_player(42);
+        let source = source_with(
+            &mut state,
+            "Evidence Card",
+            &[CoreType::Creature],
+            activated(gain_life(1), AbilityCost::CollectEvidence { amount: 3 }),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_value_na",
+        );
+    }
+
+    // --- Row 9: Tyrite-Sanctum-class beneficial counter allowed (M2) ------
+
+    #[test]
+    fn beneficial_indestructible_counter_not_rejected() {
+        // M2: real card Tyrite Sanctum parses this as PutCounter{Keyword(
+        // Indestructible)} on a target God — a beneficial counter, non-trivial.
+        let mut state = GameState::new_two_player(42);
+        let effect = put_counter(
+            CounterType::Keyword(KeywordKind::Indestructible),
+            TargetFilter::Typed(TypedFilter::default()),
+        );
+        let cost = AbilityCost::Composite {
+            costs: vec![AbilityCost::Tap, sac_land_cost()],
+        };
+        land(&mut state, "Forest");
+        let source = source_with(
+            &mut state,
+            "Tyrite Sanctum",
+            &[CoreType::Land],
+            activated(effect, cost),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    // --- Row 10: Carrion Feeder fizzle rejected, multi-authority guards ---
+
+    #[test]
+    fn self_counter_fizzles_when_source_is_only_sac_target() {
+        // Sacrifice a creature: +1/+1 on itself. With only the source creature
+        // on board, paying the cost removes the counter's only recipient →
+        // trivial → reject.
+        let mut state = GameState::new_two_player(42);
+        let effect = put_counter(CounterType::Plus1Plus1, TargetFilter::SelfRef);
+        let source = source_with(
+            &mut state,
+            "Carrion Feeder",
+            &[CoreType::Creature],
+            activated(effect, sac_creature_cost()),
+        );
+        // Make the source itself a creature that matches the sac filter.
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.power = Some(1);
+            obj.toughness = Some(1);
+        }
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn self_counter_does_not_fizzle_with_other_fodder() {
+        // Multi-authority: a separate token can be sacrificed instead, so the
+        // +1/+1 counter lands → non-trivial → not rejected.
+        let mut state = GameState::new_two_player(42);
+        let effect = put_counter(CounterType::Plus1Plus1, TargetFilter::SelfRef);
+        let source = source_with(
+            &mut state,
+            "Carrion Feeder",
+            &[CoreType::Creature],
+            activated(effect, sac_creature_cost()),
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.power = Some(1);
+            obj.toughness = Some(1);
+        }
+        token_creature(&mut state, "Zombie Token", 1, 1);
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    #[test]
+    fn counter_on_other_creature_does_not_fizzle() {
+        // recipient != source: even with the source as the only sac target, a
+        // counter aimed at a different creature filter is not a fizzle.
+        let mut state = GameState::new_two_player(42);
+        let effect = put_counter(
+            CounterType::Plus1Plus1,
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+        );
+        let source = source_with(
+            &mut state,
+            "Counter Sac",
+            &[CoreType::Creature],
+            activated(effect, sac_creature_cost()),
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.power = Some(1);
+            obj.toughness = Some(1);
+        }
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    // --- Row 11: non-self-cost / OneOf-min untouched ----------------------
+
+    #[test]
+    fn tap_only_ability_yields_na() {
+        let mut state = GameState::new_two_player(42);
+        let source = source_with(
+            &mut state,
+            "Tapper",
+            &[CoreType::Artifact],
+            activated(gain_life(1), AbilityCost::Tap),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_value_na",
+        );
+    }
+
+    #[test]
+    fn one_of_min_picks_free_alternative_never_rejects() {
+        // OneOf{ pay 3 life | {2} } — the cheapest branch is the mana cost (0),
+        // so the priced self-cost is 0 and the gate never rejects.
+        let mut state = GameState::new_two_player(42);
+        let cost = AbilityCost::OneOf {
+            costs: vec![
+                AbilityCost::PayLife {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                },
+                AbilityCost::Mana {
+                    cost: engine::types::mana::ManaCost::generic(2),
+                },
+            ],
+        };
+        let source = source_with(
+            &mut state,
+            "Flexible",
+            &[CoreType::Artifact],
+            activated(gain_life(1), cost),
+        );
+        assert_not_reject(&verdict_for(&state, source, plain_features()));
+    }
+
+    // --- Marginal branch: cheap pay-life deprioritized, never vetoed ------
+
+    #[test]
+    fn cheap_pay_life_trivial_is_marginal() {
+        let mut state = GameState::new_two_player(42);
+        let cost = AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+        };
+        let source = source_with(
+            &mut state,
+            "Life Sink",
+            &[CoreType::Artifact],
+            activated(gain_life(1), cost),
+        );
+        let verdict = verdict_for(&state, source, plain_features());
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(reason.kind, "self_cost_marginal");
+                assert!(
+                    delta < 0.0 && delta > -0.5,
+                    "expected small nudge, got {delta}"
+                );
+            }
+            PolicyVerdict::Reject { .. } => panic!("cheap pay-life must never be vetoed"),
+        }
+    }
+
+    // --- MED-1: trivial self-costs in [0.5, 1.0) deprioritize, never neutral --
+
+    #[test]
+    fn pay_five_life_trivial_deprioritizes_not_neutral() {
+        // MED-1: pay 5 life (0.75 priced, in the [0.5, 1.0) sub-veto range) for a
+        // trivial 1 lifegain used to fall through to `self_cost_benefit_present`
+        // (a losing play mislabeled as a benefit). It must now deprioritize.
+        // Reverting the widening flips this back to `self_cost_benefit_present`.
+        let mut state = GameState::new_two_player(42);
+        let cost = AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value: 5 },
+        };
+        let source = source_with(
+            &mut state,
+            "Life Sink",
+            &[CoreType::Artifact],
+            activated(gain_life(1), cost),
+        );
+        let verdict = verdict_for(&state, source, plain_features());
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(
+                    reason.kind, "self_cost_marginal",
+                    "must not be benefit_present"
+                );
+                assert!(delta < 0.0, "expected a deprioritizing nudge, got {delta}");
+            }
+            PolicyVerdict::Reject { .. } => panic!("0.75 priced cost must not hard-veto"),
+        }
+    }
+
+    #[test]
+    fn non_creature_token_sac_trivial_deprioritizes_not_neutral() {
+        // MED-1: sacrifice a non-creature token (0.5 priced, the lower edge of the
+        // [0.5, 1.0) range) for a trivial 1 lifegain must deprioritize, not resolve
+        // to `self_cost_benefit_present`.
+        let mut state = GameState::new_two_player(42);
+        artifact_token(&mut state, "Treasure");
+        // The source is an enchantment (not an artifact) so the sole artifact the
+        // "sacrifice an artifact" cost can consume is the 0.5-priced token.
+        let source = source_with(
+            &mut state,
+            "Token Sink",
+            &[CoreType::Enchantment],
+            activated(gain_life(1), sac_artifact_cost()),
+        );
+        let verdict = verdict_for(&state, source, plain_features());
+        match verdict {
+            PolicyVerdict::Score { delta, reason } => {
+                assert_eq!(
+                    reason.kind, "self_cost_marginal",
+                    "must not be benefit_present"
+                );
+                assert!(delta < 0.0, "expected a deprioritizing nudge, got {delta}");
+            }
+            PolicyVerdict::Reject { .. } => panic!("0.5 priced cost must not hard-veto"),
+        }
+    }
+
+    // --- MED-2: harmful mass counter with a worthwhile target is non-trivial --
+
+    #[test]
+    fn mass_harmful_counter_hitting_opponent_creature_not_rejected() {
+        // MED-2: "Sacrifice a creature: put a -1/-1 counter on each creature" with a
+        // worthwhile opponent creature present is real board interaction — it must
+        // NOT be auto-classified trivial and hard-vetoed. Reverting the fix (the old
+        // `counter_is_harmful(counter_type)` arm returns true → trivial) turns this
+        // into a `self_cost_trivial_benefit` reject.
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        creature(&mut state, OPP, "Ogre", 4, 4);
+        let effect = put_counter_all(
+            CounterType::Minus1Minus1,
+            TargetFilter::Typed(TypedFilter::creature()),
+        );
+        let source = source_with(
+            &mut state,
+            "Mass Wither",
+            &[CoreType::Artifact],
+            activated(effect, sac_creature_cost()),
+        );
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    #[test]
+    fn mass_harmful_counter_no_worthwhile_target_rejected() {
+        // Hostile boundary for MED-2: the same mass -1/-1 with no opponent creature
+        // on board has no worthwhile board impact → trivial → reject. This pairs
+        // with the positive row above so neither is a vacuous assertion.
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let effect = put_counter_all(
+            CounterType::Minus1Minus1,
+            TargetFilter::Typed(TypedFilter::creature()),
+        );
+        let source = source_with(
+            &mut state,
+            "Mass Wither",
+            &[CoreType::Artifact],
+            activated(effect, sac_creature_cost()),
+        );
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    // --- Row 6 threat waiver: self-protection under threat allowed --------
+
+    #[test]
+    fn discard_for_self_protection_allowed_under_threat() {
+        use engine::types::ability::{ResolvedAbility, TargetRef};
+        use engine::types::game_state::{StackEntry, StackEntryKind};
+
+        let mut state = GameState::new_two_player(42);
+        state.active_player = OPP;
+        let me_creature = creature(&mut state, AI, "Defender", 2, 2);
+        let cost = AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: None,
+            selection: Default::default(),
+            self_scope: Default::default(),
+        };
+        let source = source_with(
+            &mut state,
+            "Loopy Creature",
+            &[CoreType::Creature],
+            activated(shroud_self_grant(), cost),
+        );
+        // Opponent removal on the stack targeting an AI creature makes the
+        // protection grant a live payoff.
+        let spell_id = create_object(
+            &mut state,
+            CardId(next_id()),
+            OPP,
+            "Doom Blade".to_string(),
+            Zone::Stack,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::Destroy {
+                target: TargetFilter::Any,
+                cant_regenerate: false,
+            },
+            vec![TargetRef::Object(me_creature)],
+            spell_id,
+            OPP,
+        );
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: OPP,
+            kind: StackEntryKind::Spell {
+                card_id: CardId(99),
+                ability: Some(ability),
+                casting_variant: Default::default(),
+                actual_mana_spent: 0,
+            },
+        });
+        assert_neutral(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_benefit_present",
+        );
+    }
+
+    // --- Parsed-Oracle reach-guards (production parser AST) ----------------
+
+    #[test]
+    fn parsed_zuran_orb_rejected() {
+        use engine::parser::oracle::parse_oracle_text;
+
+        let mut state = GameState::new_two_player(42);
+        land(&mut state, "Forest");
+        let parsed = parse_oracle_text(
+            "Sacrifice a land: You gain 2 life.",
+            "Zuran Orb",
+            &[],
+            &["Artifact".to_string()],
+            &[],
+        );
+        let ability = parsed
+            .abilities
+            .into_iter()
+            .next()
+            .expect("one activated ability");
+        let source = create_object(
+            &mut state,
+            CardId(next_id()),
+            AI,
+            "Zuran Orb".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            *Arc::make_mut(&mut obj.abilities) = vec![ability];
+        }
+        assert_reject(
+            &verdict_for(&state, source, plain_features()),
+            "self_cost_trivial_benefit",
+        );
+    }
+
+    #[test]
+    fn parsed_ashnods_altar_not_rejected() {
+        use engine::parser::oracle::parse_oracle_text;
+
+        let mut state = GameState::new_two_player(42);
+        creature(&mut state, AI, "Bear", 2, 2);
+        let parsed = parse_oracle_text(
+            "Sacrifice a creature: Add {C}{C}.",
+            "Ashnod's Altar",
+            &[],
+            &["Artifact".to_string()],
+            &[],
+        );
+        let ability = parsed
+            .abilities
+            .into_iter()
+            .next()
+            .expect("one activated ability");
+        let source = create_object(
+            &mut state,
+            CardId(next_id()),
+            AI,
+            "Ashnod's Altar".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Artifact);
+            *Arc::make_mut(&mut obj.abilities) = vec![ability];
+        }
+        assert_not_reject(&verdict_for(&state, source, plain_features()));
+    }
+
+    #[test]
+    fn parsed_tyrite_sanctum_indestructible_counter_not_rejected() {
+        // LOW: production-parser reach guard for the M2 beneficial-counter path.
+        // Tyrite Sanctum's third ability parses as a Composite{Mana, Tap,
+        // Sacrifice(SelfRef)} cost with a PutCounter{indestructible} payoff on a
+        // target God — a beneficial counter, so the self-cost activation must NOT
+        // be vetoed even though the sacrificed land prices at 4.0. Guards the M2
+        // classification against future parser AST changes.
+        use engine::parser::oracle::parse_oracle_text;
+
+        let mut state = GameState::new_two_player(42);
+        let parsed = parse_oracle_text(
+            "{T}: Add {C}.\n{2}, {T}: Target legendary creature becomes a God in addition to its other types. Put a +1/+1 counter on it.\n{4}, {T}, Sacrifice this land: Put an indestructible counter on target God.",
+            "Tyrite Sanctum",
+            &[],
+            &["Land".to_string()],
+            &[],
+        );
+        let ability = parsed
+            .abilities
+            .into_iter()
+            .find(|a| a.cost.as_ref().is_some_and(self_cost_in_scope))
+            .expect("the sacrifice-this-land activation");
+        let source = create_object(
+            &mut state,
+            CardId(next_id()),
+            AI,
+            "Tyrite Sanctum".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&source).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            *Arc::make_mut(&mut obj.abilities) = vec![ability];
+        }
+        assert_not_reject(&verdict_for(&state, source, plain_features()));
+    }
+}

--- a/crates/phase-ai/src/policies/self_cost_value.rs
+++ b/crates/phase-ai/src/policies/self_cost_value.rs
@@ -416,6 +416,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         SelfCostValuePolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/separate_piles_timing.rs
+++ b/crates/phase-ai/src/policies/separate_piles_timing.rs
@@ -329,6 +329,7 @@ mod tests {
             config,
             context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         }
     }
 

--- a/crates/phase-ai/src/policies/spellskite_priority.rs
+++ b/crates/phase-ai/src/policies/spellskite_priority.rs
@@ -260,6 +260,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         SpellskitePriorityPolicy.verdict(&ctx)
     }

--- a/crates/phase-ai/src/policies/spellslinger_casting.rs
+++ b/crates/phase-ai/src/policies/spellslinger_casting.rs
@@ -366,6 +366,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -409,6 +410,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -470,6 +472,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -527,6 +530,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -570,6 +574,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -612,6 +617,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {
@@ -647,6 +653,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = SpellslingerCastingPolicy.verdict(&ctx);
         match verdict {

--- a/crates/phase-ai/src/policies/stack_awareness.rs
+++ b/crates/phase-ai/src/policies/stack_awareness.rs
@@ -415,6 +415,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         StackAwarenessPolicy.score(&ctx)
     }

--- a/crates/phase-ai/src/policies/sweeper_timing.rs
+++ b/crates/phase-ai/src/policies/sweeper_timing.rs
@@ -284,6 +284,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = SweeperTimingPolicy.verdict(&ctx);
@@ -316,6 +317,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = SweeperTimingPolicy.verdict(&ctx);
@@ -347,6 +349,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = SweeperTimingPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/synergy_casting.rs
+++ b/crates/phase-ai/src/policies/synergy_casting.rs
@@ -228,6 +228,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = SynergyCastingPolicy.score(&ctx);
@@ -268,6 +269,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(
@@ -309,6 +311,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = SynergyCastingPolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/tempo_curve.rs
+++ b/crates/phase-ai/src/policies/tempo_curve.rs
@@ -192,6 +192,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = TempoCurvePolicy.score(&ctx);
@@ -233,6 +234,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(
@@ -271,6 +273,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = TempoCurvePolicy.score(&ctx);
@@ -310,6 +313,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let score = TempoCurvePolicy.score(&ctx);

--- a/crates/phase-ai/src/policies/tests/artifact_synergy.rs
+++ b/crates/phase-ai/src/policies/tests/artifact_synergy.rs
@@ -148,6 +148,7 @@ fn affinity_for_artifacts_spell_preferred() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -181,6 +182,7 @@ fn plain_artifact_nudged() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -212,6 +214,7 @@ fn non_artifact_spell_inert() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));

--- a/crates/phase-ai/src/policies/tests/blink_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/blink_payoff.rs
@@ -172,6 +172,7 @@ fn ctx<'a>(
         config,
         context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     }
 }
 

--- a/crates/phase-ai/src/policies/tests/enchantments_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/enchantments_payoff.rs
@@ -146,6 +146,7 @@ fn enchantment_cast_scored() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -174,6 +175,7 @@ fn non_enchantment_spell_inert() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));

--- a/crates/phase-ai/src/policies/tests/energy_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/energy_payoff.rs
@@ -193,6 +193,7 @@ fn ctx<'a>(
         config,
         context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     }
 }
 

--- a/crates/phase-ai/src/policies/tests/equipment_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/equipment_payoff.rs
@@ -131,6 +131,7 @@ fn ctx<'a>(
         config,
         context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     }
 }
 

--- a/crates/phase-ai/src/policies/tests/lifegain_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/lifegain_payoff.rs
@@ -157,6 +157,7 @@ fn lifelink_source_scored() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -195,6 +196,7 @@ fn gain_life_spell_scored() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -232,6 +234,7 @@ fn trigger_borne_lifegain_source_scored() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));
@@ -255,6 +258,7 @@ fn non_source_spell_inert() {
         config: &config,
         context: &context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     };
 
     let (delta, kind) = delta_of(policy().verdict(&ctx));

--- a/crates/phase-ai/src/policies/tests/mill_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/mill_payoff.rs
@@ -154,6 +154,7 @@ fn ctx<'a>(
         config,
         context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     }
 }
 

--- a/crates/phase-ai/src/policies/tests/reanimator_payoff.rs
+++ b/crates/phase-ai/src/policies/tests/reanimator_payoff.rs
@@ -131,6 +131,7 @@ fn ctx<'a>(
         config,
         context,
         cast_facts: None,
+        search_depth: crate::policies::context::SearchDepth::Root,
     }
 }
 

--- a/crates/phase-ai/src/policies/tokens_wide.rs
+++ b/crates/phase-ai/src/policies/tokens_wide.rs
@@ -343,6 +343,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = TokensWidePolicy.verdict(&ctx);
         match verdict {
@@ -369,6 +370,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = TokensWidePolicy.verdict(&ctx);
         match verdict {
@@ -409,6 +411,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = TokensWidePolicy.verdict(&ctx);
         match verdict {
@@ -443,6 +446,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = TokensWidePolicy.verdict(&ctx);
         match verdict {
@@ -472,6 +476,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         let verdict = TokensWidePolicy.verdict(&ctx);
         match verdict {

--- a/crates/phase-ai/src/policies/tribal_lord_priority.rs
+++ b/crates/phase-ai/src/policies/tribal_lord_priority.rs
@@ -248,6 +248,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = TribalLordPriorityPolicy.verdict(&ctx);
@@ -281,6 +282,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = TribalLordPriorityPolicy.verdict(&ctx);
@@ -323,6 +325,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         let verdict = TribalLordPriorityPolicy.verdict(&ctx);

--- a/crates/phase-ai/src/policies/tutor.rs
+++ b/crates/phase-ai/src/policies/tutor.rs
@@ -497,6 +497,7 @@ mod tests {
             config: &config,
             context: &crate::context::AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert!(

--- a/crates/phase-ai/src/policies/x_cast_gate.rs
+++ b/crates/phase-ai/src/policies/x_cast_gate.rs
@@ -185,6 +185,14 @@ fn no_op_at_x_zero(
 }
 
 fn gate_rejects(ctx: &PolicyContext<'_>) -> Option<PolicyReason> {
+    // Perf: the board-wide `max_x_value` affordability sweep below only needs to
+    // be correct at the committed decision. In beam/rollout lookahead an X=0 cast
+    // is already dominated by its resulting-state eval, so scoring it neutral there
+    // costs nothing and removes the per-node sweep that regressed large boards.
+    if !ctx.at_root() {
+        return None;
+    }
+
     let state = ctx.state;
     let (ability, object_id, x_manacost, is_spell): (
         &AbilityDefinition,
@@ -227,25 +235,32 @@ fn gate_rejects(ctx: &PolicyContext<'_>) -> Option<PolicyReason> {
         _ => return None,
     };
 
-    // Reach-guard: only gate when the ONLY affordable X is 0. `max_x_value`
-    // already caps X to what the caster can legally pay (CR 601.2b/f), so
-    // max ≥ 1 means the ramp path (`XValuePolicy`) handles it — don't gate.
-    // Checked after the cheap `{X}`-shard short-circuit above so we skip the
-    // affordability sweep for non-{X} candidates.
-    if max_x_value(state, ctx.ai_player, x_manacost, Some(object_id)) != 0 {
-        return None;
-    }
-
+    // Card-local payoff walk FIRST (no board sweep): if the payoff is not a
+    // guaranteed no-op at X=0 (a fixed meaningful residual, or it does not scale
+    // with X), the gate can never fire — skip the affordability sweep entirely.
+    // AND is commutative, so ordering the cheap card-local predicate before the
+    // board-wide sweep cannot change any verdict; it only spares the sweep.
     let (effects, object_level_x) = payoff_effects_and_x_ref(ctx, object_id, ability, is_spell);
-    no_op_at_x_zero(
+    if !no_op_at_x_zero(
         state,
         ctx.ai_player,
         object_id,
         ability,
         &effects,
         object_level_x,
-    )
-    .then(|| PolicyReason::new("x_cast_zero_no_op").with_fact("max_x", 0))
+    ) {
+        return None;
+    }
+
+    // Board-wide affordability sweep LAST, only for genuine no-op-at-X=0 payoffs
+    // at the root. `max_x_value` already caps X to what the caster can legally
+    // pay (CR 601.2b/f), so max ≥ 1 means the ramp path (`XValuePolicy`) handles
+    // it — don't gate.
+    if max_x_value(state, ctx.ai_player, x_manacost, Some(object_id)) != 0 {
+        return None;
+    }
+
+    Some(PolicyReason::new("x_cast_zero_no_op").with_fact("max_x", 0))
 }
 
 #[cfg(test)]
@@ -254,6 +269,7 @@ mod tests {
     use crate::cast_facts::cast_facts_for_object;
     use crate::config::AiConfig;
     use crate::context::AiContext;
+    use crate::policies::context::SearchDepth;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::zones::create_object;
     use engine::types::ability::{
@@ -513,7 +529,7 @@ mod tests {
                 tactical_class: TacticalClass::Ability,
             },
         };
-        verdict_for(state, candidate)
+        verdict_for(state, candidate, SearchDepth::Root)
     }
 
     fn verdict_for_cast(state: &GameState, object_id: ObjectId, card_id: CardId) -> PolicyVerdict {
@@ -529,7 +545,7 @@ mod tests {
                 tactical_class: TacticalClass::Spell,
             },
         };
-        verdict_for(state, candidate)
+        verdict_for(state, candidate, SearchDepth::Root)
     }
 
     /// Like [`verdict_for_cast`] but populates the `PolicyContext::cast_facts`
@@ -569,11 +585,37 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: Some(facts),
+            search_depth: SearchDepth::Root,
         };
         XCastGatePolicy.verdict(&ctx)
     }
 
-    fn verdict_for(state: &GameState, candidate: CandidateAction) -> PolicyVerdict {
+    /// Activation verdict at a caller-chosen search depth — lets a test drive the
+    /// identical fixture at both `Root` and `Lookahead` to prove the depth guard
+    /// is the sole cause of a verdict flip.
+    fn verdict_for_activate_at(
+        state: &GameState,
+        source_id: ObjectId,
+        search_depth: SearchDepth,
+    ) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        verdict_for(state, candidate, search_depth)
+    }
+
+    fn verdict_for(
+        state: &GameState,
+        candidate: CandidateAction,
+        search_depth: SearchDepth,
+    ) -> PolicyVerdict {
         let config = AiConfig::default();
         let context = AiContext::empty(&config.weights);
         let decision = AiDecisionContext {
@@ -588,6 +630,7 @@ mod tests {
             config: &config,
             context: &context,
             cast_facts: None,
+            search_depth,
         };
         XCastGatePolicy.verdict(&ctx)
     }
@@ -621,6 +664,28 @@ mod tests {
         let mut state = base_state();
         let source = activated_source(&mut state, "Helix Pinnacle", helix_ability());
         assert_reject(&verdict_for_activate(&state, source), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn helix_pinnacle_lookahead_returns_neutral() {
+        // The fix, discriminating: the IDENTICAL zero-mana Helix fixture that
+        // `helix_pinnacle_max_x_zero_rejected` rejects at `Root` must return a
+        // neutral (non-reject) verdict at `Lookahead`. Same inputs, opposite
+        // verdicts, differing ONLY in `search_depth` — so the depth guard is the
+        // sole cause. Reverting the `if !ctx.at_root() { return None; }` first line
+        // of `gate_rejects` makes this reject (the board sweep runs, max_x=0, the
+        // PutCounter-X payoff is a no-op) → `assert_not_reject` fails.
+        //
+        // Non-vacuous: the paired Root-reject test proves the fixture reaches the
+        // real gate arm (genuine {X} no-op payoff), so neutrality here is caused by
+        // depth, not by an upstream short-circuit (non-{X} cost, wrong action, etc.).
+        let mut state = base_state();
+        let source = activated_source(&mut state, "Helix Pinnacle", helix_ability());
+        assert_not_reject(&verdict_for_activate_at(
+            &state,
+            source,
+            SearchDepth::Lookahead,
+        ));
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/x_cast_gate.rs
+++ b/crates/phase-ai/src/policies/x_cast_gate.rs
@@ -1,0 +1,915 @@
+//! Hard-veto gate for casting/activating an {X}-cost spell or ability whose
+//! only affordable X is 0 and whose payoff scales with X — a guaranteed no-op.
+//!
+//! Issue: the AI commits to `GameAction::CastSpell` / `ActivateAbility` at the
+//! `WaitingFor::Priority` seam, *before* X is chosen (X is announced downstream
+//! at `WaitingFor::ChooseXValue`, CR 601.2b/f). When the only value the AI can
+//! afford is X=0, nothing rejects the commitment, so it casts Exsanguinate for 0
+//! (draining no life), pumps Helix Pinnacle by 0 counters, wipes its own board
+//! to 0/0 with Mirror Entity, etc. `XValuePolicy` cannot help — it only scores
+//! the `ChooseX` candidates *after* the cast is already committed.
+//!
+//! This gate rejects the pre-cast commitment when three things hold:
+//! 1. the cost carries an `{X}` mana shard,
+//! 2. `casting_costs::max_x_value` (the engine's single X-affordability
+//!    authority, CR 601.2b/f) reports the only legal X is 0, and
+//! 3. the payoff genuinely scales with X (via `x_reference`, the shared
+//!    detector the ramp policy also consumes), with any *fixed* non-X residual
+//!    still being trivial (priced by `self_cost::effect_is_trivial`).
+//!
+//! Rejecting the cast makes the AI `Pass` (always a Priority candidate) and hold
+//! the card — it never loses the card, it just waits until X≥1 is affordable.
+//! Build for the class, not the card: every rule 1–3 match is gated regardless
+//! of card name; fixed-payoff {X} cards (whose payoff does not reference X) are
+//! structurally spared.
+
+use engine::game::game_object::GameObject;
+use engine::game::max_x_value;
+use engine::types::ability::{AbilityCost, AbilityDefinition, AbilityKind, Effect};
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::player::PlayerId;
+
+use crate::ability_chain::collect_chain_effects;
+use crate::cast_facts::collect_definition_effects;
+use crate::features::DeckFeatures;
+
+use super::context::PolicyContext;
+use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use super::self_cost::effect_is_trivial;
+use super::x_reference;
+
+pub struct XCastGatePolicy;
+
+impl TacticalPolicy for XCastGatePolicy {
+    fn id(&self) -> PolicyId {
+        PolicyId::XCastGate
+    }
+
+    fn decision_kinds(&self) -> &'static [DecisionKind] {
+        &[DecisionKind::CastSpell, DecisionKind::ActivateAbility]
+    }
+
+    fn activation(
+        &self,
+        _features: &DeckFeatures,
+        _state: &GameState,
+        _player: PlayerId,
+    ) -> Option<f32> {
+        // A hard-veto backstop for every {X}-cost cast / activation candidate,
+        // on or off the AI's turn (instant-speed X). The verdict is a `Reject`,
+        // not an activation-scaled delta — mirrors `SelfCostValuePolicy`.
+        // activation-constant: unconditional Reject backstop; gating in `verdict`.
+        Some(1.0)
+    }
+
+    fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
+        gate_rejects(ctx).map_or_else(
+            || PolicyVerdict::neutral(PolicyReason::new("x_cast_gate_na")),
+            PolicyVerdict::reject,
+        )
+    }
+}
+
+/// `Some(&object.mana_cost)` iff the object's printed mana cost carries an `{X}`
+/// shard, else `None`.
+fn spell_x_manacost(object: &GameObject) -> Option<&ManaCost> {
+    mana_cost_has_x(&object.mana_cost).then_some(&object.mana_cost)
+}
+
+/// The `{X}`-bearing `ManaCost` inside an activated ability's cost, if any.
+/// Exhaustive over the compositional cost shapes: a bare `Mana` cost is
+/// X-checked directly; `Composite`/`OneOf` search their sub-costs. Every other
+/// cost variant is fail-open (`None`) — a cost shape we do not model simply gets
+/// no gate rather than a spurious veto.
+fn activated_x_manacost(cost: &AbilityCost) -> Option<&ManaCost> {
+    match cost {
+        AbilityCost::Mana { cost } => mana_cost_has_x(cost).then_some(cost),
+        AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+            costs.iter().find_map(activated_x_manacost)
+        }
+        _ => None,
+    }
+}
+
+fn mana_cost_has_x(cost: &ManaCost) -> bool {
+    matches!(cost, ManaCost::Cost { shards, .. } if shards.iter().any(|s| matches!(s, ManaCostShard::X)))
+}
+
+/// Collect the payoff effects to price at X=0 and whether the spell object
+/// itself references X (X-counter-ETB creatures, dynamic-P/T statics).
+///
+/// For an activated ability the payoff is just its own resolution chain. For a
+/// spell (v3 CORRECTION 2) the residual walk takes effects from `CastFacts`'s
+/// definition lists — the printed spell abilities, immediate ETB triggers, and
+/// immediate ETB replacements — because the boolean `EffectProfile` cannot
+/// yield `&Effect`s. Object-level X detection stays independent via
+/// `spell_object_references_x`, so X-counter-ETB creatures are gated even when
+/// their X reference is a replacement rather than a flat effect.
+fn payoff_effects_and_x_ref<'a>(
+    ctx: &PolicyContext<'a>,
+    object_id: ObjectId,
+    ability: &'a AbilityDefinition,
+    is_spell: bool,
+) -> (Vec<&'a Effect>, bool) {
+    if !is_spell {
+        return (collect_chain_effects(ability), false);
+    }
+
+    let effects = match ctx.cast_facts() {
+        Some(facts) => {
+            let mut effects: Vec<&Effect> = Vec::new();
+            for def in facts.primary_effects {
+                effects.extend(collect_definition_effects(def));
+            }
+            for trigger in facts.immediate_etb_triggers {
+                if let Some(exec) = trigger.execute.as_deref() {
+                    effects.extend(collect_definition_effects(exec));
+                }
+            }
+            for replacement in facts.immediate_replacements {
+                if let Some(exec) = replacement.execute.as_deref() {
+                    effects.extend(collect_definition_effects(exec));
+                }
+            }
+            effects
+        }
+        None => collect_chain_effects(ability),
+    };
+    let object_level_x = x_reference::spell_object_references_x(ctx.state, object_id);
+    (effects, object_level_x)
+}
+
+/// The reviewer's unified predicate, made chain-aware (v3 CORRECTION 1): the
+/// payoff is a guaranteed no-op at X=0 iff every effect either scales with X (so
+/// resolves to 0) or is a trivial fixed residual — and at least one effect
+/// actually references X.
+///
+/// `prev_was_x` tracks *only the immediately preceding* effect: an effect that
+/// reads `PreviousEffectAmount` is transitively 0 at X=0 exactly when
+/// its predecessor was X-scaled (Exsanguinate's "gain life equal to the life
+/// lost this way" after "each opponent loses X life"). A non-X residual resets
+/// `prev_was_x`, so `LoseLife{X}, GainLife{Fixed 5}, Draw{PreviousEffectAmount}`
+/// does NOT treat the draw as X-scaled (the 5 came from the fixed gain).
+fn no_op_at_x_zero(
+    state: &GameState,
+    ai_player: PlayerId,
+    source_id: ObjectId,
+    ability: &AbilityDefinition,
+    effects: &[&Effect],
+    object_level_x: bool,
+) -> bool {
+    let mut references_any_x = object_level_x;
+    let mut prev_was_x = object_level_x;
+    for effect in effects {
+        if x_reference::effect_references_x(effect) {
+            references_any_x = true;
+            prev_was_x = true;
+            continue;
+        }
+        if prev_was_x && x_reference::effect_references_previous_amount(effect) {
+            // Chain-relative to an X-scaled predecessor → also 0 at X=0.
+            references_any_x = true;
+            prev_was_x = true;
+            continue;
+        }
+        if !effect_is_trivial(state, ai_player, source_id, ability, effect) {
+            // A fixed, meaningful non-X residual is worth casting at X=0.
+            return false;
+        }
+        prev_was_x = false;
+    }
+    references_any_x
+}
+
+fn gate_rejects(ctx: &PolicyContext<'_>) -> Option<PolicyReason> {
+    let state = ctx.state;
+    let (ability, object_id, x_manacost, is_spell): (
+        &AbilityDefinition,
+        ObjectId,
+        &ManaCost,
+        bool,
+    ) = match &ctx.candidate.action {
+        GameAction::CastSpell { object_id, .. } => {
+            let object = state.objects.get(object_id)?;
+            // Conservative modal/multi-Spell-ability guard: a card with more
+            // than one castable spell ability, or a modal `ChooseOneOf`
+            // chain, may have a non-no-op mode at X=0 we do not analyse —
+            // don't gate (miss a veto rather than suppress a real cast).
+            let mut spell_abilities = object
+                .abilities
+                .iter()
+                .filter(|a| a.kind == AbilityKind::Spell);
+            let ability = spell_abilities.next()?;
+            if spell_abilities.next().is_some() {
+                return None;
+            }
+            if collect_definition_effects(ability)
+                .iter()
+                .any(|e| matches!(e, Effect::ChooseOneOf { .. }))
+            {
+                return None;
+            }
+            let x_manacost = spell_x_manacost(object)?;
+            (ability, *object_id, x_manacost, true)
+        }
+        GameAction::ActivateAbility {
+            source_id,
+            ability_index,
+        } => {
+            let object = state.objects.get(source_id)?;
+            let ability = object.abilities.get(*ability_index)?;
+            let x_manacost = ability.cost.as_ref().and_then(activated_x_manacost)?;
+            (ability, *source_id, x_manacost, false)
+        }
+        _ => return None,
+    };
+
+    // Reach-guard: only gate when the ONLY affordable X is 0. `max_x_value`
+    // already caps X to what the caster can legally pay (CR 601.2b/f), so
+    // max ≥ 1 means the ramp path (`XValuePolicy`) handles it — don't gate.
+    // Checked after the cheap `{X}`-shard short-circuit above so we skip the
+    // affordability sweep for non-{X} candidates.
+    if max_x_value(state, ctx.ai_player, x_manacost, Some(object_id)) != 0 {
+        return None;
+    }
+
+    let (effects, object_level_x) = payoff_effects_and_x_ref(ctx, object_id, ability, is_spell);
+    no_op_at_x_zero(
+        state,
+        ctx.ai_player,
+        object_id,
+        ability,
+        &effects,
+        object_level_x,
+    )
+    .then(|| PolicyReason::new("x_cast_zero_no_op").with_fact("max_x", 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cast_facts::cast_facts_for_object;
+    use crate::config::AiConfig;
+    use crate::context::AiContext;
+    use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::zones::create_object;
+    use engine::types::ability::{
+        Comparator, ContinuousModification, Duration, FilterProp, QuantityExpr, QuantityRef,
+        ReplacementDefinition, StaticDefinition, TargetFilter, TypedFilter,
+    };
+    use engine::types::card_type::CoreType;
+    use engine::types::counter::CounterType;
+    use engine::types::game_state::{GameState, WaitingFor};
+    use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
+    use engine::types::keywords::Keyword;
+    use engine::types::mana::{ManaCost, ManaPipId, ManaType, ManaUnit};
+    use engine::types::replacements::ReplacementEvent;
+    use engine::types::zones::Zone;
+    use std::sync::Arc;
+
+    const AI: PlayerId = PlayerId(0);
+    const OPP: PlayerId = PlayerId(1);
+
+    // --- fixture builders -------------------------------------------------
+
+    fn x_expr() -> QuantityExpr {
+        QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        }
+    }
+
+    fn x_only_cost() -> AbilityCost {
+        AbilityCost::Mana {
+            cost: ManaCost::Cost {
+                shards: vec![ManaCostShard::X],
+                generic: 0,
+            },
+        }
+    }
+
+    fn x_bb_manacost() -> ManaCost {
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::Black, ManaCostShard::Black],
+            generic: 0,
+        }
+    }
+
+    fn colorless_unit() -> ManaUnit {
+        ManaUnit {
+            color: ManaType::Colorless,
+            source_id: ObjectId(0),
+            pip_id: ManaPipId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: Vec::new(),
+            grants: Vec::new(),
+            expiry: None,
+        }
+    }
+
+    fn add_pool(state: &mut GameState, player: PlayerId, count: usize) {
+        for _ in 0..count {
+            state.players[player.0 as usize]
+                .mana_pool
+                .add(colorless_unit());
+        }
+    }
+
+    fn base_state() -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = AI;
+        state.priority_player = AI;
+        state
+    }
+
+    /// Battlefield object carrying a single activated ability.
+    fn activated_source(state: &mut GameState, name: &str, ability: AbilityDefinition) -> ObjectId {
+        let id = create_object(
+            state,
+            CardId(next_id()),
+            AI,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        *Arc::make_mut(&mut obj.abilities) = vec![ability];
+        id
+    }
+
+    /// Hand object representing an {X}-cost spell with the given spell ability.
+    fn spell_source(
+        state: &mut GameState,
+        name: &str,
+        ability: AbilityDefinition,
+        mana_cost: ManaCost,
+    ) -> (ObjectId, CardId) {
+        let card_id = CardId(next_id());
+        let id = create_object(state, card_id, AI, name.to_string(), Zone::Hand);
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.mana_cost = mana_cost;
+        *Arc::make_mut(&mut obj.abilities) = vec![ability];
+        (id, card_id)
+    }
+
+    fn activated(effect: Effect, cost: AbilityCost) -> AbilityDefinition {
+        let mut ability = AbilityDefinition::new(AbilityKind::Activated, effect);
+        ability.cost = Some(cost);
+        ability
+    }
+
+    fn spell(effect: Effect) -> AbilityDefinition {
+        AbilityDefinition::new(AbilityKind::Spell, effect)
+    }
+
+    fn next_id() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(5000);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    // --- Exsanguinate real AST: LoseLife{X} + GainLife{PreviousEffectAmount} --
+
+    fn exsanguinate_ability() -> AbilityDefinition {
+        let mut ability = spell(Effect::LoseLife {
+            amount: x_expr(),
+            target: None,
+        });
+        ability.sub_ability = Some(Box::new(spell(Effect::GainLife {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::PreviousEffectAmount,
+            },
+            player: TargetFilter::Controller,
+        })));
+        ability
+    }
+
+    fn helix_ability() -> AbilityDefinition {
+        activated(
+            Effect::PutCounter {
+                counter_type: CounterType::Generic("tower".to_string()),
+                count: x_expr(),
+                target: TargetFilter::SelfRef,
+            },
+            x_only_cost(),
+        )
+    }
+
+    // Mirror Entity: {X}: creatures you control become X/X (dynamic P/T via
+    // CostXPaid) and gain all creature types.
+    fn mirror_entity_ability() -> AbilityDefinition {
+        let cost_x_paid = || QuantityExpr::Ref {
+            qty: QuantityRef::CostXPaid,
+        };
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(TypedFilter::creature()))
+            .modifications(vec![
+                ContinuousModification::SetPowerDynamic {
+                    value: cost_x_paid(),
+                },
+                ContinuousModification::SetToughnessDynamic {
+                    value: cost_x_paid(),
+                },
+                ContinuousModification::AddKeyword {
+                    keyword: Keyword::Changeling,
+                },
+            ]);
+        activated(
+            Effect::GenericEffect {
+                static_abilities: vec![static_def],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            },
+            x_only_cost(),
+        )
+    }
+
+    // Day of Black Sun: GenericEffect granting RemoveAllAbilities over an
+    // X-filtered subject (mana value X or less), then Destroy those creatures.
+    fn day_of_black_sun_ability() -> AbilityDefinition {
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(TypedFilter::creature().properties(
+                vec![FilterProp::Cmc {
+                    comparator: Comparator::LE,
+                    value: x_expr(),
+                }],
+            )))
+            .modifications(vec![ContinuousModification::RemoveAllAbilities]);
+        let mut ability = spell(Effect::GenericEffect {
+            static_abilities: vec![static_def],
+            duration: Some(Duration::UntilEndOfTurn),
+            target: None,
+        });
+        ability.sub_ability = Some(Box::new(spell(Effect::Destroy {
+            target: TargetFilter::TrackedSet {
+                id: TrackedSetId(0),
+            },
+            cant_regenerate: false,
+        })));
+        ability
+    }
+
+    /// Hangarback-shape ETB-X-counter creature: `{X}{X}` Artifact Creature that
+    /// "enters with X +1/+1 counters on it", modeled (per the
+    /// `spell_object_references_x` doc) as a `Moved`→`Battlefield` `SelfRef`
+    /// self-replacement whose execute puts X `+1/+1` counters. The X payoff
+    /// lives OUTSIDE the resolving spell ability, so it is recognized via
+    /// `object_level_x` (the spell-object scan), the branch no other cast test
+    /// reaches.
+    ///
+    /// Real Hangarback stamps this count as `CostXPaid`; here it is `Variable X`
+    /// (`x_expr()`), the on-cast reference the shared detector recognizes. A
+    /// permanent spell carries no meaningful spell-resolution effect, but the
+    /// gate needs one `AbilityKind::Spell` ability to engage, so a `NoOp` spell
+    /// ability stands in for "this permanent resolves and enters".
+    fn etb_x_counter_creature(state: &mut GameState) -> (ObjectId, CardId) {
+        let card_id = CardId(next_id());
+        let id = create_object(
+            state,
+            card_id,
+            AI,
+            "Hangarback Walker".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::X],
+            generic: 0,
+        };
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.core_types.push(CoreType::Creature);
+        *Arc::make_mut(&mut obj.abilities) = vec![spell(Effect::NoOp)];
+        obj.replacement_definitions.push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::PutCounter {
+                        counter_type: CounterType::Plus1Plus1,
+                        count: x_expr(),
+                        target: TargetFilter::SelfRef,
+                    },
+                ))
+                .valid_card(TargetFilter::SelfRef)
+                .destination_zone(Zone::Battlefield),
+        );
+        (id, card_id)
+    }
+
+    // --- context / verdict helpers ---------------------------------------
+
+    fn verdict_for_activate(state: &GameState, source_id: ObjectId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Ability,
+            },
+        };
+        verdict_for(state, candidate)
+    }
+
+    fn verdict_for_cast(state: &GameState, object_id: ObjectId, card_id: CardId) -> PolicyVerdict {
+        let candidate = CandidateAction {
+            action: GameAction::CastSpell {
+                object_id,
+                card_id,
+                targets: Vec::new(),
+                payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Spell,
+            },
+        };
+        verdict_for(state, candidate)
+    }
+
+    /// Like [`verdict_for_cast`] but populates the `PolicyContext::cast_facts`
+    /// field with the real [`cast_facts_for_object`] (the constructor
+    /// production uses), so the gate walks the `Some(facts)` branch of
+    /// `payoff_effects_and_x_ref` from a genuinely populated `CastFacts` rather
+    /// than the lazily-rebuilt path or the `None` fallback.
+    fn verdict_for_cast_with_facts(
+        state: &GameState,
+        object_id: ObjectId,
+        card_id: CardId,
+    ) -> PolicyVerdict {
+        let facts = cast_facts_for_object(state.objects.get(&object_id).expect("cast object"));
+        let candidate = CandidateAction {
+            action: GameAction::CastSpell {
+                object_id,
+                card_id,
+                targets: Vec::new(),
+                payment_mode: engine::types::game_state::CastPaymentMode::Auto,
+            },
+            metadata: ActionMetadata {
+                actor: Some(AI),
+                tactical_class: TacticalClass::Spell,
+            },
+        };
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: Some(facts),
+        };
+        XCastGatePolicy.verdict(&ctx)
+    }
+
+    fn verdict_for(state: &GameState, candidate: CandidateAction) -> PolicyVerdict {
+        let config = AiConfig::default();
+        let context = AiContext::empty(&config.weights);
+        let decision = AiDecisionContext {
+            waiting_for: WaitingFor::Priority { player: AI },
+            candidates: Vec::new(),
+        };
+        let ctx = PolicyContext {
+            state,
+            decision: &decision,
+            candidate: &candidate,
+            ai_player: AI,
+            config: &config,
+            context: &context,
+            cast_facts: None,
+        };
+        XCastGatePolicy.verdict(&ctx)
+    }
+
+    fn assert_reject(verdict: &PolicyVerdict, kind: &str) {
+        match verdict {
+            PolicyVerdict::Reject { reason } => assert_eq!(reason.kind, kind, "reject kind"),
+            PolicyVerdict::Score { delta, reason } => panic!(
+                "expected reject {kind}, got Score {{ delta: {delta}, kind: {} }}",
+                reason.kind
+            ),
+        }
+    }
+
+    fn assert_not_reject(verdict: &PolicyVerdict) {
+        assert!(
+            matches!(verdict, PolicyVerdict::Score { .. }),
+            "expected a non-reject (neutral) verdict, got {verdict:?}"
+        );
+    }
+
+    // --- Helix Pinnacle: detector-based gate (HIGH) -----------------------
+
+    #[test]
+    fn helix_pinnacle_max_x_zero_rejected() {
+        // {X}: put X tower counters on ~, with no mana → max X = 0. Discriminating:
+        // the reason is `x_cast_zero_no_op`, driven by the PutCounter-X detector.
+        // A `benefit_is_trivial`-delegating gate would NOT reject (Helix's
+        // beneficial self-counter is non-trivial), so a Reject here proves the
+        // detector-based gate, not a triviality delegation.
+        let mut state = base_state();
+        let source = activated_source(&mut state, "Helix Pinnacle", helix_ability());
+        assert_reject(&verdict_for_activate(&state, source), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn helix_pinnacle_max_x_one_not_rejected() {
+        // Reach-guard: one mana available → max X = 1 → the ramp handles it, the
+        // gate stands down (proves the gate keys on live affordability, not on
+        // {X}-presence).
+        let mut state = base_state();
+        let source = activated_source(&mut state, "Helix Pinnacle", helix_ability());
+        add_pool(&mut state, AI, 1);
+        assert_not_reject(&verdict_for_activate(&state, source));
+    }
+
+    // --- Exsanguinate: chain-relative residual, THREE states (v3) ---------
+
+    #[test]
+    fn exsanguinate_max_x_zero_rejected_healthy() {
+        let mut state = base_state();
+        let (obj, card) = spell_source(
+            &mut state,
+            "Exsanguinate",
+            exsanguinate_ability(),
+            x_bb_manacost(),
+        );
+        assert_reject(&verdict_for_cast(&state, obj, card), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn exsanguinate_max_x_zero_rejected_life_critical() {
+        // Without the chain-aware handling, a low-life AI treats
+        // GainLife{PreviousEffectAmount} as a non-trivial residual (self_cost's
+        // GainLife arm is non-trivial when life-critical) and does NOT gate. The
+        // chain-relative branch keeps it gated.
+        let mut state = base_state();
+        state.players[AI.0 as usize].life = 3; // ai_life_critical (<= 5)
+        let (obj, card) = spell_source(
+            &mut state,
+            "Exsanguinate",
+            exsanguinate_ability(),
+            x_bb_manacost(),
+        );
+        assert_reject(&verdict_for_cast(&state, obj, card), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn exsanguinate_max_x_zero_rejected_stale_last_effect_amount() {
+        // A stale `last_effect_amount` above the lifegain ceiling would make the
+        // GainLife residual resolve non-trivially through effect_is_trivial. The
+        // chain-relative branch short-circuits that path, so it stays gated.
+        let mut state = base_state();
+        state.last_effect_amount = Some(10); // > TRIVIAL_LIFEGAIN_CEILING
+        let (obj, card) = spell_source(
+            &mut state,
+            "Exsanguinate",
+            exsanguinate_ability(),
+            x_bb_manacost(),
+        );
+        assert_reject(&verdict_for_cast(&state, obj, card), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn exsanguinate_max_x_one_not_rejected() {
+        // Reach-guard: {X}{B}{B} with three mana → max X = 1 → not gated.
+        let mut state = base_state();
+        let (obj, card) = spell_source(
+            &mut state,
+            "Exsanguinate",
+            exsanguinate_ability(),
+            x_bb_manacost(),
+        );
+        add_pool(&mut state, AI, 3);
+        assert_not_reject(&verdict_for_cast(&state, obj, card));
+    }
+
+    // --- Interleaved-chain negative: prev_was_x resets (guards over-gating) --
+
+    #[test]
+    fn interleaved_fixed_gain_then_prev_amount_not_gated() {
+        // LoseLife{X}, GainLife{Fixed 5}, Draw{PreviousEffectAmount}: the draw's
+        // PreviousEffectAmount is 5 (from the fixed gain), NOT X. The fixed
+        // GainLife{5} is a meaningful non-X residual (> the lifegain ceiling), so
+        // the gate stands down. Reverting the immediate-predecessor reset (treating
+        // "any prior X" as latching) would wrongly gate this.
+        let mut state = base_state();
+        let mut ability = spell(Effect::LoseLife {
+            amount: x_expr(),
+            target: None,
+        });
+        let mut draw = spell(Effect::Draw {
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::PreviousEffectAmount,
+            },
+            target: TargetFilter::Controller,
+        });
+        // (draw is the tail; gain is the middle)
+        draw.sub_ability = None;
+        let mut gain = spell(Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 5 },
+            player: TargetFilter::Controller,
+        });
+        gain.sub_ability = Some(Box::new(draw));
+        ability.sub_ability = Some(Box::new(gain));
+        let (obj, card) = spell_source(&mut state, "Interleaved", ability, x_bb_manacost());
+        assert_not_reject(&verdict_for_cast(&state, obj, card));
+    }
+
+    // --- Fixed-payoff {X}: references_any_x requirement (MEDIUM-HIGH) ------
+
+    #[test]
+    fn fixed_generic_keyword_grant_not_gated() {
+        // {X} ability whose only payoff is a FIXED non-X keyword grant (GenericEffect
+        // AddKeyword). effect_is_trivial treats it as trivial, but references_any_x is
+        // false → the gate stands down. Reverting the references_any_x requirement
+        // (gate whenever all effects are trivial) would REJECT this.
+        let mut state = base_state();
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }]);
+        let ability = activated(
+            Effect::GenericEffect {
+                static_abilities: vec![static_def],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+            },
+            x_only_cost(),
+        );
+        let source = activated_source(&mut state, "Fixed Grant", ability);
+        assert_not_reject(&verdict_for_activate(&state, source));
+    }
+
+    #[test]
+    fn x_referencing_rider_now_gated() {
+        // Positive reach-guard for the row above: with the rider's count referencing
+        // X (Draw{X} standing in for Token{Variable X} to avoid a 16-field Token
+        // literal — same references_any_x flip via the count-X arm), the gate now
+        // rejects. Proves the fixed-payoff stand-down is not vacuous.
+        let mut state = base_state();
+        let ability = activated(
+            Effect::Draw {
+                count: x_expr(),
+                target: TargetFilter::Controller,
+            },
+            x_only_cost(),
+        );
+        let source = activated_source(&mut state, "X Draw", ability);
+        assert_reject(&verdict_for_activate(&state, source), "x_cast_zero_no_op");
+    }
+
+    // --- RC1: Mirror Entity (CostXPaid) + Day of Black Sun (filter-CMC-X) --
+
+    #[test]
+    fn mirror_entity_max_x_zero_rejected() {
+        // Reaches the gate only via RC1: the GenericEffect-static arm of
+        // effect_references_x + expr_references_chosen_x recognising CostXPaid in
+        // SetPowerDynamic. Reverting either arm makes references_any_x false → not
+        // gated → this Reject fails. Gating avoids wiping the AI's board to 0/0.
+        let mut state = base_state();
+        let source = activated_source(&mut state, "Mirror Entity", mirror_entity_ability());
+        assert_reject(&verdict_for_activate(&state, source), "x_cast_zero_no_op");
+    }
+
+    #[test]
+    fn mirror_entity_max_x_one_not_rejected() {
+        let mut state = base_state();
+        let source = activated_source(&mut state, "Mirror Entity", mirror_entity_ability());
+        add_pool(&mut state, AI, 1);
+        assert_not_reject(&verdict_for_activate(&state, source));
+    }
+
+    #[test]
+    fn day_of_black_sun_max_x_zero_rejected() {
+        // Reaches the gate only via RC1: the GenericEffect-static arm +
+        // target_filter_references_x recognising FilterProp::Cmc{LE, X} in the
+        // granted static's AFFECTED subject filter. At X=0 the symmetric −X/−X wipe
+        // (here modeled as RemoveAllAbilities + Destroy of the empty X-filtered set)
+        // is a no-op. Reverting the affected-filter walk makes references_any_x false.
+        let mut state = base_state();
+        let (obj, card) = spell_source(
+            &mut state,
+            "Day of Black Sun",
+            day_of_black_sun_ability(),
+            x_bb_manacost(),
+        );
+        assert_reject(&verdict_for_cast(&state, obj, card), "x_cast_zero_no_op");
+    }
+
+    // --- Non-{X} cost: cheap short-circuit, never gated -------------------
+
+    #[test]
+    fn non_x_cost_activation_not_gated() {
+        // A fixed-cost activated ability (no {X} shard) short-circuits to None
+        // before the affordability sweep — the gate only ever fires on {X} costs.
+        let mut state = base_state();
+        let ability = activated(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            AbilityCost::Mana {
+                cost: ManaCost::generic(2),
+            },
+        );
+        let source = activated_source(&mut state, "Fixed Draw", ability);
+        assert_not_reject(&verdict_for_activate(&state, source));
+    }
+
+    // --- Multi-Spell-ability guard: conservative stand-down ---------------
+
+    #[test]
+    fn multi_spell_ability_object_not_gated() {
+        // Two Spell abilities on one object → we cannot know which resolves; the
+        // conservative guard declines to gate even at max X = 0.
+        let mut state = base_state();
+        let card_id = CardId(next_id());
+        let id = create_object(&mut state, card_id, AI, "Twin".to_string(), Zone::Hand);
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.mana_cost = x_bb_manacost();
+            *Arc::make_mut(&mut obj.abilities) = vec![
+                spell(Effect::LoseLife {
+                    amount: x_expr(),
+                    target: None,
+                }),
+                spell(Effect::GainLife {
+                    amount: x_expr(),
+                    player: TargetFilter::Controller,
+                }),
+            ];
+        }
+        assert_not_reject(&verdict_for_cast(&state, id, card_id));
+        let _ = OPP;
+    }
+
+    // --- ETB-X-counter creature: object_level_x + Some(cast_facts) branch ---
+
+    #[test]
+    fn etb_x_counter_creature_max_x_zero_rejected_via_object_level_x() {
+        // A Hangarback-shape {X}{X} creature that "enters with X +1/+1 counters"
+        // via a Moved→Battlefield SelfRef replacement. At max X = 0 it would
+        // enter as a 0/0 and die immediately — a guaranteed no-op → Reject.
+        //
+        // Unlike every other cast test (whose X payoff is a flat spell-ability
+        // effect), this fixture's X reference lives on the spell OBJECT's
+        // replacement, so the rejection is driven by `object_level_x`
+        // (`spell_object_references_x`) inside the `Some(cast_facts)` arm of
+        // `payoff_effects_and_x_ref` — the previously untested production path.
+        let mut state = base_state();
+        let (obj, card) = etb_x_counter_creature(&mut state);
+
+        // Verify by construction that this drives the Some(facts) branch and
+        // object_level_x, not the None fallback:
+        // - the ETB replacement is an immediate self-replacement, so the real
+        //   CastFacts (the constructor production uses) carries it, and the
+        //   Some(facts) arm sources effects from `immediate_replacements`;
+        // - `spell_object_references_x` sees the object-level X, so
+        //   `object_level_x` is true.
+        let facts = cast_facts_for_object(state.objects.get(&obj).unwrap());
+        assert_eq!(
+            facts.immediate_replacements.len(),
+            1,
+            "the ETB replacement must be an immediate self-replacement so the \
+             Some(cast_facts) branch sources it"
+        );
+        assert!(
+            x_reference::spell_object_references_x(&state, obj),
+            "object_level_x must be true — the X lives on the spell object's \
+             replacement, not its spell-ability effect"
+        );
+
+        // Revert-failing assertion: if the gate's spell-object X handling
+        // (Some(cast_facts) branch + object_level_x) is reverted, the NoOp
+        // spell ability carries no X and this flips to a non-reject.
+        assert_reject(
+            &verdict_for_cast_with_facts(&state, obj, card),
+            "x_cast_zero_no_op",
+        );
+    }
+
+    #[test]
+    fn etb_x_counter_creature_max_x_one_not_rejected() {
+        // Reach-guard for the row above: two mana → max X = 1 → the creature
+        // enters as a 1/1, a real body, so the gate stands down (proves the
+        // X=0 rejection is not vacuous). `max_x_value != 0` short-circuits
+        // before the payoff walk even runs.
+        let mut state = base_state();
+        let (obj, card) = etb_x_counter_creature(&mut state);
+        add_pool(&mut state, AI, 2);
+        assert_not_reject(&verdict_for_cast_with_facts(&state, obj, card));
+    }
+}

--- a/crates/phase-ai/src/policies/x_reference.rs
+++ b/crates/phase-ai/src/policies/x_reference.rs
@@ -1,0 +1,392 @@
+//! X-reference detection — the single authority for "does this spell/ability's
+//! payoff depend on the chosen X?", shared by the ramp policy (`x_value.rs`,
+//! which prefers max X) and the no-op gate (`x_cast_gate.rs`, which rejects a
+//! cast whose only affordable X is 0).
+//!
+//! All detectors walk an ability/effect/static tree and delegate the per-`QuantityExpr`
+//! test to the engine's single authority `QuantityExpr::contains_x`
+//! (`QuantityRef::Variable { name: "X" }`), extended here for two cast-context
+//! references the ramp/gate also treat as X-scaled:
+//!
+//! - `CostXPaid` (CR 107.3m) — the announced X after payment, carried on the
+//!   spell object. Dynamic P/T statics granted by `{X}` abilities (Mirror
+//!   Entity) reference X this way once on the stack.
+//! - the engine's `QuantityRef::PreviousEffectAmount` — the numeric result of
+//!   the immediately preceding chain effect. When that predecessor is itself
+//!   X-scaled, this is transitively 0 at X=0 (Exsanguinate's "gain life equal to
+//!   the life lost this way").
+//!
+//! Building for the class: the gate keys on these structural detectors, never a
+//! card name, so every {X}-cost spell/ability whose payoff scales with X is
+//! covered.
+
+use engine::types::ability::{
+    AbilityDefinition, ContinuousModification, Effect, FilterProp, QuantityExpr, QuantityRef,
+    ReplacementDefinition, StaticDefinition, TargetFilter, TriggerDefinition,
+};
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::statics::{HandSizeModification, StaticMode};
+
+/// True when the spell-object-on-stack's printed triggers or replacement
+/// effects reference X. Covers X-cost creature spells whose X is consumed by
+/// cast triggers or ETB replacements rather than the resolving spell effect
+/// itself — Hydroid Krasis ("when you cast this spell, you gain X life and
+/// draw X cards" + "enters as an X/X"), Genesis Hydra ("when you cast … look
+/// at the top X cards"), Hooded Hydra / Hangarback Walker (ETB-with-X-counter
+/// replacement on the creature itself). Without this, the AI would still pick
+/// X=0 for the entire Hydra / X-counter-ETB class because their X reference
+/// is structurally outside the resolving spell ability.
+pub(crate) fn spell_object_references_x(state: &GameState, object_id: ObjectId) -> bool {
+    let Some(obj) = state.objects.get(&object_id) else {
+        return false;
+    };
+    // Spell-cast triggers / dies / etc. on the stack object.
+    for trigger in obj.trigger_definitions.iter_unchecked() {
+        if let Some(exec) = &trigger.execute {
+            if ability_definition_references_x(exec) {
+                return true;
+            }
+        }
+    }
+    // ETB-X-counter and similar self-replacements stamped on the spell
+    // object (consumed when the permanent enters the battlefield).
+    for replacement in obj.replacement_definitions.iter_unchecked() {
+        if let Some(exec) = &replacement.execute {
+            if ability_definition_references_x(exec) {
+                return true;
+            }
+        }
+    }
+    // The printed abilities themselves may reference X via repeat_for /
+    // sub_ability chains (rare but cheap to scan).
+    for ability in obj.abilities.iter() {
+        if ability_definition_references_x(ability) {
+            return true;
+        }
+    }
+    // X-cost creatures can carry their payoff as static definitions instead
+    // of spell/trigger/replacement effects, e.g. dynamic P/T or granted
+    // ability/static payloads. Scan both live and printed baselines: live
+    // definitions may be layer-filtered, while base definitions are the
+    // authoritative printed shape for the stack object.
+    for static_def in obj.static_definitions.iter_unchecked() {
+        if static_definition_references_x(static_def) {
+            return true;
+        }
+    }
+    for static_def in obj.base_static_definitions.iter() {
+        if static_definition_references_x(static_def) {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn ability_definition_references_x(ability: &AbilityDefinition) -> bool {
+    if effect_references_x(&ability.effect) {
+        return true;
+    }
+    if let Some(expr) = &ability.repeat_for {
+        if expr.contains_x() {
+            return true;
+        }
+    }
+    if let Some(sub) = &ability.sub_ability {
+        if ability_definition_references_x(sub) {
+            return true;
+        }
+    }
+    if let Some(else_branch) = &ability.else_ability {
+        if ability_definition_references_x(else_branch) {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn static_definition_references_x(static_def: &StaticDefinition) -> bool {
+    static_mode_references_x(&static_def.mode)
+        || static_def
+            .modifications
+            .iter()
+            .any(continuous_modification_references_x)
+        // RC1: a granted static whose AFFECTED subject filter references X (Day
+        // of Black Sun — "each creature with mana value X or less") scales with
+        // X even though its modifications (RemoveAllAbilities) do not.
+        || static_def
+            .affected
+            .as_ref()
+            .is_some_and(target_filter_references_x)
+}
+
+fn static_mode_references_x(mode: &StaticMode) -> bool {
+    match mode {
+        StaticMode::MaximumHandSize {
+            modification: HandSizeModification::EqualTo(expr),
+        } => expr.contains_x(),
+        StaticMode::ModifyCost {
+            dynamic_count: Some(qty),
+            ..
+        }
+        | StaticMode::ReduceAbilityCost {
+            dynamic_count: Some(qty),
+            ..
+        } => quantity_ref_references_x(qty),
+        _ => false,
+    }
+}
+
+fn continuous_modification_references_x(modification: &ContinuousModification) -> bool {
+    match modification {
+        ContinuousModification::CopyValues { values, .. } => {
+            values.abilities.iter().any(ability_definition_references_x)
+                || values
+                    .trigger_definitions
+                    .iter()
+                    .any(trigger_definition_references_x)
+                || values
+                    .replacement_definitions
+                    .iter()
+                    .any(replacement_definition_references_x)
+                || values
+                    .static_definitions
+                    .iter()
+                    .any(static_definition_references_x)
+        }
+        ContinuousModification::GrantAbility { definition } => {
+            ability_definition_references_x(definition)
+        }
+        ContinuousModification::GrantTrigger { trigger } => {
+            trigger_definition_references_x(trigger)
+        }
+        ContinuousModification::GrantStaticAbility { definition } => {
+            static_definition_references_x(definition)
+        }
+        // RC1: dynamic P/T, keyword, and enter-counter magnitudes may reference
+        // the chosen X either directly (`Variable "X"`) or via `CostXPaid` (the
+        // announced X carried on the granting object — Mirror Entity's
+        // `SetPowerDynamic { CostXPaid }`). Route through `expr_references_chosen_x`
+        // so both forms are detected without touching the engine's `contains_x`.
+        ContinuousModification::SetDynamicPower { value }
+        | ContinuousModification::SetDynamicToughness { value }
+        | ContinuousModification::SetPowerDynamic { value }
+        | ContinuousModification::SetToughnessDynamic { value }
+        | ContinuousModification::AddDynamicPower { value }
+        | ContinuousModification::AddDynamicToughness { value }
+        | ContinuousModification::AddDynamicKeyword { value, .. }
+        | ContinuousModification::AddCounterOnEnter { count: value, .. } => {
+            expr_references_chosen_x(value)
+        }
+        ContinuousModification::SetName { .. }
+        | ContinuousModification::AddPower { .. }
+        | ContinuousModification::AddToughness { .. }
+        | ContinuousModification::SetPower { .. }
+        | ContinuousModification::SetToughness { .. }
+        | ContinuousModification::AddKeyword { .. }
+        | ContinuousModification::RemoveKeyword { .. }
+        | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
+        | ContinuousModification::RemoveAllAbilities
+        | ContinuousModification::AddType { .. }
+        | ContinuousModification::RemoveType { .. }
+        | ContinuousModification::AddSubtype { .. }
+        | ContinuousModification::RemoveSubtype { .. }
+        | ContinuousModification::SetCardTypes { .. }
+        | ContinuousModification::RemoveAllSubtypes { .. }
+        | ContinuousModification::AddAllCreatureTypes
+        | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddAllLandTypes
+        | ContinuousModification::AddChosenSubtype { .. }
+        | ContinuousModification::AddChosenColor
+        | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
+        | ContinuousModification::SetColor { .. }
+        | ContinuousModification::AddColor { .. }
+        | ContinuousModification::AddStaticMode { .. }
+        | ContinuousModification::SwitchPowerToughness
+        | ContinuousModification::AssignDamageFromToughness
+        | ContinuousModification::AssignDamageAsThoughUnblocked
+        | ContinuousModification::AssignNoCombatDamage
+        | ContinuousModification::ChangeController
+        | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::AddSupertype { .. }
+        | ContinuousModification::RemoveSupertype { .. }
+        | ContinuousModification::SetStartingLoyalty { .. }
+        | ContinuousModification::RemoveManaCost => false,
+    }
+}
+
+fn trigger_definition_references_x(trigger: &TriggerDefinition) -> bool {
+    trigger
+        .execute
+        .as_ref()
+        .is_some_and(|exec| ability_definition_references_x(exec))
+}
+
+fn replacement_definition_references_x(replacement: &ReplacementDefinition) -> bool {
+    replacement
+        .execute
+        .as_ref()
+        .is_some_and(|exec| ability_definition_references_x(exec))
+}
+
+fn quantity_ref_references_x(qty: &QuantityRef) -> bool {
+    matches!(qty, QuantityRef::Variable { name } if name == "X")
+}
+
+/// Walk every `QuantityExpr` reachable from `effect` and return true if any
+/// resolves through `QuantityRef::Variable { name: "X" }` (directly, wrapped,
+/// or — for granted statics — via `CostXPaid`) or through a subject/target
+/// filter whose `Cmc`/`Counters` threshold references X. Delegates the
+/// per-expression test to `QuantityExpr::contains_x`, the engine's single
+/// authority, so the AI scores X exactly as the engine evaluates it.
+pub(crate) fn effect_references_x(effect: &Effect) -> bool {
+    match effect {
+        Effect::DealDamage { amount, .. }
+        | Effect::DamageAll { amount, .. }
+        | Effect::DamageEachPlayer { amount, .. }
+        | Effect::GainLife { amount, .. }
+        | Effect::LoseLife { amount, .. } => amount.contains_x(),
+        Effect::Draw { count, .. }
+        | Effect::Mill { count, .. }
+        | Effect::Discard { count, .. }
+        | Effect::Scry { count, .. }
+        | Effect::Surveil { count, .. }
+        | Effect::Sacrifice { count, .. }
+        | Effect::Dig { count, .. }
+        | Effect::ExileTop { count, .. }
+        | Effect::PutAtLibraryPosition { count, .. }
+        | Effect::PutCounter { count, .. }
+        | Effect::PutCounterAll { count, .. }
+        | Effect::CopyTokenOf { count, .. }
+        | Effect::SearchLibrary { count, .. } => count.contains_x(),
+        Effect::Token {
+            count,
+            enter_with_counters,
+            ..
+        } => count.contains_x() || enter_with_counters.iter().any(|(_, qty)| qty.contains_x()),
+        // RC1: `GenericEffect` carries its X payoff inside granted static
+        // definitions (Mirror Entity's dynamic P/T via `CostXPaid`; Day of
+        // Black Sun's `RemoveAllAbilities` over an `X`-filtered subject) or in a
+        // top-level `Cmc`/`Counters`-X subject filter.
+        Effect::GenericEffect {
+            static_abilities,
+            target,
+            ..
+        } => {
+            static_abilities.iter().any(static_definition_references_x)
+                || target.as_ref().is_some_and(target_filter_references_x)
+        }
+        _ => false,
+    }
+}
+
+/// True when `effect`'s numeric amount/count references
+/// `QuantityRef::PreviousEffectAmount` — the result of the immediately
+/// preceding chain effect. Mirrors [`effect_references_x`]'s
+/// per-variant amount/count extraction. Used by the gate's chain-aware no-op
+/// walk to treat "gain life equal to the life lost this way" (Exsanguinate) as
+/// 0 at X=0 whenever its predecessor is X-scaled.
+pub(crate) fn effect_references_previous_amount(effect: &Effect) -> bool {
+    match effect {
+        Effect::DealDamage { amount, .. }
+        | Effect::DamageAll { amount, .. }
+        | Effect::DamageEachPlayer { amount, .. }
+        | Effect::GainLife { amount, .. }
+        | Effect::LoseLife { amount, .. } => expr_contains_previous_amount(amount),
+        Effect::Draw { count, .. }
+        | Effect::Mill { count, .. }
+        | Effect::Discard { count, .. }
+        | Effect::Scry { count, .. }
+        | Effect::Surveil { count, .. }
+        | Effect::Sacrifice { count, .. }
+        | Effect::Dig { count, .. }
+        | Effect::ExileTop { count, .. }
+        | Effect::PutAtLibraryPosition { count, .. }
+        | Effect::PutCounter { count, .. }
+        | Effect::PutCounterAll { count, .. }
+        | Effect::CopyTokenOf { count, .. }
+        | Effect::SearchLibrary { count, .. } => expr_contains_previous_amount(count),
+        Effect::Token {
+            count,
+            enter_with_counters,
+            ..
+        } => {
+            expr_contains_previous_amount(count)
+                || enter_with_counters
+                    .iter()
+                    .any(|(_, qty)| expr_contains_previous_amount(qty))
+        }
+        _ => false,
+    }
+}
+
+/// True when `expr` references the chosen X either as the on-stack
+/// `Variable { name: "X" }` (engine authority) or as the post-announcement
+/// `CostXPaid` (CR 107.3m) carried on the granting object.
+pub(crate) fn expr_references_chosen_x(expr: &QuantityExpr) -> bool {
+    expr.contains_x() || expr_matches_ref(expr, is_cost_x_paid)
+}
+
+fn expr_contains_previous_amount(expr: &QuantityExpr) -> bool {
+    expr_matches_ref(expr, is_previous_amount)
+}
+
+fn is_cost_x_paid(qty: &QuantityRef) -> bool {
+    matches!(qty, QuantityRef::CostXPaid)
+}
+
+fn is_previous_amount(qty: &QuantityRef) -> bool {
+    matches!(qty, QuantityRef::PreviousEffectAmount)
+}
+
+/// Structural recursion over a `QuantityExpr` tree, returning true if any leaf
+/// `Ref { qty }` satisfies `pred`. Mirrors the wrapper set walked by
+/// `QuantityExpr::contains_x` so a new `QuantityExpr` variant forces this to be
+/// reconsidered rather than silently returning false.
+fn expr_matches_ref(expr: &QuantityExpr, pred: fn(&QuantityRef) -> bool) -> bool {
+    match expr {
+        QuantityExpr::Ref { qty } => pred(qty),
+        QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::UpTo { max: inner }
+        | QuantityExpr::Power {
+            exponent: inner, ..
+        } => expr_matches_ref(inner, pred),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(|e| expr_matches_ref(e, pred))
+        }
+        QuantityExpr::Difference { left, right } => {
+            expr_matches_ref(left, pred) || expr_matches_ref(right, pred)
+        }
+        QuantityExpr::Fixed { .. } => false,
+    }
+}
+
+/// True when a subject/target filter's `Cmc` or `Counters` threshold references
+/// X (Day of Black Sun's "mana value X or less"). Walks `Not`/`Or`/`And`
+/// composition; other structural filters carry no numeric threshold.
+pub(crate) fn target_filter_references_x(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.properties.iter().any(filter_prop_references_x),
+        TargetFilter::Not { filter } => target_filter_references_x(filter),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_references_x)
+        }
+        _ => false,
+    }
+}
+
+fn filter_prop_references_x(prop: &FilterProp) -> bool {
+    match prop {
+        FilterProp::Cmc { value, .. } => value.contains_x(),
+        FilterProp::Counters { count, .. } => count.contains_x(),
+        _ => false,
+    }
+}

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -273,6 +273,7 @@ mod tests {
             config,
             context: ai_context,
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         }
     }
 
@@ -360,14 +361,15 @@ mod tests {
             })
             .collect();
 
-        let priors = PolicyRegistry::shared().priors(
-            &state,
-            &decision,
-            &candidates,
-            PlayerId(0),
-            &config,
-            &ai_context,
-        );
+        let env = crate::policies::context::PriorsEnv {
+            state: &state,
+            decision: &decision,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &ai_context,
+            search_depth: crate::policies::context::SearchDepth::Lookahead,
+        };
+        let priors = PolicyRegistry::shared().priors(&env, &candidates);
 
         let prior_zero = priors
             .iter()
@@ -480,14 +482,15 @@ mod tests {
             })
             .collect();
 
-        let priors = PolicyRegistry::shared().priors(
-            &state,
-            &decision,
-            &candidates,
-            PlayerId(0),
-            &config,
-            &ai_context,
-        );
+        let env = crate::policies::context::PriorsEnv {
+            state: &state,
+            decision: &decision,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &ai_context,
+            search_depth: crate::policies::context::SearchDepth::Lookahead,
+        };
+        let priors = PolicyRegistry::shared().priors(&env, &candidates);
 
         let prior_zero = priors
             .iter()
@@ -528,14 +531,15 @@ mod tests {
             })
             .collect();
 
-        let priors = PolicyRegistry::shared().priors(
-            &state,
-            &decision,
-            &candidates,
-            PlayerId(0),
-            &config,
-            &ai_context,
-        );
+        let env = crate::policies::context::PriorsEnv {
+            state: &state,
+            decision: &decision,
+            ai_player: PlayerId(0),
+            config: &config,
+            context: &ai_context,
+            search_depth: crate::policies::context::SearchDepth::Lookahead,
+        };
+        let priors = PolicyRegistry::shared().priors(&env, &candidates);
 
         let prior_zero = priors
             .iter()

--- a/crates/phase-ai/src/policies/x_value.rs
+++ b/crates/phase-ai/src/policies/x_value.rs
@@ -24,21 +24,17 @@
 //! Krasis), and counters-X (Reinforce X, Helix Pinnacle) all share this shape
 //! and all want a non-zero X when affordable.
 
-use engine::types::ability::{
-    AbilityDefinition, ContinuousModification, Effect, QuantityRef, ResolvedAbility,
-    StaticDefinition,
-};
+use engine::types::ability::ResolvedAbility;
 use engine::types::actions::GameAction;
 use engine::types::game_state::{GameState, WaitingFor};
-use engine::types::identifiers::ObjectId;
 use engine::types::player::PlayerId;
-use engine::types::statics::{HandSizeModification, StaticMode};
 
 use crate::features::DeckFeatures;
 
 use super::activation::turn_only;
 use super::context::PolicyContext;
 use super::registry::{DecisionKind, PolicyId, PolicyReason, PolicyVerdict, TacticalPolicy};
+use super::x_reference::{effect_references_x, spell_object_references_x};
 
 pub struct XValuePolicy;
 
@@ -123,237 +119,6 @@ fn ability_references_x(ability: &ResolvedAbility) -> bool {
     false
 }
 
-/// True when the spell-object-on-stack's printed triggers or replacement
-/// effects reference X. Covers X-cost creature spells whose X is consumed by
-/// cast triggers or ETB replacements rather than the resolving spell effect
-/// itself — Hydroid Krasis ("when you cast this spell, you gain X life and
-/// draw X cards" + "enters as an X/X"), Genesis Hydra ("when you cast … look
-/// at the top X cards"), Hooded Hydra / Hangarback Walker (ETB-with-X-counter
-/// replacement on the creature itself). Without this, the AI would still pick
-/// X=0 for the entire Hydra / X-counter-ETB class because their X reference
-/// is structurally outside the resolving spell ability.
-fn spell_object_references_x(state: &GameState, object_id: ObjectId) -> bool {
-    let Some(obj) = state.objects.get(&object_id) else {
-        return false;
-    };
-    // Spell-cast triggers / dies / etc. on the stack object.
-    for trigger in obj.trigger_definitions.iter_unchecked() {
-        if let Some(exec) = &trigger.execute {
-            if ability_definition_references_x(exec) {
-                return true;
-            }
-        }
-    }
-    // ETB-X-counter and similar self-replacements stamped on the spell
-    // object (consumed when the permanent enters the battlefield).
-    for replacement in obj.replacement_definitions.iter_unchecked() {
-        if let Some(exec) = &replacement.execute {
-            if ability_definition_references_x(exec) {
-                return true;
-            }
-        }
-    }
-    // The printed abilities themselves may reference X via repeat_for /
-    // sub_ability chains (rare but cheap to scan).
-    for ability in obj.abilities.iter() {
-        if ability_definition_references_x(ability) {
-            return true;
-        }
-    }
-    // X-cost creatures can carry their payoff as static definitions instead
-    // of spell/trigger/replacement effects, e.g. dynamic P/T or granted
-    // ability/static payloads. Scan both live and printed baselines: live
-    // definitions may be layer-filtered, while base definitions are the
-    // authoritative printed shape for the stack object.
-    for static_def in obj.static_definitions.iter_unchecked() {
-        if static_definition_references_x(static_def) {
-            return true;
-        }
-    }
-    for static_def in obj.base_static_definitions.iter() {
-        if static_definition_references_x(static_def) {
-            return true;
-        }
-    }
-    false
-}
-
-fn ability_definition_references_x(ability: &AbilityDefinition) -> bool {
-    if effect_references_x(&ability.effect) {
-        return true;
-    }
-    if let Some(expr) = &ability.repeat_for {
-        if expr.contains_x() {
-            return true;
-        }
-    }
-    if let Some(sub) = &ability.sub_ability {
-        if ability_definition_references_x(sub) {
-            return true;
-        }
-    }
-    if let Some(else_branch) = &ability.else_ability {
-        if ability_definition_references_x(else_branch) {
-            return true;
-        }
-    }
-    false
-}
-
-fn static_definition_references_x(static_def: &StaticDefinition) -> bool {
-    static_mode_references_x(&static_def.mode)
-        || static_def
-            .modifications
-            .iter()
-            .any(continuous_modification_references_x)
-}
-
-fn static_mode_references_x(mode: &StaticMode) -> bool {
-    match mode {
-        StaticMode::MaximumHandSize {
-            modification: HandSizeModification::EqualTo(expr),
-        } => expr.contains_x(),
-        StaticMode::ModifyCost {
-            dynamic_count: Some(qty),
-            ..
-        }
-        | StaticMode::ReduceAbilityCost {
-            dynamic_count: Some(qty),
-            ..
-        } => quantity_ref_references_x(qty),
-        _ => false,
-    }
-}
-
-fn continuous_modification_references_x(modification: &ContinuousModification) -> bool {
-    match modification {
-        ContinuousModification::CopyValues { values, .. } => {
-            values.abilities.iter().any(ability_definition_references_x)
-                || values
-                    .trigger_definitions
-                    .iter()
-                    .any(trigger_definition_references_x)
-                || values
-                    .replacement_definitions
-                    .iter()
-                    .any(replacement_definition_references_x)
-                || values
-                    .static_definitions
-                    .iter()
-                    .any(static_definition_references_x)
-        }
-        ContinuousModification::GrantAbility { definition } => {
-            ability_definition_references_x(definition)
-        }
-        ContinuousModification::GrantTrigger { trigger } => {
-            trigger_definition_references_x(trigger)
-        }
-        ContinuousModification::GrantStaticAbility { definition } => {
-            static_definition_references_x(definition)
-        }
-        ContinuousModification::SetDynamicPower { value }
-        | ContinuousModification::SetDynamicToughness { value }
-        | ContinuousModification::SetPowerDynamic { value }
-        | ContinuousModification::SetToughnessDynamic { value }
-        | ContinuousModification::AddDynamicPower { value }
-        | ContinuousModification::AddDynamicToughness { value }
-        | ContinuousModification::AddDynamicKeyword { value, .. }
-        | ContinuousModification::AddCounterOnEnter { count: value, .. } => value.contains_x(),
-        ContinuousModification::SetName { .. }
-        | ContinuousModification::AddPower { .. }
-        | ContinuousModification::AddToughness { .. }
-        | ContinuousModification::SetPower { .. }
-        | ContinuousModification::SetToughness { .. }
-        | ContinuousModification::AddKeyword { .. }
-        | ContinuousModification::RemoveKeyword { .. }
-        | ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
-        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
-        | ContinuousModification::RemoveAllAbilities
-        | ContinuousModification::AddType { .. }
-        | ContinuousModification::RemoveType { .. }
-        | ContinuousModification::AddSubtype { .. }
-        | ContinuousModification::RemoveSubtype { .. }
-        | ContinuousModification::SetCardTypes { .. }
-        | ContinuousModification::RemoveAllSubtypes { .. }
-        | ContinuousModification::AddAllCreatureTypes
-        | ContinuousModification::AddAllBasicLandTypes
-        | ContinuousModification::AddAllLandTypes
-        | ContinuousModification::AddChosenSubtype { .. }
-        | ContinuousModification::AddChosenColor
-        | ContinuousModification::RemoveChosenKeyword
-        | ContinuousModification::AddChosenKeyword
-        | ContinuousModification::SetColor { .. }
-        | ContinuousModification::AddColor { .. }
-        | ContinuousModification::AddStaticMode { .. }
-        | ContinuousModification::SwitchPowerToughness
-        | ContinuousModification::AssignDamageFromToughness
-        | ContinuousModification::AssignDamageAsThoughUnblocked
-        | ContinuousModification::AssignNoCombatDamage
-        | ContinuousModification::ChangeController
-        | ContinuousModification::SetBasicLandType { .. }
-        | ContinuousModification::SetChosenBasicLandType
-        | ContinuousModification::RetainPrintedTriggerFromSource { .. }
-        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
-        | ContinuousModification::AddSupertype { .. }
-        | ContinuousModification::RemoveSupertype { .. }
-        | ContinuousModification::SetStartingLoyalty { .. }
-        | ContinuousModification::RemoveManaCost => false,
-    }
-}
-
-fn trigger_definition_references_x(trigger: &engine::types::ability::TriggerDefinition) -> bool {
-    trigger
-        .execute
-        .as_ref()
-        .is_some_and(|exec| ability_definition_references_x(exec))
-}
-
-fn replacement_definition_references_x(
-    replacement: &engine::types::ability::ReplacementDefinition,
-) -> bool {
-    replacement
-        .execute
-        .as_ref()
-        .is_some_and(|exec| ability_definition_references_x(exec))
-}
-
-fn quantity_ref_references_x(qty: &QuantityRef) -> bool {
-    matches!(qty, QuantityRef::Variable { name } if name == "X")
-}
-
-/// Walk every `QuantityExpr` reachable from `effect` and return true if any
-/// resolves through `QuantityRef::Variable { name: "X" }`. Delegates the
-/// per-expression test to `QuantityExpr::contains_x`, the engine's single
-/// authority, so the AI scores X exactly as the engine evaluates it.
-fn effect_references_x(effect: &Effect) -> bool {
-    match effect {
-        Effect::DealDamage { amount, .. }
-        | Effect::DamageAll { amount, .. }
-        | Effect::DamageEachPlayer { amount, .. }
-        | Effect::GainLife { amount, .. }
-        | Effect::LoseLife { amount, .. } => amount.contains_x(),
-        Effect::Draw { count, .. }
-        | Effect::Mill { count, .. }
-        | Effect::Discard { count, .. }
-        | Effect::Scry { count, .. }
-        | Effect::Surveil { count, .. }
-        | Effect::Sacrifice { count, .. }
-        | Effect::Dig { count, .. }
-        | Effect::ExileTop { count, .. }
-        | Effect::PutAtLibraryPosition { count, .. }
-        | Effect::PutCounter { count, .. }
-        | Effect::PutCounterAll { count, .. }
-        | Effect::CopyTokenOf { count, .. }
-        | Effect::SearchLibrary { count, .. } => count.contains_x(),
-        Effect::Token {
-            count,
-            enter_with_counters,
-            ..
-        } => count.contains_x() || enter_with_counters.iter().any(|(_, qty)| qty.contains_x()),
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,7 +126,8 @@ mod tests {
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
     use engine::game::scenario::{GameScenario, P0};
     use engine::types::ability::{
-        Effect as AbilityEffect, QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter,
+        ContinuousModification, Effect as AbilityEffect, QuantityExpr, QuantityRef,
+        ResolvedAbility, StaticDefinition, TargetFilter,
     };
     use engine::types::game_state::{CastPaymentMode, PendingCast};
     use engine::types::identifiers::{CardId, ObjectId};

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -30,7 +30,7 @@ use crate::planner::{
     apply_candidate, BeamContinuationPlanner, ContinuationPlanner, PlannerServices,
     RankedCandidate, SearchBudget,
 };
-use crate::policies::context::PolicyContext;
+use crate::policies::context::{PolicyContext, SearchDepth};
 use crate::policies::copy_value::score_legend_rule_keep;
 use crate::policies::tutor::{score_search_choice_cards, score_search_choice_selection};
 use crate::policies::{PolicyId, PolicyRegistry, PolicyVerdict};
@@ -603,6 +603,8 @@ pub fn emit_trace_for_candidate(
         config,
         context,
         cast_facts,
+        // The decision trace reflects the committed (root) decision.
+        search_depth: SearchDepth::Root,
     };
     let verdicts = policies.verdicts(&policy_ctx);
 
@@ -1783,7 +1785,13 @@ fn score_candidates_core(
         let mut ranked: Vec<RankedCandidate> = gated
             .iter()
             .map(|g| {
-                let tactical = services.tactical_score(state, &ctx, &g.candidate, ai_player);
+                let tactical = services.tactical_score(
+                    state,
+                    &ctx,
+                    &g.candidate,
+                    ai_player,
+                    SearchDepth::Root,
+                );
                 RankedCandidate {
                     candidate: g.candidate.clone(),
                     score: tactical + g.penalty,
@@ -1883,8 +1891,13 @@ fn score_candidates_core(
         let mut out: Vec<_> = gated
             .into_iter()
             .map(|candidate| {
-                let score = services.tactical_score(state, &ctx, &candidate.candidate, ai_player)
-                    + candidate.penalty;
+                let score = services.tactical_score(
+                    state,
+                    &ctx,
+                    &candidate.candidate,
+                    ai_player,
+                    SearchDepth::Root,
+                ) + candidate.penalty;
                 (candidate.candidate.action, score)
             })
             .collect();
@@ -2914,6 +2927,97 @@ mod tests {
         let via_wrapper = score_candidates_with_session(&state, PlayerId(0), &config, &session);
         let via_core = score_candidates_core(&state, PlayerId(0), &config, &session, None);
         assert_eq!(via_wrapper, via_core);
+    }
+
+    /// Battlefield permanent carrying a single Helix-shape `{X}` activated
+    /// ability ("{X}: put X tower counters on ~" — scales with X, a no-op at
+    /// X=0). Returns the source ObjectId; the sole ability is index 0.
+    fn add_helix_x_ability(state: &mut GameState, owner: PlayerId) -> ObjectId {
+        let id = add_creature(state, owner, 1, 1);
+        let mut ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::PutCounter {
+                counter_type: CounterType::Generic("tower".to_string()),
+                count: QuantityExpr::Ref {
+                    qty: engine::types::ability::QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target: TargetFilter::SelfRef,
+            },
+        );
+        ability.cost = Some(engine::types::ability::AbilityCost::Mana {
+            cost: engine::types::mana::ManaCost::Cost {
+                shards: vec![engine::types::mana::ManaCostShard::X],
+                generic: 0,
+            },
+        });
+        *Arc::make_mut(&mut state.objects.get_mut(&id).unwrap().abilities) = vec![ability];
+        id
+    }
+
+    fn activate_score(scored: &[(GameAction, f64)], source: ObjectId) -> Option<f64> {
+        scored.iter().find_map(|(action, score)| match action {
+            GameAction::ActivateAbility { source_id, .. } if *source_id == source => Some(*score),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn xcast_zero_no_op_not_committed_at_root() {
+        // Claim C (end-to-end, discriminating): at the real committed-decision
+        // seam (`score_candidates_core`), a Helix-shape {X} activation whose only
+        // affordable X is 0 (zero mana) must NOT be the committed argmax. The root
+        // gate scores it `NEG_INFINITY`, so `Pass` (always a Priority candidate)
+        // outranks it. Reverting the Root gate lets the X=0 activation score finite
+        // and possibly win → the "not finite / not argmax" assertions flip.
+        let mut state = make_state();
+        let source = add_helix_x_ability(&mut state, PlayerId(0)); // zero mana → max X = 0
+        let config = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(1);
+        let session = AiSession::arc_from_game(&state);
+        let scored = score_candidates_core(&state, PlayerId(0), &config, &session, None);
+
+        // Non-vacuous reach-guard: the activation candidate is actually present in
+        // the scored set (candidate generation produced the X=0 activation — the
+        // exact commitment the gate exists to stop), so the assertion below is not
+        // silently satisfied by an absent candidate.
+        let score = activate_score(&scored, source)
+            .expect("the {X}=0 activation must be an enumerated, scored candidate");
+        assert!(
+            !score.is_finite(),
+            "root gate must reject the X=0 no-op activation (got finite score {score})"
+        );
+
+        // It is therefore not the argmax — some other action (Pass) wins.
+        let best = scored
+            .iter()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal))
+            .map(|(action, _)| action.clone());
+        assert!(
+            !matches!(best, Some(GameAction::ActivateAbility { source_id, .. }) if source_id == source),
+            "the X=0 no-op activation must not be the committed decision"
+        );
+    }
+
+    #[test]
+    fn xcast_affordable_activation_committed_at_root() {
+        // Reach-guard sibling (non-vacuous): the IDENTICAL Helix fixture with
+        // enough mana for X >= 1 lets the gate stand down, so the activation scores
+        // FINITE and is a legitimate candidate. Proves the refusal above is
+        // affordability-driven, not a blanket suppression of the activation.
+        let mut state = make_state();
+        let source = add_helix_x_ability(&mut state, PlayerId(0));
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1); // max X = 1
+        let config = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(1);
+        let session = AiSession::arc_from_game(&state);
+        let scored = score_candidates_core(&state, PlayerId(0), &config, &session, None);
+
+        let score = activate_score(&scored, source)
+            .expect("the {X} activation must be an enumerated, scored candidate");
+        assert!(
+            score.is_finite(),
+            "with X >= 1 affordable the gate stands down; activation must score finite"
+        );
     }
 
     #[test]
@@ -4028,6 +4132,7 @@ mod tests {
             config: &AiConfig::default(),
             context: &crate::context::AiContext::empty(&AiConfig::default().weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
         let opp_score = policies.score(&PolicyContext {
             state: &state,
@@ -4037,6 +4142,7 @@ mod tests {
             config: &AiConfig::default(),
             context: &crate::context::AiContext::empty(&AiConfig::default().weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         });
         assert!(self_score < opp_score);
         assert!(self_score < -50.0);

--- a/crates/phase-ai/src/tactical_gate.rs
+++ b/crates/phase-ai/src/tactical_gate.rs
@@ -116,6 +116,7 @@ pub fn gate_candidates(
                     config,
                     context,
                     cast_facts: None,
+                    search_depth: crate::policies::context::SearchDepth::Root,
                 };
                 assess_candidate(&policy_ctx)
             };
@@ -737,6 +738,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
@@ -795,6 +797,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_ne!(assess_candidate(&ctx), GateDecision::Reject);
@@ -869,6 +872,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(
@@ -942,6 +946,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
 
         assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
@@ -1011,6 +1016,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
     }
@@ -1034,6 +1040,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         assert_ne!(assess_candidate(&ctx), GateDecision::Reject);
     }
@@ -1061,6 +1068,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         assert_eq!(assess_candidate(&ctx), GateDecision::Reject);
     }
@@ -1087,6 +1095,7 @@ mod tests {
             config: &config,
             context: &AiContext::empty(&config.weights),
             cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
         };
         assert_ne!(assess_candidate(&ctx), GateDecision::Reject);
     }


### PR DESCRIPTION
Batch of AI tactical-policy correctness + performance work (squashes to one commit on `main`). Cherry-picked in dependency order onto `origin/main`.

### Legality / correctness (Wave-1 AI-suggestions triage)
- **test(engine)**: lock in rules-correct behavior for AI-reported legality cases
- **feat(ai)**: veto net-negative self-cost ability activations
- **feat(ai)**: fix effect-valence target selection for grant/copy/mill
- **feat(ai)**: veto committing to X-cost casts whose only legal X is 0 (introduces `XCastGatePolicy`)

### Performance
- **perf(ai)**: gate `x_cast_gate` affordability sweep on AI search depth — `XCastGatePolicy::verdict()` called the board-wide `max_x_value` sweep per candidate at every search node (~2.1s → ~5.7s on a large late-game board). Adds typed `SearchDepth { Root, Lookahead }` + `at_root()`, gates the sweep to root nodes only (rules-correct per CR 601.2b/f: the committed action is the root argmax, and `Reject → NEG_INFINITY` can't be rescued by any finite lookahead). Commutative reorder runs the card-local no-op walk before the board-wide sweep.
- **docs(ai)**: codify the `verdict()`-is-the-search-inner-loop perf constraint in the `add-ai-feature-policy` skill.

### Verification
- `cargo ai-gate`: **PASS** (exit 0) — no win-rate regression.
- `cargo ai-perf-gate`: FAIL on 6 engine counters, verified **pre-existing baseline drift** (fails identically at the pre-change base commit; the frozen `perf-baseline.json` predates engine PRs #5022/#5003/#160 and a card-data regen — the gate itself flags the card-data hash mismatch). No new failing counters introduced by this change.

Note: the engine `perf-baseline.json` is stale and should be refreshed separately by the perf-gate owner.
