### PR TITLE
fix(engine): cast-copy-of-a-card copies never cease to exist (CR 704.5e / 707.10a)

### DIFF
--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1616,7 +1616,12 @@ fn check_counter_cancellation(
 }
 
 /// CR 704.5d: A token that's in a zone other than the battlefield ceases to exist.
-/// Tokens on the stack are excluded — spell copies resolve before the next SBA check.
+/// CR 704.5e + CR 707.10a: A copy of a card in a zone other than the stack or the
+/// battlefield also ceases to exist. Both are checked here because both are
+/// non-card objects swept by the same removal loop. The stack is excluded for both
+/// so spell copies (and copies of cards resolving as spells) finish resolving
+/// before the next SBA check; the battlefield is legal for a copy of a card
+/// (CR 707.10f) but not for a token off-battlefield.
 fn check_token_cease_to_exist(state: &mut GameState, any_performed: &mut bool) {
     let tokens_to_remove: Vec<(
         crate::types::identifiers::ObjectId,
@@ -1625,7 +1630,10 @@ fn check_token_cease_to_exist(state: &mut GameState, any_performed: &mut bool) {
     )> = state
         .objects
         .iter()
-        .filter(|(_, obj)| zones::token_is_outside_battlefield_and_stack(obj))
+        .filter(|(_, obj)| {
+            zones::token_is_outside_battlefield_and_stack(obj)
+                || zones::copy_of_card_outside_battlefield_and_stack(obj)
+        })
         .map(|(id, obj)| (*id, obj.zone, obj.owner))
         .collect();
 
@@ -4265,6 +4273,127 @@ mod tests {
         assert!(
             state.objects.contains_key(&id),
             "Token on stack should survive SBA"
+        );
+    }
+
+    // --- CR 704.5e + CR 707.10a: Copy-of-a-card cease-to-exist tests ---
+
+    /// A copy of a card (is_copy = true, is_token = false) resolving to the
+    /// graveyard — as an `Effect::CastCopyOfCard` non-permanent spell copy does —
+    /// must cease to exist as a state-based action. Revert probe: without the
+    /// `copy_of_card_outside_battlefield_and_stack` filter arm, this copy persists
+    /// forever as an orphan graveyard object (the original bug).
+    #[test]
+    fn copy_of_card_in_graveyard_ceases_to_exist() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "SpellCopy".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.is_copy = true;
+            obj.is_token = false;
+        }
+
+        let mut events = Vec::new();
+        zones::move_to_zone(&mut state, id, Zone::Graveyard, &mut events);
+        events.clear();
+
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !state.objects.contains_key(&id),
+            "Copy of a card in the graveyard should cease to exist"
+        );
+        assert!(
+            !state.players[0].graveyard.contains(&id),
+            "Copy of a card should be removed from the graveyard"
+        );
+        // CR 400.7: ceasing to exist is not a zone change — no ZoneChanged event.
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, GameEvent::ZoneChanged { object_id, .. } if *object_id == id)),
+            "SBA removal must not emit a ZoneChanged event for the ceased copy"
+        );
+    }
+
+    /// The core negative: a real card (is_copy = false, is_token = false) in the
+    /// graveyard must NOT be swept. Revert probe: an over-broad filter that removed
+    /// any graveyard object would delete this and break every graveyard mechanic.
+    #[test]
+    fn real_card_in_graveyard_survives_sba() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "RealCard".to_string(),
+            Zone::Graveyard,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.is_copy = false;
+            obj.is_token = false;
+        }
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            state.objects.contains_key(&id),
+            "A real card in the graveyard must not be swept by the copy SBA"
+        );
+    }
+
+    /// Adjacent-zone hostile: a live copy of a card ON THE BATTLEFIELD must NOT be
+    /// swept — CR 707.10f makes a permanent copy legal there. Revert probe: dropping
+    /// the `Zone::Battlefield` carve-out in the predicate would delete it.
+    #[test]
+    fn copy_of_card_on_battlefield_survives_sba() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "BattlefieldCopy".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&id).unwrap().is_copy = true;
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            state.objects.contains_key(&id),
+            "A copy of a card on the battlefield must survive the SBA"
+        );
+    }
+
+    /// Adjacent-zone hostile: a copy of a card ON THE STACK must NOT be swept —
+    /// it is still resolving. Mirrors `token_on_stack_survives_sba`.
+    #[test]
+    fn copy_of_card_on_stack_survives_sba() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "StackCopy".to_string(),
+            Zone::Stack,
+        );
+        state.objects.get_mut(&id).unwrap().is_copy = true;
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            state.objects.contains_key(&id),
+            "A copy of a card on the stack must survive the SBA"
         );
     }
 

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -710,6 +710,19 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             Zone::Graveyard
         };
         if dest == Zone::Battlefield {
+            // CR 707.10f + CR 608.3f: A copy of a permanent spell becomes a token
+            // permanent AS it resolves onto the battlefield — BEFORE the ETB
+            // replacement pipeline matches the ZoneChange and before the
+            // zone-change record snapshots is_token, so token-scoped ETB
+            // replacements and enters-the-battlefield trigger filters
+            // (FilterProp::Token/NonToken) correctly observe it as a token.
+            // Copy-gated → no-op for every non-copy battlefield entry.
+            if let Some(obj) = state.objects.get_mut(&entry.id) {
+                if obj.is_copy {
+                    obj.is_copy = false;
+                    obj.is_token = true;
+                }
+            }
             // CR 614.1c + CR 608.3: Route battlefield entry through the replacement
             // pipeline so ETB replacements (saga lore counters, enter-tapped, etc.) fire.
             let mut proposed = crate::types::proposed_event::ProposedEvent::zone_change(
@@ -3012,6 +3025,104 @@ mod tests {
         );
     }
 
+    /// CR 707.10f + CR 608.3f: A copy of a PERMANENT spell, as it resolves onto
+    /// the battlefield, ceases being a copy and becomes a token permanent. Drives
+    /// the real spell-resolution → battlefield path (`resolve_top` →
+    /// `deliver_replaced_zone_change`). Revert probe: without the copy-gated flip,
+    /// `is_copy` stays true, `is_token` stays false, and
+    /// `is_represented_by_a_card()` wrongly returns false — and the CR 704.5e SBA
+    /// would later sweep the permanent off the battlefield the moment it moved.
+    #[test]
+    fn resolving_permanent_copy_becomes_a_token() {
+        let mut state = setup();
+        let spell_id = create_object(
+            &mut state,
+            CardId(700),
+            PlayerId(0),
+            "Permanent Copy".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.is_copy = true;
+            obj.is_token = false;
+        }
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(700),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let mut events = Vec::new();
+        resolve_top(&mut state, &mut events);
+
+        let obj = &state.objects[&spell_id];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert!(
+            obj.is_token,
+            "CR 707.10f: a permanent copy becomes a token as it resolves"
+        );
+        assert!(
+            !obj.is_copy,
+            "CR 707.10f: it is no longer a copy of a spell once on the battlefield"
+        );
+        assert!(
+            !obj.is_represented_by_a_card(),
+            "CR 111.1: a token permanent is not represented by a card"
+        );
+    }
+
+    /// Multi-authority negative for the CR 707.10f flip: a REAL permanent
+    /// (is_copy = false) resolving to the battlefield stays a card — the flip is
+    /// copy-gated and must not turn every entering permanent into a token.
+    #[test]
+    fn resolving_real_permanent_stays_a_card() {
+        let mut state = setup();
+        let spell_id = create_object(
+            &mut state,
+            CardId(701),
+            PlayerId(0),
+            "Real Bear".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.is_copy = false;
+            obj.is_token = false;
+        }
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(701),
+                ability: None,
+                casting_variant: CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+
+        let mut events = Vec::new();
+        resolve_top(&mut state, &mut events);
+
+        let obj = &state.objects[&spell_id];
+        assert_eq!(obj.zone, Zone::Battlefield);
+        assert!(!obj.is_token, "a real permanent must not become a token");
+        assert!(!obj.is_copy);
+        assert!(
+            obj.is_represented_by_a_card(),
+            "a real permanent is still represented by a card"
+        );
+    }
+
     /// CR 724.1b: "end the turn" exiles every object on the stack, including
     /// the resolving spell itself. Discriminating against routing the source
     /// through the normal CR 608.2n instant/sorcery graveyard path.
@@ -4749,7 +4860,7 @@ mod tests {
         use crate::game::triggers;
         use crate::game::zones::create_object;
         use crate::types::ability::{
-            AbilityCondition, AbilityDefinition, Comparator, Duration, Effect, PtValue,
+            AbilityCondition, AbilityDefinition, Comparator, Duration, Effect, FilterProp, PtValue,
             QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter, TargetRef, TriggerCondition,
             TriggerDefinition, TypeFilter, TypedFilter,
         };
@@ -8016,6 +8127,154 @@ mod tests {
                     "{label}: keyword mismatch for {id:?}"
                 );
             }
+        }
+
+        /// Install a battlefield permanent hosting a token-scoped ETB replacement:
+        /// "each token that would enter the battlefield enters tapped." Modeled as a
+        /// `ReplacementEvent::ChangeZone` whose `valid_card` is
+        /// `Typed(Permanent, [FilterProp::Token])` and whose `execute` self-taps the
+        /// entering permanent (CR 701.26a → `EtbTapState::Tapped`). Returns the host
+        /// id. The replacement's `valid_card` is matched via
+        /// `matches_target_filter_on_battlefield_entry` DURING `replace_event`
+        /// (the pre-delivery seam) against the LIVE entering object's `is_token`.
+        fn add_token_enters_tapped_replacement(state: &mut GameState) -> ObjectId {
+            use crate::types::ability::{
+                AbilityKind, EffectScope, ReplacementDefinition, TapStateChange,
+            };
+            use crate::types::replacements::ReplacementEvent;
+            let host = create_object(
+                state,
+                CardId(970),
+                PlayerId(0),
+                "Token Taps Down".to_string(),
+                Zone::Battlefield,
+            );
+            {
+                let obj = state.objects.get_mut(&host).unwrap();
+                obj.card_types.core_types.push(CoreType::Enchantment);
+                let repl = ReplacementDefinition::new(ReplacementEvent::ChangeZone)
+                    .valid_card(TargetFilter::Typed(TypedFilter {
+                        type_filters: vec![TypeFilter::Permanent],
+                        properties: vec![FilterProp::Token],
+                        ..Default::default()
+                    }))
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Database,
+                        Effect::SetTapState {
+                            target: TargetFilter::SelfRef,
+                            scope: EffectScope::Single,
+                            state: TapStateChange::Tap,
+                        },
+                    ));
+                Arc::make_mut(&mut obj.base_replacement_definitions).push(repl.clone());
+                obj.replacement_definitions.push(repl);
+            }
+            host
+        }
+
+        /// Push a permanent-spell COPY (is_copy = true, is_token = false — exactly
+        /// the shape `Effect::CastCopyOfCard` produces for a permanent) onto the
+        /// stack and return its id.
+        fn push_permanent_copy_spell(state: &mut GameState, card_id: u64) -> ObjectId {
+            let copy_id = create_object(
+                state,
+                CardId(card_id),
+                PlayerId(0),
+                "Permanent Copy".to_string(),
+                Zone::Stack,
+            );
+            {
+                let obj = state.objects.get_mut(&copy_id).unwrap();
+                obj.card_types.core_types.push(CoreType::Creature);
+                obj.is_copy = true;
+                obj.is_token = false;
+            }
+            state.stack.push_back(StackEntry {
+                id: copy_id,
+                source_id: copy_id,
+                controller: PlayerId(0),
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(card_id),
+                    ability: None,
+                    casting_variant: super::CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            });
+            copy_id
+        }
+
+        /// CR 707.10f + CR 608.3f (PRODUCTION-PATH regression, revert-failing):
+        /// when a copy of a permanent spell resolves onto the battlefield, a
+        /// token-scoped ETB REPLACEMENT ("each token that enters enters tapped")
+        /// must OBSERVE the resolving copy as a token during `replace_event` and
+        /// therefore apply. This drives the real `resolve_top` →
+        /// `dest == Battlefield` block → `super::replacement::replace_event`
+        /// (stack.rs) path. The replacement's `valid_card`
+        /// (`FilterProp::Token`) is matched by
+        /// `matches_target_filter_on_battlefield_entry` against the LIVE entering
+        /// object BEFORE the ZoneChange is delivered.
+        ///
+        /// Revert probe: with the flip at its OLD (late) site in
+        /// `zone_pipeline::deliver_replaced_zone_change` (which runs AFTER
+        /// `replace_event`), the entering object is still `is_token = false` when
+        /// the replacement's token filter is evaluated, so the replacement does
+        /// NOT match and the copy enters UNTAPPED — the `tapped` assertion below
+        /// flips to false and the test fails.
+        #[test]
+        fn resolving_permanent_copy_is_observed_as_token_by_etb_replacement() {
+            let mut state = setup();
+            add_token_enters_tapped_replacement(&mut state);
+            let copy_id = push_permanent_copy_spell(&mut state, 972);
+
+            let mut events = Vec::new();
+            resolve_top(&mut state, &mut events);
+
+            let copy = &state.objects[&copy_id];
+            // Final-state sanity: the copy is now a token permanent (CR 707.10f).
+            assert_eq!(copy.zone, Zone::Battlefield);
+            assert!(copy.is_token, "CR 707.10f: the resolved copy is a token");
+            assert!(
+                !copy.is_copy,
+                "CR 707.10f: it is no longer a copy of a spell"
+            );
+            // The discriminating assertion: the token-scoped ETB replacement saw
+            // the entering copy as a token at `replace_event` time and tapped it.
+            assert!(
+                copy.tapped,
+                "CR 707.10f: a token-scoped ETB replacement must observe the \
+                 resolving permanent copy as a token as it enters — so it enters \
+                 tapped. If the flip lands after replace_event, it enters untapped."
+            );
+        }
+
+        /// Negative control for the token-scoped ETB replacement: a REAL permanent
+        /// (is_copy = false) resolving to the battlefield is a nontoken, so the
+        /// Token-filtered "enters tapped" replacement must NOT fire — it enters
+        /// untapped. Proves the discriminating assertion above keys on token-ness,
+        /// not on "every resolving permanent taps."
+        #[test]
+        fn resolving_real_permanent_is_not_tapped_by_token_replacement() {
+            let mut state = setup();
+            add_token_enters_tapped_replacement(&mut state);
+            let real_id = push_permanent_copy_spell(&mut state, 973);
+            // Make it a REAL permanent, not a copy.
+            {
+                let obj = state.objects.get_mut(&real_id).unwrap();
+                obj.is_copy = false;
+                obj.is_token = false;
+            }
+
+            let mut events = Vec::new();
+            resolve_top(&mut state, &mut events);
+
+            let obj = &state.objects[&real_id];
+            assert_eq!(obj.zone, Zone::Battlefield);
+            assert!(!obj.is_token, "a real permanent is not a token");
+            assert!(
+                !obj.tapped,
+                "a nontoken permanent must not be tapped by a Token-scoped ETB \
+                 replacement"
+            );
         }
     }
 

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1681,6 +1681,13 @@ pub(crate) fn deliver_replaced_zone_change(
                 obj.cast_cost_paid_object = link.cast_cost_paid_object;
             }
         }
