### PR TITLE
fix(parser): Coalition Victory drops its win condition and auto-wins the game

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -2965,6 +2965,10 @@ pub(super) fn parse_condition_text(text: &str) -> Option<AbilityCondition> {
         return Some(condition);
     }
 
+    if let Some(condition) = parse_you_control_of_each_condition_text(text) {
+        return Some(condition);
+    }
+
     if let Some(condition) = parse_controller_controlled_as_cast_condition_text(text) {
         return Some(condition);
     }
@@ -3041,6 +3045,128 @@ fn parse_urza_land_type(input: &str) -> super::super::oracle_nom::error::OracleR
         value("Mine".to_string(), tag("mine")),
         value("Power-Plant".to_string(), tag("power-plant")),
         value("Tower".to_string(), tag("tower")),
+    ))
+    .parse(input)
+}
+
+/// CR 305.6: The five basic land types, in canonical order. A parser-local copy
+/// (the deck-validation const is not `pub`) — do not cross-module-couple; both
+/// enumerate the same fixed CR 305.6 set.
+const BASIC_LAND_TYPES: [&str; 5] = ["Plains", "Island", "Swamp", "Mountain", "Forest"];
+
+/// The noun a `"you control a <noun> of each <dimension>"` clause quantifies
+/// over. Typed rather than stringly so the noun→`TypedFilter` mapping is an
+/// exhaustive `match`, not a string comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OfEachNoun {
+    Land,
+    Creature,
+    Permanent,
+}
+
+impl OfEachNoun {
+    /// The base `TypedFilter` (type + `You` controller) this noun contributes,
+    /// before the per-member dimension constraint is layered on. Exhaustive
+    /// `match` so a new noun forces a decision here.
+    fn base_filter(self) -> TypedFilter {
+        let typed = match self {
+            OfEachNoun::Land => TypedFilter::land(),
+            OfEachNoun::Creature => TypedFilter::creature(),
+            OfEachNoun::Permanent => TypedFilter::permanent(),
+        };
+        typed.controller(ControllerRef::You)
+    }
+}
+
+/// CR 305.6: one member filter per basic land type — "a land of each basic land
+/// type" requires a controlled land of that specific subtype.
+fn basic_land_member_filter(noun: OfEachNoun, subtype: &str) -> TargetFilter {
+    TargetFilter::Typed(noun.base_filter().subtype(subtype.to_string()))
+}
+
+/// CR 105.1: one member filter per color — "a <noun> of each color" requires a
+/// controlled object of that color. `FilterProp::HasColor` is
+/// `obj.color.contains(color)`, so a multicolored object counts for each of its
+/// colors (a Gruul creature satisfies both the red and green members).
+fn color_member_filter(noun: OfEachNoun, color: ManaColor) -> TargetFilter {
+    TargetFilter::Typed(
+        noun.base_filter()
+            .properties(vec![FilterProp::HasColor { color }]),
+    )
+}
+
+/// CR 104.2b + CR 608.2c: Recognize `"you control <clause> [and <clause>]…"`
+/// where each clause is `"a <noun> of each <dimension>"`, and expand every clause
+/// into `ControllerControlsMatching` members under one flat `AbilityCondition::And`.
+/// Two dimensions are supported:
+///   - `"a land of each basic land type"` → one member per CR 305.6 basic land
+///     type (Plains/Island/Swamp/Mountain/Forest).
+///   - `"a {creature|permanent} of each color"` → one member per CR 105.1 color
+///     (WUBRG).
+///
+/// The leading `"you control"` possessive scopes ALL clauses (CR 608.2c: read the
+/// whole sentence), so — unlike Urzatron's single-clause `" and "` list — the
+/// conjunction is bound INSIDE this recognizer rather than by the generic
+/// top-level splitter, which would strip the shared subject off the second
+/// conjunct (`"a creature of each color"` has no `"you control"` of its own).
+/// Motivating card: Coalition Victory ("You win the game if you control a land of
+/// each basic land type and a creature of each color"). `evaluate_condition`
+/// resolves the flat `And` identically to the nested form (`.all()`).
+fn parse_you_control_of_each_condition_text(text: &str) -> Option<AbilityCondition> {
+    let lower = text.to_ascii_lowercase();
+    let member_filters = nom_parse_lower(&lower, |i| {
+        all_consuming(parse_you_control_of_each_condition).parse(i)
+    })?;
+    let conditions = member_filters
+        .into_iter()
+        .map(|filter| AbilityCondition::ControllerControlsMatching { filter })
+        .collect();
+    Some(AbilityCondition::And { conditions })
+}
+
+/// Parses `"you control <clause> [and <clause>]…"` into the flat list of per-member
+/// `TargetFilter`s across every clause. `all_consuming` at the call site forbids a
+/// partial match (e.g. a trailing unparsed clause).
+fn parse_you_control_of_each_condition(input: &str) -> OracleResult<'_, Vec<TargetFilter>> {
+    let (mut input, _) = tag("you control ").parse(input)?;
+    let (rest, mut filters) = parse_of_each_clause(input)?;
+    input = rest;
+    // The shared `"you control"` subject distributes over each `" and "`-joined
+    // clause (CR 608.2c).
+    while let Ok((rest, more)) =
+        preceded(tag::<_, _, OracleError<'_>>(" and "), parse_of_each_clause).parse(input)
+    {
+        filters.extend(more);
+        input = rest;
+    }
+    Ok((input, filters))
+}
+
+/// Parses one `"a <noun> of each <dimension>"` clause into its per-member
+/// `TargetFilter`s (5 for either dimension), controller-scoped to `You`.
+fn parse_of_each_clause(input: &str) -> OracleResult<'_, Vec<TargetFilter>> {
+    let (input, noun) = alt((
+        value(OfEachNoun::Land, tag::<_, _, OracleError<'_>>("a land")),
+        value(OfEachNoun::Creature, tag("a creature")),
+        value(OfEachNoun::Permanent, tag("a permanent")),
+    ))
+    .parse(input)?;
+    // CR 305.6 / CR 105.1: the dimension determines the fixed member set. Land +
+    // "basic land type" enumerates CR 305.6; any noun + "color" enumerates the
+    // CR 105.1 colors.
+    alt((
+        map(tag(" of each basic land type"), move |_| {
+            BASIC_LAND_TYPES
+                .iter()
+                .map(|subtype| basic_land_member_filter(noun, subtype))
+                .collect()
+        }),
+        map(tag(" of each color"), move |_| {
+            ManaColor::ALL
+                .iter()
+                .map(|&color| color_member_filter(noun, color))
+                .collect()
+        }),
     ))
     .parse(input)
 }
