### PR TITLE
fix: require bearer auth for unauthenticated /admin/drafts endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Docker uses environment variables for the common options:
 | `PHASE_LOBBY_ONLY` | `--lobby-only` | false | Matchmaking broker mode |
 | `PHASE_LOG_JSON` | `--log-json` | false | Emit JSON logs |
 | `PHASE_LOG_DIR` | `--log-dir` | stdout | Write logs to files |
-| `PHASE_ADMIN_TOKEN` | `--admin-token` | unset | Bearer token for `/admin/*` endpoints. Unset ⇒ admin routes disabled (404). Send as `Authorization: Bearer <token>`. |
+| `PHASE_ADMIN_TOKEN` | — | unset | Bearer token for `/admin/*` endpoints (environment variable only; no CLI flag). Unset ⇒ admin routes disabled (404). Send as `Authorization: Bearer <token>`. |
 
 You can also pass server flags after the image name:
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Docker uses environment variables for the common options:
 | `PHASE_LOBBY_ONLY` | `--lobby-only` | false | Matchmaking broker mode |
 | `PHASE_LOG_JSON` | `--log-json` | false | Emit JSON logs |
 | `PHASE_LOG_DIR` | `--log-dir` | stdout | Write logs to files |
+| `PHASE_ADMIN_TOKEN` | `--admin-token` | unset | Bearer token for `/admin/*` endpoints. Unset ⇒ admin routes disabled (404). Send as `Authorization: Bearer <token>`. |
 
 You can also pass server flags after the image name:
 

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -40,3 +40,4 @@ ngrok = ["dep:ngrok"]
 futures-util = "0.3"
 tempfile = "3"
 tokio-tungstenite = "0.29"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1177,20 +1177,20 @@ async fn main() {
     }
 
     let app = app.layer(cors).with_state(AppState {
-            sessions: state,
-            draft_sessions,
-            draft_pools,
-            connections,
-            db,
-            lobby,
-            lobby_subscribers,
-            player_count,
-            game_db,
-            draft_spectators,
-            game_spectators,
-            mode,
-            public_url: advertised_public_url,
-        });
+        sessions: state,
+        draft_sessions,
+        draft_pools,
+        connections,
+        db,
+        lobby,
+        lobby_subscribers,
+        player_count,
+        game_db,
+        draft_spectators,
+        game_spectators,
+        mode,
+        public_url: advertised_public_url,
+    });
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.port))
         .await

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -10,8 +10,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::extract::ws::{Message, WebSocket};
-use axum::extract::{State, WebSocketUpgrade};
-use axum::response::IntoResponse;
+use axum::extract::{Request, State, WebSocketUpgrade};
+use axum::middleware::{from_fn_with_state, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use clap::Parser;
@@ -498,6 +499,16 @@ struct Cli {
     /// `NGROK_AUTHTOKEN` is set, the live tunnel URL is used when this is unset.
     #[arg(long, env = "PUBLIC_URL")]
     public_url: Option<String>,
+
+    /// Bearer token that gates the administrative `/admin/*` HTTP endpoints
+    /// (draft inspection and force-delete). These routes reach the server
+    /// through the same reverse proxy that serves `/ws`, so they are internet-
+    /// reachable in a typical deployment. When this is unset the admin routes
+    /// are not mounted at all (requests return 404) — the secure default.
+    /// Provide the value only via this environment variable at runtime; never
+    /// hardcode or commit it.
+    #[arg(long, env = "PHASE_ADMIN_TOKEN")]
+    admin_token: Option<String>,
 }
 
 /// Per-socket state tracking which game/player this connection belongs to.
@@ -1130,21 +1141,42 @@ async fn main() {
         info!(public_url = %url, "advertising public URL for join-code sharing");
     }
 
-    let app = Router::new()
+    // Public, client-facing HTTP surface. `/p2p-draft-backup*` is part of the
+    // normal P2P draft flow (the host adapter stores and restores backups), so
+    // it stays open; only the administrative `/admin/*` routes are gated below.
+    let mut app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/health", get(health))
-        .route("/admin/drafts", get(admin::admin_list_drafts))
-        .route(
-            "/admin/drafts/{code}",
-            get(admin::admin_get_draft).delete(admin::admin_delete_draft),
-        )
         .route("/p2p-draft-backup", post(admin::p2p_backup_store))
         .route(
             "/p2p-draft-backup/{code}",
             get(admin::p2p_backup_get).delete(admin::p2p_backup_delete),
-        )
-        .layer(cors)
-        .with_state(AppState {
+        );
+
+    // Administrative endpoints (draft enumeration, inspection, force-delete)
+    // are destructive and information-disclosing, and reachable through the
+    // same reverse proxy as `/ws`. Mount them only when an admin token is
+    // configured, behind a bearer-auth guard. Without a token they are absent
+    // entirely (404) — fail closed rather than expose them unauthenticated.
+    match cli.admin_token.as_deref().map(str::trim) {
+        Some(token) if !token.is_empty() => {
+            let expected: Arc<str> = Arc::from(token);
+            let admin_routes = Router::new()
+                .route("/admin/drafts", get(admin::admin_list_drafts))
+                .route(
+                    "/admin/drafts/{code}",
+                    get(admin::admin_get_draft).delete(admin::admin_delete_draft),
+                )
+                .layer(from_fn_with_state(expected, require_admin_auth));
+            app = app.merge(admin_routes);
+            info!("admin HTTP endpoints enabled (bearer-token authenticated)");
+        }
+        _ => {
+            info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)");
+        }
+    }
+
+    let app = app.layer(cors).with_state(AppState {
             sessions: state,
             draft_sessions,
             draft_pools,
@@ -1240,6 +1272,60 @@ async fn shutdown_signal() {
 
 async fn health() -> &'static str {
     "ok"
+}
+
+/// Constant-time byte comparison so admin-token validation does not leak the
+/// expected token through response timing. Returns `false` immediately on a
+/// length mismatch (token length is not itself sensitive here).
+fn tokens_match(presented: &[u8], expected: &[u8]) -> bool {
+    if presented.len() != expected.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (a, b) in presented.iter().zip(expected.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+/// Decide whether an `Authorization` header value authorizes an admin request.
+/// Pure so the trust decision is unit-testable without a live server: the
+/// header must be exactly `Bearer <token>` where `<token>` (after trimming)
+/// matches `expected` in constant time. A missing or malformed header, or any
+/// scheme other than `Bearer`, is unauthorized.
+fn admin_request_authorized(auth_header: Option<&str>, expected: &str) -> bool {
+    match auth_header
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+    {
+        Some(token) => tokens_match(token.as_bytes(), expected.as_bytes()),
+        None => false,
+    }
+}
+
+/// Auth guard for the administrative `/admin/*` routes.
+///
+/// Requires an `Authorization: Bearer <token>` header matching the configured
+/// admin token; any other request is rejected with `401 Unauthorized` before
+/// the handler (which can enumerate, inspect, or force-delete drafts and their
+/// live games) runs. The expected token is injected as middleware state via
+/// [`from_fn_with_state`], so it never appears in the router's shared
+/// [`AppState`].
+async fn require_admin_auth(
+    State(expected): State<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok());
+
+    if admin_request_authorized(auth_header, &expected) {
+        next.run(request).await
+    } else {
+        (http::StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+    }
 }
 
 /// Validate an operator-supplied public URL at the system boundary. It must
@@ -6982,5 +7068,39 @@ mod issue_4548_deadlock_tests {
         .expect(
             "create_and_connect_multiplayer_session must release state+connections before returning",
         );
+    }
+}
+
+#[cfg(test)]
+mod admin_auth_tests {
+    use super::{admin_request_authorized, tokens_match};
+
+    const TOKEN: &str = "s3cr3t-admin-token";
+
+    #[test]
+    fn tokens_match_is_exact() {
+        assert!(tokens_match(b"abc", b"abc"));
+        assert!(!tokens_match(b"abc", b"abd"));
+        assert!(!tokens_match(b"abc", b"ab")); // length mismatch
+        assert!(!tokens_match(b"", b"x"));
+        assert!(tokens_match(b"", b""));
+    }
+
+    #[test]
+    fn authorized_only_with_matching_bearer_token() {
+        let ok = format!("Bearer {TOKEN}");
+        assert!(admin_request_authorized(Some(&ok), TOKEN));
+        let padded = format!("Bearer   {TOKEN}  ");
+        assert!(admin_request_authorized(Some(&padded), TOKEN));
+    }
+
+    #[test]
+    fn rejects_missing_wrong_or_malformed_header() {
+        assert!(!admin_request_authorized(None, TOKEN));
+        assert!(!admin_request_authorized(Some(""), TOKEN));
+        assert!(!admin_request_authorized(Some("Bearer wrong-token"), TOKEN));
+        let basic = format!("Basic {TOKEN}");
+        assert!(!admin_request_authorized(Some(&basic), TOKEN));
+        assert!(!admin_request_authorized(Some(TOKEN), TOKEN));
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -499,16 +499,6 @@ struct Cli {
     /// `NGROK_AUTHTOKEN` is set, the live tunnel URL is used when this is unset.
     #[arg(long, env = "PUBLIC_URL")]
     public_url: Option<String>,
-
-    /// Bearer token that gates the administrative `/admin/*` HTTP endpoints
-    /// (draft inspection and force-delete). These routes reach the server
-    /// through the same reverse proxy that serves `/ws`, so they are internet-
-    /// reachable in a typical deployment. When this is unset the admin routes
-    /// are not mounted at all (requests return 404) — the secure default.
-    /// Provide the value only via this environment variable at runtime; never
-    /// hardcode or commit it.
-    #[arg(long, env = "PHASE_ADMIN_TOKEN")]
-    admin_token: Option<String>,
 }
 
 /// Per-socket state tracking which game/player this connection belongs to.
@@ -1155,26 +1145,15 @@ async fn main() {
 
     // Administrative endpoints (draft enumeration, inspection, force-delete)
     // are destructive and information-disclosing, and reachable through the
-    // same reverse proxy as `/ws`. Mount them only when an admin token is
-    // configured, behind a bearer-auth guard. Without a token they are absent
+    // same reverse proxy as `/ws`. Mount them only when PHASE_ADMIN_TOKEN is
+    // set, behind a bearer-auth guard. Without a token they are absent
     // entirely (404) — fail closed rather than expose them unauthenticated.
-    match cli.admin_token.as_deref().map(str::trim) {
-        Some(token) if !token.is_empty() => {
-            let expected: Arc<str> = Arc::from(token);
-            let admin_routes = Router::new()
-                .route("/admin/drafts", get(admin::admin_list_drafts))
-                .route(
-                    "/admin/drafts/{code}",
-                    get(admin::admin_get_draft).delete(admin::admin_delete_draft),
-                )
-                .layer(from_fn_with_state(expected, require_admin_auth));
-            app = app.merge(admin_routes);
-            info!("admin HTTP endpoints enabled (bearer-token authenticated)");
-        }
-        _ => {
-            info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)");
-        }
+    let admin_token = admin_token_from_env();
+    match admin_token.as_deref() {
+        Some(_) => info!("admin HTTP endpoints enabled (bearer-token authenticated)"),
+        None => info!("admin HTTP endpoints disabled (set PHASE_ADMIN_TOKEN to enable)"),
     }
+    app = merge_admin_routes(app, admin_token.as_deref());
 
     let app = app.layer(cors).with_state(AppState {
         sessions: state,
@@ -1286,6 +1265,32 @@ fn tokens_match(presented: &[u8], expected: &[u8]) -> bool {
         diff |= a ^ b;
     }
     diff == 0
+}
+
+/// Load the admin bearer token from the environment. Intentionally not a CLI
+/// flag — command-line secrets leak via process listings, shell history, and
+/// service manager metadata.
+fn admin_token_from_env() -> Option<String> {
+    std::env::var("PHASE_ADMIN_TOKEN")
+        .ok()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+/// Mount `/admin/*` routes when `admin_token` is present, guarded by bearer auth.
+fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Router<S> {
+    if let Some(token) = admin_token.filter(|t| !t.is_empty()) {
+        let expected: Arc<str> = Arc::from(token);
+        let admin_routes = Router::new()
+            .route("/admin/drafts", get(admin::admin_list_drafts))
+            .route(
+                "/admin/drafts/{code}",
+                get(admin::admin_get_draft).delete(admin::admin_delete_draft),
+            )
+            .layer(from_fn_with_state(expected, require_admin_auth));
+        app = app.merge(admin_routes);
+    }
+    app
 }
 
 /// Decide whether an `Authorization` header value authorizes an admin request.
@@ -7073,9 +7078,63 @@ mod issue_4548_deadlock_tests {
 
 #[cfg(test)]
 mod admin_auth_tests {
-    use super::{admin_request_authorized, tokens_match};
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Router;
+    use lobby_broker::Broker;
+    use server_core::draft_session::DraftSessionManager;
+    use server_core::session::SessionManager;
+    use tokio::sync::Mutex;
+    use tower::ServiceExt;
+
+    use super::{
+        admin_request_authorized, merge_admin_routes, tokens_match, AppState, ServerMode,
+    };
 
     const TOKEN: &str = "s3cr3t-admin-token";
+
+    fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
+        let game_db = Arc::new(
+            persistence::GameDb::open(temp_dir.path().join("games.db")).expect("game db"),
+        );
+        AppState {
+            sessions: Arc::new(Mutex::new(SessionManager::new())),
+            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
+            draft_pools: Arc::new(draft_pools::DraftPools::default()),
+            connections: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            db: Arc::new(engine::database::CardDatabase::default()),
+            lobby: Arc::new(Mutex::new(Broker::new())),
+            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
+            player_count: Arc::new(AtomicU32::new(0)),
+            game_db,
+            draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            mode: ServerMode::Full,
+            public_url: None,
+        }
+    }
+
+    fn test_admin_app(admin_token: Option<&str>) -> (Router<AppState>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let app =
+            merge_admin_routes(Router::new(), admin_token).with_state(test_app_state(&temp_dir));
+        (app, temp_dir)
+    }
+
+    async fn get_admin_drafts(app: &mut Router<AppState>, auth: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().method("GET").uri("/admin/drafts");
+        if let Some(value) = auth {
+            builder = builder.header(http::header::AUTHORIZATION, value);
+        }
+        let response = app
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .expect("router response");
+        response.status()
+    }
 
     #[test]
     fn tokens_match_is_exact() {
@@ -7102,5 +7161,35 @@ mod admin_auth_tests {
         let basic = format!("Basic {TOKEN}");
         assert!(!admin_request_authorized(Some(&basic), TOKEN));
         assert!(!admin_request_authorized(Some(TOKEN), TOKEN));
+    }
+
+    #[tokio::test]
+    async fn admin_routes_absent_without_token() {
+        let (mut app, _temp) = test_admin_app(None);
+        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_missing_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(get_admin_drafts(&mut app, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_wrong_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(&mut app, Some("Bearer wrong-token")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_routes_allow_valid_bearer() {
+        let (mut app, _temp) = test_admin_app(Some(TOKEN));
+        assert_eq!(
+            get_admin_drafts(&mut app, Some(&format!("Bearer {TOKEN}"))).await,
+            StatusCode::OK
+        );
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1295,17 +1295,19 @@ fn merge_admin_routes<S>(mut app: Router<S>, admin_token: Option<&str>) -> Route
 
 /// Decide whether an `Authorization` header value authorizes an admin request.
 /// Pure so the trust decision is unit-testable without a live server: the
-/// header must be exactly `Bearer <token>` where `<token>` (after trimming)
-/// matches `expected` in constant time. A missing or malformed header, or any
-/// scheme other than `Bearer`, is unauthorized.
+/// scheme must be `Bearer` (case-insensitive per RFC 9110) and the credential
+/// (after trimming) must match `expected` in constant time.
 fn admin_request_authorized(auth_header: Option<&str>, expected: &str) -> bool {
-    match auth_header
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .map(str::trim)
-    {
-        Some(token) => tokens_match(token.as_bytes(), expected.as_bytes()),
-        None => false,
+    let Some(value) = auth_header.map(str::trim) else {
+        return false;
+    };
+    let Some((scheme, credentials)) = value.split_once(' ') else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return false;
     }
+    tokens_match(credentials.trim().as_bytes(), expected.as_bytes())
 }
 
 /// Auth guard for the administrative `/admin/*` routes.
@@ -7151,6 +7153,8 @@ mod admin_auth_tests {
         assert!(admin_request_authorized(Some(&ok), TOKEN));
         let padded = format!("Bearer   {TOKEN}  ");
         assert!(admin_request_authorized(Some(&padded), TOKEN));
+        assert!(admin_request_authorized(Some(&format!("bearer {TOKEN}")), TOKEN));
+        assert!(admin_request_authorized(Some(&format!("BEARER {TOKEN}")), TOKEN));
     }
 
     #[test]
@@ -7189,6 +7193,10 @@ mod admin_auth_tests {
         let (mut app, _temp) = test_admin_app(Some(TOKEN));
         assert_eq!(
             get_admin_drafts(&mut app, Some(&format!("Bearer {TOKEN}"))).await,
+            StatusCode::OK
+        );
+        assert_eq!(
+            get_admin_drafts(&mut app, Some(&format!("bearer {TOKEN}"))).await,
             StatusCode::OK
         );
     }


### PR DESCRIPTION
## Summary

- **Root cause:** `/admin/drafts` routes (list, inspect, force-delete) are reachable through the default nginx `location /` reverse proxy, but were mounted without authentication. Any anonymous caller could enumerate drafts, read full session JSON, or `DELETE /admin/drafts/:code` to destroy draft pods and in-progress games.
- **Impact:** Severe availability and integrity risk (unauthenticated DoS) plus information disclosure (draft session internals on GET).
- **Fix:** Gate `/admin/*` behind `PHASE_ADMIN_TOKEN`. Routes mount only when a token is configured and require `Authorization: Bearer <token>` (constant-time comparison). Without a token, admin routes are absent (404) - fail closed. P2P backup endpoints remain public (normal client flow).

## Test plan

- [x] `admin_auth_tests` - token comparison and bearer header parsing
- [ ] Manual: with `PHASE_ADMIN_TOKEN` set, `GET /admin/drafts` without header ? 401; with valid Bearer ? 200
- [ ] Manual: without token configured, `GET /admin/drafts` ? 404

## Risks / tradeoffs

- Operators must set `PHASE_ADMIN_TOKEN` in production to use admin tooling; default is secure (routes disabled).
- Complements (does not replace) redacting secrets from admin GET responses - separate follow-up if authenticated operators should not see per-seat tokens.