### PR TITLE
feat(parser+engine): dynamic-cost keyword grants for Scavenge/Encore/…

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -12707,6 +12707,107 @@ fn granted_self_cost_encore_surfaces_graveyard_ability_at_card_mana_cost() {
     );
 }
 
+/// CR 702.97a: Varolz-class grant, but *filter-scoped* rather than
+/// `SpecificObject` — the shape a real continuous static ability actually
+/// uses ("Each creature card in your graveyard has scavenge"), which no
+/// existing test exercised through to activation. Two graveyard creatures
+/// with different mana costs must each surface their OWN scavenge cost from
+/// the SAME granting effect, proving the off-zone grant pipeline resolves
+/// `SelfManaCost` per-recipient rather than once for the whole filter.
+#[test]
+fn filter_scoped_scavenge_grant_resolves_per_object_cost_for_every_match() {
+    let mut state = setup_game_at_main_phase();
+
+    let grantor = create_object(
+        &mut state,
+        CardId(9600),
+        PlayerId(0),
+        "Varolz, the Scar-Striped".to_string(),
+        Zone::Battlefield,
+    );
+    let cheap_cost = ManaCost::Cost {
+        generic: 1,
+        shards: vec![],
+    };
+    let expensive_cost = ManaCost::Cost {
+        generic: 3,
+        shards: vec![ManaCostShard::Green],
+    };
+    let cheap_creature = create_object(
+        &mut state,
+        CardId(9601),
+        PlayerId(0),
+        "Cheap Graveyard Creature".to_string(),
+        Zone::Graveyard,
+    );
+    let expensive_creature = create_object(
+        &mut state,
+        CardId(9602),
+        PlayerId(0),
+        "Expensive Graveyard Creature".to_string(),
+        Zone::Graveyard,
+    );
+    for (id, cost) in [
+        (cheap_creature, cheap_cost.clone()),
+        (expensive_creature, expensive_cost.clone()),
+    ] {
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.mana_cost = cost;
+    }
+
+    state.add_transient_continuous_effect(
+        grantor,
+        PlayerId(0),
+        crate::types::ability::Duration::UntilEndOfTurn,
+        TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                }]),
+        ),
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Scavenge(ManaCost::SelfManaCost),
+        }],
+        None,
+    );
+
+    for (id, expected_cost) in [
+        (cheap_creature, cheap_cost),
+        (expensive_creature, expensive_cost),
+    ] {
+        let abilities = activated_ability_definitions(&state, id);
+        // CR 702.97a: identify the scavenge ability by its distinctive
+        // Composite{Mana, Exile(SelfRef, Graveyard)} cost shape (there is no
+        // dedicated `Effect::Scavenge` marker — it lowers to `Effect::PutCounter`,
+        // shared with every other +1/+1-counter effect).
+        let (_, scavenge) = abilities
+            .iter()
+            .find(|(_, a)| {
+                a.activation_zone == Some(Zone::Graveyard)
+                    && matches!(
+                        &a.cost,
+                        Some(AbilityCost::Composite { costs })
+                            if costs.iter().any(|c| matches!(c, AbilityCost::Mana { .. }))
+                    )
+            })
+            .unwrap_or_else(|| {
+                panic!("{id:?}: filter-scoped grant must surface scavenge, got {abilities:?}")
+            });
+        let Some(AbilityCost::Composite { costs }) = &scavenge.cost else {
+            unreachable!("filtered above");
+        };
+        assert!(
+            costs
+                .iter()
+                .any(|c| matches!(c, AbilityCost::Mana { cost } if *cost == expected_cost)),
+            "{id:?}: scavenge mana sub-cost must equal THIS card's own mana cost, got {costs:?}"
+        );
+    }
+}
+
 /// CR 702.74a + CR 604.1: End-to-end composition of the two evoke work items.
 /// Ashling grants evoke {4} to an Elemental permanent spell in hand; casting
 /// it for the granted evoke cost (only {4} available, printed {6} unaffordable)

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -794,6 +794,27 @@ pub(crate) fn parse_graveyard_keyword_continuation(
             }
             Some(Keyword::Encore(ManaCost::SelfManaCost))
         }
