### PR TITLE
fix(client): treat a whitespace-only deck-search query as no criteria

### DIFF
--- a/client/src/components/deck-builder/__tests__/searchFilters.test.ts
+++ b/client/src/components/deck-builder/__tests__/searchFilters.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { CardSearchFilters } from "../CardSearch";
+import { hasSearchCriteria } from "../searchFilters";
+
+function makeFilters(overrides: Partial<CardSearchFilters> = {}): CardSearchFilters {
+  return {
+    text: "",
+    colors: [],
+    type: "",
+    cmcMax: undefined,
+    sets: [],
+    browseFormat: "all",
+    ...overrides,
+  };
+}
+
+describe("hasSearchCriteria", () => {
+  it("is false for fully empty filters", () => {
+    expect(hasSearchCriteria(makeFilters())).toBe(false);
+  });
+
+  it("is true for a real text query", () => {
+    expect(hasSearchCriteria(makeFilters({ text: "bolt" }))).toBe(true);
+  });
+
+  it("is false for a whitespace-only query (not real criteria)", () => {
+    // The text box is stored raw/untrimmed, so a spaces-only value must not
+    // register as an active search — otherwise the canvas swaps to (empty)
+    // results and a no-op search fires.
+    expect(hasSearchCriteria(makeFilters({ text: "   " }))).toBe(false);
+    expect(hasSearchCriteria(makeFilters({ text: "\t\n " }))).toBe(false);
+  });
+
+  it("still detects a query that has surrounding whitespace", () => {
+    expect(hasSearchCriteria(makeFilters({ text: "  bolt  " }))).toBe(true);
+  });
+
+  it("detects non-text criteria regardless of text", () => {
+    expect(hasSearchCriteria(makeFilters({ colors: ["R"] }))).toBe(true);
+    expect(hasSearchCriteria(makeFilters({ type: "Creature" }))).toBe(true);
+    expect(hasSearchCriteria(makeFilters({ cmcMax: 0 }))).toBe(true);
+    expect(hasSearchCriteria(makeFilters({ sets: ["neo"] }))).toBe(true);
+  });
+});

--- a/client/src/components/deck-builder/searchFilters.ts
+++ b/client/src/components/deck-builder/searchFilters.ts
@@ -12,7 +12,10 @@ import type { CardSearchFilters } from "./CardSearch";
  */
 export function hasSearchCriteria(filters: CardSearchFilters): boolean {
   return Boolean(
-    filters.text
+    // `text` is the raw, untrimmed input box value, so a whitespace-only query
+    // ("   ") is not real criteria — trim before testing, or it would trip the
+    // search trigger + deck-vs-results canvas swap for an effectively empty query.
+    filters.text.trim()
       || filters.colors.length > 0
       || filters.type
       || filters.cmcMax !== undefined


### PR DESCRIPTION
## Problem

`hasSearchCriteria` (`client/src/components/deck-builder/searchFilters.ts`) is documented as *"the single authority for is-a-search-active — the search trigger, the debounce, and the deck builder's deck-vs-results canvas swap all key off it."* It tested the **raw, untrimmed** text-box value via `Boolean(filters.text)`. `handleTextChange` stores the input verbatim (`text: value`), so a whitespace-only query (`"   "`) registered as active criteria — swapping the canvas to an empty results view and firing a no-op search, contradicting the function's own "real search criteria" contract.

## Fix

Trim the text before the truthiness test (`filters.text.trim()`). Real queries — including those with surrounding whitespace — are unaffected; only all-whitespace input flips to "no criteria."

## Tests

The `searchFilters` module had no test; this adds one covering the empty, real-query, whitespace-only, surrounding-whitespace, and each non-text-criteria case. The whitespace-only assertion fails without the fix (discriminating). `tsc -b --noEmit` and `eslint` clean.

Self-contained: only `searchFilters.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8