@@ -6088,6 +6214,7 @@ fn parse_nth_resolution_condition(lower: &str) -> Option<u32> {
 mod tests {
     use super::*;
     use crate::parser::oracle_nom::condition::parse_inner_condition;
+    use crate::parser::parse_oracle_text;
     use crate::types::counter::{CounterMatch, CounterType};
 
     /// CR 400.7 + CR 608.2c: S07 Batch 1 — the leading-"if" active-voice
@@ -8743,5 +8870,200 @@ mod tests {
             ),
             "dispatcher routes the named-subject entered-this-turn gate to the detector, got {routed:?}"
         );
+    }
+
+    // ---- "you control a <noun> of each <dimension>" (Coalition Victory) ----
+
+    /// CR 305.6: the single-clause recognizer expands "a land of each basic land
+    /// type" into one `ControllerControlsMatching{land.subtype(x).You}` per basic
+    /// land type, in canonical order.
+    #[test]
+    fn of_each_basic_land_type_expands_to_five_subtypes() {
+        let cond =
+            parse_you_control_of_each_condition_text("you control a land of each basic land type")
+                .expect("clause must parse");
+        let AbilityCondition::And { conditions } = cond else {
+            panic!("expected And, got {cond:?}");
+        };
+        let subtypes: Vec<String> = conditions
+            .iter()
+            .map(|c| match c {
+                AbilityCondition::ControllerControlsMatching {
+                    filter: TargetFilter::Typed(tf),
+                } => {
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                    assert!(tf
+                        .type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Land)));
+                    tf.get_subtype().expect("subtype").to_string()
+                }
+                other => panic!("expected ControllerControlsMatching land, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            subtypes,
+            vec!["Plains", "Island", "Swamp", "Mountain", "Forest"]
+        );
+    }
+
+    /// CR 105.1: "a creature of each color" expands to one
+    /// `ControllerControlsMatching{creature.HasColor(c).You}` per WUBRG color.
+    #[test]
+    fn of_each_color_expands_to_five_colors() {
+        let cond = parse_you_control_of_each_condition_text("you control a creature of each color")
+            .expect("clause must parse");
+        let AbilityCondition::And { conditions } = cond else {
+            panic!("expected And, got {cond:?}");
+        };
+        let colors: Vec<ManaColor> = conditions
+            .iter()
+            .map(|c| match c {
+                AbilityCondition::ControllerControlsMatching {
+                    filter: TargetFilter::Typed(tf),
+                } => {
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                    assert!(tf
+                        .type_filters
+                        .iter()
+                        .any(|t| matches!(t, TypeFilter::Creature)));
+                    match tf.properties.as_slice() {
+                        [FilterProp::HasColor { color }] => *color,
+                        other => panic!("expected single HasColor prop, got {other:?}"),
+                    }
+                }
+                other => panic!("expected ControllerControlsMatching creature, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(colors, ManaColor::ALL.to_vec());
+    }
+
+    /// CR 105.1: "a permanent of each color" (Spirit of Resistance's inner clause)
+    /// parses to the same 5-color permanent expansion. This exercises the
+    /// building-block for that card's dimension; note that Spirit of Resistance's
+    /// static "as long as" path resolves through a SEPARATE `ParsedCondition`
+    /// parser (`oracle_condition.rs`) and is unaffected by this recognizer.
+    #[test]
+    fn of_each_color_permanent_variant_parses() {
+        let cond =
+            parse_you_control_of_each_condition_text("you control a permanent of each color")
+                .expect("permanent clause must parse");
+        let AbilityCondition::And { conditions } = cond else {
+            panic!("expected And, got {cond:?}");
+        };
+        assert_eq!(conditions.len(), 5);
+        for c in &conditions {
+            let AbilityCondition::ControllerControlsMatching {
+                filter: TargetFilter::Typed(tf),
+            } = c
+            else {
+                panic!("expected ControllerControlsMatching, got {c:?}");
+            };
+            assert!(tf
+                .type_filters
+                .iter()
+                .any(|t| matches!(t, TypeFilter::Permanent)));
+            assert!(tf
+                .properties
+                .iter()
+                .any(|p| matches!(p, FilterProp::HasColor { .. })));
+        }
+    }
+
+    /// The `"you control"` possessive scopes BOTH clauses, so the recognizer binds
+    /// the conjunction itself: "you control a land of each basic land type and a
+    /// creature of each color" → a flat `And` of all 10 members (5 lands + 5
+    /// colors). The generic top-level splitter would strip "you control" off the
+    /// second conjunct, which is why the conjunction lives inside this recognizer.
+    #[test]
+    fn of_each_recognizer_binds_the_shared_subject_conjunction() {
+        let cond = parse_you_control_of_each_condition_text(
+            "you control a land of each basic land type and a creature of each color",
+        )
+        .expect("full conjunction must parse");
+        let AbilityCondition::And { conditions } = cond else {
+            panic!("expected And, got {cond:?}");
+        };
+        assert_eq!(conditions.len(), 10, "5 basic land types + 5 colors");
+        // A bare clause with no leading subject must NOT parse (the possessive is
+        // mandatory — this is a controller-scoped condition).
+        assert!(
+            parse_you_control_of_each_condition_text("a creature of each color").is_none(),
+            "the 'you control' subject is required"
+        );
+    }
+
+    /// Isolates the trailing-if router: `strip_suffix_conditional` on Coalition
+    /// Victory's whole sentence must peel the effect and return the composed
+    /// `And{[…10 members]}` condition.
+    #[test]
+    fn strip_suffix_conditional_composes_coalition_victory() {
+        let (cond, body) = strip_suffix_conditional(
+            "You win the game if you control a land of each basic land type and a creature of each color",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(body, "You win the game");
+        let Some(AbilityCondition::And { conditions }) = cond else {
+            panic!("expected And, got {cond:?}");
+        };
+        assert_eq!(conditions.len(), 10);
+    }
+
+    /// CR 104.2b + CR 608.2c: Coalition Victory's whole condition attaches to the
+    /// parsed ability as a flat `And{[10× ControllerControlsMatching]}` (5 basic
+    /// land subtypes + 5 colors). Revert guard: on pre-fix code `condition` is
+    /// `None` (the win-condition was dropped and the win fired unconditionally).
+    #[test]
+    fn coalition_victory_attaches_full_ten_member_condition() {
+        let parsed = parse_oracle_text(
+            "You win the game if you control a land of each basic land type and a creature of each color.",
+            "Coalition Victory",
+            &[],
+            &["Sorcery".to_string()],
+            &[],
+        );
+        let ability = parsed
+            .abilities
+            .iter()
+            .find(|a| matches!(*a.effect, Effect::WinTheGame { .. }))
+            .expect("Coalition Victory must parse a WinTheGame ability");
+        let Some(AbilityCondition::And { conditions }) = ability.condition.clone() else {
+            panic!("expected And condition, got {:?}", ability.condition);
+        };
+        assert_eq!(conditions.len(), 10, "5 basic land types + 5 colors");
+        // 5 land-subtype members, controller-scoped.
+        let land_subtypes: Vec<String> = conditions
+            .iter()
+            .filter_map(|c| match c {
+                AbilityCondition::ControllerControlsMatching {
+                    filter: TargetFilter::Typed(tf),
+                } if tf.get_subtype().is_some() => {
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                    Some(tf.get_subtype().unwrap().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            land_subtypes,
+            vec!["Plains", "Island", "Swamp", "Mountain", "Forest"]
+        );
+        // 5 color members via HasColor, controller-scoped.
+        let colors: Vec<ManaColor> = conditions
+            .iter()
+            .filter_map(|c| match c {
+                AbilityCondition::ControllerControlsMatching {
+                    filter: TargetFilter::Typed(tf),
+                } => tf.properties.iter().find_map(|p| match p {
+                    FilterProp::HasColor { color } => {
+                        assert_eq!(tf.controller, Some(ControllerRef::You));
+                        Some(*color)
+                    }
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(colors, ManaColor::ALL.to_vec());
     }
 }

--- a/crates/engine/tests/coalition_victory_win_condition.rs
+++ b/crates/engine/tests/coalition_victory_win_condition.rs
@@ -1,0 +1,179 @@
+//! Coalition Victory — the win-condition gate (CR 104.2b + CR 608.2c).
+//!
+//! Oracle: "You win the game if you control a land of each basic land type and a
+//! creature of each color." Before the parser fix, the trailing-`if` condition was
+//! DROPPED (`ability.condition == None`), so `resolve_win` fired UNCONDITIONALLY —
+//! the controller won the instant the spell resolved, regardless of board state.
+//!
+//! The fix attaches a flat `And{[5 basic-land members + 5 color members]}` to the
+//! ability. The resolution gate at `game/effects/mod.rs` (`evaluate_condition`)
+//! then only invokes `resolve_win` when every member is satisfied.
+//!
+//! Discriminating structure (each asserts through the REAL cast+resolve pipeline,
+//! `apply()` via `GameRunner::cast(..).resolve()`):
+//!
+//! - `met`  → controller wins (`GameOver { winner }`, opponent eliminated).
+//! - `missing_one_land_type` → NO win (opponent alive, game not over). Revert guard.
+//! - `missing_one_color`     → NO win (opponent alive, game not over). Revert guard.
+//!
+//! On pre-fix code the two "missing" cases WIN (wrong), so they fail — proving the
+//! gate is live and driven by the parsed condition, not a shape assertion.
+
+use engine::game::scenario::GameScenario;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const COALITION_VICTORY: &str =
+    "You win the game if you control a land of each basic land type and a creature of each color.";
+
+/// Distinct single-color creatures for each of the five colors, keyed by color so
+/// `HasColor` (obj.color.contains) matches one member per color.
+const WUBRG: [ManaColor; 5] = [
+    ManaColor::White,
+    ManaColor::Blue,
+    ManaColor::Black,
+    ManaColor::Red,
+    ManaColor::Green,
+];
+
+/// A single-color mana cost (`{W}`, `{U}`, …) so the creature's derived color is
+/// exactly that color.
+fn one_color_cost(color: ManaColor) -> ManaCost {
+    let shard = match color {
+        ManaColor::White => ManaCostShard::White,
+        ManaColor::Blue => ManaCostShard::Blue,
+        ManaColor::Black => ManaCostShard::Black,
+        ManaColor::Red => ManaCostShard::Red,
+        ManaColor::Green => ManaCostShard::Green,
+    };
+    ManaCost::Cost {
+        generic: 0,
+        shards: vec![shard],
+    }
+}
+
+/// Build a 2-player scenario in P0's precombat main with a zero-cost Coalition
+/// Victory in hand. `land_colors` seeds one basic land per listed color (its
+/// basic land type follows), `creature_colors` seeds one single-color creature per
+/// listed color. Returns (scenario, spell id).
+fn setup(
+    land_colors: &[ManaColor],
+    creature_colors: &[ManaColor],
+) -> (GameScenario, engine::types::ObjectId) {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 20);
+    scenario.with_life(P1, 20);
+
+    for &color in land_colors {
+        scenario.add_basic_land(P0, color);
+    }
+    for (i, &color) in creature_colors.iter().enumerate() {
+        scenario
+            .add_creature(P0, &format!("Color Bearer {i}"), 1, 1)
+            .with_mana_cost(one_color_cost(color));
+    }
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Coalition Victory", false, COALITION_VICTORY)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    (scenario, spell)
+}
+
+/// CR 104.2b + CR 608.2c: with all five basic land types AND all five colors
+/// controlled, the win condition is MET — P0 wins and the sole opponent is
+/// eliminated.
+#[test]
+fn coalition_victory_condition_met_controller_wins() {
+    let (scenario, spell) = setup(&WUBRG, &WUBRG);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).resolve();
+
+    assert_eq!(
+        *outcome.final_waiting_for(),
+        WaitingFor::GameOver { winner: Some(P0) },
+        "condition met: P0 must win, got {:?}",
+        outcome.final_waiting_for()
+    );
+    assert!(
+        outcome
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .map(|p| p.is_eliminated)
+            .unwrap(),
+        "condition met: the sole opponent must be eliminated"
+    );
+}
+
+/// REVERT GUARD (the bug): missing ONE basic land type (Forest) — the condition is
+/// NOT met, so `resolve_win` must NOT fire. On pre-fix code the condition was
+/// dropped and P0 wrongly won here.
+#[test]
+fn coalition_victory_missing_one_land_type_no_win() {
+    // Four of five basic land types (no Forest); all five colors present.
+    let land_colors = [
+        ManaColor::White,
+        ManaColor::Blue,
+        ManaColor::Black,
+        ManaColor::Red,
+    ];
+    let (scenario, spell) = setup(&land_colors, &WUBRG);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).resolve();
+
+    assert_ne!(
+        *outcome.final_waiting_for(),
+        WaitingFor::GameOver { winner: Some(P0) },
+        "missing a land type: P0 must NOT win"
+    );
+    assert!(
+        !outcome
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .map(|p| p.is_eliminated)
+            .unwrap(),
+        "missing a land type: the opponent must still be alive"
+    );
+}
+
+/// REVERT GUARD (the bug): all five basic land types but missing ONE color (no
+/// green creature) — the condition is NOT met, so no win. Pre-fix, P0 wrongly won.
+#[test]
+fn coalition_victory_missing_one_color_no_win() {
+    // All five basic land types; four of five colors (no green creature).
+    let creature_colors = [
+        ManaColor::White,
+        ManaColor::Blue,
+        ManaColor::Black,
+        ManaColor::Red,
+    ];
+    let (scenario, spell) = setup(&WUBRG, &creature_colors);
+    let mut runner = scenario.build();
+    let outcome = runner.cast(spell).resolve();
+
+    assert_ne!(
+        *outcome.final_waiting_for(),
+        WaitingFor::GameOver { winner: Some(P0) },
+        "missing a color: P0 must NOT win"
+    );
+    assert!(
+        !outcome
+            .state()
+            .players
+            .iter()
+            .find(|p| p.id == P1)
+            .map(|p| p.is_eliminated)
+            .unwrap(),
+        "missing a color: the opponent must still be alive"
+    );
+}


### PR DESCRIPTION
## Summary

Coalition Victory ("You win the game if you control a land of each basic land type and a creature of each color") parsed to `Effect::WinTheGame` with the trailing win-condition **dropped** (ability condition = `null`), so `resolve_win` eliminated all opponents **unconditionally** the instant the spell resolved — an auto-win ignoring the printed condition (CR 104.2b / 608.2c). This is a parser gap: the resolution engine already gates effects on the ability condition, but no recognizer matched the "control a [noun] of each [dimension]" quantifier, so the clause was silently discarded.

## Implementation method (required)

How was the engine/parser logic in this PR produced? Check exactly one:

- [x] Produced via the `/engine-implementer` pipeline (plan → review-plan → implement → review-impl → commit)
- [ ] **Not** `/engine-implementer` — explain why below

**Disclosure:** authored with AI assistance (Claude) driving the `/engine-implementer` pipeline end-to-end — an independent plan-review agent (verified the resolution-gating claim against real code) and an independent implementation-review agent (empirically proved the fix by disabling the recognizer and confirming the revert-guard tests fail on pre-fix code) gated each stage.

## CR references

- CR 104.2b — an effect may state that a player wins the game.
- CR 608.2c — read the whole text / resolution-time condition evaluation.
- CR 305.6 — the five basic land types (Plains/Island/Swamp/Mountain/Forest).
- CR 105.1 — the five colors (WUBRG).

All grep-verified against `docs/MagicCompRules.txt`.

## Verification

Parser-only fix (no engine change, no new enum variant): a nom recognizer turns "you control a {land|creature|permanent} of each {basic land type|color}" into `AbilityCondition::And { [ControllerControlsMatching{filter} per member] }`, reusing the existing `And` + `ControllerControlsMatching` machinery exactly as the Urzatron control-condition recognizer does. The existing resolution gate then makes the win fire only when all members are satisfied.

- **Full `cargo test -p engine`**: green (0 failures).
- **3 scenario-runner runtime tests** through the real cast+resolve pipeline: condition met → controller wins; **missing one basic land type → no win**; **missing one color → no win**. The two negatives are revert guards — verified they FAIL on pre-fix code (which auto-wins).
- **6 parser/unit tests** (clause shape, permanent variant, conjunction binding, router isolation, end-to-end condition attach, composed-primitive evaluation).
- `cargo clippy -p engine --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `cargo semantic-audit`: Coalition Victory's `DroppedCondition` finding clears; no sibling regression.
- Parser combinator gate + string-dispatch gate: clean.


## Files changed

- `crates/engine/src/parser/oracle_effect/conditions.rs` — adds the composed `you control a <noun> of each <dimension>` condition recognizer.
- `crates/engine/tests/coalition_victory_win_condition.rs` — runtime cast/resolve regression tests for condition met, missing land type, and missing color.

## Track

Non-developer

## LLM

Model: Claude
Thinking: high
