### PR TITLE
fix: redact seat tokens from unauthenticated P2P draft backup HTTP endpoint

### DIFF
--- a/crates/phase-server/src/admin.rs
+++ b/crates/phase-server/src/admin.rs
@@ -6,7 +6,9 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::{info, warn};
 
-use server_core::guard_p2p_backup;
+use server_core::{
+    guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
+};
 
 use crate::AppState;
 
@@ -109,9 +111,18 @@ pub async fn p2p_backup_store(
     if let Err(reason) = guard_p2p_backup(&req.host_peer_id, &req.snapshot_json) {
         return (StatusCode::BAD_REQUEST, reason).into_response();
     }
+    if let Ok(Some((existing_peer, _, _))) = app_state.game_db.load_p2p_backup(&req.draft_code) {
+        if let Err(reason) = guard_p2p_backup_overwrite(&existing_peer, &req.host_peer_id) {
+            return (StatusCode::FORBIDDEN, reason).into_response();
+        }
+    }
+    let snapshot_json = match redact_p2p_backup_snapshot_secrets(&req.snapshot_json) {
+        Ok(json) => json,
+        Err(reason) => return (StatusCode::BAD_REQUEST, reason).into_response(),
+    };
     match app_state
         .game_db
-        .save_p2p_backup(&req.draft_code, &req.host_peer_id, &req.snapshot_json)
+        .save_p2p_backup(&req.draft_code, &req.host_peer_id, &snapshot_json)
     {
         Ok(_) => (StatusCode::OK, "Stored").into_response(),
         Err(e) => {
@@ -130,12 +141,18 @@ pub async fn p2p_backup_get(
         return (StatusCode::BAD_REQUEST, "Invalid draft code").into_response();
     }
     match app_state.game_db.load_p2p_backup(&code) {
-        Ok(Some((host_peer_id, snapshot_json, updated_at))) => Json(serde_json::json!({
-            "host_peer_id": host_peer_id,
-            "snapshot_json": snapshot_json,
-            "updated_at": updated_at,
-        }))
-        .into_response(),
+        Ok(Some((host_peer_id, snapshot_json, updated_at))) => {
+            let snapshot_json = match redact_p2p_backup_snapshot_secrets(&snapshot_json) {
+                Ok(json) => json,
+                Err(reason) => return (StatusCode::INTERNAL_SERVER_ERROR, reason).into_response(),
+            };
+            Json(serde_json::json!({
+                "host_peer_id": host_peer_id,
+                "snapshot_json": snapshot_json,
+                "updated_at": updated_at,
+            }))
+            .into_response()
+        }
         Ok(None) => (StatusCode::NOT_FOUND, "No backup found").into_response(),
         Err(e) => {
             warn!(error = %e, "P2P backup load failed");

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -50,7 +50,10 @@ pub use legacy_deck_guard::guard_legacy_deck;
 pub use legacy_join_guard::guard_legacy_join_game;
 pub use lobby::LobbyManager;
 pub use lobby_subscriber_wire_guard::{guard_lobby_subscriber_capacity, MAX_LOBBY_SUBSCRIBERS};
-pub use p2p_backup_guard::{guard_p2p_backup, MAX_P2P_SNAPSHOT_LEN};
+pub use p2p_backup_guard::{
+    guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
+    MAX_P2P_SNAPSHOT_LEN,
+};
 pub use persist::{PersistedLobbyMeta, PersistedSession};
 pub use protocol::{
     AiSeatRequest, ClientMessage, DeckChoice, DeckData, LobbyGame, PlayerSlotInfo, SeatKind,

--- a/crates/server-core/src/p2p_backup_guard.rs
+++ b/crates/server-core/src/p2p_backup_guard.rs
@@ -13,8 +13,15 @@
 //! before the database write, so both transports agree. `draft_code` is
 //! validated separately by the endpoint (the check is shared with the GET/DELETE
 //! routes); this guard bounds the two free-form fields the row stores verbatim.
+//!
+//! P2P host snapshots also carry per-seat session credentials (`seatTokens`,
+//! `kickedTokens`) that authorize WebRTC draft seats. Those secrets must never
+//! be persisted or echoed on the unauthenticated HTTP backup surface — the host
+//! keeps credentials in local IndexedDB; the server backup is for draft progress
+//! recovery only.
 
 use lobby_broker::validation::{validate_token, MAX_TOKEN_LEN};
+use serde_json::{Map, Value};
 
 /// Max byte length of the serialized draft snapshot accepted on the wire. A full
 /// draft session (up to 8 seats × 3 packs plus pools and pairings) serializes to
@@ -44,10 +51,51 @@ pub fn guard_p2p_backup(host_peer_id: &str, snapshot_json: &str) -> Result<(), S
     Ok(())
 }
 
+/// Keys stripped from a P2P host backup snapshot before SQLite persistence or
+/// HTTP response. These are session credentials, not recoverable draft state.
+const P2P_BACKUP_SECRET_KEYS: &[&str] = &["seatTokens", "kickedTokens"];
+
+/// Remove session credentials from a host backup snapshot JSON blob.
+///
+/// The backup row is keyed only by the 6-character draft code and is readable by
+/// any caller of `GET /p2p-draft-backup/{code}`, so stored snapshots must not
+/// contain per-seat tokens.
+pub fn redact_p2p_backup_snapshot_secrets(snapshot_json: &str) -> Result<String, String> {
+    let mut value: Value = serde_json::from_str(snapshot_json)
+        .map_err(|_| "snapshot_json must be a JSON object".to_string())?;
+    let Some(obj) = value.as_object_mut() else {
+        return Err("snapshot_json must be a JSON object".to_string());
+    };
+    redact_secret_keys(obj);
+    serde_json::to_string(&value).map_err(|e| format!("snapshot_json serialization failed: {e}"))
+}
+
+fn redact_secret_keys(obj: &mut Map<String, Value>) {
+    for key in P2P_BACKUP_SECRET_KEYS {
+        obj.remove(*key);
+    }
+}
+
+/// Reject overwrites from a different host peer than the row's owner.
+pub fn guard_p2p_backup_overwrite(
+    existing_host_peer_id: &str,
+    incoming_host_peer_id: &str,
+) -> Result<(), String> {
+    if existing_host_peer_id != incoming_host_peer_id {
+        Err("host_peer_id does not match the existing backup owner".to_string())
+    } else {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{guard_p2p_backup, MAX_P2P_SNAPSHOT_LEN};
+    use super::{
+        guard_p2p_backup, guard_p2p_backup_overwrite, redact_p2p_backup_snapshot_secrets,
+        MAX_P2P_SNAPSHOT_LEN,
+    };
     use lobby_broker::validation::MAX_TOKEN_LEN;
+    use serde_json::Value;
 
     #[test]
     fn accepts_valid_backup() {
@@ -96,5 +144,33 @@ mod tests {
         let oversized = "x".repeat(MAX_P2P_SNAPSHOT_LEN + 1);
         let err = guard_p2p_backup("peer", &oversized).unwrap_err();
         assert!(err.contains("snapshot_json"));
+    }
+
+    #[test]
+    fn redact_p2p_backup_snapshot_secrets_strips_seat_and_kicked_tokens() {
+        let raw = r#"{
+            "draftCode": "ABC123",
+            "seatTokens": {"0": "host-secret", "1": "guest-secret"},
+            "kickedTokens": ["evicted-secret"],
+            "draftStarted": true
+        }"#;
+        let redacted = redact_p2p_backup_snapshot_secrets(raw).expect("valid snapshot");
+        let parsed: Value = serde_json::from_str(&redacted).unwrap();
+        assert!(parsed.get("seatTokens").is_none());
+        assert!(parsed.get("kickedTokens").is_none());
+        assert_eq!(parsed["draftCode"], "ABC123");
+        assert_eq!(parsed["draftStarted"], true);
+    }
+
+    #[test]
+    fn redact_p2p_backup_snapshot_secrets_rejects_non_object() {
+        assert!(redact_p2p_backup_snapshot_secrets("[]").is_err());
+        assert!(redact_p2p_backup_snapshot_secrets("not-json").is_err());
+    }
+
+    #[test]
+    fn guard_p2p_backup_overwrite_rejects_peer_mismatch() {
+        assert!(guard_p2p_backup_overwrite("peer-a", "peer-b").is_err());
+        assert!(guard_p2p_backup_overwrite("peer-a", "peer-a").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `POST /p2p-draft-backup` persisted the host snapshot JSON verbatim, including per-seat `seatTokens` and `kickedTokens`. `GET /p2p-draft-backup/{code}` is unauthenticated and keyed only by the 6-character draft code, so anyone who knows/guesses the code could read seat session credentials and impersonate draft players.
- **Impact:** Credential leak on the public HTTP backup surface for P2P cube/pod drafts that use server backup upload.
- **Fix:** Strip `seatTokens` / `kickedTokens` before SQLite persistence and before GET responses (defense in depth for legacy rows). Reject backup overwrites when `host_peer_id` does not match the existing row owner.

Complements the size/shape bounds from #2198 — this addresses secret redaction, not payload size.

## Test plan

- [x] Unit tests: redaction removes `seatTokens` and `kickedTokens` while preserving draft metadata
- [x] Unit tests: overwrite guard rejects mismatched `host_peer_id`
- [ ] CI green