+        GrantedCastKeywordKind::Embalm => {
+            // CR 702.128a: "Its embalm cost is equal to its mana cost."
+            // (Naktamun). Same shape as scavenge/encore.
+            let (_, rest) = nom_on_lower(text, &lower, |i| {
+                value(
+                    (),
+                    alt((
+                        tag("its embalm cost is equal to "),
+                        tag("the embalm cost is equal to "),
+                    )),
+                )
+                .parse(i)
+            })?;
+            let rest = parse_self_mana_cost_suffix(rest)?;
+            if !continuation_fully_consumed(rest) {
+                return None;
+            }
+            Some(Keyword::Embalm(crate::types::keywords::EmbalmCost::Mana(
+                ManaCost::SelfManaCost,
+            )))
+        }
         GrantedCastKeywordKind::Foretell => {
             // CR 702.143a + CR 601.2f: "Its foretell cost is equal to its mana
             // cost reduced by {N}." (Dream Devourer, reduced by {2}). The bare

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -40,10 +40,12 @@ pub(crate) fn parse_graveyard_granted_keyword_kind(
         value(GrantedCastKeywordKind::Flashback, tag("flashback")),
         value(GrantedCastKeywordKind::Escape, tag("escape")),
         value(GrantedCastKeywordKind::Mayhem, tag("mayhem")),
-        // CR 702.97 / CR 702.141: Varolz, Young Deathclaws (scavenge);
-        // Wire Surgeons (encore) grant activated graveyard keywords.
+        // CR 702.97 / CR 702.141 / CR 702.128: Varolz, Young Deathclaws
+        // (scavenge); Wire Surgeons (encore); Naktamun (embalm) grant
+        // activated graveyard keywords.
         value(GrantedCastKeywordKind::Scavenge, tag("scavenge")),
         value(GrantedCastKeywordKind::Encore, tag("encore")),
+        value(GrantedCastKeywordKind::Embalm, tag("embalm")),
         // CR 702.143a / CR 702.94a: Dream Devourer grants foretell, Aminatou
         // grants miracle — hand-zone cast keywords (gated by `grant_zone`).
         value(GrantedCastKeywordKind::Foretell, tag("foretell")),
@@ -119,6 +121,7 @@ fn graveyard_granted_kind_for_keyword(keyword: &Keyword) -> Option<GrantedCastKe
         GrantedCastKeywordKind::Mayhem,
         GrantedCastKeywordKind::Scavenge,
         GrantedCastKeywordKind::Encore,
+        GrantedCastKeywordKind::Embalm,
         GrantedCastKeywordKind::Foretell,
         GrantedCastKeywordKind::Miracle,
     ]

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -579,6 +579,12 @@ pub(crate) enum GrantedCastKeywordKind {
     Foretell,
     /// CR 702.94a: Miracle functions from hand (Aminatou, Veil Piercer grant).
     Miracle,
+    /// CR 702.128a: Naktamun ("Each creature card in your graveyard has
+    /// embalm. Its embalm cost is equal to its mana cost.") — the runtime
+    /// resolver (`resolve_self_cost_graveyard_activated_keyword`) already
+    /// concretizes `Keyword::Embalm(EmbalmCost::Mana(SelfManaCost))`; this was
+    /// a pure parser-recognition gap.
+    Embalm,
 }
 
 impl GrantedCastKeywordKind {
@@ -594,10 +600,12 @@ impl GrantedCastKeywordKind {
             GrantedCastKeywordKind::Mayhem => {
                 keyword.kind() == crate::types::keywords::KeywordKind::Mayhem
             }
-            // CR 702.97 (Scavenge) / CR 702.141 (Encore): activated graveyard
-            // keywords share `KeywordKind::Unknown`, so match the variant directly.
+            // CR 702.97 (Scavenge) / CR 702.141 (Encore) / CR 702.128 (Embalm):
+            // activated graveyard keywords share `KeywordKind::Unknown`, so
+            // match the variant directly.
             GrantedCastKeywordKind::Scavenge => matches!(keyword, Keyword::Scavenge(_)),
             GrantedCastKeywordKind::Encore => matches!(keyword, Keyword::Encore(_)),
+            GrantedCastKeywordKind::Embalm => matches!(keyword, Keyword::Embalm(_)),
             // CR 702.143a / CR 702.94a: hand-zone cast keywords.
             GrantedCastKeywordKind::Foretell => {
                 keyword.kind() == crate::types::keywords::KeywordKind::Foretell
@@ -617,7 +625,8 @@ impl GrantedCastKeywordKind {
             | GrantedCastKeywordKind::Escape
             | GrantedCastKeywordKind::Mayhem
             | GrantedCastKeywordKind::Scavenge
-            | GrantedCastKeywordKind::Encore => Zone::Graveyard,
+            | GrantedCastKeywordKind::Encore
+            | GrantedCastKeywordKind::Embalm => Zone::Graveyard,
             GrantedCastKeywordKind::Foretell | GrantedCastKeywordKind::Miracle => Zone::Hand,
         }
     }

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -13766,6 +13766,49 @@ fn top_level_static_scavenge_and_encore_grants_stay_on_graveyard_cards() {
         }
 }
 
+/// CR 702.128a: Naktamun grants Embalm to every creature card in the
+/// controller's graveyard, with the embalm cost equal to that card's own
+/// mana cost — the same continuation-sentence shape as Scavenge/Encore, but
+/// for a keyword that was previously absent from `GrantedCastKeywordKind`
+/// even though the runtime resolver already supported it.
+#[test]
+fn top_level_static_embalm_grant_stays_on_graveyard_cards() {
+    let result = parse(
+        "Each creature card in your graveyard has embalm. Its embalm cost is equal to its mana cost.",
+        "Naktamun",
+        &[],
+        &["Creature"],
+        &[],
+    );
+    assert_eq!(result.statics.len(), 1, "{:?}", result.statics);
+    let static_def = &result.statics[0];
+    let TargetFilter::Typed(tf) = static_def
+        .affected
+        .as_ref()
+        .expect("expected affected filter")
+    else {
+        panic!("expected typed affected filter");
+    };
+    assert!(
+        tf.properties.contains(&FilterProp::InZone {
+            zone: Zone::Graveyard
+        }),
+        "missing graveyard filter: {:?}",
+        tf.properties
+    );
+    assert!(
+        static_def
+            .modifications
+            .contains(&ContinuousModification::AddKeyword {
+                keyword: Keyword::Embalm(crate::types::keywords::EmbalmCost::Mana(
+                    ManaCost::SelfManaCost
+                )),
+            }),
+        "missing embalm grant: {:?}",
+        static_def.modifications
+    );
+}
+
 #[test]
 fn green_goblin_full_face_parses_mayhem_and_graveyard_cost_reduction() {
     // CR 702.187b + CR 601.2f: The full Green Goblin face — flying/menace,

--- a/crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs
+++ b/crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs
@@ -385,10 +385,11 @@ fn dream_devourer_removed_after_foretell_latches_cost() {
     );
 }
 
-/// Negatives: a card with PRINTED foretell is NOT re-granted (the
-/// `WithoutKeywordKind{Foretell}` guard excludes it, so no second foretell
-/// keyword is applied); a LAND in hand is never granted foretell; an MV<2 card
-/// floors its foretell cost at {0}.
+/// Negatives: a LAND in hand is never granted foretell; an MV<2 card floors
+/// its foretell cost at {0}. The PRINTED-foretell exclusion is its own
+/// dedicated test below (`dream_devourer_declines_grant_for_printed_foretell_card`)
+/// — it needs the full parsed-static `WithoutKeywordKind{Foretell}` affected
+/// filter plus the off-zone recursion guard, not just this scenario's fixtures.
 #[test]
 fn dream_devourer_foretell_negatives() {
     use engine::game::keywords::effective_foretell_cost;
@@ -421,6 +422,56 @@ fn dream_devourer_foretell_negatives() {
     assert!(
         cheap_cost.is_without_paying_mana(),
         "MV(1) reduced by {{2}} must floor at {{0}}, got {cheap_cost:?}"
+    );
+}
+
+/// CR 613.1f + CR 702.143a/d: A hand card that already has a PRINTED Foretell
+/// keyword must be excluded from Dream Devourer's grant by the PARSED
+/// `WithoutKeywordKind(Foretell)` affected filter (not a hand-built
+/// `SpecificObject` remover), and must keep its OWN printed cost — never
+/// Dream Devourer's MV−2 grant.
+///
+/// This is also the load-bearing regression for the CR 613.1f off-zone
+/// recursion guard (`off_zone_characteristics::OffZoneRecursionGuard`):
+/// deciding whether the "without foretell" filter matches this card requires
+/// asking "does this card already have foretell", which re-enters off-zone
+/// keyword computation for the SAME object the grant is being evaluated for.
+/// Without the guard that query recurses forever; with it, the nested query
+/// resolves against `base_keywords` only, correctly seeing the printed
+/// Foretell and declining the grant. Every other test in this file removes a
+/// keyword via a synthetic `SpecificObject` continuous effect or never
+/// exercises a card with a pre-existing printed keyword at all, so none of
+/// them touch this path.
+///
+/// Revert-failing: if the affected filter's exclusion or the recursion guard
+/// regresses, this either hangs (unguarded infinite recursion) or silently
+/// returns Dream Devourer's MV−2 cost instead of the printed cost.
+#[test]
+fn dream_devourer_declines_grant_for_printed_foretell_card() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Dream Devourer", 2, 3)
+        .from_oracle_text(DREAM_DEVOURER);
+    // MV(6) so Dream Devourer's grant, if wrongly applied, would compute
+    // {4} — distinct from the printed {5} below, so the two can't be
+    // confused by coincidence.
+    let printed_cost = generic(5);
+    let card = scenario
+        .add_spell_to_hand(P0, "AlreadyForetoldSorcery", false)
+        .with_mana_cost(generic(6))
+        .with_keyword(Keyword::Foretell(printed_cost.clone()))
+        .id();
+
+    let runner = scenario.build();
+
+    let cost = effective_foretell_cost(runner.state(), card)
+        .expect("a card with printed foretell must still be foretellable");
+    assert_eq!(
+        cost, printed_cost,
+        "must keep its own printed foretell cost ({{5}}), not Dream Devourer's \
+         MV-2 grant ({{4}}) — the WithoutKeywordKind(Foretell) filter must \
+         have excluded this card from the grant entirely"
     );
 }
 


### PR DESCRIPTION

The engine already has the building blocks for a keyword-with-cost-formula grant: `ManaCost::SelfManaCost` (the card's own mana cost) plus `ContinuousModification::AddKeyword`, used for one-shot single-target grants like Snapcaster Mage's flashback trigger. A *continuous, filter-scoped* variant of the same idea already existed for a subset of graveyard keywords (Flashback/Escape/Mayhem/Scavenge/Encore via `GraveyardGrantedKeywordKind`), but stopped short of several real cards:

1. No cost-delta support — nothing could express "equal to its mana cost **reduced by {2}**".
2. Graveyard-only — the combinator hard-required the affected filter to be the controller's graveyard; hand-zone grants (Foretell) weren't recognized at all.
3. Embalm was missing from `GraveyardGrantedKeywordKind` even though the runtime resolver already supported it.
4. `can_foretell_card`/`foretell_cost` read `obj.keywords` directly instead of the off-zone-aware path graveyard keywords already used, so a continuously granted Foretell on a hand card would silently never be castable.
5. No test exercised a *filter-scoped* (not `SpecificObject`) continuous grant through to activation.

## Fix

- **`ManaCost::SelfManaCostAdjusted { delta: i32 }`** (`types/mana.rs`) — a sibling of `SelfManaCost`, not a field added to it (the bare marker is matched in ~20 call sites across casting/payment/restriction/AI code; keeping them distinct avoids a wire-format change to every existing granted keyword). Resolved at the single existing choke point, `game::keywords::resolve_keyword_mana_cost`, flooring the adjusted generic component at `{0}` per CR 601.2f.
- **`GraveyardGrantedKeywordKind::Embalm`** (CR 702.128a) — pure parser-recognition gap; the runtime resolver already handled it.
- **Hand-zone Foretell grant** (CR 702.143a/d) — a small dedicated combinator pair (`try_parse_hand_foretell_grant_clause` / `parse_hand_foretell_continuation`) mirroring the graveyard shape, reusing the already-generic `FilterProp::WithoutKeywordKind` for "without foretell".
- **`effective_foretell_cost`** (`game/keywords.rs`) — mirrors the existing `effective_harmonize_cost`/`effective_sneak_cost` family; `can_foretell_card`/`handle_foretell` now resolve through it instead of the raw battlefield-only `foretell_cost`.
- **Fixed a latent "without foretell" bug**: a bare `"foretell"` token fell through to `Keyword::from_str`, which concretizes via `parse_keyword_mana_cost("")` to `Keyword::Foretell(ManaCost::zero())` — an exact-`{0}`-cost match, not a discriminant match. `"foretell"` now joins the existing `flashback`/`embalm`/`harmonize`/... discriminant-only keyword list in `oracle_target.rs`.
- **New runtime test** proving a filter-scoped (2+ matching objects, not `SpecificObject`) continuous grant resolves each recipient's *own* mana cost correctly, for both the graveyard and hand-zone paths — this exact shape was previously unproven.

## Real cards unlocked

| Card | Legality | Zone | Keyword | Cost formula |
|---|---|---|---|---|
| Varolz, the Scar-Striped | Commander/Legacy/Modern/Pioneer/Vintage | Graveyard | Scavenge | mana cost |
| Young Deathclaws | Commander/Legacy/Vintage | Graveyard | Scavenge | mana cost |
| Wire Surgeons | Commander/Legacy/Vintage | Graveyard | Encore | mana cost |
| Bohn, Beguiling Balladeer | Commander/Legacy/Vintage | Hand | Foretell | mana cost reduced by {2} |
| Dream Devourer | Modern/Pioneer/Commander/... | Hand | Foretell | mana cost reduced by {2} |
| Naktamun (Plane) | Planechase | Graveyard | Embalm | mana cost |
| The Cave of Skulls (Plane) | Planechase | Graveyard | Scavenge | mana cost |
| Singing Towers of Darillium (Plane) | Planechase | Hand | Foretell | mana cost reduced by {2} |

Verified against `data/mtgjson/AtomicCards.json` (current, not the checked-in `card-data.json` export).

Fossilize (Sue, Everlasting Dinosaur) and Madness (Falkenrath Gorger's "isn't on the battlefield" multi-zone filter) are deliberately out of scope — Fossilize has no Comprehensive Rules entry to annotate against, and Falkenrath Gorger's zone scope is broader than hand+graveyard.

## Testing

- Parser unit tests: `top_level_static_embalm_grant_stays_on_graveyard_cards`, `top_level_static_foretell_grant_stays_on_hand_cards_with_cost_delta` (`parser/oracle_tests.rs`).
- Runtime tests: `filter_scoped_scavenge_grant_resolves_per_object_cost_for_every_match`, `filter_scoped_foretell_grant_is_visible_to_hand_cast_path_with_cost_delta` (`game/casting_tests.rs`).
- `cargo fmt --all` clean.

**Note on verification**: this environment's local Rust toolchain has no working MSVC linker (verified independently of this change — even `cargo new; cargo run` on a trivial project fails to link), so I could not run `cargo test`/`cargo clippy` locally. I did a manual, file-by-file audit of every exhaustive `match` over `ManaCost` across the whole workspace (18 files, ~20 match sites) to add the new variant safely, and traced every call site through to its caller by hand. CI (`ubuntu-latest`) is the first real compile/test signal for this PR — flagging this explicitly rather than silently.

Closes #5045