+        // CR 707.10f + CR 608.3f: The is_copy→is_token flip for a resolving
+        // permanent-spell copy now happens UPSTREAM in `stack.rs::resolve_top`,
+        // at the top of the `dest == Zone::Battlefield` block — BEFORE the
+        // ProposedEvent is built, before `replace_event` matches the ZoneChange,
+        // and before the zone-change record snapshots is_token. That is the sole
+        // path a copy (only ever created on the stack by `Effect::CastCopyOfCard`)
+        // reaches the battlefield, so no un-flipped copy can arrive here.
         if to == Zone::Battlefield || from == Zone::Battlefield {
             crate::game::layers::mark_layers_full(state);
         }

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -18,6 +18,16 @@ pub(super) fn token_is_outside_battlefield_and_stack(obj: &GameObject) -> bool {
     obj.is_token && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack
 }
 
+/// CR 704.5e + CR 707.10a: A copy of a card in any zone other than the stack or
+/// the battlefield ceases to exist as a state-based action. Distinct from the
+/// token rule (CR 704.5d): a copy of a card is legal on the battlefield
+/// (CR 707.10f makes a permanent copy a token there) and may change zones freely
+/// while alive, so this predicate is used ONLY by the cease-to-exist SBA — never
+/// by the CR 111.8 "can't change zones" movement guards, which apply to tokens only.
+pub(super) fn copy_of_card_outside_battlefield_and_stack(obj: &GameObject) -> bool {
+    obj.is_copy && obj.zone != Zone::Battlefield && obj.zone != Zone::Stack
+}
+
 /// CR 122.2 + CR 113.6b: Determine whether `object_id`'s counters survive a move
 /// into the `to` zone. The default (CR 122.2) is that counters cease to exist on
 /// any zone change. A `StaticMode::CountersPersistAcrossZones` ability overrides


