### PR TITLE
fix(client): guard resizeBand against a degenerate viewport height

### DIFF
--- a/client/src/components/flexlayout/__tests__/ZoneSplitter.test.ts
+++ b/client/src/components/flexlayout/__tests__/ZoneSplitter.test.ts
@@ -47,6 +47,18 @@ describe("resizeBand", () => {
     const next = resizeBand({ pct: 20, pxCap: 200 }, -20, VH, home); // 180px, 30px off
     expect(next.pxCap).toBe(180);
   });
+
+  it("is a no-op on a degenerate (zero/negative/NaN) viewport, never persisting a NaN track", () => {
+    // window.innerHeight can be 0 / NaN transiently (collapsed or pre-layout
+    // container); the result is written to the persisted preferences store, so a
+    // NaN would serialize to null and corrupt the stored track permanently.
+    const track = { pct: 12, pxCap: 100 };
+    expect(resizeBand(track, 50, 0)).toEqual(track);
+    expect(Number.isNaN(resizeBand(track, 50, 0).pct)).toBe(false);
+    expect(resizeBand(track, 50, Number.NaN)).toEqual(track);
+    // A negative viewport would otherwise yield a negative pxCap.
+    expect(resizeBand(track, 50, -100).pxCap).toBeGreaterThan(0);
+  });
 });
 
 describe("ratioFromPointerX", () => {

--- a/client/src/components/flexlayout/gridBandMath.ts
+++ b/client/src/components/flexlayout/gridBandMath.ts
@@ -26,6 +26,12 @@ export function resizeBand(
   viewportH: number,
   snapToDefault?: CappedTrack,
 ): CappedTrack {
+  // Degenerate viewport (zero / negative / NaN height — window.innerHeight can be
+  // 0 transiently for a collapsed/pre-layout container): no meaningful resize is
+  // possible, and the pct math below would divide by it and yield a NaN (which
+  // persists as null) or a negative pxCap. Return the current track unchanged,
+  // mirroring ratioFromPointerX's degenerate-region guard.
+  if (!(viewportH > 0)) return current;
   const currentPx = Math.min((current.pct / 100) * viewportH, current.pxCap);
   const maxPx = viewportH * MAX_FRACTION;
   const nextPx = clamp(currentPx + deltaPx, MIN_PX, maxPx);


### PR DESCRIPTION
## Problem

`resizeBand` (`client/src/components/flexlayout/gridBandMath.ts`) divides by `viewportH` (`(nextPx / viewportH) * 100`) without guarding it. `ZoneSplitter.tsx` calls it with `window.innerHeight`, which can be **0 transiently** (collapsed / hidden / pre-layout container). At `viewportH === 0`, `nextPx` clamps to 0 and `pct = (0 / 0) * 100 = NaN`; a negative height yields a negative `pxCap`. The result is written straight to the **persisted** `preferencesStore`, and `JSON.stringify(NaN) === "null"`, so a single bad read permanently corrupts the stored track — a broken `min(null%, 0px)` band that survives reloads.

## Fix

Add an early guard mirroring the sibling `ratioFromPointerX`'s existing degenerate-region check (`if (right <= left) return 0.5;`): when `viewportH` is not `> 0` (catches zero, negative, **and** NaN in one expression), return the current track unchanged — a safe no-op that preserves the last valid track.

## Tests

Adds a discriminating case to the existing `resizeBand` suite covering zero / NaN / negative viewport; it fails without the guard (returns `{pct: NaN}` / negative `pxCap`). Normal-range behavior is unchanged. `tsc -b --noEmit` and `eslint` clean.

Self-contained: one guard line in a pure function + a test; no engine/Rust/protocol changes.

Model: claude-opus-4-8