### PR TITLE
fix(client): count mana shards serialized as engine variant names

### DIFF
--- a/client/src/viewmodel/__tests__/dominantColor.test.ts
+++ b/client/src/viewmodel/__tests__/dominantColor.test.ts
@@ -118,6 +118,48 @@ describe("getDominantManaColor", () => {
     expect(result).toBe("White");
   });
 
+  it("counts shards serialized as engine variant names (e.g. 'White')", () => {
+    // The engine emits mana_cost.shards as Rust variant names, never Scryfall
+    // symbols like "W", so a colored spell's pips must still be counted.
+    const objects: Record<string, GameObject> = {
+      "1": makeGameObject({
+        id: 1,
+        name: "Serra Angel",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: ["Angel"] },
+        mana_cost: { type: "Cost", shards: ["White", "White"], generic: 3 },
+      }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Lightning Bolt",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Red"], generic: 0 },
+      }),
+    };
+
+    expect(getDominantManaColor([1, 2], objects, 0)).toBe("White");
+  });
+
+  it("counts both halves of a hybrid shard variant name (e.g. 'WhiteBlue')", () => {
+    // "WhiteBlue" bridges to "W/U"; both White and Blue should be tallied.
+    const objects: Record<string, GameObject> = {
+      "1": makeGameObject({
+        id: 1,
+        name: "Hybrid Spell",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["WhiteBlue"], generic: 0 },
+      }),
+      "2": makeGameObject({
+        id: 2,
+        name: "Blue Spell",
+        card_types: { supertypes: [], core_types: ["Creature"], subtypes: [] },
+        mana_cost: { type: "Cost", shards: ["Blue"], generic: 0 },
+      }),
+    };
+
+    // Blue appears in both objects (hybrid half + mono), White only once → Blue wins.
+    expect(getDominantManaColor([1, 2], objects, 0)).toBe("Blue");
+  });
+
   it("combines land subtypes and spell mana costs", () => {
     const objects: Record<string, GameObject> = {
       "1": makeGameObject({ id: 1, card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] } }),

--- a/client/src/viewmodel/dominantColor.ts
+++ b/client/src/viewmodel/dominantColor.ts
@@ -1,4 +1,5 @@
 import type { GameObject, ManaColor, PlayerId } from "../adapter/types";
+import { SHARD_ABBREVIATION } from "./costLabel";
 
 const LAND_SUBTYPE_TO_COLOR: Record<string, ManaColor> = {
   Plains: "White",
@@ -37,8 +38,13 @@ function countColors(
     } else if (obj.mana_cost.type === "Cost") {
       // Non-land permanents: count colored mana shards
       for (const shard of obj.mana_cost.shards) {
-        // Handle hybrid shards like "W/U" — count both halves
-        for (const part of shard.split("/")) {
+        // The engine serializes shards as Rust variant names ("White",
+        // "WhiteBlue", "TwoWhite", "PhyrexianWhite"…), so bridge to Scryfall
+        // symbols first (the same canonical map the rest of the viewmodel uses).
+        // The `?? shard` fallback also accepts an already-symbolic shard.
+        const symbol = SHARD_ABBREVIATION[shard] ?? shard;
+        // Handle hybrid shards like "W/U" — count both halves.
+        for (const part of symbol.split("/")) {
           const color = SHARD_TO_COLOR[part];
           if (color) colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
         }


### PR DESCRIPTION
## Problem

`getDominantManaColor` / `getDeckDominantColor` (`client/src/viewmodel/dominantColor.ts`) key `SHARD_TO_COLOR` by Scryfall symbols (`W`/`U`/`B`/`R`/`G`), but the engine serializes `mana_cost.shards` as **Rust variant names** — `"White"`, `"WhiteBlue"`, `"TwoWhite"`, `"PhyrexianWhite"`, … (see `SHARD_ABBREVIATION` in `costLabel.ts`, `manaValueOfShard` in `manaValue.ts`, and the fixtures used across the client). So every non-land spell shard misses the map: colored pips are silently dropped and the auto-WUBRG `BattlefieldBackground` (the sole consumer) ignores spell colors entirely. Hybrid/gold spells are doubly broken — the `split("/")` half-counting never fires because the engine emits `"WhiteBlue"`, not `"W/U"`.

## Fix

Bridge each shard through the canonical `SHARD_ABBREVIATION` map (the same map `manaCostToShards` / `manaAvailability` already use) before splitting hybrids, with a `?? shard` fallback that still accepts an already-symbolic shard. Now `White→W`, `WhiteBlue→W/U` (both halves), `TwoWhite→2/W` (W), `PhyrexianWhite→W/P` (W); `X`/`Colorless` correctly contribute no color.

## Tests

Adds discriminating tests using the **real variant-name wire format** — they fail on the current code (the shard misses the map → `null`) and pass after the fix. The existing symbol-format test still passes via the `?? shard` fallback (no regression). `tsc -b --noEmit` and `eslint` clean; `vitest` 12/12.

Self-contained: only `dominantColor.ts` + its test; no engine/Rust/protocol changes.

Model: claude-opus-4-8