### PR DESCRIPTION
## Summary
Fixes two engine bugs for "cast a copy of a card" (`Effect::CastCopyOfCard`): (1) the copy never ceased to exist off the battlefield/stack (CR 704.5e / 707.10a), persisting forever in the graveyard; (2) the CR 707.10f copy→token transition for a resolving permanent-spell copy happened too late (after `replace_event` and the zone-change record), so token-scoped ETB replacements observed it as a nontoken.

## Files changed
- crates/engine/src/game/sba.rs
- crates/engine/src/game/zones.rs
- crates/engine/src/game/stack.rs
- crates/engine/src/game/zone_pipeline.rs

## CR references
CR 704.5d, CR 704.5e, CR 707.10a, CR 707.10f, CR 608.3f, CR 400.7, CR 111.8

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- `cargo fmt --all` — clean
- `cargo clippy -p engine --all-targets -- -D warnings` — clean
- `cargo test -p engine` — 14986 pass / 0 fail (all integration binaries ok)
- Both defects proven by revert-failing tests: copy-in-graveyard ceases to exist; a resolving permanent copy is observed as a token by a token-scoped ETB replacement (matched during `replace_event`).
- `gen-card-data` / `coverage` / `semantic-audit` — N/A: engine-runtime rules fix (SBA + stack resolution), no card parsing changed.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
