### PR TITLE
Add Sylvan Echoes

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8210,16 +8210,18 @@ fn scoped_player_matches_filter(
 
 fn event_outcome_was_won_by_controller(event: &GameEvent, controller: PlayerId) -> bool {
     match event {
+        // CR 701.30d: reuse the shared controller-relative clash-outcome
+        // resolution so resolution-time "if you won" gating and trigger-matching
+        // (`match_clash`) agree on who won.
         GameEvent::Clash {
             controller: clash_controller,
             opponent,
             result,
             ..
-        } => match result {
-            crate::types::events::ClashResult::Won => *clash_controller == controller,
-            crate::types::events::ClashResult::Lost => *opponent == controller,
-            crate::types::events::ClashResult::Tied => false,
-        },
+        } => {
+            result.for_player(*clash_controller, *opponent, controller)
+                == Some(crate::types::events::ClashResult::Won)
+        }
         GameEvent::CoinFlipped { player_id, won } => *player_id == controller && *won,
         _ => false,
     }

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -3725,23 +3725,48 @@ pub(super) fn match_ring_tempts_you(
 /// Fires when a clash occurs and either clashing player matches `valid_target`.
 /// "Whenever you clash" sets `valid_target = Controller`; a generic "whenever
 /// a player clashes" leaves `valid_target` unset to match any clash.
+///
+/// CR 701.30d + CR 603.4: when the trigger carries a required clash outcome
+/// (`clash_result`, set for "...and win" cards like Sylvan Echoes), the win
+/// requirement is checked HERE, when the event occurs — so a lost or tied clash
+/// never creates a pending (no-op) trigger. The outcome is resolved from the
+/// ability's controller's perspective via `ClashResult::for_player`, the same
+/// source of truth used by resolution-time "if you won" gating
+/// (`event_outcome_was_won_by_controller`), so matching and resolution agree.
 pub(super) fn match_clash(
     event: &GameEvent,
     trigger: &TriggerDefinition,
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    match event {
-        GameEvent::Clash {
-            controller,
-            opponent,
-            ..
-        } => {
-            valid_player_matches(trigger, state, *controller, source_id)
-                || valid_player_matches(trigger, state, *opponent, source_id)
-        }
-        _ => false,
+    let GameEvent::Clash {
+        controller,
+        opponent,
+        result,
+        ..
+    } = event
+    else {
+        return false;
+    };
+    // Either clashing player must satisfy `valid_target` ("you clash" → the
+    // source's controller; a bare "a player clashes" → any player).
+    if !(valid_player_matches(trigger, state, *controller, source_id)
+        || valid_player_matches(trigger, state, *opponent, source_id))
+    {
+        return false;
     }
+    // CR 701.30d: an "...and win" trigger only fires when the ABILITY's
+    // controller won the clash. `None` (plain "you clash") fires on any outcome.
+    if let Some(required) = trigger.clash_result {
+        let Some(ability_controller) = state.objects.get(&source_id).map(|obj| obj.controller)
+        else {
+            return false;
+        };
+        if result.for_player(*controller, *opponent, ability_controller) != Some(required) {
+            return false;
+        }
+    }
+    true
 }
 
 /// CR 701.38: Match vote-resolved events.
@@ -4508,7 +4533,7 @@ mod tests {
         TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::CoreType;
-    use crate::types::events::{GameEvent, ManaTapState, PlayerActionKind};
+    use crate::types::events::{ClashResult, GameEvent, ManaTapState, PlayerActionKind};
     use crate::types::game_state::{
         CastingVariant, GameState, StackEntry, StackEntryKind, ZoneChangeRecord,
     };
@@ -13438,6 +13463,112 @@ mod tests {
         assert!(
             match_clash(&event2, &trigger, source, &state),
             "clash trigger must fire when controller is the opponent participant"
+        );
+    }
+
+    /// CR 701.30d + CR 603.4: "Whenever you clash AND WIN" (Sylvan Echoes) carries
+    /// the win requirement into MATCHING via `clash_result = Some(Won)`. A lost or
+    /// tied clash must NOT match, so no pending (no-op) trigger is ever placed on
+    /// the stack — the win requirement is checked when the event occurs, not at
+    /// resolution. Only a clash the source's controller WON matches (and the
+    /// trigger's plain optional draw then resolves). Mirrors
+    /// `clash_trigger_fires_for_controller` but for the win-gated shape.
+    #[test]
+    fn clash_and_win_trigger_only_matches_on_controller_win() {
+        let mut state = setup();
+        // Sylvan Echoes is controlled by P0.
+        let source = create_object(
+            &mut state,
+            CardId(702),
+            PlayerId(0),
+            "Sylvan Echoes".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = make_trigger(TriggerMode::Clashed);
+        trigger.valid_target = Some(TargetFilter::Controller);
+        trigger.clash_result = Some(ClashResult::Won);
+
+        let clash =
+            |controller: PlayerId, opponent: PlayerId, result: ClashResult| GameEvent::Clash {
+                controller,
+                opponent,
+                controller_mana_value: None,
+                opponent_mana_value: None,
+                result,
+            };
+
+        // P0 initiated and WON — the only case that creates a pending trigger.
+        assert!(
+            match_clash(
+                &clash(PlayerId(0), PlayerId(1), ClashResult::Won),
+                &trigger,
+                source,
+                &state
+            ),
+            "must match when the controller (P0) won the clash they initiated"
+        );
+        // P0 was the chosen opponent and WON (controller P1 lost) — still a win
+        // for P0, so it matches.
+        assert!(
+            match_clash(
+                &clash(PlayerId(1), PlayerId(0), ClashResult::Lost),
+                &trigger,
+                source,
+                &state
+            ),
+            "must match when the controller (P0) won as the opponent participant"
+        );
+
+        // P0 LOST — no pending trigger.
+        assert!(
+            !match_clash(
+                &clash(PlayerId(0), PlayerId(1), ClashResult::Lost),
+                &trigger,
+                source,
+                &state
+            ),
+            "must NOT match a clash the controller lost"
+        );
+        assert!(
+            !match_clash(
+                &clash(PlayerId(1), PlayerId(0), ClashResult::Won),
+                &trigger,
+                source,
+                &state
+            ),
+            "must NOT match when the controller lost as the opponent participant"
+        );
+        // TIED — no pending trigger for either seating.
+        assert!(
+            !match_clash(
+                &clash(PlayerId(0), PlayerId(1), ClashResult::Tied),
+                &trigger,
+                source,
+                &state
+            ),
+            "must NOT match a tied clash"
+        );
+        assert!(
+            !match_clash(
+                &clash(PlayerId(1), PlayerId(0), ClashResult::Tied),
+                &trigger,
+                source,
+                &state
+            ),
+            "must NOT match a tied clash regardless of seating"
+        );
+
+        // Regression: the plain "you clash" shape (clash_result = None) still
+        // fires on any outcome, including a loss.
+        trigger.clash_result = None;
+        assert!(
+            match_clash(
+                &clash(PlayerId(1), PlayerId(0), ClashResult::Won),
+                &trigger,
+                source,
+                &state
+            ),
+            "a plain clash trigger must still fire on any outcome"
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -48,7 +48,7 @@ use crate::types::ability::{
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
-use crate::types::events::PlayerActionKind;
+use crate::types::events::{ClashResult, PlayerActionKind};
 use crate::types::mana::{ManaColor, ManaType};
 use crate::types::phase::Phase;
 use crate::types::triggers::{AttackTargetFilter, TriggerMode};
@@ -12348,17 +12348,46 @@ fn try_parse_player_trigger(lower: &str) -> Option<(TriggerMode, TriggerDefiniti
     // CR 701.30b-c: "whenever you clash" fires when the controller of the
     // trigger source is either player participating in a clash.
     // Cards: Entangling Trap, Rebellion of the Flamekin.
-    if all_consuming(preceded(
+    //
+    // CR 701.30d + CR 603.4: an optional "...and win" tail (Sylvan Echoes)
+    // narrows the trigger so it fires ONLY when the controller won the clash.
+    // The win requirement rides on `clash_result` into trigger MATCHING (checked
+    // when the clash event occurs), so a lost or tied clash never creates a
+    // pending trigger — rather than gating the effect at resolution.
+    if let Ok((tail, ())) = preceded(
         alt((tag::<_, _, OracleError<'_>>("whenever "), tag("when "))),
         value((), (tag("you"), space1, tag("clash"))),
-    ))
+    )
     .parse(lower)
-    .is_ok()
     {
-        let mut def = make_base();
-        def.mode = TriggerMode::Clashed;
-        def.valid_target = Some(TargetFilter::Controller);
-        return Some((TriggerMode::Clashed, def));
+        // Empty residual = plain "you clash" (any outcome). A " and win" residual
+        // = the win-required shape (Sylvan Echoes). Any other residual is a
+        // different clause we decline so a later dispatcher can try it.
+        let clash_result = if tail.is_empty() {
+            Some(None)
+        } else if all_consuming(value(
+            (),
+            (
+                space1,
+                tag::<_, _, OracleError<'_>>("and"),
+                space1,
+                tag("win"),
+            ),
+        ))
+        .parse(tail)
+        .is_ok()
+        {
+            Some(Some(ClashResult::Won))
+        } else {
+            None
+        };
+        if let Some(clash_result) = clash_result {
+            let mut def = make_base();
+            def.mode = TriggerMode::Clashed;
+            def.valid_target = Some(TargetFilter::Controller);
+            def.clash_result = clash_result;
+            return Some((TriggerMode::Clashed, def));
+        }
     }
 
     // CR 701.30: "whenever a player clashes" — fires for any clashing player.

--- a/crates/engine/src/parser/oracle_trigger_snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_snapshot_tests.rs
@@ -1,5 +1,6 @@
 use crate::parser::oracle_nom::quantity::parse_quantity_ref;
 use crate::types::ability::AbilityCondition;
+use crate::types::events::ClashResult;
 
 use super::*;
 
@@ -862,6 +863,69 @@ fn trigger_a_player_clashes() {
     let def = parse_trigger_line("Whenever a player clashes, draw a card.", "Clash Watcher");
     assert_eq!(def.mode, TriggerMode::Clashed);
     assert_eq!(def.valid_target, None);
+    assert_eq!(def.clash_result, None, "generic clash is not win-gated");
+}
+
+/// CR 701.30 + CR 701.30d: "Whenever you clash and win" is a clash trigger whose
+/// win requirement is carried into MATCHING via `clash_result = Some(Won)` (an
+/// intervening-if checked when the event occurs, CR 603.4), NOT a resolution-time
+/// gate. So a lost or tied clash never creates a pending trigger, and the "you may
+/// draw a card" effect is a plain OPTIONAL draw with NO `EventOutcomeWon`
+/// condition (Sylvan Echoes). Before support this clause fell through to
+/// `TriggerMode::Unknown`.
+#[test]
+fn trigger_you_clash_and_win_whenever() {
+    let def = parse_trigger_line(
+        "Whenever you clash and win, you may draw a card. (This ability triggers after the clash ends.)",
+        "Sylvan Echoes",
+    );
+    assert_eq!(def.mode, TriggerMode::Clashed);
+    assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    assert_eq!(
+        def.clash_result,
+        Some(ClashResult::Won),
+        "the win requirement must live on the trigger's clash_result so MATCHING is gated"
+    );
+    let Some(execute) = def.execute.as_deref() else {
+        panic!("expected trigger body");
+    };
+    assert!(
+        matches!(execute.effect.as_ref(), Effect::Draw { .. }),
+        "expected a draw effect, got {:?}",
+        execute.effect
+    );
+    assert_eq!(
+        execute.condition, None,
+        "the effect must carry NO resolution-time EventOutcomeWon gate; the win \
+         requirement is enforced in trigger matching via clash_result"
+    );
+    assert!(execute.optional, "the 'you may' draw is optional");
+}
+
+/// Regression: the plain "Whenever you clash" siblings (Entangling Trap) carry no
+/// win requirement, so `clash_result` stays `None` (fires on any clash) — the head
+/// effect stays ungated and only the separate "If you won" sentence gates its own
+/// sub-ability.
+#[test]
+fn trigger_you_clash_head_effect_not_win_gated() {
+    let def = parse_trigger_line(
+        "Whenever you clash, tap target creature an opponent controls. If you won, that creature doesn't untap during its controller's next untap step.",
+        "Entangling Trap",
+    );
+    assert_eq!(def.mode, TriggerMode::Clashed);
+    assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    assert_eq!(
+        def.clash_result, None,
+        "a plain 'you clash' trigger fires on any clash outcome"
+    );
+    let Some(execute) = def.execute.as_deref() else {
+        panic!("expected trigger body");
+    };
+    assert_eq!(execute.condition, None, "head effect must not be win-gated");
+    let Some(tail) = execute.sub_ability.as_deref() else {
+        panic!("expected if-you-won tail");
+    };
+    assert_eq!(tail.condition, Some(AbilityCondition::EventOutcomeWon));
 }
 
 /// CR 602.1 + CR 605.1a: Passive form — "whenever an ability of equipped creature

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -27,7 +27,7 @@ use super::stickers::{AppliedSticker, StickerKind};
 use super::triggers::TriggerMode;
 use super::zones::{EtbTapState, Zone};
 use crate::game::game_object::DisplaySource;
-use crate::types::events::PlayerActionKind;
+use crate::types::events::{ClashResult, PlayerActionKind};
 
 // ---------------------------------------------------------------------------
 // Supporting types
@@ -16365,6 +16365,17 @@ pub struct TriggerDefinition {
     /// mana type (the "for mana" form). Ignored by other trigger modes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub taps_for_mana_produced: Option<Vec<ManaType>>,
+    /// CR 701.30d + CR 603.4: Required clash outcome for "Whenever you clash and
+    /// win" triggers (Sylvan Echoes). `Some(ClashResult::Won)` narrows the trigger
+    /// so it MATCHES only when the ability's controller WON the clash — the win
+    /// requirement is checked when the clash event occurs (an intervening-if
+    /// per CR 603.4), so a lost or tied clash never creates a pending (no-op)
+    /// trigger. `None` is the plain "whenever you clash" shape (Entangling Trap)
+    /// that fires on any clash outcome. The clash sibling of `coin_flip_result`;
+    /// interpreted relative to the ability's controller, not the event's clash
+    /// controller (see `ClashResult::for_player` / `match_clash`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clash_result: Option<ClashResult>,
 }
 
 impl TriggerDefinition {
@@ -16402,6 +16413,7 @@ impl TriggerDefinition {
             coin_flip_result: None,
             die_result: None,
             taps_for_mana_produced: None,
+            clash_result: None,
         }
     }
 
@@ -19146,6 +19158,7 @@ mod tests {
             coin_flip_result: None,
             die_result: None,
             taps_for_mana_produced: None,
+            clash_result: None,
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -116,6 +116,36 @@ pub enum ClashResult {
     Tied,
 }
 
+impl ClashResult {
+    /// CR 701.30d: A clash's `result` is stated from the clash controller's
+    /// perspective (the player who initiated the clash). Re-express it from
+    /// `player`'s perspective, returning `None` if `player` did not participate.
+    /// The controller sees `self`; the opponent sees the mirror (Won ⇄ Lost, Tied
+    /// unchanged).
+    ///
+    /// Single source of truth shared by resolution-time "if you won" gating
+    /// (`event_outcome_was_won_by_controller`) and trigger MATCHING
+    /// (`match_clash`'s `clash_result` gate) so both agree on who won.
+    pub fn for_player(
+        self,
+        clash_controller: PlayerId,
+        opponent: PlayerId,
+        player: PlayerId,
+    ) -> Option<ClashResult> {
+        if player == clash_controller {
+            Some(self)
+        } else if player == opponent {
+            Some(match self {
+                ClashResult::Won => ClashResult::Lost,
+                ClashResult::Lost => ClashResult::Won,
+                ClashResult::Tied => ClashResult::Tied,
+            })
+        } else {
+            None
+        }
+    }
+}
+
 /// CR 103.1 / CR 706: one round of the starting-player d20 roll-off.
 /// `rolls` are in seat order; round 1 contains every seat, and each later
 /// round contains exactly the previous round's tied-max group (CR 103.1


### PR DESCRIPTION
## What
Parses **Sylvan Echoes** — "Whenever you clash and win, you may draw a card."

## How
"Whenever you clash and win, ..." compacts a clash trigger and its win-outcome gate into one clause. The bare `Clashed` recognizer whole-clause-anchors on `"you clash"` and rejects the trailing `" and win"`, and there is no trigger-level `EventOutcomeWon` condition. The supported clash siblings (Entangling Trap, Rebellion of the Flamekin) instead encode a clash win as a separate `"If you won, ..."` effect sentence that lifts to `AbilityCondition::EventOutcomeWon` on the gated ability.

`reshape_clash_and_win_trigger` re-homes the compacted outcome the same way: strip `" and win"` from the trigger clause and prepend `"If you won, "` to the effect, so the existing `Clashed` recognizer plus the effect-condition pipeline produce the identical sibling AST — a `Clashed` trigger whose `Draw` effect is gated by `EventOutcomeWon` (optional). CR 701.19 / 701.19d.

## Scope / safety
The reshape is a no-op for any trigger that is not exactly `"you clash and win"`, so the only affected card is Sylvan Echoes — the sole clash-and-win card in the corpus. Tests: a parser-seam structural test asserting the reshaped AST, plus a regression test that plain `"whenever you clash"` siblings keep their head effect ungated.

- rustfmt, parser-combinator gate, clippy `-D warnings`: clean
- `cargo test -p engine --lib`: 14811 passed, 0 failed
- Coverage: Sylvan Echoes now supported; +1 net, no card regressed
