### PR TITLE
fix(client): ignore NaN in setDownloadProgress instead of storing it

### DIFF
--- a/client/src/pwa/__tests__/updateStatus.test.ts
+++ b/client/src/pwa/__tests__/updateStatus.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { getDownloadProgress, setDownloadProgress } from "../updateStatus";
+
+describe("setDownloadProgress", () => {
+  it("clamps values into the 0–100 range and rounds", () => {
+    setDownloadProgress(42.4);
+    expect(getDownloadProgress()).toBe(42);
+    setDownloadProgress(150);
+    expect(getDownloadProgress()).toBe(100);
+    setDownloadProgress(-10);
+    expect(getDownloadProgress()).toBe(0);
+  });
+
+  it("clamps ±Infinity to the range bounds", () => {
+    setDownloadProgress(Number.POSITIVE_INFINITY);
+    expect(getDownloadProgress()).toBe(100);
+    setDownloadProgress(Number.NEGATIVE_INFINITY);
+    expect(getDownloadProgress()).toBe(0);
+  });
+
+  it("ignores NaN and preserves the last valid progress", () => {
+    // NaN is what `receivedBytes / totalBytes * 100` yields when a download
+    // reports no content-length (totalBytes === 0). It must never be stored:
+    // it escapes the Math.max/min clamp and, because NaN !== NaN, defeats the
+    // change guard too, rendering "NaN%" in the UI.
+    setDownloadProgress(42);
+    expect(getDownloadProgress()).toBe(42);
+
+    setDownloadProgress(Number.NaN);
+
+    expect(Number.isNaN(getDownloadProgress())).toBe(false);
+    expect(getDownloadProgress()).toBe(42);
+  });
+});

--- a/client/src/pwa/updateStatus.ts
+++ b/client/src/pwa/updateStatus.ts
@@ -106,6 +106,12 @@ let downloadProgress = 0;
 const progressListeners = new Set<() => void>();
 
 export function setDownloadProgress(value: number) {
+  // NaN escapes the 0–100 clamp below (Math.max/min propagate NaN, and
+  // `downloadProgress === NaN` is always false so the change guard doesn't stop
+  // it), poisoning the store and the progress UI. NaN is the `received / total`
+  // result when a download reports no content-length, so ignore it and keep the
+  // last valid value. (±Infinity still clamp correctly to 100 / 0.)
+  if (Number.isNaN(value)) return;
   const clamped = Math.max(0, Math.min(100, Math.round(value)));
   if (downloadProgress === clamped) return;
   downloadProgress = clamped;


### PR DESCRIPTION
## Problem

`setDownloadProgress` (`client/src/pwa/updateStatus.ts`) documents a 0–100 clamp, but `NaN` escapes it: `Math.max`/`Math.min` propagate `NaN`, and the `downloadProgress === clamped` change guard never trips (`NaN !== NaN`), so `NaN` is stored and pushed to listeners. `BuildBadge` then renders `"NaN%"` and `style={{ width: "NaN%" }}` (invalid CSS), and each subsequent `NaN` re-notifies every listener.

`NaN` is exactly the `receivedBytes / totalBytes * 100` result when a download reports no content-length — `tauriUpdater.ts` reads `event.data.contentLength ?? 0`, so `totalBytes` can be 0. That caller already had to add a `totalBytes > 0` workaround; the utility should defend its own documented contract rather than rely on every caller to guard.

## Fix

A `Number.isNaN(value)` early return that keeps the last valid progress. Every finite value and `±Infinity` still clamp correctly (`Infinity→100`, `-Infinity→0`) — only `NaN` is rejected.

## Tests

Adds the module's first test: the clamp/rounding, `±Infinity`, and the `NaN` case (which fails without the guard — discriminating, seeded with a known value so it is immune to singleton state). `tsc -b --noEmit` and `eslint` clean.

Self-contained: only `updateStatus.ts` + a new test; no engine/Rust/protocol changes.

Model: claude-opus-4-8